### PR TITLE
fix(sync): recover finalized VM and rewind partial graph cursors

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -1608,13 +1608,7 @@ export class DKGAgentBase {
    * so denied peers must remain eligible on the next reconciler cadence.
    */
   protected readonly lastSyncProgressAt = new Map<string, number>();
-  /**
-   * Per-peer timestamp of the most recent graph-complete selected-SWM pass.
-   * Kept separate from `lastSuccessfulSyncAt` because selected refresh proves
-   * neither durable state nor unrelated Context Graphs on the same peer.
-   */
-  protected readonly lastSelectedSwmSyncAt = new Map<string, number>();
-  /** Peer + selected-CG scoped seed/retry/terminal state for RFC-64 SWM. */
+  /** Peer + selected-CG scoped seed/retry/terminal/freshness state for RFC-64 SWM. */
   protected readonly selectedSwmBootstrapAdmission = new SelectedSwmBootstrapAdmission();
   /**
    * Per-peer sync-reconciler backoff. `failures` is the count of

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -1608,6 +1608,12 @@ export class DKGAgentBase {
    * so denied peers must remain eligible on the next reconciler cadence.
    */
   protected readonly lastSyncProgressAt = new Map<string, number>();
+  /**
+   * Per-peer timestamp of the most recent graph-complete selected-SWM pass.
+   * Kept separate from `lastSuccessfulSyncAt` because selected refresh proves
+   * neither durable state nor unrelated Context Graphs on the same peer.
+   */
+  protected readonly lastSelectedSwmSyncAt = new Map<string, number>();
   /** Peer + selected-CG scoped seed/retry/terminal state for RFC-64 SWM. */
   protected readonly selectedSwmBootstrapAdmission = new SelectedSwmBootstrapAdmission();
   /**

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -4179,7 +4179,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.lastSyncDisconnectedAt.delete(remotePeer);
     this.lastSuccessfulSyncAt.delete(remotePeer);
     this.lastSyncProgressAt.delete(remotePeer);
-    this.lastSelectedSwmSyncAt.delete(remotePeer);
     this.selectedSwmBootstrapAdmission.clear(remotePeer);
     this.syncReconcilerBackoff.delete(remotePeer);
     this.warmedCores.delete(remotePeer);
@@ -4630,9 +4629,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         if (outcome?.progress) {
           this.lastSyncProgressAt.set(peerId, progressAt);
         }
-        if (outcome?.fresh) {
-          this.lastSelectedSwmSyncAt.set(peerId, progressAt);
-        }
         // A selected-only retry never stamps the whole peer fresh; durable and
         // unrelated CG lanes were deliberately outside this invocation.
         this.skippedNoSyncPeers.delete(peerId);
@@ -4906,11 +4902,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         || lastSyncCooldown <= lastDisconnected
         || (now - lastSyncCooldown) >= SYNC_STALENESS_THRESHOLD_MS);
       const selectedContextGraphIds = this.selectedSwmBootstrapContextGraphIdsForPeer(peerId);
-      const lastSelectedSwmSync = this.lastSelectedSwmSyncAt.get(peerId);
-      const selectedSwmStale = selectedContextGraphIds.length > 0 && (
-        lastSelectedSwmSync == null
-        || lastSelectedSwmSync <= lastDisconnected
-        || (now - lastSelectedSwmSync) >= SYNC_STALENESS_THRESHOLD_MS
+      const selectedSwmStale = this.selectedSwmBootstrapAdmission.shouldRefresh(
+        peerId,
+        selectedContextGraphIds,
+        {
+          now,
+          disconnectBoundary: lastDisconnected,
+          staleAfterMs: SYNC_STALENESS_THRESHOLD_MS,
+        },
       );
       if (!broadSyncStale && !selectedSwmStale) continue;
       // Per-peer exponential backoff: a peer that can never be synced
@@ -4935,8 +4934,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         // this selected graph again. Re-open only this peer/scope after the
         // bounded freshness window; the broad sync kill switch and unselected
         // graphs remain untouched.
-        this.selectedSwmBootstrapAdmission.clear(peerId);
-        this.selectedSwmBootstrapAdmission.request(peerId, selectedContextGraphIds);
+        this.selectedSwmBootstrapAdmission.requestRefresh(peerId, selectedContextGraphIds);
         this.log.info(
           ctx,
           `Sync reconciler refreshing ${selectedContextGraphIds.length} selected shared-memory Context Graph(s) from ${shortPeer}`,
@@ -4984,11 +4982,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         this.lastSyncProgressAt.delete(peerId);
       }
     }
-    for (const [peerId, ts] of this.lastSelectedSwmSyncAt) {
-      if (!connected.has(peerId) && now - ts >= SYNC_STALENESS_THRESHOLD_MS) {
-        this.lastSelectedSwmSyncAt.delete(peerId);
-      }
-    }
+    this.selectedSwmBootstrapAdmission.pruneDisconnected(
+      connected,
+      now,
+      SYNC_STALENESS_THRESHOLD_MS,
+    );
     for (const [peerId, backoff] of this.syncReconcilerBackoff) {
       if (!connected.has(peerId) && now >= backoff.nextRetryAt + SYNC_STALENESS_THRESHOLD_MS) {
         this.syncReconcilerBackoff.delete(peerId);
@@ -7249,7 +7247,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         && continuationExecution.incompleteContextGraphIds.length === 0;
       if (selectedScopeComplete) {
         this.selectedSwmBootstrapAdmission.markTransferTerminal(selectedBootstrapOwner!);
-        this.lastSelectedSwmSyncAt.set(remotePeerId, Date.now());
       }
       // Preserve the raw historical yield/failure counters for diagnostics;
       // the canonical freshness helper bounds the selected continuation's

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -1291,6 +1291,14 @@ interface RecoverContextGraphSwmFromPeerDependencies {
 
 type SyncReconcilerAttemptOutcome = SyncOnConnectOutcome | 'not-started' | 'deferred-backpressure';
 
+type SyncReconcilerAttemptPlan =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'broad' }
+  | {
+    readonly kind: 'selected-swm';
+    readonly contextGraphIds: readonly string[];
+  };
+
 export interface ContextGraphCatchupOptions {
   includeSharedMemory?: boolean;
   maxPeers?: number;
@@ -4883,6 +4891,40 @@ export class LifecycleSyncMethods extends DKGAgentBase {
    * Designed to be safe to call concurrently with the event-driven path
    * — `runSyncOnConnect` itself is idempotent via `syncingPeers`.
    */
+  planSyncReconcilerAttempt(
+    this: DKGAgent,
+    peerId: string,
+    options: {
+      readonly broadSyncEnabled: boolean;
+      readonly now: number;
+      readonly disconnectBoundary: number;
+      readonly lastSyncCooldown: number;
+    },
+  ): SyncReconcilerAttemptPlan {
+    const broadSyncStale = options.broadSyncEnabled && (
+      options.lastSyncCooldown === 0
+      || options.lastSyncCooldown <= options.disconnectBoundary
+      || (options.now - options.lastSyncCooldown) >= SYNC_STALENESS_THRESHOLD_MS
+    );
+    // Broad sync owns the attempt whenever it is due. Selected-SWM refresh is
+    // an independent fallback for deployments that disable broad sync, not a
+    // second transfer to schedule beside the same peer attempt.
+    if (broadSyncStale) return { kind: 'broad' };
+
+    const contextGraphIds = this.selectedSwmBootstrapContextGraphIdsForPeer(peerId);
+    if (!this.selectedSwmBootstrapAdmission.shouldRefresh(
+      peerId,
+      contextGraphIds,
+      {
+        now: options.now,
+        disconnectBoundary: options.disconnectBoundary,
+        staleAfterMs: SYNC_STALENESS_THRESHOLD_MS,
+      },
+    )) return { kind: 'none' };
+
+    return { kind: 'selected-swm', contextGraphIds };
+  }
+
   async reconcileSyncFromConnectedPeers(this: DKGAgent): Promise<void> {
     if (!this.started) return;
     if (!syncReconcilerEnabled(this.config)) return;
@@ -4898,20 +4940,16 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       const lastDisconnected = this.syncOnConnectDisconnectBoundary(peerId, now);
       const lastProgress = this.lastSyncProgressAt.get(peerId);
       const lastSyncCooldown = Math.max(lastOk ?? 0, lastProgress ?? 0);
-      const broadSyncStale = broadSyncEnabled && (lastSyncCooldown === 0
-        || lastSyncCooldown <= lastDisconnected
-        || (now - lastSyncCooldown) >= SYNC_STALENESS_THRESHOLD_MS);
-      const selectedContextGraphIds = this.selectedSwmBootstrapContextGraphIdsForPeer(peerId);
-      const selectedSwmStale = this.selectedSwmBootstrapAdmission.shouldRefresh(
+      const attemptPlan = this.planSyncReconcilerAttempt(
         peerId,
-        selectedContextGraphIds,
         {
+          broadSyncEnabled,
           now,
           disconnectBoundary: lastDisconnected,
-          staleAfterMs: SYNC_STALENESS_THRESHOLD_MS,
+          lastSyncCooldown,
         },
       );
-      if (!broadSyncStale && !selectedSwmStale) continue;
+      if (attemptPlan.kind === 'none') continue;
       // Per-peer exponential backoff: a peer that can never be synced
       // (dead / NAT-stuck / persistently stream-resetting) never stamps
       // `lastSuccessfulSyncAt`, so it reads as perpetually stale. Without
@@ -4929,20 +4967,20 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       }
       if (!(await this.ensurePeerAdmittedForRecovery(peerId, ctx, 'Sync reconciler'))) continue;
       const shortPeer = peerId.slice(-8);
-      if (selectedSwmStale && !broadSyncStale) {
+      if (attemptPlan.kind === 'selected-swm') {
         // Terminal means complete at the last observed head, not never refresh
         // this selected graph again. Re-open only this peer/scope after the
         // bounded freshness window; the broad sync kill switch and unselected
         // graphs remain untouched.
-        this.selectedSwmBootstrapAdmission.requestRefresh(peerId, selectedContextGraphIds);
+        this.selectedSwmBootstrapAdmission.requestRefresh(peerId, attemptPlan.contextGraphIds);
         this.log.info(
           ctx,
-          `Sync reconciler refreshing ${selectedContextGraphIds.length} selected shared-memory Context Graph(s) from ${shortPeer}`,
+          `Sync reconciler refreshing ${attemptPlan.contextGraphIds.length} selected shared-memory Context Graph(s) from ${shortPeer}`,
         );
       } else {
         this.log.info(ctx, `Sync reconciler retrying ${shortPeer} (last success: ${lastOk == null ? 'never' : `${Math.round((now - lastOk) / 1000)}s ago`}${backoff ? `, prior failures: ${backoff.failures}` : ''})`);
       }
-      const attempt = selectedSwmStale && !broadSyncStale
+      const attempt = attemptPlan.kind === 'selected-swm'
         ? this.attemptSelectedSwmRetryWithReconcilerAccounting(peerId, probe, 'reconcile')
         : this.attemptSyncFromPeerWithReconcilerAccounting(peerId, probe, 'reconcile');
       attempt

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -4179,6 +4179,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.lastSyncDisconnectedAt.delete(remotePeer);
     this.lastSuccessfulSyncAt.delete(remotePeer);
     this.lastSyncProgressAt.delete(remotePeer);
+    this.lastSelectedSwmSyncAt.delete(remotePeer);
     this.selectedSwmBootstrapAdmission.clear(remotePeer);
     this.syncReconcilerBackoff.delete(remotePeer);
     this.warmedCores.delete(remotePeer);
@@ -4629,6 +4630,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         if (outcome?.progress) {
           this.lastSyncProgressAt.set(peerId, progressAt);
         }
+        if (outcome?.fresh) {
+          this.lastSelectedSwmSyncAt.set(peerId, progressAt);
+        }
         // A selected-only retry never stamps the whole peer fresh; durable and
         // unrelated CG lanes were deliberately outside this invocation.
         this.skippedNoSyncPeers.delete(peerId);
@@ -4885,7 +4889,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
    */
   async reconcileSyncFromConnectedPeers(this: DKGAgent): Promise<void> {
     if (!this.started) return;
-    if (!syncReconcilerEnabled(this.config) || !syncOnConnectEnabled(this.config)) return;
+    if (!syncReconcilerEnabled(this.config)) return;
+    const broadSyncEnabled = syncOnConnectEnabled(this.config);
     const now = Date.now();
     const ctx = createOperationContext('sync');
     this.pruneSyncReconcilerState(now);
@@ -4897,10 +4902,17 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       const lastDisconnected = this.syncOnConnectDisconnectBoundary(peerId, now);
       const lastProgress = this.lastSyncProgressAt.get(peerId);
       const lastSyncCooldown = Math.max(lastOk ?? 0, lastProgress ?? 0);
-      const stale = lastSyncCooldown === 0
+      const broadSyncStale = broadSyncEnabled && (lastSyncCooldown === 0
         || lastSyncCooldown <= lastDisconnected
-        || (now - lastSyncCooldown) >= SYNC_STALENESS_THRESHOLD_MS;
-      if (!stale) continue;
+        || (now - lastSyncCooldown) >= SYNC_STALENESS_THRESHOLD_MS);
+      const selectedContextGraphIds = this.selectedSwmBootstrapContextGraphIdsForPeer(peerId);
+      const lastSelectedSwmSync = this.lastSelectedSwmSyncAt.get(peerId);
+      const selectedSwmStale = selectedContextGraphIds.length > 0 && (
+        lastSelectedSwmSync == null
+        || lastSelectedSwmSync <= lastDisconnected
+        || (now - lastSelectedSwmSync) >= SYNC_STALENESS_THRESHOLD_MS
+      );
+      if (!broadSyncStale && !selectedSwmStale) continue;
       // Per-peer exponential backoff: a peer that can never be synced
       // (dead / NAT-stuck / persistently stream-resetting) never stamps
       // `lastSuccessfulSyncAt`, so it reads as perpetually stale. Without
@@ -4918,8 +4930,24 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       }
       if (!(await this.ensurePeerAdmittedForRecovery(peerId, ctx, 'Sync reconciler'))) continue;
       const shortPeer = peerId.slice(-8);
-      this.log.info(ctx, `Sync reconciler retrying ${shortPeer} (last success: ${lastOk == null ? 'never' : `${Math.round((now - lastOk) / 1000)}s ago`}${backoff ? `, prior failures: ${backoff.failures}` : ''})`);
-      this.attemptSyncFromPeerWithReconcilerAccounting(peerId, probe, 'reconcile')
+      if (selectedSwmStale && !broadSyncStale) {
+        // Terminal means complete at the last observed head, not never refresh
+        // this selected graph again. Re-open only this peer/scope after the
+        // bounded freshness window; the broad sync kill switch and unselected
+        // graphs remain untouched.
+        this.selectedSwmBootstrapAdmission.clear(peerId);
+        this.selectedSwmBootstrapAdmission.request(peerId, selectedContextGraphIds);
+        this.log.info(
+          ctx,
+          `Sync reconciler refreshing ${selectedContextGraphIds.length} selected shared-memory Context Graph(s) from ${shortPeer}`,
+        );
+      } else {
+        this.log.info(ctx, `Sync reconciler retrying ${shortPeer} (last success: ${lastOk == null ? 'never' : `${Math.round((now - lastOk) / 1000)}s ago`}${backoff ? `, prior failures: ${backoff.failures}` : ''})`);
+      }
+      const attempt = selectedSwmStale && !broadSyncStale
+        ? this.attemptSelectedSwmRetryWithReconcilerAccounting(peerId, probe, 'reconcile')
+        : this.attemptSyncFromPeerWithReconcilerAccounting(peerId, probe, 'reconcile');
+      attempt
         .then(() => undefined)
         .catch((err: unknown) => {
           const message = err instanceof Error ? err.message : String(err);
@@ -4954,6 +4982,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     for (const [peerId, ts] of this.lastSyncProgressAt) {
       if (!connected.has(peerId) && now - ts >= SYNC_STALENESS_THRESHOLD_MS) {
         this.lastSyncProgressAt.delete(peerId);
+      }
+    }
+    for (const [peerId, ts] of this.lastSelectedSwmSyncAt) {
+      if (!connected.has(peerId) && now - ts >= SYNC_STALENESS_THRESHOLD_MS) {
+        this.lastSelectedSwmSyncAt.delete(peerId);
       }
     }
     for (const [peerId, backoff] of this.syncReconcilerBackoff) {
@@ -7216,6 +7249,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         && continuationExecution.incompleteContextGraphIds.length === 0;
       if (selectedScopeComplete) {
         this.selectedSwmBootstrapAdmission.markTransferTerminal(selectedBootstrapOwner!);
+        this.lastSelectedSwmSyncAt.set(remotePeerId, Date.now());
       }
       // Preserve the raw historical yield/failure counters for diagnostics;
       // the canonical freshness helper bounds the selected continuation's

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -4998,6 +4998,7 @@ export class PublishMethods extends DKGAgentBase {
           );
           const candidate = await this.store.query(
             `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${vmGraph}> { ?s ?p ?o } }`,
+            { source: 'agent.asyncVmPublish.recoveredVmCandidate' },
           );
           recoveredVmCandidate = candidate.type === 'quads'
             && candidate.quads.length === request.publicTripleCount;

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -4968,18 +4968,53 @@ export class PublishMethods extends DKGAgentBase {
           publicSnapshotStore: this.publicSnapshotStore,
         });
       } catch (error) {
-        if (
-          !(error instanceof KnowledgeAssetOperationPublicSnapshotNotFoundError)
-          || request.clearSharedMemoryAfter !== true
-        ) {
+        if (!(error instanceof KnowledgeAssetOperationPublicSnapshotNotFoundError)) {
           throw error;
         }
-        // Explicit post-publish cleanup may remove the redundant snapshot. The
-        // signed seal plus immutable queued counts still verifies exact VM.
+
+        // RFC-64 reconciliation may observe the finalized chain receipt and
+        // retire the byte-identical SWM twin before the async publisher records
+        // its own receipt. In that race the operation snapshot is intentionally
+        // gone even when the original request did not ask for cleanup. Admit
+        // only a public, count-complete VM candidate here; handleChainReconciledKC
+        // below still recomputes and verifies its Merkle root against the chain
+        // before any receipt or lifecycle state is repaired.
+        let recoveredVmCandidate = false;
+        if (
+          request.clearSharedMemoryAfter !== true
+          && request.accessPolicy === 'public'
+          && request.publicTripleCount > 0
+        ) {
+          const scope = createGraphKnowledgeAssetScope(
+            request.kaUal,
+            request.assertionVersion,
+          );
+          const vmGraph = contextGraphLayerUri(
+            request.contextGraphId,
+            MemoryLayer.VerifiableMemory,
+            scope.agentAddress,
+            BigInt(scope.kaNumber),
+            request.subGraphName,
+          );
+          const candidate = await this.store.query(
+            `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${vmGraph}> { ?s ?p ?o } }`,
+          );
+          recoveredVmCandidate = candidate.type === 'quads'
+            && candidate.quads.length === request.publicTripleCount;
+        }
+        if (request.clearSharedMemoryAfter !== true && !recoveredVmCandidate) {
+          throw error;
+        }
+
+        // Explicit cleanup, or an RFC-64-retired SWM twin with a complete VM
+        // candidate, may remove the redundant snapshot. The signed seal,
+        // immutable queued counts and chain-root verification below remain the
+        // authority for exact VM recovery.
         this.log.info(
           ctx,
           `Named KA recovery for "${request.name}" has no durable public snapshot; `
-            + `using the immutable seal envelope: ${error instanceof Error ? error.message : String(error)}`,
+            + `${recoveredVmCandidate ? 'verifying the materialized VM candidate' : 'using the immutable seal envelope'}: `
+            + `${error instanceof Error ? error.message : String(error)}`,
         );
       }
       if (snapshot) {

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -4976,32 +4976,28 @@ export class PublishMethods extends DKGAgentBase {
         // retire the byte-identical SWM twin before the async publisher records
         // its own receipt. In that race the operation snapshot is intentionally
         // gone even when the original request did not ask for cleanup. Admit
-        // only a public, count-complete VM candidate here; handleChainReconciledKC
-        // below still recomputes and verifies its Merkle root against the chain
-        // before any receipt or lifecycle state is repaired.
+        // only an exact public VM candidate here, through the finalization
+        // layer's canonical count/root verifier. handleChainReconciledKC below
+        // re-verifies it at the mutation boundary before any receipt or
+        // lifecycle state is repaired.
         let recoveredVmCandidate = false;
         if (
           request.clearSharedMemoryAfter !== true
           && request.accessPolicy === 'public'
           && request.publicTripleCount > 0
         ) {
-          const scope = createGraphKnowledgeAssetScope(
-            request.kaUal,
-            request.assertionVersion,
-          );
-          const vmGraph = contextGraphLayerUri(
-            request.contextGraphId,
-            MemoryLayer.VerifiableMemory,
-            scope.agentAddress,
-            BigInt(scope.kaNumber),
-            request.subGraphName,
-          );
-          const candidate = await this.store.query(
-            `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${vmGraph}> { ?s ?p ?o } }`,
-            { source: 'agent.asyncVmPublish.recoveredVmCandidate' },
-          );
-          recoveredVmCandidate = candidate.type === 'quads'
-            && candidate.quads.length === request.publicTripleCount;
+          recoveredVmCandidate = await this.getOrCreateFinalizationHandler()
+            .verifyRecoveredGraphScopedVmCandidate({
+              contextGraphId: request.contextGraphId,
+              ual: request.kaUal,
+              assertionVersion: request.assertionVersion,
+              publicTripleCount: request.publicTripleCount,
+              expectedMerkleRoot: ethers.getBytes(recovered.materialization.merkleRoot),
+              ...(request.privateMerkleRoot
+                ? { privateMerkleRoot: request.privateMerkleRoot }
+                : {}),
+              ...(request.subGraphName ? { subGraphName: request.subGraphName } : {}),
+            });
         }
         if (request.clearSharedMemoryAfter !== true && !recoveredVmCandidate) {
           throw error;

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -1373,6 +1373,51 @@ export class FinalizationHandler {
     return outcome;
   }
 
+  /**
+   * Admit snapshot-retirement recovery only through the canonical exact-layer
+   * verifier. A missing/wrong-count VM graph is not a recovery candidate; a
+   * count-complete but byte-different graph is an inconsistent confirmed state
+   * and must fail closed instead of being mistaken for an absent snapshot.
+   */
+  async verifyRecoveredGraphScopedVmCandidate(input: {
+    contextGraphId: string;
+    ual: string;
+    assertionVersion: string;
+    publicTripleCount: number;
+    privateMerkleRoot?: string;
+    expectedMerkleRoot: Uint8Array;
+    subGraphName?: string;
+  }): Promise<boolean> {
+    let privateMerkleRoot: Uint8Array | undefined;
+    try {
+      privateMerkleRoot = input.privateMerkleRoot
+        ? ethers.getBytes(input.privateMerkleRoot)
+        : undefined;
+    } catch {
+      throw Object.assign(
+        new Error(`Invalid private commitment for recovered graph-scoped KA ${input.ual}`),
+        { code: 'KA_VM_RECOVERY_INCONSISTENT' },
+      );
+    }
+    const verification = await this.verifyExactGraphScopedLayer({
+      contextGraphId: input.contextGraphId,
+      scope: createGraphKnowledgeAssetScope(input.ual, input.assertionVersion),
+      layer: MemoryLayer.VerifiableMemory,
+      publicTripleCount: input.publicTripleCount,
+      expectedMerkleRoot: input.expectedMerkleRoot,
+      ...(privateMerkleRoot ? { privateMerkleRoot } : {}),
+      ...(input.subGraphName ? { subGraphName: input.subGraphName } : {}),
+    });
+    if (verification.status === 'verified') return true;
+    if (verification.status === 'count-mismatch') return false;
+    throw Object.assign(
+      new Error(
+        `Recovered exact VM candidate for ${input.ual} failed ${verification.status}`,
+      ),
+      { code: 'KA_VM_RECOVERY_INCONSISTENT' },
+    );
+  }
+
   /** Load and verify one exact graph-scoped layer using the shared count/root rules. */
   private async verifyExactGraphScopedLayer(input: {
     contextGraphId: string;

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -369,6 +369,15 @@ interface ManifestSettlementCheckpoint {
   readonly numericAdvance: boolean;
 }
 
+type RootlessDataCheckpointRepair =
+  | { readonly kind: 'none' }
+  | {
+      readonly kind: 'rewind';
+      readonly offset: number;
+      readonly responderSessionOffset: number;
+    }
+  | { readonly kind: 'reset-stranded-session' };
+
 /**
  * Advance only across a contiguous prefix of graph descriptors whose exact
  * assets have finished the chain-authentication + atomic-materialization
@@ -906,8 +915,7 @@ async function runDurableSyncWithBudget(
 
       let effectiveDataResult = dataResult;
       let dataForVerification = dataResult.quads;
-      let rewoundDiscardedDataSuffix = false;
-      let resetStrandedDataSession = false;
+      let dataCheckpointRepair: RootlessDataCheckpointRepair = { kind: 'none' };
       let verificationMode: DurableBatchVerificationMode = sinceBatchId === undefined
         ? { kind: 'fullSnapshot' }
         : { kind: 'sinceBatchId', sinceBatchId };
@@ -1002,18 +1010,27 @@ async function runDurableSyncWithBudget(
           // projection deliberately drops that unusable suffix. Rebind the
           // same responder token to the last complete raw graph boundary so a
           // retry replays the dropped rows instead of skipping them forever.
-          rewoundDiscardedDataSuffix = rawNextOffset > bounded.safeRawNextOffset;
+          const rewoundDiscardedDataSuffix = rawNextOffset > bounded.safeRawNextOffset;
           // Repair checkpoints written by older code that already reached raw
           // EOF while their verified cursor remained behind. With no rows in
           // this response there is no raw-offset mapping from which to rewind,
           // so discard the paired token/checkpoint and let the next attempt
           // obtain a fresh immutable responder generation from offset zero.
-          resetStrandedDataSession = dataResult.completed
+          const resetStrandedDataSession = dataResult.completed
             && bounded.safeNextOffset < bounded.manifestRowCount
             && bounded.safeNextOffset === dataResult.resumedFromOffset
             && bounded.completedGraphCount === 0
             && rawResumedFromOffset > dataResult.resumedFromOffset
             && rawNextOffset === rawResumedFromOffset;
+          dataCheckpointRepair = resetStrandedDataSession
+            ? { kind: 'reset-stranded-session' }
+            : rewoundDiscardedDataSuffix
+              ? {
+                  kind: 'rewind',
+                  offset: bounded.safeNextOffset,
+                  responderSessionOffset: bounded.safeRawNextOffset,
+                }
+              : { kind: 'none' };
           dataForVerification = bounded.dataQuads;
           effectiveDataResult = {
             ...dataResult,
@@ -1084,54 +1101,6 @@ async function runDurableSyncWithBudget(
       if (graphScopedManifest && processed.dataRejectedMissingMeta !== 0) {
         deleteCheckpoint(rawDataResult.checkpointKey);
       }
-      if (
-        graphScopedManifest
-        && batchVerifiedCleanly
-        && processed.dataRejectedMissingMeta === 0
-        && resetStrandedDataSession
-      ) {
-        deleteCheckpoint(rawDataResult.checkpointKey);
-        logWarn(
-          ctx,
-          `Reset stranded rootless durable session for "${pid}": raw cursor `
-            + `${rawDataResult.rawResumedFromOffset ?? rawDataResult.resumedFromOffset} `
-            + `was ahead of verified graph boundary ${effectiveDataResult.resumedFromOffset}`,
-        );
-      } else if (
-        graphScopedManifest
-        && batchVerifiedCleanly
-        && processed.dataRejectedMissingMeta === 0
-        && rewoundDiscardedDataSuffix
-      ) {
-        const prefix = graphScopedDurableManifestPrefixAtOffset(
-          graphScopedManifest,
-          effectiveDataResult.nextOffset,
-        );
-        if (!prefix) {
-          deleteCheckpoint(rawDataResult.checkpointKey);
-          throw new Error(
-            `Refusing to rewind durable DATA cursor ${effectiveDataResult.nextOffset}: `
-              + 'the completed META manifest has no matching graph boundary',
-          );
-        }
-        setCheckpoint(rawDataResult.checkpointKey, {
-          offset: effectiveDataResult.nextOffset,
-          responderSessionOffset: effectiveDataResult.rawNextOffset,
-          binding: {
-            manifestDigest: graphScopedManifest.manifestDigest,
-            manifestPrefixDigest: prefix.prefixDigest,
-            terminal: false,
-          },
-        });
-        logInfo(
-          ctx,
-          `Rewound rootless durable responder cursor for "${pid}" to complete graph `
-            + `boundary ${effectiveDataResult.nextOffset} `
-            + `(raw ${rawDataResult.rawNextOffset ?? rawDataResult.nextOffset}`
-            + `->${effectiveDataResult.rawNextOffset})`,
-        );
-      }
-
       const notifyVerifiedFullSnapshot = async (): Promise<void> => {
         if (
           !onVerifiedFullSnapshot
@@ -1192,6 +1161,56 @@ async function runDurableSyncWithBudget(
         && !metaResult.timedOut
         && effectiveDataResult.completed
         && !effectiveDataResult.timedOut;
+      const settleZeroProgressDataCheckpointRepair = () => {
+        if (
+          !graphScopedManifest
+          || !batchVerifiedCleanly
+          || processed.dataRejectedMissingMeta !== 0
+          || dataCheckpointRepair.kind === 'none'
+        ) return;
+        if (dataCheckpointRepair.kind === 'reset-stranded-session') {
+          deleteCheckpoint(rawDataResult.checkpointKey);
+          logWarn(
+            ctx,
+            `Reset stranded rootless durable session for "${pid}": raw cursor `
+              + `${rawDataResult.rawResumedFromOffset ?? rawDataResult.resumedFromOffset} `
+              + `was ahead of verified graph boundary ${effectiveDataResult.resumedFromOffset}`,
+          );
+          return;
+        }
+        // A zero-length verified prefix has no store side effect to await, so
+        // it is safe to repair the raw responder cursor at the empty-response
+        // checkpoint boundary. Non-empty prefixes are deliberately left to
+        // the normal post-materialization settlement/checkpoint path below.
+        if (dataCheckpointRepair.offset !== effectiveDataResult.resumedFromOffset) return;
+        const prefix = graphScopedDurableManifestPrefixAtOffset(
+          graphScopedManifest,
+          dataCheckpointRepair.offset,
+        );
+        if (!prefix) {
+          deleteCheckpoint(rawDataResult.checkpointKey);
+          throw new Error(
+            `Refusing to rewind durable DATA cursor ${dataCheckpointRepair.offset}: `
+              + 'the completed META manifest has no matching graph boundary',
+          );
+        }
+        setCheckpoint(rawDataResult.checkpointKey, {
+          offset: dataCheckpointRepair.offset,
+          responderSessionOffset: dataCheckpointRepair.responderSessionOffset,
+          binding: {
+            manifestDigest: graphScopedManifest.manifestDigest,
+            manifestPrefixDigest: prefix.prefixDigest,
+            terminal: false,
+          },
+        });
+        logInfo(
+          ctx,
+          `Rewound rootless durable responder cursor for "${pid}" to complete graph `
+            + `boundary ${dataCheckpointRepair.offset} `
+            + `(raw ${rawDataResult.rawNextOffset ?? rawDataResult.nextOffset}`
+            + `->${dataCheckpointRepair.responderSessionOffset})`,
+        );
+      };
       const settledExactDisposition = (): ExactDurableFetchDisposition => (
         classifyExactDurableFetch({
           requestedAssetCount: exactAssetUals?.length ?? 0,
@@ -1212,6 +1231,7 @@ async function runDurableSyncWithBudget(
       ) {
         await notifyVerifiedFullSnapshot();
         throwIfOperationAborted();
+        settleZeroProgressDataCheckpointRepair();
         // The verifier reports an empty batch only when both fetched phase
         // payloads are empty. Record each phase independently: a completed
         // zero-offset phase is a real clean-empty response, while a sibling

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -906,6 +906,8 @@ async function runDurableSyncWithBudget(
 
       let effectiveDataResult = dataResult;
       let dataForVerification = dataResult.quads;
+      let rewoundDiscardedDataSuffix = false;
+      let resetStrandedDataSession = false;
       let verificationMode: DurableBatchVerificationMode = sinceBatchId === undefined
         ? { kind: 'fullSnapshot' }
         : { kind: 'sinceBatchId', sinceBatchId };
@@ -991,6 +993,27 @@ async function runDurableSyncWithBudget(
           );
         }
         if (bounded) {
+          const rawResumedFromOffset = dataResult.rawResumedFromOffset
+            ?? dataResult.resumedFromOffset;
+          const rawNextOffset = dataResult.rawNextOffset ?? dataResult.nextOffset;
+          // page-fetch owns a raw immutable responder cursor, while this layer
+          // owns the verified complete-graph cursor. A timeout may accept part
+          // of the next graph and persist the RAW cursor before this bounded
+          // projection deliberately drops that unusable suffix. Rebind the
+          // same responder token to the last complete raw graph boundary so a
+          // retry replays the dropped rows instead of skipping them forever.
+          rewoundDiscardedDataSuffix = rawNextOffset > bounded.safeRawNextOffset;
+          // Repair checkpoints written by older code that already reached raw
+          // EOF while their verified cursor remained behind. With no rows in
+          // this response there is no raw-offset mapping from which to rewind,
+          // so discard the paired token/checkpoint and let the next attempt
+          // obtain a fresh immutable responder generation from offset zero.
+          resetStrandedDataSession = dataResult.completed
+            && bounded.safeNextOffset < bounded.manifestRowCount
+            && bounded.safeNextOffset === dataResult.resumedFromOffset
+            && bounded.completedGraphCount === 0
+            && rawResumedFromOffset > dataResult.resumedFromOffset
+            && rawNextOffset === rawResumedFromOffset;
           dataForVerification = bounded.dataQuads;
           effectiveDataResult = {
             ...dataResult,
@@ -1060,6 +1083,53 @@ async function runDurableSyncWithBudget(
       }
       if (graphScopedManifest && processed.dataRejectedMissingMeta !== 0) {
         deleteCheckpoint(rawDataResult.checkpointKey);
+      }
+      if (
+        graphScopedManifest
+        && batchVerifiedCleanly
+        && processed.dataRejectedMissingMeta === 0
+        && resetStrandedDataSession
+      ) {
+        deleteCheckpoint(rawDataResult.checkpointKey);
+        logWarn(
+          ctx,
+          `Reset stranded rootless durable session for "${pid}": raw cursor `
+            + `${rawDataResult.rawResumedFromOffset ?? rawDataResult.resumedFromOffset} `
+            + `was ahead of verified graph boundary ${effectiveDataResult.resumedFromOffset}`,
+        );
+      } else if (
+        graphScopedManifest
+        && batchVerifiedCleanly
+        && processed.dataRejectedMissingMeta === 0
+        && rewoundDiscardedDataSuffix
+      ) {
+        const prefix = graphScopedDurableManifestPrefixAtOffset(
+          graphScopedManifest,
+          effectiveDataResult.nextOffset,
+        );
+        if (!prefix) {
+          deleteCheckpoint(rawDataResult.checkpointKey);
+          throw new Error(
+            `Refusing to rewind durable DATA cursor ${effectiveDataResult.nextOffset}: `
+              + 'the completed META manifest has no matching graph boundary',
+          );
+        }
+        setCheckpoint(rawDataResult.checkpointKey, {
+          offset: effectiveDataResult.nextOffset,
+          responderSessionOffset: effectiveDataResult.rawNextOffset,
+          binding: {
+            manifestDigest: graphScopedManifest.manifestDigest,
+            manifestPrefixDigest: prefix.prefixDigest,
+            terminal: false,
+          },
+        });
+        logInfo(
+          ctx,
+          `Rewound rootless durable responder cursor for "${pid}" to complete graph `
+            + `boundary ${effectiveDataResult.nextOffset} `
+            + `(raw ${rawDataResult.rawNextOffset ?? rawDataResult.nextOffset}`
+            + `->${effectiveDataResult.rawNextOffset})`,
+        );
       }
 
       const notifyVerifiedFullSnapshot = async (): Promise<void> => {

--- a/packages/agent/src/sync/selected-swm-bootstrap-admission.ts
+++ b/packages/agent/src/sync/selected-swm-bootstrap-admission.ts
@@ -5,6 +5,7 @@ export type SelectedSwmBootstrapPhase = 'retry-required' | 'terminal';
 export interface SelectedSwmBootstrapAdmissionSnapshot {
   readonly contextGraphIds: readonly string[];
   readonly phase: SelectedSwmBootstrapPhase;
+  readonly freshAtMs: number | null;
 }
 
 export interface SelectedSwmBootstrapTransferOwner {
@@ -15,6 +16,13 @@ export interface SelectedSwmBootstrapTransferOwner {
 
 interface SelectedSwmBootstrapAdmissionState extends SelectedSwmBootstrapAdmissionSnapshot {
   readonly generation: number;
+  readonly updatedAtMs: number;
+}
+
+export interface SelectedSwmRefreshOptions {
+  readonly now: number;
+  readonly disconnectBoundary: number;
+  readonly staleAfterMs: number;
 }
 
 function canonicalScope(contextGraphIds: readonly string[]): readonly string[] {
@@ -41,11 +49,15 @@ export class SelectedSwmBootstrapAdmission {
     remotePeer: string,
     contextGraphIds: readonly string[],
     phase: SelectedSwmBootstrapPhase,
+    freshAtMs: number | null = null,
+    updatedAtMs = Date.now(),
   ): SelectedSwmBootstrapAdmissionState {
     const state = Object.freeze({
       contextGraphIds: canonicalScope(contextGraphIds),
       phase,
+      freshAtMs,
       generation: this.#nextGeneration += 1,
+      updatedAtMs,
     });
     this.#byPeer.set(remotePeer, state);
     return state;
@@ -90,7 +102,10 @@ export class SelectedSwmBootstrapAdmission {
     });
   }
 
-  markTransferTerminal(owner: SelectedSwmBootstrapTransferOwner): boolean {
+  markTransferTerminal(
+    owner: SelectedSwmBootstrapTransferOwner,
+    freshAtMs = Date.now(),
+  ): boolean {
     const current = this.#byPeer.get(owner.remotePeer);
     if (
       current === undefined
@@ -100,7 +115,32 @@ export class SelectedSwmBootstrapAdmission {
     this.#byPeer.set(owner.remotePeer, Object.freeze({
       ...current,
       phase: 'terminal',
+      freshAtMs,
+      updatedAtMs: freshAtMs,
     }));
+    return true;
+  }
+
+  shouldRefresh(
+    remotePeer: string,
+    contextGraphIds: readonly string[],
+    options: SelectedSwmRefreshOptions,
+  ): boolean {
+    const scope = canonicalScope(contextGraphIds);
+    if (scope.length === 0) return false;
+    const current = this.#byPeer.get(remotePeer);
+    if (current === undefined || !sameScope(current.contextGraphIds, scope)) return true;
+    if (current.phase === 'retry-required') return true;
+    const freshAtMs = current.freshAtMs;
+    return freshAtMs === null
+      || freshAtMs <= options.disconnectBoundary
+      || options.now - freshAtMs >= options.staleAfterMs;
+  }
+
+  requestRefresh(remotePeer: string, contextGraphIds: readonly string[]): boolean {
+    const scope = canonicalScope(contextGraphIds);
+    if (scope.length === 0) return false;
+    this.#replace(remotePeer, scope, 'retry-required');
     return true;
   }
 
@@ -114,7 +154,20 @@ export class SelectedSwmBootstrapAdmission {
     return Object.freeze({
       contextGraphIds: state.contextGraphIds,
       phase: state.phase,
+      freshAtMs: state.freshAtMs,
     });
+  }
+
+  pruneDisconnected(
+    connectedPeers: ReadonlySet<string>,
+    now: number,
+    staleAfterMs: number,
+  ): void {
+    for (const [remotePeer, state] of this.#byPeer) {
+      if (!connectedPeers.has(remotePeer) && now - state.updatedAtMs >= staleAfterMs) {
+        this.#byPeer.delete(remotePeer);
+      }
+    }
   }
 
   clear(remotePeer: string): void {

--- a/packages/agent/test/durable-sync-graph-scoped-materialization.test.ts
+++ b/packages/agent/test/durable-sync-graph-scoped-materialization.test.ts
@@ -1149,7 +1149,14 @@ describe('durable graph-scoped KA materialization', () => {
       });
       expect(materialize).not.toHaveBeenCalled();
       expect(deleteCheckpoint).not.toHaveBeenCalled();
-      expect(setCheckpoint).not.toHaveBeenCalled();
+      expect(setCheckpoint).toHaveBeenCalledWith(
+        `${contextGraphId}:data`,
+        expect.objectContaining({
+          offset: 0,
+          responderSessionOffset: 0,
+          binding: expect.objectContaining({ terminal: false }),
+        }),
+      );
       expect(await graphQuads(requesterStore, assertionGraph)).toEqual([]);
 
       const complete = run(fieldSizedData, true);

--- a/packages/agent/test/e2e-memory-layers.test.ts
+++ b/packages/agent/test/e2e-memory-layers.test.ts
@@ -864,10 +864,23 @@ describe('rootless graph-scoped KA lifecycle', () => {
     snapshotQuery.mockRestore();
 
     const operationSubject = `urn:dkg:share:${CG_ID}:${intent.shareOperationId}`;
+    const recoveryVmGraph = contextGraphLayerUri(
+      CG_ID,
+      MemoryLayer.VerifiableMemory,
+      queuedScope.agentAddress,
+      BigInt(queuedScope.kaNumber),
+    );
+    const recoveryVmRows = await store.query(
+      `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${recoveryVmGraph}> { ?s ?p ?o } }`,
+    );
+    if (recoveryVmRows.type !== 'quads' || recoveryVmRows.quads.length === 0) {
+      throw new Error('expected exact VM candidate before snapshot-retirement recovery');
+    }
     await store.deleteByPattern({
       graph: contextGraphSharedMemoryMetaUri(CG_ID),
       subject: operationSubject,
     });
+    await store.deleteByPattern({ graph: recoveryVmGraph });
     await expect(agent.finalizeRecoveredQueuedKnowledgeAssetVmPublish({
       ...recoveryInput,
       request: { ...recoveryInput.request, clearSharedMemoryAfter: false },
@@ -875,8 +888,22 @@ describe('rootless graph-scoped KA lifecycle', () => {
       code: 'KA_OPERATION_PUBLIC_SNAPSHOT_NOT_FOUND',
     });
 
-    await agent.finalizeRecoveredQueuedKnowledgeAssetVmPublish(recoveryInput as any);
-    await agent.finalizeRecoveredQueuedKnowledgeAssetVmPublish(recoveryInput as any);
+    await store.insert(recoveryVmRows.quads.map((quad) => ({
+      ...quad,
+      graph: recoveryVmGraph,
+    })));
+    // RFC-64 may retire the redundant SWM snapshot after independently
+    // materializing exact VM but before the async publisher records its receipt.
+    // Recovery must accept that already-verified public VM candidate even when
+    // the original publish did not request SWM cleanup.
+    await agent.finalizeRecoveredQueuedKnowledgeAssetVmPublish({
+      ...recoveryInput,
+      request: { ...recoveryInput.request, clearSharedMemoryAfter: false },
+    } as any);
+    await agent.finalizeRecoveredQueuedKnowledgeAssetVmPublish({
+      ...recoveryInput,
+      request: { ...recoveryInput.request, clearSharedMemoryAfter: false },
+    } as any);
     expect(recoveryCleanup).not.toHaveBeenCalled();
 
     const history = await agent.assertion.history(CG_ID, name);

--- a/packages/agent/test/e2e-memory-layers.test.ts
+++ b/packages/agent/test/e2e-memory-layers.test.ts
@@ -888,6 +888,23 @@ describe('rootless graph-scoped KA lifecycle', () => {
       code: 'KA_OPERATION_PUBLIC_SNAPSHOT_NOT_FOUND',
     });
 
+    const wrongVmRows = recoveryVmRows.quads.map((quad, index) => ({
+      ...quad,
+      ...(index === 0 ? { object: '"tampered-recovery-vm"' } : {}),
+      graph: recoveryVmGraph,
+    }));
+    await store.insert(wrongVmRows);
+    await expect(agent.finalizeRecoveredQueuedKnowledgeAssetVmPublish({
+      ...recoveryInput,
+      request: { ...recoveryInput.request, clearSharedMemoryAfter: false },
+    } as any)).rejects.toMatchObject({ code: 'KA_VM_RECOVERY_INCONSISTENT' });
+    expect((await agent.assertion.history(CG_ID, name))?.state).toBe('promoted');
+    const rejectedCandidateReceipt = await store.query(`ASK { GRAPH <${metaGraph}> {
+      <${assertionUri}> <${ASSERTION_PUBLISH_RECEIPT_PREDICATES.PUBLISHED_AT_TX}> ?tx .
+    } }`);
+    expect(rejectedCandidateReceipt).toMatchObject({ type: 'boolean', value: false });
+
+    await store.deleteByPattern({ graph: recoveryVmGraph });
     await store.insert(recoveryVmRows.quads.map((quad) => ({
       ...quad,
       graph: recoveryVmGraph,

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -1192,6 +1192,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     expect((receiver as any).selectedSwmBootstrapAdmission.snapshot(providerPeerId)).toEqual({
       contextGraphIds: [CONTEXT_GRAPH_ID, secondContextGraphId].sort(),
       phase: 'retry-required',
+      freshAtMs: null,
     });
   });
 

--- a/packages/agent/test/rootless-durable-bounded-progress.test.ts
+++ b/packages/agent/test/rootless-durable-bounded-progress.test.ts
@@ -226,7 +226,11 @@ describe('bounded rootless durable progress', () => {
       ...fixtures[2]!.payload,
     ];
     const materialized: string[] = [];
-    const checkpoints: Array<[string, number]> = [];
+    const checkpoints: Array<{
+      key: string;
+      offset: number;
+      responderSessionOffset?: number;
+    }> = [];
 
     const summary = await runDurableSync({
       ctx,
@@ -359,7 +363,9 @@ describe('bounded rootless durable progress', () => {
           })
           : pageResult('data', {
             quads: rawData,
+            quadRawOffsets: [1, 2, 3, 4, 6, 7, 8, 9, 11, 12],
             nextOffset: rawData.length,
+            rawNextOffset: 13,
             completed: false,
             timedOut: true,
           });
@@ -375,7 +381,13 @@ describe('bounded rootless durable progress', () => {
         return 'applied';
       },
       deleteCheckpoint: () => {},
-      setCheckpoint: (key, checkpoint) => { checkpoints.push([key, checkpoint.offset]); },
+      setCheckpoint: (key, checkpoint) => {
+        checkpoints.push({
+          key,
+          offset: checkpoint.offset,
+          responderSessionOffset: checkpoint.responderSessionOffset,
+        });
+      },
       logInfo: () => {},
       logWarn: () => {},
       logDebug: () => {},
@@ -385,8 +397,12 @@ describe('bounded rootless durable progress', () => {
     expect(summary.complete).toBe(false);
     expect(summary.timedOutPhases).toBe(1);
     expect(summary.insertedDataTriples).toBe(8);
-    expect(checkpoints).toContainEqual([`${CONTEXT_GRAPH_ID}:data`, 8]);
-    expect(checkpoints.some(([key]) => key === `${CONTEXT_GRAPH_ID}:meta`)).toBe(false);
+    expect(checkpoints).toContainEqual({
+      key: `${CONTEXT_GRAPH_ID}:data`,
+      offset: 8,
+      responderSessionOffset: 10,
+    });
+    expect(checkpoints.some(({ key }) => key === `${CONTEXT_GRAPH_ID}:meta`)).toBe(false);
     expect(freshSessions).toEqual([
       ['meta', true],
       ['data', false],
@@ -398,6 +414,51 @@ describe('bounded rootless durable progress', () => {
     expect(materialized.flatMap((entry) => entry.dataQuads)
       .some((quad) => quad.graph === fixtures[2]!.graph)).toBe(false);
     expect(inserted.flat().some((quad) => fixtures.some((entry) => entry.graph === quad.graph))).toBe(false);
+  });
+
+  it('does not rebind a partial responder cursor before its verified prefix is stored', async () => {
+    const fixtures = orderedAssets();
+    const selected = fixtures.slice(0, 2);
+    const meta = selected.flatMap((entry) => entry.meta);
+    const rawData = [
+      ...selected[0]!.payload,
+      ...selected[1]!.payload.slice(0, 2),
+    ];
+    const checkpoints: Array<{ key: string; offset: number }> = [];
+
+    const summary = await runDurableSync({
+      ctx,
+      remotePeerId: 'peer-store-fails-before-rewind',
+      contextGraphIds: [CONTEXT_GRAPH_ID],
+      durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
+      fetchSyncPages: async ({ phase }: DurableSyncFetchRequest) => phase === 'meta'
+        ? pageResult('meta', { quads: meta, nextOffset: meta.length })
+        : pageResult('data', {
+            quads: rawData,
+            quadRawOffsets: [1, 2, 3, 4, 6, 7],
+            nextOffset: rawData.length,
+            rawNextOffset: 8,
+            completed: false,
+            timedOut: true,
+          }),
+      processDurableBatchInWorker: processBatch,
+      storeInsert: async () => {},
+      storeGraphScopedAsset: async () => {
+        throw new Error('simulated atomic store failure before commit');
+      },
+      deleteCheckpoint: () => {},
+      setCheckpoint: (key, checkpoint) => {
+        checkpoints.push({ key, offset: checkpoint.offset });
+      },
+      logInfo: () => {},
+      logWarn: () => {},
+      logDebug: () => {},
+    });
+
+    expect(summary.complete).toBe(false);
+    expect(summary.failedPhases).toBe(1);
+    expect(summary.insertedDataTriples).toBe(0);
+    expect(checkpoints).toEqual([]);
   });
 
   it('rewinds a responder cursor when a timeout leaves only a partial graph', async () => {

--- a/packages/agent/test/rootless-durable-bounded-progress.test.ts
+++ b/packages/agent/test/rootless-durable-bounded-progress.test.ts
@@ -400,6 +400,100 @@ describe('bounded rootless durable progress', () => {
     expect(inserted.flat().some((quad) => fixtures.some((entry) => entry.graph === quad.graph))).toBe(false);
   });
 
+  it('rewinds a responder cursor when a timeout leaves only a partial graph', async () => {
+    const [fixture] = orderedAssets();
+    const partialData = fixture!.payload.slice(0, 2);
+    const checkpoints: Array<{
+      offset: number;
+      responderSessionOffset?: number;
+      manifestDigest?: string;
+      terminal?: boolean;
+    }> = [];
+    const deleted: string[] = [];
+
+    const summary = await runDurableSync({
+      ctx,
+      remotePeerId: 'peer-partial-graph-timeout',
+      contextGraphIds: [CONTEXT_GRAPH_ID],
+      durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
+      fetchSyncPages: async ({ phase }: DurableSyncFetchRequest) => phase === 'meta'
+        ? pageResult('meta', { quads: fixture!.meta, nextOffset: fixture!.meta.length })
+        : pageResult('data', {
+            quads: partialData,
+            nextOffset: partialData.length,
+            rawNextOffset: partialData.length,
+            completed: false,
+            timedOut: true,
+          }),
+      processDurableBatchInWorker: processBatch,
+      storeInsert: async () => {},
+      storeGraphScopedAsset: async () => 'applied',
+      deleteCheckpoint: (key) => { deleted.push(key); },
+      setCheckpoint: (_key, checkpoint) => {
+        checkpoints.push({
+          offset: checkpoint.offset,
+          responderSessionOffset: checkpoint.responderSessionOffset,
+          manifestDigest: checkpoint.binding?.manifestDigest,
+          terminal: checkpoint.binding?.terminal,
+        });
+      },
+      logInfo: () => {},
+      logWarn: () => {},
+      logDebug: () => {},
+    });
+
+    expect(summary.complete).toBe(false);
+    expect(summary.insertedDataTriples).toBe(0);
+    expect(deleted).not.toContain(`${CONTEXT_GRAPH_ID}:data`);
+    expect(checkpoints).toContainEqual({
+      offset: 0,
+      responderSessionOffset: 0,
+      manifestDigest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
+      terminal: false,
+    });
+  });
+
+  it('self-heals a raw EOF checkpoint stranded ahead of its verified graph boundary', async () => {
+    const [fixture] = orderedAssets();
+    const manifestDigest = manifest(fixture!.meta).manifestDigest;
+    const deleted: string[] = [];
+    const dataCheckpoints: number[] = [];
+
+    const summary = await runDurableSync({
+      ctx,
+      remotePeerId: 'peer-stranded-raw-eof',
+      contextGraphIds: [CONTEXT_GRAPH_ID],
+      durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
+      fetchSyncPages: async ({ phase }: DurableSyncFetchRequest) => phase === 'meta'
+        ? pageResult('meta', { quads: fixture!.meta, nextOffset: fixture!.meta.length })
+        : pageResult('data', {
+            quads: [],
+            resumedFromOffset: 0,
+            rawResumedFromOffset: fixture!.payload.length,
+            nextOffset: fixture!.payload.length,
+            rawNextOffset: fixture!.payload.length,
+            manifestDigest,
+            completed: true,
+            timedOut: false,
+          }),
+      processDurableBatchInWorker: processBatch,
+      storeInsert: async () => {},
+      storeGraphScopedAsset: async () => 'applied',
+      deleteCheckpoint: (key) => { deleted.push(key); },
+      setCheckpoint: (key, checkpoint) => {
+        if (key.endsWith(':data')) dataCheckpoints.push(checkpoint.offset);
+      },
+      logInfo: () => {},
+      logWarn: () => {},
+      logDebug: () => {},
+    });
+
+    expect(summary.complete).toBe(false);
+    expect(summary.insertedDataTriples).toBe(0);
+    expect(deleted).toContain(`${CONTEXT_GRAPH_ID}:data`);
+    expect(dataCheckpoints).toEqual([]);
+  });
+
   it('persists an authenticated asset prefix before a later authentication deadline', async () => {
     const fixtures = orderedAssets();
     const selected = fixtures.slice(0, 2);

--- a/packages/agent/test/selected-swm-bootstrap-admission.test.ts
+++ b/packages/agent/test/selected-swm-bootstrap-admission.test.ts
@@ -6,9 +6,10 @@ const PEER = '12D3KooWScopeAwareSelectedSwmProvider';
 function completeScope(
   admission: SelectedSwmBootstrapAdmission,
   contextGraphIds: readonly string[],
+  freshAtMs = 1_000,
 ): void {
   const owner = admission.beginTransfer(PEER, contextGraphIds);
-  expect(admission.markTransferTerminal(owner)).toBe(true);
+  expect(admission.markTransferTerminal(owner, freshAtMs)).toBe(true);
 }
 
 describe('SelectedSwmBootstrapAdmission', () => {
@@ -22,6 +23,7 @@ describe('SelectedSwmBootstrapAdmission', () => {
     expect(admission.snapshot(PEER)).toEqual({
       contextGraphIds: ['cg-a', 'cg-b'],
       phase: 'terminal',
+      freshAtMs: 1_000,
     });
   });
 
@@ -35,6 +37,7 @@ describe('SelectedSwmBootstrapAdmission', () => {
     expect(admission.snapshot(PEER)).toEqual({
       contextGraphIds: ['cg-a', 'cg-b'],
       phase: 'retry-required',
+      freshAtMs: null,
     });
   });
 
@@ -48,6 +51,7 @@ describe('SelectedSwmBootstrapAdmission', () => {
     expect(admission.snapshot(PEER)).toEqual({
       contextGraphIds: ['cg-a', 'cg-b'],
       phase: 'retry-required',
+      freshAtMs: null,
     });
   });
 
@@ -69,6 +73,38 @@ describe('SelectedSwmBootstrapAdmission', () => {
     expect(admission.snapshot(PEER)).toEqual({
       contextGraphIds: [],
       phase: 'terminal',
+      freshAtMs: null,
+    });
+  });
+
+  it('plans refreshes from peer, scope, completion, and disconnect freshness', () => {
+    const admission = new SelectedSwmBootstrapAdmission();
+    const now = 20_000;
+    const options = { now, disconnectBoundary: 0, staleAfterMs: 5_000 };
+
+    expect(admission.shouldRefresh(PEER, ['cg-a'], options)).toBe(true);
+    completeScope(admission, ['cg-a'], 18_000);
+    expect(admission.shouldRefresh(PEER, ['cg-a'], options)).toBe(false);
+    expect(admission.shouldRefresh(PEER, ['cg-b'], options)).toBe(true);
+    expect(admission.shouldRefresh(PEER, ['cg-a'], {
+      ...options,
+      disconnectBoundary: 19_000,
+    })).toBe(true);
+    expect(admission.shouldRefresh(PEER, ['cg-a'], {
+      ...options,
+      now: 23_000,
+    })).toBe(true);
+  });
+
+  it('reopens a stale terminal scope without lifecycle-owned timestamp state', () => {
+    const admission = new SelectedSwmBootstrapAdmission();
+    completeScope(admission, ['cg-a'], 1_000);
+
+    expect(admission.requestRefresh(PEER, ['cg-a'])).toBe(true);
+    expect(admission.snapshot(PEER)).toEqual({
+      contextGraphIds: ['cg-a'],
+      phase: 'retry-required',
+      freshAtMs: null,
     });
   });
 });

--- a/packages/agent/test/selected-swm-lifecycle-core.test.ts
+++ b/packages/agent/test/selected-swm-lifecycle-core.test.ts
@@ -137,6 +137,11 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
       expect(summary.continuationPasses).toBe(0);
       expect(harness.probes.publicAdmissions()).toBe(1);
       expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(false);
+      expect(harness.agent.selectedSwmBootstrapAdmission.snapshot(PEER)).toMatchObject({
+        contextGraphIds: [publicCg],
+        phase: 'terminal',
+        freshAtMs: expect.any(Number),
+      });
     } finally {
       await harness.close();
     }

--- a/packages/agent/test/selected-swm-test-helpers.ts
+++ b/packages/agent/test/selected-swm-test-helpers.ts
@@ -381,7 +381,6 @@ export interface SelectedSwmLifecycleAgentFixture {
     };
   };
   selectedSwmBootstrapAdmission: SelectedSwmBootstrapAdmission;
-  lastSelectedSwmSyncAt: Map<string, number>;
   store: OxigraphStore;
   writeLocks: Map<string, Promise<void>>;
   publicSnapshotStore: {
@@ -552,7 +551,6 @@ export function createSelectedSwmLifecycleHarness(
         : {}),
     },
     selectedSwmBootstrapAdmission: new SelectedSwmBootstrapAdmission(),
-    lastSelectedSwmSyncAt: new Map(),
     store,
     writeLocks: new Map(),
     publicSnapshotStore: {

--- a/packages/agent/test/selected-swm-test-helpers.ts
+++ b/packages/agent/test/selected-swm-test-helpers.ts
@@ -381,6 +381,7 @@ export interface SelectedSwmLifecycleAgentFixture {
     };
   };
   selectedSwmBootstrapAdmission: SelectedSwmBootstrapAdmission;
+  lastSelectedSwmSyncAt: Map<string, number>;
   store: OxigraphStore;
   writeLocks: Map<string, Promise<void>>;
   publicSnapshotStore: {
@@ -551,6 +552,7 @@ export function createSelectedSwmLifecycleHarness(
         : {}),
     },
     selectedSwmBootstrapAdmission: new SelectedSwmBootstrapAdmission(),
+    lastSelectedSwmSyncAt: new Map(),
     store,
     writeLocks: new Map(),
     publicSnapshotStore: {

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -1263,6 +1263,82 @@ describe('DKGAgent sync retry — event-driven via peer:update', () => {
 });
 
 describe('DKGAgent sync retry — periodic reconciler', () => {
+  it('refreshes only selected RFC-64 SWM when broad sync-on-connect is disabled', async () => {
+    const agent = await DKGAgent.create({
+      name: 'ReconcilerSelectedSwmIndependent',
+      listenHost: '127.0.0.1',
+      chainAdapter: new MockChainAdapter(),
+      syncOnConnectEnabled: false,
+    });
+    try {
+      await agent.start();
+      allowAllNetworkAdmission(agent);
+
+      const peerA = freshPeerIdString();
+      (agent.node.libp2p as any).getPeers = recorder(() => [peerIdFromString(peerA)]);
+      (agent as any).selectedSwmBootstrapContextGraphIdsForPeer = recorder(
+        () => ['selected-public-cg'],
+      );
+      (agent as any).lastSelectedSwmSyncAt.set(peerA, Date.now() - 20 * 60_000);
+      const owner = (agent as any).selectedSwmBootstrapAdmission.beginTransfer(
+        peerA,
+        ['selected-public-cg'],
+      );
+      (agent as any).selectedSwmBootstrapAdmission.markTransferTerminal(owner);
+
+      const selectedCalls: string[] = [];
+      (agent as any).trySelectedSwmRetryFromPeer = async (
+        peerId: string,
+        onSyncAccounting?: (outcome: SyncOnConnectPeerOutcome) => void,
+      ) => {
+        selectedCalls.push(peerId);
+        onSyncAccounting?.({ progress: false, fresh: true });
+        return 'synced';
+      };
+      const broadSync = recorder(async () => 'synced');
+      (agent as any).trySyncFromPeer = broadSync;
+
+      await (agent as any).reconcileSyncFromConnectedPeers();
+      await flushMicrotasks();
+
+      expect(selectedCalls).toEqual([peerA]);
+      expect(broadSync.calls).toEqual([]);
+      expect((agent as any).selectedSwmBootstrapAdmission.isRetryRequired(peerA)).toBe(true);
+      expect((agent as any).lastSuccessfulSyncAt.has(peerA)).toBe(false);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('does not refresh a recently completed selected RFC-64 SWM scope', async () => {
+    const agent = await DKGAgent.create({
+      name: 'ReconcilerSelectedSwmFresh',
+      listenHost: '127.0.0.1',
+      chainAdapter: new MockChainAdapter(),
+      syncOnConnectEnabled: false,
+    });
+    try {
+      await agent.start();
+      allowAllNetworkAdmission(agent);
+
+      const peerA = freshPeerIdString();
+      (agent.node.libp2p as any).getPeers = recorder(() => [peerIdFromString(peerA)]);
+      (agent as any).selectedSwmBootstrapContextGraphIdsForPeer = recorder(
+        () => ['selected-public-cg'],
+      );
+      (agent as any).lastSelectedSwmSyncAt.set(peerA, Date.now());
+      const selectedRetry = recorder(async () => 'synced');
+      (agent as any).trySelectedSwmRetryFromPeer = selectedRetry;
+
+      await (agent as any).reconcileSyncFromConnectedPeers();
+      await flushMicrotasks();
+
+      expect(selectedRetry.calls).toEqual([]);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
   it('retries connected peers with no successful sync on record', async () => {
     const agent = await DKGAgent.create({
       name: 'ReconcilerNeverSynced',

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -1279,12 +1279,14 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
       (agent as any).selectedSwmBootstrapContextGraphIdsForPeer = recorder(
         () => ['selected-public-cg'],
       );
-      (agent as any).lastSelectedSwmSyncAt.set(peerA, Date.now() - 20 * 60_000);
       const owner = (agent as any).selectedSwmBootstrapAdmission.beginTransfer(
         peerA,
         ['selected-public-cg'],
       );
-      (agent as any).selectedSwmBootstrapAdmission.markTransferTerminal(owner);
+      (agent as any).selectedSwmBootstrapAdmission.markTransferTerminal(
+        owner,
+        Date.now() - 20 * 60_000,
+      );
 
       const selectedCalls: string[] = [];
       (agent as any).trySelectedSwmRetryFromPeer = async (
@@ -1326,7 +1328,11 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
       (agent as any).selectedSwmBootstrapContextGraphIdsForPeer = recorder(
         () => ['selected-public-cg'],
       );
-      (agent as any).lastSelectedSwmSyncAt.set(peerA, Date.now());
+      const owner = (agent as any).selectedSwmBootstrapAdmission.beginTransfer(
+        peerA,
+        ['selected-public-cg'],
+      );
+      (agent as any).selectedSwmBootstrapAdmission.markTransferTerminal(owner, Date.now());
       const selectedRetry = recorder(async () => 'synced');
       (agent as any).trySelectedSwmRetryFromPeer = selectedRetry;
 
@@ -2006,6 +2012,14 @@ describe('DKGAgent sync state lifecycle', () => {
         nextRetryAt: now - 20 * 60_000,
       });
       (agent as any).lastSyncDisconnectedAt.set(remotePeer, now - 20 * 60_000);
+      const selectedOwner = (agent as any).selectedSwmBootstrapAdmission.beginTransfer(
+        remotePeer,
+        ['selected-public-cg'],
+      );
+      (agent as any).selectedSwmBootstrapAdmission.markTransferTerminal(
+        selectedOwner,
+        now - 20 * 60_000,
+      );
       (agent.node.libp2p as any).getPeers = recorder(() => []);
 
       (agent as any).pruneSyncReconcilerState(now);
@@ -2015,6 +2029,7 @@ describe('DKGAgent sync state lifecycle', () => {
       expect((agent as any).lastSyncProgressAt.has(remotePeer)).toBe(false);
       expect((agent as any).syncReconcilerBackoff.has(remotePeer)).toBe(false);
       expect((agent as any).lastSyncDisconnectedAt.has(remotePeer)).toBe(false);
+      expect((agent as any).selectedSwmBootstrapAdmission.snapshot(remotePeer)).toBeNull();
     } finally {
       await agent.stop().catch(() => {});
     }


### PR DESCRIPTION
## Summary

This stacks on #2275 and closes two gaps exposed by the 500 SWM / 500 VM Testnet workload:

- recover an asynchronous finalized VM publication when RFC-64 reconciliation has already retired its byte-identical SWM operation snapshot;
- rewind a raw durable responder cursor to the last verified complete-graph boundary after a timeout, and reset legacy sessions stranded at raw EOF ahead of their verified cursor.

## User impact

Before, a publication could be finalized on-chain yet remain locally unresolved if RFC-64 snapshot retirement won the race, and a receiver could permanently miss one VM graph after accepting only a partial raw suffix.

After, the publisher reconstructs only a public, count-complete VM candidate and still verifies its Merkle root against the chain. The receiver retries discarded partial rows from the last authenticated graph boundary; an already-stranded EOF checkpoint starts a fresh immutable responder generation.

## Safety boundaries

- VM recovery is public-only and requires the queued triple count before the existing chain-root verification repairs lifecycle state.
- Cursor rewind is bound to the completed metadata manifest and an exact graph-boundary prefix digest.
- Rejected or metadata-incomplete pages still delete the checkpoint and fail closed.

## Validation

- Independent no-spend Testnet recertification: PASS.
- Source: 500/500 SWM and 500/500 VM exact.
- Independent local receiver: 500/500 SWM and 500/500 VM exact.
- Failures: 0. No new Testnet publishing or token spend during recertification.
- Run ID: recertify-open-20260814-c49e0-1a002891207.
- Focused cursor, graph materialization, and query-attribution lane: 54/54 passed.
- Agent build, type tests, package-root test, and diff check passed.
- Broad unit lane: 2,887 tests passed; its sole static attribution failure was repaired and the exact failed gate reran green. GitHub CI now supplies the clean-head full-lane result.

## Evidence boundary

The live workload reproduced the publication race and the one-asset VM gap, and the complete branch recertified at 500/500. The old stranded responder session expired before the final sweep, so the explicit rewind/reset branches are proven by exact regression tests rather than by claiming a live reset log that was not observed.