### PR TITLE
D-13 follow-up: bound the lane-policy guard's claim and name its one bypass

### DIFF
--- a/packages/agent/src/sync/system-context-graph-policy.ts
+++ b/packages/agent/src/sync/system-context-graph-policy.ts
@@ -57,9 +57,19 @@ export type ChangelogLaneDisposition =
  * The `satisfies Record<SystemContextGraphId, ...>` is the enforcement, and it
  * is the point of this table rather than a decoration: adding a member to
  * `SYSTEM_CONTEXT_GRAPHS` makes this object stop satisfying the constraint and
- * FAILS THE BUILD until someone states that graph's lane disposition. Verified
- * by construction — a third member was added experimentally and `tsc` rejected
- * this table until it was given a value.
+ * FAILS THE BUILD until that graph is given a lane disposition. Verified by
+ * construction — a third member was added experimentally and `tsc` rejected this
+ * table until it was given a value.
+ *
+ * THE HONEST BOUND ON THAT GUARD: it forces a STATEMENT, not a DECISION. Someone
+ * adding a system graph under deadline can discharge the error by writing
+ * `'undecided-rides-changelog-lane'` and shipping. What it buys is that the
+ * choice becomes visible in a diff and greppable — strictly more than a comment
+ * achieved, and strictly less than a decision. Do not cite it as more.
+ *
+ * IT ALSO HAS EXACTLY ONE BYPASS, named here so that taking it reads as a
+ * downgrade rather than a tidy-up: replacing `satisfies` with `as` silences the
+ * constraint entirely, and the enforcement is gone with nothing failing.
  *
  * That matters because the sibling policy cannot ask the same question: the
  * verification-posture check (`acceptUnverified`) keys on membership of the

--- a/packages/agent/src/sync/system-context-graph-policy.ts
+++ b/packages/agent/src/sync/system-context-graph-policy.ts
@@ -54,22 +54,20 @@ export type ChangelogLaneDisposition =
 /**
  * Lane disposition for EVERY system Context Graph.
  *
- * The `satisfies Record<SystemContextGraphId, ...>` is the enforcement, and it
- * is the point of this table rather than a decoration: adding a member to
- * `SYSTEM_CONTEXT_GRAPHS` makes this object stop satisfying the constraint and
- * FAILS THE BUILD until that graph is given a lane disposition. Verified by
- * construction — a third member was added experimentally and `tsc` rejected this
- * table until it was given a value.
+ * The `satisfies Record<SystemContextGraphId, ...>` is the enforcement rather
+ * than a decoration: adding a member to `SYSTEM_CONTEXT_GRAPHS` makes this object
+ * stop satisfying the constraint, and `tsc` rejects it until that graph is given
+ * a disposition (verified by adding a third member experimentally).
  *
- * THE HONEST BOUND ON THAT GUARD: it forces a STATEMENT, not a DECISION. Someone
- * adding a system graph under deadline can discharge the error by writing
- * `'undecided-rides-changelog-lane'` and shipping. What it buys is that the
- * choice becomes visible in a diff and greppable — strictly more than a comment
- * achieved, and strictly less than a decision. Do not cite it as more.
+ * Its bound, so it is not trusted past its range: it forces a STATEMENT, not a
+ * decision — a graph can be added as `'undecided-rides-changelog-lane'` and
+ * shipped. What it buys is that the choice becomes visible in a diff and
+ * greppable.
  *
- * IT ALSO HAS EXACTLY ONE BYPASS, named here so that taking it reads as a
- * downgrade rather than a tidy-up: replacing `satisfies` with `as` silences the
- * constraint entirely, and the enforcement is gone with nothing failing.
+ * The enforcement lives entirely in that type boundary, and weakening the
+ * boundary removes it silently, with nothing failing: swapping `satisfies` for
+ * `as`, making the Record `Partial`, or widening the key type would each do it.
+ * Treat such an edit as a downgrade rather than a tidy-up.
  *
  * That matters because the sibling policy cannot ask the same question: the
  * verification-posture check (`acceptUnverified`) keys on membership of the

--- a/packages/agent/src/sync/system-context-graph-policy.ts
+++ b/packages/agent/src/sync/system-context-graph-policy.ts
@@ -59,10 +59,10 @@ export type ChangelogLaneDisposition =
  * stop satisfying the constraint, and `tsc` rejects it until that graph is given
  * a disposition (verified by adding a third member experimentally).
  *
- * Its bound, so it is not trusted past its range: it forces a STATEMENT, not a
- * decision — a graph can be added as `'undecided-rides-changelog-lane'` and
- * shipped. What it buys is that the choice becomes visible in a diff and
- * greppable.
+ * It is bounded, and the bound is written down so the guard is not trusted past
+ * its range: it forces a STATEMENT, not a decision — a graph can be added as
+ * `'undecided-rides-changelog-lane'` and shipped. What it buys is that the
+ * choice becomes visible in a diff and greppable.
  *
  * The enforcement lives entirely in that type boundary, and weakening the
  * boundary removes it silently, with nothing failing: swapping `satisfies` for


### PR DESCRIPTION
## What this is

Protocol's review note on #2260, which merged while the change was in flight. **Comment-only** — one docblock, no code line touched.

## Why

The docblock claimed the `satisfies` constraint *"fails the build until someone states that graph's lane disposition."* That is true, and it reads stronger than it is.

**The type forces a STATEMENT, not a DECISION.** Someone adding a system Context Graph under deadline can discharge the error by writing `'undecided-rides-changelog-lane'` and shipping. What the guard actually buys is that the choice becomes **visible in a diff and greppable** — strictly more than the comment it replaced, and strictly less than a decision.

That distinction matters because **a guard described as stronger than it is gets trusted past its range.** The bound is now stated rather than left to the stronger reading.

## And it names its one bypass

Replacing `satisfies` with `as` silences the constraint entirely, and the enforcement disappears with nothing failing. Naming that at the site means a future `as` reads as a **downgrade** rather than a tidy-up.

This is deliberately a sentence rather than a runtime test. A runtime exhaustiveness mirror would need a new export whose only consumer is its own test, and it would fire strictly later than the compile error it duplicates — but it would have covered the `as` swap. Naming the bypass closes that same gap at the one place someone would be standing when they open it.

## Verification

Base `3551cb19e` (the #2260 merge commit).

- The diff touches **no code line** — confirmed by reading every changed line; all are `*` comment lines.
- This exact blob was typechecked and exercised before #2260 merged: `tsc --noEmit` exit 0, and 36/36 green across `system-context-graph-policy.test.ts` and `durable-sync-lifecycle-binding.test.ts`. The cherry-pick onto the new base is **byte-identical** to that verified content (`git diff` against the pre-merge commit is empty), and the policy file was unchanged by the merge.
- CI re-runs the full suite here regardless, including the package build that compiles this file.

Refs #2052. Follows #2260.
