### PR TITLE
test(storage): pin the built-input collapse at 273, and stop calling 576 cells-per-input

### DIFF
--- a/packages/storage/test/authority-verdict-diff-projection-equivalence-v1.test.ts
+++ b/packages/storage/test/authority-verdict-diff-projection-equivalence-v1.test.ts
@@ -222,12 +222,22 @@ describe('verdict-diff projection equivalence', { timeout: VERDICT_DIFF_SUITE_TI
    * That is not a defect in the key. Its contract is only that cells SHARING a
    * key present identical inputs, which over-discrimination cannot violate, and
    * running 855 projections where 285 would do costs nothing worth having. It is
-   * recorded as a MEASUREMENT instead, because the number is the finding: a
-   * storage input stands for 576 cells, not 192, and the three clock values are
-   * served by one byte-identical input. That is the sharpest available statement
+   * recorded as a MEASUREMENT instead, because the number is the finding: each
+   * CLOCK-INDEPENDENT KEY-GROUP covers 576 cells, not 192, and the three clock
+   * values are served by one byte-identical input. That is the sharpest available statement
    * of the clock divergence -- not merely that storage has no clock, but that
    * the same storage input answers for a candidate core refuses on skew and for
    * one it accepts.
+   *
+   * 576 IS CELLS PER KEY-GROUP, NEVER CELLS PER INPUT, AND THE DISTINCTION IS
+   * MEASURABLE RATHER THAN PEDANTIC. The built inputs number 273, and 273 does
+   * NOT divide 164,160 -- it leaves remainder 87, giving ~601.3 cells per input.
+   * A non-integer is the proof that inputs are NOT uniformly sized: they collapse
+   * further than the key-groups, across applied statuses and operations wherever
+   * those agree. Any sentence of the form "N cells per storage input" derived
+   * from a KEY count is describing the key, which is the same conflation that
+   * once had this suite credited with measuring 285 built inputs it never
+   * measured.
    */
   it('measures that the clock cannot reach a storage input', () => {
     const distinctKeys = new Set(cells.map(storageInputProjectionKeyV1));
@@ -239,8 +249,13 @@ describe('verdict-diff projection equivalence', { timeout: VERDICT_DIFF_SUITE_TI
     expect(distinctKeys.size).toBe(855);
     expect(withoutClock.size).toBe(285);
     expect(distinctKeys.size).toBe(withoutClock.size * 3);
-    // The built inputs themselves collapse further than either key: the head is
+    // THE EMPIRICAL INPUT-COLLAPSE FIGURE, PINNED RATHER THAN BOUNDED. The old
+    // one-sided bound is satisfied by any degenerate fingerprint -- 1 < 855 --
+    // so it could not distinguish a real collapse from a broken instrument, and
+    // it is the number the artifact spent four sentences claiming to have.
+    // The built inputs collapse further than either key because the head is
     // shared across applied statuses and operations wherever those agree.
-    expect(distinctInputs.size).toBeLessThan(distinctKeys.size);
+    expect(distinctInputs.size).toBe(273);
+    expect(distinctInputs.size).toBeLessThan(withoutClock.size);
   });
 });

--- a/packages/storage/test/authority-verdict-diff-projection-v1.test.ts
+++ b/packages/storage/test/authority-verdict-diff-projection-v1.test.ts
@@ -33,9 +33,12 @@ import { resolveConstructibilityV1 } from './helpers/authority-verdict-diff-cons
  * futureSkew do not occur anywhere in packages/storage/src -- so the storage
  * projection keys collapse 855 -> 285 once the clock segment is removed, which
  * is KEY ARITHMETIC (855 = 285 x 3) rather than a byte comparison of built
- * inputs, and the honest figure is 576 cells per input, not 192. Both numbers are real
- * and they answer different questions -- 192 is what the committed projection
- * key groups, 576 is what storage can actually see.
+ * inputs, and the honest figure is 576 cells per CLOCK-INDEPENDENT KEY-GROUP,
+ * not 192. Both numbers are real and they answer different questions -- 192 is
+ * what the committed projection key groups, 576 is what a clock-independent
+ * group covers. NEITHER is cells-per-input: the built inputs number 273, which
+ * does not divide 164,160 (remainder 87, ~601.3 cells each), and a non-integer
+ * is the proof that inputs are not uniformly sized.
  */
 // Stated rather than inherited, for the reason recorded in the generator's own
 // suite: vitest's 5s default already cost this lane a run once, and the space


### PR DESCRIPTION
Follow-up to the axis-L re-attribution merged in #2254, landed on a fresh branch off the post-merge integration head because #2254's head branch is now a merged PR's dead letterbox.

## What was still wrong

#2254 corrected a clause crediting the projection-equivalence suite with measuring *"855 projection keys collapsed to 285 distinct built inputs"*. 285 is the storage projection key **without its clock segment** — key arithmetic, not an input measurement.

**That fix kept the same conflation one level down.** Two sentences derived a per-unit figure from the key count and attached the wrong noun:

- `a storage input stands for 576 cells, not 192`
- `the honest figure is 576 cells per input, not 192`

576 is right. *Per input* is not.

## The divisibility is the proof

| quotient | result |
|---|---|
| `164,160 / 855` | **192**, exact |
| `164,160 / 285` | **576**, exact |
| `164,160 / 273` | **601.318…**, remainder 87 |

**273 does not divide the cell space at all.** A non-integer quotient falsifies the noun outright — 273 cannot be a per-unit divisor — and the fact that it isn't one *is* the finding: the built inputs are **not uniformly sized**. They collapse further than the key-groups, across applied statuses and operations wherever those agree, so a storage input covers roughly 601 cells on average rather than a fixed 576.

So 576 is cells per **clock-independent key-group**. Both sentences now name that subject, with the reason recorded at the site rather than left to be rediscovered.

## 273 is now pinned rather than bounded

The suite asserted only `distinctInputs.size < distinctKeys.size` — a one-sided bound satisfied by **any** degenerate fingerprint, since `1 < 855`. It could not distinguish a real collapse from a broken instrument.

It is also the empirical input-collapse number the artifact spent four sentences claiming to have measured while never asserting it anywhere. **A fact stated in an artifact but asserted nowhere is unguarded**, and this one was stated four times. Pinning it retires the confusion at its root.

## Non-vacuity of the 273 pin — measured, not inferred

The pin is killed by the constant-fingerprint mutant, run against **this** assertion rather than inferred from the earlier floor work. It was tempting to call it already-demonstrated, since the same degenerate fingerprint killed the floor on the parent PR — but that mutant ran when this line still read `toBeLessThan(distinctKeys.size)`, which a constant satisfies. The assertion being killed is new, so it earned its own run.

Mutant: `storageInputFingerprintV1` returns a constant. **Predicted 2 failed | 3 passed** — the floor and the 273 pin, with the three equivalence rows unaffected. **Observed exactly that**, the pin failing `expected 1 to be 273`. Restored and re-run green at 5 passed as the control.

## Verification

- Lane: **12 files / 81 tests, zero failures**, node v22.
- Test-only: 2 files, both `packages/storage/test/*.test.ts`. No helper, fixture or table data touched; no verdict, count, image or digest moves.
- Branched from `6913bb0df` (integration head after #2254 merged).
