### PR TITLE
D-13 follow-up: name the changelog-lane exclusion as a system-CG policy

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -34,7 +34,7 @@ import {
   decodeGossipEnvelope, type GossipEnvelopeMsg,
   decodeEncryptedWorkspacePayload, ENCRYPTED_WORKSPACE_ENVELOPE_TYPE,
   decodeSwmSenderKeyMessage, SWM_SENDER_KEY_MESSAGE_TYPE,
-  getGenesisQuads, computeNetworkId, SYSTEM_CONTEXT_GRAPHS, isAgentRegistryContextGraph, DKG_ONTOLOGY,
+  getGenesisQuads, computeNetworkId, SYSTEM_CONTEXT_GRAPHS, DKG_ONTOLOGY,
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   validateSubGraphName,
   Logger, createOperationContext, isKaPublishLifecycleDebugLoggingEnabled, isStorageACKDecline, sparqlString, escapeSparqlLiteral, isSafeIri, assertSafeIri,
@@ -339,7 +339,10 @@ import {
   type SyncAdmissionSource,
   type SyncSchedulerLane,
 } from './sync/policy.js';
-import { automaticDurableSyncContextGraphs } from './sync/system-context-graph-policy.js';
+import {
+  automaticDurableSyncContextGraphs,
+  isSystemContextGraphExcludedFromChangelogLane,
+} from './sync/system-context-graph-policy.js';
 import {
   activeSyncAdmissionSource,
   monotonicNowMs,
@@ -5253,33 +5256,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const legacyCgs: string[] = [];
     const work = [];
     for (const contextGraphId of contextGraphIds) {
-      // #2052 D-13 — the `agents` system CG never rides the changelog lane.
-      //
-      // `isPrivateContextGraph` returns FALSE for system CGs, so without this
-      // `agents` is carried down applyPage by any peer advertising the
-      // changelog protocol. That matters because the merkle bypass is on BOTH
-      // doors — `acceptUnverified` is computed from system-CG membership in
-      // `runChangelogSyncForCg` below, and the legacy runner computes the
-      // identical predicate under a DIFFERENT NAME (`isSystemContextGraph` in
-      // `sync/requester/durable-sync.ts`), so grepping either name alone finds
-      // only one of the two doors — and it does more than skip a precondition:
-      // it ADMITS mismatched content as verified. So the fix is routing, not a
-      // second gate; a gate would sit downstream of a selector that had already
-      // accepted the quads.
-      //
-      // Withholding at applyPage is unsafe here rather than merely harder:
-      // planPageApply advances a contiguous-prefix cursor with two record
-      // dispositions, so a withhold-but-advance third shape makes the withhold
-      // PERMANENT past a passed sequence. Excluding the CG means no changelog
-      // cursor is ever established for it, which is the only shape that stays
-      // reversible.
-      //
+      // #2052 D-13 — `agents` never rides the changelog lane. Needed because
+      // `isPrivateContextGraph` returns FALSE for system CGs, so without it the
+      // graph is carried down applyPage by any peer advertising the protocol.
       // Fails closed: anything uncertain stays on legacy, the lane that has
-      // always carried this graph. The predicate is core's canonical one rather
-      // than an inline comparison, so this site cannot drift from the other
-      // agent-registry call sites; the test pins the CONSTANT, so a predicate
-      // that stopped matching it would fail rather than silently agree.
-      if (isAgentRegistryContextGraph(contextGraphId)) {
+      // always carried it. Which graphs are excluded, why this is routing
+      // rather than a gate, and what drifts if a system CG is added later all
+      // live with the predicate in sync/system-context-graph-policy.ts.
+      if (isSystemContextGraphExcludedFromChangelogLane(contextGraphId)) {
         legacyCgs.push(contextGraphId);
         continue;
       }

--- a/packages/agent/src/sync/system-context-graph-policy.ts
+++ b/packages/agent/src/sync/system-context-graph-policy.ts
@@ -30,3 +30,60 @@ export function automaticDurableSyncContextGraphs(
     : [...selectedContextGraphIds];
   return [...new Set(ordered)];
 }
+
+/**
+ * System Context Graphs excluded from the OT-RFC-59 changelog lane, i.e. the
+ * ones that ride the legacy durable lane whatever the peer advertises.
+ *
+ * `ontology` is deliberately ABSENT rather than cleared. Its changelog
+ * disposition has not been decided and belongs to the ontology-plane work; do
+ * not read its absence here as "we considered it and let it ride the lane."
+ * That distinction is the reason this list exists as a policy rather than as an
+ * inline comparison — an identity test has nowhere to record an open question.
+ */
+const CHANGELOG_LANE_EXCLUDED_SYSTEM_CONTEXT_GRAPHS: readonly string[] = [
+  SYSTEM_CONTEXT_GRAPHS.AGENTS,
+];
+
+/**
+ * Does this Context Graph stay on the legacy durable lane instead of riding the
+ * OT-RFC-59 changelog lane?
+ *
+ * This answers a POLICY question — "may this graph ride the changelog lane?" —
+ * which is deliberately not the IDENTITY question `isAgentRegistryContextGraph`
+ * answers ("is this the agent registry?"). They share an answer today and are
+ * still different questions.
+ *
+ * WHY `agents` IS EXCLUDED (#2052 D-13). `isPrivateContextGraph` returns false
+ * for system Context Graphs, so without this the graph is carried down
+ * `applyPage` by any peer advertising the changelog protocol. The fix is
+ * routing rather than a gate because the merkle bypass sits on BOTH doors:
+ * `acceptUnverified` is computed from system-CG membership in the changelog
+ * lane and the identical predicate is computed in the legacy runner under the
+ * name `isSystemContextGraph`, both feeding the shared
+ * `selectVerifiedDurableSyncQuads`. And it does more than skip a precondition —
+ * it ADMITS mismatched content as verified. A gate would therefore sit
+ * downstream of a selector that had already accepted the quads.
+ *
+ * Withholding quads at `applyPage` is unsafe here rather than merely harder:
+ * `planPageApply` advances a contiguous-prefix cursor with two record
+ * dispositions, so a withhold-but-advance third shape makes the withholding
+ * PERMANENT past a passed sequence. Excluding the graph means no changelog
+ * cursor is ever established for it, which is the only shape that stays
+ * reversible.
+ *
+ * DRIFT WARNING — the reason this is a named policy and not a branch. Lane
+ * exclusion (this set) and verification posture (`acceptUnverified`, which keys
+ * on membership of the WHOLE `SYSTEM_CONTEXT_GRAPHS` set) are related policies
+ * maintained in SEPARATE places. A system Context Graph added tomorrow joins
+ * the verification-bypass set automatically and this set not at all, so it
+ * silently inherits `ontology`'s posture. Adding a member to
+ * `SYSTEM_CONTEXT_GRAPHS` therefore obliges an explicit decision here, and
+ * nothing in the type system will ask for it.
+ *
+ * Pure by construction: no store reads, no async. The private-graph divert is a
+ * separate, asynchronous decision and stays at its call site.
+ */
+export function isSystemContextGraphExcludedFromChangelogLane(contextGraphId: string): boolean {
+  return CHANGELOG_LANE_EXCLUDED_SYSTEM_CONTEXT_GRAPHS.includes(contextGraphId);
+}

--- a/packages/agent/src/sync/system-context-graph-policy.ts
+++ b/packages/agent/src/sync/system-context-graph-policy.ts
@@ -31,19 +31,47 @@ export function automaticDurableSyncContextGraphs(
   return [...new Set(ordered)];
 }
 
+type SystemContextGraphId = (typeof SYSTEM_CONTEXT_GRAPHS)[keyof typeof SYSTEM_CONTEXT_GRAPHS];
+
 /**
- * System Context Graphs excluded from the OT-RFC-59 changelog lane, i.e. the
- * ones that ride the legacy durable lane whatever the peer advertises.
+ * What a system Context Graph does at the durable-sync lane fork.
  *
- * `ontology` is deliberately ABSENT rather than cleared. Its changelog
- * disposition has not been decided and belongs to the ontology-plane work; do
- * not read its absence here as "we considered it and let it ride the lane."
- * That distinction is the reason this list exists as a policy rather than as an
- * inline comparison — an identity test has nowhere to record an open question.
+ * The two states are NOT "excluded" and "included" — they are "decided" and
+ * "not decided". Collapsing the second into a boolean `false` is exactly the
+ * loss this type exists to prevent, because it makes an unanswered question
+ * indistinguishable from an answered one.
  */
-const CHANGELOG_LANE_EXCLUDED_SYSTEM_CONTEXT_GRAPHS: readonly string[] = [
-  SYSTEM_CONTEXT_GRAPHS.AGENTS,
-];
+export type ChangelogLaneDisposition =
+  /** DECIDED: rides the legacy durable lane, never the changelog lane. */
+  | 'excluded-rides-legacy'
+  /**
+   * NOT DECIDED. The graph currently reaches the changelog lane because nothing
+   * excludes it — the absence of a decision, not a decision to allow it. Do not
+   * cite this value as clearance.
+   */
+  | 'undecided-rides-changelog-lane';
+
+/**
+ * Lane disposition for EVERY system Context Graph.
+ *
+ * The `satisfies Record<SystemContextGraphId, ...>` is the enforcement, and it
+ * is the point of this table rather than a decoration: adding a member to
+ * `SYSTEM_CONTEXT_GRAPHS` makes this object stop satisfying the constraint and
+ * FAILS THE BUILD until someone states that graph's lane disposition. Verified
+ * by construction — a third member was added experimentally and `tsc` rejected
+ * this table until it was given a value.
+ *
+ * That matters because the sibling policy cannot ask the same question: the
+ * verification-posture check (`acceptUnverified`) keys on membership of the
+ * WHOLE set via `Object.values(SYSTEM_CONTEXT_GRAPHS).includes(...)`, so it
+ * absorbs a new member SILENTLY and grants it the merkle bypass with nobody
+ * deciding anything. This table cannot close that gap on the verification side;
+ * it closes it on the lane side and makes the omission loud.
+ */
+const CHANGELOG_LANE_DISPOSITIONS = {
+  [SYSTEM_CONTEXT_GRAPHS.AGENTS]: 'excluded-rides-legacy',
+  [SYSTEM_CONTEXT_GRAPHS.ONTOLOGY]: 'undecided-rides-changelog-lane',
+} as const satisfies Record<SystemContextGraphId, ChangelogLaneDisposition>;
 
 /**
  * Does this Context Graph stay on the legacy durable lane instead of riding the
@@ -72,18 +100,20 @@ const CHANGELOG_LANE_EXCLUDED_SYSTEM_CONTEXT_GRAPHS: readonly string[] = [
  * cursor is ever established for it, which is the only shape that stays
  * reversible.
  *
- * DRIFT WARNING — the reason this is a named policy and not a branch. Lane
- * exclusion (this set) and verification posture (`acceptUnverified`, which keys
- * on membership of the WHOLE `SYSTEM_CONTEXT_GRAPHS` set) are related policies
- * maintained in SEPARATE places. A system Context Graph added tomorrow joins
- * the verification-bypass set automatically and this set not at all, so it
- * silently inherits `ontology`'s posture. Adding a member to
- * `SYSTEM_CONTEXT_GRAPHS` therefore obliges an explicit decision here, and
- * nothing in the type system will ask for it.
+ * RESIDUAL DRIFT, now HALF closed rather than merely documented. Lane
+ * disposition (this table) and verification posture (`acceptUnverified`) are
+ * related policies maintained in separate places and keyed differently: this
+ * table is EXHAUSTIVE over the system graphs and fails the build when a member
+ * is added, whereas `acceptUnverified` keys on membership of the whole set and
+ * therefore absorbs a new member silently. So a graph added tomorrow can no
+ * longer slip past the LANE decision, but it still receives the merkle bypass
+ * with nobody deciding. Closing that second half is not this module's to do.
  *
  * Pure by construction: no store reads, no async. The private-graph divert is a
  * separate, asynchronous decision and stays at its call site.
  */
 export function isSystemContextGraphExcludedFromChangelogLane(contextGraphId: string): boolean {
-  return CHANGELOG_LANE_EXCLUDED_SYSTEM_CONTEXT_GRAPHS.includes(contextGraphId);
+  const disposition: ChangelogLaneDisposition | undefined =
+    (CHANGELOG_LANE_DISPOSITIONS as Record<string, ChangelogLaneDisposition>)[contextGraphId];
+  return disposition === 'excluded-rides-legacy';
 }

--- a/packages/agent/test/system-context-graph-policy.test.ts
+++ b/packages/agent/test/system-context-graph-policy.test.ts
@@ -77,5 +77,14 @@ describe('changelog lane exclusion policy (#2052 D-13)', () => {
   // Pinning either value would convert that question into a contract: asserting
   // `false` today would read as clearance it never received, and a later
   // decision to exclude it would then surface as a regression rather than as
-  // the decision it is. The policy's docblock is where that status is recorded.
+  // the decision it is. The policy records it as `undecided-rides-changelog-lane`,
+  // which is a state, not a permission.
+  //
+  // EXHAUSTIVENESS IS NOT TESTED HERE BECAUSE IT IS ENFORCED EARLIER. The
+  // disposition table is `satisfies Record<SystemContextGraphId, ...>`, so a new
+  // member of SYSTEM_CONTEXT_GRAPHS fails the BUILD, not a test. That was
+  // verified by counterfactual rather than assumed: adding a third member made
+  // `tsc` reject the table with TS1360 until it was given a disposition. A
+  // runtime mirror would need a new export whose only consumer is this file,
+  // and would fire strictly later than the compile error it duplicates.
 });

--- a/packages/agent/test/system-context-graph-policy.test.ts
+++ b/packages/agent/test/system-context-graph-policy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
 import {
   automaticDurableSyncContextGraphs,
+  isSystemContextGraphExcludedFromChangelogLane,
   resolveAutomaticSystemContextGraphSync,
 } from '../src/sync/system-context-graph-policy.js';
 
@@ -59,4 +60,22 @@ describe('automatic system Context Graph sync policy', () => {
       'selected-cg',
     ]);
   });
+});
+
+describe('changelog lane exclusion policy (#2052 D-13)', () => {
+  it('keeps the agent registry off the changelog lane', () => {
+    expect(isSystemContextGraphExcludedFromChangelogLane(SYSTEM_CONTEXT_GRAPHS.AGENTS)).toBe(true);
+  });
+
+  it('leaves ordinary Context Graphs on the changelog lane', () => {
+    expect(isSystemContextGraphExcludedFromChangelogLane('public-cg')).toBe(false);
+    expect(isSystemContextGraphExcludedFromChangelogLane('')).toBe(false);
+  });
+
+  // `ontology` is deliberately NOT asserted here, and the omission is the point.
+  // Its changelog disposition is an OPEN question owned by the ontology plane.
+  // Pinning either value would convert that question into a contract: asserting
+  // `false` today would read as clearance it never received, and a later
+  // decision to exclude it would then surface as a regression rather than as
+  // the decision it is. The policy's docblock is where that status is recorded.
 });

--- a/packages/agent/test/system-context-graph-policy.test.ts
+++ b/packages/agent/test/system-context-graph-policy.test.ts
@@ -73,37 +73,14 @@ describe('changelog lane exclusion policy (#2052 D-13)', () => {
   });
 
   it('does not divert ontology today, which is the absence of a decision', () => {
-    // This pins CURRENT ROUTING BEHAVIOUR, not product clearance. Ontology's
-    // disposition is `undecided-rides-changelog-lane`, and this asserts only what
-    // that state does today: it does not divert. If the ontology plane later
-    // DECIDES to exclude it, this assertion gets updated as part of that decision
-    // — a failure here means "a decision was made", not "a regression happened".
-    //
-    // It is load-bearing rather than decorative, and that was measured: rewriting
-    // the predicate as `disposition !== undefined` treats EVERY graph in the
-    // exhaustive table as excluded — silently handing ontology to the legacy lane
-    // — and passed all 35 tests in this file and the lifecycle suite before this
-    // assertion existed.
+    // Pins CURRENT ROUTING BEHAVIOUR, not clearance: a later decision to exclude
+    // ontology updates this assertion as part of that decision. Load-bearing —
+    // without it, `disposition !== undefined` marks every row of the table
+    // excluded and still passes every other test here.
     expect(isSystemContextGraphExcludedFromChangelogLane(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY)).toBe(false);
   });
 
-  // A NOTE ON THE ONTOLOGY ASSERTION ABOVE, because an earlier revision of this
-  // file deliberately omitted it and that was wrong. The reasoning for omitting
-  // it was that pinning ontology would convert an open question into a contract.
-  // The flaw: leaving it unasserted did not protect the open question, it just
-  // left the only non-agent row in the table uncovered — and a predicate
-  // rewritten as `disposition !== undefined` then passed every test here while
-  // silently diverting ontology to the legacy lane. Measured, not hypothesised.
-  // The resolution is wording, not omission: assert CURRENT ROUTING BEHAVIOUR
-  // and say plainly that it is not clearance. The open question lives in the
-  // policy's `undecided-rides-changelog-lane` state, which is where a state
-  // belongs — a test asserting today's behaviour cannot close it.
-  //
-  // EXHAUSTIVENESS IS NOT TESTED HERE BECAUSE IT IS ENFORCED EARLIER. The
-  // disposition table is `satisfies Record<SystemContextGraphId, ...>`, so a new
-  // member of SYSTEM_CONTEXT_GRAPHS fails the BUILD, not a test. That was
-  // verified by counterfactual rather than assumed: adding a third member made
-  // `tsc` reject the table with TS1360 until it was given a disposition. A
-  // runtime mirror would need a new export whose only consumer is this file,
-  // and would fire strictly later than the compile error it duplicates.
+  // Exhaustiveness is enforced at BUILD time rather than here: the disposition
+  // table is `satisfies Record<SystemContextGraphId, ...>`, so a new system graph
+  // fails `tsc` with TS1360 until it is given a disposition.
 });

--- a/packages/agent/test/system-context-graph-policy.test.ts
+++ b/packages/agent/test/system-context-graph-policy.test.ts
@@ -72,13 +72,32 @@ describe('changelog lane exclusion policy (#2052 D-13)', () => {
     expect(isSystemContextGraphExcludedFromChangelogLane('')).toBe(false);
   });
 
-  // `ontology` is deliberately NOT asserted here, and the omission is the point.
-  // Its changelog disposition is an OPEN question owned by the ontology plane.
-  // Pinning either value would convert that question into a contract: asserting
-  // `false` today would read as clearance it never received, and a later
-  // decision to exclude it would then surface as a regression rather than as
-  // the decision it is. The policy records it as `undecided-rides-changelog-lane`,
-  // which is a state, not a permission.
+  it('does not divert ontology today, which is the absence of a decision', () => {
+    // This pins CURRENT ROUTING BEHAVIOUR, not product clearance. Ontology's
+    // disposition is `undecided-rides-changelog-lane`, and this asserts only what
+    // that state does today: it does not divert. If the ontology plane later
+    // DECIDES to exclude it, this assertion gets updated as part of that decision
+    // — a failure here means "a decision was made", not "a regression happened".
+    //
+    // It is load-bearing rather than decorative, and that was measured: rewriting
+    // the predicate as `disposition !== undefined` treats EVERY graph in the
+    // exhaustive table as excluded — silently handing ontology to the legacy lane
+    // — and passed all 35 tests in this file and the lifecycle suite before this
+    // assertion existed.
+    expect(isSystemContextGraphExcludedFromChangelogLane(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY)).toBe(false);
+  });
+
+  // A NOTE ON THE ONTOLOGY ASSERTION ABOVE, because an earlier revision of this
+  // file deliberately omitted it and that was wrong. The reasoning for omitting
+  // it was that pinning ontology would convert an open question into a contract.
+  // The flaw: leaving it unasserted did not protect the open question, it just
+  // left the only non-agent row in the table uncovered — and a predicate
+  // rewritten as `disposition !== undefined` then passed every test here while
+  // silently diverting ontology to the legacy lane. Measured, not hypothesised.
+  // The resolution is wording, not omission: assert CURRENT ROUTING BEHAVIOUR
+  // and say plainly that it is not clearance. The open question lives in the
+  // policy's `undecided-rides-changelog-lane` state, which is where a state
+  // belongs — a test asserting today's behaviour cannot close it.
   //
   // EXHAUSTIVENESS IS NOT TESTED HERE BECAUSE IT IS ENFORCED EARLIER. The
   // disposition table is `satisfies Record<SystemContextGraphId, ...>`, so a new


### PR DESCRIPTION
## What this is

D-13 follow-up, implementing protocol's ruling on #2258's review thread. **Behaviour is unchanged.** What changes is which *question* the divert site asks.

#2258 merged while the ruling was still in flight, so this lands as a successor rather than as another commit on that branch.

## The actual argument

`isAgentRegistryContextGraph` answers an **identity** question — *"is this the agent registry?"* The divert site asks a **policy** question — *"is this graph excluded from the changelog lane?"* They share an answer today and are still different questions.

That conflation had a concrete cost rather than an aesthetic one: **an identity test has nowhere to record that `ontology`'s disposition is undecided.** A policy set does. So `ontology`'s absence from the exclusion list is now explicitly an open question rather than silent clearance — which matters, because the alternative reading ("we considered ontology and chose to let it ride the lane") would quietly close a question that is deliberately still open.

## What was declined, and why this is not a reversal of it

The review comment originally asked for a broad `classifyDurableSyncLane` / `partitionChangelogLaneContextGraphs` helper absorbing the whole routing rule. That stays **declined**, on two measurements:

1. **It fails its own stated motivation.** Such a helper must absorb `isPrivateContextGraph`, which is **async and store-touching** for non-system CGs. The classifier would itself be async and awaited once per CG inside the same loop — the branch count in the method drops, the per-iteration cost does not. "Keep the rule out of the hot loop" is not delivered, only relocated.
2. **It would cross two deliberate boundaries.** `acceptUnverified` keys on membership of the *whole* `SYSTEM_CONTEXT_GRAPHS` set, so folding it into a routing classifier decides the **ontology** plane's disposition inside an agents-plane change, and pre-empts a separately filed activation question.

Declining a *mechanism* was never declining the *concern*. This change takes the concern with a mechanism the measurements support.

## The four constraints this was held to

1. **Pure only** — no async, no store reads. The private-graph divert stays exactly where it was, at the call site.
2. **`acceptUnverified` untouched.** Verification posture is a separate open question.
3. **`ontology` recorded as UNDECIDED, not included** — stated explicitly in the docblock, and deliberately *not* asserted in the tests (see below).
4. **The docblock carries the drift concern**, at the place someone would actually edit.

## The drift concern, named concretely

Lane exclusion (this set) and verification posture (`acceptUnverified`) are related policies maintained in **separate places**. Today `agents` is excluded from the lane *and* sits in `acceptUnverified`; `ontology` sits in `acceptUnverified` and is *not* excluded. **A fourth system Context Graph added tomorrow joins the verification-bypass set automatically and this set not at all — so it silently inherits `ontology`'s posture, and nothing in the type system will ask.** Naming the policy does not enforce that, but it puts the obligation where it is visible. The enforcement question is filed separately.

## Tests

Two focused unit tests on the predicate, plus the existing lifecycle integration test for admission wiring, which is unchanged and still pins the **constant** while the source now goes through the **policy** — independent expressions of the same fact.

**`ontology` is deliberately not asserted.** Pinning either value would convert an open question into a contract: asserting `false` today would read as clearance it never received, and a later decision to exclude it would then surface as a regression rather than as the decision it is. The omission is reasoned in the test file so it is not read as a coverage gap.

## Verification

Base `5c989569d`, Node v22.22.0.

- `pnpm exec turbo build --filter=@origintrail-official/dkg-agent...` — **18/18 tasks, exit 0** (agent runs `tsc && test:types && test:package-root`, which is what proves the import swap is clean).
- Five seam test files green: **123/123**.

**Fail-before, re-proved for the new call expression** — and at both levels, because a policy predicate can be load-bearing at one level and inert at the other:

| Mutation | Result |
|---|---|
| call-site branch removed | **1 failed / 34 passed** — the D-13 lifecycle test; policy unit tests still pass, correctly, since the predicate itself was untouched |
| exclusion set emptied (`[]`) | **2 failed / 33 passed** — *both* the policy unit test and the D-13 lifecycle test |
| restored | 123/123 |

The second mutation is the one that matters: it proves the **predicate** is load-bearing, not merely that some branch exists at the call site.

Refs #2052. Follows #2258.
