### PR TITLE
fix(sync): fence selected SWM to RFC-64 complete providers

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -4343,7 +4343,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           peerId,
           this.config.syncContextGraphs ?? [],
           createOperationContext('sync'),
-          { completeProviderOnly: automaticPeerSweep },
         );
         sharedMemorySyncPlans.set(peerId, plan);
       }
@@ -4561,7 +4560,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     contextGraphIds: readonly string[],
     ctx: OperationContext,
     options: {
-      completeProviderOnly?: boolean;
       requireCompleteProviderMatch?: boolean;
     } = {},
   ): Promise<SharedMemorySyncContextGraphPlan> {
@@ -4690,14 +4688,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         continue;
       }
       if (
-        options.completeProviderOnly
-        && remotePeerId !== undefined
+        remotePeerId !== undefined
         && completeSwmProviders.length > 0
         && !completeSwmProviders.includes(remotePeerId)
       ) {
         this.log.debug(
           ctx,
-          `SWM sync: skipping "${contextGraphId}" from ${remotePeerId.slice(-8)} — RFC-64 complete provider selected`,
+          `SWM sync: rejecting "${contextGraphId}" from ${remotePeerId.slice(-8)} — RFC-64 complete provider selected`,
         );
         continue;
       }
@@ -6670,9 +6667,39 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       contextGraphId,
     );
     const planned = options?.sharedMemorySyncPlan;
-    const plan = planned && sameStringArray(planned.eligibleContextGraphIds, contextGraphIds)
+    const initialPlan = planned && sameStringArray(planned.eligibleContextGraphIds, contextGraphIds)
       ? planned
       : await this.planSharedMemorySyncContextGraphs(remotePeerId, contextGraphIds, ctx);
+    // A caller-supplied plan is only an optimization snapshot; it is not an
+    // authority token. Re-apply the RFC-64 complete-provider fence at the
+    // execution boundary so manual catch-up, coalesced work, or a stale plan
+    // cannot import a selected public CG from an arbitrary peer.
+    const rejectedPublicContextGraphIds = new Set(
+      initialPlan.publicContextGraphIds.filter((contextGraphId) => {
+        const completeSwmProviders = this.resolveRfc64CompleteSwmProviderPeerIdsV1(
+          contextGraphId,
+        );
+        return completeSwmProviders.length > 0
+          && !completeSwmProviders.includes(remotePeerId);
+      }),
+    );
+    for (const contextGraphId of rejectedPublicContextGraphIds) {
+      this.log.debug(
+        ctx,
+        `SWM sync: rejecting preplanned "${contextGraphId}" from ${remotePeerId.slice(-8)} — RFC-64 complete provider selected`,
+      );
+    }
+    const plan = rejectedPublicContextGraphIds.size === 0
+      ? initialPlan
+      : {
+        publicContextGraphIds: initialPlan.publicContextGraphIds.filter(
+          (contextGraphId) => !rejectedPublicContextGraphIds.has(contextGraphId),
+        ),
+        privateRecoverFromCurator: initialPlan.privateRecoverFromCurator,
+        eligibleContextGraphIds: initialPlan.eligibleContextGraphIds.filter(
+          (contextGraphId) => !rejectedPublicContextGraphIds.has(contextGraphId),
+        ),
+      };
     const publicContextGraphIds = orderContextGraphIdsByPriority(
       plan.publicContextGraphIds,
       this.config.syncContextGraphPriorities,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -1204,6 +1204,35 @@ type SharedMemorySyncContextGraphPlan = {
   eligibleContextGraphIds: string[];
 };
 
+function enforceRfc64CompleteProviderAuthority(
+  plan: SharedMemorySyncContextGraphPlan,
+  remotePeerId: string | undefined,
+  resolveCompleteProviders: (contextGraphId: string) => readonly string[],
+  onRejected: (contextGraphId: string, remotePeerId: string) => void,
+): SharedMemorySyncContextGraphPlan {
+  if (remotePeerId === undefined) return plan;
+  const rejectedPublicContextGraphIds = new Set(
+    plan.publicContextGraphIds.filter((contextGraphId) => {
+      const completeSwmProviders = resolveCompleteProviders(contextGraphId);
+      return completeSwmProviders.length > 0
+        && !completeSwmProviders.includes(remotePeerId);
+    }),
+  );
+  if (rejectedPublicContextGraphIds.size === 0) return plan;
+  for (const contextGraphId of rejectedPublicContextGraphIds) {
+    onRejected(contextGraphId, remotePeerId);
+  }
+  return {
+    publicContextGraphIds: plan.publicContextGraphIds.filter(
+      (contextGraphId) => !rejectedPublicContextGraphIds.has(contextGraphId),
+    ),
+    privateRecoverFromCurator: plan.privateRecoverFromCurator,
+    eligibleContextGraphIds: plan.eligibleContextGraphIds.filter(
+      (contextGraphId) => !rejectedPublicContextGraphIds.has(contextGraphId),
+    ),
+  };
+}
+
 type RecoverContextGraphSwmOptions = Parameters<typeof recoverContextGraphSwm>[0];
 
 interface RecoverContextGraphSwmFromPeerDependencies {
@@ -4687,21 +4716,18 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       ) {
         continue;
       }
-      if (
-        remotePeerId !== undefined
-        && completeSwmProviders.length > 0
-        && !completeSwmProviders.includes(remotePeerId)
-      ) {
-        this.log.debug(
-          ctx,
-          `SWM sync: rejecting "${contextGraphId}" from ${remotePeerId.slice(-8)} — RFC-64 complete provider selected`,
-        );
-        continue;
-      }
       publicContextGraphIds.push(contextGraphId);
       eligibleContextGraphIds.push(contextGraphId);
     }
-    return { publicContextGraphIds, privateRecoverFromCurator, eligibleContextGraphIds };
+    return enforceRfc64CompleteProviderAuthority(
+      { publicContextGraphIds, privateRecoverFromCurator, eligibleContextGraphIds },
+      remotePeerId,
+      (contextGraphId) => this.resolveRfc64CompleteSwmProviderPeerIdsV1(contextGraphId),
+      (contextGraphId, peerId) => this.log.debug(
+        ctx,
+        `SWM sync: rejecting "${contextGraphId}" from ${peerId.slice(-8)} — RFC-64 complete provider selected`,
+      ),
+    );
   }
 
   async getSharedMemorySyncContextGraphs(this: DKGAgent, remotePeerId?: string): Promise<string[]> {
@@ -6671,35 +6697,17 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       ? planned
       : await this.planSharedMemorySyncContextGraphs(remotePeerId, contextGraphIds, ctx);
     // A caller-supplied plan is only an optimization snapshot; it is not an
-    // authority token. Re-apply the RFC-64 complete-provider fence at the
-    // execution boundary so manual catch-up, coalesced work, or a stale plan
-    // cannot import a selected public CG from an arbitrary peer.
-    const rejectedPublicContextGraphIds = new Set(
-      initialPlan.publicContextGraphIds.filter((contextGraphId) => {
-        const completeSwmProviders = this.resolveRfc64CompleteSwmProviderPeerIdsV1(
-          contextGraphId,
-        );
-        return completeSwmProviders.length > 0
-          && !completeSwmProviders.includes(remotePeerId);
-      }),
-    );
-    for (const contextGraphId of rejectedPublicContextGraphIds) {
-      this.log.debug(
+    // authority token. Normalize both freshly planned and cached inputs through
+    // the same source-authority helper used by the planner.
+    const plan = enforceRfc64CompleteProviderAuthority(
+      initialPlan,
+      remotePeerId,
+      (contextGraphId) => this.resolveRfc64CompleteSwmProviderPeerIdsV1(contextGraphId),
+      (contextGraphId, peerId) => this.log.debug(
         ctx,
-        `SWM sync: rejecting preplanned "${contextGraphId}" from ${remotePeerId.slice(-8)} — RFC-64 complete provider selected`,
-      );
-    }
-    const plan = rejectedPublicContextGraphIds.size === 0
-      ? initialPlan
-      : {
-        publicContextGraphIds: initialPlan.publicContextGraphIds.filter(
-          (contextGraphId) => !rejectedPublicContextGraphIds.has(contextGraphId),
-        ),
-        privateRecoverFromCurator: initialPlan.privateRecoverFromCurator,
-        eligibleContextGraphIds: initialPlan.eligibleContextGraphIds.filter(
-          (contextGraphId) => !rejectedPublicContextGraphIds.has(contextGraphId),
-        ),
-      };
+        `SWM sync: rejecting preplanned "${contextGraphId}" from ${peerId.slice(-8)} — RFC-64 complete provider selected`,
+      ),
+    );
     const publicContextGraphIds = orderContextGraphIdsByPriority(
       plan.publicContextGraphIds,
       this.config.syncContextGraphPriorities,

--- a/packages/agent/test/selected-swm-lifecycle-queue.test.ts
+++ b/packages/agent/test/selected-swm-lifecycle-queue.test.ts
@@ -10,6 +10,36 @@ import {
 } from './selected-swm-test-helpers.js';
 
 describe('selected RFC-64 SWM lifecycle queue and budgets', () => {
+  it('does not fetch a selected scope when the caller-supplied plan names a non-provider peer', async () => {
+    const publicCg = 'selected-preplanned-non-provider';
+    const manifest = snapshotManifest(publicCg, 1);
+    const harness = createSelectedSwmLifecycleHarness({
+      contextGraphs: { public: publicCg },
+      manifest,
+      completeSwmProviders: ['12D3KooWAnotherCompleteProvider'],
+      clock: { now: () => 1_000, deadline: () => 61_000 },
+    });
+
+    try {
+      const summary = await callSelectedSharedMemorySummary(harness.agent, [publicCg], {
+        selectedSwmPriority: true,
+        priority: 2_000,
+        sharedMemorySyncPlan: {
+          publicContextGraphIds: [publicCg],
+          privateRecoverFromCurator: [],
+          eligibleContextGraphIds: [publicCg],
+        },
+      });
+
+      expect(harness.probes.metaFetches()).toBe(0);
+      expect(harness.probes.dataFetches()).toBe(0);
+      expect(harness.probes.snapshotReads()).toBe(0);
+      expect(summary.insertedTriples).toBe(0);
+    } finally {
+      await harness.close();
+    }
+  });
+
   it('releases the shared metadata budget before the next serialized owner generation', async () => {
     const publicCg = 'selected-overlap-shared-retention-budget';
     const manifest = snapshotManifest(publicCg, 2);

--- a/packages/agent/test/selected-swm-test-helpers.ts
+++ b/packages/agent/test/selected-swm-test-helpers.ts
@@ -324,6 +324,8 @@ export interface SelectedSwmLifecycleHarnessOptions {
     readonly deadline: () => number;
   };
   readonly priorities?: Readonly<Record<string, number>>;
+  /** RFC-64 complete providers accepted for the selected public scope. */
+  readonly completeSwmProviders?: readonly string[];
   readonly onSnapshotRead?: (probe: {
     readonly ref: string;
     readonly publicAdmission: number;
@@ -427,6 +429,7 @@ export interface SelectedSwmLifecycleAgentFixture {
   contextGraphMetaProjection: { markDirtyFromQuads: () => void };
   oversizeTombstoneLog: { record: () => void };
   log: { info: () => void; warn: () => void; debug: () => void };
+  resolveRfc64CompleteSwmProviderPeerIdsV1: (contextGraphId: string) => string[];
   syncSharedMemoryFromPeerDetailedExecution:
     typeof LifecycleSyncMethods.prototype.syncSharedMemoryFromPeerDetailedExecution;
 }
@@ -709,6 +712,11 @@ export function createSelectedSwmLifecycleHarness(
     contextGraphMetaProjection: { markDirtyFromQuads: () => {} },
     oversizeTombstoneLog: { record: () => {} },
     log: { info: () => {}, warn: () => {}, debug: () => {} },
+    resolveRfc64CompleteSwmProviderPeerIdsV1: (contextGraphId) => (
+      contextGraphId === options.contextGraphs.public
+        ? [...(options.completeSwmProviders ?? [PEER])]
+        : []
+    ),
     syncSharedMemoryFromPeerDetailedExecution:
       LifecycleSyncMethods.prototype.syncSharedMemoryFromPeerDetailedExecution,
     getSelectedSwmMetaTransfers: () => {

--- a/packages/agent/test/selected-swm-test-helpers.ts
+++ b/packages/agent/test/selected-swm-test-helpers.ts
@@ -324,7 +324,11 @@ export interface SelectedSwmLifecycleHarnessOptions {
     readonly deadline: () => number;
   };
   readonly priorities?: Readonly<Record<string, number>>;
-  /** RFC-64 complete providers accepted for the selected public scope. */
+  /**
+   * RFC-64 complete providers accepted for the selected public scope.
+   * Defaults to [PEER] because this harness models the selected RFC-64 lane;
+   * pass [] explicitly when testing ordinary public SWM behavior.
+   */
   readonly completeSwmProviders?: readonly string[];
   readonly onSnapshotRead?: (probe: {
     readonly ref: string;

--- a/packages/agent/test/swm-curator-recovery-plan.test.ts
+++ b/packages/agent/test/swm-curator-recovery-plan.test.ts
@@ -85,7 +85,6 @@ describe('private SWM curator recovery planning', () => {
       '12D3KooWUnrelatedEdge',
       [contextGraphId],
       createOperationContext('sync'),
-      { completeProviderOnly: true },
     )).resolves.toMatchObject({
       publicContextGraphIds: [],
       eligibleContextGraphIds: [],
@@ -95,7 +94,6 @@ describe('private SWM curator recovery planning', () => {
       completeProvider,
       [contextGraphId],
       createOperationContext('sync'),
-      { completeProviderOnly: true },
     )).resolves.toMatchObject({
       publicContextGraphIds: [contextGraphId],
       eligibleContextGraphIds: [contextGraphId],
@@ -125,7 +123,7 @@ describe('private SWM curator recovery planning', () => {
     });
   });
 
-  it('retains union fallback for explicit catch-up even when RFC-64 providers are configured', async () => {
+  it('rejects explicit catch-up from a non-authoritative peer when RFC-64 providers are configured', async () => {
     const contextGraphId = `${ethers.Wallet.createRandom().address}/selected-public-fallback`;
     const agent = await createAgent('ExplicitPublicSwmFallbackPlan');
     const internals = agent as any;
@@ -135,6 +133,24 @@ describe('private SWM curator recovery planning', () => {
 
     await expect(agent.planSharedMemorySyncContextGraphs(
       '12D3KooWFallbackPeer',
+      [contextGraphId],
+      createOperationContext('sync'),
+    )).resolves.toMatchObject({
+      publicContextGraphIds: [],
+      eligibleContextGraphIds: [],
+    });
+  });
+
+  it('retains ordinary public union sync when no RFC-64 complete provider is configured', async () => {
+    const contextGraphId = `${ethers.Wallet.createRandom().address}/ordinary-public-fallback`;
+    const agent = await createAgent('OrdinaryPublicSwmFallbackPlan');
+    const internals = agent as any;
+    internals.canUseSharedMemoryForContextGraph = async () => true;
+    internals.isPrivateContextGraph = async () => false;
+    internals.resolveRfc64CompleteSwmProviderPeerIdsV1 = () => [];
+
+    await expect(agent.planSharedMemorySyncContextGraphs(
+      '12D3KooWOrdinaryPeer',
       [contextGraphId],
       createOperationContext('sync'),
     )).resolves.toMatchObject({

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -851,6 +851,34 @@ describe('DKGAgent sync fetch coalescing', () => {
     }
   });
 
+  it('does not let a supplied plan bypass an RFC-64 complete-provider fence', async () => {
+    let fetchCalls = 0;
+    const selectedContextGraphId = 'selected-cg';
+    const completeProvider = '12D3KooWCompleteSwmProvider';
+    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    const sharedMemorySyncPlan = {
+      eligibleContextGraphIds: [selectedContextGraphId],
+      publicContextGraphIds: [selectedContextGraphId],
+      privateRecoverFromCurator: [],
+    };
+    (agent as any).resolveRfc64CompleteSwmProviderPeerIdsV1 = () => [completeProvider];
+    stubLifecycleFetch(agent, async ({ phase }) => {
+      fetchCalls++;
+      return emptySyncPage(phase);
+    });
+
+    try {
+      await expect((agent as any).syncSharedMemoryFromPeerDetailed(
+        PEER_A,
+        [selectedContextGraphId],
+        { sharedMemorySyncPlan },
+      )).resolves.toMatchObject({ failedPeers: 0 });
+      expect(fetchCalls).toBe(0);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
   it('does not join direct shared-memory syncs with different admission priorities', async () => {
     let fetchCalls = 0;
     const agent = await createAgentWithSend(async () => new Uint8Array(0));

--- a/packages/agent/test/sync-requester-bailout.test.ts
+++ b/packages/agent/test/sync-requester-bailout.test.ts
@@ -540,6 +540,9 @@ describe('lifecycle shared-memory fanout isolation', () => {
       syncCheckpoints: new Map(),
       workspaceOwnedEntities: new Map(),
       log: { info: noop, warn: noop, debug: noop },
+      // This fixture exercises ordinary public SWM fanout, not an RFC-64
+      // selected scope.
+      resolveRfc64CompleteSwmProviderPeerIdsV1: () => [],
       syncSharedMemoryFromPeerDetailedExecution:
         LifecycleSyncMethods.prototype.syncSharedMemoryFromPeerDetailedExecution,
     };

--- a/packages/agent/test/sync-requester-priority.test.ts
+++ b/packages/agent/test/sync-requester-priority.test.ts
@@ -282,6 +282,7 @@ describe('requester per-CG priority admission', () => {
         warn: (_ctx: unknown, message: string) => warnings.push(message),
         debug: noop,
       },
+      resolveRfc64CompleteSwmProviderPeerIdsV1: () => [],
       syncSharedMemoryFromPeerDetailedExecution:
         LifecycleSyncMethods.prototype.syncSharedMemoryFromPeerDetailedExecution,
     };
@@ -322,6 +323,7 @@ describe('requester per-CG priority admission', () => {
       syncCheckpoints: new Map(),
       workspaceOwnedEntities: new Map(),
       log: { info: noop, warn: noop, debug: noop },
+      resolveRfc64CompleteSwmProviderPeerIdsV1: () => [],
       syncSharedMemoryFromPeerDetailedExecution:
         LifecycleSyncMethods.prototype.syncSharedMemoryFromPeerDetailedExecution,
     };


### PR DESCRIPTION
## User impact

An Edge that selects a public CG through RFC-64 now receives that CG's SWM only from the graph-complete provider peers named by its accepted policy. Automatic sync, manual catch-up, coalesced work, and caller-supplied plans all obey the same source boundary.

Public CGs without an RFC-64 complete-provider declaration keep the existing multi-peer union behavior. Private-CG curator recovery is unchanged.

This closes the live canary failure where a non-authoritative Core supplied 24 extra SWM assets and the VM reconciler later promoted them, leaving the receiver above the curator's exact inventory.

## Before

```mermaid
sequenceDiagram
    participant Receiver as "Selected Edge receiver"
    participant Core as "Unrelated Core peer"
    participant Provider as "RFC-64 complete provider"
    participant Store as "Receiver store"

    Core->>Receiver: Ordinary or manual SWM sync trigger
    Receiver->>Core: Fetch selected CG through fallback path
    Core-->>Receiver: Non-authoritative selected-CG assets
    Receiver->>Store: Union insert extra SWM state
    Provider-->>Receiver: Authoritative selected-CG transfer
    Receiver->>Store: Insert authoritative state without removing extras
```

## After

```mermaid
sequenceDiagram
    participant Receiver as "Selected Edge receiver"
    participant Core as "Unrelated Core peer"
    participant Provider as "RFC-64 complete provider"
    participant Store as "Receiver store"

    Core->>Receiver: Any SWM sync trigger for selected CG
    Receiver-->>Core: Reject CG at planner and execution boundary
    Provider->>Receiver: SWM sync trigger for selected CG
    Receiver->>Provider: Fetch selected CG
    Provider-->>Receiver: Graph-complete authoritative transfer
    Receiver->>Store: Insert selected-CG state
```

## Safety properties

- A caller-supplied plan is an optimization only, never an authority token.
- The execution boundary re-resolves the accepted complete-provider set.
- Mixed plans remove only fenced public CGs; private curator recovery remains eligible.
- No complete-provider declaration means no behavioral change.

## Validation

- `pnpm run build` in `packages/agent` (TypeScript, type tests, package-root exports)
- `vitest.unit.config.ts`:
  - `swm-curator-recovery-plan.test.ts`
  - `sync-fetch-coalescing.test.ts`
- 99 tests passed, 0 failed after review hardening (including selected lifecycle and cached-plan source fencing)
- `git diff --check`

## Release validation

After this PR and the finalized SWM-twin cleanup PR land on `testnet-canary`, rerun the two-receiver Blackbox test with exact inventory enabled. Acceptance is 0 missing, 0 mismatched, and 0 extra assets for both SWM and VM.