### PR TITLE
fix(storage): cap process concurrency to available CPUs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -528,7 +528,12 @@ jobs:
         # leaf for the same typed literal (else RandomSampling forks). dateTime/time
         # are fixed here; date/gregorian/double/escaping remain it.fails pending
         # the rest of the backend-independent canon.
-        run: pnpm --filter @origintrail-official/dkg-storage exec vitest run test/blazegraph.integration.test.ts test/term-canon-blazegraph-oracle.test.ts
+        # Both files share Blazegraph's single `kb` namespace. Unique graph IRIs
+        # isolate assertions, but the 2.1.5 bulk-load stream is namespace-global:
+        # concurrent inserts intermittently fail with `IllegalStateException:
+        # STREAM` and leave later requests timing out. Keep the unit lanes
+        # parallel; serialize only these two live-server files.
+        run: pnpm --filter @origintrail-official/dkg-storage exec vitest run --no-file-parallelism test/blazegraph.integration.test.ts test/term-canon-blazegraph-oracle.test.ts
 
   # ------------------------------------------------------------------
   # Tornado publisher lane — sharded across 4 parallel runners.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ A selected-public convergence release. An Edge node can opt a bounded set of pub
 - **Selected manifests activate the RFC-64 lane directly** (#2272): a valid accepted non-empty bootstrap manifest with `enabled` omitted is active by default, while an absent block and explicit `enabled: false` stay dormant. This removes a redundant configuration switch without expanding an Edge node beyond its operator-selected Context Graphs.
 - **Cold selected CG bindings resolve directly from chain state** (#2205): a fresh receiver can map the configured public graph to its numeric on-chain identity without relying on pre-existing ontology/store metadata, and ambiguous or stale bindings fail closed.
 - **Publisher workspace-head writes remain on the StorageACK lane** (#2178), preventing unrelated normal-lane store work from delaying acknowledgement-critical state.
+- **Process-level store concurrency respects host CPU capacity** (#2277): `DKG_STORE_MAX_CONCURRENT` is capped at the runtime's available parallelism so stale or over-aggressive tuning cannot starve acknowledgement-critical work; explicit constructor overrides for embedded callers and tests remain unchanged.
 - **Prime Agent legacy chat memory migrates to numbered, graph-scoped working memory** (#2151, #2153) without mistaking orphan lifecycle rows for legacy drafts.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ A selected-public convergence release. An Edge node can opt a bounded set of pub
 - **Selected manifests activate the RFC-64 lane directly** (#2272): a valid accepted non-empty bootstrap manifest with `enabled` omitted is active by default, while an absent block and explicit `enabled: false` stay dormant. This removes a redundant configuration switch without expanding an Edge node beyond its operator-selected Context Graphs.
 - **Cold selected CG bindings resolve directly from chain state** (#2205): a fresh receiver can map the configured public graph to its numeric on-chain identity without relying on pre-existing ontology/store metadata, and ambiguous or stale bindings fail closed.
 - **Publisher workspace-head writes remain on the StorageACK lane** (#2178), preventing unrelated normal-lane store work from delaying acknowledgement-critical state.
-- **Process-level store concurrency respects host CPU capacity** (#2277): `DKG_STORE_MAX_CONCURRENT` is capped at the runtime's available parallelism so stale or over-aggressive tuning cannot starve acknowledgement-critical work; explicit constructor overrides for embedded callers and tests remain unchanged.
+- **Process-level store concurrency respects host CPU capacity** (#2277): `DKG_STORE_MAX_CONCURRENT` is capped at the runtime's available parallelism on hosts with at least two logical CPUs; single-vCPU hosts retain the two-slot minimum needed for the default ACK reservation. Explicitly lower environment values and constructor overrides remain unchanged.
 - **Prime Agent legacy chat memory migrates to numbered, graph-scoped working memory** (#2151, #2153) without mistaking orphan lifecycle rows for legacy drafts.
 
 ### Fixed

--- a/packages/storage/src/store-priority-scheduler.ts
+++ b/packages/storage/src/store-priority-scheduler.ts
@@ -104,6 +104,7 @@ interface LegacyStorePrioritySchedulerArguments {
 // operations by default, while still allowing operators to tune explicitly.
 const DEFAULT_MAX_CONCURRENT = 4;
 const DEFAULT_ACK_RESERVED_SLOTS = 1;
+const MIN_ACK_SAFE_MAX_CONCURRENT = DEFAULT_ACK_RESERVED_SLOTS + 1;
 const DEFAULT_HEALTH_RESERVED_SLOTS = 1;
 const DEFAULT_NORMAL_RESERVED_SLOTS = 1;
 const DEFAULT_BACKGROUND_RESERVED_SLOTS = 1;
@@ -135,7 +136,14 @@ function resolveMaxConcurrentFromEnv(): number {
   // even while the JS scheduler reports empty queues. Keep explicit constructor
   // options available to tests/embedded callers, but make the process-level
   // environment setting a hardware-aware ceiling.
-  return Math.min(configured, Math.max(1, availableParallelism()));
+  // A one-slot automatic ceiling would normalize the default ACK reservation
+  // to zero. Keep one ordinary slot plus the default reserved ACK slot even on
+  // a single-vCPU runtime. An explicitly lower process setting is still
+  // honored because it remains the first operand of Math.min().
+  return Math.min(
+    configured,
+    Math.max(MIN_ACK_SAFE_MAX_CONCURRENT, availableParallelism()),
+  );
 }
 
 function resolveQueueLimitsFromEnv(): StorePriorityQueueLimits {

--- a/packages/storage/src/store-priority-scheduler.ts
+++ b/packages/storage/src/store-priority-scheduler.ts
@@ -1,4 +1,5 @@
 import { performance } from 'node:perf_hooks';
+import { availableParallelism } from 'node:os';
 import {
   backpressureRegistry,
   getMetrics,
@@ -121,6 +122,20 @@ function parseNonNegativeIntegerEnv(name: string, fallback: number): number {
   if (!raw) return fallback;
   const parsed = Number(raw);
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function resolveMaxConcurrentFromEnv(): number {
+  const configured = parsePositiveIntegerEnv(
+    'DKG_STORE_MAX_CONCURRENT',
+    DEFAULT_MAX_CONCURRENT,
+  );
+  // One admitted SPARQL request can use several Oxigraph/Rayon worker threads.
+  // Letting an operator's stale tuning admit more store jobs than the host has
+  // logical CPUs multiplies runnable work and can starve the reserved ACK lane
+  // even while the JS scheduler reports empty queues. Keep explicit constructor
+  // options available to tests/embedded callers, but make the process-level
+  // environment setting a hardware-aware ceiling.
+  return Math.min(configured, Math.max(1, availableParallelism()));
 }
 
 function resolveQueueLimitsFromEnv(): StorePriorityQueueLimits {
@@ -277,8 +292,7 @@ export class StorePriorityScheduler extends ObservableScheduler {
         stalledActiveAgeMs: 30_000,
       },
     });
-    this.maxConcurrent = options.maxConcurrent
-      ?? parsePositiveIntegerEnv('DKG_STORE_MAX_CONCURRENT', DEFAULT_MAX_CONCURRENT);
+    this.maxConcurrent = options.maxConcurrent ?? resolveMaxConcurrentFromEnv();
     const requestedAckReservedSlots = options.ackReservedSlots
       ?? parsePositiveIntegerEnv('DKG_STORE_ACK_RESERVED_SLOTS', DEFAULT_ACK_RESERVED_SLOTS);
     this.ackReservedSlots = Math.min(

--- a/packages/storage/test/blazegraph.unit.test.ts
+++ b/packages/storage/test/blazegraph.unit.test.ts
@@ -553,7 +553,11 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     await expect(s.query('SELECT ?s WHERE { ?s ?p ?o }')).rejects.toBeDefined();
     expect(active).toBe(0);
 
-    await expect(s.query('SELECT ?s WHERE { ?s ?p ?o }')).resolves.toMatchObject({
+    // The 5 ms budget above exists only to trigger cancellation. Reusing it
+    // for the recovery probe makes this assertion depend on host scheduling
+    // latency rather than on whether the previous attempt released its slot.
+    const recoveryStore = new BlazegraphStore(baseUrl, { timeout: 200 });
+    await expect(recoveryStore.query('SELECT ?s WHERE { ?s ?p ?o }')).resolves.toMatchObject({
       type: 'bindings',
     });
     expect(maxActive).toBe(1);

--- a/packages/storage/test/store-priority-scheduler.test.ts
+++ b/packages/storage/test/store-priority-scheduler.test.ts
@@ -3,11 +3,24 @@ import {
   StorePriorityScheduler,
   StoreSchedulerBusyError,
 } from '../src/store-priority-scheduler.js';
+import { availableParallelism } from 'node:os';
 import type { StoreWorkPriority } from '../src/triple-store.js';
 
 const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
 describe('StorePriorityScheduler', () => {
+  it('caps process-level concurrency at the host logical CPU count', () => {
+    const previous = process.env.DKG_STORE_MAX_CONCURRENT;
+    process.env.DKG_STORE_MAX_CONCURRENT = '1000000';
+    try {
+      const scheduler = new StorePriorityScheduler();
+      expect(scheduler.snapshot.maxConcurrent).toBe(availableParallelism());
+    } finally {
+      if (previous === undefined) delete process.env.DKG_STORE_MAX_CONCURRENT;
+      else process.env.DKG_STORE_MAX_CONCURRENT = previous;
+    }
+  });
+
   for (const priority of ['ack', 'health', 'normal', 'background'] as const satisfies readonly StoreWorkPriority[]) {
     it(`bounds the ${priority} queue and returns a typed retryable rejection`, async () => {
       const scheduler = new StorePriorityScheduler({

--- a/packages/storage/test/store-priority-scheduler.test.ts
+++ b/packages/storage/test/store-priority-scheduler.test.ts
@@ -1,23 +1,79 @@
 import { describe, expect, it, vi } from 'vitest';
+import { availableParallelism } from 'node:os';
 import {
   StorePriorityScheduler,
   StoreSchedulerBusyError,
 } from '../src/store-priority-scheduler.js';
-import { availableParallelism } from 'node:os';
 import type { StoreWorkPriority } from '../src/triple-store.js';
 
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return {
+    ...actual,
+    availableParallelism: vi.fn(() => 4),
+  };
+});
+
 const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+const mockedAvailableParallelism = vi.mocked(availableParallelism);
 
 describe('StorePriorityScheduler', () => {
-  it('caps process-level concurrency at the host logical CPU count', () => {
+  it('caps only oversized process settings while preserving lower values and constructor overrides', () => {
     const previous = process.env.DKG_STORE_MAX_CONCURRENT;
-    process.env.DKG_STORE_MAX_CONCURRENT = '1000000';
+    mockedAvailableParallelism.mockReturnValue(4);
     try {
-      const scheduler = new StorePriorityScheduler();
-      expect(scheduler.snapshot.maxConcurrent).toBe(availableParallelism());
+      process.env.DKG_STORE_MAX_CONCURRENT = '2';
+      expect(new StorePriorityScheduler().snapshot.maxConcurrent).toBe(2);
+
+      process.env.DKG_STORE_MAX_CONCURRENT = '1000000';
+      expect(new StorePriorityScheduler().snapshot.maxConcurrent).toBe(4);
+
+      expect(new StorePriorityScheduler({ maxConcurrent: 5 }).snapshot.maxConcurrent).toBe(5);
     } finally {
+      mockedAvailableParallelism.mockReturnValue(4);
       if (previous === undefined) delete process.env.DKG_STORE_MAX_CONCURRENT;
       else process.env.DKG_STORE_MAX_CONCURRENT = previous;
+    }
+  });
+
+  it('preserves default ACK admission when the runtime reports one logical CPU', async () => {
+    const previousMaxConcurrent = process.env.DKG_STORE_MAX_CONCURRENT;
+    const previousAckReservedSlots = process.env.DKG_STORE_ACK_RESERVED_SLOTS;
+    let releaseNormal: (() => void) | undefined;
+    let normal: Promise<string> | undefined;
+    mockedAvailableParallelism.mockReturnValue(1);
+    delete process.env.DKG_STORE_MAX_CONCURRENT;
+    delete process.env.DKG_STORE_ACK_RESERVED_SLOTS;
+    try {
+      const scheduler = new StorePriorityScheduler({
+        healthReservedSlots: 0,
+        queueWaitTimeoutMs: 20,
+      });
+      expect(scheduler.snapshot).toMatchObject({
+        maxConcurrent: 2,
+        ackReservedSlots: 1,
+      });
+
+      normal = scheduler.run('normal', 'query.long-running', async () => {
+        await new Promise<void>((resolve) => {
+          releaseNormal = resolve;
+        });
+        return 'normal';
+      });
+      expect(scheduler.snapshot.normalInflight).toBe(1);
+
+      await expect(
+        scheduler.run('ack', 'storage-ack.persist', async () => 'ack'),
+      ).resolves.toBe('ack');
+      expect(scheduler.snapshot.ackQueued).toBe(0);
+    } finally {
+      releaseNormal?.();
+      await normal;
+      mockedAvailableParallelism.mockReturnValue(4);
+      if (previousMaxConcurrent === undefined) delete process.env.DKG_STORE_MAX_CONCURRENT;
+      else process.env.DKG_STORE_MAX_CONCURRENT = previousMaxConcurrent;
+      if (previousAckReservedSlots === undefined) delete process.env.DKG_STORE_ACK_RESERVED_SLOTS;
+      else process.env.DKG_STORE_ACK_RESERVED_SLOTS = previousAckReservedSlots;
     }
   });
 


### PR DESCRIPTION
## Impact

Prevents a stale or over-aggressive `DKG_STORE_MAX_CONCURRENT` override from admitting more concurrent SPARQL work than the host's available CPU parallelism. Explicit constructor options remain unchanged for tests and embedded callers.

This protects the reserved ACK lane from host-level CPU starvation that is invisible to JS queue telemetry.

## Before

```mermaid
sequenceDiagram
    participant Operator
    participant Scheduler
    participant Store as Oxigraph
    participant Ack as ACK handler
    Operator->>Scheduler: Configure concurrency above host capacity
    Scheduler->>Store: Admit excessive parallel SPARQL work
    Store-->>Store: Saturate available CPU
    Ack->>Store: Submit reserved ACK query
    Store-->>Ack: Miss handler deadline
```

## After

```mermaid
sequenceDiagram
    participant Operator
    participant Scheduler
    participant Host
    participant Store as Oxigraph
    participant Ack as ACK handler
    Operator->>Scheduler: Configure desired concurrency
    Scheduler->>Host: Read available CPU parallelism
    Scheduler->>Store: Admit min(configured, available CPUs)
    Ack->>Store: Submit reserved ACK query
    Store-->>Ack: Complete within reserved capacity
```

## Validation

- Storage scheduler focused suite: 23/23 passed.
- Storage TypeScript build passed.
- `git diff --check` passed.
- Direct Testnet validation artifact on beacon-01/02/03 (all 4-core hosts with CPUQuota=250%): effective limit resolved from stale configured 8 to 2.
- Oxigraph CPU fell from roughly 300% to 20-100% after warm-up.
- ACK lane remained healthy and empty with zero ACK-handler deadline failures in each post-restart invocation.
- VM jobs that had timed out before the hotfix subsequently reached `validated`.

Direct node patches are validation artifacts only; the source change in this PR is the reviewable deliverable.
