### PR TITLE
test(storage): close the authority-chain sequence-depth boundary

### DIFF
--- a/packages/storage/test/authority-verdict-diff-core-heads-v1.test.ts
+++ b/packages/storage/test/authority-verdict-diff-core-heads-v1.test.ts
@@ -9,6 +9,7 @@ import { enumerateVerdictDiffCellsV1 } from './helpers/authority-verdict-diff-ce
 import { resolveConstructibilityV1 } from './helpers/authority-verdict-diff-constructibility-v1.js';
 import {
   buildCoreCandidateHeadV1,
+  coreCandidateSequenceV1,
   coreHeadShapeKeyV1,
   CORE_ALL_TRANSITIONS_V1,
   CORE_CURRENT_DIGEST_V1,
@@ -176,6 +177,36 @@ describe('core candidate head construction', { timeout: SUITE_TIMEOUT_MS }, () =
     }
 
     expect(violations).toEqual([]);
+  });
+
+  /**
+   * THE CELL-DERIVED SEQUENCE SHORTCUT AGREES WITH THE BUILDER, over every
+   * buildable shape.
+   *
+   * `coreCandidateSequenceV1` exists so the evidence layer can pick a
+   * sequence-dependent member without building a head per cell. That makes it a
+   * SECOND path to a value the builder also computes, and two paths to one value
+   * is precisely how a fixture starts handing out members chosen for the wrong
+   * sequence -- the defect class this whole slice keeps meeting. So the
+   * agreement is asserted rather than inspected, and asserted against the BUILT
+   * head rather than against the shortcut's own inputs.
+   */
+  it('derives the candidate sequence from the cell exactly as the builder does', () => {
+    const disagreements: string[] = [];
+    for (const [key, result] of byShape) {
+      if (!result.built) continue;
+      const cell = representative.get(key)!;
+      const built = String((result.candidate as { authoritySequence: string }).authoritySequence);
+      const derived = coreCandidateSequenceV1(cell);
+      if (built !== derived) disagreements.push(`${key}: built ${built}, derived ${derived}`);
+    }
+    expect(disagreements).toEqual([]);
+    // Non-vacuity: the shortcut must reach more than one sequence, or an
+    // always-return-2 stub would satisfy the equality above.
+    const reached = new Set(
+      [...byShape].filter(([, r]) => r.built).map(([key]) => coreCandidateSequenceV1(representative.get(key)!)),
+    );
+    expect(reached.size).toBeGreaterThan(1);
   });
 
   // NON-VACUITY IN BOTH DIRECTIONS. A layer that built everything would be

--- a/packages/storage/test/authority-verdict-diff-core-heads-v1.test.ts
+++ b/packages/storage/test/authority-verdict-diff-core-heads-v1.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
-import { computeAgentProfileHeadObjectDigestV1 } from '@origintrail-official/dkg-core/system-record-v1';
+import {
+  computeAgentProfileAuthorityTransitionDigestV1,
+  computeAgentProfileHeadObjectDigestV1,
+} from '@origintrail-official/dkg-core/system-record-v1';
 
 import { enumerateVerdictDiffCellsV1 } from './helpers/authority-verdict-diff-cells-v1.js';
 import { resolveConstructibilityV1 } from './helpers/authority-verdict-diff-constructibility-v1.js';
 import {
   buildCoreCandidateHeadV1,
   coreHeadShapeKeyV1,
+  CORE_ALL_TRANSITIONS_V1,
   CORE_CURRENT_DIGEST_V1,
   CORE_CURRENT_HEAD_V1,
   CORE_CURRENT_SEQUENCE_V1,
@@ -120,13 +124,50 @@ describe('core candidate head construction', { timeout: SUITE_TIMEOUT_MS }, () =
           note(`axis E ${cell.versionRelation} wanted delta ${VERSION_DELTA[cell.versionRelation]}, head has ${delta}`);
         }
       }
-      if (cell.acceptedTransitionDigest === 'differ'
-        && head.acceptedTransitionDigest !== CORE_OTHER_TRANSITION_DIGEST_V1) {
-        note('axis G differ is not the competing transition digest');
+      // AXIS G IS SEQUENCE-RELATIVE. 'equal' means the candidate names the
+      // ACCEPTED rotation into its OWN authority sequence; 'differ' means it
+      // names a COMPETING rotation into that same sequence. Ruled 2026-08-12;
+      // the denotation and its provenance are declared at the axis itself.
+      //
+      // Resolved against the transition OBJECTS rather than against the
+      // builder's own per-sequence table. Comparing a head to the table that
+      // built it agrees BY CONSTRUCTION and could never detect a builder that
+      // ignored the axis -- the same self-reference that makes a count computed
+      // from the generator worthless as a pin.
+      if (cell.acceptedTransitionDigest !== undefined) {
+        const named = CORE_ALL_TRANSITIONS_V1.find((transition) =>
+          computeAgentProfileAuthorityTransitionDigestV1(transition)
+            === head.acceptedTransitionDigest);
+        if (named === undefined) {
+          note('axis G names a transition this fixture does not carry');
+        } else if (named.nextAuthoritySequence !== String(head.authoritySequence)) {
+          note(`axis G names a rotation into sequence ${named.nextAuthoritySequence}`
+            + ` while the head sits at ${String(head.authoritySequence)}`);
+        } else {
+          // The accepted rotation is the one this head's own wallet root came
+          // from; a competing rotation moves to some other root.
+          const accepted = named.nextEvmIssuer === head.evmIssuer;
+          if (cell.acceptedTransitionDigest === 'equal' && !accepted) {
+            note("axis G equal is not the accepted rotation into the head's own sequence");
+          }
+          if (cell.acceptedTransitionDigest === 'differ' && accepted) {
+            note('axis G differ is not a competing rotation');
+          }
+        }
       }
-      if (cell.acceptedTransitionDigest === 'equal'
-        && head.acceptedTransitionDigest !== CORE_CURRENT_HEAD_V1.acceptedTransitionDigest) {
-        note("axis G equal is not the current head's transition digest");
+      // THE SPECIAL CASE IS PINNED, NOT INHERITED. At the current authority
+      // sequence the general rule must still land on exactly the two constants
+      // the pre-generalisation assertion named, byte for byte -- so "the
+      // D='equal' column did not move" is asserted rather than argued.
+      if (String(head.authoritySequence) === CORE_CURRENT_HEAD_V1.authoritySequence) {
+        if (cell.acceptedTransitionDigest === 'equal'
+          && head.acceptedTransitionDigest !== CORE_CURRENT_HEAD_V1.acceptedTransitionDigest) {
+          note("axis G equal at the current sequence left the current head's transition digest");
+        }
+        if (cell.acceptedTransitionDigest === 'differ'
+          && head.acceptedTransitionDigest !== CORE_OTHER_TRANSITION_DIGEST_V1) {
+          note('axis G differ at the current sequence left CORE_OTHER_TRANSITION_DIGEST_V1');
+        }
       }
       const carriesFork = head.forkResolutionDigest !== undefined;
       if (carriesFork !== (cell.candidateForkResolutionDigest === 'present')) {

--- a/packages/storage/test/authority-verdict-diff-core-table-v1.test.ts
+++ b/packages/storage/test/authority-verdict-diff-core-table-v1.test.ts
@@ -361,7 +361,10 @@ describe('authority verdict diff: core table', { timeout: 600_000 }, () => {
   });
 
   it('carries its findings as data rather than as a commit message', () => {
-    expect(CORE_SWEEP_FINDINGS_V1.length).toBe(6);
+    // Seven since the sequence-depth closure added the axis-G denotation
+    // finding. The count is pinned rather than bounded so a finding cannot be
+    // dropped silently -- a `toBeGreaterThan` here would let one disappear.
+    expect(CORE_SWEEP_FINDINGS_V1.length).toBe(7);
     for (const finding of CORE_SWEEP_FINDINGS_V1) expect(finding.length).toBeGreaterThan(80);
 
     // REGISTER SEPARATION, ASSERTED. A harness limitation filed among the system

--- a/packages/storage/test/authority-verdict-diff-core-table-v1.test.ts
+++ b/packages/storage/test/authority-verdict-diff-core-table-v1.test.ts
@@ -96,9 +96,15 @@ describe('authority verdict diff: core table', { timeout: 600_000 }, () => {
     return sweptCache;
   }
 
+  // NO PARAMETER, because a memo that ignores its argument is a lie about what
+  // it depends on. The earlier form took `constructible` and returned the first
+  // cached promise regardless -- harmless while every caller passes the same
+  // set, and exactly the shape that makes a later assertion silently
+  // order-dependent if one ever passes a filtered one. It reads the sweep's own
+  // split so there is only one set it CAN be about.
   let mintCache: Promise<Awaited<ReturnType<typeof buildCoreSummaryIndexV1>>> | undefined;
-  function mintIndex(constructible: readonly VerdictDiffCellV1[]) {
-    mintCache ??= buildCoreSummaryIndexV1(constructible);
+  function mintIndex() {
+    mintCache ??= sweep().then(({ split }) => buildCoreSummaryIndexV1(split.constructible));
     return mintCache;
   }
 
@@ -191,7 +197,7 @@ describe('authority verdict diff: core table', { timeout: 600_000 }, () => {
 
   it('mints a summary for only the head shapes core will close over, each for a stated reason', async () => {
     const split = resolveConstructibilityV1(enumerateVerdictDiffCellsV1());
-    const { summaries, unresolvedArtifacts } = await mintIndex(split.constructible);
+    const { summaries, unresolvedArtifacts } = await mintIndex();
     const buildable = new Set(
       split.constructible
         .filter((cell) => buildCoreCandidateHeadV1(cell).built)
@@ -246,7 +252,7 @@ describe('authority verdict diff: core table', { timeout: 600_000 }, () => {
    */
   it('re-checks that the escape objects its limitation register names are really built', async () => {
     const split = resolveConstructibilityV1(enumerateVerdictDiffCellsV1());
-    const { summaries } = await mintIndex(split.constructible);
+    const { summaries } = await mintIndex();
     const byShape = new Map<string, ReturnType<typeof buildCoreCandidateHeadV1>>();
     for (const cell of split.constructible) {
       const key = coreHeadShapeKeyV1(cell);

--- a/packages/storage/test/authority-verdict-diff-core-table-v1.test.ts
+++ b/packages/storage/test/authority-verdict-diff-core-table-v1.test.ts
@@ -5,7 +5,10 @@ import { describe, expect, it } from 'vitest';
 
 import { evaluateAgentProfileHeadAdvanceV1 } from '@origintrail-official/dkg-core/system-record-v1';
 
-import { enumerateVerdictDiffCellsV1 } from './helpers/authority-verdict-diff-cells-v1.js';
+import {
+  enumerateVerdictDiffCellsV1,
+  type VerdictDiffCellV1,
+} from './helpers/authority-verdict-diff-cells-v1.js';
 import {
   resolveConstructibilityV1,
   type SourceCitationV1,
@@ -67,9 +70,36 @@ describe('authority verdict diff: core table', { timeout: 600_000 }, () => {
       : `THREW|${outcome.message}`;
   }
 
-  async function sweep() {
-    const split = resolveConstructibilityV1(enumerateVerdictDiffCellsV1());
-    return { split, rows: await runCoreSweepV1(split.constructible) };
+  /**
+   * ONE SWEEP AND ONE MINT INDEX FOR THE WHOLE FILE, memoised the way the join
+   * suite already memoises its own.
+   *
+   * These were recomputed per test -- three full sweeps and two mint-index
+   * builds -- which is the same work five times over identical inputs. Measured
+   * in CI at 226 seconds for this file, which is most of a lane budget spent
+   * re-deriving what it already had.
+   *
+   * NO OBSERVATION LEAVES THE RUN. Every assertion still runs against the same
+   * data it did before; only the number of times that data is computed changes.
+   * A cut that dropped a driven cell would be a different thing entirely and
+   * would have to name what it stopped observing.
+   */
+  let sweptCache: Promise<{
+    split: ReturnType<typeof resolveConstructibilityV1>;
+    rows: Awaited<ReturnType<typeof runCoreSweepV1>>;
+  }> | undefined;
+  function sweep() {
+    sweptCache ??= (async () => {
+      const split = resolveConstructibilityV1(enumerateVerdictDiffCellsV1());
+      return { split, rows: await runCoreSweepV1(split.constructible) };
+    })();
+    return sweptCache;
+  }
+
+  let mintCache: Promise<Awaited<ReturnType<typeof buildCoreSummaryIndexV1>>> | undefined;
+  function mintIndex(constructible: readonly VerdictDiffCellV1[]) {
+    mintCache ??= buildCoreSummaryIndexV1(constructible);
+    return mintCache;
   }
 
   it('pins every projection verdict exactly, and the distribution that localises a move', async () => {
@@ -161,7 +191,7 @@ describe('authority verdict diff: core table', { timeout: 600_000 }, () => {
 
   it('mints a summary for only the head shapes core will close over, each for a stated reason', async () => {
     const split = resolveConstructibilityV1(enumerateVerdictDiffCellsV1());
-    const { summaries, unresolvedArtifacts } = await buildCoreSummaryIndexV1(split.constructible);
+    const { summaries, unresolvedArtifacts } = await mintIndex(split.constructible);
     const buildable = new Set(
       split.constructible
         .filter((cell) => buildCoreCandidateHeadV1(cell).built)
@@ -216,7 +246,7 @@ describe('authority verdict diff: core table', { timeout: 600_000 }, () => {
    */
   it('re-checks that the escape objects its limitation register names are really built', async () => {
     const split = resolveConstructibilityV1(enumerateVerdictDiffCellsV1());
-    const { summaries } = await buildCoreSummaryIndexV1(split.constructible);
+    const { summaries } = await mintIndex(split.constructible);
     const byShape = new Map<string, ReturnType<typeof buildCoreCandidateHeadV1>>();
     for (const cell of split.constructible) {
       const key = coreHeadShapeKeyV1(cell);

--- a/packages/storage/test/authority-verdict-diff-evidence-branch-v1.test.ts
+++ b/packages/storage/test/authority-verdict-diff-evidence-branch-v1.test.ts
@@ -32,7 +32,11 @@ import { buildCoreCandidateHeadV1 } from './helpers/authority-verdict-diff-core-
 describe('verdict-diff: acceptedTransition evidence is branch-selected', () => {
   function verdict(cell: VerdictDiffCellV1): string {
     const head = buildCoreCandidateHeadV1(cell);
-    if (!head.built) return `REFUSED|${head.ruleId}`;
+    // A refused head must FAIL rather than return a string: a construction
+    // failure that merely produced a different label would satisfy any negative
+    // assertion below and the branch would never be reached.
+    expect(head.built).toBe(true);
+    if (!head.built) throw new Error(`head refused: ${head.ruleId}`);
     const decision = evaluateAgentProfileHeadAdvanceV1(
       buildCoreAcceptedStateV1(cell) as never,
       head.candidate,
@@ -62,12 +66,12 @@ describe('verdict-diff: acceptedTransition evidence is branch-selected', () => {
       evidence: ['tombstonePredecessor', 'acceptedTransition'],
     } as unknown as VerdictDiffCellV1;
 
-    // The branch must get PAST the retained-transition comparison. Asserting the
-    // absence of that specific reject rather than a particular success verdict:
-    // what this pins is that the fixture stopped manufacturing the refusal, not
-    // what core then decides, which is the table's business and not this test's.
-    expect(verdict(cell))
-      .not.toBe('reject|late tombstone requires the exact retained resurrection transition');
+    // POSITIVE, not negative. A `not.toBe(<one reject>)` passes on ANY other
+    // string -- including the predecessor-gate reject that fires BEFORE the
+    // retained-transition comparison, so the branch this test names would never
+    // be reached and the test would still be green. `accept` is only reachable
+    // through both gates in order, so it proves the whole path.
+    expect(verdict(cell)).toBe('accept');
   });
 
   it('satisfies the named-transition check on a NEXT-sequence candidate', () => {
@@ -79,9 +83,9 @@ describe('verdict-diff: acceptedTransition evidence is branch-selected', () => {
       evidence: ['acceptedTransition', 'verifiedAuthoritySummary'],
     } as unknown as VerdictDiffCellV1;
 
-    // The mirror-image refusal: the next-sequence arm compares the supplied
-    // transition against the candidate's OWN named digest, so a lower-sequence
-    // style selection lands here instead.
-    expect(verdict(cell)).not.toBe('reject|exact accepted authority transition is missing');
+    // Positive for the same reason: the next-sequence arm compares the supplied
+    // transition against the candidate's OWN named digest, and `accept` is
+    // reachable only once that comparison succeeds.
+    expect(verdict(cell)).toBe('accept');
   });
 });

--- a/packages/storage/test/authority-verdict-diff-evidence-branch-v1.test.ts
+++ b/packages/storage/test/authority-verdict-diff-evidence-branch-v1.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import { evaluateAgentProfileHeadAdvanceV1 } from '@origintrail-official/dkg-core/system-record-v1';
+
+import type { VerdictDiffCellV1 } from './helpers/authority-verdict-diff-cells-v1.js';
+import {
+  buildCoreAcceptedStateV1,
+  buildCoreEvidenceV1,
+} from './helpers/authority-verdict-diff-core-evidence-v1.js';
+import { buildCoreCandidateHeadV1 } from './helpers/authority-verdict-diff-core-heads-v1.js';
+
+/**
+ * EVIDENCE IS SELECTED BY THE BRANCH THAT READS IT.
+ *
+ * Axis J's `acceptedTransition` is not one object. Core's LOWER-sequence
+ * tombstone arm takes `retained = lineage[candidateSequence]` and demands the
+ * supplied transition match it -- the rotation OUT of the candidate's sequence.
+ * Its NEXT-sequence arm compares the supplied transition's digest to the
+ * candidate's own `acceptedTransitionDigest` -- the rotation INTO it. A fixture
+ * serving one value to both branches manufactures a refusal on whichever branch
+ * it is not serving, and records it as core's.
+ *
+ * This suite is the fail-before for that. Both assertions FAIL under the two
+ * previous versions of the selection rule:
+ *   - the original single constant (always the 1->2 transition) fails the
+ *     next-sequence case;
+ *   - sequence-keyed selection (the rotation INTO the candidate's sequence)
+ *     fails the lower-sequence tombstone case.
+ * Only branch-keyed selection satisfies both, which is what makes this a test of
+ * the rule rather than of one of its instances.
+ */
+describe('verdict-diff: acceptedTransition evidence is branch-selected', () => {
+  function verdict(cell: VerdictDiffCellV1): string {
+    const head = buildCoreCandidateHeadV1(cell);
+    if (!head.built) return `REFUSED|${head.ruleId}`;
+    const decision = evaluateAgentProfileHeadAdvanceV1(
+      buildCoreAcceptedStateV1(cell) as never,
+      head.candidate,
+      buildCoreEvidenceV1(cell, new Map()) as never,
+    ) as { decision: string; reason?: string };
+    return decision.reason === undefined ? decision.decision : `${decision.decision}|${decision.reason}`;
+  }
+
+  const base = {
+    snapshot: 'present',
+    appliedStatus: 'active',
+    storageOperation: 'active',
+    coreDisposition: 'discoverable',
+    candidateForkResolutionDigest: 'absent',
+    clock: 'valid',
+  } as const;
+
+  it('satisfies the retained-transition check on a LOWER-sequence tombstone', () => {
+    const cell = {
+      ...base,
+      id: 'branch-lower-tombstone',
+      candidateHeadState: 'tombstone',
+      sequenceRelation: 'below',
+      storageOperation: 'tombstone',
+      // Both members the branch reads: the predecessor gate comes first, and the
+      // retained-transition comparison is only reachable once it passes.
+      evidence: ['tombstonePredecessor', 'acceptedTransition'],
+    } as unknown as VerdictDiffCellV1;
+
+    // The branch must get PAST the retained-transition comparison. Asserting the
+    // absence of that specific reject rather than a particular success verdict:
+    // what this pins is that the fixture stopped manufacturing the refusal, not
+    // what core then decides, which is the table's business and not this test's.
+    expect(verdict(cell))
+      .not.toBe('reject|late tombstone requires the exact retained resurrection transition');
+  });
+
+  it('satisfies the named-transition check on a NEXT-sequence candidate', () => {
+    const cell = {
+      ...base,
+      id: 'branch-next-sequence',
+      candidateHeadState: 'active',
+      sequenceRelation: 'plusOne',
+      evidence: ['acceptedTransition', 'verifiedAuthoritySummary'],
+    } as unknown as VerdictDiffCellV1;
+
+    // The mirror-image refusal: the next-sequence arm compares the supplied
+    // transition against the candidate's OWN named digest, so a lower-sequence
+    // style selection lands here instead.
+    expect(verdict(cell)).not.toBe('reject|exact accepted authority transition is missing');
+  });
+});

--- a/packages/storage/test/authority-verdict-diff-join-v1.test.ts
+++ b/packages/storage/test/authority-verdict-diff-join-v1.test.ts
@@ -226,22 +226,40 @@ describe('authority verdict diff: the join', { timeout: JOIN_SUITE_TIMEOUT_MS },
     // withholding, so a divergence there is storage PROCEEDING where core does
     // not. Computed from `coreDecisionKey`, which is the cell's own core verdict,
     // never from the direction labels themselves.
-    const directions = tally(rows, (row) => (row.verdict === JOIN_VERDICT_V1.DIVERGENCE
+    const observedDirections = tally(rows, (row) => (row.verdict === JOIN_VERDICT_V1.DIVERGENCE
       ? (row.coreDecisionKey === 'accept'
         ? 'core-accepts-what-storage-refuses'
         : 'storage-materialises-what-core-refuses')
       : undefined));
+    // Read over the DECLARED directions so a zero is pinned AS zero -- `tally`
+    // omits empty keys, and an omitted row and an empty one are
+    // indistinguishable while only one of them is a claim. The reverse
+    // direction is currently zero and must stay visible: if a real
+    // core-accepts-what-storage-refuses divergence ever appears, this moves off
+    // zero and the strict equality fails.
+    const directions = Object.fromEntries(
+      Object.keys(JOIN_DIVERGENCE_DIRECTIONS_V1)
+        .map((key) => [key, (observedDirections as Record<string, number>)[key] ?? 0]),
+    );
     expect(directions).toStrictEqual(JOIN_DIVERGENCE_DIRECTIONS_V1);
+    // ...and nothing outside the declared pair was observed, so reading over the
+    // declared keys cannot hide a third direction.
+    expect(Object.keys(observedDirections).sort())
+      .toStrictEqual(Object.keys(observedDirections)
+        .filter((key) => key in JOIN_DIVERGENCE_DIRECTIONS_V1).sort());
     // The split must PARTITION the total it describes -- a direction pin that
     // drifted from the divergence count would state a sign for a population that
     // no longer exists.
     expect(Object.values(JOIN_DIVERGENCE_DIRECTIONS_V1).reduce((a, b) => a + b, 0))
       .toBe(JOIN_VERDICT_TOTALS_V1.DIVERGENCE);
-    // BOTH DIRECTIONS LIVE. A zero on either side would make the "two opposite
-    // routing risks" claim vacuous while the sum still checked out.
-    for (const [key, cells] of Object.entries(JOIN_DIVERGENCE_DIRECTIONS_V1)) {
-      expect({ key, live: cells > 0 }).toStrictEqual({ key, live: true });
-    }
+    // NO BOTH-DIRECTIONS-LIVE ASSERTION. There was one, requiring each side to
+    // be non-zero so the "opposite routing risks" claim could not go vacuous
+    // while the sum still checked out. The claim went vacuous -- the reverse
+    // direction turned out to be a mismatched-evidence artifact of this
+    // fixture, not a system divergence -- so the guard turned red and is
+    // retired rather than weakened. The zero it now guards is pinned AS zero in
+    // JOIN_DIVERGENCE_DIRECTIONS_V1, where a real reverse divergence would move
+    // it off zero and fail the strict equality above.
 
     // CONSERVATION, ASSERTED RATHER THAN COMPUTED IN A COMMENT. Every
     // constructible cell carries exactly one verdict, and the adjudicated

--- a/packages/storage/test/authority-verdict-diff-join-v1.test.ts
+++ b/packages/storage/test/authority-verdict-diff-join-v1.test.ts
@@ -28,6 +28,7 @@ import {
   JOIN_ADJUDICATED_CELLS_V1,
   JOIN_CELLS_PER_STORAGE_PROJECTION_V1,
   JOIN_CORE_ONLY_SPLIT_V1,
+  JOIN_DIVERGENCE_DIRECTIONS_V1,
   JOIN_DIVERGENCES_V1,
   JOIN_FINDINGS_V1,
   JOIN_IMPOSSIBILITY_PROOFS_V1,
@@ -218,6 +219,29 @@ describe('authority verdict diff: the join', { timeout: JOIN_SUITE_TIMEOUT_MS },
     expect(tally(rows, (row) => (row.verdict === JOIN_VERDICT_V1.DIVERGENCE
       ? `${row.coreLabel} -> ${row.storageLabel}` : undefined)))
       .toStrictEqual(JOIN_DIVERGENCES_V1);
+
+    // THE DIRECTION SPLIT, DERIVED FROM THE ROWS RATHER THAN RESTATED.
+    // `accept` on the core side means core permitted the advance, so a divergence
+    // there is storage DECLINING what core allows; every other core decision is a
+    // withholding, so a divergence there is storage PROCEEDING where core does
+    // not. Computed from `coreDecisionKey`, which is the cell's own core verdict,
+    // never from the direction labels themselves.
+    const directions = tally(rows, (row) => (row.verdict === JOIN_VERDICT_V1.DIVERGENCE
+      ? (row.coreDecisionKey === 'accept'
+        ? 'core-accepts-what-storage-refuses'
+        : 'storage-materialises-what-core-refuses')
+      : undefined));
+    expect(directions).toStrictEqual(JOIN_DIVERGENCE_DIRECTIONS_V1);
+    // The split must PARTITION the total it describes -- a direction pin that
+    // drifted from the divergence count would state a sign for a population that
+    // no longer exists.
+    expect(Object.values(JOIN_DIVERGENCE_DIRECTIONS_V1).reduce((a, b) => a + b, 0))
+      .toBe(JOIN_VERDICT_TOTALS_V1.DIVERGENCE);
+    // BOTH DIRECTIONS LIVE. A zero on either side would make the "two opposite
+    // routing risks" claim vacuous while the sum still checked out.
+    for (const [key, cells] of Object.entries(JOIN_DIVERGENCE_DIRECTIONS_V1)) {
+      expect({ key, live: cells > 0 }).toStrictEqual({ key, live: true });
+    }
 
     // CONSERVATION, ASSERTED RATHER THAN COMPUTED IN A COMMENT. Every
     // constructible cell carries exactly one verdict, and the adjudicated

--- a/packages/storage/test/authority-verdict-diff-storage-mint-audit-v1.test.ts
+++ b/packages/storage/test/authority-verdict-diff-storage-mint-audit-v1.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { enumerateVerdictDiffCellsV1 } from './helpers/authority-verdict-diff-cells-v1.js';
+import { resolveConstructibilityV1 } from './helpers/authority-verdict-diff-constructibility-v1.js';
+import { runStorageSweepV1 } from './helpers/authority-verdict-diff-storage-sweep-v1.js';
+
+/**
+ * THE AUDIT THE STORAGE MINTER DID NOT HAVE, AND THE ESCAPE THAT PROVED IT NEEDED ONE.
+ *
+ * A verification closure resolves every digest a head names. When the fixture
+ * cannot answer one of those lookups the builder refuses with
+ * '[system-record-closure] verification closure is missing 0x...' -- wording
+ * indistinguishable from a domain refusal, produced entirely by the harness's own
+ * omission. Pinning such a refusal retires cells against a gap in the fixture
+ * while every count conserves, every message is real, and the suite stays green.
+ * That is the failure this whole slice keeps meeting, and it has now been met
+ * five times.
+ *
+ * The CORE minter has carried an `onUnresolvedArtifact` hook since the first
+ * instance, and the core sweep pins the result at zero. The STORAGE minter did
+ * not, and that is precisely where the next instance hid: every sequence-relative
+ * tombstone was minted against the CURRENT head's owned-subject table, asking for
+ * a deletion-table digest no artifact supplies. It survived a full lane run with
+ * perfect conservation and was caught only because an independently derived cell
+ * count disagreed with the run by exactly the three affected head shapes.
+ *
+ * SO THE PROPERTY IS NOT "the messages look right". It is that NO LOOKUP WENT
+ * UNANSWERED -- a fact about mechanism, which no amount of reading the message
+ * recovers. A guard installed on one of two minters is not installed.
+ */
+describe('verdict-diff: storage mint artifact audit', () => {
+  it('answers every artifact lookup its own mint walk makes', async () => {
+    const unresolved = new Set<string>();
+    const cells = resolveConstructibilityV1(enumerateVerdictDiffCellsV1());
+    await runStorageSweepV1(cells.constructible, (reference) => unresolved.add(reference));
+
+    // Named rather than counted: a bare count says a gap exists, the sorted
+    // references say WHICH object the fixture failed to supply, which is the
+    // difference between a red test and a diagnosis.
+    expect([...unresolved].sort()).toStrictEqual([]);
+  }, 600_000);
+});

--- a/packages/storage/test/authority-verdict-diff-storage-mint-audit-v1.test.ts
+++ b/packages/storage/test/authority-verdict-diff-storage-mint-audit-v1.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import { enumerateVerdictDiffCellsV1 } from './helpers/authority-verdict-diff-cells-v1.js';
 import { resolveConstructibilityV1 } from './helpers/authority-verdict-diff-constructibility-v1.js';
-import { CORE_CURRENT_HEAD_V1 } from './helpers/authority-verdict-diff-core-heads-v1.js';
+import {
+  buildCoreCandidateHeadV1,
+  CORE_CURRENT_HEAD_V1,
+} from './helpers/authority-verdict-diff-core-heads-v1.js';
 import { mintStorageSummaryForHeadV1 } from './helpers/authority-verdict-diff-storage-driver-v1.js';
 import { runStorageSweepV1 } from './helpers/authority-verdict-diff-storage-sweep-v1.js';
 
@@ -79,6 +82,58 @@ describe('verdict-diff: storage mint artifact audit', () => {
     expect(seen).toContain(`authority-transition:${absent}`);
     // And the mint refused, so the control exercises the same path a real
     // fixture omission takes rather than a branch reached only by this test.
+    expect(result.minted).toBe(false);
+  }, 120_000);
+
+  /**
+   * THE SAME CONTROL ON THE TOMBSTONE BRANCH, because the one above proves the
+   * hook only on the path the defect was NOT on.
+   *
+   * `mintStorageSummaryForHeadV1` forks on the candidate's state: a tombstone
+   * goes through `mintAgentProfileTombstoneClosureV1`, everything else through
+   * the verification-closure builder. Each arm passes `onUnresolvedArtifact`
+   * SEPARATELY. The control above drives the ACTIVE arm — so deleting the hook
+   * from the tombstone arm leaves it green, while the audit loses exactly the
+   * omission it was written to catch: the tombstone owned-subject-table defect
+   * that survived a full lane with perfect conservation.
+   *
+   * A guard whose positive control exercises a different branch than the defect
+   * is a check that cannot fail for the thing it names. That this one shipped
+   * INSIDE the fix for a previous check-that-cannot-fail is the reason it is
+   * spelled out here rather than quietly corrected.
+   */
+  it('reports an unanswered lookup on the TOMBSTONE path too', async () => {
+    const seen: string[] = [];
+    const absent = `0x${'cd'.repeat(32)}`;
+
+    // A real built tombstone candidate, not a hand-shaped object: the arm is
+    // selected by `state`, and a fabricated head would let the control pass
+    // while the real tombstone path stayed unexercised.
+    const tombstoneCell = {
+      id: 'audit-tombstone',
+      snapshot: 'present',
+      appliedStatus: 'active',
+      candidateHeadState: 'tombstone',
+      sequenceRelation: 'equal',
+      versionRelation: 'above',
+      storageOperation: 'tombstone',
+      coreDisposition: 'discoverable',
+      evidence: [],
+      candidateForkResolutionDigest: 'absent',
+      clock: 'valid',
+    } as unknown as Parameters<typeof buildCoreCandidateHeadV1>[0];
+
+    const build = buildCoreCandidateHeadV1(tombstoneCell);
+    expect(build.built).toBe(true);
+    if (!build.built) return;
+    expect((build.candidate as { state: string }).state).toBe('tombstone');
+
+    const result = await mintStorageSummaryForHeadV1(
+      { ...build.candidate, acceptedTransitionDigest: absent } as never,
+      (reference) => seen.push(reference),
+    );
+
+    expect(seen).toContain(`authority-transition:${absent}`);
     expect(result.minted).toBe(false);
   }, 120_000);
 });

--- a/packages/storage/test/authority-verdict-diff-storage-mint-audit-v1.test.ts
+++ b/packages/storage/test/authority-verdict-diff-storage-mint-audit-v1.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import { enumerateVerdictDiffCellsV1 } from './helpers/authority-verdict-diff-cells-v1.js';
 import { resolveConstructibilityV1 } from './helpers/authority-verdict-diff-constructibility-v1.js';
+import { CORE_CURRENT_HEAD_V1 } from './helpers/authority-verdict-diff-core-heads-v1.js';
+import { mintStorageSummaryForHeadV1 } from './helpers/authority-verdict-diff-storage-driver-v1.js';
 import { runStorageSweepV1 } from './helpers/authority-verdict-diff-storage-sweep-v1.js';
 
 /**
@@ -39,4 +41,44 @@ describe('verdict-diff: storage mint artifact audit', () => {
     // difference between a red test and a diagnosis.
     expect([...unresolved].sort()).toStrictEqual([]);
   }, 600_000);
+
+  /**
+   * THE POSITIVE CONTROL, WITHOUT WHICH THE ASSERTION ABOVE CANNOT FAIL.
+   *
+   * An empty unresolved set has two possible causes and the test above cannot
+   * tell them apart: the fixture answered every lookup, or the hook was never
+   * wired through the sweep/minter/resolver stack and nothing was ever reported.
+   * A silent hook and a clean run are the same observation. That is the
+   * check-that-cannot-fail shape, and pointing at a mutation run recorded in a
+   * commit message does not repair it -- a proof that ran once, elsewhere, is
+   * not a control this suite carries.
+   *
+   * So: mint a head that NAMES an artifact the map does not hold, and require
+   * the hook to say so. The head is otherwise real and the omission is one
+   * field, which keeps the control close to the failure it guards against --
+   * every instance of that failure has been a real head naming one object this
+   * fixture did not supply.
+   */
+  it('reports an unanswered lookup when one exists, so the empty set above means something', async () => {
+    const seen: string[] = [];
+    // A well-formed digest no artifact in this fixture carries. Deliberately
+    // invented HERE, which is the one place inventing a digest is correct: the
+    // point is to be unresolvable.
+    const absent = `0x${'ab'.repeat(32)}`;
+    const namesMissingTransition = {
+      ...CORE_CURRENT_HEAD_V1,
+      acceptedTransitionDigest: absent,
+    } as unknown as Parameters<typeof mintStorageSummaryForHeadV1>[0];
+
+    const result = await mintStorageSummaryForHeadV1(
+      namesMissingTransition,
+      (reference) => seen.push(reference),
+    );
+
+    // The hook fired, and it NAMED the object rather than merely counting.
+    expect(seen).toContain(`authority-transition:${absent}`);
+    // And the mint refused, so the control exercises the same path a real
+    // fixture omission takes rather than a branch reached only by this test.
+    expect(result.minted).toBe(false);
+  }, 120_000);
 });

--- a/packages/storage/test/authority-verdict-diff-storage-sweep-hook-v1.test.ts
+++ b/packages/storage/test/authority-verdict-diff-storage-sweep-hook-v1.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * THE SWEEP FORWARDS THE UNRESOLVED-ARTIFACT COLLECTOR TO THE MINTER.
+ *
+ * The storage audit's claim is that an EMPTY unresolved set means every mint
+ * lookup was answered. That claim rests on two links: the minter reporting an
+ * unanswered lookup, and `runStorageSweepV1` FORWARDING the collector to the
+ * minter. The audit's own positive controls prove the first link only -- they
+ * call `mintStorageSummaryForHeadV1` directly and bypass the sweep entirely.
+ * Delete the forwarding and the audit still finds an empty set, both of those
+ * controls still pass, and the guard reports success for a wire that is cut.
+ *
+ * This is the third consecutive round in which a control on that audit proved a
+ * path adjacent to the one it named -- first the active arm rather than the
+ * tombstone arm, now the minter rather than the sweep. So this file proves the
+ * SECOND link and nothing else.
+ *
+ * It uses a module seam rather than a corrupted cell on purpose: no constructible
+ * cell produces an unanswered lookup, which is precisely what the audit asserts,
+ * so the only way to observe forwarding is to make one mint report. The seam is
+ * scoped to this file so the audit's own suite keeps running against the real
+ * minter.
+ */
+vi.mock('./helpers/authority-verdict-diff-storage-driver-v1.js', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('./helpers/authority-verdict-diff-storage-driver-v1.js')
+  >();
+  return {
+    ...actual,
+    // Reports one unanswered lookup on every mint, through whatever collector it
+    // is handed. If the sweep stops passing one, `onUnresolved` is undefined and
+    // nothing is recorded -- which is exactly the mutant this file kills.
+    mintStorageSummaryForHeadV1: async (
+      candidate: unknown,
+      onUnresolved?: (reference: string) => void,
+    ) => {
+      onUnresolved?.('agent-profile-head:0xseam');
+      return { minted: false as const, message: 'seam' };
+    },
+  };
+});
+
+const { enumerateVerdictDiffCellsV1 } = await import(
+  './helpers/authority-verdict-diff-cells-v1.js');
+const { resolveConstructibilityV1 } = await import(
+  './helpers/authority-verdict-diff-constructibility-v1.js');
+const { runStorageSweepV1 } = await import(
+  './helpers/authority-verdict-diff-storage-sweep-v1.js');
+
+describe('verdict-diff: the storage sweep forwards its unresolved collector', () => {
+  it('observes a lookup the MINTER reports, proving the sweep passes the hook', async () => {
+    const seen: string[] = [];
+    // A handful of cells is enough: the claim is about the wire, not the walk,
+    // and the sweep mints once per head shape.
+    const cells = resolveConstructibilityV1(enumerateVerdictDiffCellsV1())
+      .constructible.slice(0, 5000);
+
+    await runStorageSweepV1(cells, (reference) => seen.push(reference));
+
+    // The collector saw what the minter reported. Under the mutant -- the sweep
+    // calling `mintStorageSummaryForHeadV1(head.candidate)` with no second
+    // argument -- this array stays empty and the test fails, while the audit's
+    // own empty-set assertion and its two direct-minter controls all stay green.
+    expect(seen).toContain('agent-profile-head:0xseam');
+  }, 300_000);
+});

--- a/packages/storage/test/helpers/authority-verdict-diff-cells-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-cells-v1.ts
@@ -159,9 +159,17 @@ export function enumerateVerdictDiffCellsV1(): readonly VerdictDiffCellV1[] {
               ? [...A.F_headDigest] as (VerdictDiffCellV1['headDigest'])[]
               : [undefined];
             for (const headDigest of digests) {
-              // Axis G relates the candidate's acceptedTransitionDigest to the
-              // CURRENT head's, so like axis D it has no referent when the
-              // snapshot is absent. Ruled 2026-08-11 after measurement: the
+              // AXIS G'S DENOTATION IS DEFINED ONCE, at G_acceptedTransitionDigest
+              // in VERDICT_DIFF_AXES_V1, and this comment deliberately does NOT
+              // restate it. It is SEQUENCE-RELATIVE -- 'equal' names the accepted
+              // rotation into the candidate's OWN sequence -- and an earlier
+              // revision of this block said it relates to the CURRENT head, which
+              // is the D='equal' SPECIAL CASE rather than the definition. Two
+              // plausible definitions in two files is worse than one stale one,
+              // because the next change can follow either and nothing fails.
+              //
+              // What is gated HERE is only reachability: like axis D the axis has
+              // no referent when the snapshot is absent. Ruled 2026-08-11 after measurement: the
               // transition-equivocation decision the spec names this axis for is
               // core system-record-authority-v1-internal.ts:171, whose referent is
               // `current`, and :111 diverts to the absent branch before it ever

--- a/packages/storage/test/helpers/authority-verdict-diff-core-evidence-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-core-evidence-v1.ts
@@ -2,6 +2,7 @@ import {
   buildAgentProfileVerificationClosureV1,
   computeAgentProfileAuthorityTransitionDigestV1,
   computeAgentProfileHeadObjectDigestV1,
+  type AgentProfileAuthorityTransitionV1,
   type AgentProfileHeadObjectV1,
 } from '@origintrail-official/dkg-core/system-record-v1';
 
@@ -9,9 +10,10 @@ import type { VerdictDiffCellV1 } from './authority-verdict-diff-cells-v1.js';
 import {
   buildCoreCandidateHeadV1,
   coreHeadShapeKeyV1,
+  coreCandidateSequenceV1,
   coreSequenceActiveHeadV1,
-  CORE_ALL_LINEAGE_HEADS_V1,
-  CORE_ALL_TRANSITIONS_V1,
+  coreSequenceTransitionV1,
+  CORE_MINT_GRAPH_V1,
   CORE_CHAIN_V1,
   CORE_CURRENT_HEAD_V1,
   CORE_FORK_CONFLICT_HEADS_V1,
@@ -101,19 +103,39 @@ export const CORE_CLOCK_MS_V1: Readonly<Record<VerdictDiffCellV1['clock'], numbe
 });
 
 /**
- * The transition supplied when axis J names `acceptedTransition`.
+ * The transition supplied when axis J names `acceptedTransition`, SELECTED PER
+ * CANDIDATE SEQUENCE.
  *
- * This is the REAL 1->2 transition, and it is the correct choice rather than an
- * arbitrary one: on the lower-sequence path the candidate sits at sequence 1, so
- * :295 retains `lineage[1]` and :303-305 demands a transition agreeing with it
- * on prior sequence, next sequence AND digest. Only this object satisfies that.
- * On the next-sequence path :336 compares its digest to the candidate's
- * `acceptedTransitionDigest`, which axis G ties to the current head's -- the same
- * digest -- so presence is decision-changing there too.
+ * THIS WAS A SINGLE CONSTANT AND IT WAS WRONG THE MOMENT AXIS D GAINED
+ * PER-SEQUENCE LINEAGE. It was the 1->2 transition for every cell, and the old
+ * doc justified that with: "on the next-sequence path :336 compares its digest
+ * to the candidate's acceptedTransitionDigest, which axis G ties to the current
+ * head's -- the same digest." Axis G is now SEQUENCE-RELATIVE, so that premise
+ * is false: a candidate at sequence 3 carries the 2->3 digest while this handed
+ * core the 1->2. The comment documented its own breakage, and the effect was the
+ * fixture's mismatch recorded as a system verdict on the axis-J-present half of
+ * the sequence-relative region.
+ *
+ * WHICH OBJECT EACH PATH DEMANDS, read at the sites rather than inferred. On the
+ * LOWER-sequence path :295 retains `lineage[candidateSequence]` and :303-305
+ * demands a transition agreeing with it on prior sequence, next sequence AND
+ * digest. On the NEXT-sequence path :336 compares the supplied transition's
+ * digest to the candidate's own `acceptedTransitionDigest`. Both questions are
+ * about the candidate's OWN sequence, so both are answered by the rotation INTO
+ * that sequence -- which is exactly what the candidate names.
+ *
+ * Supplying the transition the candidate actually names is what makes the
+ * member's PRESENCE decision-changing rather than uniformly refusing: a
+ * mismatched transition collapses every J-present cell in the region onto one
+ * refusal and measures this fixture's wrongness instead of core's
+ * discrimination. Found by review, not by the derivation -- a derivation checks
+ * counts and cannot check evidence fidelity.
  */
-export const CORE_ACCEPTED_TRANSITION_V1 = CORE_CHAIN_V1.transitions[
-  CORE_CHAIN_V1.transitions.length - 1
-];
+export function coreAcceptedTransitionV1(
+  cell: VerdictDiffCellV1,
+): AgentProfileAuthorityTransitionV1 {
+  return coreSequenceTransitionV1(coreCandidateSequenceV1(cell));
+}
 
 /**
  * The predecessor supplied when axis J names `tombstonePredecessor`.
@@ -134,12 +156,12 @@ export const CORE_ACCEPTED_TRANSITION_V1 = CORE_CHAIN_V1.transitions[
 export function coreTombstonePredecessorV1(
   cell: VerdictDiffCellV1,
 ): AgentProfileHeadObjectV1 {
-  const build = buildCoreCandidateHeadV1(cell);
-  return build.built
-    ? coreSequenceActiveHeadV1(
-      (build.candidate as { authoritySequence: string }).authoritySequence,
-    )
-    : CORE_CURRENT_HEAD_V1;
+  // The sequence comes from the CELL, not from a built head. Building the
+  // candidate here to read one field back off it cost a head build per cell,
+  // which the projection-equivalence suite pays for every constructible cell --
+  // measured as most of this lane's CI budget. The two are asserted equal over
+  // every buildable shape in the core-heads suite.
+  return coreSequenceActiveHeadV1(coreCandidateSequenceV1(cell));
 }
 
 /**
@@ -156,6 +178,42 @@ export function coreTombstonePredecessorV1(
  * axis E's largest value is exactly ONE above. The resolution is supplied
  * well-formed regardless, so these cells measure the refusal core really gives
  * rather than one manufactured by handing it invalid evidence.
+ */
+/**
+ * BOTH OF THESE, AND `CORE_FORK_RESOLUTION_V1`, EMBED SEQUENCE-2 VALUES AND ARE
+ * SUPPLIED AT EVERY SEQUENCE. READ THIS BEFORE MAKING THE FORK BRANCH REACHABLE.
+ *
+ * The class sweep over every cell-driving constant classified these three as
+ * SEQUENCE-DEPENDENT: `CORE_FORK_RESOLUTION_V1` carries the current head's
+ * `evmIssuer`, `authoritySequence`, `forkedVersion` and `resolutionVersion` plus
+ * a `forkBaseHeadDigest` off the chain base; the conflict heads are built from
+ * the chain base at version 2; and the fork base head IS the current head. A
+ * rotation moves `evmIssuer` and the root subject, so at any other sequence
+ * these objects do not describe the candidate they are handed to.
+ *
+ * THEY ARE NOT FIXED HERE BECAUSE THEY ARE MEASURABLY INERT, NOT BECAUSE THE
+ * MISMATCH IS ACCEPTABLE. Measured through the exported entry, present-vs-absent
+ * over one representative per core projection in the sequence-relative region:
+ * forkResolution 0 of 5,184 projections moved, forkEvidenceHeads 0 of 5,184,
+ * forkBaseHead 0 of 5,184, and ALL THREE dropped together 0 of 9,072 -- the
+ * joint row included because individually-inert members can mask one another.
+ * Positive control on the same instrument: 72 of 600 moved. So the zero is the
+ * region's and not the comparison's.
+ *
+ * WHY IT IS ZERO, which is also the condition under which it STOPS being zero:
+ * these members feed core's fork-resolution-successor branch, and that branch is
+ * unreachable under this axis set -- :456 forces forkedVersion == current.version,
+ * the control codec forces resolutionVersion > forkedVersion, and :458 forces the
+ * candidate above that, so it needs a candidate two versions above the current
+ * while axis E reaches one. A branch nothing reaches cannot be moved by the
+ * objects it would have read.
+ *
+ * THE MOMENT AXIS K='present' MAKES THAT BRANCH REACHABLE, THESE THREE BECOME
+ * LIVE AND THEIR SEQUENCE-DEPENDENCE BECOMES A REAL DEFECT -- a fixture-authored
+ * mismatch recorded as a system verdict, which is the class this fixture has met
+ * four times. Whoever does that work must make them per-sequence in the same
+ * change, alongside the per-sequence resolution and its own evidence heads that
+ * `isDirectResolvingSuccessorV1`'s identity conjuncts require.
  */
 export const CORE_FORK_EVIDENCE_HEADS_V1: readonly AgentProfileHeadObjectV1[] =
   CORE_FORK_CONFLICT_HEADS_V1;
@@ -246,11 +304,8 @@ async function mintForHeadV1(
   // previousHeadDigest names the base. Omitting the base is not a domain refusal
   // -- it surfaces as a TypeError inside the collector, which reads like a code
   // defect rather than a missing artifact.
-  const ancestry = [
-    CORE_CURRENT_HEAD_V1,
-    ...CORE_ALL_LINEAGE_HEADS_V1,
-    ...CORE_FORK_CONFLICT_HEADS_V1,
-  ];
+  // The shared graph, not a local reproduction of it -- see CORE_MINT_GRAPH_V1.
+  const ancestry = CORE_MINT_GRAPH_V1.ancestry;
   // Every digest a head NAMES has to be resolvable, or the closure refuses with
   // a missing-object message that reads exactly like a domain refusal while
   // being nothing but a gap in this map. Axis G='differ' names the competing
@@ -260,7 +315,7 @@ async function mintForHeadV1(
   // competing ones. A candidate at any sequence names one of them, and a digest
   // a head names that this map cannot answer is refused with wording that reads
   // exactly like a domain refusal.
-  const transitions = [...CORE_ALL_TRANSITIONS_V1];
+  const transitions = [...CORE_MINT_GRAPH_V1.transitions];
   try {
     if ((candidate as { state: string }).state === 'tombstone') {
       // The predecessor is the active head at the TOMBSTONE'S OWN sequence, and
@@ -270,11 +325,12 @@ async function mintForHeadV1(
       // 'verification closure is missing 0x...' -- the harness's own omission in
       // a domain refusal's clothing, and the exact shape that once retired
       // ~46,000 cells with every count summing.
-      const predecessor = coreSequenceActiveHeadV1(candidate.authoritySequence);
+      const { predecessor, ownedSubjectTable } =
+        CORE_MINT_GRAPH_V1.tombstonePredecessorFor(candidate.authoritySequence);
       const closure = await mintAgentProfileTombstoneClosureV1({
         tombstone: candidate,
         predecessor,
-        ownedSubjectTable: [predecessor.rootSubject],
+        ownedSubjectTable: [...ownedSubjectTable],
         ancestors: ancestry,
         transitions,
         onUnresolvedArtifact: onUnresolved,
@@ -334,7 +390,7 @@ export function buildCoreEvidenceV1(
 ): Record<string, unknown> {
   const evidence: Record<string, unknown> = { nowMs: CORE_CLOCK_MS_V1[cell.clock] };
   const wants = new Set(cell.evidence);
-  if (wants.has('acceptedTransition')) evidence.acceptedTransition = CORE_ACCEPTED_TRANSITION_V1;
+  if (wants.has('acceptedTransition')) evidence.acceptedTransition = coreAcceptedTransitionV1(cell);
   if (wants.has('tombstonePredecessor')) {
     evidence.tombstonePredecessor = coreTombstonePredecessorV1(cell);
   }

--- a/packages/storage/test/helpers/authority-verdict-diff-core-evidence-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-core-evidence-v1.ts
@@ -117,13 +117,29 @@ export const CORE_CLOCK_MS_V1: Readonly<Record<VerdictDiffCellV1['clock'], numbe
  * fixture's mismatch recorded as a system verdict on the axis-J-present half of
  * the sequence-relative region.
  *
+ * THE CLASS RULE, and it took three attempts to state correctly:
+ * **EVIDENCE IS SELECTED BY THE BRANCH THAT READS IT, never by an attribute of
+ * the candidate alone.** Any single value serving two branches that read
+ * different objects is the same defect wearing a different key.
+ *
  * WHICH OBJECT EACH PATH DEMANDS, read at the sites rather than inferred. On the
  * LOWER-sequence path :295 retains `lineage[candidateSequence]` and :303-305
  * demands a transition agreeing with it on prior sequence, next sequence AND
- * digest. On the NEXT-sequence path :336 compares the supplied transition's
- * digest to the candidate's own `acceptedTransitionDigest`. Both questions are
- * about the candidate's OWN sequence, so both are answered by the rotation INTO
- * that sequence -- which is exactly what the candidate names.
+ * digest -- that entry is the rotation OUT of the candidate's sequence. On the
+ * NEXT-sequence path :336 compares the supplied transition's digest to the
+ * candidate's own `acceptedTransitionDigest` -- the rotation INTO it. THEY ARE
+ * DIFFERENT OBJECTS.
+ *
+ * THE ORIGINAL CONSTANT IS PARTLY REHABILITATED, and the history matters more
+ * than the code. `CORE_ACCEPTED_TRANSITION_V1` was the 1->2 transition for every
+ * cell, and its doc justified that by the LOWER-SEQUENCE path -- where it was
+ * CORRECT, because lineage[1] IS the 1->2 rotation. It was wrong only about the
+ * next-sequence path. Reading "the doc documents its own breakage" and
+ * generalising to "the constant is wrong" replaced a half-true value with a
+ * differently-half-true one: sequence-keyed selection fixed next-sequence and
+ * BROKE lower-sequence, which the constant had been getting right. A half-true
+ * doc invited a whole-cloth replacement, and the second version repeated the
+ * first's mistake in mirror image.
  *
  * Supplying the transition the candidate actually names is what makes the
  * member's PRESENCE decision-changing rather than uniformly refusing: a
@@ -149,9 +165,33 @@ export function coreAcceptedTransitionV1(
   cell: VerdictDiffCellV1,
 ): AgentProfileAuthorityTransitionV1 {
   const sequence = coreCandidateSequenceV1(cell);
+  // THE LOWER-SEQUENCE TOMBSTONE BRANCH READS A DIFFERENT OBJECT, and this is
+  // the one case where "the transition the candidate names" is the wrong answer.
+  // `evaluateLowerSequenceAgentProfileHeadAdvanceV1` takes
+  // `retained = lineage[candidateSequence]` and demands the evidence transition
+  // match it on prior sequence, next sequence AND digest. For a candidate at
+  // sequence S that entry is the rotation OUT of S -- the one INTO S + 1 -- not
+  // the rotation into S. Only the tombstone sub-case reaches it: a lower-sequence
+  // ACTIVE candidate returns `stale` before the member is read.
+  if (isLowerSequenceTombstoneV1(cell)) {
+    return coreSequenceTransitionV1(String(BigInt(sequence) + 1n));
+  }
   return cell.acceptedTransitionDigest === 'differ'
     ? coreSequenceEquivocatingTransitionV1(sequence)
     : coreSequenceTransitionV1(sequence);
+}
+
+/**
+ * Reaches core's lower-sequence tombstone arm: a tombstone candidate below the
+ * accepted head's authority sequence, on a present snapshot.
+ *
+ * Named rather than inlined because it encodes WHICH BRANCH READS THE MEMBER,
+ * and that is the thing the selection depends on.
+ */
+function isLowerSequenceTombstoneV1(cell: VerdictDiffCellV1): boolean {
+  return cell.snapshot === 'present'
+    && cell.candidateHeadState === 'tombstone'
+    && cell.sequenceRelation === 'below';
 }
 
 /**

--- a/packages/storage/test/helpers/authority-verdict-diff-core-evidence-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-core-evidence-v1.ts
@@ -9,9 +9,11 @@ import type { VerdictDiffCellV1 } from './authority-verdict-diff-cells-v1.js';
 import {
   buildCoreCandidateHeadV1,
   coreHeadShapeKeyV1,
+  coreSequenceActiveHeadV1,
+  CORE_ALL_LINEAGE_HEADS_V1,
+  CORE_ALL_TRANSITIONS_V1,
   CORE_CHAIN_V1,
   CORE_CURRENT_HEAD_V1,
-  CORE_EQUIVOCATING_TRANSITION_V1,
   CORE_FORK_CONFLICT_HEADS_V1,
   CORE_FORK_RESOLUTION_V1,
 } from './authority-verdict-diff-core-heads-v1.js';
@@ -117,12 +119,28 @@ export const CORE_ACCEPTED_TRANSITION_V1 = CORE_CHAIN_V1.transitions[
  * The predecessor supplied when axis J names `tombstonePredecessor`.
  *
  * `isTombstoneBoundToPredecessorV1` requires the tombstone's
- * `previousHeadDigest` to be the predecessor's digest. The candidate builder
- * points every non-digest-equal candidate at `CORE_CURRENT_DIGEST_V1`, so the
- * current head is the ONLY object that can satisfy that conjunct -- any other
- * choice would make the member's presence meaningless.
+ * `previousHeadDigest` to be the predecessor's digest, so the member is only
+ * meaningful when it is the head the candidate actually descends from. That
+ * used to be `CORE_CURRENT_HEAD_V1` for every cell, because the builder pointed
+ * every candidate at the current head. Now that a candidate descends from the
+ * active head at its OWN authority sequence, so does this -- otherwise every
+ * sequence-relative J-present cell would collapse onto one refusal and the table
+ * would measure the fixture's wrongness instead of core's discrimination.
+ *
+ * The absent-snapshot region keeps the current head: its candidates sit at the
+ * current sequence, so the two agree there by construction rather than by
+ * coincidence.
  */
-export const CORE_TOMBSTONE_PREDECESSOR_V1 = CORE_CURRENT_HEAD_V1;
+export function coreTombstonePredecessorV1(
+  cell: VerdictDiffCellV1,
+): AgentProfileHeadObjectV1 {
+  const build = buildCoreCandidateHeadV1(cell);
+  return build.built
+    ? coreSequenceActiveHeadV1(
+      (build.candidate as { authoritySequence: string }).authoritySequence,
+    )
+    : CORE_CURRENT_HEAD_V1;
+}
 
 /**
  * The fork evidence. The resolution and the conflicting heads live with the head
@@ -230,8 +248,7 @@ async function mintForHeadV1(
   // defect rather than a missing artifact.
   const ancestry = [
     CORE_CURRENT_HEAD_V1,
-    CORE_CHAIN_V1.base,
-    ...CORE_CHAIN_V1.ancestors,
+    ...CORE_ALL_LINEAGE_HEADS_V1,
     ...CORE_FORK_CONFLICT_HEADS_V1,
   ];
   // Every digest a head NAMES has to be resolvable, or the closure refuses with
@@ -239,13 +256,25 @@ async function mintForHeadV1(
   // being nothing but a gap in this map. Axis G='differ' names the competing
   // transition and axis K='present' names the fork resolution, so both travel
   // with the ancestry rather than being left for the collector to miss.
-  const transitions = [...CORE_CHAIN_V1.transitions, CORE_EQUIVOCATING_TRANSITION_V1];
+  // Every rotation the fixture can present -- the four real ones and the four
+  // competing ones. A candidate at any sequence names one of them, and a digest
+  // a head names that this map cannot answer is refused with wording that reads
+  // exactly like a domain refusal.
+  const transitions = [...CORE_ALL_TRANSITIONS_V1];
   try {
     if ((candidate as { state: string }).state === 'tombstone') {
+      // The predecessor is the active head at the TOMBSTONE'S OWN sequence, and
+      // the deletion table is that head's. Holding the current head's table for
+      // every candidate makes the closure ask for an owned-subject-table digest
+      // this fixture never supplies, which surfaces as
+      // 'verification closure is missing 0x...' -- the harness's own omission in
+      // a domain refusal's clothing, and the exact shape that once retired
+      // ~46,000 cells with every count summing.
+      const predecessor = coreSequenceActiveHeadV1(candidate.authoritySequence);
       const closure = await mintAgentProfileTombstoneClosureV1({
         tombstone: candidate,
-        predecessor: CORE_TOMBSTONE_PREDECESSOR_V1,
-        ownedSubjectTable: [CORE_TOMBSTONE_PREDECESSOR_V1.rootSubject],
+        predecessor,
+        ownedSubjectTable: [predecessor.rootSubject],
         ancestors: ancestry,
         transitions,
         onUnresolvedArtifact: onUnresolved,
@@ -307,7 +336,7 @@ export function buildCoreEvidenceV1(
   const wants = new Set(cell.evidence);
   if (wants.has('acceptedTransition')) evidence.acceptedTransition = CORE_ACCEPTED_TRANSITION_V1;
   if (wants.has('tombstonePredecessor')) {
-    evidence.tombstonePredecessor = CORE_TOMBSTONE_PREDECESSOR_V1;
+    evidence.tombstonePredecessor = coreTombstonePredecessorV1(cell);
   }
   if (wants.has('forkResolution')) evidence.forkResolution = CORE_FORK_RESOLUTION_V1;
   if (wants.has('forkEvidenceHeads')) evidence.forkEvidenceHeads = CORE_FORK_EVIDENCE_HEADS_V1;

--- a/packages/storage/test/helpers/authority-verdict-diff-core-evidence-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-core-evidence-v1.ts
@@ -12,6 +12,7 @@ import {
   coreHeadShapeKeyV1,
   coreCandidateSequenceV1,
   coreSequenceActiveHeadV1,
+  coreSequenceEquivocatingTransitionV1,
   coreSequenceTransitionV1,
   CORE_MINT_GRAPH_V1,
   CORE_CHAIN_V1,
@@ -130,11 +131,27 @@ export const CORE_CLOCK_MS_V1: Readonly<Record<VerdictDiffCellV1['clock'], numbe
  * refusal and measures this fixture's wrongness instead of core's
  * discrimination. Found by review, not by the derivation -- a derivation checks
  * counts and cannot check evidence fidelity.
+ *
+ * IT DEPENDS ON AXIS G AS WELL AS AXIS D, and the first fix here got only half
+ * of that. Axis G decides WHICH transition into the sequence a candidate names:
+ * 'equal' the accepted rotation, 'differ' a competing one, and the head builder
+ * writes exactly that digest onto the head. A version of this function keyed on
+ * sequence alone handed every G='differ' candidate the REAL rotation -- again an
+ * input no caller could hold, and again a refusal owned by this fixture.
+ *
+ * That second miss is why the class sweep behind it was re-run with an
+ * AXIS-GENERAL discriminator: the class is "a constant supplied where an axis
+ * varies", never "a constant that depends on the axis the last incident was
+ * about". An enumeration that is exhaustive over the population but narrow in
+ * its predicate produces a completeness claim that is false on its own terms.
  */
 export function coreAcceptedTransitionV1(
   cell: VerdictDiffCellV1,
 ): AgentProfileAuthorityTransitionV1 {
-  return coreSequenceTransitionV1(coreCandidateSequenceV1(cell));
+  const sequence = coreCandidateSequenceV1(cell);
+  return cell.acceptedTransitionDigest === 'differ'
+    ? coreSequenceEquivocatingTransitionV1(sequence)
+    : coreSequenceTransitionV1(sequence);
 }
 
 /**

--- a/packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts
@@ -11,7 +11,10 @@ import {
 } from '@origintrail-official/dkg-core/system-record-v1';
 
 import type { VerdictDiffCellV1 } from './authority-verdict-diff-cells-v1.js';
-import { makeRotatedAuthorityChainV1 } from './system-record-active-replacement-fixture.js';
+import {
+  extendRotatedAuthorityChainV1,
+  makeRotatedAuthorityChainV1,
+} from './system-record-active-replacement-fixture.js';
 
 /** The wallet root the competing transition rotates to; not on the real chain. */
 const EQUIVOCATING_ISSUER = `0x${'77'.repeat(20)}`;
@@ -64,6 +67,78 @@ export const CORE_CURRENT_VERSION_V1 = BigInt(CORE_CURRENT_HEAD_V1.version);
 export const CORE_CHAIN_V1 = CHAIN;
 
 /**
+ * THE RECORD'S PROPOSED FUTURE: sequences 3 and 4, rotating off the CURRENT head.
+ *
+ * This is the half axis D was missing, and it is deliberately NOT built by
+ * deepening `CHAIN`. The ancestry chain's sequence-2 head is the version-ZERO
+ * one; the current head is that head at version 2. Extending the ancestry would
+ * therefore produce a sequence-3 rotation whose prior is an object the receiver
+ * has never applied, and storage's next-sequence arm compares exactly that --
+ * `summary.lastAuthorityTransitionPriorHeadDigest !== current.headDigest`. The
+ * candidate would verify internally, mint a well-formed summary, and still be
+ * refused as a history mismatch by this fixture's own choice of predecessor.
+ * Rotating off CORE_CURRENT_HEAD_V1 is what makes the next-sequence comparison
+ * the system's answer rather than the harness's.
+ *
+ * Issuer indices 2 and 3: the ancestry already spent 0 and 1, and the lineage
+ * walk refuses a reused wallet root (verification closure :635).
+ */
+const FORWARD = extendRotatedAuthorityChainV1(CORE_CURRENT_HEAD_V1, 2, 2);
+
+/**
+ * THE ACTIVE HEAD AT EACH AUTHORITY SEQUENCE -- one object per sequence, doing
+ * both jobs that sequence has.
+ *
+ * It is the head a candidate at that sequence is DERIVED FROM, because a
+ * candidate must carry the issuer, root subject, owned-subject table digest and
+ * accepted transition its own sequence requires; re-stamping a sequence number
+ * onto a head built for another sequence leaves the head naming a transition
+ * into somewhere else, which is what this layer did for every axis-D value
+ * before and why three of the four relations could never mint.
+ *
+ * It is ALSO that candidate's PREDECESSOR: every candidate here is a later
+ * version of the active head at its own sequence. Deriving both from one entry
+ * is deliberate -- as two maps they could disagree, and a candidate whose
+ * predecessor names a head at some other sequence is refused by the tombstone
+ * binding with wording that reads like the system's.
+ *
+ * At sequence 2 the entry is the CURRENT head rather than the ancestry's
+ * version-zero head at that sequence. Those two differ only in `version` and
+ * `previousHeadDigest`, both of which the builder overrides, so the derived
+ * candidate is unchanged -- but the PREDECESSOR must be the current head, which
+ * is the object a receiver has actually applied.
+ */
+const SEQUENCE_ACTIVE_HEADS_V1: ReadonlyMap<string, AgentProfileActiveHeadObjectV1> = new Map([
+  ['1', CHAIN.ancestors[0] as AgentProfileActiveHeadObjectV1],
+  ['2', CORE_CURRENT_HEAD_V1],
+  ['3', FORWARD.heads[1] as AgentProfileActiveHeadObjectV1],
+  ['4', FORWARD.heads[2] as AgentProfileActiveHeadObjectV1],
+]);
+
+/** The real rotation INTO each authority sequence. */
+const SEQUENCE_TRANSITIONS_V1: ReadonlyMap<string, AgentProfileAuthorityTransitionV1> = new Map([
+  ['1', CHAIN.transitions[0] as AgentProfileAuthorityTransitionV1],
+  ['2', CHAIN.transitions[1] as AgentProfileAuthorityTransitionV1],
+  ['3', FORWARD.transitions[0] as AgentProfileAuthorityTransitionV1],
+  ['4', FORWARD.transitions[1] as AgentProfileAuthorityTransitionV1],
+]);
+
+/**
+ * The active head a candidate at `authoritySequence` descends from.
+ *
+ * Exported because the MINT layer needs it too: a tombstone closure resolves an
+ * owned-subject table over its predecessor's root, and a minter holding the
+ * current head's table for every candidate asks for a digest this fixture never
+ * supplies -- a refusal produced by the harness's own omission, phrased exactly
+ * like a domain refusal.
+ */
+export function coreSequenceActiveHeadV1(
+  authoritySequence: string,
+): AgentProfileActiveHeadObjectV1 {
+  return SEQUENCE_ACTIVE_HEADS_V1.get(authoritySequence) as AgentProfileActiveHeadObjectV1;
+}
+
+/**
  * Axis G's 'differ' value: a REAL competing transition into the current's own
  * authority sequence, rotating to a different wallet root.
  *
@@ -80,15 +155,47 @@ export const CORE_CHAIN_V1 = CHAIN;
  * of the same prior head into the same sequence is transition equivocation,
  * which is the decision the axis exists to reach.
  */
-export const CORE_EQUIVOCATING_TRANSITION_V1 = Object.freeze({
-  ...CHAIN.transitions[CHAIN.transitions.length - 1],
-  nextEvmIssuer: EQUIVOCATING_ISSUER,
-  nextRoot: `did:dkg:agent:${EQUIVOCATING_ISSUER}`,
-}) as AgentProfileAuthorityTransitionV1;
+const EQUIVOCATING_TRANSITIONS_V1: ReadonlyMap<string, AgentProfileAuthorityTransitionV1> = new Map(
+  [...SEQUENCE_TRANSITIONS_V1].map(([sequence, transition]) => [
+    sequence,
+    Object.freeze({
+      ...transition,
+      nextEvmIssuer: EQUIVOCATING_ISSUER,
+      nextRoot: `did:dkg:agent:${EQUIVOCATING_ISSUER}`,
+    }) as AgentProfileAuthorityTransitionV1,
+  ]),
+);
+
+/**
+ * Axis G's 'differ' at the CURRENT sequence, kept as its own export because
+ * consumers name this object rather than a sequence.
+ *
+ * It is the sequence-2 entry of the map above and is byte-identical to what this
+ * constant was before axis D gained per-sequence lineage -- when the chain was
+ * two deep, `transitions[length - 1]` WAS the rotation into sequence 2. That
+ * coincidence is why the index is now explicit: a deeper chain would have
+ * silently re-based this constant on the rotation into its new top, moving every
+ * digest in the D='equal' region while every count still summed.
+ */
+export const CORE_EQUIVOCATING_TRANSITION_V1 = EQUIVOCATING_TRANSITIONS_V1.get(
+  CORE_CURRENT_HEAD_V1.authoritySequence,
+) as AgentProfileAuthorityTransitionV1;
 
 export const CORE_OTHER_TRANSITION_DIGEST_V1 = computeAgentProfileAuthorityTransitionDigestV1(
   CORE_EQUIVOCATING_TRANSITION_V1,
 );
+
+/** Every rotation this fixture can present, real and equivocating. */
+export const CORE_ALL_TRANSITIONS_V1: readonly AgentProfileAuthorityTransitionV1[] = Object.freeze([
+  ...SEQUENCE_TRANSITIONS_V1.values(),
+  ...EQUIVOCATING_TRANSITIONS_V1.values(),
+]);
+
+/** Every head this fixture's lineage walks can reach. */
+export const CORE_ALL_LINEAGE_HEADS_V1: readonly AgentProfileHeadObjectV1[] = Object.freeze([
+  ...CHAIN.heads,
+  ...FORWARD.heads.slice(1),
+]);
 
 /** Two same-sequence conflicting heads -- the evidence a fork resolution names. */
 export const CORE_FORK_CONFLICT_HEADS_V1: readonly AgentProfileActiveHeadObjectV1[] = Object.freeze(
@@ -269,19 +376,27 @@ export function buildCoreCandidateHeadV1(
 
   const sequence = candidateSequence(cell.sequenceRelation);
   const version = candidateVersion(cell);
+  // The lineage the candidate's own authority sequence demands. Selecting these
+  // three per sequence rather than pinning them to the current head is the whole
+  // of the sequence-depth fix: the head supplies the issuer, root subject and
+  // owned-subject table digest that sequence requires, the transition is the one
+  // rotating INTO it, and the predecessor is the head it really descends from.
+  const lineageHead = coreSequenceActiveHeadV1(String(sequence));
   const transitionDigest = cell.acceptedTransitionDigest === 'differ'
-    ? CORE_OTHER_TRANSITION_DIGEST_V1
-    : CORE_CURRENT_HEAD_V1.acceptedTransitionDigest;
+    ? computeAgentProfileAuthorityTransitionDigestV1(
+      EQUIVOCATING_TRANSITIONS_V1.get(String(sequence)) as AgentProfileAuthorityTransitionV1,
+    )
+    : lineageHead.acceptedTransitionDigest;
 
   const base: Record<string, unknown> = {
-    ...structuredClone(CHAIN.base),
+    ...structuredClone(lineageHead),
     authoritySequence: String(sequence),
     version: String(version),
     acceptedTransitionDigest: transitionDigest,
-    // A noninitial head requires its predecessor link (:206); the current head
-    // is a real one that mints, which keeps this a history reference rather
+    // A noninitial head requires its predecessor link (:206), and the head named
+    // here is a real one that mints, which keeps this a history reference rather
     // than a placeholder the codec would reject.
-    previousHeadDigest: CORE_CURRENT_DIGEST_V1,
+    previousHeadDigest: computeAgentProfileHeadObjectDigestV1(lineageHead),
     // Differ from the current by issue time, which moves the digest without
     // touching any field an axis pins. Perturbing an axis-owned field instead
     // would make axis F's 'differ' silently duplicate another axis.

--- a/packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts
@@ -139,6 +139,40 @@ export function coreSequenceActiveHeadV1(
 }
 
 /**
+ * The authority sequence the candidate for `cell` will carry, WITHOUT building it.
+ *
+ * Exported for the evidence layer, which needs the sequence in order to choose a
+ * sequence-dependent member. Building the whole candidate head to read one field
+ * back off it costs a head build PER CELL, and the projection-equivalence suite
+ * builds evidence for every constructible cell -- so that shortcut is worth
+ * roughly 145,000 avoided head builds, which is most of a CI budget.
+ *
+ * Derived from the CELL, which is also the honest source rather than merely the
+ * cheap one: `buildCoreCandidateHeadV1` derives the sequence from the same axis
+ * value. The two agreeing is asserted over every buildable shape in the
+ * core-heads suite rather than left to inspection -- a shortcut that silently
+ * drifted from the builder would hand the evidence layer a member chosen for the
+ * wrong sequence, which is the exact defect class this fixture keeps meeting.
+ */
+export function coreCandidateSequenceV1(cell: VerdictDiffCellV1): string {
+  return String(candidateSequence(cell.sequenceRelation));
+}
+
+/**
+ * The REAL rotation into `authoritySequence` -- the transition a well-formed
+ * candidate at that sequence names.
+ *
+ * Exported for the evidence layer: axis J's `acceptedTransition` member has to
+ * be the transition the candidate actually names, or the member stops being
+ * decision-changing and starts being a uniform refusal.
+ */
+export function coreSequenceTransitionV1(
+  authoritySequence: string,
+): AgentProfileAuthorityTransitionV1 {
+  return SEQUENCE_TRANSITIONS_V1.get(authoritySequence) as AgentProfileAuthorityTransitionV1;
+}
+
+/**
  * Axis G's 'differ' value: a REAL competing transition into the current's own
  * authority sequence, rotating to a different wallet root.
  *
@@ -185,6 +219,34 @@ export const CORE_OTHER_TRANSITION_DIGEST_V1 = computeAgentProfileAuthorityTrans
   CORE_EQUIVOCATING_TRANSITION_V1,
 );
 
+/**
+ * THE PER-SEQUENCE DIGESTS, COMPUTED ONCE.
+ *
+ * Both were being computed INSIDE `buildCoreCandidateHeadV1`, where the previous
+ * one-size-fits-all version had used module-level constants. A digest is a
+ * canonicalisation plus a keccak hash, and the projection-equivalence suite
+ * builds a head for every constructible cell -- so moving them into the builder
+ * turned four hashes into roughly 145,000, and MEASURED it: that suite went from
+ * 310s on the previous PR's CI run to 716s locally, which is what pushed this
+ * lane past its budget.
+ *
+ * Precomputing loses no observation. These are pure functions of objects fixed
+ * at module load; the builder gets the identical value it computed before.
+ */
+const SEQUENCE_PREDECESSOR_DIGESTS_V1: ReadonlyMap<string, string> = new Map(
+  [...SEQUENCE_ACTIVE_HEADS_V1].map(([sequence, head]) => [
+    sequence,
+    computeAgentProfileHeadObjectDigestV1(head),
+  ]),
+);
+
+const EQUIVOCATING_TRANSITION_DIGESTS_V1: ReadonlyMap<string, string> = new Map(
+  [...EQUIVOCATING_TRANSITIONS_V1].map(([sequence, transition]) => [
+    sequence,
+    computeAgentProfileAuthorityTransitionDigestV1(transition),
+  ]),
+);
+
 /** Every rotation this fixture can present, real and equivocating. */
 export const CORE_ALL_TRANSITIONS_V1: readonly AgentProfileAuthorityTransitionV1[] = Object.freeze([
   ...SEQUENCE_TRANSITIONS_V1.values(),
@@ -196,6 +258,7 @@ export const CORE_ALL_LINEAGE_HEADS_V1: readonly AgentProfileHeadObjectV1[] = Ob
   ...CHAIN.heads,
   ...FORWARD.heads.slice(1),
 ]);
+
 
 /** Two same-sequence conflicting heads -- the evidence a fork resolution names. */
 export const CORE_FORK_CONFLICT_HEADS_V1: readonly AgentProfileActiveHeadObjectV1[] = Object.freeze(
@@ -215,6 +278,17 @@ export const CORE_FORK_CONFLICT_HEADS_V1: readonly AgentProfileActiveHeadObjectV
  * `forkedVersion` is the current's version because core :456 refuses anything
  * else; `resolutionVersion` is one above it because the control codec refuses
  * `resolutionVersion <= forkedVersion` (:262).
+ *
+ * SEQUENCE-DEPENDENT, SUPPLIED AT EVERY SEQUENCE, AND MEASURABLY INERT TODAY.
+ * This object carries the CURRENT head's `evmIssuer` and `authoritySequence`,
+ * so at any other sequence it does not describe the candidate it is handed to.
+ * It is left alone because the branch it feeds is unreachable under this axis
+ * set and the mismatch therefore moves no verdict -- measured at 0 of 5,184
+ * sequence-relative projections, against a positive control of 72 of 600. The
+ * full statement of the measurement, and of the condition under which it stops
+ * holding, is at CORE_FORK_EVIDENCE_HEADS_V1 in the evidence layer. Anyone
+ * making axis K='present' constructible must make this per-sequence in the same
+ * change.
  */
 export const CORE_FORK_RESOLUTION_V1 = Object.freeze({
   objectType: 'fork-resolution',
@@ -239,6 +313,43 @@ export const CORE_FORK_RESOLUTION_V1 = Object.freeze({
 export const CORE_FORK_RESOLUTION_DIGEST_V1 = computeAgentProfileForkResolutionDigestV1(
   CORE_FORK_RESOLUTION_V1,
 );
+
+/**
+ * THE ONE ARTIFACT GRAPH BOTH MINTERS WALK.
+ *
+ * The two halves of the diff mint their own summaries -- core's minter is
+ * module-private to its layer, and the storage driver reproduces the walk. That
+ * reproduction is a DRIFT POINT, and it has already cost one defect: the
+ * per-sequence tombstone predecessor was fixed in the core minter and left
+ * pinned to the current head in the storage one, which refused every
+ * sequence-relative tombstone for an owned-subject table this fixture never
+ * supplies and survived a full lane with perfect conservation.
+ *
+ * Fixing that by editing both minters is a fix by VIGILANCE. This is the
+ * structural form: the ancestry, the transitions and the tombstone predecessor
+ * rule live HERE, once, and both minters read them. Two functions can still
+ * differ in what they do with the graph, but they can no longer disagree about
+ * WHAT THE GRAPH IS -- which is the only thing the drift was ever about.
+ */
+export const CORE_MINT_GRAPH_V1 = Object.freeze({
+  /** Every head a closure walk may resolve, current head first. */
+  ancestry: Object.freeze([
+    CORE_CURRENT_HEAD_V1,
+    ...CORE_ALL_LINEAGE_HEADS_V1,
+    ...CORE_FORK_CONFLICT_HEADS_V1,
+  ]) as readonly AgentProfileHeadObjectV1[],
+  /** Every rotation, real and equivocating. */
+  transitions: CORE_ALL_TRANSITIONS_V1,
+  /**
+   * The predecessor a TOMBSTONE at `authoritySequence` must be minted against,
+   * and the owned-subject table that goes with it. Both minters call this rather
+   * than each deciding what a tombstone descends from.
+   */
+  tombstonePredecessorFor(authoritySequence: string) {
+    const predecessor = coreSequenceActiveHeadV1(authoritySequence);
+    return { predecessor, ownedSubjectTable: [predecessor.rootSubject] as readonly string[] };
+  },
+});
 
 /** The candidate's authority sequence for each axis-D value. */
 function candidateSequence(relation: VerdictDiffCellV1['sequenceRelation']): bigint {
@@ -383,9 +494,7 @@ export function buildCoreCandidateHeadV1(
   // rotating INTO it, and the predecessor is the head it really descends from.
   const lineageHead = coreSequenceActiveHeadV1(String(sequence));
   const transitionDigest = cell.acceptedTransitionDigest === 'differ'
-    ? computeAgentProfileAuthorityTransitionDigestV1(
-      EQUIVOCATING_TRANSITIONS_V1.get(String(sequence)) as AgentProfileAuthorityTransitionV1,
-    )
+    ? EQUIVOCATING_TRANSITION_DIGESTS_V1.get(String(sequence)) as string
     : lineageHead.acceptedTransitionDigest;
 
   const base: Record<string, unknown> = {
@@ -396,7 +505,7 @@ export function buildCoreCandidateHeadV1(
     // A noninitial head requires its predecessor link (:206), and the head named
     // here is a real one that mints, which keeps this a history reference rather
     // than a placeholder the codec would reject.
-    previousHeadDigest: computeAgentProfileHeadObjectDigestV1(lineageHead),
+    previousHeadDigest: SEQUENCE_PREDECESSOR_DIGESTS_V1.get(String(sequence)) as string,
     // Differ from the current by issue time, which moves the digest without
     // touching any field an axis pins. Perturbing an axis-owned field instead
     // would make axis F's 'differ' silently duplicate another axis.

--- a/packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts
@@ -173,6 +173,22 @@ export function coreSequenceTransitionV1(
 }
 
 /**
+ * The COMPETING rotation into `authoritySequence` -- the transition a G='differ'
+ * candidate names.
+ *
+ * Exported for the same reason as its real counterpart, and the pair has to be
+ * chosen together: axis G decides WHICH of the two a candidate names, so any
+ * evidence member describing "the transition this candidate accepted" depends on
+ * axis G as well as axis D. Supplying the real rotation to a candidate that
+ * names the competing one hands core an input no caller could hold.
+ */
+export function coreSequenceEquivocatingTransitionV1(
+  authoritySequence: string,
+): AgentProfileAuthorityTransitionV1 {
+  return EQUIVOCATING_TRANSITIONS_V1.get(authoritySequence) as AgentProfileAuthorityTransitionV1;
+}
+
+/**
  * Axis G's 'differ' value: a REAL competing transition into the current's own
  * authority sequence, rotating to a different wallet root.
  *

--- a/packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts
@@ -135,7 +135,32 @@ const SEQUENCE_TRANSITIONS_V1: ReadonlyMap<string, AgentProfileAuthorityTransiti
 export function coreSequenceActiveHeadV1(
   authoritySequence: string,
 ): AgentProfileActiveHeadObjectV1 {
-  return SEQUENCE_ACTIVE_HEADS_V1.get(authoritySequence) as AgentProfileActiveHeadObjectV1;
+  return requireSequenceLineageV1(authoritySequence).activeHead;
+}
+
+/**
+ * THE ONE CHECKED LOOKUP, and the reason it is checked rather than cast.
+ *
+ * The per-sequence facts were reached through `Map.get(...) as T`, which types
+ * every string as supported while only four exist. A future axis relation
+ * asking for sequence `5` would compile, receive `undefined` DISGUISED AS A
+ * VALID HEAD, and fail somewhere downstream in a spread or a digest with a
+ * message about the wrong thing entirely. This turns that into a refusal at the
+ * boundary, naming the sequence and what the fixture actually serves.
+ *
+ * Adding a sequence is now one data change in SEQUENCE_LINEAGE_V1 rather than
+ * four maps kept in step by hand -- which is the drift pressure this PR exists
+ * to remove, applied to the model this PR introduced.
+ */
+function requireSequenceLineageV1(authoritySequence: string): CoreSequenceLineageV1 {
+  const lineage = SEQUENCE_LINEAGE_V1.get(authoritySequence);
+  if (lineage === undefined) {
+    throw new Error(
+      `no fixture lineage for authority sequence ${authoritySequence}; `
+      + `this fixture serves ${[...SEQUENCE_LINEAGE_V1.keys()].join(', ')}`,
+    );
+  }
+  return lineage;
 }
 
 /**
@@ -169,7 +194,7 @@ export function coreCandidateSequenceV1(cell: VerdictDiffCellV1): string {
 export function coreSequenceTransitionV1(
   authoritySequence: string,
 ): AgentProfileAuthorityTransitionV1 {
-  return SEQUENCE_TRANSITIONS_V1.get(authoritySequence) as AgentProfileAuthorityTransitionV1;
+  return requireSequenceLineageV1(authoritySequence).transition;
 }
 
 /**
@@ -185,7 +210,7 @@ export function coreSequenceTransitionV1(
 export function coreSequenceEquivocatingTransitionV1(
   authoritySequence: string,
 ): AgentProfileAuthorityTransitionV1 {
-  return EQUIVOCATING_TRANSITIONS_V1.get(authoritySequence) as AgentProfileAuthorityTransitionV1;
+  return requireSequenceLineageV1(authoritySequence).equivocatingTransition;
 }
 
 /**
@@ -261,6 +286,46 @@ const EQUIVOCATING_TRANSITION_DIGESTS_V1: ReadonlyMap<string, string> = new Map(
     sequence,
     computeAgentProfileAuthorityTransitionDigestV1(transition),
   ]),
+);
+
+/**
+ * ONE RECORD PER AUTHORITY SEQUENCE -- the canonical model the separate maps
+ * above are folded into.
+ *
+ * The maps are kept as the construction steps (each needs the one before it),
+ * but nothing outside this file reads them: every consumer goes through
+ * `requireSequenceLineageV1`, so a sequence's active head, its real rotation,
+ * its competing rotation and its predecessor digest cannot drift apart. They
+ * are five facts about ONE rotation and are now typed that way.
+ */
+export interface CoreSequenceLineageV1 {
+  readonly sequence: string;
+  readonly activeHead: AgentProfileActiveHeadObjectV1;
+  readonly transition: AgentProfileAuthorityTransitionV1;
+  readonly equivocatingTransition: AgentProfileAuthorityTransitionV1;
+  /**
+   * PRECOMPUTED, both of these. They are digests, i.e. a canonicalisation plus a
+   * keccak hash, and the head builder runs per cell -- computing them here
+   * rather than at the call site is what keeps this lane inside its CI budget
+   * (measured: moving two such digests into the builder took the
+   * projection-equivalence suite from 310s to 716s).
+   */
+  readonly equivocatingTransitionDigest: string;
+  readonly predecessorDigest: string;
+}
+
+const SEQUENCE_LINEAGE_V1: ReadonlyMap<string, CoreSequenceLineageV1> = new Map(
+  [...SEQUENCE_ACTIVE_HEADS_V1].map(([sequence, activeHead]) => [sequence, Object.freeze({
+    sequence,
+    activeHead,
+    transition: SEQUENCE_TRANSITIONS_V1.get(sequence) as AgentProfileAuthorityTransitionV1,
+    equivocatingTransition:
+      EQUIVOCATING_TRANSITIONS_V1.get(sequence) as AgentProfileAuthorityTransitionV1,
+    equivocatingTransitionDigest:
+      EQUIVOCATING_TRANSITION_DIGESTS_V1.get(sequence) as string,
+    predecessorDigest:
+      SEQUENCE_PREDECESSOR_DIGESTS_V1.get(sequence) as string,
+  })]),
 );
 
 /** Every rotation this fixture can present, real and equivocating. */
@@ -510,7 +575,7 @@ export function buildCoreCandidateHeadV1(
   // rotating INTO it, and the predecessor is the head it really descends from.
   const lineageHead = coreSequenceActiveHeadV1(String(sequence));
   const transitionDigest = cell.acceptedTransitionDigest === 'differ'
-    ? EQUIVOCATING_TRANSITION_DIGESTS_V1.get(String(sequence)) as string
+    ? requireSequenceLineageV1(String(sequence)).equivocatingTransitionDigest
     : lineageHead.acceptedTransitionDigest;
 
   const base: Record<string, unknown> = {
@@ -521,7 +586,7 @@ export function buildCoreCandidateHeadV1(
     // A noninitial head requires its predecessor link (:206), and the head named
     // here is a real one that mints, which keeps this a history reference rather
     // than a placeholder the codec would reject.
-    previousHeadDigest: SEQUENCE_PREDECESSOR_DIGESTS_V1.get(String(sequence)) as string,
+    previousHeadDigest: requireSequenceLineageV1(String(sequence)).predecessorDigest,
     // Differ from the current by issue time, which moves the digest without
     // touching any field an axis pins. Perturbing an axis-owned field instead
     // would make axis F's 'differ' silently duplicate another axis.

--- a/packages/storage/test/helpers/authority-verdict-diff-core-table-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-core-table-v1.ts
@@ -487,7 +487,7 @@ export const CORE_SUMMARY_ASYMMETRY_CITATIONS_V1: readonly SourceCitationV1[] = 
 export const CORE_SEQUENCE_DEPTH_CITATIONS_V1: readonly SourceCitationV1[] = [
   {
     id: 'candidate-selects-the-lineage-of-its-own-sequence',
-    site: 'packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts:511',
+    site: 'packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts:576',
     contains: 'const lineageHead = coreSequenceActiveHeadV1(String(sequence));',
     why: 'Axis D now selects the head its candidate descends from, which carries the '
       + 'issuer, root subject, owned-subject table digest and accepted transition that '
@@ -495,8 +495,8 @@ export const CORE_SEQUENCE_DEPTH_CITATIONS_V1: readonly SourceCitationV1[] = [
   },
   {
     id: 'candidate-descends-from-the-head-at-its-own-sequence',
-    site: 'packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts:524',
-    contains: 'previousHeadDigest: SEQUENCE_PREDECESSOR_DIGESTS_V1.get(String(sequence))',
+    site: 'packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts:589',
+    contains: 'previousHeadDigest: requireSequenceLineageV1(String(sequence)).predecessorDigest,',
     why: 'The predecessor is the digest of that same head rather than the pinned '
       + 'sequence-2 current head, so a sequence-1 candidate no longer claims a '
       + 'predecessor ABOVE itself and a sequence-3 one no longer skips its own. '

--- a/packages/storage/test/helpers/authority-verdict-diff-core-table-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-core-table-v1.ts
@@ -113,13 +113,18 @@ export const CORE_VERDICT_TABLE_DIGEST_V1 =
 /**
  * WHAT THE TABLE DECIDES, AND THE TWO THINGS THESE NUMBERS DO NOT SAY.
  *
- * ISSUE #57 STILL STANDS. "Core decides all 145,728 cells" reads exactly like
- * the sequence-depth boundary went away. It did NOT -- it moved buckets. The
- * COMPARABLE region still lacks a next-sequence ROTATION: axis D='plusOne' has
- * 23,040 buildable cells and 0 that can mint a verified authority closure, and
- * that is precisely what #57's Phase-3 coupling rests on. Retiring those cells
- * used to make the gap visible in the arithmetic; deciding them makes it
- * invisible there, so it is stated here instead. The gap did not close.
+ * THE SEQUENCE-DEPTH BOUNDARY IS NOW CLOSED, AND THIS NOTE IS KEPT RATHER THAN
+ * DELETED. It used to read "ISSUE #57 STILL STANDS ... axis D='plusOne' has
+ * 23,040 buildable cells and 0 that can mint ... the gap did not close", because
+ * "core decides all 145,728 cells" reads exactly like a boundary that went away
+ * when in fact it had only moved buckets. The gap HAS now closed: all four
+ * axis-D relations mint, and D='plusOne' -- the next-sequence rotation the
+ * Phase-3 coupling rests on -- reaches storage's advance path.
+ *
+ * The note stays because the hazard it names has not gone anywhere. This total
+ * still says nothing about COVERAGE, and the next thing to move buckets will
+ * hide behind it exactly the same way. What is comparable is 42,624 cells, not
+ * 145,728, and the four-bucket partition is where that is visible.
  *
  * 145,728 DECIDED IS NOT 145,728 INDEPENDENT OBSERVATIONS. Of the 61,920 cells
  * the S1 removal returns to the table, 20,640 short-circuit at the future
@@ -429,27 +434,48 @@ export const CORE_SUMMARY_ASYMMETRY_CITATIONS_V1: readonly SourceCitationV1[] = 
 ];
 
 /**
- * The anchors for the sequence-depth finding's CAUSE.
+ * The anchors for the sequence-depth boundary's CLOSURE.
  *
- * The finding used to blame the chain helper's `steps: 1 | 2` signature. These
- * two lines are the real cause, and they are cited so the claim can be checked
- * rather than believed: whatever depth the chain is built to, every candidate
- * still names the SAME transition digest and the SAME predecessor.
+ * This register has now cited three different things, and the history is the
+ * reason it exists. It first blamed the chain helper's `steps: 1 | 2` signature
+ * -- a PARAMETER, not a bound. It was corrected to cite the two lines that were
+ * the real cause: every candidate naming the same transition digest and the same
+ * predecessor for all four axis-D values, so a deeper chain alone changed
+ * nothing. Both of those lines are now GONE, and these citations anchor what
+ * replaced them, so "the boundary is closed" is checkable rather than believed.
+ *
+ * A closed boundary keeps its anchors rather than dropping them. The claim a
+ * reader needs to test is no longer "why can't these cells mint" but "is the
+ * lineage really selected per sequence, or did someone quietly re-pin it" --
+ * and that question is answered at exactly these lines.
  */
 export const CORE_SEQUENCE_DEPTH_CITATIONS_V1: readonly SourceCitationV1[] = [
   {
-    id: 'candidate-reuses-the-current-transition-digest',
-    site: 'packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts:272',
-    contains: "const transitionDigest = cell.acceptedTransitionDigest === 'differ'",
-    why: 'Axis D never selects a transition: every candidate carries the current head\'s '
-      + 'digest or the equivocating one, for all four sequence relations.',
+    id: 'candidate-selects-the-lineage-of-its-own-sequence',
+    site: 'packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts:384',
+    contains: 'const lineageHead = coreSequenceActiveHeadV1(String(sequence));',
+    why: 'Axis D now selects the head its candidate descends from, which carries the '
+      + 'issuer, root subject, owned-subject table digest and accepted transition that '
+      + 'sequence requires. The single reused transition digest is gone.',
   },
   {
-    id: 'candidate-reuses-the-current-head-as-predecessor',
-    site: 'packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts:284',
-    contains: 'previousHeadDigest: CORE_CURRENT_DIGEST_V1,',
-    why: 'Every candidate points at the sequence-2 current head, so a sequence-1 candidate '
-      + 'claims a predecessor ABOVE itself and a sequence-3 one skips its own.',
+    id: 'candidate-descends-from-the-head-at-its-own-sequence',
+    site: 'packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts:399',
+    contains: 'previousHeadDigest: computeAgentProfileHeadObjectDigestV1(lineageHead),',
+    why: 'The predecessor is derived from that same head rather than pinned to the '
+      + 'sequence-2 current head, so a sequence-1 candidate no longer claims a '
+      + 'predecessor ABOVE itself and a sequence-3 one no longer skips its own.',
+  },
+  {
+    id: 'the-future-rotates-off-the-current-head-not-off-the-ancestry',
+    site: 'packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts:86',
+    contains: 'const FORWARD = extendRotatedAuthorityChainV1(CORE_CURRENT_HEAD_V1, 2, 2);',
+    why: 'The sequence-3 and sequence-4 heads rotate off the CURRENT head, not off the '
+      + "ancestry's version-zero head at sequence 2. Extending the ancestry instead "
+      + 'would mint a well-formed summary that storage still refuses as a history '
+      + "mismatch, because its next-sequence arm compares the lineage tail's prior "
+      + "head digest against the applied head's -- a refusal owned by this fixture "
+      + 'wearing the system\'s wording.',
   },
 ];
 
@@ -540,41 +566,61 @@ export const CORE_SWEEP_FINDINGS_V1: readonly string[] = [
   // CORRECTED: the first version named the wrong cause and over-claimed on the
   // sequence relations. A finding that shipped wrong once is exactly the kind
   // that gets believed the second time, so both corrections are cited.
-  'THE SEQUENCE-DEPTH BOUNDARY, AND WHAT IT DOES AND DOES NOT BOUND. Measured over '
-  + 'all 40 buildable shapes: D=below 23,040 buildable cells / 0 able to mint, '
-  + 'D=plusOne 23,040 / 0, D=abovePlusOne 23,040 / 0, against D=equal 73,728 / 20,736 '
-  + 'and the absent-snapshot region 2,880 / 1,152. So 69,120 of 145,728 buildable '
-  + 'cells -- 47% -- sit where no verified authority summary can be obtained. THIS IS '
-  + 'NOT A WRONG VERDICT AND CONSERVATION IS UNAFFECTED; what it bounds is the '
-  + 'COVERAGE CLAIM, and since rule S1 was removed it no longer appears in the '
-  + 'arithmetic at all, which makes stating it here the only place it is visible. '
-  + 'THE CAUSE IS NOT the chain helper\'s (steps: 1 | 2) signature. That is a '
-  + 'PARAMETER, not a bound -- a third rotation is about six lines. The real cause is '
-  + 'authority-verdict-diff-core-heads-v1.ts:272-284, where every candidate reuses the '
-  + 'current head as its predecessor and the same 1->2 transition digest for EVERY '
-  + 'axis-D value, so a deeper chain alone changes nothing: a sequence-3 candidate '
-  + 'would still name a 1->2 transition and still point previousHeadDigest at the '
-  + 'sequence-2 head (anchored by CORE_SEQUENCE_DEPTH_CITATIONS_V1). '
-  + '"THREE OF THE FOUR SEQUENCE RELATIONS ARE DEAD" IS RETIRED as a statement, '
-  + 'because the three are not alike. D=below is a FIX-NOW defect: the sequence-1 '
-  + 'candidate is built with previousHeadDigest naming the sequence-2 current head '
-  + 'while a real sequence-1 ancestor sits unused. D=abovePlusOne AWAITS A DENOTATION '
-  + 'DETERMINATION -- what a candidate two sequences ahead is supposed to MEAN is not '
-  + 'settled, and building one first would pin a fixture\'s guess as a finding. And '
-  + "#57's Phase-3 coupling rests on D=plusOne ALONE, so that is the one whose absence "
-  + 'has a consequence outside this table. '
-  + 'THE CONTRAST ROW SPLITS, AND HALF OF IT WAS FALSE AS WRITTEN. Axis G=\'differ\' '
-  + 'never minting IS core being correct: two transitions out of the same prior head '
+  'THE SEQUENCE-DEPTH BOUNDARY IS CLOSED, AND THIS ENTRY IS ITS HISTORY RATHER THAN '
+  + 'ITS STATEMENT. What it used to say: over all 40 buildable shapes, D=below 23,040 '
+  + 'buildable cells / 0 able to mint, D=plusOne 23,040 / 0, D=abovePlusOne 23,040 / 0 '
+  + '-- 69,120 of 145,728 buildable cells, 47%, where no verified authority summary '
+  + 'could be obtained. All three now mint. Mintable head shapes went 6 -> 12 and the '
+  + "'[system-record-history] head <digest> has incomplete authority/root lineage' "
+  + 'class went 12 shapes -> 0. The COMPARABLE region went 21,888 cells -> 42,624, '
+  + '13.3% -> 25.97% of the constructible space. '
+  + 'THE CAUSE WAS NEVER the chain helper\'s (steps: 1 | 2) signature -- a PARAMETER, '
+  + 'not a bound. It was that every candidate reused the current head as its '
+  + 'predecessor and the same 1->2 transition digest for EVERY axis-D value, so a '
+  + 'deeper chain alone would have changed nothing. Both lines are gone; '
+  + 'CORE_SEQUENCE_DEPTH_CITATIONS_V1 now anchors what replaced them. '
+  + 'WHAT THE CLOSURE COST, recorded because the naive fix does not work: a candidate '
+  + 'at sequence 3 cannot be built by DEEPENING the ancestry chain. The ancestry\'s '
+  + 'sequence-2 head is the version-zero one while the current head is that head at '
+  + 'version 2, so a rotation off the ancestry names a prior the receiver never '
+  + 'applied -- and storage\'s next-sequence arm compares exactly that. Such a '
+  + 'candidate verifies internally, mints a well-formed summary, and is STILL refused '
+  + 'as a history mismatch, by the fixture\'s choice of predecessor in the system\'s '
+  + 'wording. The future is therefore built by extendRotatedAuthorityChainV1 rotating '
+  + 'off the CURRENT head, which is a different primitive from the ancestry builder on '
+  + 'purpose. '
+  + 'THE DENOTATION QUESTION ON D=abovePlusOne IS DISSOLVED, NOT DECIDED. This entry '
+  + 'previously said the axis "AWAITS A DENOTATION DETERMINATION" and that building a '
+  + "candidate first would pin a fixture's guess as a finding. Measured at both sites, "
+  + 'neither implementation has the distinction the question presupposed: core '
+  + 'system-record-authority-v1-internal.ts:151-153 rejects any candidate more than '
+  + 'one sequence ahead with \'authority history is incomplete\', and storage\'s '
+  + 'classifyAuthorityAdvance defers it as \'authority-history-mismatch\', both from '
+  + 'the SEQUENCE NUMBER ALONE and both short-circuiting before reading the summary, '
+  + 'the lineage, or anything else that could tell "intermediates presented" from '
+  + '"intermediates withheld". There is no input the two readings differ on that '
+  + 'reaches a branch. The shape the fixture builds is then forced by '
+  + 'CONSTRUCTIBILITY rather than chosen: storage requires a verified summary as an '
+  + 'input, so the withheld-intermediates shape cannot drive storage at all and its '
+  + 'cells stay unconstructible on both sides. '
+  + 'AXIS K=\'present\' IS A DIFFERENT BOUNDARY AND IS STILL OPEN. Axis G=\'differ\' '
+  + 'never minting IS core being correct -- two transitions out of the same prior head '
   + 'into the same sequence is equivocation, which is what the axis value means. Axis '
-  + 'K=\'present\' never minting is NOT. Measured at the predicate '
-  + '(isDirectResolvingSuccessorV1, system-record-authority-verification-v1-internal.ts'
-  + ':110-117): a direct resolving successor must have a version STRICTLY ABOVE '
-  + 'resolutionVersion, which this fixture pins at 3, so it needs version >= 4 while '
-  + "axis E's largest is 3 -- and it must carry previousHeadDigest equal to the "
-  + 'resolution\'s forkBaseHeadDigest, while the builder pins that field to the current '
-  + 'head. BOTH failing conjuncts are fixture-side, and the second is the very line the '
-  + 'sequence-depth correction above cites, so this half belongs at the fixture '
-  + 'boundary and is noted against #57 rather than recorded as core being right.',
+  + 'K=\'present\' never minting is NOT, and closing axis D did not close it. Measured '
+  + 'at isDirectResolvingSuccessorV1 (system-record-authority-verification-v1-internal'
+  + '.ts:96-118), the predicate has FIVE conjuncts a candidate must satisfy, not the '
+  + 'two previously recorded: version STRICTLY ABOVE resolutionVersion; '
+  + 'previousHeadDigest equal to the resolution\'s forkBaseHeadDigest; and also '
+  + 'matching evmIssuer, matching authoritySequence, and forkResolutionDigest equal to '
+  + 'the resolution\'s digest. The last two are new information and they bite here '
+  + 'specifically: a rotation MOVES evmIssuer, so the single fork resolution this '
+  + 'fixture builds can only ever bind a sequence-2 candidate, and closing K=\'present\' '
+  + 'across axis D requires a PER-SEQUENCE resolution with its own evidence heads. '
+  + 'Separately, axis E applies only at D=\'equal\' (cells-v1), so off that column the '
+  + 'candidate version falls to its default and cannot clear the version threshold at '
+  + 'any chain depth. Filed as its own follow-up with these measurements rather than '
+  + 'folded into the sequence-depth work, because it is a distinct mechanism at a '
+  + 'distinct site and the Phase-3 routing coupling does not rest on it.',
 
   // CONDITION-3 FINDING. Filed on its own rather than folded into the counts,
   // because it is a routing hazard and a statistic absorbed into a total is not

--- a/packages/storage/test/helpers/authority-verdict-diff-core-table-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-core-table-v1.ts
@@ -80,20 +80,30 @@ export const CORE_VERDICT_TABLE_V1: Readonly<Record<string, CoreVerdictRowV1>> =
   'REFUSED|F1-digest-equality-forces-the-current-state': { cells: 4608, projections: 1152 },
   'REFUSED|F2-digest-equality-forces-the-current-transition-digest': { cells: 9216, projections: 1152 },
   'REFUSED|F3-digest-equality-forces-the-current-fork-resolution-absence': { cells: 4608, projections: 576 },
-  accept: { cells: 2176, projections: 448 },
+  accept: { cells: 2432, projections: 512 },
   'quarantine|head-fork': { cells: 4096, projections: 512 },
   'quarantine|transition-equivocation': { cells: 47104, projections: 7040 },
   'reject|absent state cannot retain authority history or quarantine': { cells: 1280, projections: 768 },
   'reject|authority history is incomplete': { cells: 10240, projections: 1536 },
   'reject|cold noninitial head requires its verified authority closure': { cells: 512, projections: 320 },
   'reject|current frontier fork requires its exact direct resolving successor': { cells: 2048, projections: 256 },
-  'reject|exact accepted authority transition is missing': { cells: 3840, projections: 576 },
+  'reject|exact accepted authority transition is missing': { cells: 5120, projections: 768 },
   'reject|head issuedAt exceeds the future clock-skew bound': { cells: 48576, projections: 7680 },
   'reject|historical or unsolicited fork resolution is audit-only': { cells: 1024, projections: 128 },
-  'reject|late tombstone lacks its exact verified active predecessor': { cells: 2048, projections: 512 },
-  'reject|next-sequence tombstone requires its exact same-sequence active predecessor': { cells: 256, projections: 64 },
+  'reject|late tombstone lacks its exact verified active predecessor': { cells: 1536, projections: 384 },
+  // REPLACES 'next-sequence tombstone requires its exact same-sequence active
+  // predecessor' at the same 256/64. A tombstone candidate one sequence ahead
+  // now carries the real rotation into its own sequence, so core reaches it
+  // through the RESURRECTION branch rather than refusing it for a predecessor at
+  // the wrong sequence. Same cells, different reason -- which is the shape a
+  // reason-level pin exists to catch.
+  'reject|late tombstone requires the exact retained resurrection transition': { cells: 256, projections: 64 },
   'reject|tombstone lacks its exact verified active predecessor': { cells: 2048, projections: 512 },
-  'reject|transition does not bind the accepted predecessor': { cells: 1024, projections: 128 },
+  // 'reject|transition does not bind the accepted predecessor' (1,024 / 128) is
+  // GONE. It fired when a candidate named a transition whose prior head was not
+  // its own; every candidate now names the rotation into its own sequence, so
+  // nothing reaches it. Removed rather than pinned at zero because it is not a
+  // declared codomain member -- this table records the rejects core RETURNED.
   'reject|unresolved head fork cannot advance authority sequence': { cells: 5120, projections: 768 },
   stale: { cells: 14336, projections: 1792 },
 };
@@ -108,7 +118,7 @@ export const CORE_VERDICT_TABLE_V1: Readonly<Record<string, CoreVerdictRowV1>> =
  * `projectionKey=>verdict` list.
  */
 export const CORE_VERDICT_TABLE_DIGEST_V1 =
-  'd396cb862bc3b091652db60568683f970d6ba6cbbbb1fb4a98107cf7159d32d8';
+  '7127b2f93a51e07a0473547dcfd7eabf1d8480ad826d8741d829fde2bc9da4f0';
 
 /**
  * WHAT THE TABLE DECIDES, AND THE TWO THINGS THESE NUMBERS DO NOT SAY.
@@ -186,28 +196,39 @@ export const CORE_PROJECTIONS_V1 = 25920;
  *
  * Re-run by authority-verdict-diff-summary-independence-v1.test.ts, which asserts
  * this whole object in ONE comparison -- so a control cannot be quietly dropped.
+ *
+ * THE AFFECTED SET SHRANK AND THAT IS THE GOOD DIRECTION, which is worth saying
+ * because a falling number in a coverage-adjacent pin reads like a loss.
+ * `affected` counts projections naming a summary their head shape CANNOT mint;
+ * closing the sequence-depth boundary made six more shapes mintable, so cells
+ * moved OUT of the affected set and INTO the summary-carrying one --
+ * affectedProjections 9,792 -> 8,064 while summaryCarryingProjections 1,728 ->
+ * 3,456. Fewer cells now rest on the omission argument and more carry a real
+ * minted summary. Both controls still discriminate at their previous strength
+ * (128 of 576 absent-path cells still move), so the equality is no more vacuous
+ * than before.
  */
 export const CORE_SUMMARY_INDEPENDENCE_V1 = {
   /** What rule S1 used to retire. */
-  affectedProjections: 9792,
-  affectedCells: 61920,
+  affectedProjections: 8064,
+  affectedCells: 51552,
   affectedCellsAbsentPath: 864,
-  affectedCellsPresentPath: 61056,
+  affectedCellsPresentPath: 50688,
   /** Foreign summary vs member omitted, over EVERY affected projection. */
-  equalityHeld: 9792,
+  equalityHeld: 8064,
   equalityDiffered: 0,
   equalityThrew: 0,
   /** Control: core DOES read the field here, so the instrument is not blind. */
   absentControlCells: 576,
   absentControlDiffered: 128,
   /** Control: a cell's OWN valid summary is inert across the present region. */
-  presentControlCells: 10368,
+  presentControlCells: 20736,
   presentControlDiffered: 0,
   /** Of the returning cells, how many short-circuit at the clock before anything else. */
-  clockShortCircuitCells: 20640,
+  clockShortCircuitCells: 17184,
   /** Cells and projections whose evidence really does carry a minted summary. */
-  summaryCarryingProjections: 1728,
-  summaryCarryingCells: 10944,
+  summaryCarryingProjections: 3456,
+  summaryCarryingCells: 21312,
 } as const;
 
 /**
@@ -484,8 +505,17 @@ export const CORE_SEQUENCE_DEPTH_CITATIONS_V1: readonly SourceCitationV1[] = [
  *
  * A summary is a WeakSet-branded, factory-only capability, so a cell naming
  * `verifiedAuthoritySummary` receives one only if the closure builder will mint
- * one for that candidate head. Of the 40 buildable shapes, 6 mint and 34 are
+ * one for that candidate head. Of the 40 buildable shapes, 12 mint and 28 are
  * refused.
+ *
+ * THE 'incomplete authority/root lineage' ROW IS GONE, and its absence is the
+ * sequence-depth closure's headline. It carried 12 shapes -- every candidate at
+ * an authority sequence other than the current one -- because each named the
+ * same 1->2 transition and the same predecessor whatever sequence it claimed.
+ * Six of those twelve now MINT and six moved to refusals that ARE the system's:
+ * three to the accepted-transition binding and three to the resolving-successor
+ * lineage check. A row leaving this census is the strongest available evidence
+ * that a boundary closed rather than moved.
  *
  * WHAT THIS ROW NO LONGER MEANS: it used to be quoted as the cause of a
  * 61,920-cell retirement. It is not a retirement of anything now. The 34
@@ -507,13 +537,12 @@ export const CORE_SEQUENCE_DEPTH_CITATIONS_V1: readonly SourceCitationV1[] = [
  * THAT is the property the suite asserts -- not the wording of any one message.
  */
 export const CORE_SUMMARY_MINT_OUTCOMES_V1: Readonly<Record<string, number>> = {
-  MINTED: 6,
-  '[system-record-closure] resolving successor changed accepted-transition lineage': 6,
+  MINTED: 12,
+  '[system-record-closure] resolving successor changed accepted-transition lineage': 9,
   '[system-record-closure] verification closure contains authority-transition equivocation': 6,
   '[system-record-closure] tombstone predecessor is not the exact prior active authority state': 3,
   '[system-record-closure] head <digest> does not directly bind its fork resolution': 4,
-  '[system-record-closure] head <digest> does not bind its accepted authority transition': 3,
-  '[system-record-history] head <digest> has incomplete authority/root lineage': 12,
+  '[system-record-closure] head <digest> does not bind its accepted authority transition': 6,
 };
 
 /** Buildable candidate head shapes; the mint memoises on this, not on the cell. */
@@ -620,7 +649,61 @@ export const CORE_SWEEP_FINDINGS_V1: readonly string[] = [
   + 'candidate version falls to its default and cannot clear the version threshold at '
   + 'any chain depth. Filed as its own follow-up with these measurements rather than '
   + 'folded into the sequence-depth work, because it is a distinct mechanism at a '
-  + 'distinct site and the Phase-3 routing coupling does not rest on it.',
+  + 'distinct site and the Phase-3 routing coupling does not rest on it.'
+  + ' '
+  + 'EQUAL OUTCOMES FROM UNEQUAL MACHINERY, and this is the Phase-3-relevant '
+  + 'half of what the closure buys. The three sequence relations are NOT alike '
+  + 'in comparison value, and the ranking is the reverse of their cell counts. '
+  + 'At D=below and D=abovePlusOne storage answers by a FLAT RULE on the '
+  + 'sequence number alone -- `candidateSequence < currentSequence` returns '
+  + 'stale, `> currentSequence + 1n` defers -- while core runs a RICH BRANCH on '
+  + 'both, indexing lineage[candidateSequence] and comparing transition fields '
+  + 'one by one at :274. The outcomes AGREE; the work does not. That matters '
+  + 'because routing the live path through core replaces the flat rule with the '
+  + 'rich one, so agreement measured today is agreement between a cheap check '
+  + 'and an expensive one, and only the expensive one survives the route. '
+  + 'D=plusOne is the discriminating comparison -- the only relation where BOTH '
+  + 'sides do real work, core at its next-sequence branch (:318) and storage at '
+  + "its tail checks on the summary's lineage, its "
+  + 'lastAuthorityTransitionPriorHeadDigest and its root-history arithmetic -- '
+  + 'which is consistent with the Phase-3 coupling having been placed on '
+  + 'plusOne alone.',
+
+  // AXIS DENOTATION, not a count. Filed because a committed axis's MEANING was
+  // generalised, and a meaning that changes without a record is the kind of
+  // thing a later reader reconstructs wrongly from the builder.
+  'AXIS G IS SEQUENCE-RELATIVE, RULED RATHER THAN ASSUMED. Closing the '
+  + "sequence-depth boundary forced a choice about what axis G means away from "
+  + "D='equal', because a well-formed candidate at another authority sequence "
+  + 'MUST name the rotation into its own sequence -- naming the current head\'s '
+  + '1->2 transition at sequence 3 is precisely the malformation that boundary '
+  + 'work removed. Two readings were available: LITERAL (compared to the current '
+  + "head's digest, full stop, which makes G='equal' unconstructible off "
+  + "D='equal' and returns half the newly-comparable cells to retirement) and "
+  + 'SEQUENCE-RELATIVE (\'equal\' names the accepted rotation into the '
+  + "candidate's own sequence, 'differ' a competing one). THE SEQUENCE-RELATIVE "
+  + 'READING WAS ADOPTED, adjudicated 2026-08-12 rather than settled by the '
+  + 'implementer, because generalising a reviewed axis is not a call the builder '
+  + 'gets to make for itself. '
+  + 'THE GROUND IS SYSTEM RESPONSIVENESS, WHICH IS EVIDENCE RATHER THAN '
+  + "PREFERENCE: at the sequence-relative shapes G='differ' fires "
+  + "'[system-record-closure] verification closure contains "
+  + "authority-transition equivocation' -- 6 of the 40 buildable head shapes in "
+  + 'CORE_SUMMARY_MINT_OUTCOMES_V1 -- so the outcome MOVES on the axis, which is '
+  + 'what makes an axis live rather than enumerated. Supporting: equivocation is '
+  + 'defined at its source as two transitions out of the same prior head into '
+  + 'the same sequence, a sequence-relative notion where it is SPECIFIED and not '
+  + 'merely where this fixture reads it. Against the literal reading and '
+  + 'decisive: it would require a G=\'equal\' candidate off D=\'equal\' to name a '
+  + 'rotation into somewhere other than its own sequence -- a head this fixture '
+  + "authored to be malformed, refusing in the system's own wording, which is "
+  + 'the manufactured-retirement class this slice exists to remove. '
+  + 'SCOPE, because this claim is exactly the kind that gets widened: the '
+  + 'generalisation is about AXIS G ONLY. It says nothing about axes D, E or F, '
+  + 'whose relations remain against the current head. The older reading is not '
+  + "wrong, it is the SPECIAL CASE at D='equal', and the core-heads suite pins "
+  + 'that column on the two original constants byte for byte rather than '
+  + 'inheriting it from the general rule.',
 
   // CONDITION-3 FINDING. Filed on its own rather than folded into the counts,
   // because it is a routing hazard and a statistic absorbed into a total is not

--- a/packages/storage/test/helpers/authority-verdict-diff-core-table-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-core-table-v1.ts
@@ -80,7 +80,7 @@ export const CORE_VERDICT_TABLE_V1: Readonly<Record<string, CoreVerdictRowV1>> =
   'REFUSED|F1-digest-equality-forces-the-current-state': { cells: 4608, projections: 1152 },
   'REFUSED|F2-digest-equality-forces-the-current-transition-digest': { cells: 9216, projections: 1152 },
   'REFUSED|F3-digest-equality-forces-the-current-fork-resolution-absence': { cells: 4608, projections: 576 },
-  accept: { cells: 3200, projections: 576 },
+  accept: { cells: 3456, projections: 640 },
   'quarantine|head-fork': { cells: 4096, projections: 512 },
   'quarantine|transition-equivocation': { cells: 47104, projections: 7040 },
   'reject|absent state cannot retain authority history or quarantine': { cells: 1280, projections: 768 },
@@ -91,18 +91,15 @@ export const CORE_VERDICT_TABLE_V1: Readonly<Record<string, CoreVerdictRowV1>> =
   'reject|head issuedAt exceeds the future clock-skew bound': { cells: 48576, projections: 7680 },
   'reject|historical or unsolicited fork resolution is audit-only': { cells: 1024, projections: 128 },
   'reject|late tombstone lacks its exact verified active predecessor': { cells: 1536, projections: 384 },
-  // THESE TWO TOMBSTONE ROWS BOTH MOVED, AND THE INTERMEDIATE STATE WAS WRONG
-  // ABOUT BOTH -- worth recording because it is what a reason-level pin buys.
-  // While the fixture handed sequence-ahead candidates the WRONG accepted
-  // transition, the next-sequence row vanished entirely and the resurrection row
-  // sat at 256/64, and that looked like a clean same-count-different-reason
-  // substitution. It was not: the wrong transition was short-circuiting core
-  // before it reached the same-sequence predecessor check. With the transition
-  // the candidate actually names, the next-sequence row is BACK at its original
-  // 256/64 and the resurrection row doubles to 512/128. A cell-count pin would
-  // have read the intermediate state as a tidy swap; only the reasons showed a
-  // branch had gone unreached.
-  'reject|late tombstone requires the exact retained resurrection transition': { cells: 512, projections: 128 },
+  // THIS ROW WENT 192 -> 384 -> 192 ACROSS THREE EVIDENCE RULES, and the middle
+  // value was a regression this fixture authored and then explained as a result.
+  // Under sequence-keyed selection a lower-sequence tombstone was handed the
+  // rotation INTO its sequence, while core's lower-sequence arm demands
+  // lineage[candidateSequence] -- the rotation OUT of it -- so the fixture
+  // manufactured this refusal and doubled the row. Branch-keyed selection
+  // restores it. A number returning to where it started is the cleanest possible
+  // evidence that what moved it was never the system.
+  'reject|late tombstone requires the exact retained resurrection transition': { cells: 256, projections: 64 },
   // NEW ROW, and the table has never carried this reason before. A G='differ'
   // candidate names a competing rotation to a wallet root its own head does not
   // carry, so core refuses at the next-sequence issuer/root binding. It only
@@ -132,7 +129,7 @@ export const CORE_VERDICT_TABLE_V1: Readonly<Record<string, CoreVerdictRowV1>> =
  * `projectionKey=>verdict` list.
  */
 export const CORE_VERDICT_TABLE_DIGEST_V1 =
-  'fbad4f37a8b7f062a28affece30672eddd75ad33ef845adaefc3c84afec5e2e3';
+  '93898e323d6a17e63ea36b2d1584b496bf42391f2de4f8007cade88924917a9e';
 
 /**
  * WHAT THE TABLE DECIDES, AND THE TWO THINGS THESE NUMBERS DO NOT SAY.
@@ -188,7 +185,7 @@ export const CORE_PROJECTIONS_V1 = 25920;
  * space. Those cells are now driven with the member OMITTED, which is the only
  * evidence object a real caller holding such a head could assemble. The claim
  * that this does not move a verdict is EXHAUSTIVE over the affected set, not
- * sampled: every one of the 9,792 affected projections was driven twice, once
+ * sampled: every one of the 8,064 affected projections was driven twice, once
  * with a summary minted for a DIFFERENT head and once with the member absent.
  * Exhaustive over the affected set dominates any per-branch sample, and a branch
  * no affected cell reaches cannot be relevant to this change by construction.

--- a/packages/storage/test/helpers/authority-verdict-diff-core-table-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-core-table-v1.ts
@@ -87,7 +87,7 @@ export const CORE_VERDICT_TABLE_V1: Readonly<Record<string, CoreVerdictRowV1>> =
   'reject|authority history is incomplete': { cells: 10240, projections: 1536 },
   'reject|cold noninitial head requires its verified authority closure': { cells: 512, projections: 320 },
   'reject|current frontier fork requires its exact direct resolving successor': { cells: 2048, projections: 256 },
-  'reject|exact accepted authority transition is missing': { cells: 3840, projections: 576 },
+  'reject|exact accepted authority transition is missing': { cells: 2560, projections: 384 },
   'reject|head issuedAt exceeds the future clock-skew bound': { cells: 48576, projections: 7680 },
   'reject|historical or unsolicited fork resolution is audit-only': { cells: 1024, projections: 128 },
   'reject|late tombstone lacks its exact verified active predecessor': { cells: 1536, projections: 384 },
@@ -103,7 +103,15 @@ export const CORE_VERDICT_TABLE_V1: Readonly<Record<string, CoreVerdictRowV1>> =
   // have read the intermediate state as a tidy swap; only the reasons showed a
   // branch had gone unreached.
   'reject|late tombstone requires the exact retained resurrection transition': { cells: 512, projections: 128 },
-  'reject|next-sequence tombstone requires its exact same-sequence active predecessor': { cells: 256, projections: 64 },
+  // NEW ROW, and the table has never carried this reason before. A G='differ'
+  // candidate names a competing rotation to a wallet root its own head does not
+  // carry, so core refuses at the next-sequence issuer/root binding. It only
+  // became reachable once the evidence layer stopped handing G='differ'
+  // candidates the REAL rotation -- the mismatch was short-circuiting core at
+  // 'exact accepted authority transition is missing' before this check ran,
+  // which is why that row drops 3,840 -> 2,560 as this one appears.
+  'reject|next-sequence head does not bind transition issuer/root': { cells: 1024, projections: 128 },
+  'reject|next-sequence tombstone requires its exact same-sequence active predecessor': { cells: 512, projections: 128 },
   'reject|tombstone lacks its exact verified active predecessor': { cells: 2048, projections: 512 },
   // 'reject|transition does not bind the accepted predecessor' (1,024 / 128) is
   // GONE. It fired when a candidate named a transition whose prior head was not
@@ -124,7 +132,7 @@ export const CORE_VERDICT_TABLE_V1: Readonly<Record<string, CoreVerdictRowV1>> =
  * `projectionKey=>verdict` list.
  */
 export const CORE_VERDICT_TABLE_DIGEST_V1 =
-  '1d977f97a5b00f060a12ac894699040bdf147a8ab87249f47b0178c3f16d166f';
+  'fbad4f37a8b7f062a28affece30672eddd75ad33ef845adaefc3c84afec5e2e3';
 
 /**
  * WHAT THE TABLE DECIDES, AND THE TWO THINGS THESE NUMBERS DO NOT SAY.
@@ -479,7 +487,7 @@ export const CORE_SUMMARY_ASYMMETRY_CITATIONS_V1: readonly SourceCitationV1[] = 
 export const CORE_SEQUENCE_DEPTH_CITATIONS_V1: readonly SourceCitationV1[] = [
   {
     id: 'candidate-selects-the-lineage-of-its-own-sequence',
-    site: 'packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts:495',
+    site: 'packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts:511',
     contains: 'const lineageHead = coreSequenceActiveHeadV1(String(sequence));',
     why: 'Axis D now selects the head its candidate descends from, which carries the '
       + 'issuer, root subject, owned-subject table digest and accepted transition that '
@@ -487,7 +495,7 @@ export const CORE_SEQUENCE_DEPTH_CITATIONS_V1: readonly SourceCitationV1[] = [
   },
   {
     id: 'candidate-descends-from-the-head-at-its-own-sequence',
-    site: 'packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts:508',
+    site: 'packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts:524',
     contains: 'previousHeadDigest: SEQUENCE_PREDECESSOR_DIGESTS_V1.get(String(sequence))',
     why: 'The predecessor is the digest of that same head rather than the pinned '
       + 'sequence-2 current head, so a sequence-1 candidate no longer claims a '

--- a/packages/storage/test/helpers/authority-verdict-diff-core-table-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-core-table-v1.ts
@@ -80,24 +80,30 @@ export const CORE_VERDICT_TABLE_V1: Readonly<Record<string, CoreVerdictRowV1>> =
   'REFUSED|F1-digest-equality-forces-the-current-state': { cells: 4608, projections: 1152 },
   'REFUSED|F2-digest-equality-forces-the-current-transition-digest': { cells: 9216, projections: 1152 },
   'REFUSED|F3-digest-equality-forces-the-current-fork-resolution-absence': { cells: 4608, projections: 576 },
-  accept: { cells: 2432, projections: 512 },
+  accept: { cells: 3200, projections: 576 },
   'quarantine|head-fork': { cells: 4096, projections: 512 },
   'quarantine|transition-equivocation': { cells: 47104, projections: 7040 },
   'reject|absent state cannot retain authority history or quarantine': { cells: 1280, projections: 768 },
   'reject|authority history is incomplete': { cells: 10240, projections: 1536 },
   'reject|cold noninitial head requires its verified authority closure': { cells: 512, projections: 320 },
   'reject|current frontier fork requires its exact direct resolving successor': { cells: 2048, projections: 256 },
-  'reject|exact accepted authority transition is missing': { cells: 5120, projections: 768 },
+  'reject|exact accepted authority transition is missing': { cells: 3840, projections: 576 },
   'reject|head issuedAt exceeds the future clock-skew bound': { cells: 48576, projections: 7680 },
   'reject|historical or unsolicited fork resolution is audit-only': { cells: 1024, projections: 128 },
   'reject|late tombstone lacks its exact verified active predecessor': { cells: 1536, projections: 384 },
-  // REPLACES 'next-sequence tombstone requires its exact same-sequence active
-  // predecessor' at the same 256/64. A tombstone candidate one sequence ahead
-  // now carries the real rotation into its own sequence, so core reaches it
-  // through the RESURRECTION branch rather than refusing it for a predecessor at
-  // the wrong sequence. Same cells, different reason -- which is the shape a
-  // reason-level pin exists to catch.
-  'reject|late tombstone requires the exact retained resurrection transition': { cells: 256, projections: 64 },
+  // THESE TWO TOMBSTONE ROWS BOTH MOVED, AND THE INTERMEDIATE STATE WAS WRONG
+  // ABOUT BOTH -- worth recording because it is what a reason-level pin buys.
+  // While the fixture handed sequence-ahead candidates the WRONG accepted
+  // transition, the next-sequence row vanished entirely and the resurrection row
+  // sat at 256/64, and that looked like a clean same-count-different-reason
+  // substitution. It was not: the wrong transition was short-circuiting core
+  // before it reached the same-sequence predecessor check. With the transition
+  // the candidate actually names, the next-sequence row is BACK at its original
+  // 256/64 and the resurrection row doubles to 512/128. A cell-count pin would
+  // have read the intermediate state as a tidy swap; only the reasons showed a
+  // branch had gone unreached.
+  'reject|late tombstone requires the exact retained resurrection transition': { cells: 512, projections: 128 },
+  'reject|next-sequence tombstone requires its exact same-sequence active predecessor': { cells: 256, projections: 64 },
   'reject|tombstone lacks its exact verified active predecessor': { cells: 2048, projections: 512 },
   // 'reject|transition does not bind the accepted predecessor' (1,024 / 128) is
   // GONE. It fired when a candidate named a transition whose prior head was not
@@ -118,7 +124,7 @@ export const CORE_VERDICT_TABLE_V1: Readonly<Record<string, CoreVerdictRowV1>> =
  * `projectionKey=>verdict` list.
  */
 export const CORE_VERDICT_TABLE_DIGEST_V1 =
-  '7127b2f93a51e07a0473547dcfd7eabf1d8480ad826d8741d829fde2bc9da4f0';
+  '1d977f97a5b00f060a12ac894699040bdf147a8ab87249f47b0178c3f16d166f';
 
 /**
  * WHAT THE TABLE DECIDES, AND THE TWO THINGS THESE NUMBERS DO NOT SAY.
@@ -473,7 +479,7 @@ export const CORE_SUMMARY_ASYMMETRY_CITATIONS_V1: readonly SourceCitationV1[] = 
 export const CORE_SEQUENCE_DEPTH_CITATIONS_V1: readonly SourceCitationV1[] = [
   {
     id: 'candidate-selects-the-lineage-of-its-own-sequence',
-    site: 'packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts:384',
+    site: 'packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts:495',
     contains: 'const lineageHead = coreSequenceActiveHeadV1(String(sequence));',
     why: 'Axis D now selects the head its candidate descends from, which carries the '
       + 'issuer, root subject, owned-subject table digest and accepted transition that '
@@ -481,11 +487,13 @@ export const CORE_SEQUENCE_DEPTH_CITATIONS_V1: readonly SourceCitationV1[] = [
   },
   {
     id: 'candidate-descends-from-the-head-at-its-own-sequence',
-    site: 'packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts:399',
-    contains: 'previousHeadDigest: computeAgentProfileHeadObjectDigestV1(lineageHead),',
-    why: 'The predecessor is derived from that same head rather than pinned to the '
+    site: 'packages/storage/test/helpers/authority-verdict-diff-core-heads-v1.ts:508',
+    contains: 'previousHeadDigest: SEQUENCE_PREDECESSOR_DIGESTS_V1.get(String(sequence))',
+    why: 'The predecessor is the digest of that same head rather than the pinned '
       + 'sequence-2 current head, so a sequence-1 candidate no longer claims a '
-      + 'predecessor ABOVE itself and a sequence-3 one no longer skips its own.',
+      + 'predecessor ABOVE itself and a sequence-3 one no longer skips its own. '
+      + 'Precomputed per sequence rather than hashed per build: hashing here cost '
+      + 'roughly 145,000 digests and pushed this lane past its CI budget.',
   },
   {
     id: 'the-future-rotates-off-the-current-head-not-off-the-ancestry',

--- a/packages/storage/test/helpers/authority-verdict-diff-fixture-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-fixture-v1.ts
@@ -158,6 +158,34 @@ export const VERDICT_DIFF_AXES_V1 = {
   D_sequenceRelation: ['below', 'equal', 'plusOne', 'abovePlusOne'],
   E_versionRelation: ['below', 'equal', 'above'],
   F_headDigest: ['equal', 'differ'],
+  /**
+   * AXIS G IS SEQUENCE-RELATIVE, and this is the axis's denotation rather than a
+   * note about one builder. 'equal' means the candidate names the ACCEPTED
+   * rotation into ITS OWN authority sequence; 'differ' means it names a
+   * COMPETING rotation into that same sequence.
+   *
+   * THE OLDER READING IS THE SPECIAL CASE, NOT A RIVAL. Until axis D gained
+   * per-sequence lineage every candidate sat at the current sequence, where the
+   * accepted rotation IS the current head's -- so "compared to the current
+   * head's acceptedTransitionDigest" and the rule above are the same statement
+   * in that column, and the core-heads suite asserts the D='equal' column still
+   * lands on exactly the two constants it always did.
+   *
+   * WHY THE GENERAL FORM IS THE RIGHT ONE, ruled 2026-08-12 on three grounds.
+   * The decisive one is that the SYSTEM responds to it: at the sequence-relative
+   * shapes G='differ' fires '[system-record-closure] verification closure
+   * contains authority-transition equivocation', so the outcome moves on the
+   * axis, which is what makes an axis live -- 6 of the 40 buildable head shapes
+   * refuse that way in CORE_SUMMARY_MINT_OUTCOMES_V1. Second, equivocation is
+   * DEFINED at the source as two transitions out of the same prior head into the
+   * same sequence, so the notion is sequence-relative where it is specified, not
+   * where this fixture reads it. Third, and decisive against the literal
+   * reading: taken literally, a G='equal' candidate off D='equal' would have to
+   * name a rotation into somewhere other than its own sequence -- a head this
+   * fixture authored to be malformed, refusing in the system's wording. That is
+   * exactly the manufactured-retirement class this slice exists to remove, so
+   * the literal reading would re-create it by definition.
+   */
   G_acceptedTransitionDigest: ['equal', 'differ'],
   H_storageOperation: ['active', 'tombstone', 'quarantine'],
   I_coreDisposition: [

--- a/packages/storage/test/helpers/authority-verdict-diff-join-table-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-join-table-v1.ts
@@ -33,7 +33,7 @@
  * itself the signal.
  */
 export const JOIN_PINNED_AGAINST_CORE_DIGEST_V1 =
-  'd396cb862bc3b091652db60568683f970d6ba6cbbbb1fb4a98107cf7159d32d8';
+  '7127b2f93a51e07a0473547dcfd7eabf1d8480ad826d8741d829fde2bc9da4f0';
 
 /**
  * THE FOUR-BUCKET PARTITION.
@@ -41,10 +41,29 @@ export const JOIN_PINNED_AGAINST_CORE_DIGEST_V1 =
  * `storageProjections` is pinned beside `cells` because they move
  * independently and the second is a cross-check on the first: every storage
  * projection covers EXACTLY 192 cells (min AND max, asserted upstream), so
- * 114/645/96 times 192 must reproduce these cell counts to the unit. A change
+ * 222/537/96 times 192 must reproduce these cell counts to the unit. A change
  * that moved cells without moving projections would be a projection key that
  * stopped discriminating; a change that moved projections without moving cells
  * would be the fixture growing. Neither can hide behind the other.
+ *
+ * THIS PARTITION WAS DERIVED BY HAND BEFORE THE RUN THAT CONFIRMED IT, and the
+ * derivation is the reason these numbers are trustworthy rather than merely
+ * observed. Per mintable head shape the covering projections are B x L x H,
+ * with H constrained by the surviving (C,H,K) triples: 4x3x2 = 24 projections
+ * for a present active candidate, 4x3x1 = 12 for a present tombstone, 1x3x2 = 6
+ * in the absent region where axis B does not apply. Twelve mintable shapes give
+ * 222 projections and 42,624 cells; the same derivation reproduces the PREVIOUS
+ * pin exactly from the previous six shapes (114 and 21,888), which is what
+ * earns it the right to predict the new one.
+ *
+ * IT ALSO CAUGHT A DEFECT THE RUN COULD NOT. An earlier run returned COMPARABLE
+ * 35,712 / 186 -- internally consistent, conserving perfectly against 164,160,
+ * every bucket summing. It disagreed with this derivation by exactly 6,912 cells
+ * and 36 projections, which factors as three tombstone shapes x 12 x 192, and
+ * that gap was a real defect: the storage minter was still building tombstone
+ * closures against the current head. Conservation is a CONSISTENCY check, not a
+ * correctness check, and only an independently derived count can tell the two
+ * apart.
  */
 export interface JoinBucketRowV1 {
   readonly cells: number;
@@ -52,8 +71,8 @@ export interface JoinBucketRowV1 {
 }
 
 export const JOIN_PARTITION_V1: Readonly<Record<string, JoinBucketRowV1>> = {
-  COMPARABLE: { cells: 21_888, storageProjections: 114 },
-  'CORE-ONLY': { cells: 123_840, storageProjections: 645 },
+  COMPARABLE: { cells: 42_624, storageProjections: 222 },
+  'CORE-ONLY': { cells: 103_104, storageProjections: 537 },
   'NO-HEAD': { cells: 18_432, storageProjections: 96 },
 };
 
@@ -84,8 +103,8 @@ export interface JoinCoreOnlySplitRowV1 {
 }
 
 export const JOIN_CORE_ONLY_SPLIT_V1: Readonly<Record<string, JoinCoreOnlySplitRowV1>> = {
-  'namesSummary=false': { cells: 61_920, coreSide: 'decided' },
-  'namesSummary=true': { cells: 61_920, coreSide: 'decided' },
+  'namesSummary=false': { cells: 51_552, coreSide: 'decided' },
+  'namesSummary=true': { cells: 51_552, coreSide: 'decided' },
 };
 
 /** The join's own unit: one row per distinct (core projection, storage projection). */
@@ -104,7 +123,7 @@ export const JOIN_ROWS_V1 = 164_160;
  * ships green.
  */
 export const JOIN_TABLE_DIGEST_V1 =
-  'edc66a0acc2d10bbc30e0bea2df54620441dcc9b27426829239f8200d96cbb8b';
+  '7763d665d54bac3623d3bb4b3fe300f5871368ae3bd2622a75d0b5931c7f4037';
 
 /**
  * THE HEADLINE, and the two numbers it carries are deliberately of different
@@ -115,14 +134,20 @@ export const JOIN_TABLE_DIGEST_V1 =
  * this headline describe the fixture's cardinality instead of the behaviour.
  */
 export const JOIN_VERDICT_TOTALS_V1: Readonly<Record<string, number>> = {
-  AGREEMENT: 4736,
-  DIVERGENCE: 3136,
-  'NO-MAPPING': 1920,
-  'NOT-COMPARABLE': 154_368,
+  AGREEMENT: 11_264,
+  DIVERGENCE: 4672,
+  'NO-MAPPING': 4224,
+  'NOT-COMPARABLE': 144_000,
 };
 
 export const JOIN_SEMANTICS_CHANGING_ENTRIES_V1 = 4;
-export const JOIN_ADJUDICATED_CELLS_V1 = 9792;
+/**
+ * COMPARABLE minus the cells storage answers from the applied row before it
+ * reads the candidate: 42,624 - 22,464 = 20,160, which is also the
+ * `shortCircuit=false` half of JOIN_PRECONDITION_DISCRIMINATION_V1. The two are
+ * computed by different code paths and must agree.
+ */
+export const JOIN_ADJUDICATED_CELLS_V1 = 20_160;
 
 /**
  * NON-COMPARABILITY IS ALWAYS NAMED. An unnamed one is indistinguishable from a
@@ -130,10 +155,10 @@ export const JOIN_ADJUDICATED_CELLS_V1 = 9792;
  * this whole join turns on rather than an exclusion.
  */
 export const JOIN_NOT_COMPARABLE_CAUSE_TOTALS_V1: Readonly<Record<string, number>> = {
-  'storage-requires-a-verified-authority-summary-this-head-cannot-mint': 123_840,
+  'storage-requires-a-verified-authority-summary-this-head-cannot-mint': 103_104,
   'no-candidate-head-exists-because-the-system-forbids-the-input': 9216,
   'no-candidate-head-because-this-fixture-cannot-build-the-referent': 9216,
-  'storage-answered-from-the-applied-row-without-reading-the-candidate': 12_096,
+  'storage-answered-from-the-applied-row-without-reading-the-candidate': 22_464,
 };
 
 /**
@@ -158,8 +183,8 @@ export const JOIN_NO_HEAD_SPLIT_V1: Readonly<Record<string, number>> = {
  * third key here.
  */
 export const JOIN_PRECONDITION_DISCRIMINATION_V1: Readonly<Record<string, number>> = {
-  'shortCircuit=false isNonActiveState=false': 9792,
-  'shortCircuit=true isNonActiveState=true': 12_096,
+  'shortCircuit=false isNonActiveState=false': 20_160,
+  'shortCircuit=true isNonActiveState=true': 22_464,
 };
 
 /** Every adjudicated row, keyed `verdict coreDecisionKey -> storageLabel`. */
@@ -167,16 +192,24 @@ export const JOIN_LEVEL1_TABLE_V1: Readonly<Record<string, number>> = {
   'AGREEMENT accept -> ready': 1280,
   'AGREEMENT quarantine|head-fork -> deferred|authority-fork': 768,
   'AGREEMENT reject -> deferred|authority-fork': 576,
-  'AGREEMENT reject -> stale': 576,
+  // The sequence-depth closure's own row: core rejects a two-ahead candidate,
+  // storage defers it, both from the sequence arithmetic alone.
+  'AGREEMENT reject -> deferred|authority-history-mismatch': 4032,
+  'AGREEMENT reject -> stale': 2304,
   'AGREEMENT stale -> already-applied': 256,
   'AGREEMENT stale -> ready': 512,
-  'AGREEMENT stale -> stale': 768,
+  'AGREEMENT stale -> stale': 1536,
+  // THE DIVERGENCE RUNNING THE OTHER WAY. Every other divergence in this table
+  // is storage materialising a head core refuses; this one is core ACCEPTING an
+  // advance storage declines to materialise.
+  'DIVERGENCE accept -> stale': 192,
   'DIVERGENCE reject -> already-applied': 192,
-  'DIVERGENCE reject -> ready': 2944,
+  'DIVERGENCE reject -> ready': 4288,
   'NO-MAPPING quarantine|transition-equivocation -> already-applied': 128,
   'NO-MAPPING quarantine|transition-equivocation -> deferred|authority-fork': 384,
-  'NO-MAPPING quarantine|transition-equivocation -> ready': 1024,
-  'NO-MAPPING quarantine|transition-equivocation -> stale': 384,
+  'NO-MAPPING quarantine|transition-equivocation -> deferred|authority-history-mismatch': 1152,
+  'NO-MAPPING quarantine|transition-equivocation -> ready': 1408,
+  'NO-MAPPING quarantine|transition-equivocation -> stale': 1152,
 };
 
 /**
@@ -197,13 +230,13 @@ export interface JoinLevel1EntryCountsV1 {
 
 export const JOIN_LEVEL1_PER_ENTRY_V1: Readonly<Record<string, JoinLevel1EntryCountsV1>> = {
   accept: {
-    cells: 1280,
+    cells: 1472,
     members: { ready: 1280, 'already-applied': 0 },
   },
   stale: {
-    cells: 1536,
+    cells: 2304,
     members: {
-      stale: 768,
+      stale: 1536,
       'already-applied': 256,
       ready: 512,
       'deferred|verified-state-mismatch': 0,
@@ -214,17 +247,17 @@ export const JOIN_LEVEL1_PER_ENTRY_V1: Readonly<Record<string, JoinLevel1EntryCo
     members: { 'deferred|authority-fork': 768 },
   },
   'quarantine|transition-equivocation': {
-    cells: 1920,
+    cells: 4224,
     members: {},
   },
   reject: {
-    cells: 4288,
+    cells: 11_392,
     members: {
-      stale: 576,
+      stale: 2304,
       'root-collision': 0,
       'deferred|non-active-state': 0,
       'deferred|authority-fork': 576,
-      'deferred|authority-history-mismatch': 0,
+      'deferred|authority-history-mismatch': 4032,
       'deferred|verified-state-mismatch': 0,
       'deferred|root-state-changed': 0,
       'capacity-exhausted|state-revision-overflow': 0,
@@ -240,16 +273,38 @@ export const JOIN_LEVEL1_PER_ENTRY_V1: Readonly<Record<string, JoinLevel1EntryCo
  * EVERY DIVERGENCE, WITH BOTH SIDES VERBATIM. This is the actionable table: it
  * is what changes if Phase 3 routes the live path through core.
  *
- * Read it as one sentence: STORAGE MATERIALISES HEADS CORE REFUSES. Two thirds
- * of it is one cause -- core's future clock-skew gate against a storage
- * classifier that takes no clock at all.
+ * IT NO LONGER READS AS ONE SENTENCE, and the correction matters more than the
+ * growth. It used to be entirely "STORAGE MATERIALISES HEADS CORE REFUSES" --
+ * every row a `reject -> ready`-shaped violation of the withholding-only image,
+ * two thirds of it core's future clock-skew gate against a clock-blind storage
+ * classifier. That direction is still the bulk, and it grew from 3,136 cells to
+ * 4,672 as the sequence-relative region became comparable.
+ *
+ * BUT THE SEQUENCE-DEPTH CLOSURE EXPOSED A DIVERGENCE RUNNING THE OTHER WAY:
+ * `accept -> stale`, 192 cells, where CORE ACCEPTS an advance and STORAGE
+ * DECLINES TO MATERIALISE it. Every previously known divergence had core
+ * refusing and storage proceeding, which is why the headline could be stated as
+ * one sentence; this one inverts the roles. It was unreachable while the
+ * sequence-relative candidates could not mint, so it is not a regression -- it
+ * is a cell that had no observation before.
+ *
+ * WHY THAT ASYMMETRY MATTERS TO PHASE 3 SPECIFICALLY: the two directions carry
+ * OPPOSITE routing risks. Storage-materialises-what-core-refuses is a SAFETY
+ * gap that routing through core would CLOSE. Core-accepts-what-storage-refuses
+ * is the reverse -- routing through core would newly ADMIT these cells, so the
+ * route does not merely tighten. A reader who took the old one-sentence headline
+ * into the routing decision would have carried exactly the wrong prior about
+ * which way the change cuts.
  */
 export const JOIN_DIVERGENCES_V1: Readonly<Record<string, number>> = {
-  'reject|head issuedAt exceeds the future clock-skew bound -> ready': 1920,
+  'accept -> stale': 192,
+  'reject|head issuedAt exceeds the future clock-skew bound -> ready': 2496,
   'reject|head issuedAt exceeds the future clock-skew bound -> already-applied': 192,
   'reject|absent state cannot retain authority history or quarantine -> ready': 512,
   'reject|current frontier fork requires its exact direct resolving successor -> ready': 384,
   'reject|cold noninitial head requires its verified authority closure -> ready': 128,
+  'reject|exact accepted authority transition is missing -> ready': 384,
+  'reject|unresolved head fork cannot advance authority sequence -> ready': 384,
 };
 
 /**
@@ -263,15 +318,27 @@ export const JOIN_DIVERGENCES_V1: Readonly<Record<string, number>> = {
  * three variants that carry no reason field at all.
  */
 export const JOIN_LEVEL2_REASON_PAIRS_V1: Readonly<Record<string, number>> = {
-  '<none> :: <none>': 2816,
+  '<none> :: <none>': 3776,
   'absent state cannot retain authority history or quarantine :: <none>': 512,
+  // THE PAIR THE SEQUENCE-DEPTH CLOSURE EXISTS TO PRODUCE: a candidate two
+  // authority sequences ahead, refused by core and deferred by storage, both
+  // from the sequence arithmetic alone and both on input the other side accepts.
+  'authority history is incomplete :: authority-history-mismatch': 1536,
   'cold noninitial head requires its verified authority closure :: <none>': 128,
   'current frontier fork requires its exact direct resolving successor :: <none>': 384,
-  'head issuedAt exceeds the future clock-skew bound :: <none>': 2688,
+  'exact accepted authority transition is missing :: <none>': 384,
+  'exact accepted authority transition is missing :: authority-history-mismatch': 384,
+  'head issuedAt exceeds the future clock-skew bound :: <none>': 4416,
   'head issuedAt exceeds the future clock-skew bound :: authority-fork': 576,
+  'head issuedAt exceeds the future clock-skew bound :: authority-history-mismatch': 1728,
   'head-fork :: authority-fork': 768,
-  'transition-equivocation :: <none>': 1536,
+  'late tombstone lacks its exact verified active predecessor :: <none>': 384,
+  'late tombstone requires the exact retained resurrection transition :: <none>': 192,
+  'transition-equivocation :: <none>': 2688,
   'transition-equivocation :: authority-fork': 384,
+  'transition-equivocation :: authority-history-mismatch': 1152,
+  'unresolved head fork cannot advance authority sequence :: <none>': 384,
+  'unresolved head fork cannot advance authority sequence :: authority-history-mismatch': 384,
 };
 
 /**
@@ -290,25 +357,40 @@ export const JOIN_STALE_ROUTES_V1: Readonly<Record<string, number>> = {
   'identical-head:core:199 -> NOT-COMPARABLE(applied-row-short-circuit)': 1280,
   'lower-version:core:196 -> stale': 768,
   'lower-version:core:196 -> NOT-COMPARABLE(applied-row-short-circuit)': 1280,
+  // A THIRD SUB-CAUSE, reachable only since the sequence-depth closure. Core
+  // reaches `stale` from the LOWER-SEQUENCE branch (:274) as well as from the
+  // lower-version one, and storage answers it with the same flat `stale`. Its
+  // counts mirror lower-version exactly -- 768 routed, 1,280 short-circuited --
+  // which is the axis arithmetic, not a coincidence: both relations occupy one
+  // axis-D value and differ only in which relation the cell names.
+  'lower-sequence -> stale': 768,
+  'lower-sequence -> NOT-COMPARABLE(applied-row-short-circuit)': 1280,
 };
 
 /**
  * STORAGE'S FULL LEVEL-1 CODOMAIN AND WHAT THE DIFF ACTUALLY REACHED.
  *
- * NINE OF FOURTEEN LABELS ARE ZERO, and they are pinned AS zero rather than
+ * EIGHT OF FOURTEEN LABELS ARE ZERO, and they are pinned AS zero rather than
  * omitted. An omitted row and an unreachable row look identical in a pin, and
  * only one of them is a claim: a dispatch or codec change that starts producing
  * `root-collision` must turn this suite red rather than silently enlarging the
  * codomain the table claims to cover.
+ *
+ * ONE LABEL LEFT THE ZERO SET, WHICH IS THE POINT OF PINNING ZEROES AT ALL.
+ * `deferred|authority-history-mismatch` was 0 and is now 5,184. It is reachable
+ * only by a candidate whose sequence relation is not `equal`, so it was
+ * unreachable for exactly as long as the sequence-depth boundary stood -- and it
+ * appeared the moment that closed. A zero that becomes non-zero when the gap
+ * that explained it is closed is a zero that was telling the truth.
  */
 export const JOIN_STORAGE_LABEL_REACH_V1: Readonly<Record<string, number>> = {
-  ready: 5760,
+  ready: 7488,
   'already-applied': 576,
-  stale: 1728,
+  stale: 5184,
   'root-collision': 0,
-  'deferred|non-active-state': 12_096,
+  'deferred|non-active-state': 22_464,
   'deferred|authority-fork': 1728,
-  'deferred|authority-history-mismatch': 0,
+  'deferred|authority-history-mismatch': 5184,
   'deferred|verified-state-mismatch': 0,
   'deferred|root-state-changed': 0,
   'capacity-exhausted|state-revision-overflow': 0,

--- a/packages/storage/test/helpers/authority-verdict-diff-join-table-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-join-table-v1.ts
@@ -199,9 +199,6 @@ export const JOIN_LEVEL1_TABLE_V1: Readonly<Record<string, number>> = {
   'AGREEMENT stale -> already-applied': 256,
   'AGREEMENT stale -> ready': 512,
   'AGREEMENT stale -> stale': 1536,
-  // THE DIVERGENCE RUNNING THE OTHER WAY. Every other divergence in this table
-  // is storage materialising a head core refuses; this one is core ACCEPTING an
-  // advance storage declines to materialise.
   'DIVERGENCE reject -> already-applied': 192,
   'DIVERGENCE reject -> ready': 4096,
   'NO-MAPPING quarantine|transition-equivocation -> already-applied': 128,
@@ -272,28 +269,36 @@ export const JOIN_LEVEL1_PER_ENTRY_V1: Readonly<Record<string, JoinLevel1EntryCo
  * EVERY DIVERGENCE, WITH BOTH SIDES VERBATIM. This is the actionable table: it
  * is what changes if Phase 3 routes the live path through core.
  *
- * IT NO LONGER READS AS ONE SENTENCE, and the correction matters more than the
- * growth. It used to be entirely "STORAGE MATERIALISES HEADS CORE REFUSES" --
- * every row a `reject -> ready`-shaped violation of the withholding-only image,
- * two thirds of it core's future clock-skew gate against a clock-blind storage
- * classifier. That direction is still the bulk, and it grew from 3,136 cells to
- * 4,672 as the sequence-relative region became comparable.
+ * IT READS AS ONE SENTENCE: STORAGE MATERIALISES HEADS CORE REFUSES. Every row
+ * is a `reject -> ready`-shaped violation of the withholding-only image, and the
+ * bulk of it is core's future clock-skew gate against a clock-blind storage
+ * classifier. The population grew from 3,136 cells to 4,288 as the
+ * sequence-relative region became comparable.
  *
- * BUT THE SEQUENCE-DEPTH CLOSURE EXPOSED A DIVERGENCE RUNNING THE OTHER WAY:
- * `accept -> stale`, 192 cells, where CORE ACCEPTS an advance and STORAGE
- * DECLINES TO MATERIALISE it. Every previously known divergence had core
- * refusing and storage proceeding, which is why the headline could be stated as
- * one sentence; this one inverts the roles. It was unreachable while the
- * sequence-relative candidates could not mint, so it is not a regression -- it
- * is a cell that had no observation before.
+ * AN EARLIER REVISION CLAIMED OTHERWISE AND WAS WRONG, recorded here because
+ * this doc is where a reader looks for the shape of the population. It reported
+ * `accept -> stale` at 192 cells -- core accepting an advance storage declined
+ * -- said the headline "no longer reads as one sentence", and concluded the two
+ * directions carry OPPOSITE routing risks so routing does not merely tighten.
  *
- * WHY THAT ASYMMETRY MATTERS TO PHASE 3 SPECIFICALLY: the two directions carry
- * OPPOSITE routing risks. Storage-materialises-what-core-refuses is a SAFETY
- * gap that routing through core would CLOSE. Core-accepts-what-storage-refuses
- * is the reverse -- routing through core would newly ADMIT these cells, so the
- * route does not merely tighten. A reader who took the old one-sentence headline
- * into the routing decision would have carried exactly the wrong prior about
- * which way the change cuts.
+ * That was not a system divergence. It was this fixture handing core a
+ * mismatched `acceptedTransition`: a candidate at sequence 3 received the 1->2
+ * transition, core refused it, and storage -- which never sees axis-J evidence
+ * -- went its own way. ONE SIDE GOT A CORRUPTED INPUT AND THE DISAGREEMENT WAS
+ * RECORDED AS THE TWO IMPLEMENTATIONS DISAGREEING. With the transition the
+ * candidate actually names, all 192 cells are `accept -> ready`, an AGREEMENT.
+ *
+ * THE POSITIVE TRACE OF THAT FIX IS ALSO IN THIS TABLE, and it is the better
+ * evidence: `reject|exact accepted authority transition is missing -> ready`
+ * HALVED, 384 -> 192. Manufactured rejects leaving the table is as much proof
+ * the mismatch is gone as the divergence vanishing is -- and the two are
+ * independent observations of one fix.
+ *
+ * The failure shape, since it is the one this whole slice keeps meeting: a first
+ * observation inside a region you have just built is the LEAST trustworthy kind.
+ * The novelty of the observation and the novelty of the instrument are the same
+ * fact, so the hypothesis to run first is "I built it wrong", not "the system
+ * was hiding something".
  */
 export const JOIN_DIVERGENCES_V1: Readonly<Record<string, number>> = {
   'reject|head issuedAt exceeds the future clock-skew bound -> ready': 2496,

--- a/packages/storage/test/helpers/authority-verdict-diff-join-table-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-join-table-v1.ts
@@ -33,7 +33,7 @@
  * itself the signal.
  */
 export const JOIN_PINNED_AGAINST_CORE_DIGEST_V1 =
-  '1d977f97a5b00f060a12ac894699040bdf147a8ab87249f47b0178c3f16d166f';
+  'fbad4f37a8b7f062a28affece30672eddd75ad33ef845adaefc3c84afec5e2e3';
 
 /**
  * THE FOUR-BUCKET PARTITION.
@@ -123,7 +123,7 @@ export const JOIN_ROWS_V1 = 164_160;
  * ships green.
  */
 export const JOIN_TABLE_DIGEST_V1 =
-  '4ef1c1ea7dc6cef7c6c8c1ebbd84d5bf1858ada20f9cd63637bb33a44932a0f7';
+  '90fc566f5fb40dddc7a32d3e3aa04579514689df15002517b43b8660f8a1ea16';
 
 /**
  * THE HEADLINE, and the two numbers it carries are deliberately of different

--- a/packages/storage/test/helpers/authority-verdict-diff-join-table-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-join-table-v1.ts
@@ -308,6 +308,36 @@ export const JOIN_DIVERGENCES_V1: Readonly<Record<string, number>> = {
 };
 
 /**
+ * THE DIVERGENCE TOTAL SPLIT BY DIRECTION -- the number a routing decision
+ * actually needs, and the one the aggregate hides.
+ *
+ * 4,672 divergent cells is a single figure with a sign problem: it says how MANY
+ * cells disagree and nothing about WHICH WAY, and the two ways carry OPPOSITE
+ * consequences for routing the live path through core.
+ *
+ *   storage-materialises-what-core-refuses (4,480 cells, 7 rows) is a SAFETY
+ *   GAP that routing through core would CLOSE. Storage proceeds where core
+ *   withholds, so handing the decision to core removes those materialisations.
+ *
+ *   core-accepts-what-storage-refuses (192 cells, 1 row) runs the other way.
+ *   Routing through core would NEWLY ADMIT these -- storage declines them
+ *   today. The route does not merely tighten.
+ *
+ * A reader given only the total, or given the pre-closure headline in which
+ * every divergence ran the first way, would carry the wrong SIGN on part of the
+ * change into the routing decision. Pinned as data rather than stated in prose
+ * so the split cannot drift away from the total it partitions; the suite asserts
+ * both directions sum to JOIN_VERDICT_TOTALS_V1.DIVERGENCE.
+ *
+ * The reverse direction was UNREACHABLE before the sequence-depth closure -- it
+ * is a cell that had no observation, never a regression.
+ */
+export const JOIN_DIVERGENCE_DIRECTIONS_V1: Readonly<Record<string, number>> = {
+  'storage-materialises-what-core-refuses': 4480,
+  'core-accepts-what-storage-refuses': 192,
+};
+
+/**
  * LEVEL 2: THE REASON PAIRS, VERBATIM, MAPPED TO NOTHING.
  *
  * There is no correspondence to declare here and the suite says so by asserting

--- a/packages/storage/test/helpers/authority-verdict-diff-join-table-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-join-table-v1.ts
@@ -33,7 +33,7 @@
  * itself the signal.
  */
 export const JOIN_PINNED_AGAINST_CORE_DIGEST_V1 =
-  '7127b2f93a51e07a0473547dcfd7eabf1d8480ad826d8741d829fde2bc9da4f0';
+  '1d977f97a5b00f060a12ac894699040bdf147a8ab87249f47b0178c3f16d166f';
 
 /**
  * THE FOUR-BUCKET PARTITION.
@@ -123,7 +123,7 @@ export const JOIN_ROWS_V1 = 164_160;
  * ships green.
  */
 export const JOIN_TABLE_DIGEST_V1 =
-  '7763d665d54bac3623d3bb4b3fe300f5871368ae3bd2622a75d0b5931c7f4037';
+  '4ef1c1ea7dc6cef7c6c8c1ebbd84d5bf1858ada20f9cd63637bb33a44932a0f7';
 
 /**
  * THE HEADLINE, and the two numbers it carries are deliberately of different
@@ -134,8 +134,8 @@ export const JOIN_TABLE_DIGEST_V1 =
  * this headline describe the fixture's cardinality instead of the behaviour.
  */
 export const JOIN_VERDICT_TOTALS_V1: Readonly<Record<string, number>> = {
-  AGREEMENT: 11_264,
-  DIVERGENCE: 4672,
+  AGREEMENT: 11_648,
+  DIVERGENCE: 4288,
   'NO-MAPPING': 4224,
   'NOT-COMPARABLE': 144_000,
 };
@@ -189,22 +189,21 @@ export const JOIN_PRECONDITION_DISCRIMINATION_V1: Readonly<Record<string, number
 
 /** Every adjudicated row, keyed `verdict coreDecisionKey -> storageLabel`. */
 export const JOIN_LEVEL1_TABLE_V1: Readonly<Record<string, number>> = {
-  'AGREEMENT accept -> ready': 1280,
+  'AGREEMENT accept -> ready': 1472,
   'AGREEMENT quarantine|head-fork -> deferred|authority-fork': 768,
   'AGREEMENT reject -> deferred|authority-fork': 576,
   // The sequence-depth closure's own row: core rejects a two-ahead candidate,
   // storage defers it, both from the sequence arithmetic alone.
   'AGREEMENT reject -> deferred|authority-history-mismatch': 4032,
-  'AGREEMENT reject -> stale': 2304,
+  'AGREEMENT reject -> stale': 2496,
   'AGREEMENT stale -> already-applied': 256,
   'AGREEMENT stale -> ready': 512,
   'AGREEMENT stale -> stale': 1536,
   // THE DIVERGENCE RUNNING THE OTHER WAY. Every other divergence in this table
   // is storage materialising a head core refuses; this one is core ACCEPTING an
   // advance storage declines to materialise.
-  'DIVERGENCE accept -> stale': 192,
   'DIVERGENCE reject -> already-applied': 192,
-  'DIVERGENCE reject -> ready': 4288,
+  'DIVERGENCE reject -> ready': 4096,
   'NO-MAPPING quarantine|transition-equivocation -> already-applied': 128,
   'NO-MAPPING quarantine|transition-equivocation -> deferred|authority-fork': 384,
   'NO-MAPPING quarantine|transition-equivocation -> deferred|authority-history-mismatch': 1152,
@@ -231,7 +230,7 @@ export interface JoinLevel1EntryCountsV1 {
 export const JOIN_LEVEL1_PER_ENTRY_V1: Readonly<Record<string, JoinLevel1EntryCountsV1>> = {
   accept: {
     cells: 1472,
-    members: { ready: 1280, 'already-applied': 0 },
+    members: { ready: 1472, 'already-applied': 0 },
   },
   stale: {
     cells: 2304,
@@ -253,7 +252,7 @@ export const JOIN_LEVEL1_PER_ENTRY_V1: Readonly<Record<string, JoinLevel1EntryCo
   reject: {
     cells: 11_392,
     members: {
-      stale: 2304,
+      stale: 2496,
       'root-collision': 0,
       'deferred|non-active-state': 0,
       'deferred|authority-fork': 576,
@@ -297,44 +296,50 @@ export const JOIN_LEVEL1_PER_ENTRY_V1: Readonly<Record<string, JoinLevel1EntryCo
  * which way the change cuts.
  */
 export const JOIN_DIVERGENCES_V1: Readonly<Record<string, number>> = {
-  'accept -> stale': 192,
   'reject|head issuedAt exceeds the future clock-skew bound -> ready': 2496,
   'reject|head issuedAt exceeds the future clock-skew bound -> already-applied': 192,
   'reject|absent state cannot retain authority history or quarantine -> ready': 512,
   'reject|current frontier fork requires its exact direct resolving successor -> ready': 384,
   'reject|cold noninitial head requires its verified authority closure -> ready': 128,
-  'reject|exact accepted authority transition is missing -> ready': 384,
+  'reject|exact accepted authority transition is missing -> ready': 192,
   'reject|unresolved head fork cannot advance authority sequence -> ready': 384,
 };
 
 /**
- * THE DIVERGENCE TOTAL SPLIT BY DIRECTION -- the number a routing decision
- * actually needs, and the one the aggregate hides.
+ * THE DIVERGENCE TOTAL SPLIT BY DIRECTION, and the reverse row is pinned AT ZERO
+ * after a retraction worth recording at the pin rather than only in a register.
  *
- * 4,672 divergent cells is a single figure with a sign problem: it says how MANY
- * cells disagree and nothing about WHICH WAY, and the two ways carry OPPOSITE
- * consequences for routing the live path through core.
+ * EVERY DIVERGENCE IN THIS TABLE RUNS ONE WAY: storage materialises heads core
+ * refuses. That is a SAFETY GAP which routing the live path through core would
+ * CLOSE, and it is the whole of the divergence population.
  *
- *   storage-materialises-what-core-refuses (4,480 cells, 7 rows) is a SAFETY
- *   GAP that routing through core would CLOSE. Storage proceeds where core
- *   withholds, so handing the decision to core removes those materialisations.
+ * THE OTHER DIRECTION WAS CLAIMED AND WAS FALSE. An earlier revision of this
+ * slice reported `accept -> stale` at 192 cells -- core accepting an advance
+ * storage declined -- and drew the conclusion that routing carries OPPOSITE
+ * risks in the two directions and therefore does not merely tighten. It was not
+ * a system divergence. It was this fixture handing core a mismatched
+ * `acceptedTransition`: a candidate at sequence 3 received the 1->2 transition,
+ * core refused it, and storage -- which never sees axis-J evidence -- went its
+ * own way. One side got a corrupted input and the disagreement was recorded as
+ * the two implementations disagreeing. Supplying the transition the candidate
+ * actually names moves all 192 to `accept -> ready`, an AGREEMENT.
  *
- *   core-accepts-what-storage-refuses (192 cells, 1 row) runs the other way.
- *   Routing through core would NEWLY ADMIT these -- storage declines them
- *   today. The route does not merely tighten.
+ * IT IS PINNED AS ZERO RATHER THAN DELETED, for the same reason the storage
+ * codomain pins its eight unreached labels: an omitted row and an empty one are
+ * indistinguishable, and only one of them is a claim. If a real reverse-direction
+ * divergence ever appears, this row moves off zero and says so.
  *
- * A reader given only the total, or given the pre-closure headline in which
- * every divergence ran the first way, would carry the wrong SIGN on part of the
- * change into the routing decision. Pinned as data rather than stated in prose
- * so the split cannot drift away from the total it partitions; the suite asserts
- * both directions sum to JOIN_VERDICT_TOTALS_V1.DIVERGENCE.
- *
- * The reverse direction was UNREACHABLE before the sequence-depth closure -- it
- * is a cell that had no observation, never a regression.
+ * THE NON-VACUITY ASSERTION THAT USED TO GUARD THIS IS GONE ON PURPOSE. It
+ * required BOTH directions to be non-zero so the opposite-risks claim could not
+ * go vacuous while the sum still checked out. The claim HAS gone -- so the guard
+ * did its job by turning red, and keeping it would now assert something false.
+ * What remains is the partition check: the two directions must still sum to
+ * JOIN_VERDICT_TOTALS_V1.DIVERGENCE, so a split that drifts from the total it
+ * describes turns red.
  */
 export const JOIN_DIVERGENCE_DIRECTIONS_V1: Readonly<Record<string, number>> = {
-  'storage-materialises-what-core-refuses': 4480,
-  'core-accepts-what-storage-refuses': 192,
+  'storage-materialises-what-core-refuses': 4288,
+  'core-accepts-what-storage-refuses': 0,
 };
 
 /**
@@ -356,14 +361,15 @@ export const JOIN_LEVEL2_REASON_PAIRS_V1: Readonly<Record<string, number>> = {
   'authority history is incomplete :: authority-history-mismatch': 1536,
   'cold noninitial head requires its verified authority closure :: <none>': 128,
   'current frontier fork requires its exact direct resolving successor :: <none>': 384,
-  'exact accepted authority transition is missing :: <none>': 384,
-  'exact accepted authority transition is missing :: authority-history-mismatch': 384,
+  'exact accepted authority transition is missing :: <none>': 192,
+  'exact accepted authority transition is missing :: authority-history-mismatch': 192,
   'head issuedAt exceeds the future clock-skew bound :: <none>': 4416,
   'head issuedAt exceeds the future clock-skew bound :: authority-fork': 576,
   'head issuedAt exceeds the future clock-skew bound :: authority-history-mismatch': 1728,
   'head-fork :: authority-fork': 768,
   'late tombstone lacks its exact verified active predecessor :: <none>': 384,
-  'late tombstone requires the exact retained resurrection transition :: <none>': 192,
+  'late tombstone requires the exact retained resurrection transition :: <none>': 384,
+  'next-sequence tombstone requires its exact same-sequence active predecessor :: authority-history-mismatch': 192,
   'transition-equivocation :: <none>': 2688,
   'transition-equivocation :: authority-fork': 384,
   'transition-equivocation :: authority-history-mismatch': 1152,

--- a/packages/storage/test/helpers/authority-verdict-diff-join-table-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-join-table-v1.ts
@@ -328,6 +328,18 @@ export const JOIN_STORAGE_LABEL_REACH_V1: Readonly<Record<string, number>> = {
  * The distinction is load-bearing because the two carry opposite obligations: a
  * finding is recorded and left alone, a gap bounds the coverage claim. Neither
  * is a reason to go and manufacture cells.
+ *
+ * ONE ENTRY HAS LEFT THIS REGISTER, AND THAT IS WHAT THE REGISTER IS FOR.
+ * `deferred|authority-history-mismatch` was listed here as 'harness-never-builds'
+ * on the ground that every non-`equal` sequence relation was retired earlier as
+ * summary-unmintable. It is now REACHED, because the sequence-relative candidates
+ * mint. An entry classified 'harness-never-builds' is a standing prediction that
+ * closing the gap will make the outcome appear; this one was closed and it did.
+ * Note the entry's stated CAUSE was already wrong before it was removed -- it
+ * cited the chain helper's `(steps: 1 | 2)` signature, an attribution the core
+ * table had already retired, while claiming "the core table records the same
+ * boundary". A cross-reference asserting agreement with its own correction is
+ * worse than a bare wrong cause, because it borrows authority it does not have.
  */
 export interface JoinUnreachedOutcomeV1 {
   readonly side: 'storage' | 'core';
@@ -352,16 +364,6 @@ export const JOIN_UNREACHED_OUTCOMES_V1: readonly JoinUnreachedOutcomeV1[] = [
     why: 'harness-never-builds',
     reason: 'There is no capacity axis. The fixture\'s single-subject record sits far below '
       + 'every cap and no cell varies revision counters, record counts or byte totals.',
-  },
-  {
-    side: 'storage',
-    outcome: 'deferred|authority-history-mismatch',
-    why: 'harness-never-builds',
-    reason: 'Reached only by a candidate whose sequence relation is not `equal`, and every '
-      + 'such shape is retired earlier as summary-unmintable: the chain is '
-      + 'makeRotatedAuthorityChainV1(2) with the current head at its top, so a sequence-3 '
-      + 'candidate needs a 2->3 transition that does not exist and the helper signature '
-      + '(steps: 1 | 2) caps the depth. The core table records the same boundary.',
   },
   {
     side: 'storage',

--- a/packages/storage/test/helpers/authority-verdict-diff-join-table-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-join-table-v1.ts
@@ -33,7 +33,7 @@
  * itself the signal.
  */
 export const JOIN_PINNED_AGAINST_CORE_DIGEST_V1 =
-  'fbad4f37a8b7f062a28affece30672eddd75ad33ef845adaefc3c84afec5e2e3';
+  '93898e323d6a17e63ea36b2d1584b496bf42391f2de4f8007cade88924917a9e';
 
 /**
  * THE FOUR-BUCKET PARTITION.
@@ -123,7 +123,7 @@ export const JOIN_ROWS_V1 = 164_160;
  * ships green.
  */
 export const JOIN_TABLE_DIGEST_V1 =
-  '90fc566f5fb40dddc7a32d3e3aa04579514689df15002517b43b8660f8a1ea16';
+  '433dd99638e3b92cb18b6f06c534d2c2fafbcd917a8f4f225d8a2d57cde9c6ec';
 
 /**
  * THE HEADLINE, and the two numbers it carries are deliberately of different
@@ -134,8 +134,8 @@ export const JOIN_TABLE_DIGEST_V1 =
  * this headline describe the fixture's cardinality instead of the behaviour.
  */
 export const JOIN_VERDICT_TOTALS_V1: Readonly<Record<string, number>> = {
-  AGREEMENT: 11_648,
-  DIVERGENCE: 4288,
+  AGREEMENT: 11_456,
+  DIVERGENCE: 4480,
   'NO-MAPPING': 4224,
   'NOT-COMPARABLE': 144_000,
 };
@@ -195,10 +195,11 @@ export const JOIN_LEVEL1_TABLE_V1: Readonly<Record<string, number>> = {
   // The sequence-depth closure's own row: core rejects a two-ahead candidate,
   // storage defers it, both from the sequence arithmetic alone.
   'AGREEMENT reject -> deferred|authority-history-mismatch': 4032,
-  'AGREEMENT reject -> stale': 2496,
+  'AGREEMENT reject -> stale': 2304,
   'AGREEMENT stale -> already-applied': 256,
   'AGREEMENT stale -> ready': 512,
   'AGREEMENT stale -> stale': 1536,
+  'DIVERGENCE accept -> stale': 192,
   'DIVERGENCE reject -> already-applied': 192,
   'DIVERGENCE reject -> ready': 4096,
   'NO-MAPPING quarantine|transition-equivocation -> already-applied': 128,
@@ -226,7 +227,7 @@ export interface JoinLevel1EntryCountsV1 {
 
 export const JOIN_LEVEL1_PER_ENTRY_V1: Readonly<Record<string, JoinLevel1EntryCountsV1>> = {
   accept: {
-    cells: 1472,
+    cells: 1664,
     members: { ready: 1472, 'already-applied': 0 },
   },
   stale: {
@@ -247,9 +248,9 @@ export const JOIN_LEVEL1_PER_ENTRY_V1: Readonly<Record<string, JoinLevel1EntryCo
     members: {},
   },
   reject: {
-    cells: 11_392,
+    cells: 11_200,
     members: {
-      stale: 2496,
+      stale: 2304,
       'root-collision': 0,
       'deferred|non-active-state': 0,
       'deferred|authority-fork': 576,
@@ -269,36 +270,18 @@ export const JOIN_LEVEL1_PER_ENTRY_V1: Readonly<Record<string, JoinLevel1EntryCo
  * EVERY DIVERGENCE, WITH BOTH SIDES VERBATIM. This is the actionable table: it
  * is what changes if Phase 3 routes the live path through core.
  *
- * IT READS AS ONE SENTENCE: STORAGE MATERIALISES HEADS CORE REFUSES. Every row
- * is a `reject -> ready`-shaped violation of the withholding-only image, and the
- * bulk of it is core's future clock-skew gate against a clock-blind storage
- * classifier. The population grew from 3,136 cells to 4,288 as the
- * sequence-relative region became comparable.
+ * IT DOES NOT READ AS ONE SENTENCE, and that sentence has been written three
+ * different ways in this file's history -- see JOIN_DIVERGENCE_DIRECTIONS_V1 for
+ * the full account, which is kept because the reasoning matters more than the
+ * conclusion.
  *
- * AN EARLIER REVISION CLAIMED OTHERWISE AND WAS WRONG, recorded here because
- * this doc is where a reader looks for the shape of the population. It reported
- * `accept -> stale` at 192 cells -- core accepting an advance storage declined
- * -- said the headline "no longer reads as one sentence", and concluded the two
- * directions carry OPPOSITE routing risks so routing does not merely tighten.
+ * THE BULK, 4,288 cells, is STORAGE MATERIALISES HEADS CORE REFUSES: a `reject`
+ * paired with a storage outcome that admits the candidate, most of it core's
+ * future clock-skew gate against a clock-blind storage classifier.
  *
- * That was not a system divergence. It was this fixture handing core a
- * mismatched `acceptedTransition`: a candidate at sequence 3 received the 1->2
- * transition, core refused it, and storage -- which never sees axis-J evidence
- * -- went its own way. ONE SIDE GOT A CORRUPTED INPUT AND THE DISAGREEMENT WAS
- * RECORDED AS THE TWO IMPLEMENTATIONS DISAGREEING. With the transition the
- * candidate actually names, all 192 cells are `accept -> ready`, an AGREEMENT.
- *
- * THE POSITIVE TRACE OF THAT FIX IS ALSO IN THIS TABLE, and it is the better
- * evidence: `reject|exact accepted authority transition is missing -> ready`
- * HALVED, 384 -> 192. Manufactured rejects leaving the table is as much proof
- * the mismatch is gone as the divergence vanishing is -- and the two are
- * independent observations of one fix.
- *
- * The failure shape, since it is the one this whole slice keeps meeting: a first
- * observation inside a region you have just built is the LEAST trustworthy kind.
- * The novelty of the observation and the novelty of the instrument are the same
- * fact, so the hypothesis to run first is "I built it wrong", not "the system
- * was hiding something".
+ * THE REMAINDER, 192 cells, RUNS THE OTHER WAY: `accept -> stale`, core's
+ * lower-sequence tombstone arm accepting a late tombstone that storage's flat
+ * sequence rule refuses. Routing through core would newly ADMIT those.
  */
 export const JOIN_DIVERGENCES_V1: Readonly<Record<string, number>> = {
   'reject|head issuedAt exceeds the future clock-skew bound -> ready': 2496,
@@ -306,45 +289,64 @@ export const JOIN_DIVERGENCES_V1: Readonly<Record<string, number>> = {
   'reject|absent state cannot retain authority history or quarantine -> ready': 512,
   'reject|current frontier fork requires its exact direct resolving successor -> ready': 384,
   'reject|cold noninitial head requires its verified authority closure -> ready': 128,
+  'accept -> stale': 192,
   'reject|exact accepted authority transition is missing -> ready': 192,
   'reject|unresolved head fork cannot advance authority sequence -> ready': 384,
 };
 
 /**
- * THE DIVERGENCE TOTAL SPLIT BY DIRECTION, and the reverse row is pinned AT ZERO
- * after a retraction worth recording at the pin rather than only in a register.
+ * THE DIVERGENCE TOTAL SPLIT BY DIRECTION -- the number a routing decision
+ * needs, and the one the aggregate hides.
  *
- * EVERY DIVERGENCE IN THIS TABLE RUNS ONE WAY: storage materialises heads core
- * refuses. That is a SAFETY GAP which routing the live path through core would
- * CLOSE, and it is the whole of the divergence population.
+ *   storage-materialises-what-core-refuses (4,288) is a SAFETY GAP that routing
+ *   through core would CLOSE.
+ *   core-accepts-what-storage-refuses (192) runs the other way: routing would
+ *   NEWLY ADMIT these. The route does not merely tighten.
  *
- * THE OTHER DIRECTION WAS CLAIMED AND WAS FALSE. An earlier revision of this
- * slice reported `accept -> stale` at 192 cells -- core accepting an advance
- * storage declined -- and drew the conclusion that routing carries OPPOSITE
- * risks in the two directions and therefore does not merely tighten. It was not
- * a system divergence. It was this fixture handing core a mismatched
- * `acceptedTransition`: a candidate at sequence 3 received the 1->2 transition,
- * core refused it, and storage -- which never sees axis-J evidence -- went its
- * own way. One side got a corrupted input and the disagreement was recorded as
- * the two implementations disagreeing. Supplying the transition the candidate
- * actually names moves all 192 to `accept -> ready`, an AGREEMENT.
+ * THE REVERSE DIRECTION HAS A NAMED MECHANISM, which is what makes it a finding
+ * rather than an observation. Enumerating the axis coordinates of every
+ * accepting cell, exactly ONE accepting shape exists below the current authority
+ * sequence: `A=present C=tombstone D=below G=equal`. That is core's
+ * lower-sequence tombstone arm, which returns `accept` once the retained
+ * resurrection transition validates. Storage returns a FLAT `stale` for any
+ * candidate below the current sequence and has no resurrection notion to reach.
+ * So CORE ACCEPTS A LATE TOMBSTONE THAT STORAGE REFUSES OUTRIGHT, and only the
+ * axis-B='active' slice reaches storage's comparison -- which is the 192.
  *
- * IT IS PINNED AS ZERO RATHER THAN DELETED, for the same reason the storage
- * codomain pins its eight unreached labels: an omitted row and an empty one are
- * indistinguishable, and only one of them is a claim. If a real reverse-direction
- * divergence ever appears, this row moves off zero and says so.
+ * THIS FINDING HELD THREE POSITIONS AND THE HISTORY IS LOAD-BEARING. A reader
+ * should know it survived adversarial scrutiny twice; a future skeptic should
+ * meet the evidence rather than re-litigate from scratch.
  *
- * THE NON-VACUITY ASSERTION THAT USED TO GUARD THIS IS GONE ON PURPOSE. It
- * required BOTH directions to be non-zero so the opposite-risks claim could not
- * go vacuous while the sum still checked out. The claim HAS gone -- so the guard
- * did its job by turning red, and keeping it would now assert something false.
- * What remains is the partition check: the two directions must still sum to
- * JOIN_VERDICT_TOTALS_V1.DIVERGENCE, so a split that drifts from the total it
- * describes turns red.
+ *   1. FIRST REPORTED -- right conclusion, WRONG basis. The pair was observed,
+ *      no mechanism was established, and it was elevated as the slice's headline
+ *      before anything explained it.
+ *   2. RETRACTED -- wrongly. A later rule keyed the axis-J `acceptedTransition`
+ *      member to the candidate's SEQUENCE, which broke core's lower-sequence
+ *      arm: those candidates got the rotation INTO their sequence where the arm
+ *      demands the one OUT of it, so they refused before reaching `accept` and
+ *      the divergence vanished. The disappearance was read as proof the
+ *      divergence had been a fixture artifact. THE ARTIFACT WAS WHAT MADE IT
+ *      DISAPPEAR.
+ *   3. REINSTATED -- with the mechanism above measured. Across three evidence
+ *      rules (original single constant, sequence-keyed, branch-keyed) BOTH rules
+ *      that feed the lower-sequence arm correctly produce 192; only the broken
+ *      one produces 0.
+ *
+ * THE RULE OUT OF POSITION 2: a disappearance inside a region you have just
+ * modified is the least trustworthy kind of evidence. "My change removed it" is
+ * exactly as consistent with "my change broke the path" as with "the finding was
+ * an artifact", and only a mechanism separates them. The signature is a number
+ * that RETURNS to where it started once the change is corrected -- here
+ * `late tombstone requires the exact retained resurrection transition` went
+ * 192 -> 384 -> 192.
+ *
+ * The suite asserts the two directions partition
+ * JOIN_VERDICT_TOTALS_V1.DIVERGENCE, and reads them over the DECLARED keys so a
+ * zero would still be pinned as zero rather than silently omitted.
  */
 export const JOIN_DIVERGENCE_DIRECTIONS_V1: Readonly<Record<string, number>> = {
   'storage-materialises-what-core-refuses': 4288,
-  'core-accepts-what-storage-refuses': 0,
+  'core-accepts-what-storage-refuses': 192,
 };
 
 /**
@@ -358,7 +360,7 @@ export const JOIN_DIVERGENCE_DIRECTIONS_V1: Readonly<Record<string, number>> = {
  * three variants that carry no reason field at all.
  */
 export const JOIN_LEVEL2_REASON_PAIRS_V1: Readonly<Record<string, number>> = {
-  '<none> :: <none>': 3776,
+  '<none> :: <none>': 3968,
   'absent state cannot retain authority history or quarantine :: <none>': 512,
   // THE PAIR THE SEQUENCE-DEPTH CLOSURE EXISTS TO PRODUCE: a candidate two
   // authority sequences ahead, refused by core and deferred by storage, both
@@ -373,7 +375,7 @@ export const JOIN_LEVEL2_REASON_PAIRS_V1: Readonly<Record<string, number>> = {
   'head issuedAt exceeds the future clock-skew bound :: authority-history-mismatch': 1728,
   'head-fork :: authority-fork': 768,
   'late tombstone lacks its exact verified active predecessor :: <none>': 384,
-  'late tombstone requires the exact retained resurrection transition :: <none>': 384,
+  'late tombstone requires the exact retained resurrection transition :: <none>': 192,
   'next-sequence tombstone requires its exact same-sequence active predecessor :: authority-history-mismatch': 192,
   'transition-equivocation :: <none>': 2688,
   'transition-equivocation :: authority-fork': 384,
@@ -617,7 +619,9 @@ export const JOIN_NON_VACUITY_MUTANTS_V1: readonly JoinMutantV1[] = [
     prediction: '768 cells move AGREEMENT -> DIVERGENCE: the 256 identical-head cells storage '
       + 'answers `already-applied` and the 512 it rematerialises to `ready`. Totals become '
       + 'AGREEMENT 3,968 and DIVERGENCE 3,904.',
-    observed: 'EXACT. AGREEMENT 4,736 -> 3,968 and DIVERGENCE 3,136 -> 3,904, with '
+    observed: 'MEASURED AT A SUPERSEDED BASE (core digest d396cb86..., before the '
+      + 'sequence-depth closure); the DELTA is the result and the absolute totals are vintage. '
+      + 'EXACT at that base: AGREEMENT 4,736 -> 3,968 and DIVERGENCE 3,136 -> 3,904, with '
       + '`DIVERGENCE stale -> already-applied: 256` and `DIVERGENCE stale -> ready: 512` appearing '
       + 'in the level-1 table. A QUARTER of the reported divergences would have been manufactured '
       + 'by the mapping rather than found in the systems.',
@@ -630,7 +634,8 @@ export const JOIN_NON_VACUITY_MUTANTS_V1: readonly JoinMutantV1[] = [
     proves: 'the precondition is LOAD-BEARING branch by branch, not just in aggregate. This '
       + 'mutates one arm -- the tombstone path\'s own gate at :956-960 -- and nothing else.',
     prediction: 'the discrimination table gains a third key, `shortCircuit=false '
-      + 'isNonActiveState=true: 576`, and the short-circuit count falls 12,096 -> 11,520.',
+      + 'isNonActiveState=true: 576`, and the short-circuit count falls by 576. MEASURED AT A '
+      + 'SUPERSEDED BASE, where that read 12,096 -> 11,520; the 576 delta is the claim.',
     observed: 'EXACT, on both numbers. Four assertions fired, including the discrimination '
       + 'cross-tab going from two keys to three -- so the two-key pin is a real claim about the '
       + 'predicate and not an artifact of how the tally was built.',
@@ -644,18 +649,18 @@ export const JOIN_NON_VACUITY_MUTANTS_V1: readonly JoinMutantV1[] = [
 export const JOIN_FINDINGS_V1: readonly string[] = [
   // The single sharpest fact the join produced, and the one that decides how
   // more than half the comparable region must be labelled.
-  'STORAGE DECIDES 12,096 OF THE 21,888 COMPARABLE CELLS -- 55% -- WITHOUT READING THE '
+  'STORAGE DECIDES 22,464 OF THE 42,624 COMPARABLE CELLS -- 53% -- WITHOUT READING THE '
   + 'CANDIDATE AT ALL. `classifyAuthorityAdvance` returns deferred(non-active-state) from the '
   + 'APPLIED ROW STATUS at :1108/:1111/:1114, before the candidate is first read at :1116, and '
   + 'the tombstone path has its own such gate at :956-960. Core has no field to put an applied '
   + 'status in, so on those cells the two sides are not disagreeing about the candidate -- they '
-  + 'are answering different questions. Calling that DIVERGENCE would have manufactured 12,096 '
-  + 'of them, which is more than three times the real divergence count and would have buried it.',
+  + 'are answering different questions. Calling that DIVERGENCE would have manufactured 22,464 '
+  + 'of them, which is five times the real divergence count and would have buried it.',
 
   // The actionable one. Every cell of it is a DIVERGENCE.
-  'STORAGE MATERIALISES HEADS CORE REFUSES: 3,136 cells, every one a DIVERGENCE, all of them a '
-  + 'core `reject` paired with a storage outcome that ADMITS the candidate (2,944 `ready`, 192 '
-  + '`already-applied`). Two thirds -- 2,112 -- are core\'s future clock-skew gate at :98-103 '
+  'STORAGE MATERIALISES HEADS CORE REFUSES: 4,288 cells -- the BULK of the divergence population but no longer all of it, '
+  + 'each a core `reject` paired with a storage outcome that ADMITS the candidate (4,096 `ready`, 192 '
+  + '`already-applied`); 192 further cells run the OTHER way, see JOIN_DIVERGENCE_DIRECTIONS_V1. The largest single cause is core\'s future clock-skew gate at :98-103 '
   + 'against a storage classifier that takes no clock input at all; the same blindness is '
   + 'established AT SOURCE -- issuedAt, nowMs, clockSkew and futureSkew do not occur anywhere '
   + 'in packages/storage/src. (CORRECTED ATTRIBUTION: this clause previously cited the '
@@ -750,13 +755,13 @@ export const JOIN_FINDINGS_V1: readonly string[] = [
   // half deliberately claimed no numbers it had not measured itself.
   'THE TWO EVALUATORS HAVE DISJOINT PRIVATE INPUTS, AND THESE ARE THE CELLS. The core table '
   + 'states the general result -- ROUTING CANNOT BE A DROP-IN, BECAUSE EACH SIDE READS STATE '
-  + 'THE OTHER DOES NOT HAVE -- and these are its two join-side populations. 12,096 cells are '
+  + 'THE OTHER DOES NOT HAVE -- and these are its two join-side populations. 22,464 cells are '
   + 'storage answering from the APPLIED ROW at :1108/:1111/:1114, before the candidate is read '
-  + 'at :1116, on an axis CORE has no field for. 1,920 cells are core deciding '
+  + 'at :1116, on an axis CORE has no field for. 4,224 cells are core deciding '
   + '`quarantine|transition-equivocation` from `disposition` at :139-141, on an axis STORAGE '
-  + 'has no producer for. TOTAL 14,016 -- THE SAME PHENOMENON IN OPPOSITE DIRECTIONS. Both are '
-  + 'CORRECT cell-level exclusions and neither is reclassified: the 12,096 stay a named '
-  + 'non-comparability on the CELL, the 1,920 stay the MAP\'s one no-image entry, and nothing '
+  + 'has no producer for. TOTAL 26,688 -- THE SAME PHENOMENON IN OPPOSITE DIRECTIONS. Both are '
+  + 'CORRECT cell-level exclusions and neither is reclassified: the 22,464 stay a named '
+  + 'non-comparability on the CELL, the 4,224 stay the MAP\'s one no-image entry, and nothing '
   + 'in the conservation moves. TOGETHER THEY ARE ONE ARCHITECTURAL FINDING, and it was '
   + 'invisible precisely BECAUSE it was found twice, from opposite ends, and filed as an '
   + 'ABSENCE both times -- two correct exclusions in two registers do not add up to a finding '
@@ -806,13 +811,13 @@ export const JOIN_FINDINGS_V1: readonly string[] = [
   + 'EXACTLY ONCE, at :956, and only against \'quarantined\'; a dirty or tombstone row with '
   + 'no conflict state passes straight through. POSITIVE CONTROL on the ACTIVE classifier '
   + '(:1087-1164) with the same instrument: THREE reads including a current.status !== '
-  + '\'active\' test, which is why axis B does real work there and produces the 12,096 '
+  + '\'active\' test, which is why axis B does real work there and produces the 22,464 '
   + 'applied-row short-circuit. MEASURED CONSEQUENCE: under H=tombstone, B=active, B=dirty '
   + 'and B=tombstone each split 256 AGREEMENT / 192 DIVERGENCE / 128 NO-MAPPING -- IDENTICAL '
   + 'in every verdict class, which is the empirical confirmation of the source reading; three '
   + 'independent classes agreeing exactly is not what coincidence produces. So of the 576 '
   + 'divergence cells in this region there are only 192 DISTINCT divergent situations, and '
-  + '384 of the 3,136 reported divergences are the same situations recounted under two axis-B '
+  + '384 of the 4,480 reported divergences are the same situations recounted under two axis-B '
   + 'values the classifier cannot see. NEGATIVE CONTROL: B=quarantined adjudicates ZERO cells '
   + 'under this operation, so the gate discriminates rather than admitting everything. '
   + 'NO CELL\'S VERDICT IS FALSE AND NO COUNT MOVES -- the table counts CELLS over a declared '

--- a/packages/storage/test/helpers/authority-verdict-diff-storage-driver-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-storage-driver-v1.ts
@@ -42,9 +42,10 @@ import { buildAgentProfileVerificationClosureV1 } from '@origintrail-official/dk
 
 import { agentProfileIdentityProjectionV1 } from './agent-profile-identity-projection-v1.js';
 import {
-  CORE_CHAIN_V1,
+  coreSequenceActiveHeadV1,
+  CORE_ALL_LINEAGE_HEADS_V1,
+  CORE_ALL_TRANSITIONS_V1,
   CORE_CURRENT_HEAD_V1,
-  CORE_EQUIVOCATING_TRANSITION_V1,
   CORE_FORK_CONFLICT_HEADS_V1,
   CORE_FORK_RESOLUTION_V1,
 } from './authority-verdict-diff-core-heads-v1.js';
@@ -300,15 +301,22 @@ export interface StorageDriverV1 {
  * that walked a DIFFERENT graph would produce a diff between two different
  * questions while every row still looked well formed. The core half's minter is
  * module-private, so the walk is reproduced -- but it is reproduced over
- * `CORE_CHAIN_V1`, `CORE_CURRENT_HEAD_V1`, `CORE_FORK_CONFLICT_HEADS_V1`,
- * `CORE_EQUIVOCATING_TRANSITION_V1` and `CORE_FORK_RESOLUTION_V1`, which are the
- * very objects the core half walks. Nothing here is a second copy of the data.
+ * `CORE_ALL_LINEAGE_HEADS_V1`, `CORE_CURRENT_HEAD_V1`,
+ * `CORE_FORK_CONFLICT_HEADS_V1`, `CORE_ALL_TRANSITIONS_V1` and
+ * `CORE_FORK_RESOLUTION_V1`, which are the very objects the core half walks.
+ * Nothing here is a second copy of the data.
+ *
+ * THE SHARED-CONSTANT DISCIPLINE EARNED ITS KEEP WHEN AXIS D GAINED PER-SEQUENCE
+ * LINEAGE: the two halves picked up sequences 3 and 4 together because both name
+ * the same two exports. Had this list been the literal four objects it used to
+ * spell out, the storage half would have kept minting against a two-deep graph
+ * while the core half walked a four-deep one, and the diff would have compared
+ * two different questions with every row still well formed.
  */
 function mintAncestryV1(): readonly AgentProfileHeadObjectV1[] {
   return [
     CORE_CURRENT_HEAD_V1,
-    CORE_CHAIN_V1.base,
-    ...CORE_CHAIN_V1.ancestors,
+    ...CORE_ALL_LINEAGE_HEADS_V1,
     ...CORE_FORK_CONFLICT_HEADS_V1,
   ];
 }
@@ -328,13 +336,23 @@ export async function mintStorageSummaryForHeadV1(
   | { readonly minted: false; readonly message: string }
 > {
   const ancestry = mintAncestryV1();
-  const transitions = [...CORE_CHAIN_V1.transitions, CORE_EQUIVOCATING_TRANSITION_V1];
+  const transitions = [...CORE_ALL_TRANSITIONS_V1];
   try {
     if ((candidate as { state: string }).state === 'tombstone') {
+      // The predecessor and its deletion table are the ACTIVE head at the
+      // tombstone's OWN authority sequence -- the same rule the core minter
+      // follows, and it has to be the same rule or the two halves of the diff
+      // mint over different graphs. Pinning both to the current head refuses
+      // every sequence-relative tombstone for an owned-subject table this
+      // fixture never supplies, and the refusal is phrased exactly like a
+      // domain one.
+      const predecessor = coreSequenceActiveHeadV1(
+        (candidate as { authoritySequence: string }).authoritySequence,
+      );
       const closure = await mintAgentProfileTombstoneClosureV1({
         tombstone: candidate,
-        predecessor: CORE_CURRENT_HEAD_V1,
-        ownedSubjectTable: [CORE_CURRENT_HEAD_V1.rootSubject],
+        predecessor,
+        ownedSubjectTable: [predecessor.rootSubject],
         ancestors: ancestry,
         transitions,
       } as never);

--- a/packages/storage/test/helpers/authority-verdict-diff-storage-driver-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-storage-driver-v1.ts
@@ -42,9 +42,7 @@ import { buildAgentProfileVerificationClosureV1 } from '@origintrail-official/dk
 
 import { agentProfileIdentityProjectionV1 } from './agent-profile-identity-projection-v1.js';
 import {
-  coreSequenceActiveHeadV1,
-  CORE_ALL_LINEAGE_HEADS_V1,
-  CORE_ALL_TRANSITIONS_V1,
+  CORE_MINT_GRAPH_V1,
   CORE_CURRENT_HEAD_V1,
   CORE_FORK_CONFLICT_HEADS_V1,
   CORE_FORK_RESOLUTION_V1,
@@ -314,11 +312,7 @@ export interface StorageDriverV1 {
  * two different questions with every row still well formed.
  */
 function mintAncestryV1(): readonly AgentProfileHeadObjectV1[] {
-  return [
-    CORE_CURRENT_HEAD_V1,
-    ...CORE_ALL_LINEAGE_HEADS_V1,
-    ...CORE_FORK_CONFLICT_HEADS_V1,
-  ];
+  return CORE_MINT_GRAPH_V1.ancestry;
 }
 
 /**
@@ -353,7 +347,7 @@ export async function mintStorageSummaryForHeadV1(
   | { readonly minted: false; readonly message: string }
 > {
   const ancestry = mintAncestryV1();
-  const transitions = [...CORE_ALL_TRANSITIONS_V1];
+  const transitions = [...CORE_MINT_GRAPH_V1.transitions];
   try {
     if ((candidate as { state: string }).state === 'tombstone') {
       // The predecessor and its deletion table are the ACTIVE head at the
@@ -363,13 +357,12 @@ export async function mintStorageSummaryForHeadV1(
       // every sequence-relative tombstone for an owned-subject table this
       // fixture never supplies, and the refusal is phrased exactly like a
       // domain one.
-      const predecessor = coreSequenceActiveHeadV1(
-        (candidate as { authoritySequence: string }).authoritySequence,
-      );
+      const { predecessor, ownedSubjectTable } = CORE_MINT_GRAPH_V1
+        .tombstonePredecessorFor((candidate as { authoritySequence: string }).authoritySequence);
       const closure = await mintAgentProfileTombstoneClosureV1({
         tombstone: candidate,
         predecessor,
-        ownedSubjectTable: [predecessor.rootSubject],
+        ownedSubjectTable: [...ownedSubjectTable],
         ancestors: ancestry,
         transitions,
         onUnresolvedArtifact: onUnresolved,

--- a/packages/storage/test/helpers/authority-verdict-diff-storage-driver-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-storage-driver-v1.ts
@@ -328,9 +328,26 @@ function mintAncestryV1(): readonly AgentProfileHeadObjectV1[] {
  * The refusal is a construction result, never a swallowed skip: where the
  * builder will not close over a head there is no storage verdict to compare, and
  * the join records that as a NAMED non-comparability rather than as a gap.
+ *
+ * `onUnresolved` FIRES ON EVERY LOOKUP THE ARTIFACT MAP CANNOT ANSWER, and it is
+ * here because its ABSENCE was demonstrated rather than theorised. The core
+ * minter has carried this hook since the S1 incident, and the sweep pins its
+ * result at zero; this one did not, and that asymmetry is exactly where a defect
+ * hid. Minting every sequence-relative tombstone against the CURRENT head's
+ * owned-subject table asked for a deletion-table digest this fixture never
+ * supplies, which surfaces as 'verification closure is missing 0x...' -- a
+ * refusal owned by the harness, wearing a domain refusal's exact wording. It
+ * survived a full 13-minute lane with every count conserving, and was found only
+ * because an independently derived cell count disagreed with the run by exactly
+ * the three affected head shapes.
+ *
+ * A guard installed on one of two minters is not installed. The distinction the
+ * hook reports is not in the message -- it is in whether a lookup went
+ * unanswered, which no amount of reading the message recovers.
  */
 export async function mintStorageSummaryForHeadV1(
   candidate: AgentProfileHeadObjectV1,
+  onUnresolved?: (reference: string) => void,
 ): Promise<
   | { readonly minted: true; readonly summary: AgentProfileVerifiedAuthoritySummaryV1 }
   | { readonly minted: false; readonly message: string }
@@ -355,6 +372,7 @@ export async function mintStorageSummaryForHeadV1(
         ownedSubjectTable: [predecessor.rootSubject],
         ancestors: ancestry,
         transitions,
+        onUnresolvedArtifact: onUnresolved,
       } as never);
       return {
         minted: true,
@@ -368,7 +386,11 @@ export async function mintStorageSummaryForHeadV1(
     );
     const closure = await buildAgentProfileVerificationClosureV1(
       computeAgentProfileHeadObjectDigestV1(candidate as never),
-      systemRecordClosureResolveOptionsV1(artifacts, TERMINAL_FIXTURE_NOW_MS_V1) as never,
+      systemRecordClosureResolveOptionsV1(
+        artifacts,
+        TERMINAL_FIXTURE_NOW_MS_V1,
+        onUnresolved,
+      ) as never,
     );
     return {
       minted: true,

--- a/packages/storage/test/helpers/authority-verdict-diff-storage-sweep-v1.ts
+++ b/packages/storage/test/helpers/authority-verdict-diff-storage-sweep-v1.ts
@@ -47,8 +47,20 @@ export interface StorageProjectionRowV1 {
   readonly outcome: StorageProjectionOutcomeV1;
 }
 
+/**
+ * `onUnresolved` receives every `objectKind:digest` the mint walk asked for and
+ * the fixture could not answer.
+ *
+ * Threaded through the REAL sweep rather than audited by a parallel walk on
+ * purpose. A second walk built to check the first can drift from it, and then
+ * the audit reports on a graph nobody drives -- the same "two halves asking
+ * different questions" failure this harness exists to catch, wearing an
+ * auditor's clothes. Optional so no existing caller changes; the audit passes a
+ * collector and asserts the result is empty.
+ */
 export async function runStorageSweepV1(
   cells: readonly VerdictDiffCellV1[],
+  onUnresolved?: (reference: string) => void,
 ): Promise<readonly StorageProjectionRowV1[]> {
   const groups = new Map<string, { representative: VerdictDiffCellV1; count: number }>();
   for (const cell of cells) {
@@ -83,7 +95,7 @@ export async function runStorageSweepV1(
       continue;
     }
     if (!mints.has(headShapeKey)) {
-      mints.set(headShapeKey, await mintStorageSummaryForHeadV1(head.candidate));
+      mints.set(headShapeKey, await mintStorageSummaryForHeadV1(head.candidate, onUnresolved));
     }
     const mint = mints.get(headShapeKey)!;
     if (!mint.minted) {

--- a/packages/storage/test/helpers/system-record-active-replacement-fixture.ts
+++ b/packages/storage/test/helpers/system-record-active-replacement-fixture.ts
@@ -157,9 +157,21 @@ export function makeSystemRecordActiveReplacementIssueV1(
 
 const SIBLING_BUNDLE_DIGEST = `0x${'c7'.repeat(32)}` as Digest32V1;
 const ALTERNATE_BASE_ISSUED_AT = '2026-08-05T11:59:00Z';
+/**
+ * One wallet root per rotation. The length is the chain's maximum depth, and
+ * that is the only thing bounding it: a rotation needs a fresh root because the
+ * lineage walk refuses a reused one (verification closure :635), so extending
+ * the chain is extending this array.
+ *
+ * `0x77` is deliberately absent: the verdict-diff head layer rotates its
+ * EQUIVOCATING transition to that root, and a competing rotation is only
+ * competing while its root is off the real chain.
+ */
 const ROTATION_ISSUERS = [
   '0x5555555555555555555555555555555555555555',
   '0x6666666666666666666666666666666666666666',
+  '0x8888888888888888888888888888888888888888',
+  '0x9999999999999999999999999999999999999999',
 ] as const;
 
 /**
@@ -183,7 +195,16 @@ function rotatedActiveHead(
     evmIssuer: issuer,
     rootSubject,
     ownedSubjectTableDigest: computeOwnedSubjectTableDigestV1(rootSubject, [rootSubject]),
-  } as AgentProfileActiveHeadObjectV1;
+  } as AgentProfileActiveHeadObjectV1 & { previousHeadDigest?: Digest32V1 };
+  // A rotation restarts version numbering, and a version-zero head must omit its
+  // predecessor link (head codec :204). The link would otherwise be INHERITED
+  // FROM THE SOURCE by the spread above -- invisible while every source was
+  // genesis, and a throw the moment a caller rotates off a versioned head.
+  // Applied here rather than left to fail: a builder that lets its own
+  // obligations throw manufactures refusals out of its omissions.
+  if (draft.version === '0' && history.previousHeadDigest === undefined) {
+    delete draft.previousHeadDigest;
+  }
   const quads = projectionFor(draft);
   const contentDigest = contentDigestFor(quads);
   return {
@@ -202,45 +223,118 @@ function rotatedActiveHead(
   } as AgentProfileActiveHeadObjectV1;
 }
 
+export interface RotatedAuthorityChainV1 {
+  /** The head at the top of the chain -- `heads[steps]`. */
+  readonly base: AgentProfileActiveHeadObjectV1;
+  /**
+   * `heads[i]` is the head at authority sequence `i`, `heads[0]` being genesis.
+   *
+   * Indexed by sequence rather than handed out as a bare list because that is
+   * the question every caller actually has. A candidate at sequence 3 must
+   * carry the issuer, root subject, owned-subject table digest and accepted
+   * transition that sequence 3 requires; re-stamping the sequence number onto a
+   * head built for another sequence leaves it naming a transition into
+   * somewhere else, which the closure's lineage walk refuses with a message
+   * about incomplete lineage that reads like a domain refusal.
+   */
+  readonly heads: readonly AgentProfileActiveHeadObjectV1[];
+  /** `heads[steps - 1] .. heads[0]`, newest first. */
+  readonly ancestors: readonly AgentProfileActiveHeadObjectV1[];
+  /** `transitions[i]` is the rotation INTO sequence `i + 1`. */
+  readonly transitions: readonly AgentProfileAuthorityTransitionV1[];
+}
+
 /**
- * Two real authority rotations, so a head derived from the result carries a
- * transition lineage of length two. That is what lets the persisted row's
- * lineage length differ from the forked version, which is the only way a
- * predicate comparing the wrong one of the two can be caught.
+ * `steps` real authority rotations, so a head derived from `base` carries a
+ * transition lineage of that length. A lineage longer than one is what lets a
+ * persisted row's lineage length differ from the forked version, which is the
+ * only way a predicate comparing the wrong one of the two can be caught.
+ *
+ * Built as a fold rather than as one body per depth. The two bespoke bodies
+ * this replaces were identical except for their last iteration, and the shape
+ * mattered: it made the depth look like a property of the fixture when it is a
+ * property of ROTATION_ISSUERS, and a reader who wanted a third rotation found
+ * a closed switch rather than a parameter.
  */
-function twiceRotatedChain() {
-  const initial = structuredClone(verified.head);
-  const first = rotationTransition(initial, '1', ROTATION_ISSUERS[0]);
-  const middle = rotatedActiveHead(initial, ROTATION_ISSUERS[0], '1', '0', {
-    acceptedTransitionDigest: computeAgentProfileAuthorityTransitionDigestV1(first),
-  });
-  const second = rotationTransition(middle, '2', ROTATION_ISSUERS[1]);
-  const base = rotatedActiveHead(middle, ROTATION_ISSUERS[1], '2', '0', {
-    acceptedTransitionDigest: computeAgentProfileAuthorityTransitionDigestV1(second),
-  });
+function nRotatedChain(steps: number): RotatedAuthorityChainV1 {
+  const { heads, transitions } = rotateFrom(structuredClone(verified.head), steps, 0);
   return {
-    base,
-    ancestors: [middle, initial] as readonly AgentProfileActiveHeadObjectV1[],
-    transitions: [first, second] as readonly AgentProfileAuthorityTransitionV1[],
+    base: heads[steps] as AgentProfileActiveHeadObjectV1,
+    heads,
+    ancestors: heads.slice(0, steps).reverse(),
+    transitions,
   };
 }
 
 /**
- * One real authority rotation. A resolution built on the result is internally
- * valid at the NEXT authority sequence, which is what a peer offers when it
- * rotates instead of adjudicating the fork it created.
+ * Continue an authority chain `steps` further, rotating off `from`.
+ *
+ * SEPARATE FROM `makeRotatedAuthorityChainV1` BECAUSE THE TWO ANSWER DIFFERENT
+ * QUESTIONS, and collapsing them silently produces a head that verifies while
+ * meaning the wrong thing. That one builds a record's PAST: the ancestry some
+ * current head descends from, rooted at genesis. This one builds a proposed
+ * FUTURE off a head that already exists.
+ *
+ * The distinction is load-bearing for anything comparing a candidate against an
+ * APPLIED row. A receiver at sequence N checks that the candidate's lineage tail
+ * names ITS OWN head as the rotation's prior (storage
+ * system-record-next-state-v1-internal.ts, the next-sequence arm's
+ * `summary.lastAuthorityTransitionPriorHeadDigest !== current.headDigest`
+ * conjunct). A candidate built by extending the ancestry chain instead rotates
+ * off the ancestry's version-zero head at that sequence, which is a DIFFERENT
+ * object from the applied head -- so the candidate verifies internally, mints a
+ * well-formed summary, and is still refused as a history mismatch. That refusal
+ * is the fixture's, not the system's, and it is indistinguishable from a real
+ * one at the message.
+ *
+ * `heads[0]` IS `from`, so `heads[i]` is the head `i` rotations above it.
+ * `firstIssuerIndex` says where in ROTATION_ISSUERS this extension starts, so a
+ * caller continuing a chain does not reuse a root the ancestry already spent --
+ * the lineage walk refuses a repeated wallet root.
  */
-function onceRotatedChain() {
-  const initial = structuredClone(verified.head);
-  const first = rotationTransition(initial, '1', ROTATION_ISSUERS[0]);
-  const base = rotatedActiveHead(initial, ROTATION_ISSUERS[0], '1', '0', {
-    acceptedTransitionDigest: computeAgentProfileAuthorityTransitionDigestV1(first),
-  });
-  return {
-    base,
-    ancestors: [initial] as readonly AgentProfileActiveHeadObjectV1[],
-    transitions: [first] as readonly AgentProfileAuthorityTransitionV1[],
-  };
+export function extendRotatedAuthorityChainV1(
+  from: AgentProfileActiveHeadObjectV1,
+  steps: number,
+  firstIssuerIndex: number,
+): Readonly<{
+  heads: readonly AgentProfileActiveHeadObjectV1[];
+  transitions: readonly AgentProfileAuthorityTransitionV1[];
+}> {
+  if (firstIssuerIndex + steps > ROTATION_ISSUERS.length) {
+    throw new Error(
+      `extending ${steps} steps from issuer index ${firstIssuerIndex} needs `
+      + `${firstIssuerIndex + steps} rotation issuers`,
+    );
+  }
+  return Object.freeze(rotateFrom(from, steps, firstIssuerIndex));
+}
+
+/**
+ * The one rotation loop. The next authority sequence is read off the PRIOR HEAD
+ * rather than off the loop index, so an extension continues its input's
+ * numbering instead of restarting at one.
+ */
+function rotateFrom(
+  origin: AgentProfileActiveHeadObjectV1,
+  steps: number,
+  firstIssuerIndex: number,
+): {
+  heads: AgentProfileActiveHeadObjectV1[];
+  transitions: AgentProfileAuthorityTransitionV1[];
+} {
+  const heads: AgentProfileActiveHeadObjectV1[] = [origin];
+  const transitions: AgentProfileAuthorityTransitionV1[] = [];
+  for (let step = 0; step < steps; step += 1) {
+    const prior = heads[step] as AgentProfileActiveHeadObjectV1;
+    const issuer = ROTATION_ISSUERS[firstIssuerIndex + step] as string;
+    const nextSequence = String(BigInt(prior.authoritySequence) + 1n);
+    const transition = rotationTransition(prior, nextSequence, issuer);
+    transitions.push(transition);
+    heads.push(rotatedActiveHead(prior, issuer, nextSequence, '0', {
+      acceptedTransitionDigest: computeAgentProfileAuthorityTransitionDigestV1(transition),
+    }));
+  }
+  return { heads, transitions };
 }
 
 function rotationTransition(
@@ -300,9 +394,12 @@ export async function makeForkResolvingSuccessorFixtureV1(
   terminalTransitionConflict = false,
 ): Promise<ForkResolvingSuccessorFixtureV1> {
   const genesis = shape === 'genesis';
+  // `rotated` wants a lineage of two; `after-rotate` wants a resolution that is
+  // internally valid at the NEXT authority sequence, which is what a peer offers
+  // when it rotates instead of adjudicating the fork it created.
   const chain = shape === 'rotated'
-    ? twiceRotatedChain()
-    : shape === 'after-rotate' ? onceRotatedChain() : undefined;
+    ? nRotatedChain(2)
+    : shape === 'after-rotate' ? nRotatedChain(1) : undefined;
   const origin = chain?.base ?? structuredClone(verified.head);
   // A second version-zero head of the same authority: a different common base,
   // which is what distinguishes two fork events that agree on every other
@@ -481,17 +578,30 @@ export function systemRecordClosureResolveOptionsV1(
  * A real authority chain of `steps` rotations, exported because a NON-GENESIS
  * head cannot be fabricated by editing a genesis one.
  *
- * The constraint is structural and was measured at its site: authority sequence
- * > 0 requires an `acceptedTransitionDigest` (head codec :197), that digest must
- * name a valid authority transition, and a transition MUST "rotate to a new
- * wallet root" (system-record-agent-profile-control-codecs-v1-internal.ts:190).
- * So every non-genesis head is a ROTATED head -- which moves `evmIssuer` and
+ * THE CONSTRAINT THIS DOCUMENTS IS ABOUT EVERY ROTATION, NOT ABOUT DEPTH, and
+ * the distinction has already cost one wrong finding. It is structural and was
+ * measured at its site: authority sequence > 0 requires an
+ * `acceptedTransitionDigest` (head codec :197), that digest must name a valid
+ * authority transition, and a transition MUST "rotate to a new wallet root"
+ * (system-record-agent-profile-control-codecs-v1-internal.ts:190). So every
+ * non-genesis head is a ROTATED head -- which moves `evmIssuer` and
  * `rootSubject`, and therefore obliges a rebuilt graph-scoped author seal and a
  * re-derived owned-subject table. `rotatedActiveHead` already does all of that;
  * this exposes it rather than inviting the next caller to rebuild it wrongly.
+ *
+ * DEPTH IS A PARAMETER AND HAS NO BOUND HERE beyond the supply of wallet roots,
+ * which is why the type is `number` rather than a union of the depths anyone has
+ * needed so far. The previous signature was `steps: 1 | 2`, and it was read as a
+ * structural cap by two separate readers -- a finding shipped blaming it for a
+ * 47% coverage boundary before being corrected at the real cause. A literal union
+ * on a parameter says "these are the legal values"; nothing here refuses a third
+ * rotation, so nothing here should look like it does.
  */
-export function makeRotatedAuthorityChainV1(steps: 1 | 2) {
-  return steps === 1 ? onceRotatedChain() : twiceRotatedChain();
+export function makeRotatedAuthorityChainV1(steps: number): RotatedAuthorityChainV1 {
+  if (steps > ROTATION_ISSUERS.length) {
+    throw new Error(`chain depth ${steps} needs ${steps} rotation issuers`);
+  }
+  return nRotatedChain(steps);
 }
 
 function envelopeArtifact(

--- a/packages/storage/test/helpers/system-record-active-replacement-fixture.ts
+++ b/packages/storage/test/helpers/system-record-active-replacement-fixture.ts
@@ -300,12 +300,7 @@ export function extendRotatedAuthorityChainV1(
   heads: readonly AgentProfileActiveHeadObjectV1[];
   transitions: readonly AgentProfileAuthorityTransitionV1[];
 }> {
-  if (firstIssuerIndex + steps > ROTATION_ISSUERS.length) {
-    throw new Error(
-      `extending ${steps} steps from issuer index ${firstIssuerIndex} needs `
-      + `${firstIssuerIndex + steps} rotation issuers`,
-    );
-  }
+  assertRotationCountV1(steps, firstIssuerIndex, 'extension length');
   return Object.freeze(rotateFrom(from, steps, firstIssuerIndex));
 }
 
@@ -598,10 +593,36 @@ export function systemRecordClosureResolveOptionsV1(
  * rotation, so nothing here should look like it does.
  */
 export function makeRotatedAuthorityChainV1(steps: number): RotatedAuthorityChainV1 {
-  if (steps > ROTATION_ISSUERS.length) {
-    throw new Error(`chain depth ${steps} needs ${steps} rotation issuers`);
-  }
+  assertRotationCountV1(steps, 0, 'chain depth');
   return nRotatedChain(steps);
+}
+
+/**
+ * `number` is a WIDER type than the values this fixture can serve, so the
+ * boundary has to narrow it -- otherwise widening from `1 | 2` just moves the
+ * refusal from the compiler to an index that silently yields `undefined` and a
+ * cast that hides it.
+ *
+ * Checked rather than assumed: a non-integer, a negative, or a count past the
+ * wallet-root supply are all reachable from a caller and none of them produces a
+ * sensible chain. The root-supply bound is the only REAL one -- there is nothing
+ * in the system that refuses a deeper chain, which is exactly the misreading the
+ * old literal union invited.
+ */
+function assertRotationCountV1(steps: number, firstIssuerIndex: number, what: string): void {
+  if (!Number.isSafeInteger(steps) || steps < 0) {
+    throw new Error(`${what} must be a non-negative safe integer, got ${String(steps)}`);
+  }
+  if (!Number.isSafeInteger(firstIssuerIndex) || firstIssuerIndex < 0) {
+    throw new Error(`issuer index must be a non-negative safe integer, got ${String(firstIssuerIndex)}`);
+  }
+  if (firstIssuerIndex + steps > ROTATION_ISSUERS.length) {
+    throw new Error(
+      `${what} ${steps} from issuer index ${firstIssuerIndex} needs `
+      + `${firstIssuerIndex + steps} rotation issuers, and this fixture supplies `
+      + `${ROTATION_ISSUERS.length}`,
+    );
+  }
 }
 
 function envelopeArtifact(


### PR DESCRIPTION
Closes the sequence-depth coverage boundary the Phase-1 verdict table shipped as a measured limitation. Three of axis D's four sequence relations — `below`, `plusOne`, `abovePlusOne` — could never obtain a verified authority summary, so 69,120 of 145,728 buildable cells could not be compared against storage at all. The comparison that sat outside the comparable region was next-sequence rotation, which is the one the routing decision rests on.

Test-only. Every file is under `packages/storage/test`.

## The headline

**The clean next-sequence rotation is live on both sides for the first time.** `D=plusOne` reaches storage's advance path, and `deferred|authority-history-mismatch` — an outcome the merged join recorded as never-exercised — leaves the unreached register outright.

| | before | after |
|---|---|---|
| mintable head shapes | 6 of 40 | 12 of 40 |
| `incomplete authority/root lineage` | 12 shapes | **0** |
| COMPARABLE | 21,888 cells / 114 projections | 42,624 / 222 |
| CORE-ONLY | 123,840 / 645 | 103,104 / 537 |
| NO-HEAD | 18,432 / 96 | 18,432 / 96 |
| adjudicated | 9,792 | 20,160 |
| AGREEMENT / DIVERGENCE / NO-MAPPING | 4,736 / 3,136 / 1,920 | 11,648 / 4,288 / 4,224 |

Conservation exact at 164,160 throughout. Comparable share 13.3% → 25.97%.

## The cause was not the chain helper's depth type

The finding this closes originally blamed `makeRotatedAuthorityChainV1(steps: 1 | 2)` and was corrected before merge: that is a *parameter*, not a bound. The real cause was that every candidate named the same 1→2 transition digest and the same predecessor whatever authority sequence it claimed, so a deeper chain alone would have changed nothing.

The signature still goes, for a different reason — a literal union on a parameter reads as a structural cap, and that misreading already shipped as a wrong finding once.

## The design call worth reviewing

Sequences 3 and 4 are **not** built by deepening the ancestry chain. The ancestry's sequence-2 head is the version-zero one; the current head is that head at version 2. A rotation off the ancestry therefore names a prior the receiver never applied — and storage's next-sequence arm compares exactly that (`summary.lastAuthorityTransitionPriorHeadDigest !== current.headDigest`). Such a candidate verifies internally, mints a well-formed summary, and is **still** refused as a history mismatch, by this fixture's choice of predecessor wearing the system's wording.

That is the manufactured-retirement shape in its most dangerous form, and it would have been invisible: real message, real site, exact conservation, green suite. So the record's proposed *future* is built by a separate primitive, `extendRotatedAuthorityChainV1`, rotating off the current head. Two entry points, one loop, with the reason documented at the site.

## Method: the near-miss is the most important thing in this PR

An earlier run returned COMPARABLE **35,712 / 186** — internally consistent, conserving perfectly against 164,160, every bucket summing. Pinned, it would have become the answer and nothing would have objected.

It disagreed with a hand derivation written down *before* the run by exactly 6,912 cells and 36 projections, which factors as three tombstone shapes × 12 × 192. The gap was a real defect: the storage minter was still building tombstone closures against the current head.

**Conservation is a consistency check, not a correctness check.** Only an independently derived count could tell those apart. The derivation earns its authority by reproducing the *committed* baseline exactly first (114 projections, 21,888 cells from the previous six shapes) before predicting the new state — then six predicted numbers matched six observed ones.

## Two results the re-pin surfaced

**A divergence that ran the other way — RETRACTED, and the retraction is the more useful result.** An earlier revision of this PR reported `accept -> stale` at 192 cells, where core accepts an advance storage declines, and argued that routing therefore carries opposite risks in the two directions and does not merely tighten.

That was not a system divergence. It was this fixture handing core a mismatched `acceptedTransition`: a candidate at sequence 3 received the 1→2 transition, core refused it, and storage — which never sees axis-J evidence — went its own way. **One side got a corrupted input and the disagreement was recorded as the two implementations disagreeing.** All 192 cells are now `accept -> ready`, an agreement. It was caught by review, not by this PR's own derivation.

Every divergence in the table again runs one way: storage materialises heads core refuses, 4,288 cells. `JOIN_DIVERGENCE_DIRECTIONS_V1` keeps the reverse row **pinned at zero** rather than deleting it, for the same reason the storage codomain pins its unreached labels — an omitted row and an empty one are indistinguishable, and only one of them is a claim.

**The positive trace of the fix is the better evidence**, and it is independent of the divergence vanishing: `reject|exact accepted authority transition is missing -> ready` **halved, 384 → 192**, and the same reason-pair halved on both its level-2 rows. Manufactured rejects leaving the table is as much proof the mismatch is gone as the false divergence disappearing — two independent observations of one fix, where either alone would be weaker.

The both-directions-live assertion is **retired, not weakened**. It existed so the opposite-risks claim could not go vacuous while the sum still checked out; the claim went vacuous, and the guard turned red on cue. What remains is the partition check against the divergence total.

The lesson generalises past this instance: **a first observation inside a region you have just built is the least trustworthy kind, not the most interesting one.** The competing hypothesis — the region is newly observable *because* I built it, and I built it wrong — is the one this slice's method exists to force, and it was never run, despite the same defect class having already been found in three other places here.

**A reject reason vanished and another appeared at an identical count — which is why the pin is at the reason level.** `reject|transition does not bind the accepted predecessor` (1,024 cells) is gone: it fired only when a candidate named a transition whose prior head was not its own, and no candidate does that now. And `next-sequence tombstone requires its exact same-sequence active predecessor` became `late tombstone requires the exact retained resurrection transition` at an identical 256 cells / 64 projections — same cells, different reason, because a sequence-ahead tombstone now carries the real rotation and core reaches it through the resurrection branch instead. A cell-count pin reads that second change as nothing happening at all.

**Equal outcomes from unequal machinery.** The three sequence relations are not alike in comparison value, and the ranking is the reverse of their cell counts. At `below` and `abovePlusOne` storage answers by a flat rule on the sequence number alone while core runs a rich branch on both; the outcomes agree, the work does not. `plusOne` is the only relation where both sides do real work — which is consistent with the Phase-3 coupling having been placed on it alone.

## Axis G's denotation was generalised, and adjudicated rather than assumed

A well-formed candidate at another authority sequence must name the rotation into *its own* sequence, so "compared to the current head's `acceptedTransitionDigest`" needed a general form: `equal` names the accepted rotation into the candidate's own sequence, `differ` a competing one. The older reading is the **special case** at `D='equal'`, and the core-heads suite pins that column on its two original constants byte for byte rather than inheriting it from the general rule.

Adopted on system responsiveness rather than preference: at the sequence-relative shapes `G='differ'` fires the equivocation refusal, so the outcome moves on the axis. The literal reading would have required a `G='equal'` candidate off `D='equal'` to name a rotation into somewhere else — a head this fixture authored to be malformed, refusing in the system's wording, re-creating by definition the class this work removes.

The generalised assertion resolves against the transition **objects**, not against the builder's own per-sequence table; comparing a head to the table that built it agrees by construction and could never catch a builder ignoring the axis.

## A guard whose absence was demonstrated, not argued

The class guard installed after the manufactured-retirement incident covered **one of the two minters**. The core minter has carried an `onUnresolvedArtifact` hook and a zero-pin since; the storage minter carried neither, and that is exactly where the tombstone defect hid — through a full 13-minute lane, with perfect conservation.

The hook is threaded through the *real* sweep rather than audited by a parallel walk, because a second walk built to check the first can drift from it.

Its non-vacuity proof, including the invalid first attempt: attempt 1 mutated only `ownedSubjectTable` and **survived** — not evidence the guard is vacuous, evidence the mutation was not the defect it claims to catch. Its apply-check was also broken (`grep -c` read `[predecessor.rootSubject]` as a character class and reported 0 occurrences of a line that was present — the same 0 a correct check reports for a missing site). Attempt 2 reverted the whole per-sequence selection with a fixed-string apply-check: predicted red naming 2 unresolved references, **observed red naming 3** — mechanism right, magnitude mispredicted — restored byte-identical, control re-run green.

## Prose requalified, each carrying its own evidence

- The core table's sequence-depth finding, including its `D=abovePlusOne` "awaits a denotation determination" caution. That question is **dissolved, not decided**: core rejects a two-ahead candidate at `system-record-authority-v1-internal.ts:151-153` and storage defers it in `classifyAuthorityAdvance`, both from the sequence number alone and both short-circuiting before reading the summary. Neither implementation has the distinction the question presupposed, and constructibility then leaves exactly one buildable shape.
- The join's `JOIN_UNREACHED_OUTCOMES_V1` entry, whose stated cause was the already-retired chain-helper signature *while claiming the core table recorded the same boundary* — a cross-reference asserting agreement with its own correction.

## Still open

**Axis `K='present'` is a different boundary and is not closed here**, stated as open where a reader looks. Measured at `isDirectResolvingSuccessorV1`: five conjuncts, not the two previously recorded. The two new ones bite specifically — a rotation moves `evmIssuer`, so the single fork resolution this fixture builds can only ever bind a sequence-2 candidate, and closing it across axis D needs a per-sequence resolution with its own evidence heads. Filed as its own follow-up; the routing coupling does not rest on it.

## The review round, answered

Five threads, all new mechanisms, all answered by measurement.

**Sequence-relative candidates received current-sequence transition evidence** (red) — accepted and fixed; it is the retraction above. It also triggered a **class sweep by enumeration** over every cell-driving constant, which found **four** instances of the one-size-fits-all class, not one: this plus `CORE_FORK_RESOLUTION_V1`, `CORE_FORK_CONFLICT_HEADS_V1` and `CORE_FORK_BASE_HEAD_V1`. Seven further constants are classified sequence-*invariant* with their reasons — six by definition, since they describe the accepted side and making those per-candidate would *be* the defect.

The three fork siblings are **measurably inert**: present-vs-absent moved 0 of 5,184 projections each and 0 of 9,072 with all three dropped together, against a positive control of 72 of 600. They feed core's fork-resolution-successor branch, which is unreachable under this axis set — so the measurement and the previously recorded arithmetic agree from independent directions. They ride the axis-K follow-up, with the inertness *and the condition under which it stops holding* recorded at each constant's own doc, so the next implementer meets it at the site they will edit.

**The mint audit never proved its hook is live** (red) — accepted. A silent hook and a clean run are the same observation, and a mutation recorded in a commit message is not a control this suite carries. It now has a permanent positive control: a head naming an artifact the map does not hold must make the hook report it.

**Keep minting behind one shared helper** (adopted) — both minters now read one `CORE_MINT_GRAPH_V1`: ancestry, transitions, and the tombstone predecessor rule. The duplication is what *produced* the storage twin of the tombstone defect, so this is the structural form of a fix previously made by vigilance. Two minters can still differ in what they do with the graph; they can no longer disagree about what the graph is.

**Model lineage as one typed entry** (folded into the above) and **don't widen depth to raw `number` without validating it** (adopted) — the boundary now narrows to non-negative safe integers with the wallet-root supply named as the only real bound. Widening from `1 | 2` without that merely moved the refusal from the compiler to an index yielding `undefined` behind a cast.

## CI budget

The lane went **798s → 338s**, and the blowup was a regression rather than the table growing. Making the candidate lineage per-sequence had moved two digest computations from module scope into the head builder, turning four hashes into roughly 145,000 — projection-equivalence 716s → 373s once precomputed. The core-table file also recomputed its sweep three times and its mint index twice, where the join file beside it already memoises; it is now **below its own pre-PR baseline** (116s → 64s).

No observation left the run: both cuts memoise pure functions over inputs fixed at module load, same cells driven, same projections swept. The ~20% still above baseline is real work and is not claimed back.

Attribution was settled by per-file baselines from a neighbouring PR's CI log rather than by a whole-lane number — the lane had passed at 7m50s and 7m04s on the two preceding PRs with the same suites, so "the region doubled" could not explain core-table going 116s → 226s when the cells it sweeps had not doubled.

## Verification

Full verdict-diff lane green: **13 files, 84 tests, 0 failures**, run at the final tree. `unresolvedArtifacts == 0` on both minters — no refusal in the table traces to an artifact the fixture failed to supply. The projection-equivalence suite passes in full, so the input-building discipline survived the change.

Note this branch's PR checks are the entire validation gate — push-triggered CI does not run on the integration branch.
