### PR TITLE
feat(agent): wire the legacy agent-profile gate into the durable-sync ingest seam (#2052 D-8)

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -343,6 +343,8 @@ import {
   automaticDurableSyncContextGraphs,
   isSystemContextGraphExcludedFromChangelogLane,
 } from './sync/system-context-graph-policy.js';
+import { createLegacyAgentProfileGateV1 } from './system-records/legacy-profile-gate-v1.js';
+import { createLegacyAgentProfileGateLookupV1 } from './system-records/legacy-profile-gate-lookup-v1.js';
 import {
   activeSyncAdmissionSource,
   monotonicNowMs,
@@ -5041,6 +5043,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       contextGraphId,
       remainingContextGraphs,
     });
+    const networkId = this.config.networkIdentity?.networkId;
     const durableContext: DurableSyncContext = {
       ctx,
       remotePeerId,
@@ -5089,6 +5092,26 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           signal: operationSignal,
         });
       },
+      // #2052 D-8 (#53) — the inbound legacy `agents` gate. Supplied here because this is
+      // the only production construction site for the legacy durable-sync seam.
+      //
+      // THE MODE IS `shadow`, AND THAT IS NOT A DEFAULT I PICKED. It is the plan's
+      // documented pre-activation state — `SystemRecordLaneActivationV1` says in its own
+      // docblock that "Pre-activation shadow mode keeps the legacy lane authoritative" —
+      // and there is nothing to read it from, because the mode is an input to
+      // `SystemRecordLaneControllerV1.open()` and no production path opens a lane. So the
+      // gate is inert BY MODE rather than by being absent: it is constructed, it runs on
+      // every legacy page, and it withholds nothing because no projection is authoritative
+      // yet. D-12 owns replacing this expression with the activation's own mode, and owns
+      // the proof that flipping it makes the gate fire.
+      //
+      // Without a network identity the root-claim subjects cannot be derived at all, so
+      // the gate is not constructed rather than constructed against an invented id. A
+      // system-record activation carries a networkId, so this cannot be absent once the
+      // lane it protects is live.
+      legacyAgentProfileGate: networkId === undefined ? undefined : createLegacyAgentProfileGateV1(
+        createLegacyAgentProfileGateLookupV1({ store: this.store, networkId, mode: 'shadow' }),
+      ),
       storeGraphScopedAsset: ({
         asset,
         authenticationDeadline,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -5092,7 +5092,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           signal: operationSignal,
         });
       },
-      // #2052 D-8 (#53) — the inbound legacy `agents` gate. Supplied here because this is
+      // #2052 D-8 — the inbound legacy `agents` gate. Supplied here because this is
       // the only production construction site for the legacy durable-sync seam.
       //
       // THE LITERAL `shadow` IS CORRECT HERE, AND IS NOT A DEFAULT STANDING IN FOR A

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -5095,15 +5095,23 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // #2052 D-8 (#53) — the inbound legacy `agents` gate. Supplied here because this is
       // the only production construction site for the legacy durable-sync seam.
       //
-      // THE MODE IS `shadow`, AND THAT IS NOT A DEFAULT I PICKED. It is the plan's
-      // documented pre-activation state — `SystemRecordLaneActivationV1` says in its own
-      // docblock that "Pre-activation shadow mode keeps the legacy lane authoritative" —
-      // and there is nothing to read it from, because the mode is an input to
-      // `SystemRecordLaneControllerV1.open()` and no production path opens a lane. So the
-      // gate is inert BY MODE rather than by being absent: it is constructed, it runs on
-      // every legacy page, and it withholds nothing because no projection is authoritative
-      // yet. D-12 owns replacing this expression with the activation's own mode, and owns
-      // the proof that flipping it makes the gate fire.
+      // THE LITERAL `shadow` IS CORRECT HERE, AND IS NOT A DEFAULT STANDING IN FOR A
+      // LOOKUP. There is nothing to read the mode from: it is an INPUT to
+      // `SystemRecordLaneControllerV1.open()`, not state the controller exposes, and no
+      // production path opens a lane — so pre-activation this is the only place a mode can
+      // be expressed at all. The value is the plan's documented pre-activation state:
+      // `SystemRecordLaneActivationV1`'s own docblock says "Pre-activation shadow mode
+      // keeps the legacy lane authoritative".
+      //
+      // DO NOT "FIX" THIS into reading a config key or an agent-side default. No such
+      // source exists, inventing one would give the mode a second home, and the mode
+      // having exactly one home is what stops the gate and the projection disagreeing
+      // about which graph is authoritative.
+      //
+      // So the gate is inert BY MODE rather than by being absent: it is constructed, it
+      // runs on every legacy page, and it withholds nothing because no projection is
+      // authoritative yet. D-12 owns replacing this one expression with the activation's
+      // own mode, and owns the proof that flipping it makes the gate fire.
       //
       // Without a network identity the root-claim subjects cannot be derived at all, so
       // the gate is not constructed rather than constructed against an invented id. A

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -27,6 +27,7 @@ import type {
   GraphScopedMaterializationOutcome,
   VerifiedGraphScopedAsset,
 } from './graph-scoped-materialization.js';
+import type { LegacyAgentProfileGateV1 } from '../../system-records/legacy-profile-gate-v1.js';
 import type { DurableSyncBudget } from './durable-sync-budget.js';
 import {
   normalizeDurableSyncContext,
@@ -191,6 +192,24 @@ export interface DurableSyncContext {
     dataRejectedMissingMeta: number;
   }>;
   storeInsert: (request: DurableSyncStoreInsertRequest) => Promise<void>;
+  /**
+   * #2052 D-8 — the inbound legacy `agents` duplicate/conflict gate (plan :924, :1505).
+   *
+   * Filter-before-insert at this seam, the same shape the oversize guard uses, so that
+   * unsigned legacy quads never reach the store for a root that already carries an
+   * applied signed record. It is scoped by SUBJECT, not by context graph: a page that
+   * derives no `did:dkg:agent:` root is returned untouched and costs no store read, so
+   * the gate is inert on every non-`agents` page without needing to know which page it
+   * is looking at.
+   *
+   * OPTIONAL, and deliberately not fail-closed on absence. The trigger for a
+   * fail-closed throw would be "this page derived an agent root", which is true of every
+   * ordinary `agents` page — and `runDurableSync` is reachable outside this package
+   * through the `"./dist/*"` export wildcard, so throwing would break safe and unsafe
+   * external callers alike. Enforcement lives where it can be proven instead: the
+   * production construction site supplies one, and a test asserts that it does.
+   */
+  legacyAgentProfileGate?: LegacyAgentProfileGateV1;
   /** Exact replacement path for verified V2 KAs; absent capability fails closed. */
   storeGraphScopedAsset?: (
     request: DurableSyncGraphScopedStoreRequest,
@@ -246,6 +265,7 @@ async function runDurableSyncWithBudget(
     stopOnBackoffWorthyFailure = false,
     processDurableBatchInWorker,
     storeInsert,
+    legacyAgentProfileGate,
     storeGraphScopedAsset,
     onVerifiedFullSnapshot,
     deleteCheckpoint,
@@ -267,6 +287,39 @@ async function runDurableSyncWithBudget(
     deadline,
     signal,
   });
+
+  /**
+   * #2052 D-8 — run one legacy page through the agent-profile gate before insertion.
+   *
+   * Data and meta are fetched in separate pagination loops and are therefore separate
+   * pages, so each is entitled to :926's two store requests and gating both stays inside
+   * that bound. A page deriving no agent root short-circuits inside the gate and issues
+   * no read at all, which is what makes gating the meta page free in the default
+   * configuration (`agents/_meta` is opt-in and off).
+   */
+  const gateLegacyAgentProfilePage = async (pid: string, quads: Quad[]): Promise<Quad[]> => {
+    if (legacyAgentProfileGate === undefined || quads.length === 0) return quads;
+    const gated = await legacyAgentProfileGate.filterPage(quads, signal);
+    if (gated.withheld.length > 0) {
+      // Withholding means an applied signed record disagreed with this page, so it is
+      // operationally significant: the phonebook a peer served is contradicting signed
+      // state, or a bounded lookup could not decide. Duplicates are routine replay and
+      // stay at debug so a post-cutover node does not warn on every page.
+      logWarn(
+        ctx,
+        `Legacy agent-profile gate withheld ${gated.withheld.length} quad(s) for "${pid}": `
+        + `${gated.conflictedRoots} conflicting root(s), ${gated.unclassifiedRoots} unclassified `
+        + `(${gated.discardedDuplicates} exact duplicate(s) discarded, ${gated.storeRequests} store read(s))`,
+      );
+    } else if (gated.discardedDuplicates > 0) {
+      logDebug(
+        ctx,
+        `Legacy agent-profile gate discarded ${gated.discardedDuplicates} duplicate quad(s) `
+        + `for "${pid}" (${gated.storeRequests} store read(s))`,
+      );
+    }
+    return [...gated.insert];
+  };
 
   const accumulator = createDurableSyncAccumulator();
   const exactFetchDispositions: ExactDurableFetchDisposition[] = [];
@@ -660,25 +713,36 @@ async function runDurableSyncWithBudget(
       }
       if (partitioned.remainingData.length > 0) {
         throwIfOperationAborted();
-        await storeInsert({
-          quads: partitioned.remainingData,
-          signal,
-        });
-        recordDurableSyncDiagnostics(accumulator, {
-          insertedTriples: partitioned.remainingData.length,
-          insertedDataTriples: partitioned.remainingData.length,
-        });
+        const insertableData = await gateLegacyAgentProfilePage(pid, partitioned.remainingData);
+        throwIfOperationAborted();
+        if (insertableData.length > 0) {
+          await storeInsert({
+            quads: insertableData,
+            signal,
+          });
+          // Counted from what was offered to the store, never from the page size: a
+          // withheld quad that still reported as inserted would make the diagnostics
+          // claim progress the store never took.
+          recordDurableSyncDiagnostics(accumulator, {
+            insertedTriples: insertableData.length,
+            insertedDataTriples: insertableData.length,
+          });
+        }
       }
       if (partitioned.remainingMeta.length > 0) {
         throwIfOperationAborted();
-        await storeInsert({
-          quads: partitioned.remainingMeta,
-          signal,
-        });
-        recordDurableSyncDiagnostics(accumulator, {
-          insertedTriples: partitioned.remainingMeta.length,
-          insertedMetaTriples: partitioned.remainingMeta.length,
-        });
+        const insertableMeta = await gateLegacyAgentProfilePage(pid, partitioned.remainingMeta);
+        throwIfOperationAborted();
+        if (insertableMeta.length > 0) {
+          await storeInsert({
+            quads: insertableMeta,
+            signal,
+          });
+          recordDurableSyncDiagnostics(accumulator, {
+            insertedTriples: insertableMeta.length,
+            insertedMetaTriples: insertableMeta.length,
+          });
+        }
       }
       // An already-started atomic write is awaited and counted truthfully, but
       // an expired operation may not advance a page checkpoint or enter the

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -197,10 +197,18 @@ export interface DurableSyncContext {
    *
    * Filter-before-insert at this seam, the same shape the oversize guard uses, so that
    * unsigned legacy quads never reach the store for a root that already carries an
-   * applied signed record. It is scoped by SUBJECT, not by context graph: a page that
-   * derives no `did:dkg:agent:` root is returned untouched and costs no store read, so
-   * the gate is inert on every non-`agents` page without needing to know which page it
-   * is looking at.
+   * applied signed record.
+   *
+   * SCOPE, STATED AS MEASURED. The gate is scoped by DESTINATION GRAPH conjoined with the
+   * subject derivation — not by the page's context-graph id, and not by the subject alone.
+   * A quad is a candidate only when it derives a `did:dkg:agent:` root AND is bound for
+   * the graph the applied projection occupies, because that is the only place legacy
+   * insertion can physically collide with signed state.
+   *
+   * It is therefore inert, at no store read, on any page carrying no such quad. It is NOT
+   * accurate to say it is inert on "every non-`agents` page": a page under any id can
+   * carry a quad bound for the aggregate graph, and that quad is exactly the one that
+   * scoping by page id would have inserted over signed state.
    *
    * OPTIONAL, and deliberately not fail-closed on absence. The trigger for a
    * fail-closed throw would be "this page derived an agent root", which is true of every
@@ -293,9 +301,9 @@ async function runDurableSyncWithBudget(
    *
    * Data and meta are fetched in separate pagination loops and are therefore separate
    * pages, so each is entitled to :926's two store requests and gating both stays inside
-   * that bound. A page deriving no agent root short-circuits inside the gate and issues
-   * no read at all, which is what makes gating the meta page free in the default
-   * configuration (`agents/_meta` is opt-in and off).
+   * that bound. A page carrying no quad bound for the projection graph short-circuits
+   * inside the gate and issues no read at all, which is what makes gating the meta page
+   * free in the default configuration (`agents/_meta` is opt-in and off).
    */
   const gateLegacyAgentProfilePage = async (pid: string, quads: Quad[]): Promise<Quad[]> => {
     if (legacyAgentProfileGate === undefined || quads.length === 0) return quads;

--- a/packages/agent/src/system-records/legacy-profile-gate-lookup-v1.ts
+++ b/packages/agent/src/system-records/legacy-profile-gate-lookup-v1.ts
@@ -1,5 +1,5 @@
 /**
- * The production lookup behind `LegacyAgentProfileGateV1` (#2052 D-8, #53).
+ * The production lookup behind `LegacyAgentProfileGateV1` (#2052 D-8).
  *
  * A thin adapter and nothing more: it holds no policy, caches nothing, and decides
  * nothing. The gate owns the classification, storage owns the two bounded reads and both

--- a/packages/agent/src/system-records/legacy-profile-gate-lookup-v1.ts
+++ b/packages/agent/src/system-records/legacy-profile-gate-lookup-v1.ts
@@ -15,6 +15,7 @@
 import {
   readLegacyAgentProfileAppliedRootsV1,
   readLegacyAgentProfileProjectionV1,
+  systemRecordProjectionGraphV1,
   type SystemRecordMaterializationModeV1,
 } from '@origintrail-official/dkg-storage/internal/system-record-legacy-gate-read-v1';
 import type { TripleStore } from '@origintrail-official/dkg-storage';
@@ -28,6 +29,11 @@ export function createLegacyAgentProfileGateLookupV1(input: {
 }): LegacyAgentProfileGateLookupV1 {
   const { store, networkId, mode } = input;
   return Object.freeze({
+    // Derived from the SAME `mode` the two reads below are given, and derived by the
+    // materializer's own function rather than restated as an agent-side constant. That is
+    // what keeps the destination-graph conjunct and the reads from ever disagreeing about
+    // which graph is authoritative.
+    projectionGraph: systemRecordProjectionGraphV1(mode),
     lookupAppliedRoots: (roots: readonly string[], signal?: AbortSignal) =>
       readLegacyAgentProfileAppliedRootsV1({ store, networkId, mode, roots, signal }),
     lookupProjectionMembership: (subjects: readonly string[], signal?: AbortSignal) =>

--- a/packages/agent/src/system-records/legacy-profile-gate-lookup-v1.ts
+++ b/packages/agent/src/system-records/legacy-profile-gate-lookup-v1.ts
@@ -1,0 +1,36 @@
+/**
+ * The production lookup behind `LegacyAgentProfileGateV1` (#2052 D-8, #53).
+ *
+ * A thin adapter and nothing more: it holds no policy, caches nothing, and decides
+ * nothing. The gate owns the classification, storage owns the two bounded reads and both
+ * of :926's byte caps, and this exists only because the gate must not import a storage
+ * internal directly.
+ *
+ * MODE IS PASSED IN, NEVER DERIVED HERE. The projection mode has one home — the
+ * materializer's `SystemRecordLaneActivationV1` — and a second copy of it living in the
+ * agent package is exactly the defect the ruling on this slice forbids. So the type comes
+ * from storage and the value comes from the caller; this module cannot invent one.
+ */
+
+import {
+  readLegacyAgentProfileAppliedRootsV1,
+  readLegacyAgentProfileProjectionV1,
+  type SystemRecordMaterializationModeV1,
+} from '@origintrail-official/dkg-storage/internal/system-record-legacy-gate-read-v1';
+import type { TripleStore } from '@origintrail-official/dkg-storage';
+
+import type { LegacyAgentProfileGateLookupV1 } from './legacy-profile-gate-v1.js';
+
+export function createLegacyAgentProfileGateLookupV1(input: {
+  readonly store: TripleStore;
+  readonly networkId: string;
+  readonly mode: SystemRecordMaterializationModeV1;
+}): LegacyAgentProfileGateLookupV1 {
+  const { store, networkId, mode } = input;
+  return Object.freeze({
+    lookupAppliedRoots: (roots: readonly string[], signal?: AbortSignal) =>
+      readLegacyAgentProfileAppliedRootsV1({ store, networkId, mode, roots, signal }),
+    lookupProjectionMembership: (subjects: readonly string[], signal?: AbortSignal) =>
+      readLegacyAgentProfileProjectionV1({ store, mode, subjects, signal }),
+  });
+}

--- a/packages/agent/src/system-records/legacy-profile-gate-v1.ts
+++ b/packages/agent/src/system-records/legacy-profile-gate-v1.ts
@@ -64,30 +64,60 @@ export interface LegacyAgentProfileAppliedRootV1 {
 }
 
 /**
+ * Request one's answer: the applied records found, and the roots it could NOT decide.
+ *
+ * `unclassifiedRoots` exists because absence and ignorance are different answers and the
+ * gate cannot tell them apart on its own. A root that was asked about and is simply
+ * missing from `records` means "no applied record", and its quads take the ordinary
+ * legacy path. A root the implementation could not classify — because a bounded response
+ * ran out before reaching it — must NOT take that path, or honouring a byte cap silently
+ * becomes an insertion of unsigned quads over signed state. :926 requires the opposite
+ * ("signed-root quads not classified within the selected bounded batch are withheld"), so
+ * the implementation names what it could not decide and the gate withholds it.
+ */
+export interface LegacyAgentProfileAppliedRootsV1 {
+  readonly records: readonly LegacyAgentProfileAppliedRootV1[];
+  /** Requested roots this bounded response did not decide. Their quads are withheld. */
+  readonly unclassifiedRoots: readonly string[];
+}
+
+/** Request two's answer: the projection rows, and whether they are the exact set. */
+export interface LegacyAgentProfileProjectionV1 {
+  readonly rows: readonly Quad[];
+  /**
+   * True when a bound stopped this response short of the exact projection. Row-count
+   * overflow is visible to the gate; the 2-MiB byte bound is not, so the implementation
+   * reports it. Either way every covered root is withheld rather than compared against a
+   * partial projection, which would misread a real duplicate as a conflict.
+   */
+  readonly truncated: boolean;
+}
+
+/**
  * The two bounded store reads this gate is allowed for one legacy page.
  *
  * Implementations own the batching; the gate guarantees it calls each at most once per
  * page and never per root or per quad.
+ *
+ * BOTH BYTE CAPS BELONG TO THE IMPLEMENTATION, AND NEITHER MAY BE HONOURED SILENTLY.
+ * :926 caps request one at 1 MiB and request two at 2 MiB, and by the time the gate holds
+ * a result the bytes have already transferred — so the gate can only refuse to trust an
+ * answer, never prevent it. An implementation that cannot honour a cap reports the
+ * shortfall (`unclassifiedRoots` / `truncated`); it must not simply return less, because
+ * a short response is indistinguishable from "no record here" and so fails toward
+ * insertion — the one direction :1505 forbids.
  */
 export interface LegacyAgentProfileGateLookupV1 {
-  /**
-   * Request one: which of these derived roots carry an applied signed record.
-   *
-   * :926 puts the owned-subject lists in this response and caps it at 1 MiB. That byte
-   * cap belongs to the implementation, because by the time the gate holds the result the
-   * bytes have already been transferred — the gate can only refuse to trust an oversized
-   * answer, which it does per record below. An implementation that cannot honour the cap
-   * must return fewer roots rather than a larger response.
-   */
+  /** Request one: which of these derived roots carry an applied signed record. */
   lookupAppliedRoots(
     roots: readonly string[],
     signal?: AbortSignal,
-  ): Promise<readonly LegacyAgentProfileAppliedRootV1[]>;
+  ): Promise<LegacyAgentProfileAppliedRootsV1>;
   /** Request two: the exact projection triples owned by these subjects. */
   lookupProjectionMembership(
     subjects: readonly string[],
     signal?: AbortSignal,
-  ): Promise<readonly Quad[]>;
+  ): Promise<LegacyAgentProfileProjectionV1>;
 }
 
 export interface LegacyAgentProfileGateResultV1 {
@@ -209,8 +239,13 @@ export function createLegacyAgentProfileGateV1(
         const applied = await lookup.lookupAppliedRoots(selected, signal);
         storeRequests += 1;
         const appliedByRoot = new Map<string, LegacyAgentProfileAppliedRootV1>();
+        // Roots the response itself declined to decide. Kept separate from `untrusted`
+        // only for readability; both end in the same disposition, because "the batch ran
+        // out before this root" and "this record's table cannot be believed" are the same
+        // thing to a gate that must not insert on an unverified assumption.
+        const undecided = new Set(applied.unclassifiedRoots);
         const untrusted = new Set<string>();
-        for (const record of applied) {
+        for (const record of applied.records) {
           if (!roots.has(record.root)) continue;
           // Fail closed on data crossing the injected lookup boundary. A well-formed
           // record cannot exceed the owned-subject cap, so an over-cap table means this
@@ -223,7 +258,7 @@ export function createLegacyAgentProfileGateV1(
           appliedByRoot.set(record.root, record);
         }
         for (const root of selected) {
-          if (untrusted.has(root)) {
+          if (untrusted.has(root) || undecided.has(root)) {
             disposition.set(root, { kind: 'unclassified' });
             continue;
           }
@@ -245,15 +280,16 @@ export function createLegacyAgentProfileGateV1(
         if (subjects.size > SYSTEM_RECORD_MAX_OWNED_SUBJECTS) {
           for (const root of appliedByRoot.keys()) disposition.set(root, { kind: 'unclassified' });
         } else if (subjects.size > 0) {
-          const rows = await lookup.lookupProjectionMembership([...subjects].sort(), signal);
+          const membership = await lookup.lookupProjectionMembership([...subjects].sort(), signal);
           storeRequests += 1;
-          if (rows.length > SYSTEM_RECORD_MAX_PROJECTION_QUADS) {
-            // An over-cap response cannot be trusted as the exact applied set, so every
-            // covered root falls back to withhold rather than being compared against a
-            // truncated projection.
+          // Two independent ways this response can fail to be the exact projection: a row
+          // count the gate can see, and a byte bound only the implementation can. Both
+          // land here, because a partial projection makes a real duplicate look like a
+          // conflict, and comparing against it would withhold on manufactured evidence.
+          if (membership.truncated || membership.rows.length > SYSTEM_RECORD_MAX_PROJECTION_QUADS) {
             for (const root of appliedByRoot.keys()) disposition.set(root, { kind: 'unclassified' });
           } else {
-            for (const row of rows) projection.add(projectionKeyV1(row));
+            for (const row of membership.rows) projection.add(projectionKeyV1(row));
           }
         }
       }

--- a/packages/agent/src/system-records/legacy-profile-gate-v1.ts
+++ b/packages/agent/src/system-records/legacy-profile-gate-v1.ts
@@ -100,14 +100,25 @@ export interface LegacyAgentProfileProjectionV1 {
  * page and never per root or per quad.
  *
  * BOTH BYTE CAPS BELONG TO THE IMPLEMENTATION, AND NEITHER MAY BE HONOURED SILENTLY.
- * :926 caps request one at 1 MiB and request two at 2 MiB, and by the time the gate holds
- * a result the bytes have already transferred — so the gate can only refuse to trust an
- * answer, never prevent it. An implementation that cannot honour a cap reports the
- * shortfall (`unclassifiedRoots` / `truncated`); it must not simply return less, because
- * a short response is indistinguishable from "no record here" and so fails toward
- * insertion — the one direction :1505 forbids.
+ * :926 caps request one at 1 MiB and request two at 2 MiB. Where the store has a wire the
+ * implementation may refuse the body before parsing it; where it does not, the cap can
+ * only be measured after the answer arrives. Either way the gate can only refuse to TRUST
+ * an answer, so an implementation that cannot honour a cap reports the shortfall
+ * (`unclassifiedRoots` / `truncated`); it must not simply return less, because a short
+ * response is indistinguishable from "no record here" and so fails toward insertion —
+ * the one direction :1505 forbids.
  */
 export interface LegacyAgentProfileGateLookupV1 {
+  /**
+   * The graph an applied projection occupies under THIS lookup's mode — the only graph in
+   * which legacy insertion can physically collide with signed state.
+   *
+   * It rides on the lookup rather than arriving as a separate gate argument so the graph
+   * and the reads cannot be handed different modes: one value, one mode, one home. A gate
+   * built against one mode's projection graph while reading another's would be deciding
+   * collisions in a graph it never actually read.
+   */
+  readonly projectionGraph: string;
   /** Request one: which of these derived roots carry an applied signed record. */
   lookupAppliedRoots(
     roots: readonly string[],
@@ -212,10 +223,24 @@ export function createLegacyAgentProfileGateV1(
     ): Promise<LegacyAgentProfileGateResultV1> {
       // Phase 1 — derive once per quad, keeping the result positionally so the final pass
       // never re-derives. No query.
+      //
+      // TWO CONJUNCTS, AND NEITHER IMPLIES THE OTHER. A quad is a candidate only if its
+      // subject derives an agent root AND it is destined for the graph the applied
+      // projection occupies. The subject alone is not enough: the collision this gate
+      // exists to prevent is PHYSICAL, so a quad about an agent bound for some other
+      // context graph cannot overwrite signed state and must pass through untouched.
+      // The destination alone is not enough either: the aggregate graph holds quads about
+      // subjects no signed record covers, and those take the ordinary legacy path.
+      //
+      // Scoping by the page's context-graph id instead would be the unsafe reading: a page
+      // whose id is not `agents` can still carry a quad destined for the aggregate graph,
+      // and lane-scoping would insert it — failing toward insertion, which :1505 forbids.
       const rootByIndex: (string | null)[] = new Array(quads.length);
       const roots = new Set<string>();
       for (const [index, quad] of quads.entries()) {
-        const root = deriveLegacyAgentProfileRootV1(quad.subject);
+        const root = quad.graph === lookup.projectionGraph
+          ? deriveLegacyAgentProfileRootV1(quad.subject)
+          : null;
         rootByIndex[index] = root;
         if (root !== null) roots.add(root);
       }

--- a/packages/agent/src/system-records/legacy-profile-gate-v1.ts
+++ b/packages/agent/src/system-records/legacy-profile-gate-v1.ts
@@ -113,10 +113,22 @@ export interface LegacyAgentProfileGateLookupV1 {
    * The graph an applied projection occupies under THIS lookup's mode — the only graph in
    * which legacy insertion can physically collide with signed state.
    *
-   * It rides on the lookup rather than arriving as a separate gate argument so the graph
-   * and the reads cannot be handed different modes: one value, one mode, one home. A gate
-   * built against one mode's projection graph while reading another's would be deciding
-   * collisions in a graph it never actually read.
+   * It rides on the lookup rather than arriving as a separate gate argument so that the
+   * graph and the reads travel together. A gate built against one mode's projection graph
+   * while reading another's would be deciding collisions in a graph it never actually
+   * read.
+   *
+   * WHERE THAT IS ENFORCED, STATED PRECISELY BECAUSE THIS SAYING IT IS NOT ENFORCEMENT.
+   * The consistency is guaranteed by the ADAPTER, not by this type: the production
+   * constructor takes one `mode` and derives all three members from it, so production
+   * cannot mint a mixed lookup. This interface is deliberately three independent members
+   * so the gate can be driven by fakes that never touch storage — which is what its own
+   * suite does — and that permissiveness is the cost of it.
+   *
+   * So a HAND-BUILT lookup can pair one mode's graph with another mode's reads and will
+   * compile. Nothing here stops it; only the adapter's single `mode` input does. Making
+   * that unrepresentable in the type is a real improvement and is filed as its own change,
+   * because it reshapes the port every fake also implements.
    */
   readonly projectionGraph: string;
   /** Request one: which of these derived roots carry an applied signed record. */

--- a/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
+++ b/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
@@ -22,6 +22,7 @@ import {
   createLegacyAgentProfileGateV1,
   type LegacyAgentProfileAppliedRootV1,
 } from '../src/system-records/legacy-profile-gate-v1.js';
+import { createLegacyAgentProfileGateLookupV1 } from '../src/system-records/legacy-profile-gate-lookup-v1.js';
 import { uniformDurableSyncBudget } from './durable-sync-test-helpers.js';
 
 const ctx = createOperationContext('sync');
@@ -154,6 +155,58 @@ describe('durable-sync legacy agent-profile gate seam (#2052 D-8)', () => {
 
     expect(lookupAppliedRoots).not.toHaveBeenCalled();
     expect(offered).toEqual(page);
+  });
+
+  // The seam half of the mode counterfactual (the read layer carries the other half in
+  // packages/storage). This composes the REAL adapter, the REAL storage reads and the REAL
+  // gate over one store, and flips ONLY the mode — so it covers the case a controller-
+  // presence inference would have missed: an authoritative projection persisted by an
+  // earlier process, on a node whose lane is not currently open.
+  describe('end to end, only the mode differs', () => {
+    const conflicting = quad(ROOT, 'urn:p', 'rewritten-by-legacy');
+
+    /** Answers the reserved-state join for any claim, and the projection for any subject. */
+    function storeWithAppliedRecord() {
+      const query = vi.fn(async (sparql: string) => (
+        sparql.includes('?claim ?table')
+          ? {
+            type: 'bindings' as const,
+            bindings: [{ claim: /<([^>]*root:[^>]*)>/.exec(sparql)?.[1] ?? '', table: `"[\\"${ROOT}\\"]"^^<urn:json>` }],
+          }
+          : {
+            type: 'bindings' as const,
+            bindings: [{ s: ROOT, p: 'urn:p', o: '"signed"' }],
+          }
+      ));
+      return { query } as never;
+    }
+
+    // The uncovered quad rides along in BOTH runs on purpose. Asserting only that the
+    // conflicting quad disappears would also pass if `filterPage` THREW — the per-CG catch
+    // would drop the whole page and the page would look withheld. Requiring the uncovered
+    // quad to survive means the gate ran to completion and discriminated, so a thrown
+    // lookup can no longer wear a withhold's clothes.
+    const uncovered = quad('urn:ordinary-subject', 'urn:p', 'o');
+
+    it('withholds the conflicting quad when the projection is authoritative', async () => {
+      const gate = createLegacyAgentProfileGateV1(createLegacyAgentProfileGateLookupV1({
+        store: storeWithAppliedRecord(), networkId: 'otp:2043', mode: 'authoritative',
+      }));
+
+      const { offered } = await runSeam([conflicting, uncovered], gate);
+
+      expect(offered).toEqual([uncovered]);
+    });
+
+    it('passes the same quad through when the projection is only shadow', async () => {
+      const gate = createLegacyAgentProfileGateV1(createLegacyAgentProfileGateLookupV1({
+        store: storeWithAppliedRecord(), networkId: 'otp:2043', mode: 'shadow',
+      }));
+
+      const { offered } = await runSeam([conflicting, uncovered], gate);
+
+      expect(offered).toEqual([conflicting, uncovered]);
+    });
   });
 
   // Withheld quads never reached the store, so counting them as inserted would report

--- a/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
+++ b/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
@@ -201,6 +201,36 @@ describe('durable-sync legacy agent-profile gate seam (#2052 D-8)', () => {
     expect(result.result.insertedTriples).toBe(1);
   });
 
+  // Adopted from review. Awaiting the gate opens an abort WINDOW: the operation can be
+  // cancelled while `filterPage` is in flight, and the post-gate `throwIfOperationAborted`
+  // is what stops the page reaching the store afterwards. Every signal case so far proved
+  // the signal is HANDED OVER; none proved the guard that acts on it, so deleting that
+  // guard left them all green while durable sync wrote quads after cancellation.
+  it('does not insert when the operation is aborted while the gate is running', async () => {
+    const controller = new AbortController();
+    const page = [quad('urn:ordinary-subject', 'urn:p', 'o')];
+    // Cancels mid-gate, then returns the page untouched — the gate itself withholds
+    // nothing, so only the post-gate abort check can keep this out of the store.
+    const aborting = {
+      filterPage: async (quads: Quad[]) => {
+        controller.abort();
+        return {
+          insert: quads,
+          withheld: [],
+          discardedDuplicates: 0,
+          conflictedRoots: 0,
+          unclassifiedRoots: 0,
+          storeRequests: 0,
+        };
+      },
+    } as unknown as ReturnType<typeof createLegacyAgentProfileGateV1>;
+
+    const { offered, result } = await runSeam(page, aborting, 'data', 'agents', controller.signal);
+
+    expect(offered).toEqual([]);
+    expect(result.result.insertedTriples).toBe(0);
+  });
+
   // T1, half A — the half that scoping by the page's context-graph id would get WRONG.
   // The page is served under `project-x`, but the quad it carries is bound for the
   // aggregate graph where the applied projection lives, so the collision is real and the

--- a/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
+++ b/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
@@ -1,0 +1,177 @@
+/**
+ * #2052 D-8 — the legacy `agents` gate at the durable-sync ingest seam (plan :924, :1505).
+ *
+ * These are SEAM tests, not gate tests: `system-record-legacy-gate-v1.test.ts` already
+ * pins what the gate decides, and repeating that here would prove the gate twice and the
+ * wiring never. What is under test is the composition — that a page really travels through
+ * the gate on its way to `storeInsert`, that what the store is offered is the gate's
+ * `insert` set rather than the page, and that the accounting describes the former.
+ *
+ * The REAL gate is used, driven by a fake lookup. A stub gate would let the seam pass
+ * while the composition was wrong in any way the stub happened to mirror.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { createOperationContext } from '@origintrail-official/dkg-core';
+import type { Quad } from '@origintrail-official/dkg-storage';
+
+import {
+  runDurableSyncDetailed,
+  type DurableSyncFetchRequest,
+} from '../src/sync/requester/durable-sync.js';
+import {
+  createLegacyAgentProfileGateV1,
+  type LegacyAgentProfileAppliedRootV1,
+} from '../src/system-records/legacy-profile-gate-v1.js';
+import { uniformDurableSyncBudget } from './durable-sync-test-helpers.js';
+
+const ctx = createOperationContext('sync');
+const noop = () => {};
+
+const ROOT = `did:dkg:agent:0x${'1'.repeat(40)}`;
+const AGENTS_GRAPH = 'did:dkg:context-graph:agents';
+
+/** An inbound legacy quad: carries the aggregate agents graph. */
+function quad(subject: string, predicate: string, object: string): Quad {
+  return { subject, predicate, object, graph: AGENTS_GRAPH };
+}
+
+/** An applied-projection row as the store really holds it: graphless. */
+function projectionRow(subject: string, predicate: string, object: string): Quad {
+  return { subject, predicate, object, graph: '' };
+}
+
+function fakeLookup(
+  records: readonly LegacyAgentProfileAppliedRootV1[],
+  projection: readonly Quad[],
+) {
+  const lookupAppliedRoots = vi.fn(async (roots: readonly string[]) => ({
+    records: records.filter((record) => roots.includes(record.root)),
+    unclassifiedRoots: [] as readonly string[],
+  }));
+  const lookupProjectionMembership = vi.fn(async (subjects: readonly string[]) => ({
+    rows: projection.filter((row) => subjects.includes(row.subject)),
+    truncated: false,
+  }));
+  return { lookup: { lookupAppliedRoots, lookupProjectionMembership }, lookupAppliedRoots };
+}
+
+/**
+ * One durable-sync run over one page of already-verified data quads.
+ *
+ * `inserted` collects every quad the seam actually offered the store, which is the
+ * observable the property is stated in terms of.
+ */
+async function runSeam(page: Quad[], gate?: ReturnType<typeof createLegacyAgentProfileGateV1>) {
+  const inserted: Quad[][] = [];
+  let served = false;
+  const result = await runDurableSyncDetailed({
+    ctx,
+    remotePeerId: 'peer',
+    contextGraphIds: ['agents'],
+    durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 1_000),
+    fetchSyncPages: async ({ phase }: DurableSyncFetchRequest) => {
+      // Serve the page once on the data phase, then run dry so the loop terminates.
+      const first = phase === 'data' && !served;
+      if (first) served = true;
+      return {
+        quads: first ? page : [],
+        bytesReceived: 0,
+        resumedFromOffset: 0,
+        nextOffset: 0,
+        checkpointKey: `agents:${phase}`,
+        completed: true,
+        timedOut: false,
+      };
+    },
+    processDurableBatchInWorker: async (dataQuads: Quad[], metaQuads: Quad[]) => ({
+      verifiedData: dataQuads,
+      verifiedMeta: metaQuads,
+      consumedUnpersistedMetaTriples: 0,
+      totalFetchedDataQuads: dataQuads.length,
+      totalFetchedMetaQuads: metaQuads.length,
+      rejectedKcs: 0,
+      emptyResponses: dataQuads.length === 0 && metaQuads.length === 0 ? 1 : 0,
+      metaOnlyResponses: 0,
+      verifiedPrivateOnlyResponses: 0,
+      dataRejectedMissingMeta: 0,
+    }),
+    storeInsert: async ({ quads }) => {
+      inserted.push([...quads]);
+    },
+    legacyAgentProfileGate: gate,
+    deleteCheckpoint: noop,
+    setCheckpoint: noop,
+    logInfo: noop,
+    logWarn: noop,
+    logDebug: noop,
+  });
+  return { inserted, offered: inserted.flat(), result };
+}
+
+describe('durable-sync legacy agent-profile gate seam (#2052 D-8)', () => {
+  // The load-bearing seam test. The page carries two quads whose ONLY difference is
+  // whether an applied signed record covers their root, so a seam that forwarded the page
+  // unfiltered and a seam that dropped everything both fail: exactly one quad must survive.
+  it('offers the store the gate\'s insert set, not the page', async () => {
+    const { lookup } = fakeLookup(
+      [{ root: ROOT, ownedSubjects: [ROOT] }],
+      [projectionRow(ROOT, 'urn:p', 'signed')],
+    );
+    const conflicting = quad(ROOT, 'urn:p', 'rewritten-by-legacy');
+    const uncovered = quad('urn:ordinary-subject', 'urn:p', 'o');
+
+    const { offered } = await runSeam(
+      [conflicting, uncovered],
+      createLegacyAgentProfileGateV1(lookup),
+    );
+
+    expect(offered).toEqual([uncovered]);
+    expect(offered).not.toContainEqual(conflicting);
+  });
+
+  // Without a gate the seam must behave exactly as it did before #53, because
+  // `runDurableSync` is reachable outside this package and the port is optional.
+  it('offers the page unchanged when no gate is supplied', async () => {
+    const conflicting = quad(ROOT, 'urn:p', 'rewritten-by-legacy');
+    const uncovered = quad('urn:ordinary-subject', 'urn:p', 'o');
+
+    const { offered } = await runSeam([conflicting, uncovered]);
+
+    expect(offered).toEqual([conflicting, uncovered]);
+  });
+
+  // The always-wired posture (ruled option A, no config flag) is only defensible if it
+  // costs nothing when there is nothing to protect. A page deriving no agent root must
+  // issue NO store read at all — not a cheap one.
+  it('performs no store read for a page that derives no agent root', async () => {
+    const { lookup, lookupAppliedRoots } = fakeLookup([], []);
+    const page = [
+      quad('urn:ordinary-subject', 'urn:p', 'o'),
+      quad('https://example.com/thing', 'urn:p', 'o'),
+    ];
+
+    const { offered } = await runSeam(page, createLegacyAgentProfileGateV1(lookup));
+
+    expect(lookupAppliedRoots).not.toHaveBeenCalled();
+    expect(offered).toEqual(page);
+  });
+
+  // Withheld quads never reached the store, so counting them as inserted would report
+  // progress the store never took.
+  it('counts inserted triples from what the store was offered', async () => {
+    const { lookup } = fakeLookup(
+      [{ root: ROOT, ownedSubjects: [ROOT] }],
+      [projectionRow(ROOT, 'urn:p', 'signed')],
+    );
+    const page = [
+      quad(ROOT, 'urn:p', 'rewritten-by-legacy'),
+      quad('urn:ordinary-subject', 'urn:p', 'o'),
+    ];
+
+    const { offered, result } = await runSeam(page, createLegacyAgentProfileGateV1(lookup));
+
+    expect(offered).toHaveLength(1);
+    expect(result.result.insertedTriples).toBe(1);
+    expect(result.result.insertedTriples).not.toBe(page.length);
+  });
+});

--- a/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
+++ b/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
@@ -231,6 +231,33 @@ describe('durable-sync legacy agent-profile gate seam (#2052 D-8)', () => {
     expect(result.result.insertedTriples).toBe(0);
   });
 
+  // The metadata branch gates through the same helper behind its OWN post-gate abort
+  // check, and the case above cannot reach it: served on the data phase, it leaves the
+  // meta guard deletable with this file green. Found by auditing the guard's siblings
+  // rather than by waiting for the abort window to be re-derived one branch over.
+  it('does not insert metadata when the operation is aborted while the gate is running', async () => {
+    const controller = new AbortController();
+    const page = [quad('urn:ordinary-subject', 'urn:p', 'o')];
+    const aborting = {
+      filterPage: async (quads: Quad[]) => {
+        controller.abort();
+        return {
+          insert: quads,
+          withheld: [],
+          discardedDuplicates: 0,
+          conflictedRoots: 0,
+          unclassifiedRoots: 0,
+          storeRequests: 0,
+        };
+      },
+    } as unknown as ReturnType<typeof createLegacyAgentProfileGateV1>;
+
+    const { offered, result } = await runSeam(page, aborting, 'meta', 'agents', controller.signal);
+
+    expect(offered).toEqual([]);
+    expect(result.result.insertedMetaTriples).toBe(0);
+  });
+
   // T1, half A — the half that scoping by the page's context-graph id would get WRONG.
   // The page is served under `project-x`, but the quad it carries is bound for the
   // aggregate graph where the applied projection lives, so the collision is real and the

--- a/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
+++ b/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
@@ -292,5 +292,11 @@ describe('durable-sync legacy agent-profile gate seam (#2052 D-8)', () => {
     expect(offered).toHaveLength(1);
     expect(result.result.insertedTriples).toBe(1);
     expect(result.result.insertedTriples).not.toBe(page.length);
+    // The data branch writes TWO counters from the gate's insert set, and the aggregate
+    // one alone cannot see a regression in the other: changing only `insertedDataTriples`
+    // back to the page length leaves `insertedTriples` correct and this test green. The
+    // meta branch already asserts its own counter; this is the matching half.
+    expect(result.result.insertedDataTriples).toBe(1);
+    expect(result.result.insertedDataTriples).not.toBe(page.length);
   });
 });

--- a/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
+++ b/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
@@ -11,6 +11,7 @@
  * while the composition was wrong in any way the stub happened to mirror.
  */
 import { describe, expect, it, vi } from 'vitest';
+import { SYSTEM_RECORD_V1_JSON_DATATYPE } from '@origintrail-official/dkg-storage/internal/system-record-legacy-gate-read-v1';
 import { createOperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 
@@ -266,7 +267,7 @@ describe('durable-sync legacy agent-profile gate seam (#2052 D-8)', () => {
           ? {
             type: 'bindings' as const,
             bindings: sparql.includes(`<${claim}>`)
-              ? [{ claim, table: `"[\\"${ROOT}\\"]"^^<urn:json>` }]
+              ? [{ claim, table: `"[\\"${ROOT}\\"]"^^<${SYSTEM_RECORD_V1_JSON_DATATYPE}>` }]
               : [],
           }
           : {

--- a/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
+++ b/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
@@ -130,7 +130,7 @@ describe('durable-sync legacy agent-profile gate seam (#2052 D-8)', () => {
     expect(offered).not.toContainEqual(conflicting);
   });
 
-  // Without a gate the seam must behave exactly as it did before #53, because
+  // Without a gate the seam must behave exactly as it did before this slice, because
   // `runDurableSync` is reachable outside this package and the port is optional.
   it('offers the page unchanged when no gate is supplied', async () => {
     const conflicting = quad(ROOT, 'urn:p', 'rewritten-by-legacy');

--- a/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
+++ b/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
@@ -172,6 +172,35 @@ describe('durable-sync legacy agent-profile gate seam (#2052 D-8)', () => {
     expect(seen[0]).toBe(controller.signal);
   });
 
+  // Adopted from review. The gate keeps a quad out of the store TWO ways -- `withheld`
+  // (conflict or undecidable) and exact-duplicate DISCARD -- and every seam case here
+  // proved only the first. The reviewer's regression is the point: a seam rewritten as
+  // `quads.filter((q) => !gated.withheld.includes(q))` passes every other case in this
+  // file while forwarding exact duplicates back into the store, re-inserting rows the
+  // signed projection already holds.
+  //
+  // The seam contract is "offer exactly `gated.insert`", and only a duplicate can tell
+  // that apart from "offer everything the gate did not withhold".
+  it('does not offer an exact duplicate of the signed projection to the store', async () => {
+    const { lookup } = fakeLookup(
+      [{ root: ROOT, ownedSubjects: [ROOT] }],
+      [projectionRow(ROOT, 'urn:p', 'signed')],
+    );
+    // Byte-for-byte what the projection already holds.
+    const duplicate = quad(ROOT, 'urn:p', 'signed');
+    const uncovered = quad('urn:ordinary-subject', 'urn:p', 'o');
+
+    const { offered, result } = await runSeam(
+      [duplicate, uncovered],
+      createLegacyAgentProfileGateV1(lookup),
+    );
+
+    expect(offered).toEqual([uncovered]);
+    expect(offered).not.toContainEqual(duplicate);
+    // And it must not be counted as progress the store never took.
+    expect(result.result.insertedTriples).toBe(1);
+  });
+
   // T1, half A — the half that scoping by the page's context-graph id would get WRONG.
   // The page is served under `project-x`, but the quad it carries is bound for the
   // aggregate graph where the applied projection lives, so the collision is real and the

--- a/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
+++ b/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
@@ -53,7 +53,15 @@ function fakeLookup(
     rows: projection.filter((row) => subjects.includes(row.subject)),
     truncated: false,
   }));
-  return { lookup: { lookupAppliedRoots, lookupProjectionMembership }, lookupAppliedRoots };
+  return {
+    lookup: { projectionGraph: AGENTS_GRAPH, lookupAppliedRoots, lookupProjectionMembership },
+    lookupAppliedRoots,
+  };
+}
+
+/** A quad bound for a context graph that is NOT where the applied projection lives. */
+function quadInGraph(subject: string, predicate: string, object: string, graph: string): Quad {
+  return { subject, predicate, object, graph };
 }
 
 /**
@@ -66,13 +74,14 @@ async function runSeam(
   page: Quad[],
   gate?: ReturnType<typeof createLegacyAgentProfileGateV1>,
   servePhase: 'data' | 'meta' = 'data',
+  contextGraphId = 'agents',
 ) {
   const inserted: Quad[][] = [];
   let served = false;
   const result = await runDurableSyncDetailed({
     ctx,
     remotePeerId: 'peer',
-    contextGraphIds: ['agents'],
+    contextGraphIds: [contextGraphId],
     durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 1_000),
     fetchSyncPages: async ({ phase }: DurableSyncFetchRequest) => {
       // Serve the page once on the requested phase, then run dry so the loop terminates.
@@ -128,6 +137,30 @@ describe('durable-sync legacy agent-profile gate seam (#2052 D-8)', () => {
     const { offered } = await runSeam(
       [conflicting, uncovered],
       createLegacyAgentProfileGateV1(lookup),
+    );
+
+    expect(offered).toEqual([uncovered]);
+    expect(offered).not.toContainEqual(conflicting);
+  });
+
+  // T1, half A — the half that scoping by the page's context-graph id would get WRONG.
+  // The page is served under `project-x`, but the quad it carries is bound for the
+  // aggregate graph where the applied projection lives, so the collision is real and the
+  // quad must be withheld. A lane-scoped gate (`pid === 'agents'`) would insert it, which
+  // is failing toward insertion — the direction :1505 forbids.
+  it('withholds an aggregate-graph quad even when the page is not the agents lane', async () => {
+    const { lookup } = fakeLookup(
+      [{ root: ROOT, ownedSubjects: [ROOT] }],
+      [projectionRow(ROOT, 'urn:p', 'signed')],
+    );
+    const conflicting = quad(ROOT, 'urn:p', 'rewritten-by-legacy');
+    const uncovered = quad('urn:ordinary-subject', 'urn:p', 'o');
+
+    const { offered } = await runSeam(
+      [conflicting, uncovered],
+      createLegacyAgentProfileGateV1(lookup),
+      'data',
+      'project-x',
     );
 
     expect(offered).toEqual([uncovered]);

--- a/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
+++ b/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
@@ -76,6 +76,7 @@ async function runSeam(
   gate?: ReturnType<typeof createLegacyAgentProfileGateV1>,
   servePhase: 'data' | 'meta' = 'data',
   contextGraphId = 'agents',
+  signal?: AbortSignal,
 ) {
   const inserted: Quad[][] = [];
   let served = false;
@@ -114,6 +115,7 @@ async function runSeam(
       inserted.push([...quads]);
     },
     legacyAgentProfileGate: gate,
+    signal,
     deleteCheckpoint: noop,
     setCheckpoint: noop,
     logInfo: noop,
@@ -142,6 +144,32 @@ describe('durable-sync legacy agent-profile gate seam (#2052 D-8)', () => {
 
     expect(offered).toEqual([uncovered]);
     expect(offered).not.toContainEqual(conflicting);
+  });
+
+  // Adopted from review, the seam half of the cancellation finding. The reader half lives
+  // in the storage suite; this proves the signal actually REACHES the gate from durable
+  // sync. Threading it through production without a test meant a regression calling
+  // `filterPage(quads)` would leave every case here green while an aborted sync waited on
+  // the gate's store reads.
+  //
+  // Identity again, not presence: a seam handing the gate SOME signal is not the same as
+  // handing it the operation's own.
+  it('hands the gate the operation abort signal', async () => {
+    const { lookup } = fakeLookup([], []);
+    const seen: Array<AbortSignal | undefined> = [];
+    const real = createLegacyAgentProfileGateV1(lookup);
+    const recording = {
+      filterPage: (quads: Quad[], signal?: AbortSignal) => {
+        seen.push(signal);
+        return real.filterPage(quads, signal);
+      },
+    } as ReturnType<typeof createLegacyAgentProfileGateV1>;
+    const controller = new AbortController();
+
+    await runSeam([quad(ROOT, 'urn:p', 'o')], recording, 'data', 'agents', controller.signal);
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toBe(controller.signal);
   });
 
   // T1, half A — the half that scoping by the page's context-graph id would get WRONG.

--- a/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
+++ b/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
@@ -62,7 +62,11 @@ function fakeLookup(
  * `inserted` collects every quad the seam actually offered the store, which is the
  * observable the property is stated in terms of.
  */
-async function runSeam(page: Quad[], gate?: ReturnType<typeof createLegacyAgentProfileGateV1>) {
+async function runSeam(
+  page: Quad[],
+  gate?: ReturnType<typeof createLegacyAgentProfileGateV1>,
+  servePhase: 'data' | 'meta' = 'data',
+) {
   const inserted: Quad[][] = [];
   let served = false;
   const result = await runDurableSyncDetailed({
@@ -71,8 +75,8 @@ async function runSeam(page: Quad[], gate?: ReturnType<typeof createLegacyAgentP
     contextGraphIds: ['agents'],
     durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 1_000),
     fetchSyncPages: async ({ phase }: DurableSyncFetchRequest) => {
-      // Serve the page once on the data phase, then run dry so the loop terminates.
-      const first = phase === 'data' && !served;
+      // Serve the page once on the requested phase, then run dry so the loop terminates.
+      const first = phase === servePhase && !served;
       if (first) served = true;
       return {
         quads: first ? page : [],
@@ -128,6 +132,35 @@ describe('durable-sync legacy agent-profile gate seam (#2052 D-8)', () => {
 
     expect(offered).toEqual([uncovered]);
     expect(offered).not.toContainEqual(conflicting);
+  });
+
+  // The meta branch is a SECOND insertion path with its own gate call, its own
+  // skip-when-empty and its own diagnostic field, and every other test here serves the
+  // page on the data phase only. So a regression that reverted `remainingMeta` to
+  // `storeInsert({ quads: partitioned.remainingMeta })` would leave this whole file
+  // green — the fixture would simply never route a quad through the branch it broke.
+  //
+  // The count is asserted as well as the offer, because those are two different
+  // failures: forwarding the raw page breaks the offer, while gating correctly but
+  // still counting `partitioned.remainingMeta.length` would report progress the store
+  // never took and no offer-only assertion could see it.
+  it('gates the metadata branch, and counts insertedMetaTriples from what was offered', async () => {
+    const { lookup } = fakeLookup(
+      [{ root: ROOT, ownedSubjects: [ROOT] }],
+      [projectionRow(ROOT, 'urn:p', 'signed')],
+    );
+    const conflicting = quad(ROOT, 'urn:p', 'rewritten-by-legacy');
+    const uncovered = quad('urn:ordinary-subject', 'urn:p', 'o');
+
+    const { offered, result } = await runSeam(
+      [conflicting, uncovered],
+      createLegacyAgentProfileGateV1(lookup),
+      'meta',
+    );
+
+    expect(offered).toEqual([uncovered]);
+    expect(offered).not.toContainEqual(conflicting);
+    expect(result.result.insertedMetaTriples).toBe(1);
   });
 
   // Without a gate the seam must behave exactly as it did before this slice, because

--- a/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
+++ b/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
@@ -231,13 +231,43 @@ describe('durable-sync legacy agent-profile gate seam (#2052 D-8)', () => {
   describe('end to end, only the mode differs', () => {
     const conflicting = quad(ROOT, 'urn:p', 'rewritten-by-legacy');
 
-    /** Answers the reserved-state join for any claim, and the projection for any subject. */
-    function storeWithAppliedRecord() {
+    const NETWORK_ID = 'otp:2043';
+
+    /**
+     * The claim IRI a correctly-configured adapter actually asks for, RECORDED from a live
+     * run rather than restated.
+     *
+     * This fixture used to echo back whichever claim the query happened to name, so it
+     * answered for ANY network identity — an adapter that dropped or hard-coded the wrong
+     * one still looked covered, on the path where being wrong means unsigned legacy quads
+     * land on top of signed state. Recording the real question keeps the identity
+     * load-bearing without restating its derivation: the id is base64url-encoded into the
+     * claim subject, and restating that encoding here would just be testing the fixture.
+     */
+    async function claimAskedFor(networkId: string): Promise<string> {
+      const seen: string[] = [];
+      const recorder = {
+        query: async (sparql: string) => {
+          seen.push(sparql);
+          return { type: 'bindings' as const, bindings: [] };
+        },
+      } as never;
+      const probe = createLegacyAgentProfileGateV1(createLegacyAgentProfileGateLookupV1({
+        store: recorder, networkId, mode: 'authoritative',
+      }));
+      await probe.filterPage([conflicting]);
+      return /<([^>]*root:[^>]*)>/.exec(seen[0] ?? '')?.[1] ?? '';
+    }
+
+    /** Answers the reserved-state join ONLY for the exact claim it was built for. */
+    function storeWithAppliedRecord(claim: string) {
       const query = vi.fn(async (sparql: string) => (
         sparql.includes('?claim ?table')
           ? {
             type: 'bindings' as const,
-            bindings: [{ claim: /<([^>]*root:[^>]*)>/.exec(sparql)?.[1] ?? '', table: `"[\\"${ROOT}\\"]"^^<urn:json>` }],
+            bindings: sparql.includes(`<${claim}>`)
+              ? [{ claim, table: `"[\\"${ROOT}\\"]"^^<urn:json>` }]
+              : [],
           }
           : {
             type: 'bindings' as const,
@@ -256,7 +286,9 @@ describe('durable-sync legacy agent-profile gate seam (#2052 D-8)', () => {
 
     it('withholds the conflicting quad when the projection is authoritative', async () => {
       const gate = createLegacyAgentProfileGateV1(createLegacyAgentProfileGateLookupV1({
-        store: storeWithAppliedRecord(), networkId: 'otp:2043', mode: 'authoritative',
+        store: storeWithAppliedRecord(await claimAskedFor(NETWORK_ID)),
+        networkId: NETWORK_ID,
+        mode: 'authoritative',
       }));
 
       const { offered } = await runSeam([conflicting, uncovered], gate);
@@ -264,9 +296,28 @@ describe('durable-sync legacy agent-profile gate seam (#2052 D-8)', () => {
       expect(offered).toEqual([uncovered]);
     });
 
+    // The identity half. Same store, same mode, same page — only the adapter's network
+    // identity is wrong, so it asks about a claim the store does not hold and the root is
+    // uncovered. Without this, an adapter that dropped or hard-coded `networkId` would
+    // still pass the case above, and in production would miss applied roots and insert
+    // unsigned legacy quads over signed state.
+    it('does not cover the root when the adapter carries the wrong network identity', async () => {
+      const gate = createLegacyAgentProfileGateV1(createLegacyAgentProfileGateLookupV1({
+        store: storeWithAppliedRecord(await claimAskedFor(NETWORK_ID)),
+        networkId: 'otp:20430',
+        mode: 'authoritative',
+      }));
+
+      const { offered } = await runSeam([conflicting, uncovered], gate);
+
+      expect(offered).toEqual([conflicting, uncovered]);
+    });
+
     it('passes the same quad through when the projection is only shadow', async () => {
       const gate = createLegacyAgentProfileGateV1(createLegacyAgentProfileGateLookupV1({
-        store: storeWithAppliedRecord(), networkId: 'otp:2043', mode: 'shadow',
+        store: storeWithAppliedRecord(await claimAskedFor(NETWORK_ID)),
+        networkId: NETWORK_ID,
+        mode: 'shadow',
       }));
 
       const { offered } = await runSeam([conflicting, uncovered], gate);

--- a/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
+++ b/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
@@ -313,6 +313,31 @@ describe('durable-sync legacy agent-profile gate seam (#2052 D-8)', () => {
     // lookup can no longer wear a withhold's clothes.
     const uncovered = quad('urn:ordinary-subject', 'urn:p', 'o');
 
+    // Adopted from review: the MIDDLE link of the cancellation chain. Durable-sync -> gate
+    // is proven at the seam, and reader -> store.query is proven in the storage suite, but
+    // the adapter between them is the code this PR actually adds and nothing covered it.
+    // Dropping `signal` from either read call here would pass both of those tests while an
+    // aborted sync stopped cancelling the production reads.
+    it('forwards the abort signal through the adapter into both store reads', async () => {
+      const options: Array<Record<string, unknown>> = [];
+      const store = {
+        query: async (_sparql: string, opts?: Record<string, unknown>) => {
+          options.push(opts ?? {});
+          return { type: 'bindings' as const, bindings: [] };
+        },
+      } as never;
+      const controller = new AbortController();
+      const gate = createLegacyAgentProfileGateV1(createLegacyAgentProfileGateLookupV1({
+        store, networkId: NETWORK_ID, mode: 'authoritative',
+      }));
+
+      await gate.filterPage([conflicting], controller.signal);
+
+      // Request one must have run and carried the caller's own signal.
+      expect(options.length).toBeGreaterThan(0);
+      for (const opts of options) expect(opts.signal).toBe(controller.signal);
+    });
+
     it('withholds the conflicting quad when the projection is authoritative', async () => {
       const gate = createLegacyAgentProfileGateV1(createLegacyAgentProfileGateLookupV1({
         store: storeWithAppliedRecord(await claimAskedFor(NETWORK_ID)),

--- a/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
+++ b/packages/agent/test/durable-sync-legacy-profile-gate.test.ts
@@ -315,15 +315,28 @@ describe('durable-sync legacy agent-profile gate seam (#2052 D-8)', () => {
 
     // Adopted from review: the MIDDLE link of the cancellation chain. Durable-sync -> gate
     // is proven at the seam, and reader -> store.query is proven in the storage suite, but
-    // the adapter between them is the code this PR actually adds and nothing covered it.
-    // Dropping `signal` from either read call here would pass both of those tests while an
-    // aborted sync stopped cancelling the production reads.
+    // the adapter between them is the code this PR adds and nothing covered it.
+    //
+    // CORRECTED after a second review round: the first version of this case used a store
+    // that answered nothing, so `lookupAppliedRoots` found no records, no subjects were
+    // collected, and `lookupProjectionMembership` WAS NEVER CALLED. It asserted "every
+    // options object carries the signal" over a set of exactly one — proving one link
+    // while its name claimed two. The store now returns a covered root AND a projection
+    // row, so both adapter calls actually run, and the count is asserted so the case
+    // cannot quietly go back to proving half of itself.
     it('forwards the abort signal through the adapter into both store reads', async () => {
       const options: Array<Record<string, unknown>> = [];
       const store = {
-        query: async (_sparql: string, opts?: Record<string, unknown>) => {
+        query: async (sparql: string, opts?: Record<string, unknown>) => {
           options.push(opts ?? {});
-          return { type: 'bindings' as const, bindings: [] };
+          if (sparql.includes('?claim ?table')) {
+            const claim = /<([^>]*root:[^>]*)>/.exec(sparql)?.[1] ?? '';
+            return {
+              type: 'bindings' as const,
+              bindings: [{ claim, table: `"[\\"${ROOT}\\"]"^^<${SYSTEM_RECORD_V1_JSON_DATATYPE}>` }],
+            };
+          }
+          return { type: 'bindings' as const, bindings: [{ s: ROOT, p: 'urn:p', o: '"signed"' }] };
         },
       } as never;
       const controller = new AbortController();
@@ -333,8 +346,8 @@ describe('durable-sync legacy agent-profile gate seam (#2052 D-8)', () => {
 
       await gate.filterPage([conflicting], controller.signal);
 
-      // Request one must have run and carried the caller's own signal.
-      expect(options.length).toBeGreaterThan(0);
+      // BOTH bounded reads must have run — one alone would prove only half the adapter.
+      expect(options).toHaveLength(2);
       for (const opts of options) expect(opts.signal).toBe(controller.signal);
     });
 

--- a/packages/agent/test/durable-sync-lifecycle-binding.test.ts
+++ b/packages/agent/test/durable-sync-lifecycle-binding.test.ts
@@ -366,6 +366,55 @@ describe('durable sync lifecycle chain binding', () => {
     expect(gate!.filterPage).toBeTypeOf('function');
   });
 
+  // Adopted from review, which pointed out that the assertion above proves PRESENCE and
+  // nothing else. The pre-activation `shadow` literal is the load-bearing part of this
+  // construction site, and `expect(gate).toBeDefined()` stays green if it is changed to
+  // `authoritative` — at which point a pre-cutover node starts querying and withholding
+  // agent-root quads. So exercise the gate the production site actually built.
+  //
+  // The store is the discriminator: under shadow the projection graph is the reserved
+  // one, no legacy quad is a candidate, and the gate short-circuits before any read. A
+  // gate built with the wrong mode reaches the store, and the spy fires.
+  it('supplies a gate that is inert BY MODE, not merely present', async () => {
+    const query = vi.fn(async () => ({ type: 'bindings', bindings: [] }));
+    const agentLike: any = {
+      config: { networkIdentity: { networkId: 'otp:2043' } },
+      chain: { chainId: 'none' },
+      store: { query },
+      subscribedContextGraphs: new Map(),
+      contextGraphBindingGenerations: new Map(),
+      wireIdToLocalCgId: new Map(),
+      bindSubscriptionOnChainId: vi.fn(),
+      persistContextGraphSubscriptionStrict: vi.fn(),
+      processDurableBatchInWorker: async () => ({}),
+      insertSyncedQuadsAndInvalidateListCache: async () => {},
+      syncCheckpoints: new Map(),
+      oversizeTombstoneLog: { record: () => {} },
+      invalidateListContextGraphsCache: vi.fn(),
+      contextGraphMetaProjection: { markDirtyFromQuads: vi.fn() },
+      log: { info: () => {}, warn: () => {}, debug: () => {} },
+    };
+
+    await LifecycleSyncMethods.prototype.runLegacyDurableSyncForContextGraph.call(
+      agentLike, ctx, 'peer-gate-mode', contextGraphId, 1, {},
+    );
+
+    const gate = mockedRunDurableSync.mock.calls[0]![0].legacyAgentProfileGate;
+    const page = [{
+      subject: `did:dkg:agent:0x${'1'.repeat(40)}`,
+      predicate: 'urn:p',
+      object: 'legacy',
+      graph: 'did:dkg:context-graph:agents',
+    }];
+
+    const result = await gate!.filterPage(page);
+
+    expect(result.insert).toEqual(page);
+    expect(result.withheld).toEqual([]);
+    expect(result.storeRequests).toBe(0);
+    expect(query).not.toHaveBeenCalled();
+  });
+
   // The negative half, which is what keeps the assertion above from being vacuous: the
   // field is genuinely conditional, so the supply test passing means the condition HELD
   // rather than that the field is unconditionally present.

--- a/packages/agent/test/durable-sync-lifecycle-binding.test.ts
+++ b/packages/agent/test/durable-sync-lifecycle-binding.test.ts
@@ -333,6 +333,68 @@ describe('durable sync lifecycle chain binding', () => {
     });
   });
 
+  // #2052 D-8 (#53). The seam's gate port is OPTIONAL, so "durable sync uses a gate when
+  // it is given one" — proven in durable-sync-legacy-profile-gate.test.ts — says nothing
+  // about production: a construction site that silently omitted the field would satisfy
+  // that test and still ship an open door. This asserts the SUPPLY, at the only
+  // production construction site for the legacy seam.
+  it('supplies the legacy agent-profile gate to durable sync', async () => {
+    const agentLike: any = {
+      config: { networkIdentity: { networkId: 'otp:2043' } },
+      chain: { chainId: 'none' },
+      store: {},
+      subscribedContextGraphs: new Map(),
+      contextGraphBindingGenerations: new Map(),
+      wireIdToLocalCgId: new Map(),
+      bindSubscriptionOnChainId: vi.fn(),
+      persistContextGraphSubscriptionStrict: vi.fn(),
+      processDurableBatchInWorker: async () => ({}),
+      insertSyncedQuadsAndInvalidateListCache: async () => {},
+      syncCheckpoints: new Map(),
+      oversizeTombstoneLog: { record: () => {} },
+      invalidateListContextGraphsCache: vi.fn(),
+      contextGraphMetaProjection: { markDirtyFromQuads: vi.fn() },
+      log: { info: () => {}, warn: () => {}, debug: () => {} },
+    };
+
+    await LifecycleSyncMethods.prototype.runLegacyDurableSyncForContextGraph.call(
+      agentLike, ctx, 'peer-gate-supply', contextGraphId, 1, {},
+    );
+
+    const gate = mockedRunDurableSync.mock.calls[0]![0].legacyAgentProfileGate;
+    expect(gate).toBeDefined();
+    expect(gate!.filterPage).toBeTypeOf('function');
+  });
+
+  // The negative half, which is what keeps the assertion above from being vacuous: the
+  // field is genuinely conditional, so the supply test passing means the condition HELD
+  // rather than that the field is unconditionally present.
+  it('supplies no gate when the node has no network identity', async () => {
+    const agentLike: any = {
+      config: {},
+      chain: { chainId: 'none' },
+      store: {},
+      subscribedContextGraphs: new Map(),
+      contextGraphBindingGenerations: new Map(),
+      wireIdToLocalCgId: new Map(),
+      bindSubscriptionOnChainId: vi.fn(),
+      persistContextGraphSubscriptionStrict: vi.fn(),
+      processDurableBatchInWorker: async () => ({}),
+      insertSyncedQuadsAndInvalidateListCache: async () => {},
+      syncCheckpoints: new Map(),
+      oversizeTombstoneLog: { record: () => {} },
+      invalidateListContextGraphsCache: vi.fn(),
+      contextGraphMetaProjection: { markDirtyFromQuads: vi.fn() },
+      log: { info: () => {}, warn: () => {}, debug: () => {} },
+    };
+
+    await LifecycleSyncMethods.prototype.runLegacyDurableSyncForContextGraph.call(
+      agentLike, ctx, 'peer-gate-no-identity', contextGraphId, 1, {},
+    );
+
+    expect(mockedRunDurableSync.mock.calls[0]![0].legacyAgentProfileGate).toBeUndefined();
+  });
+
   it('selects the dedicated field-sized exact-recovery transfer policy', async () => {
     const physicalResult = {} as Awaited<ReturnType<typeof runDurableSync>>;
     const runLegacyDurableSyncDetailed = vi.fn(async () => ({

--- a/packages/agent/test/durable-sync-lifecycle-binding.test.ts
+++ b/packages/agent/test/durable-sync-lifecycle-binding.test.ts
@@ -333,7 +333,7 @@ describe('durable sync lifecycle chain binding', () => {
     });
   });
 
-  // #2052 D-8 (#53). The seam's gate port is OPTIONAL, so "durable sync uses a gate when
+  // #2052 D-8. The seam's gate port is OPTIONAL, so "durable sync uses a gate when
   // it is given one" — proven in durable-sync-legacy-profile-gate.test.ts — says nothing
   // about production: a construction site that silently omitted the field would satisfy
   // that test and still ship an open door. This asserts the SUPPLY, at the only

--- a/packages/agent/test/system-record-legacy-gate-v1.test.ts
+++ b/packages/agent/test/system-record-legacy-gate-v1.test.ts
@@ -50,12 +50,26 @@ function projectionRow(subject: string, predicate: string, object: string): Quad
 /**
  * A lookup that answers from an explicit applied set and records its call shape, so every
  * assertion about the store budget is made against calls that actually happened.
+ *
+ * `bounds` models an implementation that hit one of :926's byte caps. It is deliberately
+ * expressed as a response the gate RECEIVES rather than as a shorter list, because the
+ * whole point of the reported channel is that a short list is indistinguishable from
+ * "no record here" — a fixture that simulated a byte cap by returning fewer records
+ * would be testing the very confusion the contract exists to remove.
  */
-function fakeLookup(records: readonly LegacyAgentProfileAppliedRootV1[], projection: readonly Quad[]) {
-  const lookupAppliedRoots = vi.fn(async (roots: readonly string[]) =>
-    records.filter((record) => roots.includes(record.root)));
-  const lookupProjectionMembership = vi.fn(async (subjects: readonly string[]) =>
-    projection.filter((row) => subjects.includes(row.subject)));
+function fakeLookup(
+  records: readonly LegacyAgentProfileAppliedRootV1[],
+  projection: readonly Quad[],
+  bounds: { unclassifiedRoots?: readonly string[]; truncated?: boolean } = {},
+) {
+  const lookupAppliedRoots = vi.fn(async (roots: readonly string[]) => ({
+    records: records.filter((record) => roots.includes(record.root)),
+    unclassifiedRoots: (bounds.unclassifiedRoots ?? []).filter((root) => roots.includes(root)),
+  }));
+  const lookupProjectionMembership = vi.fn(async (subjects: readonly string[]) => ({
+    rows: projection.filter((row) => subjects.includes(row.subject)),
+    truncated: bounds.truncated ?? false,
+  }));
   const lookup: LegacyAgentProfileGateLookupV1 = { lookupAppliedRoots, lookupProjectionMembership };
   return { lookup, lookupAppliedRoots, lookupProjectionMembership };
 }
@@ -427,6 +441,46 @@ describe('LegacyAgentProfileGateV1 — bounded store requests (:926)', () => {
     expect(result.withheld).toHaveLength(1);
     expect(result.unclassifiedRoots).toBe(1);
     expect(result.discardedDuplicates).toBe(0);
+    expect(result.storeRequests).toBe(2);
+  });
+
+  // :926 request one — "one batched VALUES query ... with a 1-MiB response cap".
+  //
+  // The cap can only be honoured by answering about fewer roots, and an unmentioned root
+  // is otherwise indistinguishable from one that simply has no applied record. The two
+  // roots below are BOTH absent from `records`; the reported channel is the only thing
+  // that differs between them, so this fails if the gate ever reads omission as absence.
+  it('withholds a root the applied-roots response reports it could not classify', async () => {
+    const { lookup, lookupProjectionMembership } = fakeLookup([], [], {
+      unclassifiedRoots: [OTHER_ROOT],
+    });
+    const page = [quad(ROOT, 'p', 'o'), quad(OTHER_ROOT, 'p', 'o')];
+
+    const result = await createLegacyAgentProfileGateV1(lookup).filterPage(page);
+
+    expect(result.insert).toEqual([page[0]]);
+    expect(result.withheld).toEqual([page[1]]);
+    expect(result.unclassifiedRoots).toBe(1);
+    expect(result.conflictedRoots).toBe(0);
+    // No root was classified as covered, so the membership read is never issued.
+    expect(lookupProjectionMembership).not.toHaveBeenCalled();
+    expect(result.storeRequests).toBe(1);
+  });
+
+  // :926 request two — "10,000 quads, and 2 MiB". The row count is visible to the gate;
+  // the byte bound is not. The single row below IS the page's quad, so without the
+  // reported flag this quad is an exact duplicate and is DISCARDED. The flag is therefore
+  // the only difference between discarding and withholding.
+  it('withholds covered roots when the membership response reports it was truncated', async () => {
+    const applied: LegacyAgentProfileAppliedRootV1 = { root: ROOT, ownedSubjects: [ROOT] };
+    const { lookup } = fakeLookup([applied], [projectionRow(ROOT, 'p', 'o')], { truncated: true });
+
+    const result = await createLegacyAgentProfileGateV1(lookup).filterPage([quad(ROOT, 'p', 'o')]);
+
+    expect(result.discardedDuplicates).toBe(0);
+    expect(result.withheld).toHaveLength(1);
+    expect(result.insert).toEqual([]);
+    expect(result.unclassifiedRoots).toBe(1);
     expect(result.storeRequests).toBe(2);
   });
 });

--- a/packages/agent/test/system-record-legacy-gate-v1.test.ts
+++ b/packages/agent/test/system-record-legacy-gate-v1.test.ts
@@ -26,6 +26,7 @@ import {
   type LegacyAgentProfileAppliedRootV1,
   type LegacyAgentProfileGateLookupV1,
 } from '../src/system-records/legacy-profile-gate-v1.js';
+import { systemRecordProjectionGraphV1 } from '@origintrail-official/dkg-storage/internal/system-record-legacy-gate-read-v1';
 
 const AGENTS_GRAPH = 'did:dkg:context-graph:agents';
 
@@ -203,6 +204,39 @@ describe('LegacyAgentProfileGateV1 — covered roots (:924, :925)', () => {
     expect(result.discardedDuplicates).toBe(1);
     expect(result.withheld).toEqual([]);
     expect(result.conflictedRoots).toBe(0);
+  });
+
+  // Review found a REAL pre-activation data-loss bug here, and this is its regression.
+  //
+  // The batch-cap overflow disposition is set BEFORE the lookup runs, so under the old
+  // subject-only scoping a shadow-mode page carrying more than the cap's worth of agent
+  // roots had its overflow roots marked unclassified and WITHHELD — even though the
+  // shadow lookup answers empty and nothing authoritative exists to protect. Silent loss
+  // of legacy quads before cutover, with the checkpoint advancing over it.
+  //
+  // Under destination-graph scoping the shadow projection graph is the namespace-hidden
+  // reserved one, which no legacy page targets, so no root is derived at all and the
+  // overflow path is never reached. This pins that: ABOVE the cap, everything passes and
+  // nothing is read.
+  it('passes a page above the batch cap untouched in shadow mode, and reads nothing', async () => {
+    const { lookup, lookupAppliedRoots } = fakeLookup([applied], projection);
+    const shadow: LegacyAgentProfileGateLookupV1 = {
+      ...lookup,
+      // The materializer's own answer for shadow, not a restated constant.
+      projectionGraph: systemRecordProjectionGraphV1('shadow'),
+    };
+    const page = Array.from(
+      { length: LEGACY_AGENT_PROFILE_GATE_MAX_BATCH_ROOTS_V1 + 1 },
+      (_, i) => quad(`did:dkg:agent:0x${i.toString(16).padStart(40, '0')}`, 'p', 'o'),
+    );
+
+    const result = await createLegacyAgentProfileGateV1(shadow).filterPage(page);
+
+    expect(result.insert).toEqual(page);
+    expect(result.withheld).toEqual([]);
+    expect(result.unclassifiedRoots).toBe(0);
+    expect(result.storeRequests).toBe(0);
+    expect(lookupAppliedRoots).not.toHaveBeenCalled();
   });
 
   // T1, half B — the half that scoping by SUBJECT ALONE gets wrong, and the reason the

--- a/packages/agent/test/system-record-legacy-gate-v1.test.ts
+++ b/packages/agent/test/system-record-legacy-gate-v1.test.ts
@@ -70,7 +70,11 @@ function fakeLookup(
     rows: projection.filter((row) => subjects.includes(row.subject)),
     truncated: bounds.truncated ?? false,
   }));
-  const lookup: LegacyAgentProfileGateLookupV1 = { lookupAppliedRoots, lookupProjectionMembership };
+  const lookup: LegacyAgentProfileGateLookupV1 = {
+    projectionGraph: AGENTS_GRAPH,
+    lookupAppliedRoots,
+    lookupProjectionMembership,
+  };
   return { lookup, lookupAppliedRoots, lookupProjectionMembership };
 }
 
@@ -199,6 +203,31 @@ describe('LegacyAgentProfileGateV1 — covered roots (:924, :925)', () => {
     expect(result.discardedDuplicates).toBe(1);
     expect(result.withheld).toEqual([]);
     expect(result.conflictedRoots).toBe(0);
+  });
+
+  // T1, half B — the half that scoping by SUBJECT ALONE gets wrong, and the reason the
+  // two conjuncts are independent. This quad names a covered agent root and would
+  // conflict with the projection on content, but it is bound for a different context
+  // graph, where the signed projection does not live. Nothing can be overwritten there,
+  // so withholding it would be pure data loss in an unrelated graph.
+  //
+  // The zero-read assertion is what makes it a scope test rather than a duplicate of the
+  // pass-through case: a gate that consulted the store and then decided to pass would
+  // also satisfy the offer assertion, while spending :926's budget on a page that cannot
+  // collide with anything.
+  it('passes an agent-root quad bound for another context graph, and reads nothing', async () => {
+    const { lookup, lookupAppliedRoots } = fakeLookup([applied], projection);
+    const elsewhere = {
+      subject: ROOT, predicate: 'p', object: 'different', graph: 'did:dkg:context-graph:project-x',
+    };
+
+    const result = await createLegacyAgentProfileGateV1(lookup).filterPage([elsewhere]);
+
+    expect(result.insert).toEqual([elsewhere]);
+    expect(result.withheld).toEqual([]);
+    expect(result.conflictedRoots).toBe(0);
+    expect(result.storeRequests).toBe(0);
+    expect(lookupAppliedRoots).not.toHaveBeenCalled();
   });
 
   it('withholds a conflicting quad and counts the root as conflicted', async () => {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -15,6 +15,11 @@
       "import": "./dist/internal/managed-oxigraph-ownership-v1.js",
       "default": "./dist/internal/managed-oxigraph-ownership-v1.js"
     },
+    "./internal/system-record-legacy-gate-read-v1": {
+      "types": "./dist/internal/system-record-legacy-gate-read-v1.d.ts",
+      "import": "./dist/internal/system-record-legacy-gate-read-v1.js",
+      "default": "./dist/internal/system-record-legacy-gate-read-v1.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/storage/scripts/pack-gate/probe-fixture.mjs
+++ b/packages/storage/scripts/pack-gate/probe-fixture.mjs
@@ -54,6 +54,8 @@ const verdicts = [
   [!(cfg.publicError in internal), 'the public error is not doubled through the authority entry'],
   [(cfg.gateReadExports ?? []).every((n) => typeof gateRead[n] === 'function'),
     `gate-read entry exports its consumed surface (missing: ${(cfg.gateReadExports ?? []).filter((n) => typeof gateRead[n] !== 'function').join(',') || '-'})`],
+  [(cfg.gateReadConstants ?? []).every((n) => typeof gateRead[n] === 'string' && gateRead[n].length > 0),
+    `gate-read entry exports its consumed constants (missing: ${(cfg.gateReadConstants ?? []).filter((n) => typeof gateRead[n] !== 'string').join(',') || '-'})`],
 ];
 for (const [ok, label] of verdicts) {
   if (!ok) {

--- a/packages/storage/scripts/pack-gate/probe-fixture.mjs
+++ b/packages/storage/scripts/pack-gate/probe-fixture.mjs
@@ -16,6 +16,9 @@ for (const [specifier, shouldResolve] of cfg.resolutionExpectations ?? []) {
 
 const barrel = await import(cfg.pkg);
 const internal = await import(cfg.internalEntry);
+// #2052 D-8 — the gate-read subpath is LOADED, not merely resolved. Resolver metadata can
+// be correct while the packed JS lacks the functions its one consumer calls.
+const gateRead = await import(cfg.gateReadEntry);
 
 // IDENTITY-based leak detection: an authority export on the barrel is a leak
 // under ANY name. Comparing values, not keys, catches aliased re-exports
@@ -49,6 +52,8 @@ const verdicts = [
   [leaks.length === 0, `barrel exports no authority value under any name (leaked: ${leaks.join('; ')})`],
   [typeof internal[cfg.ownershipMint] === 'function', 'internal entry exports the ownership mint'],
   [!(cfg.publicError in internal), 'the public error is not doubled through the authority entry'],
+  [(cfg.gateReadExports ?? []).every((n) => typeof gateRead[n] === 'function'),
+    `gate-read entry exports its consumed surface (missing: ${(cfg.gateReadExports ?? []).filter((n) => typeof gateRead[n] !== 'function').join(',') || '-'})`],
 ];
 for (const [ok, label] of verdicts) {
   if (!ok) {

--- a/packages/storage/scripts/pack-gate/type-fixture.ts
+++ b/packages/storage/scripts/pack-gate/type-fixture.ts
@@ -10,6 +10,16 @@ import {
   type StructuredMutationSnapshot,
 } from '@origintrail-official/dkg-storage';
 import type { ManagedOxigraphSupervisorHandoffV1 } from '@origintrail-official/dkg-storage/internal/managed-oxigraph-ownership-v1';
+// #2052 D-8 — the gate-read subpath's DECLARATIONS, compiled against the packed d.ts.
+// The agent adapter imports exactly these names; a packed artifact that resolves but
+// ships no declarations for them breaks the only consumer while passing a
+// resolution-only check.
+import {
+  readLegacyAgentProfileAppliedRootsV1,
+  readLegacyAgentProfileProjectionV1,
+  systemRecordProjectionGraphV1,
+  type SystemRecordMaterializationModeV1,
+} from '@origintrail-official/dkg-storage/internal/system-record-legacy-gate-read-v1';
 // @ts-expect-error — final mutation materialization has no supported package subpath
 import { materializeStructuredMutation } from '@origintrail-official/dkg-storage/structured-mutation-materialization-internal';
 // @ts-expect-error — the ownership mint is not on the public barrel
@@ -37,4 +47,12 @@ const snapshotWitness: StructuredMutationSnapshot = captureStructuredMutationSna
 });
 void materializeStructuredMutation;
 void snapshotWitness;
+// The gate-read surface as the adapter actually uses it: the mode type names the union,
+// and the graph function is applied to it. Referencing the values (not just importing
+// them) is what makes a missing declaration a compile error rather than an unused import.
+const gateReadMode: SystemRecordMaterializationModeV1 = 'shadow';
+const gateReadWitness: string = systemRecordProjectionGraphV1(gateReadMode);
+void readLegacyAgentProfileAppliedRootsV1;
+void readLegacyAgentProfileProjectionV1;
+void gateReadWitness;
 export default witness;

--- a/packages/storage/scripts/verify-pack-exports.mjs
+++ b/packages/storage/scripts/verify-pack-exports.mjs
@@ -48,7 +48,7 @@ const GATE = Object.freeze({
   exportsAllowlist: [
     '.',
     './internal/managed-oxigraph-ownership-v1',
-    // #2052 D-8 (#53) — the legacy `agents` gate's two bounded reads. A DELIBERATE
+    // #2052 D-8 — the legacy `agents` gate's two bounded reads. A DELIBERATE
     // surface addition: the gate lives in the agent package and the reads must not,
     // because only storage knows where reserved state and projections live. Narrow
     // subpath rather than the barrel, so the reads stay reachable by exactly one

--- a/packages/storage/scripts/verify-pack-exports.mjs
+++ b/packages/storage/scripts/verify-pack-exports.mjs
@@ -55,6 +55,8 @@ const GATE = Object.freeze({
     'readLegacyAgentProfileProjectionV1',
     'systemRecordProjectionGraphV1',
   ],
+  /** Non-function members of the same subpath, checked by presence rather than type. */
+  gateReadConstants: ['SYSTEM_RECORD_V1_JSON_DATATYPE'],
   /** The packed exports map must carry EXACTLY these keys. */
   exportsAllowlist: [
     '.',

--- a/packages/storage/scripts/verify-pack-exports.mjs
+++ b/packages/storage/scripts/verify-pack-exports.mjs
@@ -44,6 +44,17 @@ const GATE = Object.freeze({
   internalEntry: '@origintrail-official/dkg-storage/internal/managed-oxigraph-ownership-v1',
   ownershipMint: 'createManagedOxigraphOwnershipControllerV1',
   publicError: 'ManagedOxigraphBackendUnownedError',
+  // #2052 D-8 — the gate-read subpath and the exact surface its one consumer imports.
+  // Resolution is NOT enough: a packed artifact whose `exports` map resolves while the
+  // built JS or its declarations lack these names satisfies the resolution expectation
+  // below and still breaks the agent adapter. So the probe IMPORTS it and the type
+  // fixture COMPILES against it.
+  gateReadEntry: '@origintrail-official/dkg-storage/internal/system-record-legacy-gate-read-v1',
+  gateReadExports: [
+    'readLegacyAgentProfileAppliedRootsV1',
+    'readLegacyAgentProfileProjectionV1',
+    'systemRecordProjectionGraphV1',
+  ],
   /** The packed exports map must carry EXACTLY these keys. */
   exportsAllowlist: [
     '.',

--- a/packages/storage/scripts/verify-pack-exports.mjs
+++ b/packages/storage/scripts/verify-pack-exports.mjs
@@ -45,13 +45,25 @@ const GATE = Object.freeze({
   ownershipMint: 'createManagedOxigraphOwnershipControllerV1',
   publicError: 'ManagedOxigraphBackendUnownedError',
   /** The packed exports map must carry EXACTLY these keys. */
-  exportsAllowlist: ['.', './internal/managed-oxigraph-ownership-v1', './package.json'],
+  exportsAllowlist: [
+    '.',
+    './internal/managed-oxigraph-ownership-v1',
+    // #2052 D-8 (#53) — the legacy `agents` gate's two bounded reads. A DELIBERATE
+    // surface addition: the gate lives in the agent package and the reads must not,
+    // because only storage knows where reserved state and projections live. Narrow
+    // subpath rather than the barrel, so the reads stay reachable by exactly one
+    // consumer without widening what the root export promises.
+    './internal/system-record-legacy-gate-read-v1',
+    './package.json',
+  ],
   resolutionExpectations: [
     ['@origintrail-official/dkg-storage', true],
     ['@origintrail-official/dkg-storage/internal/managed-oxigraph-ownership-v1', true],
+    ['@origintrail-official/dkg-storage/internal/system-record-legacy-gate-read-v1', true],
     // The manifest is a STABLE metadata subpath, per ecosystem convention.
     ['@origintrail-official/dkg-storage/package.json', true],
     ['@origintrail-official/dkg-storage/dist/internal/managed-oxigraph-ownership-v1.js', false],
+    ['@origintrail-official/dkg-storage/dist/internal/system-record-legacy-gate-read-v1.js', false],
     ['@origintrail-official/dkg-storage/dist/store-priority-scheduler.js', false],
     ['@origintrail-official/dkg-storage/structured-mutation-materialization-internal', false],
     ['@origintrail-official/dkg-storage/dist/structured-mutation-materialization-internal.js', false],

--- a/packages/storage/src/adapters/managed-http-client.ts
+++ b/packages/storage/src/adapters/managed-http-client.ts
@@ -1,5 +1,6 @@
 import { Agent, request as httpRequest, type IncomingMessage } from 'node:http';
 import { performance } from 'node:perf_hooks';
+import { STORE_RESPONSE_TOO_LARGE_CODE } from '../http-response-limit.js';
 import {
   SYSTEM_RECORD_MAX_MATERIALIZER_WRITE_CONCURRENCY,
 } from '@origintrail-official/dkg-core/system-record-v1';
@@ -296,8 +297,12 @@ export class OwnedManagedHttpClient {
               if (maxResponseBytes !== undefined
                   && chunkBytes > maxResponseBytes - responseBytes) {
                 failResponse(
-                  new Error(
-                    `managed SPARQL response body exceeded ${maxResponseBytes} bytes`,
+                  // Tagged with the canonical code so callers that degrade on an oversized
+                  // response recognise this refusal too. Previously this client's cap was
+                  // the one shape no shared check could see.
+                  Object.assign(
+                    new Error(`managed SPARQL response body exceeded ${maxResponseBytes} bytes`),
+                    { code: STORE_RESPONSE_TOO_LARGE_CODE },
                   ),
                 );
                 return;

--- a/packages/storage/src/adapters/managed-http-client.ts
+++ b/packages/storage/src/adapters/managed-http-client.ts
@@ -399,9 +399,17 @@ export class OwnedManagedHttpClient {
               declaredLength = Number(contentLengthHeader);
               if (maxResponseBytes !== undefined && declaredLength > maxResponseBytes) {
                 failResponse(
-                  new Error(
-                    `managed SPARQL response body declares ${declaredLength} bytes; ` +
-                      `maximum is ${maxResponseBytes} bytes`,
+                  // Same code as the chunked refusal below, because this is the same
+                  // refusal: the body exceeds `maxResponseBytes`. A server that sends
+                  // Content-Length lands HERE rather than there, so leaving this site
+                  // untagged left the likelier of the two paths invisible to the shared
+                  // check — the shared bounded reader already types both of its own.
+                  Object.assign(
+                    new Error(
+                      `managed SPARQL response body declares ${declaredLength} bytes; ` +
+                        `maximum is ${maxResponseBytes} bytes`,
+                    ),
+                    { code: STORE_RESPONSE_TOO_LARGE_CODE },
                   ),
                 );
                 return;

--- a/packages/storage/src/http-response-limit.ts
+++ b/packages/storage/src/http-response-limit.ts
@@ -1,5 +1,7 @@
+export const STORE_RESPONSE_TOO_LARGE_CODE = 'STORE_RESPONSE_TOO_LARGE';
+
 export class StoreResponseTooLargeError extends Error {
-  readonly code = 'STORE_RESPONSE_TOO_LARGE';
+  readonly code = STORE_RESPONSE_TOO_LARGE_CODE;
   readonly maxBytes: number;
   readonly actualBytes: number | bigint;
 
@@ -9,6 +11,21 @@ export class StoreResponseTooLargeError extends Error {
     this.maxBytes = maxBytes;
     this.actualBytes = actualBytes;
   }
+}
+
+/**
+ * THE canonical test for "the transport refused an oversized body".
+ *
+ * Lives next to the class that defines the code so a caller never has to restate either.
+ * Deliberately NOT `instanceof` alone: not every client throws this class — the managed
+ * SPARQL client raises its own error when a chunk would exceed the remaining budget — so
+ * the code is the wider net, and both shapes carry it.
+ */
+export function isStoreResponseTooLargeErrorV1(error: unknown): boolean {
+  return error instanceof StoreResponseTooLargeError
+    || (typeof error === 'object'
+      && error !== null
+      && (error as { code?: unknown }).code === STORE_RESPONSE_TOO_LARGE_CODE);
 }
 
 /** Read a fetch response body without ever buffering more than `maxBytes`. */

--- a/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
+++ b/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
@@ -44,6 +44,10 @@ import {
 } from '@origintrail-official/dkg-core/system-record-v1';
 import type { Quad, TripleStore } from '../triple-store.js';
 import { SYSTEM_RECORD_V1_STATE_GRAPH } from '../internal-graph-policy.js';
+// The canonical retained-byte accounting, shared with the inspection path rather than
+// re-derived here. Request one measures a literal rather than quads, so it keeps its own
+// term measurement; request two measures rows, which is exactly what this helper counts.
+import { retainedSystemRecordInspectionQuadsBytesV1 } from '../system-record-inspection-v1-internal.js';
 import {
   SYSTEM_RECORD_V1_PREDICATES,
   systemRecordProjectionGraphV1,
@@ -306,11 +310,18 @@ export async function readLegacyAgentProfileProjectionV1(input: {
   for (const binding of bindings) {
     const { s, p, o } = binding;
     if (s === undefined || p === undefined || o === undefined) continue;
-    retainedBytes += termBytes(s) + termBytes(p) + termBytes(o);
+    const row = { subject: s, predicate: p, object: o, graph };
+    // The system's OWN definition of retained bytes, not a local sum. Adopted from review:
+    // a hand-rolled `s + p + o` in UTF-8 under-counts what is actually retained by more
+    // than half — it ignores the graph term, JS string retention, and per-entry container
+    // overhead — so a cap measured that way lets the process hold materially more than
+    // the bound intends. Reusing the canonical helper also keeps this path from drifting
+    // away from the accounting the sibling inspection path uses.
+    retainedBytes += retainedSystemRecordInspectionQuadsBytesV1([row]);
     if (retainedBytes > SYSTEM_RECORD_MAX_PROJECTION_BYTES) {
       return Object.freeze({ rows: [], truncated: true });
     }
-    rows.push({ subject: s, predicate: p, object: o, graph });
+    rows.push(row);
   }
   return Object.freeze({ rows: Object.freeze(rows), truncated: false }) as LegacyAgentProfileProjectionV1;
 }

--- a/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
+++ b/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
@@ -51,6 +51,7 @@ import {
   buildSystemRecordProjectionInspectionQueryV1,
   retainedSystemRecordInspectionQuadsBytesV1,
 } from '../system-record-inspection-v1-internal.js';
+import { isSystemRecordBoundedBuildOverflowV1 } from '../system-record-bounded-utf8-builder-v1-internal.js';
 import {
   SYSTEM_RECORD_V1_JSON_DATATYPE,
   SYSTEM_RECORD_V1_PREDICATES,
@@ -137,15 +138,17 @@ function isStoreResponseTooLargeV1(error: unknown): boolean {
 }
 
 /**
- * The canonical query builder's own refusal to emit an over-bound REQUEST.
+ * The canonical query builder's own refusal to emit an over-bound REQUEST, recognised by
+ * the builder's OWN typed code rather than by its English message.
  *
- * Distinguished from its accounting-mismatch throws, which would be defects in this
- * module and must keep propagating. Matching the bound suffix rather than the label keeps
- * this from widening if the label is ever reworded.
+ * The first version of this matched the message text, which review correctly called
+ * brittle — and inconsistent with the argument made a few lines above about the transport
+ * cap, where message matching was rejected for exactly this reason. A reworded message
+ * would have silently stopped translating a refusal; an unrelated error ending the same
+ * way would have been swallowed as truncation.
  */
 function isBoundedBuilderOverflowV1(error: unknown): boolean {
-  return error instanceof Error
-    && / exceeds its (encoded|retained)-byte bound$/.test(error.message);
+  return isSystemRecordBoundedBuildOverflowV1(error);
 }
 
 function valuesClause(variable: string, iris: readonly string[]): string {

--- a/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
+++ b/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
@@ -216,23 +216,48 @@ export async function readLegacyAgentProfileAppliedRootsV1(input: {
     return Object.freeze({ records: [], unclassifiedRoots: Object.freeze([...ordered]) });
   }
 
+  // THE RESPONSE MAY NOT BE THE EXACT SET, AND THAT CHANGES WHAT ABSENCE MEANS.
+  //
+  // The query asks for `LIMIT ordered.length + 1`, so at most one row per requested root
+  // plus one. More rows than roots means either duplicates or a bound that cut the answer
+  // short — and a cut answer can have pushed a DIFFERENT root's row out of the result.
+  // Reading that root as "no applied record" would classify it uncovered and insert
+  // unsigned legacy quads over signed state, which is the exact fail-open this port
+  // contract exists to close. So when the answer is not exact, absence stops being an
+  // answer and every undecided root is reported undecided.
+  const saturated = bindings.length > ordered.length;
+
   const tableByRoot = new Map<string, string>();
+  // Roots the reserved graph answered for more than once. A duplicate current claim means
+  // the graph is not the shape this reader can classify, and picking whichever row arrived
+  // first would be deciding insert-or-discard from an arbitrary one.
+  const ambiguousRoots = new Set<string>();
   for (const binding of bindings) {
     const root = binding.claim === undefined ? undefined : rootByClaim.get(binding.claim);
-    // A row for a claim nobody asked about, or a duplicate current claim, means the
-    // reserved graph is not the shape this reader assumes. Ignore the row rather than
-    // guess: an unrecognised row can only make coverage narrower, and the roots it would
-    // have covered stay unclassified below.
+    // A row for a claim nobody asked about cannot narrow or widen coverage; ignore it.
     if (root === undefined || binding.table === undefined) continue;
-    if (!tableByRoot.has(root)) tableByRoot.set(root, binding.table);
+    if (tableByRoot.has(root)) {
+      ambiguousRoots.add(root);
+      continue;
+    }
+    tableByRoot.set(root, binding.table);
   }
 
   const records: LegacyAgentProfileAppliedRootV1[] = [];
   const unclassifiedRoots: string[] = [];
   let retainedBytes = 0;
   for (const root of ordered) {
+    if (ambiguousRoots.has(root)) {
+      unclassifiedRoots.push(root);
+      continue;
+    }
     const table = tableByRoot.get(root);
-    if (table === undefined) continue; // Asked, answered: no applied record.
+    if (table === undefined) {
+      // Asked, answered: no applied record — but ONLY when the answer was exact. Under a
+      // saturated response the row for this root may simply not have fitted.
+      if (saturated) unclassifiedRoots.push(root);
+      continue;
+    }
     // DELIBERATELY NOT `retainedSystemRecordInspectionQuadsBytesV1`, which request two
     // uses. That helper measures QUADS; what is retained here is a single literal — the
     // owned-subject table — so wrapping it in a synthetic quad to reuse the helper would

--- a/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
+++ b/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
@@ -49,6 +49,7 @@ import { SYSTEM_RECORD_V1_STATE_GRAPH } from '../internal-graph-policy.js';
 // term measurement; request two measures rows, which is exactly what this helper counts.
 import { retainedSystemRecordInspectionQuadsBytesV1 } from '../system-record-inspection-v1-internal.js';
 import {
+  SYSTEM_RECORD_V1_JSON_DATATYPE,
   SYSTEM_RECORD_V1_PREDICATES,
   systemRecordProjectionGraphV1,
   systemRecordRootClaimSubjectV1,
@@ -75,6 +76,16 @@ export type { SystemRecordMaterializationModeV1 };
  * reads: pre-cutover there is nothing for legacy insertion to collide with.
  */
 export { systemRecordProjectionGraphV1 };
+
+/**
+ * The canonical typed-literal datatype an owned-subject table must carry.
+ *
+ * Exported because this reader now ENFORCES it: a table literal of any other datatype is
+ * reported undecided rather than accepted. A consumer constructing or asserting against
+ * reserved state needs the same constant the reader compares to, or its fixtures test a
+ * shape production never produces — which is exactly how the missing check was found.
+ */
+export { SYSTEM_RECORD_V1_JSON_DATATYPE };
 
 /** One applied signed record, keyed by the agent root the caller asked about. */
 export interface LegacyAgentProfileAppliedRootV1 {
@@ -232,7 +243,19 @@ export async function readLegacyAgentProfileAppliedRootsV1(input: {
       continue;
     }
     const literal = parseRdfLiteralTerm(table);
-    if (literal === null) {
+    // The DATATYPE is part of the contract, not decoration. Adopted from review, which
+    // caught it with a fixture typed `urn:json` that passed anyway: this reader used to
+    // take any literal's value, so reserved state the writer could never emit — a plain
+    // literal, a language-tagged one, any datatype at all — was accepted as a valid
+    // applied record. The canonical decode below still bounded what such a table could
+    // SAY, but a reader looser than its writer's encoding is a hole on its own.
+    //
+    // A mismatch is UNDECIDED, never "no record" — the same disposition as a table that
+    // will not decode, for the same reason: an answer this reader cannot vouch for must
+    // not become the `uncovered` that lets legacy quads through.
+    if (literal === null
+      || literal.kind !== 'typed'
+      || literal.datatype !== SYSTEM_RECORD_V1_JSON_DATATYPE) {
       unclassifiedRoots.push(root);
       continue;
     }

--- a/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
+++ b/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
@@ -123,34 +123,6 @@ function assertQueryableIri(iri: string): void {
   if (!isSafeIri(iri)) throw new Error('legacy agent-profile gate read built an unsafe IRI');
 }
 
-/**
- * Delegates to the canonical predicate that lives beside the error class.
- *
- * This used to restate the code as a local string — review pointed out that the same PR
- * had just introduced a shared typed predicate for the builder's overflow and left this
- * sibling case on an ad-hoc check, inconsistent inside one function. The canonical form
- * also closes what was documented here as a residual: the managed SPARQL client raises a
- * refusal that is not an instance of the error class, and it now carries the same code, so
- * one predicate recognises both shapes.
- */
-function isStoreResponseTooLargeV1(error: unknown): boolean {
-  return isStoreResponseTooLargeErrorV1(error);
-}
-
-/**
- * The canonical query builder's own refusal to emit an over-bound REQUEST, recognised by
- * the builder's OWN typed code rather than by its English message.
- *
- * The first version of this matched the message text, which review correctly called
- * brittle — and inconsistent with the argument made a few lines above about the transport
- * cap, where message matching was rejected for exactly this reason. A reworded message
- * would have silently stopped translating a refusal; an unrelated error ending the same
- * way would have been swallowed as truncation.
- */
-function isBoundedBuilderOverflowV1(error: unknown): boolean {
-  return isSystemRecordBoundedBuildOverflowV1(error);
-}
-
 function valuesClause(variable: string, iris: readonly string[]): string {
   for (const iri of iris) assertQueryableIri(iri);
   return `VALUES ${variable} { ${iris.map((iri) => `<${iri}>`).join(' ')} }`;
@@ -246,7 +218,12 @@ export async function readLegacyAgentProfileAppliedRootsV1(input: {
       signal,
     }) as { type: string; bindings?: Array<Record<string, string>> });
   } catch (error) {
-    if (!isStoreResponseTooLargeV1(error)) throw error;
+    // Recognised by CODE rather than by class or message, which is what makes this catch
+    // total: the shared bounded reader throws the error class, and the managed SPARQL
+    // client throws a plain Error carrying the same code from either of its two cap
+    // checks. One canonical predicate sees all three shapes; an `instanceof` would miss
+    // two of them, and a message match would break on a reworded string.
+    if (!isStoreResponseTooLargeErrorV1(error)) throw error;
     // The transport refused the body before parsing it. Report rather than rethrow: at
     // the seam a throw drops the whole page, which is the retry-storm this port contract
     // was rewritten to avoid, and "could not classify" is already the answer the gate
@@ -390,6 +367,15 @@ export async function readLegacyAgentProfileProjectionV1(input: {
   // That last one was a real gap: 2,048 arbitrarily long subjects could previously build
   // an unbounded request string, and only the RESPONSE was ever capped.
   //
+  // REQUEST ONE NEEDS NO EQUIVALENT, AND THAT IS MEASURED RATHER THAN ASSUMED — recorded
+  // here because the sentence above otherwise reads as an asymmetry someone should close.
+  // Request one's VALUES list carries DERIVED root-claim IRIs rather than caller strings:
+  // base64url of the network id plus base64url of the agent root, a fixed 117 characters
+  // each. At the gate's 256-root batch cap that is roughly 31 KB against the same 4 MiB
+  // request cap — two orders of magnitude clear — and nothing caller-supplied can lengthen
+  // them, because callers supply roots and this module derives the IRIs. The difference is
+  // a property of the two request shapes, not an unclosed gap.
+  //
   // Its own preconditions are already satisfied above: it throws below one subject and
   // above the owned-subject bound, and both are returned early.
   //
@@ -408,7 +394,12 @@ export async function readLegacyAgentProfileProjectionV1(input: {
   try {
     query = buildSystemRecordProjectionInspectionQueryV1(mode, ordered);
   } catch (error) {
-    if (!isBoundedBuilderOverflowV1(error)) throw error;
+    // The builder's OWN typed code, not its English message. Matching the text was the
+    // first form here and review correctly called it brittle: a reworded message would
+    // silently stop translating a real refusal, and an unrelated error ending the same way
+    // would be swallowed as truncation. The builder's suite pins both polarities of that
+    // code, so a bound refusal is translatable and an accounting mismatch is not.
+    if (!isSystemRecordBoundedBuildOverflowV1(error)) throw error;
     return Object.freeze({ rows: [], truncated: true });
   }
 
@@ -421,7 +412,8 @@ export async function readLegacyAgentProfileProjectionV1(input: {
       signal,
     }) as { type: string; bindings?: Array<Record<string, string>> });
   } catch (error) {
-    if (!isStoreResponseTooLargeV1(error)) throw error;
+    // Same canonical predicate as request one's catch, for the same three refusal shapes.
+    if (!isStoreResponseTooLargeErrorV1(error)) throw error;
     return Object.freeze({ rows: [], truncated: true });
   }
 

--- a/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
+++ b/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
@@ -136,6 +136,18 @@ function isStoreResponseTooLargeV1(error: unknown): boolean {
     && (error as { code?: unknown }).code === 'STORE_RESPONSE_TOO_LARGE';
 }
 
+/**
+ * The canonical query builder's own refusal to emit an over-bound REQUEST.
+ *
+ * Distinguished from its accounting-mismatch throws, which would be defects in this
+ * module and must keep propagating. Matching the bound suffix rather than the label keeps
+ * this from widening if the label is ever reworded.
+ */
+function isBoundedBuilderOverflowV1(error: unknown): boolean {
+  return error instanceof Error
+    && / exceeds its (encoded|retained)-byte bound$/.test(error.message);
+}
+
 function valuesClause(variable: string, iris: readonly string[]): string {
   for (const iri of iris) assertQueryableIri(iri);
   return `VALUES ${variable} { ${iris.map((iri) => `<${iri}>`).join(' ')} }`;
@@ -353,8 +365,25 @@ export async function readLegacyAgentProfileProjectionV1(input: {
   //
   // Its own preconditions are already satisfied above: it throws below one subject and
   // above the owned-subject bound, and both are returned early.
+  //
+  // AND ITS REFUSAL IS TRANSLATED, NOT PROPAGATED. Adopted from review, which caught a
+  // defect this adoption itself introduced: the builder refuses an over-bound request by
+  // THROWING, where the previous local construction had no request bound at all. So
+  // adopting it turned "no cap" into "a cap that kills the page" — the throw escapes
+  // through the gate, the per-context-graph catch drops the whole page, and durable sync
+  // retries it forever. A request this reader cannot ask is exactly the case the gate
+  // already has an answer for: report it undecidable and let the gate withhold.
+  //
+  // Valid long owned subjects reach this: the subject count can sit under its bound while
+  // the encoded VALUES clause crosses the request cap.
   const ordered = [...subjects].sort();
-  const query = buildSystemRecordProjectionInspectionQueryV1(mode, ordered);
+  let query: string;
+  try {
+    query = buildSystemRecordProjectionInspectionQueryV1(mode, ordered);
+  } catch (error) {
+    if (!isBoundedBuilderOverflowV1(error)) throw error;
+    return Object.freeze({ rows: [], truncated: true });
+  }
 
   let bindings: Array<Record<string, string>>;
   try {

--- a/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
+++ b/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
@@ -219,6 +219,11 @@ export async function readLegacyAgentProfileAppliedRootsV1(input: {
   for (const root of ordered) {
     const table = tableByRoot.get(root);
     if (table === undefined) continue; // Asked, answered: no applied record.
+    // DELIBERATELY NOT `retainedSystemRecordInspectionQuadsBytesV1`, which request two
+    // uses. That helper measures QUADS; what is retained here is a single literal — the
+    // owned-subject table — so wrapping it in a synthetic quad to reuse the helper would
+    // inflate the count with subject, predicate and graph terms this response never
+    // carries. Same cap, different measured object.
     retainedBytes += termBytes(table);
     if (retainedBytes > SYSTEM_RECORD_MAX_ATOMIC_RESERVED_INSPECTION_RESPONSE_BYTES) {
       // Past the budget the answer is no longer one this reader will vouch for. Every

--- a/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
+++ b/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
@@ -1,0 +1,261 @@
+/**
+ * Storage read path for the inbound legacy `agents` gate (#2052 D-8; plan :924, :926, :1505).
+ *
+ * The gate lives in the agent package and owns the decision; this module owns the two
+ * bounded reads that decision needs, because only storage knows where reserved state and
+ * projections live and what a bounded response looks like.
+ *
+ * WHY THIS IS NOT THE ATOMIC-APPLY INSPECTION PATH. `readReserved`/`readProjection` in
+ * `system-record-atomic-apply-executor-v1-internal.ts` are bound to a managed-Oxigraph
+ * HTTP client and get their byte caps enforced at the transport. Riding that path would
+ * make the gate work only on daemon-managed leased endpoints, so a node on any other
+ * backend would have no gate at all — and an invariant that holds only on some backends
+ * is not an invariant. These reads go through `TripleStore.query`, which every store
+ * implements.
+ *
+ * WHERE THE BYTE CAPS LAND, AND WHY THAT IS A DERIVATION RATHER THAN PLAN LETTER. :926
+ * caps request one at 1 MiB and request two at 2 MiB as *response* caps, which presumes a
+ * wire. An embedded store has no wire, so the faithful analogue is the retained size of
+ * the decoded answer, measured after it arrives. That is late by construction — the bytes
+ * exist before anything can refuse them — so these functions never pretend to have
+ * prevented an oversized answer. They report what they could not classify and let the gate
+ * withhold, which is exactly :926's own remedy ("signed-root quads not classified within
+ * the selected bounded batch are withheld").
+ *
+ * MODE. Covered means an applied record whose projection is AUTHORITATIVE. Pre-cutover the
+ * projection lives in its own shadow graph, so legacy insertion into the aggregate `agents`
+ * graph cannot collide with it, and `SYSTEM_RECORD_V1_SHADOW_AGENTS_GRAPH`'s own contract
+ * is that shadow rows "never make the legacy lane non-authoritative". A gate that withheld
+ * legacy quads on the strength of a shadow row would violate that directly. So under
+ * `shadow` these reads answer empty WITHOUT querying, and the mode is supplied by the
+ * caller from the materializer's own lane activation rather than inferred here — an
+ * absent lane controller proves nothing can apply a record *now*, not that none persists
+ * from an earlier process.
+ */
+
+import { parseRdfLiteralTerm } from '@origintrail-official/dkg-rdf-utils';
+import { isSafeIri } from '@origintrail-official/dkg-core';
+import {
+  parseCanonicalOwnedSubjectTableObjectV1,
+  SYSTEM_RECORD_MAX_ATOMIC_RESERVED_INSPECTION_RESPONSE_BYTES,
+  SYSTEM_RECORD_MAX_OWNED_SUBJECTS,
+  SYSTEM_RECORD_MAX_PROJECTION_BYTES,
+  SYSTEM_RECORD_MAX_PROJECTION_QUADS,
+} from '@origintrail-official/dkg-core/system-record-v1';
+import type { Quad, TripleStore } from '../triple-store.js';
+import { SYSTEM_RECORD_V1_STATE_GRAPH } from '../internal-graph-policy.js';
+import {
+  SYSTEM_RECORD_V1_PREDICATES,
+  systemRecordProjectionGraphV1,
+  systemRecordRootClaimSubjectV1,
+  type SystemRecordMaterializationModeV1,
+} from '../system-record-rdf-schema-v1-internal.js';
+
+/** One applied signed record, keyed by the agent root the caller asked about. */
+export interface LegacyAgentProfileAppliedRootV1 {
+  readonly root: string;
+  readonly ownedSubjects: readonly string[];
+}
+
+export interface LegacyAgentProfileAppliedRootsV1 {
+  readonly records: readonly LegacyAgentProfileAppliedRootV1[];
+  /**
+   * Roots that were asked about and NOT decided. Distinct from roots simply absent from
+   * `records`, which means "no applied record" and is a real answer.
+   */
+  readonly unclassifiedRoots: readonly string[];
+}
+
+export interface LegacyAgentProfileProjectionV1 {
+  readonly rows: readonly Quad[];
+  readonly truncated: boolean;
+}
+
+const UTF8 = new TextEncoder();
+
+function termBytes(value: string): number {
+  return UTF8.encode(value).length;
+}
+
+function assertQueryableIri(iri: string): void {
+  if (!isSafeIri(iri)) throw new Error('legacy agent-profile gate read built an unsafe IRI');
+}
+
+function valuesClause(variable: string, iris: readonly string[]): string {
+  for (const iri of iris) assertQueryableIri(iri);
+  return `VALUES ${variable} { ${iris.map((iri) => `<${iri}>`).join(' ')} }`;
+}
+
+function selectBindings(result: {
+  type: string;
+  bindings?: Array<Record<string, string>>;
+}): Array<Record<string, string>> {
+  // A non-SELECT answer here means the query text and the reader disagree, which is a
+  // defect in this module rather than a condition to tolerate.
+  if (result.type !== 'bindings' || !Array.isArray(result.bindings)) {
+    throw new Error('legacy agent-profile gate read expected SPARQL bindings');
+  }
+  return result.bindings;
+}
+
+/**
+ * Request one — map derived agent roots to their applied record's owned-subject table.
+ *
+ * Two hops in ONE physical request, which is what keeps :926's two-request budget
+ * reachable: a root-claim subject is derivable from the root with no read
+ * (`systemRecordRootClaimSubjectV1`), the claim names its record through `claimedBy`, and
+ * the record carries the table. A per-root or per-quad query is never issued.
+ *
+ * COVERAGE IS SCOPED TO THE CURRENT CLAIM. `claimPosition` distinguishes a record's
+ * current root from roots it held before an authority transition, whose projection was
+ * "removed atomically" (plan :1503) — so a historical root has no signed state left to
+ * protect, and the legacy path is correct for it. It is also the only case that can be
+ * verified: the owned-subject table is canonicalized against the record's CURRENT root,
+ * so validating it against a historical root would fail by construction.
+ */
+export async function readLegacyAgentProfileAppliedRootsV1(input: {
+  readonly store: TripleStore;
+  readonly networkId: string;
+  readonly mode: SystemRecordMaterializationModeV1;
+  readonly roots: readonly string[];
+  readonly signal?: AbortSignal;
+}): Promise<LegacyAgentProfileAppliedRootsV1> {
+  const { store, networkId, mode, roots, signal } = input;
+  if (mode !== 'authoritative' || roots.length === 0) {
+    return Object.freeze({ records: [], unclassifiedRoots: [] });
+  }
+
+  // Deterministic order, and the same order the gate selects in, so which roots fall
+  // outside the byte budget is a function of the request rather than of result ordering.
+  const ordered = [...roots].sort();
+  const claimByRoot = new Map<string, string>();
+  for (const root of ordered) {
+    claimByRoot.set(root, systemRecordRootClaimSubjectV1(networkId, root));
+  }
+  const rootByClaim = new Map([...claimByRoot].map(([root, claim]) => [claim, root]));
+
+  assertQueryableIri(SYSTEM_RECORD_V1_STATE_GRAPH);
+  const query = `SELECT ?claim ?table WHERE {\n`
+    + `  GRAPH <${SYSTEM_RECORD_V1_STATE_GRAPH}> {\n`
+    + `    ${valuesClause('?claim', [...claimByRoot.values()])}\n`
+    + `    ?claim <${SYSTEM_RECORD_V1_PREDICATES.claimPosition}> "current" .\n`
+    + `    ?claim <${SYSTEM_RECORD_V1_PREDICATES.claimedBy}> ?record .\n`
+    + `    ?record <${SYSTEM_RECORD_V1_PREDICATES.ownedSubjectTable}> ?table .\n`
+    + `  }\n`
+    + `}\nLIMIT ${ordered.length + 1}`;
+
+  const bindings = selectBindings(await store.query(query, {
+    source: 'storage.systemRecord.legacyGate.appliedRoots',
+    priority: 'background',
+    signal,
+  }) as { type: string; bindings?: Array<Record<string, string>> });
+
+  const tableByRoot = new Map<string, string>();
+  for (const binding of bindings) {
+    const root = binding.claim === undefined ? undefined : rootByClaim.get(binding.claim);
+    // A row for a claim nobody asked about, or a duplicate current claim, means the
+    // reserved graph is not the shape this reader assumes. Ignore the row rather than
+    // guess: an unrecognised row can only make coverage narrower, and the roots it would
+    // have covered stay unclassified below.
+    if (root === undefined || binding.table === undefined) continue;
+    if (!tableByRoot.has(root)) tableByRoot.set(root, binding.table);
+  }
+
+  const records: LegacyAgentProfileAppliedRootV1[] = [];
+  const unclassifiedRoots: string[] = [];
+  let retainedBytes = 0;
+  for (const root of ordered) {
+    const table = tableByRoot.get(root);
+    if (table === undefined) continue; // Asked, answered: no applied record.
+    retainedBytes += termBytes(table);
+    if (retainedBytes > SYSTEM_RECORD_MAX_ATOMIC_RESERVED_INSPECTION_RESPONSE_BYTES) {
+      // Past the budget the answer is no longer one this reader will vouch for. Every
+      // remaining root is reported undecided, never as "no record".
+      unclassifiedRoots.push(root);
+      continue;
+    }
+    const literal = parseRdfLiteralTerm(table);
+    if (literal === null) {
+      unclassifiedRoots.push(root);
+      continue;
+    }
+    let ownedSubjects: readonly string[];
+    try {
+      ownedSubjects = parseCanonicalOwnedSubjectTableObjectV1(root, literal.value);
+    } catch {
+      // A table that will not decode against its own root cannot be used to classify that
+      // root's quads. Undecided, not uncovered.
+      unclassifiedRoots.push(root);
+      continue;
+    }
+    if (ownedSubjects.length > SYSTEM_RECORD_MAX_OWNED_SUBJECTS) {
+      unclassifiedRoots.push(root);
+      continue;
+    }
+    records.push(Object.freeze({ root, ownedSubjects: Object.freeze([...ownedSubjects]) }));
+  }
+
+  return Object.freeze({
+    records: Object.freeze(records),
+    unclassifiedRoots: Object.freeze(unclassifiedRoots),
+  }) as LegacyAgentProfileAppliedRootsV1;
+}
+
+/**
+ * Request two — the exact projection triples owned by these subjects.
+ *
+ * `truncated` covers both bounds that can stop this response short of the exact
+ * projection: the row count, which the gate could see for itself, and the 2-MiB retained
+ * size, which it cannot. Reporting them through one flag keeps the gate's fallback single:
+ * a partial projection is never compared against, because a missing row would read as a
+ * conflict and withhold on manufactured evidence.
+ */
+export async function readLegacyAgentProfileProjectionV1(input: {
+  readonly store: TripleStore;
+  readonly mode: SystemRecordMaterializationModeV1;
+  readonly subjects: readonly string[];
+  readonly signal?: AbortSignal;
+}): Promise<LegacyAgentProfileProjectionV1> {
+  const { store, mode, subjects, signal } = input;
+  if (mode !== 'authoritative' || subjects.length === 0) {
+    return Object.freeze({ rows: [], truncated: false });
+  }
+  if (subjects.length > SYSTEM_RECORD_MAX_OWNED_SUBJECTS) {
+    // :926 bounds request two at 2,048 subjects. Over that this reader cannot ask an
+    // exact question, so it reports a truncated answer instead of asking a partial one.
+    return Object.freeze({ rows: [], truncated: true });
+  }
+
+  const graph = systemRecordProjectionGraphV1(mode);
+  assertQueryableIri(graph);
+  const ordered = [...subjects].sort();
+  const query = `SELECT ?s ?p ?o WHERE {\n`
+    + `  GRAPH <${graph}> {\n`
+    + `    ${valuesClause('?s', ordered)}\n`
+    + `    ?s ?p ?o .\n`
+    + `  }\n`
+    + `}\nLIMIT ${SYSTEM_RECORD_MAX_PROJECTION_QUADS + 1}`;
+
+  const bindings = selectBindings(await store.query(query, {
+    source: 'storage.systemRecord.legacyGate.projection',
+    priority: 'background',
+    signal,
+  }) as { type: string; bindings?: Array<Record<string, string>> });
+
+  if (bindings.length > SYSTEM_RECORD_MAX_PROJECTION_QUADS) {
+    return Object.freeze({ rows: [], truncated: true });
+  }
+
+  const rows: Quad[] = [];
+  let retainedBytes = 0;
+  for (const binding of bindings) {
+    const { s, p, o } = binding;
+    if (s === undefined || p === undefined || o === undefined) continue;
+    retainedBytes += termBytes(s) + termBytes(p) + termBytes(o);
+    if (retainedBytes > SYSTEM_RECORD_MAX_PROJECTION_BYTES) {
+      return Object.freeze({ rows: [], truncated: true });
+    }
+    rows.push({ subject: s, predicate: p, object: o, graph });
+  }
+  return Object.freeze({ rows: Object.freeze(rows), truncated: false }) as LegacyAgentProfileProjectionV1;
+}

--- a/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
+++ b/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
@@ -250,9 +250,15 @@ export async function readLegacyAgentProfileAppliedRootsV1(input: {
     // applied record. The canonical decode below still bounded what such a table could
     // SAY, but a reader looser than its writer's encoding is a hole on its own.
     //
-    // A mismatch is UNDECIDED, never "no record" — the same disposition as a table that
-    // will not decode, for the same reason: an answer this reader cannot vouch for must
-    // not become the `uncovered` that lets legacy quads through.
+    // A mismatch is UNDECIDED, never "no record" — treated exactly like a table that will
+    // not decode, for the same reason: an answer this reader cannot vouch for must not
+    // become the `uncovered` that lets legacy quads through.
+    //
+    // (Wording note: a sibling slice pins that this package produces none of core's
+    // authority-classification vocabulary, and it does so with a raw substring scan over
+    // every `.ts` file in `src`. That scan cannot tell a term of art from the same word in
+    // ordinary English, so prose here avoids the vocabulary entirely — including in this
+    // note. Their invariant is correct; the collision is purely lexical.)
     if (literal === null
       || literal.kind !== 'typed'
       || literal.datatype !== SYSTEM_RECORD_V1_JSON_DATATYPE) {

--- a/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
+++ b/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
@@ -44,6 +44,7 @@ import {
 } from '@origintrail-official/dkg-core/system-record-v1';
 import type { Quad, TripleStore } from '../triple-store.js';
 import { SYSTEM_RECORD_V1_STATE_GRAPH } from '../internal-graph-policy.js';
+import { isStoreResponseTooLargeErrorV1 } from '../http-response-limit.js';
 // The canonical retained-byte accounting, shared with the inspection path rather than
 // re-derived here. Request one measures a literal rather than quads, so it keeps its own
 // term measurement; request two measures rows, which is exactly what this helper counts.
@@ -122,19 +123,17 @@ function assertQueryableIri(iri: string): void {
 }
 
 /**
- * The transport's own refusal to buffer an oversized body, recognised by its stable
- * `code` rather than by its message.
+ * Delegates to the canonical predicate that lives beside the error class.
  *
- * Only the canonical `StoreResponseTooLargeError` counts. A store whose client reports
- * the overrun as an untyped error still propagates — which fails CLOSED (the page is
- * dropped, nothing is inserted), just more bluntly. That is named as a known residual
- * rather than papered over with message matching, which would silently widen to
- * unrelated failures and start reporting real errors as "could not classify".
+ * This used to restate the code as a local string — review pointed out that the same PR
+ * had just introduced a shared typed predicate for the builder's overflow and left this
+ * sibling case on an ad-hoc check, inconsistent inside one function. The canonical form
+ * also closes what was documented here as a residual: the managed SPARQL client raises a
+ * refusal that is not an instance of the error class, and it now carries the same code, so
+ * one predicate recognises both shapes.
  */
 function isStoreResponseTooLargeV1(error: unknown): boolean {
-  return typeof error === 'object'
-    && error !== null
-    && (error as { code?: unknown }).code === 'STORE_RESPONSE_TOO_LARGE';
+  return isStoreResponseTooLargeErrorV1(error);
 }
 
 /**

--- a/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
+++ b/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
@@ -47,7 +47,10 @@ import { SYSTEM_RECORD_V1_STATE_GRAPH } from '../internal-graph-policy.js';
 // The canonical retained-byte accounting, shared with the inspection path rather than
 // re-derived here. Request one measures a literal rather than quads, so it keeps its own
 // term measurement; request two measures rows, which is exactly what this helper counts.
-import { retainedSystemRecordInspectionQuadsBytesV1 } from '../system-record-inspection-v1-internal.js';
+import {
+  buildSystemRecordProjectionInspectionQueryV1,
+  retainedSystemRecordInspectionQuadsBytesV1,
+} from '../system-record-inspection-v1-internal.js';
 import {
   SYSTEM_RECORD_V1_JSON_DATATYPE,
   SYSTEM_RECORD_V1_PREDICATES,
@@ -313,14 +316,20 @@ export async function readLegacyAgentProfileProjectionV1(input: {
   }
 
   const graph = systemRecordProjectionGraphV1(mode);
-  assertQueryableIri(graph);
+  // THE CANONICAL BUILDER, not a local one. Adopted from review after measuring the two
+  // against each other rather than arguing layering: it emits the same graph, the same
+  // exact-subject shape, and the same bound (its
+  // `SYSTEM_RECORD_MAX_PROJECTION_INSPECTION_ROWS_V1` resolves to
+  // `SYSTEM_RECORD_MAX_PROJECTION_QUADS + 1`), and it is STRICTLY STRONGER on three
+  // counts the local version lacked — it rejects duplicate subjects, orders them
+  // deterministically, and bounds the ENCODED REQUEST at the atomic SPARQL byte cap.
+  // That last one was a real gap: 2,048 arbitrarily long subjects could previously build
+  // an unbounded request string, and only the RESPONSE was ever capped.
+  //
+  // Its own preconditions are already satisfied above: it throws below one subject and
+  // above the owned-subject bound, and both are returned early.
   const ordered = [...subjects].sort();
-  const query = `SELECT ?s ?p ?o WHERE {\n`
-    + `  GRAPH <${graph}> {\n`
-    + `    ${valuesClause('?s', ordered)}\n`
-    + `    ?s ?p ?o .\n`
-    + `  }\n`
-    + `}\nLIMIT ${SYSTEM_RECORD_MAX_PROJECTION_QUADS + 1}`;
+  const query = buildSystemRecordProjectionInspectionQueryV1(mode, ordered);
 
   let bindings: Array<Record<string, string>>;
   try {

--- a/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
+++ b/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
@@ -36,6 +36,7 @@
 import { parseRdfLiteralTerm } from '@origintrail-official/dkg-rdf-utils';
 import { isSafeIri } from '@origintrail-official/dkg-core';
 import {
+  assertAgentRootV1,
   parseCanonicalOwnedSubjectTableObjectV1,
   SYSTEM_RECORD_MAX_ATOMIC_RESERVED_INSPECTION_RESPONSE_BYTES,
   SYSTEM_RECORD_MAX_OWNED_SUBJECTS,
@@ -198,8 +199,31 @@ export async function readLegacyAgentProfileAppliedRootsV1(input: {
   // outside the byte budget is a function of the request rather than of result ordering.
   const ordered = [...roots].sort();
   const claimByRoot = new Map<string, string>();
+  // Roots this reader cannot even NAME.
+  //
+  // The agent-side derivation that feeds the gate is LOOSER than storage's namer: it
+  // derives a root from any `did:dkg:agent:0x<40 lowercase hex>` subject, while naming
+  // that root's claim additionally rejects the zero address. So exactly one derivable
+  // root reaches the namer and makes it throw — and a throw here does not degrade, it
+  // drops the whole durable-sync page, on every retry, for as long as a peer keeps
+  // serving that subject. That is the retry-storm the transport-refusal translation
+  // below exists to prevent, arriving through the one input this reader does not choose.
+  //
+  // Undecided is the answer this reader already has for "cannot classify", and it
+  // withholds. The guard wraps the validation ALONE, so a malformed network id still
+  // throws from the namer rather than being mislabelled as an unnameable root.
+  const unnameableRoots = new Set<string>();
   for (const root of ordered) {
+    try {
+      assertAgentRootV1(root);
+    } catch {
+      unnameableRoots.add(root);
+      continue;
+    }
     claimByRoot.set(root, systemRecordRootClaimSubjectV1(networkId, root));
+  }
+  if (claimByRoot.size === 0) {
+    return Object.freeze({ records: [], unclassifiedRoots: Object.freeze([...ordered]) });
   }
   const rootByClaim = new Map([...claimByRoot].map(([root, claim]) => [claim, root]));
 
@@ -211,7 +235,7 @@ export async function readLegacyAgentProfileAppliedRootsV1(input: {
     + `    ?claim <${SYSTEM_RECORD_V1_PREDICATES.claimedBy}> ?record .\n`
     + `    ?record <${SYSTEM_RECORD_V1_PREDICATES.ownedSubjectTable}> ?table .\n`
     + `  }\n`
-    + `}\nLIMIT ${ordered.length + 1}`;
+    + `}\nLIMIT ${claimByRoot.size + 1}`;
 
   let bindings: Array<Record<string, string>>;
   try {
@@ -232,14 +256,15 @@ export async function readLegacyAgentProfileAppliedRootsV1(input: {
 
   // THE RESPONSE MAY NOT BE THE EXACT SET, AND THAT CHANGES WHAT ABSENCE MEANS.
   //
-  // The query asks for `LIMIT ordered.length + 1`, so at most one row per requested root
-  // plus one. More rows than roots means either duplicates or a bound that cut the answer
-  // short — and a cut answer can have pushed a DIFFERENT root's row out of the result.
+  // The query asks for one row more than it has claims, so at most one row per asked-about
+  // root plus one. More rows than claims means either duplicates or a bound that cut the
+  // answer short — and a cut answer can have pushed a DIFFERENT root's row out of the
+  // result.
   // Reading that root as "no applied record" would classify it uncovered and insert
   // unsigned legacy quads over signed state, which is the exact fail-open this port
   // contract exists to close. So when the answer is not exact, absence stops being an
   // answer and every undecided root is reported undecided.
-  const saturated = bindings.length > ordered.length;
+  const saturated = bindings.length > claimByRoot.size;
 
   const tableByRoot = new Map<string, string>();
   // Roots the reserved graph answered for more than once. A duplicate current claim means
@@ -261,7 +286,7 @@ export async function readLegacyAgentProfileAppliedRootsV1(input: {
   const unclassifiedRoots: string[] = [];
   let retainedBytes = 0;
   for (const root of ordered) {
-    if (ambiguousRoots.has(root)) {
+    if (unnameableRoots.has(root) || ambiguousRoots.has(root)) {
       unclassifiedRoots.push(root);
       continue;
     }

--- a/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
+++ b/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
@@ -51,6 +51,12 @@ import {
   type SystemRecordMaterializationModeV1,
 } from '../system-record-rdf-schema-v1-internal.js';
 
+/**
+ * Re-exported so a consumer names the mode with the materializer's own type rather than
+ * restating the union. There is exactly one mode, and it has exactly one definition here.
+ */
+export type { SystemRecordMaterializationModeV1 };
+
 /** One applied signed record, keyed by the agent root the caller asked about. */
 export interface LegacyAgentProfileAppliedRootV1 {
   readonly root: string;

--- a/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
+++ b/packages/storage/src/internal/system-record-legacy-gate-read-v1.ts
@@ -57,6 +57,21 @@ import {
  */
 export type { SystemRecordMaterializationModeV1 };
 
+/**
+ * The graph an applied projection occupies for a mode — the ONLY graph in which legacy
+ * insertion can physically collide with signed state.
+ *
+ * Exported for the gate's destination-graph scope. It is deliberately the materializer's
+ * own function rather than a constant restated agent-side: the gate must decide "would
+ * this insert land where the projection lives" against the same answer the projection
+ * itself uses, or the two could disagree about which graph is authoritative.
+ *
+ * Under `shadow` this is the namespace-hidden reserved graph, which no legacy page ever
+ * targets — so the mode keeps the gate inert here too, and for the same reason as the
+ * reads: pre-cutover there is nothing for legacy insertion to collide with.
+ */
+export { systemRecordProjectionGraphV1 };
+
 /** One applied signed record, keyed by the agent root the caller asked about. */
 export interface LegacyAgentProfileAppliedRootV1 {
   readonly root: string;
@@ -85,6 +100,22 @@ function termBytes(value: string): number {
 
 function assertQueryableIri(iri: string): void {
   if (!isSafeIri(iri)) throw new Error('legacy agent-profile gate read built an unsafe IRI');
+}
+
+/**
+ * The transport's own refusal to buffer an oversized body, recognised by its stable
+ * `code` rather than by its message.
+ *
+ * Only the canonical `StoreResponseTooLargeError` counts. A store whose client reports
+ * the overrun as an untyped error still propagates — which fails CLOSED (the page is
+ * dropped, nothing is inserted), just more bluntly. That is named as a known residual
+ * rather than papered over with message matching, which would silently widen to
+ * unrelated failures and start reporting real errors as "could not classify".
+ */
+function isStoreResponseTooLargeV1(error: unknown): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && (error as { code?: unknown }).code === 'STORE_RESPONSE_TOO_LARGE';
 }
 
 function valuesClause(variable: string, iris: readonly string[]): string {
@@ -150,11 +181,22 @@ export async function readLegacyAgentProfileAppliedRootsV1(input: {
     + `  }\n`
     + `}\nLIMIT ${ordered.length + 1}`;
 
-  const bindings = selectBindings(await store.query(query, {
-    source: 'storage.systemRecord.legacyGate.appliedRoots',
-    priority: 'background',
-    signal,
-  }) as { type: string; bindings?: Array<Record<string, string>> });
+  let bindings: Array<Record<string, string>>;
+  try {
+    bindings = selectBindings(await store.query(query, {
+      source: 'storage.systemRecord.legacyGate.appliedRoots',
+      priority: 'background',
+      maxResponseBytes: SYSTEM_RECORD_MAX_ATOMIC_RESERVED_INSPECTION_RESPONSE_BYTES,
+      signal,
+    }) as { type: string; bindings?: Array<Record<string, string>> });
+  } catch (error) {
+    if (!isStoreResponseTooLargeV1(error)) throw error;
+    // The transport refused the body before parsing it. Report rather than rethrow: at
+    // the seam a throw drops the whole page, which is the retry-storm this port contract
+    // was rewritten to avoid, and "could not classify" is already the answer the gate
+    // knows how to act on.
+    return Object.freeze({ records: [], unclassifiedRoots: Object.freeze([...ordered]) });
+  }
 
   const tableByRoot = new Map<string, string>();
   for (const binding of bindings) {
@@ -242,11 +284,18 @@ export async function readLegacyAgentProfileProjectionV1(input: {
     + `  }\n`
     + `}\nLIMIT ${SYSTEM_RECORD_MAX_PROJECTION_QUADS + 1}`;
 
-  const bindings = selectBindings(await store.query(query, {
-    source: 'storage.systemRecord.legacyGate.projection',
-    priority: 'background',
-    signal,
-  }) as { type: string; bindings?: Array<Record<string, string>> });
+  let bindings: Array<Record<string, string>>;
+  try {
+    bindings = selectBindings(await store.query(query, {
+      source: 'storage.systemRecord.legacyGate.projection',
+      priority: 'background',
+      maxResponseBytes: SYSTEM_RECORD_MAX_PROJECTION_BYTES,
+      signal,
+    }) as { type: string; bindings?: Array<Record<string, string>> });
+  } catch (error) {
+    if (!isStoreResponseTooLargeV1(error)) throw error;
+    return Object.freeze({ rows: [], truncated: true });
+  }
 
   if (bindings.length > SYSTEM_RECORD_MAX_PROJECTION_QUADS) {
     return Object.freeze({ rows: [], truncated: true });

--- a/packages/storage/src/system-record-bounded-utf8-builder-v1-internal.ts
+++ b/packages/storage/src/system-record-bounded-utf8-builder-v1-internal.ts
@@ -7,6 +7,26 @@ export interface BoundedSystemRecordUtf8BuildV1 {
   readonly encodedBytes: number;
 }
 
+/**
+ * The stable code a REFUSAL carries, so callers can distinguish "this request is too big
+ * to ask" from an accounting defect in this builder without reading English text.
+ *
+ * A bound refusal is an expected condition for a caller that can degrade — the legacy
+ * gate reports it as an undecidable answer rather than failing its page. An accounting
+ * mismatch is a defect here and keeps propagating untagged.
+ */
+export const SYSTEM_RECORD_BOUNDED_BUILD_OVERFLOW_V1 = 'SYSTEM_RECORD_BOUNDED_BUILD_OVERFLOW';
+
+export function isSystemRecordBoundedBuildOverflowV1(error: unknown): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && (error as { code?: unknown }).code === SYSTEM_RECORD_BOUNDED_BUILD_OVERFLOW_V1;
+}
+
+function boundedBuildOverflowV1(message: string): Error {
+  return Object.assign(new Error(message), { code: SYSTEM_RECORD_BOUNDED_BUILD_OVERFLOW_V1 });
+}
+
 export function buildBoundedSystemRecordUtf8V1(input: Readonly<{
   emit(writer: SystemRecordUtf8WriterV1): void;
   maxEncodedBytes: number;
@@ -19,14 +39,14 @@ export function buildBoundedSystemRecordUtf8V1(input: Readonly<{
     add(value): void {
       const bytes = Buffer.byteLength(value, 'utf8');
       if (bytes > input.maxEncodedBytes - encodedBytes) {
-        throw new Error(`${input.label} exceeds its encoded-byte bound`);
+        throw boundedBuildOverflowV1(`${input.label} exceeds its encoded-byte bound`);
       }
       encodedBytes += bytes;
     },
   });
   const peakRetainedBytes = encodedBytes * 3;
   if (peakRetainedBytes > input.maxRetainedBytes) {
-    throw new Error(`${input.label} exceeds its retained-byte bound`);
+    throw boundedBuildOverflowV1(`${input.label} exceeds its retained-byte bound`);
   }
   input.replaceCharge?.(peakRetainedBytes);
   let buffer: Buffer | null = Buffer.allocUnsafe(encodedBytes);

--- a/packages/storage/test/http-response-limit-v1.test.ts
+++ b/packages/storage/test/http-response-limit-v1.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The shared bounded response reader, and the identity of its refusal.
+ *
+ * `readResponseTextBounded` is the cap for every fetch-dispatched store — sparql-http and
+ * blazegraph both route through it — and it refuses in TWO places: a Content-Length
+ * preflight before any body is read, and a running total while the stream arrives. Only
+ * the streaming half had coverage, because every fixture elsewhere builds a body without
+ * a declared length, so deleting the preflight left every suite green.
+ *
+ * That matters beyond the missing branch. The preflight is what makes the cap a REFUSAL
+ * rather than a late detection: without it an oversized answer is buffered up to the bound
+ * before anything objects. And the refusal's IDENTITY is a contract — the legacy
+ * agent-profile gate read degrades to "undecided" on it instead of dropping a durable-sync
+ * page, and it recognises it through the canonical predicate rather than a message.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  isStoreResponseTooLargeErrorV1,
+  readResponseTextBounded,
+  StoreResponseTooLargeError,
+  STORE_RESPONSE_TOO_LARGE_CODE,
+} from '../src/http-response-limit.js';
+
+/** A body that arrives in chunks and declares no length, so the preflight cannot see it. */
+function streamedResponse(body: string): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(body));
+      controller.close();
+    },
+  });
+  return new Response(stream);
+}
+
+const thrown = async (run: () => Promise<unknown>): Promise<unknown> => {
+  try {
+    await run();
+    return null;
+  } catch (error) {
+    return error;
+  }
+};
+
+describe('readResponseTextBounded', () => {
+  // The discriminator is the SMALL body behind the LARGE declared length. With the
+  // preflight in place the declaration alone refuses the response; with it deleted the
+  // three actual bytes sail under the cap and the read succeeds. A fixture whose body was
+  // genuinely oversized would pass either way and would be testing the streaming branch
+  // over again.
+  it('refuses on the declared length alone, before reading a body that would fit', async () => {
+    const response = new Response('abc', { headers: { 'content-length': '999' } });
+
+    const refusal = await thrown(() => readResponseTextBounded(response, 10));
+
+    expect(refusal).toBeInstanceOf(StoreResponseTooLargeError);
+    expect((refusal as StoreResponseTooLargeError).maxBytes).toBe(10);
+    expect(Number((refusal as StoreResponseTooLargeError).actualBytes)).toBe(999);
+  });
+
+  // Identity at the SOURCE. Every other suite either constructs this error itself or fakes
+  // its shape, so nothing pinned that the reader's own refusal satisfies the predicate the
+  // gate read discriminates on — the class could have stopped carrying the code with all
+  // of them green.
+  it('raises a refusal that satisfies the canonical predicate and carries the code', async () => {
+    const refusal = await thrown(() => readResponseTextBounded(
+      new Response('abc', { headers: { 'content-length': '999' } }),
+      10,
+    ));
+
+    expect(isStoreResponseTooLargeErrorV1(refusal)).toBe(true);
+    expect((refusal as { code?: unknown }).code).toBe(STORE_RESPONSE_TOO_LARGE_CODE);
+  });
+
+  it('refuses a streamed body that crosses the bound without declaring a length', async () => {
+    const refusal = await thrown(() => readResponseTextBounded(streamedResponse('abcdefghijk'), 5));
+
+    expect(refusal).toBeInstanceOf(StoreResponseTooLargeError);
+    expect(isStoreResponseTooLargeErrorV1(refusal)).toBe(true);
+  });
+
+  it('returns a body that fits, so the cases above are refusals rather than a broken read', async () => {
+    await expect(readResponseTextBounded(streamedResponse('abcde'), 5)).resolves.toBe('abcde');
+  });
+});

--- a/packages/storage/test/managed-http-client-v1.test.ts
+++ b/packages/storage/test/managed-http-client-v1.test.ts
@@ -3,6 +3,7 @@ import { createServer, type Server } from 'node:http';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { OwnedManagedHttpClient } from '../src/adapters/managed-http-client.js';
+import { isStoreResponseTooLargeErrorV1 } from '../src/http-response-limit.js';
 
 /**
  * A local server with one deliberately slow route, so a second request must
@@ -142,6 +143,18 @@ describe('OwnedManagedHttpClient', () => {
           maxResponseBytes: 5,
         }),
       ).rejects.toThrow(/response body exceeded 5 bytes/);
+
+      // The refusal must carry the CANONICAL code, not just a recognisable message.
+      // Callers that degrade on an oversized response (the legacy agent-profile gate reads
+      // report it as undecidable rather than failing their page) recognise this refusal by
+      // code. Asserting only the message let the tag be deleted with every suite green:
+      // the reader tests supply the code themselves, so they cannot witness this client
+      // emitting it.
+      const refusal = await client.post(`${base}/chunked-overflow`, UPDATE, 'x', 5_000, undefined, {
+        maxRequestBytes: 1,
+        maxResponseBytes: 5,
+      }).then(() => null, (error: unknown) => error);
+      expect(isStoreResponseTooLargeErrorV1(refusal)).toBe(true);
 
       await vi.waitFor(() => expect(overflowClosedBeforeTail).toBe(true));
     } finally {

--- a/packages/storage/test/managed-http-client-v1.test.ts
+++ b/packages/storage/test/managed-http-client-v1.test.ts
@@ -224,6 +224,16 @@ describe('OwnedManagedHttpClient', () => {
         }),
       ).rejects.toThrow(/response body declares 6 bytes; maximum is 5 bytes/);
       expect(reserveResponseCapacity).not.toHaveBeenCalled();
+
+      // The declared-length refusal carries the canonical code for the same reason the
+      // chunked one does, and it matters MORE: an endpoint that sends Content-Length never
+      // reaches the chunked check, so this is the path a real oversized answer takes.
+      // Message-only assertions cannot tell a tagged refusal from an untagged one.
+      const refusal = await client.post(`${base}/declared-overflow`, UPDATE, 'x', 5_000, undefined, {
+        maxRequestBytes: 1,
+        maxResponseBytes: 5,
+      }).then(() => null, (error: unknown) => error);
+      expect(isStoreResponseTooLargeErrorV1(refusal)).toBe(true);
     } finally {
       await client.destroyAndSettle().catch(() => undefined);
     }

--- a/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
+++ b/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
@@ -1,0 +1,223 @@
+/**
+ * The covering predicate for the inbound legacy `agents` gate (#2052 D-8, #53).
+ *
+ * The headline here is the MODE COUNTERFACTUAL. "Pre-cutover the gate is inert" is only a
+ * safety property if inertness is caused by the mode; an implementation that returns
+ * nothing because its query is broken, its predicates are misspelled, or its root-claim
+ * derivation is wrong is ALSO inert, and indistinguishable from the correct one by any
+ * test that only ever runs in shadow. So every inertness assertion below is paired with an
+ * authoritative run over the SAME fixture that must produce the record — the pair is the
+ * discriminator, and neither half means anything alone.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  readLegacyAgentProfileAppliedRootsV1,
+  readLegacyAgentProfileProjectionV1,
+} from '../src/internal/system-record-legacy-gate-read-v1.js';
+import {
+  SYSTEM_RECORD_V1_JSON_DATATYPE,
+  SYSTEM_RECORD_V1_PREDICATES,
+  systemRecordProjectionGraphV1,
+  systemRecordRootClaimSubjectV1,
+} from '../src/system-record-rdf-schema-v1-internal.js';
+import { SYSTEM_RECORD_V1_STATE_GRAPH } from '../src/internal-graph-policy.js';
+import type { Quad, QueryResult, TripleStore } from '../src/triple-store.js';
+
+const NETWORK_ID = 'otp:2043';
+const ROOT = `did:dkg:agent:0x${'1'.repeat(40)}`;
+const OTHER_ROOT = `did:dkg:agent:0x${'2'.repeat(40)}`;
+// The REAL datatype, imported rather than restated: a fixture that pinned an invented IRI
+// would pass against a reader that never checks it and prove nothing about the encoding.
+const JSON_DATATYPE = SYSTEM_RECORD_V1_JSON_DATATYPE;
+
+/**
+ * A store that answers SELECT from an explicit quad set by honouring the two clauses these
+ * queries actually use: a `VALUES` list and fixed predicates. It is deliberately literal —
+ * matching on the same predicate IRIs the reader emits — so a reader that queried the
+ * wrong predicate or the wrong graph gets nothing back, which is what lets the
+ * authoritative half of each counterfactual fail loudly rather than pass vacuously.
+ */
+function fakeStore(quads: readonly Quad[]): TripleStore & { queries: string[] } {
+  const queries: string[] = [];
+  const store = {
+    queries,
+    async query(sparql: string): Promise<QueryResult> {
+      queries.push(sparql);
+      const graph = /GRAPH <([^>]+)>/.exec(sparql)?.[1];
+      const values = [...sparql.matchAll(/<([^>]+)>/g)].map((m) => m[1]!);
+      const inGraph = quads.filter((quad) => quad.graph === graph);
+
+      if (sparql.includes('?claim ?table')) {
+        const bindings: Array<Record<string, string>> = [];
+        for (const claim of values) {
+          const position = inGraph.find((q) => q.subject === claim
+            && q.predicate === SYSTEM_RECORD_V1_PREDICATES.claimPosition);
+          if (position?.object !== '"current"') continue;
+          const claimedBy = inGraph.find((q) => q.subject === claim
+            && q.predicate === SYSTEM_RECORD_V1_PREDICATES.claimedBy);
+          if (!claimedBy) continue;
+          const table = inGraph.find((q) => q.subject === claimedBy.object
+            && q.predicate === SYSTEM_RECORD_V1_PREDICATES.ownedSubjectTable);
+          if (!table) continue;
+          bindings.push({ claim, table: table.object });
+        }
+        return { type: 'bindings', bindings };
+      }
+
+      const subjects = new Set(values);
+      return {
+        type: 'bindings',
+        bindings: inGraph
+          .filter((quad) => subjects.has(quad.subject))
+          .map((quad) => ({ s: quad.subject, p: quad.predicate, o: quad.object })),
+      };
+    },
+  } as unknown as TripleStore & { queries: string[] };
+  return store;
+}
+
+function jsonLiteral(value: unknown): string {
+  return `"${JSON.stringify(value).replace(/["\\]/g, (c) => `\\${c}`)}"^^<${JSON_DATATYPE}>`;
+}
+
+/** Reserved state for one record whose CURRENT root is `root`. */
+function appliedRecordQuads(root: string, ownedSubjects: readonly string[]): Quad[] {
+  const claim = systemRecordRootClaimSubjectV1(NETWORK_ID, root);
+  const record = `urn:system-record:${root}`;
+  return [
+    { subject: claim, predicate: SYSTEM_RECORD_V1_PREDICATES.root, object: root, graph: SYSTEM_RECORD_V1_STATE_GRAPH },
+    { subject: claim, predicate: SYSTEM_RECORD_V1_PREDICATES.claimedBy, object: record, graph: SYSTEM_RECORD_V1_STATE_GRAPH },
+    { subject: claim, predicate: SYSTEM_RECORD_V1_PREDICATES.claimPosition, object: '"current"', graph: SYSTEM_RECORD_V1_STATE_GRAPH },
+    {
+      subject: record,
+      predicate: SYSTEM_RECORD_V1_PREDICATES.ownedSubjectTable,
+      object: jsonLiteral([...ownedSubjects]),
+      graph: SYSTEM_RECORD_V1_STATE_GRAPH,
+    },
+  ];
+}
+
+describe('legacy agent-profile gate read — the mode counterfactual (#2052 D-8)', () => {
+  it('reports the applied record under authoritative mode', async () => {
+    const store = fakeStore(appliedRecordQuads(ROOT, [ROOT]));
+
+    const read = await readLegacyAgentProfileAppliedRootsV1({
+      store, networkId: NETWORK_ID, mode: 'authoritative', roots: [ROOT],
+    });
+
+    expect(read.records).toEqual([{ root: ROOT, ownedSubjects: [ROOT] }]);
+    expect(read.unclassifiedRoots).toEqual([]);
+  });
+
+  // The other half. Same fixture, same root, only the mode differs — so this passing while
+  // the test above passes is the evidence that inertness is caused by the mode and not by
+  // a reader that cannot find anything.
+  it('reports nothing under shadow mode, and issues no query at all', async () => {
+    const store = fakeStore(appliedRecordQuads(ROOT, [ROOT]));
+
+    const read = await readLegacyAgentProfileAppliedRootsV1({
+      store, networkId: NETWORK_ID, mode: 'shadow', roots: [ROOT],
+    });
+
+    expect(read.records).toEqual([]);
+    expect(read.unclassifiedRoots).toEqual([]);
+    // Inert by mode means it does not even ask: pre-cutover the gate costs nothing.
+    expect(store.queries).toEqual([]);
+  });
+
+  it('answers "no applied record" for an uncovered root without calling it undecided', async () => {
+    const store = fakeStore(appliedRecordQuads(ROOT, [ROOT]));
+
+    const read = await readLegacyAgentProfileAppliedRootsV1({
+      store, networkId: NETWORK_ID, mode: 'authoritative', roots: [ROOT, OTHER_ROOT],
+    });
+
+    expect(read.records.map((record) => record.root)).toEqual([ROOT]);
+    // The distinction the whole port contract exists for: absent from `records` is an
+    // ANSWER, and must not be reported as an inability to decide.
+    expect(read.unclassifiedRoots).toEqual([]);
+  });
+
+  // plan :1503 — an authority transition removes the old projection atomically, so a
+  // historical root has no signed state left to protect and the legacy path is correct.
+  it('does not cover a root whose claim is historical rather than current', async () => {
+    const quads = appliedRecordQuads(ROOT, [ROOT]).map((quad) => (
+      quad.predicate === SYSTEM_RECORD_V1_PREDICATES.claimPosition
+        ? { ...quad, object: '"historical:0"' }
+        : quad
+    ));
+    const store = fakeStore(quads);
+
+    const read = await readLegacyAgentProfileAppliedRootsV1({
+      store, networkId: NETWORK_ID, mode: 'authoritative', roots: [ROOT],
+    });
+
+    expect(read.records).toEqual([]);
+    expect(read.unclassifiedRoots).toEqual([]);
+  });
+
+  it('reports a root undecided when its owned-subject table will not decode', async () => {
+    const quads = appliedRecordQuads(ROOT, [ROOT]).map((quad) => (
+      quad.predicate === SYSTEM_RECORD_V1_PREDICATES.ownedSubjectTable
+        ? { ...quad, object: jsonLiteral(['did:dkg:agent:0xnot-this-record']) }
+        : quad
+    ));
+    const store = fakeStore(quads);
+
+    const read = await readLegacyAgentProfileAppliedRootsV1({
+      store, networkId: NETWORK_ID, mode: 'authoritative', roots: [ROOT],
+    });
+
+    // Undecided, never uncovered: a table that cannot be validated against its own root
+    // cannot be used to classify that root's quads, and guessing would insert.
+    expect(read.records).toEqual([]);
+    expect(read.unclassifiedRoots).toEqual([ROOT]);
+  });
+});
+
+describe('legacy agent-profile gate read — projection membership', () => {
+  const projectionGraph = systemRecordProjectionGraphV1('authoritative');
+
+  it('returns the projection rows under authoritative mode', async () => {
+    const store = fakeStore([
+      { subject: ROOT, predicate: 'urn:p', object: '"signed"', graph: projectionGraph },
+    ]);
+
+    const read = await readLegacyAgentProfileProjectionV1({
+      store, mode: 'authoritative', subjects: [ROOT],
+    });
+
+    expect(read.truncated).toBe(false);
+    expect(read.rows).toEqual([
+      { subject: ROOT, predicate: 'urn:p', object: '"signed"', graph: projectionGraph },
+    ]);
+  });
+
+  it('reports nothing under shadow mode, and issues no query at all', async () => {
+    const store = fakeStore([
+      { subject: ROOT, predicate: 'urn:p', object: '"signed"', graph: projectionGraph },
+    ]);
+
+    const read = await readLegacyAgentProfileProjectionV1({
+      store, mode: 'shadow', subjects: [ROOT],
+    });
+
+    expect(read.rows).toEqual([]);
+    expect(read.truncated).toBe(false);
+    expect(store.queries).toEqual([]);
+  });
+
+  it('reports truncated rather than asking a partial question above the subject bound', async () => {
+    const store = fakeStore([]);
+    const subjects = Array.from({ length: 2_049 }, (_, i) => `${ROOT}/.well-known/genid/capability${i + 1}`);
+
+    const read = await readLegacyAgentProfileProjectionV1({
+      store, mode: 'authoritative', subjects,
+    });
+
+    expect(read.truncated).toBe(true);
+    expect(read.rows).toEqual([]);
+    expect(store.queries).toEqual([]);
+  });
+});

--- a/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
+++ b/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
@@ -32,6 +32,7 @@ import {
 } from '@origintrail-official/dkg-core/system-record-v1';
 import type { Quad, QueryResult, TripleStore } from '../src/triple-store.js';
 import { OxigraphStore } from '../src/index.js';
+import { StoreResponseTooLargeError } from '../src/http-response-limit.js';
 
 const NETWORK_ID = 'otp:2043';
 const ROOT = `did:dkg:agent:0x${'1'.repeat(40)}`;
@@ -404,6 +405,23 @@ describe('bounded-read overflow, computed by the real reader', () => {
 
     expect(read.records).toEqual([]);
     expect([...read.unclassifiedRoots].sort()).toEqual([ROOT, OTHER_ROOT].sort());
+  });
+
+  // The canonical predicate must recognise BOTH refusal shapes. `instanceof` alone -- the
+  // form review first suggested -- would catch this one and miss the managed client's,
+  // which is a plain Error carrying the same code; a code-only check catches that one and
+  // is a restatement. This pins the class shape; the case above pins the untyped one.
+  it('turns a real StoreResponseTooLargeError into undecided roots', async () => {
+    const refusing = {
+      async query() { throw new StoreResponseTooLargeError(1024, 4096); },
+    } as unknown as TripleStore;
+
+    const read = await readLegacyAgentProfileAppliedRootsV1({
+      store: refusing, networkId: NETWORK_ID, mode: 'authoritative', roots: [ROOT],
+    });
+
+    expect(read.records).toEqual([]);
+    expect(read.unclassifiedRoots).toEqual([ROOT]);
   });
 
   it('turns a transport cap refusal into a truncated projection rather than throwing', async () => {

--- a/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
+++ b/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
@@ -424,6 +424,29 @@ describe('bounded-read overflow, computed by the real reader', () => {
     expect(read.unclassifiedRoots).toEqual([ROOT]);
   });
 
+  // The agent-side derivation that feeds this reader is LOOSER than the storage-side
+  // namer. Deriving a root accepts any `did:dkg:agent:0x<40 lowercase hex>`; naming its
+  // claim additionally rejects the zero address, so that one value used to reach the claim
+  // builder and THROW. An uncaught throw here drops the whole durable-sync page — on every
+  // retry, for as long as a peer keeps serving that subject — which is the same
+  // retry-storm the transport-refusal cases above exist to prevent, arriving through the
+  // one input this reader does not control.
+  it('reports a root the claim namer refuses as undecided instead of throwing', async () => {
+    const store = fakeStore([]);
+    const unnameable = `did:dkg:agent:0x${'0'.repeat(40)}`;
+
+    const read = await readLegacyAgentProfileAppliedRootsV1({
+      store, networkId: NETWORK_ID, mode: 'authoritative', roots: [unnameable, ROOT],
+    });
+
+    // Undecided, never "no applied record": the direction that withholds.
+    expect(read.records).toEqual([]);
+    expect(read.unclassifiedRoots).toContain(unnameable);
+    // ...and the batch beside it survives, rather than the page dying with it.
+    expect(store.queries).toHaveLength(1);
+    expect(store.queries[0]).toContain(systemRecordRootClaimSubjectV1(NETWORK_ID, ROOT));
+  });
+
   it('turns a transport cap refusal into a truncated projection rather than throwing', async () => {
     const read = await readLegacyAgentProfileProjectionV1({
       store: refusingStore(), mode: 'authoritative', subjects: [ROOT],

--- a/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
+++ b/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
@@ -1,5 +1,5 @@
 /**
- * The covering predicate for the inbound legacy `agents` gate (#2052 D-8, #53).
+ * The covering predicate for the inbound legacy `agents` gate (#2052 D-8).
  *
  * The headline here is the MODE COUNTERFACTUAL. "Pre-cutover the gate is inert" is only a
  * safety property if inertness is caused by the mode; an implementation that returns

--- a/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
+++ b/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
@@ -415,6 +415,64 @@ describe('bounded-read overflow, computed by the real reader', () => {
     expect(read.truncated).toBe(true);
   });
 
+  /**
+   * A store that returns EXACT bindings for request one.
+   *
+   * The quad-driven fake cannot express these cases: it resolves one table per claim with
+   * `.find`, so it can never emit a duplicate row, and it cannot simulate a response that
+   * hit its own bound. Both defects here live in how the reader interprets the binding
+   * LIST, so the fixture has to speak at that layer.
+   */
+  function bindingStore(rows: Array<Record<string, string>>): TripleStore {
+    return {
+      async query(sparql: string) {
+        if (!sparql.includes('?claim ?table')) return { type: 'bindings' as const, bindings: [] };
+        return { type: 'bindings' as const, bindings: rows };
+      },
+    } as unknown as TripleStore;
+  }
+
+  const claimOf = (root: string) => systemRecordRootClaimSubjectV1(NETWORK_ID, root);
+
+  // Adopted from review, and it is a fail-OPEN the port contract exists to close. A
+  // duplicate current claim means the reserved graph is not a shape this reader can
+  // classify; the previous code kept whichever table arrived first, so durable sync could
+  // decide insert-or-discard from an arbitrary reserved row.
+  it('reports a root undecided when the reserved graph answers for it twice', async () => {
+    const store = bindingStore([
+      { claim: claimOf(ROOT), table: jsonLiteral([ROOT]) },
+      { claim: claimOf(ROOT), table: jsonLiteral([]) },
+    ]);
+
+    const read = await readLegacyAgentProfileAppliedRootsV1({
+      store, networkId: NETWORK_ID, mode: 'authoritative', roots: [ROOT],
+    });
+
+    expect(read.records).toEqual([]);
+    expect(read.unclassifiedRoots).toEqual([ROOT]);
+  });
+
+  // The sharper half of the same finding: duplicate rows consume the query's own LIMIT, so
+  // a DIFFERENT root's row can be cut from the answer. Reading that root as "no applied
+  // record" classifies it uncovered and inserts unsigned legacy quads over signed state.
+  // Absence is only an answer when the answer was exact.
+  it('does not read absence as "no record" when the response filled its bound', async () => {
+    // Two roots asked about, three rows returned — all for ROOT. OTHER_ROOT's row could
+    // have been the one the bound cut.
+    const store = bindingStore([
+      { claim: claimOf(ROOT), table: jsonLiteral([ROOT]) },
+      { claim: claimOf(ROOT), table: jsonLiteral([]) },
+      { claim: claimOf(ROOT), table: jsonLiteral([ROOT]) },
+    ]);
+
+    const read = await readLegacyAgentProfileAppliedRootsV1({
+      store, networkId: NETWORK_ID, mode: 'authoritative', roots: [ROOT, OTHER_ROOT],
+    });
+
+    expect(read.records.map((r) => r.root)).not.toContain(OTHER_ROOT);
+    expect(read.unclassifiedRoots).toContain(OTHER_ROOT);
+  });
+
   // The bound must be IN THE QUERY, not only in the post-decode check. Adopted from
   // review: drop the projection `LIMIT` and every other case here still passes, because
   // the fake returns all fixture rows and `bindings.length` catches the overflow after

--- a/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
+++ b/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
@@ -374,6 +374,26 @@ describe('bounded-read overflow, computed by the real reader', () => {
     expect(store.options[1]?.maxResponseBytes).toBe(SYSTEM_RECORD_MAX_PROJECTION_BYTES);
   });
 
+  // Adopted from review. Both reads happen while durable sync may be aborting, and the
+  // signal was threaded through production without any test making it load-bearing:
+  // dropping it left every case here green while an aborted sync would sit inside the
+  // gate lookup until the store answered. Identity is asserted, not mere presence — a
+  // read forwarding SOME signal is not the same as forwarding the caller's.
+  it('forwards the caller abort signal to both bounded reads', async () => {
+    const store = fakeStore(appliedRecordQuads(ROOT, [ROOT]));
+    const controller = new AbortController();
+
+    await readLegacyAgentProfileAppliedRootsV1({
+      store, networkId: NETWORK_ID, mode: 'authoritative', roots: [ROOT], signal: controller.signal,
+    });
+    await readLegacyAgentProfileProjectionV1({
+      store, mode: 'authoritative', subjects: [ROOT], signal: controller.signal,
+    });
+
+    expect(store.options[0]?.signal).toBe(controller.signal);
+    expect(store.options[1]?.signal).toBe(controller.signal);
+  });
+
   // ...and only a contract if the refusal is TRANSLATED. Rethrowing instead would drop the
   // whole page at the seam, which is the retry-storm the port contract exists to avoid —
   // and no test here would have noticed, because no fake store threw the canonical error.

--- a/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
+++ b/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
@@ -373,6 +373,31 @@ describe('bounded-read overflow, computed by the real reader', () => {
     expect(read.truncated).toBe(true);
   });
 
+  // The DISCRIMINATOR between the canonical retained-byte accounting and a hand-rolled
+  // `s + p + o` sum. This payload is deliberately UNDER the cap by the naive measure and
+  // OVER it by the real one, so a reader counting bytes locally would hand back these rows
+  // as an exact projection while the process retains well past the bound. It asserts the
+  // observable (`truncated`), not the formula.
+  it('counts retained bytes the way the rest of system-record does, not a local sum', async () => {
+    const rows = Array.from({ length: 3 }, (_, i) => ({
+      subject: ROOT,
+      predicate: `urn:p${i}`,
+      object: `"${'z'.repeat(480_000)}"`,
+      graph: systemRecordProjectionGraphV1('authoritative'),
+    }));
+    const naive = rows.reduce((n, r) => n
+      + Buffer.byteLength(r.subject) + Buffer.byteLength(r.predicate) + Buffer.byteLength(r.object), 0);
+    // The premise, asserted rather than assumed: naive accounting would NOT have tripped.
+    expect(naive).toBeLessThan(SYSTEM_RECORD_MAX_PROJECTION_BYTES);
+
+    const read = await readLegacyAgentProfileProjectionV1({
+      store: fakeStore(rows), mode: 'authoritative', subjects: [ROOT],
+    });
+
+    expect(read.truncated).toBe(true);
+    expect(read.rows).toEqual([]);
+  });
+
   it('reports truncated when the projection response exceeds the byte cap under the row cap', async () => {
     // Deliberately FEW rows, so only the byte accounting can detect this. A reader that
     // implemented the row cap alone passes every other case in this file and fails here.

--- a/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
+++ b/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
@@ -171,6 +171,27 @@ describe('legacy agent-profile gate read — the mode counterfactual (#2052 D-8)
     expect(read.unclassifiedRoots).toEqual([]);
   });
 
+  // Adopted from review. The reader used to take any literal's VALUE, so a table carrying
+  // a perfectly valid JSON payload under a datatype the writer never emits was accepted as
+  // a real applied record. The payload here is valid on purpose — only the datatype is
+  // wrong — so this fails for exactly one reason.
+  it('reports a root undecided when the table literal carries the wrong datatype', async () => {
+    const quads = appliedRecordQuads(ROOT, [ROOT]).map((quad) => (
+      quad.predicate === SYSTEM_RECORD_V1_PREDICATES.ownedSubjectTable
+        ? { ...quad, object: `"[\\"${ROOT}\\"]"^^<urn:not-the-canonical-datatype>` }
+        : quad
+    ));
+    const store = fakeStore(quads);
+
+    const read = await readLegacyAgentProfileAppliedRootsV1({
+      store, networkId: NETWORK_ID, mode: 'authoritative', roots: [ROOT],
+    });
+
+    // Undecided, NOT "no applied record" — the distinction that keeps legacy quads out.
+    expect(read.records).toEqual([]);
+    expect(read.unclassifiedRoots).toEqual([ROOT]);
+  });
+
   it('reports a root undecided when its owned-subject table will not decode', async () => {
     const quads = appliedRecordQuads(ROOT, [ROOT]).map((quad) => (
       quad.predicate === SYSTEM_RECORD_V1_PREDICATES.ownedSubjectTable

--- a/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
+++ b/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
@@ -395,6 +395,27 @@ describe('bounded-read overflow, computed by the real reader', () => {
     expect(read.truncated).toBe(true);
   });
 
+  // The bound must be IN THE QUERY, not only in the post-decode check. Adopted from
+  // review: drop the projection `LIMIT` and every other case here still passes, because
+  // the fake returns all fixture rows and `bindings.length` catches the overflow after
+  // materialization. That is the wrong layer — the LIMIT is what stops an enormous result
+  // being decoded at all, and the post-decode check is the floor beneath it, not a
+  // substitute. Asserted against the real constants so it cannot pass at a different bound.
+  it('asks the store for a bounded result, not merely a bounded answer', async () => {
+    const store = fakeStore(appliedRecordQuads(ROOT, [ROOT]));
+
+    await readLegacyAgentProfileAppliedRootsV1({
+      store, networkId: NETWORK_ID, mode: 'authoritative', roots: [ROOT, OTHER_ROOT],
+    });
+    await readLegacyAgentProfileProjectionV1({
+      store, mode: 'authoritative', subjects: [ROOT],
+    });
+
+    // Request one bounds by the roots it actually asked about, +1 so overflow is visible.
+    expect(store.queries[0]).toContain('LIMIT 3');
+    expect(store.queries[1]).toContain(`LIMIT ${SYSTEM_RECORD_MAX_PROJECTION_QUADS + 1}`);
+  });
+
   // The DISCRIMINATOR between the canonical retained-byte accounting and a hand-rolled
   // `s + p + o` sum. This payload is deliberately UNDER the cap by the naive measure and
   // OVER it by the real one, so a reader counting bytes locally would hand back these rows

--- a/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
+++ b/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
@@ -31,6 +31,7 @@ import {
   SYSTEM_RECORD_MAX_PROJECTION_QUADS,
 } from '@origintrail-official/dkg-core/system-record-v1';
 import type { Quad, QueryResult, TripleStore } from '../src/triple-store.js';
+import { OxigraphStore } from '../src/index.js';
 
 const NETWORK_ID = 'otp:2043';
 const ROOT = `did:dkg:agent:0x${'1'.repeat(40)}`;
@@ -417,5 +418,68 @@ describe('bounded-read overflow, computed by the real reader', () => {
     expect(rows.length).toBeLessThan(SYSTEM_RECORD_MAX_PROJECTION_QUADS);
     expect(read.truncated).toBe(true);
     expect(read.rows).toEqual([]);
+  });
+});
+
+/**
+ * The queries actually PARSE AND RUN.
+ *
+ * Adopted from review. Every case above answers through a string-scanning fake, which
+ * validates this module's expectations about its own SPARQL rather than the SPARQL. A
+ * regression emitting malformed text that still contained `GRAPH <...>`, `?claim ?table`
+ * and the right IRIs would satisfy that fake completely — and a real store would reject
+ * it, which at the seam means the lookup THROWS and the per-context-graph catch drops the
+ * whole page. Silent loss of legacy sync, from a suite that stayed green.
+ *
+ * So this seeds a real Oxigraph and runs both reads end to end. It is deliberately a
+ * smoke test: the bounded/overflow edges stay on the fake, where they can be driven
+ * precisely. What this adds is the one property the fake structurally cannot give —
+ * that the emitted query is valid against the engine production uses.
+ */
+describe('the generated SPARQL against a real store', () => {
+  const PROJECTION_GRAPH = systemRecordProjectionGraphV1('authoritative');
+
+  async function seededStore(): Promise<OxigraphStore> {
+    const store = new OxigraphStore();
+    await store.insert([
+      ...appliedRecordQuads(ROOT, [ROOT]),
+      { subject: ROOT, predicate: 'urn:p', object: '"signed"', graph: PROJECTION_GRAPH },
+    ]);
+    return store;
+  }
+
+  it('resolves the applied root through a real engine, and stays inert under shadow', async () => {
+    const store = await seededStore();
+
+    const live = await readLegacyAgentProfileAppliedRootsV1({
+      store, networkId: NETWORK_ID, mode: 'authoritative', roots: [ROOT],
+    });
+    const shadow = await readLegacyAgentProfileAppliedRootsV1({
+      store, networkId: NETWORK_ID, mode: 'shadow', roots: [ROOT],
+    });
+
+    expect(live.records).toEqual([{ root: ROOT, ownedSubjects: [ROOT] }]);
+    expect(live.unclassifiedRoots).toEqual([]);
+    // The mode counterfactual again, but here the authoritative half proves the query is
+    // executable rather than merely well-scanned — so the shadow half's emptiness is
+    // known to be the mode and not a query the engine refused.
+    expect(shadow.records).toEqual([]);
+  });
+
+  it('reads the projection row through a real engine, and stays inert under shadow', async () => {
+    const store = await seededStore();
+
+    const live = await readLegacyAgentProfileProjectionV1({
+      store, mode: 'authoritative', subjects: [ROOT],
+    });
+    const shadow = await readLegacyAgentProfileProjectionV1({
+      store, mode: 'shadow', subjects: [ROOT],
+    });
+
+    expect(live.truncated).toBe(false);
+    expect(live.rows).toEqual([
+      { subject: ROOT, predicate: 'urn:p', object: '"signed"', graph: PROJECTION_GRAPH },
+    ]);
+    expect(shadow.rows).toEqual([]);
   });
 });

--- a/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
+++ b/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
@@ -22,6 +22,14 @@ import {
   systemRecordRootClaimSubjectV1,
 } from '../src/system-record-rdf-schema-v1-internal.js';
 import { SYSTEM_RECORD_V1_STATE_GRAPH } from '../src/internal-graph-policy.js';
+// The REAL caps. A fixture that restated them would still pass against a reader that cut
+// at a different bound, which is the whole property these cases exist to pin.
+import {
+  SYSTEM_RECORD_MAX_ATOMIC_RESERVED_INSPECTION_RESPONSE_BYTES,
+  SYSTEM_RECORD_MAX_PROJECTION_BYTES,
+  SYSTEM_RECORD_MAX_OWNED_SUBJECTS,
+  SYSTEM_RECORD_MAX_PROJECTION_QUADS,
+} from '@origintrail-official/dkg-core/system-record-v1';
 import type { Quad, QueryResult, TripleStore } from '../src/triple-store.js';
 
 const NETWORK_ID = 'otp:2043';
@@ -219,5 +227,115 @@ describe('legacy agent-profile gate read — projection membership', () => {
     expect(read.truncated).toBe(true);
     expect(read.rows).toEqual([]);
     expect(store.queries).toEqual([]);
+  });
+});
+
+/**
+ * The overflow channels the gate acts on, driven through the REAL reader.
+ *
+ * Everything above this point either fakes the reported channel at the gate layer or
+ * exercises a pre-query shortcut that returns before the store is touched. Neither reaches
+ * the code that DECIDES a response was too large — the running byte total, the cut, and
+ * the row-count detection. Those are the branches the whole byte-cap argument rests on,
+ * and until now they could have been deleted with the suite still green.
+ *
+ * The caps are the real imported constants, so these cannot pass against a reader that
+ * invented its own bound.
+ */
+describe('bounded-read overflow, computed by the real reader', () => {
+  /**
+   * A bulky but entirely VALID owned-subject table: the root plus the largest run of
+   * capability subjects the record may own, UTF-8 sorted and duplicate-free.
+   *
+   * Bulk has to come from many real subjects rather than one long one. A padded IRI is
+   * rejected as a table that cannot be decoded against its own root, and an over-long
+   * table trips its own 256 KiB cap — either way the root lands in `unclassifiedRoots`
+   * for a reason that has nothing to do with the response budget, and the test would pass
+   * while proving nothing about the cut.
+   */
+  function bulkOwnedSubjects(root: string): string[] {
+    const capabilities = Array.from(
+      { length: SYSTEM_RECORD_MAX_OWNED_SUBJECTS - 1 },
+      // `cap<n>` is the REAL indexed-genid shape. `capability<n>` looks plausible and is
+      // rejected: it starts with the `cap` prefix but leaves `ability<n>`, which is not an
+      // ordinal. A fixture using it lands every root in `unclassifiedRoots` for a
+      // validation reason and the byte-budget assertion would never be reached.
+      (_, i) => `${root}/.well-known/genid/cap${i + 1}`,
+    ).sort();
+    return [root, ...capabilities];
+  }
+
+  function bulkRecordQuads(root: string): Quad[] {
+    return appliedRecordQuads(root, bulkOwnedSubjects(root));
+  }
+
+  it('reports the roots that cross the applied-roots byte budget, and keeps the ones before', async () => {
+    // No SINGLE table can cross the response budget — an owned-subject table has its own
+    // smaller cap, and an over-cap table is rejected as undecodable for a different
+    // reason entirely. The response budget is a RUNNING total across roots, so crossing
+    // it is inherently a multi-root property and the fixture has to be built that way.
+    //
+    // Asserting BOTH halves is the point: a reader that gave up on the whole batch as
+    // soon as any budget was touched would also "withhold safely", while destroying the
+    // coverage this gate exists to provide.
+    const root = (i: number) => `did:dkg:agent:0x${(i + 1).toString(16).repeat(40).slice(0, 40)}`;
+    // The budget is measured against the literal the reader actually retains, so the cut
+    // point is derived from that same literal rather than from a guessed table size.
+    const per = jsonLiteral(bulkOwnedSubjects(root(0))).length;
+    const fits = Math.floor(SYSTEM_RECORD_MAX_ATOMIC_RESERVED_INSPECTION_RESPONSE_BYTES / per);
+    const roots = Array.from({ length: fits + 2 }, (_, i) => root(i));
+    const ordered = [...roots].sort();
+    const store = fakeStore(ordered.flatMap(bulkRecordQuads));
+
+    const read = await readLegacyAgentProfileAppliedRootsV1({
+      store, networkId: NETWORK_ID, mode: 'authoritative', roots,
+    });
+
+    // Deterministic in sorted root order, so WHICH roots fall outside the budget is a
+    // function of the request rather than of result ordering.
+    expect(read.records.map((record) => record.root)).toEqual(ordered.slice(0, fits));
+    expect(read.unclassifiedRoots).toEqual(ordered.slice(fits));
+    expect(read.unclassifiedRoots.length).toBeGreaterThan(0);
+  });
+
+  it('reports truncated when the projection response exceeds the row cap', async () => {
+    const rows = Array.from({ length: SYSTEM_RECORD_MAX_PROJECTION_QUADS + 1 }, (_, i) => ({
+      subject: ROOT,
+      predicate: `urn:p${i}`,
+      object: '"o"',
+      graph: systemRecordProjectionGraphV1('authoritative'),
+    }));
+    const store = fakeStore(rows);
+
+    const read = await readLegacyAgentProfileProjectionV1({
+      store, mode: 'authoritative', subjects: [ROOT],
+    });
+
+    expect(read.truncated).toBe(true);
+    expect(read.rows).toEqual([]);
+    // It really asked — this is the post-decode branch, not the pre-query shortcut the
+    // subject-bound case above takes.
+    expect(store.queries).toHaveLength(1);
+  });
+
+  it('reports truncated when the projection response exceeds the byte cap under the row cap', async () => {
+    // Deliberately FEW rows, so only the byte accounting can detect this. A reader that
+    // implemented the row cap alone passes every other case in this file and fails here.
+    const wide = Math.ceil(SYSTEM_RECORD_MAX_PROJECTION_BYTES / 4);
+    const rows = Array.from({ length: 5 }, (_, i) => ({
+      subject: ROOT,
+      predicate: `urn:p${i}`,
+      object: `"${'y'.repeat(wide)}"`,
+      graph: systemRecordProjectionGraphV1('authoritative'),
+    }));
+    const store = fakeStore(rows);
+
+    const read = await readLegacyAgentProfileProjectionV1({
+      store, mode: 'authoritative', subjects: [ROOT],
+    });
+
+    expect(rows.length).toBeLessThan(SYSTEM_RECORD_MAX_PROJECTION_QUADS);
+    expect(read.truncated).toBe(true);
+    expect(read.rows).toEqual([]);
   });
 });

--- a/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
+++ b/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
@@ -473,6 +473,30 @@ describe('bounded-read overflow, computed by the real reader', () => {
     expect(read.unclassifiedRoots).toContain(OTHER_ROOT);
   });
 
+  // Adopted from review, and it is a defect the canonical-builder adoption itself created.
+  // That builder REFUSES an over-bound request by throwing, where the previous local
+  // construction had no request bound at all. Unhandled, the throw escapes the gate, the
+  // per-context-graph catch drops the whole page, and durable sync retries it forever --
+  // instead of the gate's own answer for "cannot ask an exact question", which is to
+  // withhold. Subject COUNT stays under its bound here; the encoded VALUES clause is what
+  // crosses the request cap, which is why the count guard above does not catch it.
+  it('reports truncated when the request itself would exceed its bound', async () => {
+    const long = 'a'.repeat(300_000);
+    const subjects = Array.from({ length: 20 }, (_, i) => `${ROOT}/.well-known/genid/cap${i + 1}${long}`);
+    const store = fakeStore([]);
+
+    const read = await readLegacyAgentProfileProjectionV1({
+      store, mode: 'authoritative', subjects,
+    });
+
+    // Under its own subject bound, so this is the REQUEST size, not the count.
+    expect(subjects.length).toBeLessThan(SYSTEM_RECORD_MAX_OWNED_SUBJECTS);
+    expect(read.truncated).toBe(true);
+    expect(read.rows).toEqual([]);
+    // It never got as far as asking.
+    expect(store.queries).toEqual([]);
+  });
+
   // The bound must be IN THE QUERY, not only in the post-decode check. Adopted from
   // review: drop the projection `LIMIT` and every other case here still passes, because
   // the fake returns all fixture rows and `bindings.length` catches the overflow after

--- a/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
+++ b/packages/storage/test/system-record-legacy-gate-read-v1.test.ts
@@ -46,12 +46,17 @@ const JSON_DATATYPE = SYSTEM_RECORD_V1_JSON_DATATYPE;
  * wrong predicate or the wrong graph gets nothing back, which is what lets the
  * authoritative half of each counterfactual fail loudly rather than pass vacuously.
  */
-function fakeStore(quads: readonly Quad[]): TripleStore & { queries: string[] } {
+function fakeStore(
+  quads: readonly Quad[],
+): TripleStore & { queries: string[]; options: Array<Record<string, unknown>> } {
   const queries: string[] = [];
+  const options: Array<Record<string, unknown>> = [];
   const store = {
     queries,
-    async query(sparql: string): Promise<QueryResult> {
+    options,
+    async query(sparql: string, opts?: Record<string, unknown>): Promise<QueryResult> {
       queries.push(sparql);
+      options.push(opts ?? {});
       const graph = /GRAPH <([^>]+)>/.exec(sparql)?.[1];
       const values = [...sparql.matchAll(/<([^>]+)>/g)].map((m) => m[1]!);
       const inGraph = quads.filter((quad) => quad.graph === graph);
@@ -316,6 +321,56 @@ describe('bounded-read overflow, computed by the real reader', () => {
     // It really asked — this is the post-decode branch, not the pre-query shortcut the
     // subject-bound case above takes.
     expect(store.queries).toHaveLength(1);
+  });
+
+  /** A store whose transport refuses the body before parsing, the way a real one does. */
+  function refusingStore(): TripleStore {
+    return {
+      async query(): Promise<QueryResult> {
+        throw Object.assign(new Error('Triple-store response exceeds byte limit'), {
+          code: 'STORE_RESPONSE_TOO_LARGE',
+        });
+      },
+    } as unknown as TripleStore;
+  }
+
+  // The transport cap is only a contract if it is actually REQUESTED. Deleting the option
+  // from either call leaves every other case in this file green, because a fake store that
+  // ignores options behaves identically with and without it.
+  it('asks the store to enforce each read\'s response cap', async () => {
+    const store = fakeStore(appliedRecordQuads(ROOT, [ROOT]));
+
+    await readLegacyAgentProfileAppliedRootsV1({
+      store, networkId: NETWORK_ID, mode: 'authoritative', roots: [ROOT],
+    });
+    await readLegacyAgentProfileProjectionV1({
+      store, mode: 'authoritative', subjects: [ROOT],
+    });
+
+    expect(store.options[0]?.maxResponseBytes)
+      .toBe(SYSTEM_RECORD_MAX_ATOMIC_RESERVED_INSPECTION_RESPONSE_BYTES);
+    expect(store.options[1]?.maxResponseBytes).toBe(SYSTEM_RECORD_MAX_PROJECTION_BYTES);
+  });
+
+  // ...and only a contract if the refusal is TRANSLATED. Rethrowing instead would drop the
+  // whole page at the seam, which is the retry-storm the port contract exists to avoid —
+  // and no test here would have noticed, because no fake store threw the canonical error.
+  it('turns a transport cap refusal into undecided roots rather than throwing', async () => {
+    const read = await readLegacyAgentProfileAppliedRootsV1({
+      store: refusingStore(), networkId: NETWORK_ID, mode: 'authoritative', roots: [ROOT, OTHER_ROOT],
+    });
+
+    expect(read.records).toEqual([]);
+    expect([...read.unclassifiedRoots].sort()).toEqual([ROOT, OTHER_ROOT].sort());
+  });
+
+  it('turns a transport cap refusal into a truncated projection rather than throwing', async () => {
+    const read = await readLegacyAgentProfileProjectionV1({
+      store: refusingStore(), mode: 'authoritative', subjects: [ROOT],
+    });
+
+    expect(read.rows).toEqual([]);
+    expect(read.truncated).toBe(true);
   });
 
   it('reports truncated when the projection response exceeds the byte cap under the row cap', async () => {

--- a/packages/storage/test/system-record-storage-primitives-v1.test.ts
+++ b/packages/storage/test/system-record-storage-primitives-v1.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildBoundedSystemRecordUtf8V1 } from '../src/system-record-bounded-utf8-builder-v1-internal.js';
+import {
+  buildBoundedSystemRecordUtf8V1,
+  isSystemRecordBoundedBuildOverflowV1,
+  SYSTEM_RECORD_BOUNDED_BUILD_OVERFLOW_V1,
+} from '../src/system-record-bounded-utf8-builder-v1-internal.js';
 import {
   snapshotSystemRecordDenseArrayV1,
   snapshotSystemRecordExactDataRecordV1,
@@ -93,5 +97,59 @@ describe('system-record storage trust-boundary primitives', () => {
       replaceCharge: (bytes) => charges.push(bytes),
     })).toThrow(/retained-byte bound/);
     expect(charges).toEqual([]);
+  });
+
+  // Identity at the SOURCE, in BOTH polarities.
+  //
+  // The cases above assert by MESSAGE, which cannot tell a tagged refusal from an untagged
+  // one: drop the code and every one of them still passes. The only consumer — the legacy
+  // agent-profile gate read, which turns an over-bound REQUEST into a truncated answer
+  // rather than a thrown page — discriminates on the code, so an untagged refusal there
+  // silently reverts to rethrowing.
+  //
+  // The negative half carries equal weight. An accounting mismatch is a broken internal
+  // invariant, not a caller asking for more than the bound allows; translating it into a
+  // bounded answer would hide a defect behind a normal-looking result. Nothing pinned that
+  // separation, so the two throws could have converged on one code without a failure.
+  //
+  // SCOPE OF THE NEGATIVE HALF, stated because a mutant proved the looser reading wrong:
+  // it covers the WRITE-PHASE accounting guard, which is the only one of the four a caller
+  // can drive from `emit`. Tagging any of the other three still passes this case — they
+  // are reachable only if the builder's own two-pass accounting is already broken, so no
+  // fixture short of editing the builder reaches them.
+  it('tags both bound refusals with the canonical code, and the drift error with none', () => {
+    const thrown = (run: () => unknown): unknown => {
+      try { run(); return null; } catch (error) { return error; }
+    };
+
+    const encodedOverflow = thrown(() => buildBoundedSystemRecordUtf8V1({
+      emit: (writer) => writer.add('abcd'),
+      maxEncodedBytes: 3,
+      maxRetainedBytes: 9,
+      label: 'test payload',
+    }));
+    expect(isSystemRecordBoundedBuildOverflowV1(encodedOverflow)).toBe(true);
+    expect((encodedOverflow as { code?: unknown }).code)
+      .toBe(SYSTEM_RECORD_BOUNDED_BUILD_OVERFLOW_V1);
+
+    const retainedOverflow = thrown(() => buildBoundedSystemRecordUtf8V1({
+      emit: (writer) => writer.add('abcd'),
+      maxEncodedBytes: 4,
+      maxRetainedBytes: 11,
+      label: 'test payload',
+    }));
+    expect(isSystemRecordBoundedBuildOverflowV1(retainedOverflow)).toBe(true);
+
+    let pass = 0;
+    const drift = thrown(() => buildBoundedSystemRecordUtf8V1({
+      emit: (writer) => writer.add(pass++ === 0 ? 'a' : 'bb'),
+      maxEncodedBytes: 2,
+      maxRetainedBytes: 6,
+      label: 'test payload',
+    }));
+    // Asserted to BE an error first: a run that threw nothing would satisfy the negative
+    // assertion below just as well, and prove nothing.
+    expect(drift).toBeInstanceOf(Error);
+    expect(isSystemRecordBoundedBuildOverflowV1(drift)).toBe(false);
   });
 });


### PR DESCRIPTION
Wires `LegacyAgentProfileGateV1` (shipped dormant in #2253) into the legacy durable-sync ingest seam, adds the storage read path it needs, and closes a fail-open in the gate's own port contract. Issue #2052, Stack D slice D-8 residual.

## What this is for

Legacy aggregate sync replays whole `agents` pages. Once a root carries an applied signed record those pages are redundant at best and contradictory at worst, so plan `:924` partitions incoming `agents` quads by canonical root and `:1505` states the invariant: **signed state cannot be overwritten**. #2253 built the gate that decides this and deliberately shipped it with zero callers. This wires it.

**Post-cutover the collision is physical, not merely semantic.** `systemRecordProjectionGraphV1('authoritative')` returns `did:dkg:context-graph:agents` — the same graph legacy sync inserts into. Pre-cutover the projection lives in its own shadow graph, so graph separation already protects it. That asymmetry is what shapes the mode handling below.

## What the gate acts on: destination graph AND subject

Adopted from review, which caught the original scope as too broad. The gate ran on every page and classified by **subject alone**, so a quad about an agent bound for some unrelated context graph could be withheld once a projection is authoritative — data loss in a graph where no collision is possible.

Scoping to the `agents` **lane** instead — the reviewer's suggestion — would have been wrong in the more dangerous direction: a page under any context-graph id can carry a quad bound for the aggregate graph, and lane-scoping inserts it. That is failing toward insertion, the one direction `:1505` forbids.

The predicate is neither. Because the collision is **physical**, the question is whether the insert lands in the graph the applied projection occupies, conjoined with the existing subject derivation. **Both conjuncts, and neither implies the other** — proven by two mutants that kill different halves.

The projection graph rides on the *lookup* rather than arriving as its own gate argument, and is produced by the materializer's own `systemRecordProjectionGraphV1` applied to the same `mode` the two reads receive. One value, one mode, one home: a gate cannot be built against one mode's graph while reading another's. Under `shadow` that graph is the namespace-hidden reserved one, which no legacy page targets — so the mode keeps the gate inert here too, now at **zero store reads**.

## The defect this fixes, which is not the wiring

The gate's port told an implementation that could not honour `:926`'s 1-MiB response cap to *"return fewer roots rather than a larger response"*. But the gate classified any root it asked about and did not get back as `uncovered`, and inserted its quads. **Honouring the byte cap therefore failed toward insertion — the one direction `:1505` forbids**, and a short response was indistinguishable from "no applied record here".

`lookupAppliedRoots` now returns `{ records, unclassifiedRoots }` and `lookupProjectionMembership` returns `{ rows, truncated }`, so a bounded response says what it could not decide and the gate withholds it. The unsafe instruction is deleted and replaced by the reason it was unsafe, so the next reader does not re-derive it.

**Both caps move together, not only the one the task named.** The row count is visible to the gate; the byte bound is not. A partial projection would make a real duplicate look like a conflict, so it is never compared against.

**This is load-bearing rather than precautionary.** The reserved-inspection primitive already in storage caps at 128 rows — it is sized for one record's reserved tuple, so it is **the wrong tool here, not merely too small**: feeding it a 256-root batch truncates straight into the fail-open above. And an owned-subject table is capped at 256 KiB each, so 256 roots is up to 64 MiB — **truncation is the normal case at the top of the range**, not an edge case.

## Where the byte caps land, recorded as DERIVED rather than plan letter

`:926` writes both caps as *response* caps, which presumes a wire. The read path deliberately does **not** ride the atomic-apply inspection path (`readReserved`/`readProjection`), because that is bound to a managed-Oxigraph HTTP client — riding it would give the gate to daemon-managed leased endpoints and nobody else, and an invariant that holds only on some backends is not an invariant. These reads go through `TripleStore.query`, which every store implements.

**Both halves, and the first was missing until review caught it.** Where the store *has* a wire, both reads now pass `maxResponseBytes`, which the adapters enforce **before parsing** — bounded body reads, and a managed client that aborts mid-stream. The earlier post-decode-only accounting left the documented protection unimplemented on exactly the stores that have a wire, and the paragraph you are reading previously implied no transport enforcement was possible at all. It was.

An embedded store has no wire, so the retained size of the decoded answer remains the universal floor, measured after it arrives. That floor is late by construction, so these functions never claim to have *prevented* an oversized answer there — they report what they could not classify and let the gate withhold, which is `:926`'s own remedy. The cut is deterministic in sorted root order, so which roots fall outside the budget is a function of the request rather than of result ordering.

A transport refusal is **reported, not rethrown**: at the seam a throw drops the whole page, which is the retry-storm this port contract was rewritten to avoid, and "could not classify" is already an answer the gate acts on. Only the canonical `STORE_RESPONSE_TOO_LARGE` counts — a store reporting the overrun untyped still propagates, which fails closed, and that is named in the code as a residual rather than papered over with message matching.

## Mode: covered means AUTHORITATIVE

Covered = an applied record whose projection is authoritative. Under `shadow` the reads answer empty **without querying**. Grounds: the shadow graph's own contract is that its rows *"never make the legacy lane non-authoritative"*, so a gate that withheld legacy quads on the strength of a shadow row would violate it directly; and in shadow mode graph separation already provides the physical protection, so the gate's subject only exists in authoritative mode.

**The mode has exactly one home** — `SystemRecordLaneActivationV1` — and the agent mints no copy of it. The supplier passes the literal `shadow` because there is nothing to read it from: the mode is an *input* to `SystemRecordLaneControllerV1.open()`, not state the controller exposes, and no production path opens a lane. The comment at the supplier carries both the D-12 pointer and the reason a literal is correct there, with an explicit warning against "fixing" it into a config lookup that does not exist.

## Why this ships without a flag

The first fair objection to an unconditional gate on an ingest path is that it should sit behind a control. It should not, and the reason is the plan's own rollout order rather than a preference.

**No existing control fits it.** The ratified inventory for this stack is producer tracking, provider advertisement, the requester lane, and legacy capable-peer selection. None of the four is this gate. The nearest by name — legacy capable-peer selection — governs peer *preference* inside catch-up sync: a different mechanism pointed at a different object.

**Binding it to the requester lane would be unsafe in the prescribed sequence, not hypothetically.** The rollout enables the producer at step 2 and holds the requester off through step 3 — *"Enable provider advertisement; requester remains off"* — with the requester arriving only at step 4. And `:1090` states that capable peers stop aggregate legacy `agents` **only after** the coordinated activation gate: *"before activation the signed lane is additive/shadow"*. Applied signed records therefore exist **while legacy aggregate sync is still replaying pages**, for the whole of steps 2 and 3. A gate bound to the requester flag would be off across precisely the window it exists to protect.

That leaves inventing a new control, which would need its own ratification, weighed against an unconditional gate that is:

- **safe in all sixteen combinations** of the four ratified flags;
- consistent with the sibling door in this stack, which is likewise an unconditional exclusion with no flag;
- degrading toward **withholding** — `:926`'s own remedy — rather than toward insertion;
- **switched by state rather than by config**: it is a no-op exactly when no applied record exists, which is the condition on every node today.

**The zero-cost-when-inert claim is pinned by a test, not asserted.** A page deriving no `did:dkg:agent:` root performs zero store lookups, pinned at the gate and again at the seam, neither pin implying the other. Worth stating what those pins do *not* prove: when the seam's gate call was mutated away, the zero-read pin stayed **silent** — an unwired seam performs no lookups either, so it pins cost, not wiring. The composition test is the wiring discriminator. Treating the cheap pin as the wiring proof would have shipped a check that cannot fail for the property it appears to guard.

The rollback line's *"disabling requester/gate atomically rotates `materializationEpoch`"* is a real residual, but it belongs to the teardown and activation slices that own the epoch, and is recorded against them.

## Scope, stated rather than implied

**No door is closed by this PR.** Nothing supplies an authoritative projection, so the gate is inert by mode: it is constructed, it runs on every legacy page, and it withholds nothing. **D-12 activation precondition (a) is NOT discharged here** — it is discharged when D-12 flips that one expression, and D-12 gains the accompanying proof obligation that flipping it makes the gate fire.

**Three doors, and only one of them is this PR's.** This wires the legacy **durable-sync** ingest door. The changelog door was closed by the sibling slice. The **SWM gossip-ingest** door is a third seam and is **open** — measured, named in the residuals below, and filed separately. Merging this should not be read as closing any of the other two.

Coverage scopes to `claimPosition === 'current'`: an authority transition removes the old projection atomically (`:1503`), so a historical root has no signed state left to protect, and it is also the only verifiable case — the owned-subject table is canonicalized against the record's *current* root.

Both the data and meta inserts are gated. They are fetched in separate pagination loops and are therefore separate pages, so `:926`'s two-requests-per-page bound holds for each; a page deriving no agent root issues **no store read at all**, which is what makes gating the meta page free (`agents/_meta` is opt-in and off by default).

`insertedTriples` now counts what the store was offered rather than the page size — previously a withheld quad would have reported progress the store never took.

## Surface change

A second `./internal/` subpath on `packages/storage`, matching the existing house precedent, added to `verify-pack-exports.mjs`'s **exact** allowlist. That gate passed with all fifteen of its own properties and mutants intact, and its exactness check names the new subpath.

The seam's gate port is **optional** and deliberately not fail-closed on absence: a fail-closed throw would trigger on "this page derived an agent root", true of every ordinary `agents` page, and `runDurableSync` is reachable outside the package through the agent map's open `"./dist/*"` wildcard — so it would break safe and unsafe external callers alike. Enforcement lives where it can be proven instead: the production construction site supplies a gate, and a test asserts that it does.

## Verification

`pnpm exec turbo build --filter=@origintrail-official/dkg-agent...` 18/18 including `test:types` and `test:package-root`. Node v22.22.0 printed by every run.

- Agent: 13 files / 301 tests, zero failures. Storage read module: 8/8. Counts reconcile: 293 pre-supplier baseline + 4 seam file + 2 supplier + 2 counterfactual.
- **Re-measured at the final head after every review adoption**: the affected agent set is **17 files / 362 tests**, zero failures; the storage read module is **14/14**; the package-exports gate holds all fifteen properties with every mutant killed, now with the added export in its surface. `turbo build` 18/18 including `test:types` and `test:package-root`.
- Five mutants, each **predicted before running**, applied-proof read back **by line number**, restored with a green control after each:
  - `undecided` conjunct (gate `:261`) removed solo → 1 failed / 23 passed, the failing test matched by name.
  - `truncated` conjunct (gate `:289`) removed solo → same shape.
  - the seam's gate call replaced by the raw page (`durable-sync:716`) → exactly the two predicted failures.
  - the mode guard (read `:124`) removed solo → the shadow half alone.
  - the supply expression at the lifecycle construction site — the `createLegacyAgentProfileGateLookupV1({ …, mode: 'shadow' })` call — replaced by `undefined` → the supply test alone, its negative half surviving. (Named by expression rather than by line: comment edits in this same PR shifted that line, and a line-anchored citation would already be pointing at the wrong place.)

### Review adoptions, each with its own fail-before

Five further mutants, same discipline — predicted first, applied-proof read back by line, restored with a control:

- **the graph conjunct removed** (subject-only) → the pass-through-in-another-graph case fails **alone**, 1 failed / 32 passed.
- **lane-scoping added at the seam** (`pid !== 'agents'`) → the aggregate-graph-quad-on-a-foreign-page case fails **alone**, 1 failed / 32 passed. Two mutants killing *different* halves is the independence claim, not an assertion about it.
- **the applied-roots cut never trips** → the byte-budget case alone, 1/10.
- **the projection row detection never trips** → the row-cap case alone, 1/10.
- **the projection byte cut never trips** → the byte-cap case alone, 1/10.

Those last three matter because of what they target. Every earlier mutant on this slice hit the gate's *consumption* of the overflow channels; the code that **decides** a response was too large had no solo-removal proof at all, so it could have been deleted with the suite still green. It cannot now.

- **the metadata branch reverted to the raw page** → the new meta case alone, 1 failed / 6 passed. All six pre-existing cases pass under that mutant, which is the evidence the gap was real rather than theoretical.
- **the supplier's mode literal flipped to `authoritative`** → the new lifecycle case alone, 1 failed / 30 passed — **with the previous `toBeDefined()` assertion still passing under it**. The production wiring test proved presence and nothing else; the most consequential literal in this PR was unprotected.
- **`maxResponseBytes` removed from the applied-roots query** → the options case alone, 1 failed / 13 passed. **Both cap catches flipped to rethrow** → both refusal cases and nothing else, 2 failed / 12 passed. Passing the cap and translating the refusal were themselves untested when first added here; review caught that, correctly.
- **`insertedDataTriples` regressed to the page length** while the aggregate counter stays correct → the data diagnostics case alone, 1 failed / 7 passed. The meta branch had its counter pinned first; this is the matching half.
- **the gate-read export removed and storage rebuilt**, so the packed artifact genuinely lacked it → the packed-consumer probe and the type fixture both fail. **The point is what did NOT fail: `exactness: packed exports map carries exactly the allowlist` still passed.** The new subpath was previously only *resolved* — never imported, never compiled against — so resolver metadata could be correct while the artifact was broken. The pack gate now loads it and compiles the exact surface the agent adapter consumes.

### A one-pass audit of the mechanisms this review itself introduced

Several consecutive rounds each found a gap in the *previous* round's fix. Rather than wait for that to be re-derived one round at a time, every mechanism added since the typed error contracts was audited in a single pass — each checked for a witness at its **source** (not only at a consumer), coverage of its **sibling sites**, and the **channel it reports failure on**. Nine mechanisms in the first pass, then both refusal families across their throw and catch sites in a second; six gaps closed in total, all of them here.

- **The managed client's declared-`Content-Length` refusal was untagged** while its chunked refusal carried the canonical code. This is the likelier of the two paths: an endpoint that sends `Content-Length` never reaches the chunked check, so the gate reads would rethrow it and drop the page instead of degrading to undecided. Tagged, with the assertion in the client's **own** overflow test — under the mutant that deletes the tag, the reader suite stays **24/24 green**, which is exactly why the witness cannot live there. (The shared bounded reader already typed both of its own paths; only this client was asymmetric.)
- **The post-gate abort guard on the metadata branch had no test.** Deleting it left all 17 affected agent suites green — 367 tests. The case that pins the data branch is served on the data phase and cannot reach the meta copy. Each guard now fails **alone** when removed alone.
- **The reader threw on a root it could not name**, and this one is a correctness defect rather than a coverage gap. The agent-side derivation accepts any `did:dkg:agent:0x<40 lowercase hex>` subject; naming that root's claim additionally rejects the zero address. So one derivable root reached the namer and made it **throw** — uncaught, dropping the whole durable-sync page, on every retry, for as long as a peer kept serving that subject. That is the retry-storm the transport-refusal translation exists to prevent, arriving through the one input the reader does not choose. It is now reported **undecided**, the answer that withholds. Fail-before: `[system-record-scalar] agent root must be a canonical did:dkg:agent address`. The mutant that stops reporting it undecided makes the reader classify it *uncovered* — the fail-**open** direction — and fails the case alone. Reachable only under authoritative mode: inert today, live at the cutover.

Request one's `LIMIT` and its saturation comparison now key off the claim count rather than the root count, so the one-row sentinel stays exact when a root is dropped before the query is built.

A second pass over the same family — this time over both refusal mechanisms across every throw and catch site — closed three more, all of them missing **identity at the source** rather than missing behaviour:

- **The bounded builder's own suite asserted overflow by message only**, so the canonical code had no witness beside the throw. Both tagged refusals now assert the code and the predicate, and the **negative** polarity is asserted too: an accounting mismatch must *not* satisfy the predicate, or a broken internal invariant could be translated into a normal-looking bounded answer. A mutant then showed that negative assertion was narrower than it read — it covers the write-phase guard, the only one of the four a caller can drive — so the test states that scope instead of implying it.
- **The shared bounded reader's `Content-Length` preflight had no test at all.** Every fixture elsewhere builds a body without a declared length, so all coverage landed on the streaming branch: with the preflight made inert, **108 adapter tests stayed green** across sparql-http, blazegraph and blank nodes. The new case is built so the preflight is the only thing that can satisfy it — a three-byte body behind a 999-byte declaration under a ten-byte cap, which refuses on the declaration alone and succeeds without it. The refusal's class, code and byte fields are asserted here too, which nothing did before.
- **A comment invited a fix to a gap that does not exist.** It recorded that only the *response* used to be capped, which reads as an asymmetry someone should close for request one. Request one cannot overflow its request bound: its VALUES entries are derived claim IRIs of a fixed 117 characters — roughly 31 KB at the 256-root batch cap against a 4 MiB cap — and callers supply roots, not IRIs. The comment now carries that measurement and its mechanism.

Review also caught something the audit had just re-proved in the opposite direction: two local predicates in the gate read were **identity wrappers** around the canonical ones, carrying review history and no policy. They are deleted and the catches call the canonical predicates directly, with the rationale moved to the catch sites. Behaviour is unchanged by measurement rather than by inspection — dropping the builder's tag still fails the request-overflow case alone.

Two mechanisms were examined and deliberately left as they are. The response-too-large predicate's `instanceof` arm is redundant **by construction** — the error class assigns the code as an instance field — so no mutant can falsify it; it is defence in depth, not an untested branch. And the managed client's capacity-accounting throw stays untagged for the same reason the builder's accounting throws do: it means "our arithmetic is broken", not "the answer exceeded the cap we set", and the guard above it makes `required > maximum` unreachable.

### A real pre-activation bug, found by review and fixed

Worth stating separately because it was live, not hypothetical. The gate sets its batch-cap overflow disposition **before** the lookup runs. Under the original subject-only scoping, a **shadow-mode** page carrying more than 256 distinct agent roots therefore had its overflow roots marked unclassified and **withheld** — although the shadow lookup answers empty and nothing authoritative exists to protect. Silent loss of legacy quads before cutover, with the durable-sync checkpoint advancing over it.

The destination-graph scope closes it: under `shadow` the projection graph is the reserved one, no root is derived, and the overflow path is unreachable. That is pinned rather than left as a side effect — a page **above** the cap in shadow mode must pass through untouched at zero store reads, and restoring subject-only scoping **reproduces the bug** (2 failed / 24 passed: the shadow-above-cap case and the other-context-graph case).

Two fixture assumptions were wrong and are worth recording, because both would have produced a green test that proved nothing: no *single* owned-subject table can cross the 1-MiB response budget (a table has its own smaller cap, and an over-cap table is rejected for an unrelated reason — crossing is inherently a running total across roots); and the indexed-genid shape is `cap<n>`, not `capability<n>`, which passes the prefix test but leaves a non-ordinal remainder and lands every root in `unclassifiedRoots` on validation.

### Two false-pass risks closed at design time

**The mode counterfactual needs both halves.** "Returns nothing under shadow" is equally satisfied by a reader whose query is broken, whose predicates are misspelled, or whose root-claim derivation is wrong. Only an authoritative run *over the same fixture* separates inert-by-mode from broken, so every shadow assertion is paired — at the read layer and again end-to-end at the seam. The mutation confirms the pair discriminates.

**At the seam, "the conflicting quad disappeared" would also pass if `filterPage` threw** — the per-CG catch drops the whole page, which looks identical to a withhold. So an uncovered quad rides along in both runs and must survive; a thrown lookup can no longer wear a withhold's clothes.

The byte-cap tests are built so the **reported channel is the only discriminator**: in the request-one test both roots are absent from `records` and differ only by being named unclassified; in the request-two test the row *is* the page's quad, so without the flag it is discarded as a duplicate. A fixture that simulated a byte cap by returning a shorter list would have been testing the exact confusion the contract exists to remove. The fixture's canonical-json datatype is imported rather than restated, so it cannot pass against a reader that never checks the encoding.

### What CI on this base does and does not cover

Worth stating plainly for whoever merges this. Pull-request runs against `integration/2052-system-record-sync` do execute the full lane — but **pushes to that branch trigger no workflow at all**, so the merge commit itself gets zero check-runs. **This PR's own checks are the entire validation gate**; nothing catches a bad interaction after the fact, and cross-PR combinations are only ever validated by the next PR's run at the new base.

## Measured facts worth carrying forward

- The cross-adapter term encoding is **uniform**: oxigraph, blazegraph and sparql-http all funnel typed literals through the same `formatCanonicalRdfLiteralTerm`, so `parseRdfLiteralTerm` is a safe inverse. Measured at all three sites before any parsing code was written, because a tolerant parser fitted to one adapter would have been the backend-conditional defect rejected above.
- The agent package's `"./dist/*"` export entry is the **open** wildcard `"./dist/*": "./dist/*"`, not `null`; only `./dist/system-records/*` and `./dist/rfc64/*` are null. Package-internality is per-subpath, not per-package.

## Residuals, named not hidden

- **Core reverse root derivation** (tracked as its own follow-up) moves from latent to live-but-drift-only: the gate derives roots at a fixed separator set, so a future core owned-subject shape carrying a new separator would derive `null` and take the legacy path. It needs a future core change to fire, and the guard cannot live agent-side because the policy table is module-private — which is that follow-up's whole point. It should be re-prioritized whenever core next touches subject shapes.
- **SWM third door — OPEN, and this replaces an earlier claim in this description that it was closed by a state precondition.** That claim was measured and is wrong. It was true only of the shared-memory *durable-sync candidate set*, which is a config shape rather than a guard. On the **gossip-ingest** seam the door is open by construction: `agents` is subscribed to its own SWM topic at boot; `hasConfirmedMetaState` returns `true` for system context graphs **unconditionally, as its first statement**, and `isPrivateContextGraph` returns `false` for them — so *both* conjuncts of `canUseSharedMemoryForContextGraph` short-circuit **in favour of** system CGs, and a member-mode apply handler is installed. Nothing restricts `did:dkg:agent:` subjects from SWM writes. Stated limits: the rejection branches inside the envelope handler and the workspace→aggregate flow were not traced, so a downstream envelope check could still refuse such a message in practice — which would still not be a system-CG guard. It is filed as its own follow-up, with the runtime witness (assert the topic registration after boot) as its first step. **It is a different seam from the one this PR closes and does not block it**, but it must not be described as closed.
- **A TOCTOU window** exists between the gate's lookup and `storeInsert`; it is not closable in this slice (it needs `:927`'s record capability, which does not exist — repo-wide grep returns one hit, the gate's own comment). Pre-activation the window is vacuous because no applier can run, which is what makes it a **D-12 activation precondition (e)** rather than a live defect.
- Record-dirty marking stays deferred: `:927` requires the identical mechanism, so it belongs where both consumers reach it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

