### PR TITLE
feat(sync): default public SWM to RFC-64 scheduling

### DIFF
--- a/docs/use-dkg/rfc64-selected-public-catalog.md
+++ b/docs/use-dkg/rfc64-selected-public-catalog.md
@@ -157,15 +157,16 @@ catalog is configured:
 {
   "rfc64SelectedPublicSync": {
     "defaultEnabled": true,
-    "selectedContextGraphs": ["0x.../selected-public-cg"],
+    "requestedContextGraphs": ["0x.../selected-public-cg"],
     "catalogBackedContextGraphs": []
   }
 }
 ```
 
-`selectedContextGraphs` is the agent's live explicit sync scope, not an
-all-public discovery result. The public-CG catch-up boundary applies selected
-scheduling; the private-CG boundary ignores it and retains curator recovery.
+`requestedContextGraphs` is the agent's live explicit scheduling scope. Entries
+are not classified as public merely by appearing there: the public-CG catch-up
+boundary applies selected scheduling, while the private-CG boundary ignores it
+and retains curator recovery.
 
 For a signed-catalog target gate, activation alone is not sufficient. Every
 intended target must report `outcome: "applied"`, a non-null

--- a/docs/use-dkg/rfc64-selected-public-catalog.md
+++ b/docs/use-dkg/rfc64-selected-public-catalog.md
@@ -16,8 +16,18 @@ CG IDs in that manifest are the single source for:
 - optional graph-complete-provider native SWM recovery.
 
 There is no `sync all public CGs` mode in this release. Existing `contextGraphs`
-selection continues to work normally, and CGs outside the RFC-64 manifest stay
-on the existing publication and synchronization paths.
+selection continues to work normally. A foreground subscription that requests
+SWM now uses RFC-64 selected scheduling and bounded continuation by default for
+its explicit public CG, including across multiple candidate peers. This changes
+how the requested work is scheduled; it does not turn those peers into catalog
+authorities and does not select any additional CG.
+
+Signed-catalog activation remains the stronger, separate control plane described
+below. Only an operator-pinned `completeSwmProviders` peer may prove the whole
+selected SWM scope terminal. Without that assertion, the receiver retains
+multi-peer union convergence and never treats one ordinary peer's local manifest
+as graph-complete. Private CGs retain curator recovery, and VM remains
+chain/curator driven.
 
 ## Configuration
 
@@ -139,6 +149,23 @@ Restart the daemon and inspect `GET /api/status`:
   }
 }
 ```
+
+The independent scheduling-default projection is visible even when no signed
+catalog is configured:
+
+```json
+{
+  "rfc64SelectedPublicSync": {
+    "defaultEnabled": true,
+    "selectedContextGraphs": ["0x.../selected-public-cg"],
+    "catalogBackedContextGraphs": []
+  }
+}
+```
+
+`selectedContextGraphs` is the agent's live explicit sync scope, not an
+all-public discovery result. The public-CG catch-up boundary applies selected
+scheduling; the private-CG boundary ignores it and retains curator recovery.
 
 For a signed-catalog target gate, activation alone is not sufficient. Every
 intended target must report `outcome: "applied"`, a non-null

--- a/packages/agent/src/dkg-agent-swm-substrate.ts
+++ b/packages/agent/src/dkg-agent-swm-substrate.ts
@@ -916,6 +916,18 @@ export class SwmSubstrateMethods extends DKGAgentBase {
     return true;
   }
 
+  /**
+   * Snapshot the agent's LIVE explicit sync scope for status/preflight callers.
+   *
+   * `subscribeToContextGraph()` mutates this runtime scope without mutating the
+   * daemon's startup `DkgConfig`, so projecting startup configuration would make
+   * an exact-CG preflight stale immediately after a successful subscription.
+   * Return a copy so diagnostics cannot mutate scheduling state.
+   */
+  public getSyncContextGraphIds(this: DKGAgent): readonly string[] {
+    return Object.freeze([...(this.config.syncContextGraphs ?? [])]);
+  }
+
   getOrCreateGossipPublishHandler(this: DKGAgent): GossipPublishHandler {
     if (!this.gossipPublishHandler) {
       this.gossipPublishHandler = new GossipPublishHandler(

--- a/packages/agent/test/agent.part-15.test.ts
+++ b/packages/agent/test/agent.part-15.test.ts
@@ -77,10 +77,16 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       try {
         await agent.start();
         expect((agent as any).config.syncContextGraphs ?? []).not.toContain('runtime-contextGraph');
+        expect(agent.getSyncContextGraphIds()).not.toContain('runtime-contextGraph');
 
         agent.subscribeToContextGraph('runtime-contextGraph');
 
         expect((agent as any).config.syncContextGraphs ?? []).toContain('runtime-contextGraph');
+        const projectedScope = agent.getSyncContextGraphIds();
+        expect(projectedScope).toContain('runtime-contextGraph');
+        expect(Object.isFrozen(projectedScope)).toBe(true);
+        expect(() => (projectedScope as string[]).push('status-reader-mutation')).toThrow();
+        expect(agent.getSyncContextGraphIds()).not.toContain('status-reader-mutation');
       } finally {
         await agent.stop().catch(() => {});
       }

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -334,13 +334,14 @@ export interface DaemonStatusResponse {
   multiaddrs: string[];
   relay: RelayStatusResponse;
   /**
-   * RFC-64 scheduling for explicitly requested public Context Graphs. This is
-   * independent from signed-catalog activation: catalog authority is optional,
-   * while selected scheduling/continuation is the public-SWM default.
+   * RFC-64 scheduling input for explicitly requested Context Graphs. The
+   * requested scope is not a public classification; runtime classification
+   * still chooses the public or private synchronization lane.
    */
   rfc64SelectedPublicSync?: {
     defaultEnabled: boolean;
-    selectedContextGraphs: string[];
+    /** Requested scheduling scope; runtime classification still chooses the lane. */
+    requestedContextGraphs: string[];
     catalogBackedContextGraphs: string[];
   };
   chain?: {

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -333,6 +333,16 @@ export interface DaemonStatusResponse {
   relayConnected: boolean;
   multiaddrs: string[];
   relay: RelayStatusResponse;
+  /**
+   * RFC-64 scheduling for explicitly requested public Context Graphs. This is
+   * independent from signed-catalog activation: catalog authority is optional,
+   * while selected scheduling/continuation is the public-SWM default.
+   */
+  rfc64SelectedPublicSync?: {
+    defaultEnabled: boolean;
+    selectedContextGraphs: string[];
+    catalogBackedContextGraphs: string[];
+  };
   chain?: {
     chainId: string | null;
     configured: boolean;

--- a/packages/cli/src/catchup-runner-worker-impl.ts
+++ b/packages/cli/src/catchup-runner-worker-impl.ts
@@ -118,14 +118,17 @@ interface CatchupSharedMemoryPlane {
 
 function normalizeCatchupSharedMemoryResult(
   result: CatchupSharedMemoryRpcResult,
-  selectedRequested: boolean,
+  terminalBoundaryRequired: boolean,
 ): CatchupSharedMemoryPlane {
   const selected = selectedSharedMemoryResult(result);
   const payload = selected?.shared ?? result as SharedMemorySyncResult;
-  // A selected request that receives an older/raw host response is incomplete,
-  // not ordinary success. That makes rolling upgrades fail closed at the one
-  // boundary where the requested lane is still known.
-  const progress = selectedRequested
+  // Only an operator-pinned graph-complete provider may terminate the whole
+  // selected SWM scope. Every explicitly subscribed PUBLIC CG still uses the
+  // selected scheduler/continuation lane by default, but an ordinary peer's
+  // terminal verdict describes only that peer's local manifest and must not
+  // replace multi-peer union convergence. A complete-provider request that
+  // receives an older/raw host response remains fail-closed.
+  const progress = terminalBoundaryRequired
     ? classifySharedMemoryFreshness(payload, {
       complete: selected?.selectedScopeComplete ?? false,
     })
@@ -133,8 +136,8 @@ function normalizeCatchupSharedMemoryResult(
   return {
     payload,
     progress,
-    terminalBoundaryRequired: selectedRequested,
-    selectedScopeProven: selectedRequested
+    terminalBoundaryRequired,
+    selectedScopeProven: terminalBoundaryRequired
       && selected?.selectedScopeComplete === true
       && progress.completedWithoutFailure,
     deferredBackpressure: payload.deferredBackpressure,
@@ -468,17 +471,24 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     const syncSharedMemory = (
       { priority, source }: CatchupPlaneContext,
     ): Promise<CatchupSharedMemoryPlane> => {
-      const selectedRequested = authoritativeSharedMemoryPeerIds.has(peerId);
+      // A foreground subscribe job is already scoped to one explicit CG. For
+      // public SWM, make RFC-64 selected scheduling and bounded continuation the
+      // default on every candidate peer. This does NOT make every candidate an
+      // authority: only a pinned complete provider may furnish the terminal
+      // whole-scope proof consumed below.
+      const selectedSchedulingRequested = request.includeSharedMemory
+        && !prepared.isPrivateContextGraph;
+      const terminalBoundaryRequired = authoritativeSharedMemoryPeerIds.has(peerId);
       return invoke<CatchupSharedMemoryRpcResult>(
         'syncSharedMemory',
         peerId,
         request.contextGraphId,
         priority,
         source,
-        selectedRequested,
+        selectedSchedulingRequested,
       )
-        .then((result) => normalizeCatchupSharedMemoryResult(result, selectedRequested))
-        .catch(() => normalizeCatchupSharedMemoryResult(emptyShared(), selectedRequested));
+        .then((result) => normalizeCatchupSharedMemoryResult(result, terminalBoundaryRequired))
+        .catch(() => normalizeCatchupSharedMemoryResult(emptyShared(), terminalBoundaryRequired));
     };
 
     // Narrow each fallback peer to the planes the AUTHORITY has not already
@@ -533,6 +543,10 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
     const round = await runCatchupPlanesWithPolicy({
       mode: 'foreground',
       includeSharedMemory: needSharedMemory,
+      // Preserve the durable-before-SWM dependency for ordinary candidates.
+      // Only an explicit graph-complete SWM provider earns the shared-first
+      // optimization; selected scheduling still applies when the SWM plane is
+      // admitted below.
       planeOrder: needSharedMemory && authoritativeSharedMemoryPeerIds.has(peerId)
         ? 'shared-first'
         : 'durable-first',

--- a/packages/cli/src/catchup-runner-worker-impl.ts
+++ b/packages/cli/src/catchup-runner-worker-impl.ts
@@ -116,9 +116,16 @@ interface CatchupSharedMemoryPlane {
   readonly deferredBackpressure?: number;
 }
 
+interface CatchupSharedMemoryPolicy {
+  /** Request the selected scheduler/continuation lane for this explicit public CG. */
+  readonly selectedSchedulingRequested: boolean;
+  /** Require a graph-complete provider's typed terminal boundary. */
+  readonly terminalBoundaryRequired: boolean;
+}
+
 function normalizeCatchupSharedMemoryResult(
   result: CatchupSharedMemoryRpcResult,
-  terminalBoundaryRequired: boolean,
+  policy: CatchupSharedMemoryPolicy,
 ): CatchupSharedMemoryPlane {
   const selected = selectedSharedMemoryResult(result);
   const payload = selected?.shared ?? result as SharedMemorySyncResult;
@@ -128,16 +135,18 @@ function normalizeCatchupSharedMemoryResult(
   // terminal verdict describes only that peer's local manifest and must not
   // replace multi-peer union convergence. A complete-provider request that
   // receives an older/raw host response remains fail-closed.
-  const progress = terminalBoundaryRequired
+  const progress = policy.selectedSchedulingRequested
     ? classifySharedMemoryFreshness(payload, {
-      complete: selected?.selectedScopeComplete ?? false,
+      complete: policy.terminalBoundaryRequired
+        ? selected?.selectedScopeComplete === true
+        : true,
     })
     : classifyDurableProgress(payload);
   return {
     payload,
     progress,
-    terminalBoundaryRequired,
-    selectedScopeProven: terminalBoundaryRequired
+    terminalBoundaryRequired: policy.terminalBoundaryRequired,
+    selectedScopeProven: policy.terminalBoundaryRequired
       && selected?.selectedScopeComplete === true
       && progress.completedWithoutFailure,
     deferredBackpressure: payload.deferredBackpressure,
@@ -476,19 +485,21 @@ async function runCatchup(request: CatchupRunRequest): Promise<CatchupJobResult>
       // default on every candidate peer. This does NOT make every candidate an
       // authority: only a pinned complete provider may furnish the terminal
       // whole-scope proof consumed below.
-      const selectedSchedulingRequested = request.includeSharedMemory
-        && !prepared.isPrivateContextGraph;
-      const terminalBoundaryRequired = authoritativeSharedMemoryPeerIds.has(peerId);
+      const policy: CatchupSharedMemoryPolicy = {
+        selectedSchedulingRequested: request.includeSharedMemory
+          && !prepared.isPrivateContextGraph,
+        terminalBoundaryRequired: authoritativeSharedMemoryPeerIds.has(peerId),
+      };
       return invoke<CatchupSharedMemoryRpcResult>(
         'syncSharedMemory',
         peerId,
         request.contextGraphId,
         priority,
         source,
-        selectedSchedulingRequested,
+        policy.selectedSchedulingRequested,
       )
-        .then((result) => normalizeCatchupSharedMemoryResult(result, terminalBoundaryRequired))
-        .catch(() => normalizeCatchupSharedMemoryResult(emptyShared(), terminalBoundaryRequired));
+        .then((result) => normalizeCatchupSharedMemoryResult(result, policy))
+        .catch(() => normalizeCatchupSharedMemoryResult(emptyShared(), policy));
     };
 
     // Narrow each fallback peer to the planes the AUTHORITY has not already

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -98,6 +98,7 @@ import {
   type LocalAgentIntegrationStatus,
   type LocalAgentIntegrationTransport,
   resolveContextGraphs,
+  resolveNetworkDefaultContextGraphs,
   resolveNetworkConfigName,
   resolveSharedMemoryTtlMs,
   repoDir,
@@ -580,6 +581,25 @@ function summarizeRegistryEntry(e: IntegrationEntry) {
   };
 }
 
+function projectRfc64SelectedPublicSyncStatus(
+  agent: DKGAgent,
+  networkDefaultContextGraphs: readonly string[],
+  catalogBackedContextGraphs: readonly string[],
+) {
+  // This is the effective requested sync scope, not proof that every listed
+  // graph is public. Runtime classification still decides whether a graph uses
+  // the RFC-64 selected-public lane or the private curator-recovery lane.
+  const requestedContextGraphs = [...new Set([
+    ...agent.getSyncContextGraphIds(),
+    ...networkDefaultContextGraphs,
+  ])];
+  return {
+    defaultEnabled: true,
+    selectedContextGraphs: requestedContextGraphs,
+    catalogBackedContextGraphs: [...new Set(catalogBackedContextGraphs)],
+  };
+}
+
 export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
   const {
     req,
@@ -771,12 +791,11 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
           providers: accepted.completeSwmProviders,
         }))
       : [];
-    const rfc64SelectedPublicSyncContextGraphs = typeof agent.getSyncContextGraphIds === 'function'
-      ? agent.getSyncContextGraphIds()
-      : [
-        ...resolveContextGraphs(config),
-        ...rfc64PublicCatalogActivation.selectedContextGraphs,
-      ];
+    const rfc64SelectedPublicSync = projectRfc64SelectedPublicSyncStatus(
+      agent,
+      resolveNetworkDefaultContextGraphs(network),
+      rfc64PublicCatalogActivation.selectedContextGraphs,
+    );
     const unavailableFinalizationRecovery = (reason: string) => ({
       available: false,
       closed: false,
@@ -900,11 +919,7 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       // curator recovery, and only `completeSwmProviders` may prove a whole
       // public SWM scope terminal. The harness knows its generated CG is public
       // and uses this exact requested-scope projection as its no-spend preflight.
-      rfc64SelectedPublicSync: {
-        defaultEnabled: true,
-        selectedContextGraphs: [...new Set(rfc64SelectedPublicSyncContextGraphs)],
-        catalogBackedContextGraphs: rfc64PublicCatalogActivation.selectedContextGraphs,
-      },
+      rfc64SelectedPublicSync,
       hasOpenClawChannel: hasConfiguredLocalAgentChat(config, 'openclaw'),
       localAgentIntegrations,
       connectedLocalAgentIds: localAgentIntegrations.filter((integration) => integration.enabled).map((integration) => integration.id),

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -595,7 +595,7 @@ function projectRfc64SelectedPublicSyncStatus(
   ])];
   return {
     defaultEnabled: true,
-    selectedContextGraphs: requestedContextGraphs,
+    requestedContextGraphs,
     catalogBackedContextGraphs: [...new Set(catalogBackedContextGraphs)],
   };
 }

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -98,7 +98,6 @@ import {
   type LocalAgentIntegrationStatus,
   type LocalAgentIntegrationTransport,
   resolveContextGraphs,
-  resolveNetworkDefaultContextGraphs,
   resolveNetworkConfigName,
   resolveSharedMemoryTtlMs,
   repoDir,
@@ -772,6 +771,12 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
           providers: accepted.completeSwmProviders,
         }))
       : [];
+    const rfc64SelectedPublicSyncContextGraphs = typeof agent.getSyncContextGraphIds === 'function'
+      ? agent.getSyncContextGraphIds()
+      : [
+        ...resolveContextGraphs(config),
+        ...rfc64PublicCatalogActivation.selectedContextGraphs,
+      ];
     const unavailableFinalizationRecovery = (reason: string) => ({
       available: false,
       closed: false,
@@ -888,6 +893,17 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
         completeSwmProviders: rfc64CompleteSwmProviders,
         service: rfc64PublicCatalogService,
         bootstrap: rfc64PublicCatalogBootstrap,
+      },
+      // Product-default scheduling is deliberately separate from the signed
+      // catalog authority surface above. Every explicitly requested CG is
+      // eligible for RFC-64 selected PUBLIC-SWM scheduling; private CGs retain
+      // curator recovery, and only `completeSwmProviders` may prove a whole
+      // public SWM scope terminal. The harness knows its generated CG is public
+      // and uses this exact requested-scope projection as its no-spend preflight.
+      rfc64SelectedPublicSync: {
+        defaultEnabled: true,
+        selectedContextGraphs: [...new Set(rfc64SelectedPublicSyncContextGraphs)],
+        catalogBackedContextGraphs: rfc64PublicCatalogActivation.selectedContextGraphs,
       },
       hasOpenClawChannel: hasConfiguredLocalAgentChat(config, 'openclaw'),
       localAgentIntegrations,

--- a/packages/cli/test/catchup-runner-worker-impl.test.ts
+++ b/packages/cli/test/catchup-runner-worker-impl.test.ts
@@ -506,6 +506,53 @@ describe('catchup-runner-worker-impl bounded fan-out (sync-storm mitigation C-1)
     expect(result.cleanPlaneCompletions?.sharedMemory.selectedScopeCompletePeers ?? 0).toBe(0);
   });
 
+  it('still calls every ordinary peer after a selected-complete local manifest response', async () => {
+    const peerIds = ['peer-ordinary-a', 'peer-ordinary-b'];
+    const sharedCalls: string[] = [];
+    const result = await runWorkerCatchup(
+      { contextGraphId: 'cg-public-selected-union', includeSharedMemory: true },
+      async (method, args) => {
+        switch (method) {
+          case 'prepareCatchup':
+            return {
+              isPrivateContextGraph: false,
+              authoritativeSharedMemoryPeerIds: [],
+              peerIds,
+              connectedPeers: peerIds.length,
+            };
+          case 'waitForSyncProtocol':
+            return true;
+          case 'syncDurable':
+            return { ...durableResult(), complete: false, failedPhases: 1 };
+          case 'syncSharedMemory': {
+            expect(args[4]).toBe(true);
+            sharedCalls.push(String(args[0]));
+            return {
+              kind: 'selected-shared-memory',
+              shared: {
+                ...sharedResult(),
+                insertedTriples: 0,
+                fetchedDataTriples: 0,
+                insertedDataTriples: 0,
+                bytesReceived: 0,
+                emptyResponses: 1,
+              },
+              selectedScopeComplete: true,
+            };
+          }
+          case 'finalizeCatchup':
+            return null;
+          default:
+            throw new Error(`unexpected invoke: ${method}`);
+        }
+      },
+    );
+
+    expect(sharedCalls.sort()).toEqual([...peerIds].sort());
+    expect(result.peersTried).toBe(peerIds.length);
+    expect(result.cleanPlaneCompletions?.sharedMemory.selectedScopeCompletePeers ?? 0).toBe(0);
+  });
+
   it('escalates waves and still caps in-flight peer syncs when no peer proves the plane', async () => {
     const peerIds = Array.from({ length: 20 }, (_, i) => `peer-${i}`);
     // The bound is only observable when the peer set exceeds the cap.

--- a/packages/cli/test/catchup-runner-worker-impl.test.ts
+++ b/packages/cli/test/catchup-runner-worker-impl.test.ts
@@ -467,6 +467,45 @@ describe('catchup-runner-worker-impl bounded fan-out (sync-storm mitigation C-1)
     expect(result.peersSucceeded).toBe(1);
   });
 
+  it('uses selected scheduling for public SWM without promoting an ordinary peer to graph authority', async () => {
+    const selectedFlags: unknown[] = [];
+    const result = await runWorkerCatchup(
+      { contextGraphId: 'cg-public-selected-default', includeSharedMemory: true },
+      async (method, args) => {
+        switch (method) {
+          case 'prepareCatchup':
+            return {
+              preferredPeerId: 'peer-curator',
+              authoritativePeerId: 'peer-curator',
+              authoritativeSharedMemoryPeerIds: [],
+              isPrivateContextGraph: false,
+              peerIds: ['peer-curator'],
+              connectedPeers: 1,
+            };
+          case 'waitForSyncProtocol':
+            return true;
+          case 'syncDurable':
+            return durableResult();
+          case 'syncSharedMemory':
+            selectedFlags.push(args[4]);
+            return {
+              kind: 'selected-shared-memory',
+              shared: sharedResult(),
+              selectedScopeComplete: true,
+            };
+          case 'finalizeCatchup':
+            return null;
+          default:
+            throw new Error(`unexpected invoke: ${method}`);
+        }
+      },
+    );
+
+    expect(selectedFlags).toEqual([true]);
+    expect(result.cleanPlaneCompletions?.sharedMemory.verifiedDataPeers).toBe(1);
+    expect(result.cleanPlaneCompletions?.sharedMemory.selectedScopeCompletePeers ?? 0).toBe(0);
+  });
+
   it('escalates waves and still caps in-flight peer syncs when no peer proves the plane', async () => {
     const peerIds = Array.from({ length: 20 }, (_, i) => `peer-${i}`);
     // The bound is only observable when the peer set exceeds the cap.
@@ -578,6 +617,7 @@ describe('catchup-runner-worker-impl bounded fan-out (sync-storm mitigation C-1)
           durableCalls.push(args[0] as string);
           return { ...durableResult(), complete: false };
         case 'syncSharedMemory':
+          expect(args[4]).toBe(true);
           sharedCalls.push(args[0] as string);
           return sharedResult();
         case 'finalizeCatchup':
@@ -677,6 +717,7 @@ describe('catchup-runner-worker-impl bounded fan-out (sync-storm mitigation C-1)
           durableCalls.push(args[0] as string);
           return durableResult();
         case 'syncSharedMemory':
+          expect(args[4]).toBe(true);
           sharedCalls.push(args[0] as string);
           // The curator has nothing; a later member holds the rows.
           if (args[0] === 'peer-0') {
@@ -901,6 +942,7 @@ describe('catchup-runner-worker-impl bounded fan-out (sync-storm mitigation C-1)
             verifiedPrivateOnlyResponses: 1,
           };
         case 'syncSharedMemory':
+          expect(args[4]).toBe(false);
           sharedCalls.push(args[0] as string);
           return {
             ...sharedResult(),

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -64,6 +64,7 @@ async function requestStatusWithAgent(
   agentOverrides: Record<string, unknown>,
   configOverrides: Record<string, unknown> = {},
   requestPath = '/api/status',
+  networkOverride: RequestContext['network'] = null,
 ): Promise<{ status: number; body: any }> {
   const server = createServer(async (req, res) => {
     const url = new URL(req.url ?? '/', 'http://127.0.0.1');
@@ -79,7 +80,7 @@ async function requestStatusWithAgent(
       publisherState: DISABLED_PUBLISHER_STATE,
       path: url.pathname,
       url,
-      network: null,
+      network: networkOverride,
       config,
       rfc64PublicCatalog: resolveRfc64PublicCatalogActivation(
         config as never,
@@ -94,6 +95,7 @@ async function requestStatusWithAgent(
           getRelayStats: () => null,
         },
         publisher: { getIdentityId: () => 0n },
+        getSyncContextGraphIds: () => [],
         ...agentOverrides,
       },
       nodeVersion: '0.0.0-test',
@@ -424,6 +426,22 @@ describe('/api/status RFC-64 selected-public activation', () => {
     });
   });
 
+  it('includes network-default graphs in the effective requested sync scope', async () => {
+    const response = await requestStatusWithAgent(
+      { getSyncContextGraphIds: () => ['explicit-public-cg'] },
+      {},
+      '/api/status',
+      { defaultContextGraphs: ['network-default-cg', 'explicit-public-cg'] } as never,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.rfc64SelectedPublicSync).toEqual({
+      defaultEnabled: true,
+      selectedContextGraphs: ['explicit-public-cg', 'network-default-cg'],
+      catalogBackedContextGraphs: [],
+    });
+  });
+
   it('reports the fail-closed disabled state without invoking catalog controls', async () => {
     const catalogStats = vi.fn(() => {
       throw new Error('disabled status must not read catalog service state');
@@ -470,6 +488,7 @@ describe('/api/status RFC-64 selected-public activation', () => {
       {
         rfc64PublicCatalogStatsV1: () => service,
         readRfc64PublicCatalogBootstrapStatusV1: () => bootstrap,
+        getSyncContextGraphIds: () => ['selected-public-cg'],
       },
       {
         rfc64PublicCatalog: {
@@ -499,6 +518,11 @@ describe('/api/status RFC-64 selected-public activation', () => {
       }],
       service,
       bootstrap,
+    });
+    expect(response.body.rfc64SelectedPublicSync).toEqual({
+      defaultEnabled: true,
+      selectedContextGraphs: ['selected-public-cg'],
+      catalogBackedContextGraphs: ['selected-public-cg'],
     });
   });
 

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -584,6 +584,7 @@ describe('/api/status selected overlay details', () => {
         agent: {
           peerId: 'peer-status-test',
           multiaddrs: [],
+          getSyncContextGraphIds: () => [],
           node: {
             libp2p: { getConnections: () => [] },
             getRelayStats: () => null,
@@ -656,6 +657,7 @@ describe('/api/status selected overlay details', () => {
           agent: {
             peerId: 'peer-status-test',
             multiaddrs: [],
+            getSyncContextGraphIds: () => [],
             node: { libp2p: { getConnections: () => [] }, getRelayStats: () => null },
             publisher: { getIdentityId: () => 0n },
           },

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -410,6 +410,20 @@ describe('/api/status finalization recovery health', () => {
 });
 
 describe('/api/status RFC-64 selected-public activation', () => {
+  it('reports RFC-64 selected public scheduling as the default for explicit subscriptions', async () => {
+    const response = await requestStatusWithAgent({
+      // Runtime subscribe mutates the agent scope, not the startup CLI config.
+      getSyncContextGraphIds: () => ['explicit-public-cg'],
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.rfc64SelectedPublicSync).toEqual({
+      defaultEnabled: true,
+      selectedContextGraphs: ['explicit-public-cg'],
+      catalogBackedContextGraphs: [],
+    });
+  });
+
   it('reports the fail-closed disabled state without invoking catalog controls', async () => {
     const catalogStats = vi.fn(() => {
       throw new Error('disabled status must not read catalog service state');

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -421,23 +421,23 @@ describe('/api/status RFC-64 selected-public activation', () => {
     expect(response.status).toBe(200);
     expect(response.body.rfc64SelectedPublicSync).toEqual({
       defaultEnabled: true,
-      selectedContextGraphs: ['explicit-public-cg'],
+      requestedContextGraphs: ['explicit-public-cg'],
       catalogBackedContextGraphs: [],
     });
   });
 
-  it('includes network-default graphs in the effective requested sync scope', async () => {
+  it('reports mixed requested scopes without classifying a network-default graph as public', async () => {
     const response = await requestStatusWithAgent(
       { getSyncContextGraphIds: () => ['explicit-public-cg'] },
       {},
       '/api/status',
-      { defaultContextGraphs: ['network-default-cg', 'explicit-public-cg'] } as never,
+      { defaultContextGraphs: ['private-network-default-cg', 'explicit-public-cg'] } as never,
     );
 
     expect(response.status).toBe(200);
     expect(response.body.rfc64SelectedPublicSync).toEqual({
       defaultEnabled: true,
-      selectedContextGraphs: ['explicit-public-cg', 'network-default-cg'],
+      requestedContextGraphs: ['explicit-public-cg', 'private-network-default-cg'],
       catalogBackedContextGraphs: [],
     });
   });
@@ -521,7 +521,7 @@ describe('/api/status RFC-64 selected-public activation', () => {
     });
     expect(response.body.rfc64SelectedPublicSync).toEqual({
       defaultEnabled: true,
-      selectedContextGraphs: ['selected-public-cg'],
+      requestedContextGraphs: ['selected-public-cg'],
       catalogBackedContextGraphs: ['selected-public-cg'],
     });
   });

--- a/packages/cli/test/status-route-store-quads.test.ts
+++ b/packages/cli/test/status-route-store-quads.test.ts
@@ -64,6 +64,7 @@ async function startStatusServer(query: () => Promise<unknown>): Promise<{
       agent: {
         peerId: 'peer-status-store-quads-test',
         multiaddrs: [],
+        getSyncContextGraphIds: () => [],
         store: { query },
         node: {
           libp2p: { getConnections: () => [] },


### PR DESCRIPTION
## Impact

An explicit foreground subscription to a public Context Graph now uses the RFC-64 selected SWM scheduler and bounded continuation lane by default on every candidate peer. Operators no longer need a signed-catalog manifest merely to get selected scheduling for the CG they explicitly requested.

This does **not** sync all public CGs and does **not** make ordinary peers authoritative. Multi-peer union convergence remains in force unless the operator explicitly pins an RFC-64 `completeSwmProviders` peer. Only that stronger provider assertion may prove the whole SWM scope terminal. Private CG curator recovery and chain-driven VM recovery are unchanged.

`GET /api/status` now exposes the independently testable product default as `rfc64SelectedPublicSync`, sourced from the agent's live sync scope rather than stale startup configuration. This gives the Blackbox harness a fail-closed, exact-CG preflight after subscription and before it publishes or spends.

## Before

```mermaid
sequenceDiagram
    participant User
    participant Receiver
    participant Peers
    User->>Receiver: Subscribe to public CG with SWM
    Receiver->>Peers: Ordinary bounded peer walk
    Note over Receiver,Peers: RFC-64 continuation required a pinned complete provider
```

## After

```mermaid
sequenceDiagram
    participant User
    participant Receiver
    participant Peers
    User->>Receiver: Subscribe to explicit public CG with SWM
    Receiver->>Receiver: Add CG to live sync scope
    Receiver->>Receiver: Select RFC-64 scheduling by default
    Receiver->>Peers: Run selected scheduling and bounded continuation
    alt Complete provider explicitly pinned
        Peers-->>Receiver: Graph-complete terminal proof
        Receiver-->>User: Whole SWM scope proven
    else Ordinary candidate peers
        Peers-->>Receiver: Per-peer content and progress
        Receiver->>Peers: Preserve multi-peer union convergence
    end
```

## Safety boundaries

- Edge nodes still synchronize only their selected sync scope.
- VM remains chain/curator driven.
- Private CGs retain curator recovery.
- An ordinary peer's selected-lane completion cannot increment `selectedScopeCompletePeers` or terminate the graph-wide walk.
- Existing complete-provider requests remain fail-closed if the typed terminal boundary is missing.
- Status returns a copy of the live scope; diagnostics cannot mutate scheduler state.

## Evidence

- Agent build, type tests, and package-root tests: pass.
- CLI build, TypeScript, catch-up worker package boundary, and runtime asset copy: pass.
- Catch-up worker and host bridge: 66 tests passed.
- Exact live-scope status projection regression: passed.
- `git diff --check`: clean.

## Harness

Companion harness PR: OriginTrail/dkg-blackbox-harness#15. It refuses an SWM run before ticket issuance/publication unless the exact run CG appears under `rfc64SelectedPublicSync.selectedContextGraphs` with the product default enabled.
