### PR TITLE
feat(rfc64): activate selected manifests by default

### DIFF
--- a/docs/use-dkg/rfc64-selected-public-catalog.md
+++ b/docs/use-dkg/rfc64-selected-public-catalog.md
@@ -1,9 +1,11 @@
 # RFC-64 selected-public catalog activation
 
-RFC-64 public catalog synchronization is opt-in. A node with no
-`rfc64PublicCatalog` block, or with `enabled: false`, keeps the catalog lane
-fail-closed: it accepts no catalog policy, starts no bootstrap pulls, and does
-not advance catalogs after ordinary KA publication.
+RFC-64 public catalog synchronization is selected and fail-closed. A valid
+`rfc64PublicCatalog.bootstrap.acceptedPublicPolicies` manifest activates the
+exact CGs it names; no second enable switch is required. A node with no
+`rfc64PublicCatalog` block, or with explicit `enabled: false`, accepts no catalog
+policy, starts no bootstrap pulls, and does not advance catalogs after ordinary
+KA publication.
 
 This activation is intentionally selective. The operator supplies a bounded
 manifest of independently verified, finalized public-CG policy envelopes. The
@@ -24,7 +26,6 @@ Add the following shape to `~/.dkg/config.json`:
 ```json
 {
   "rfc64PublicCatalog": {
-    "enabled": true,
     "autoPublish": {
       "peers": ["12D3Koo...receiver"],
       "catalogIssuerDelegationExpiresAt": "1893456000000"
@@ -77,6 +78,9 @@ Add the following shape to `~/.dkg/config.json`:
   }
 }
 ```
+
+`enabled: true` remains accepted for compatibility, but is redundant when a
+valid manifest is present. `enabled: false` is the explicit kill switch.
 
 The example shows structure only. Do not invent or copy placeholder control
 values. The complete `policyEnvelope` must be the output of an independent
@@ -136,7 +140,7 @@ Restart the daemon and inspect `GET /api/status`:
 }
 ```
 
-For a signed-catalog target gate, `enabled: true` is not sufficient. Every
+For a signed-catalog target gate, activation alone is not sufficient. Every
 intended target must report `outcome: "applied"`, a non-null
 `appliedHeadDigest`, and the expected `inventoryRowCount`. A `not-found` or
 `failed` target is a failed catalog gate even if ordinary durable sync reports

--- a/packages/agent/src/rfc64/public-catalog-activation-config-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-activation-config-v1.ts
@@ -172,7 +172,15 @@ export function resolveRfc64PublicCatalogActivationConfigV1(
     });
   }
   assertRfc64PublicCatalogActivationConfigV1(activation);
-  const enabled = activation.enabled;
+  const enabledInput = activation.enabled;
+  if (enabledInput !== undefined && typeof enabledInput !== 'boolean') {
+    throw new TypeError('rfc64PublicCatalog.enabled must be a boolean');
+  }
+  // Supplying a valid selected-public manifest is itself the operator's
+  // activation decision. Keep absence and explicit `enabled: false`
+  // fail-closed, while avoiding a second switch that can silently leave an
+  // otherwise complete RFC-64 selection dormant.
+  const enabled = enabledInput ?? true;
   const bootstrapInput = activation.bootstrap;
   const autoPublishInput = activation.autoPublish;
   const deploymentProfileInput = activation.deploymentProfile;
@@ -181,9 +189,6 @@ export function resolveRfc64PublicCatalogActivationConfigV1(
       enabled: false,
       selectedContextGraphs: Object.freeze([]),
     });
-  }
-  if (enabled !== true) {
-    throw new TypeError('rfc64PublicCatalog.enabled must be a boolean');
   }
   const bootstrap = snapshotRfc64PublicCatalogBootstrapConfigV1(bootstrapInput);
   if (bootstrap === undefined || bootstrap.acceptedPublicPolicies.length === 0) {

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -833,6 +833,29 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     expect((agent as any).config.syncContextGraphs).toContain(CONTEXT_GRAPH_ID);
   });
 
+  it('projects a manifest-selected activation without an explicit enabled switch', async () => {
+    const selectedPolicy = buildOpenOwnerContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    const agent = await startNativeAgentWithOptions({
+      name: 'direct-manifest-selected-sync-scope',
+      activation: {
+        deploymentProfile: NATIVE_DEPLOYMENT,
+        bootstrap: {
+          acceptedPublicPolicies: [{
+            policyEnvelope: unsignedOpenContextGraphPolicyEnvelopeV1(selectedPolicy),
+            targets: [],
+          }],
+        },
+      },
+    });
+
+    expect((agent as any).config.syncContextGraphs).toContain(CONTEXT_GRAPH_ID);
+    expect((agent as any).config.rfc64PublicCatalogBootstrap).toBeDefined();
+  });
+
   it('keeps direct disabled activation fail-closed even when stale controls are present', async () => {
     const ignoredPolicy = buildOpenOwnerContextGraphPolicyV1({
       networkId: NETWORK_ID,

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -486,10 +486,10 @@ export interface GraphSetIndexConfig {
 }
 
 /**
- * Explicit selected-public RFC-64 activation. Omitted or `enabled: false`
- * leaves the catalog data plane fail-closed with no accepted policies and no
- * ordinary-publication hook. The bootstrap manifest is the selected CG set;
- * the daemon adds only those graph IDs to durable synchronization.
+ * Selected-public RFC-64 activation. An accepted bootstrap manifest activates
+ * its selected CGs by default; an omitted block or explicit `enabled: false`
+ * leaves the catalog data plane fail-closed. The daemon adds only manifest
+ * graph IDs to durable synchronization.
  */
 export type Rfc64PublicCatalogActivationConfig = Rfc64PublicCatalogActivationConfigV1;
 export type ResolvedRfc64PublicCatalogActivationConfig =

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -131,6 +131,32 @@ describe('resolveRfc64PublicCatalogActivation', () => {
     });
   });
 
+  it('activates a valid selected manifest without a redundant enabled switch', () => {
+    const resolved = resolveRfc64PublicCatalogActivation({
+      rfc64PublicCatalog: {
+        bootstrap: {
+          acceptedPublicPolicies: [policy('selected-by-manifest')],
+        },
+      },
+    }, chainIdentity);
+
+    expect(resolved).toMatchObject({
+      enabled: true,
+      selectedContextGraphs: ['selected-by-manifest'],
+    });
+  });
+
+  it('still rejects a non-boolean enabled value', () => {
+    expect(() => resolveRfc64PublicCatalogActivation({
+      rfc64PublicCatalog: {
+        enabled: 'true',
+        bootstrap: {
+          acceptedPublicPolicies: [policy('selected-invalid-switch')],
+        },
+      } as any,
+    }, chainIdentity)).toThrow(/enabled must be a boolean/u);
+  });
+
   it('keeps receiver-only activation selected while leaving auto-publish absent', () => {
     const resolved = resolveRfc64PublicCatalogActivation({
       rfc64PublicCatalog: {


### PR DESCRIPTION
## User impact

An operator-selected RFC-64 public-CG manifest now activates the exact CGs it names without requiring a second `enabled: true` switch. This prevents a correctly configured selected-public receiver from remaining unexpectedly dormant.

This is not a global public-CG sync default:

- no `rfc64PublicCatalog` block remains dormant;
- explicit `enabled: false` remains the kill switch;
- only CGs in the independently verified bootstrap manifest are selected;
- public CGs outside that manifest remain on existing paths.

Existing configurations with `enabled: true` remain valid.

## Before

```mermaid
sequenceDiagram
    participant Operator as "Node operator"
    participant Config as "RFC-64 config resolver"
    participant Agent as "DKG Agent"

    Operator->>Config: Supply accepted selected-CG manifest
    alt "enabled true also present"
        Config->>Agent: Activate manifest CGs
    else "enabled omitted"
        Config-->>Operator: Reject configuration
        Note over Agent: RFC-64 lane never starts
    end
```

## After

```mermaid
sequenceDiagram
    participant Operator as "Node operator"
    participant Config as "RFC-64 config resolver"
    participant Agent as "DKG Agent"

    Operator->>Config: Supply accepted selected-CG manifest
    alt "enabled false"
        Config-->>Agent: Keep RFC-64 dormant
    else "enabled true or omitted"
        Config->>Agent: Activate exact manifest CGs
        Agent->>Agent: Add only selected CGs to durable sync scope
    end
```

## Safety properties

- Manifest omission remains fail-closed.
- Non-boolean `enabled` values are rejected.
- Enabled activation still requires a non-empty accepted-policy manifest.
- Cross-network, duplicate, malformed, or oversized manifests remain rejected.
- Direct `DKGAgent.create()` and daemon configuration resolve identically.

## Validation

- Full dependency, agent, and CLI build: passed.
- CLI activation/config lane: 126/126 tests passed.
- Native RFC-64 agent wiring lane: 41/41 tests passed.
- `git diff --check`: passed.

## Release validation

After this PR, the authoritative-source fence, and finalized SWM-twin cleanup land on `testnet-canary`, rerun the two-receiver Blackbox test with exact inventory enabled. Acceptance is 0 missing, 0 mismatched, and 0 extra assets for both SWM and VM.
