### PR TITLE
fix(sync): recover graph-backed SWM snapshots

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -6983,23 +6983,23 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           stopOnBackoffWorthyFailure,
           snapshotEvidencePolicy: selectedSwmEnabled
             ? {
-              // Any graph-backed operation sits outside the immutable snapshot
-              // walk, including when other operations in the same manifest do
-              // have store-backed refs. Until this requester has count/digest-
-              // bound transport evidence for every such operation, the selected
-              // lane must fail closed.
+              // A selected non-empty scope is complete only when it exposes at
+              // least one immutable content commitment. Store-backed refs use
+              // the snapshot protocol; graph-backed operations use the batched
+              // aggregate data plan and the same count/digest materializer.
               accepts: ({
                 verifiedMetadataTriples,
                 snapshotReferences,
                 graphBackedOperations,
               }) => (
                 verifiedMetadataTriples === 0
-                || (snapshotReferences > 0 && graphBackedOperations === 0)
+                || snapshotReferences + graphBackedOperations > 0
               ),
             }
             : undefined,
           metadataFetcher: selectedMetaFetcher?.strategy,
           snapshotRecoveryOrder: selectedSwmEnabled ? 'recent-balanced' : 'manifest',
+          dataRequesterScope: selectedSwmEnabled ? 'selected-swm-data:graph-v1' : undefined,
           ensureContextGraph: async (contextGraphId) => {
             const graphManager = new GraphManager(this.store);
             await graphManager.ensureContextGraph(contextGraphId);
@@ -7059,7 +7059,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           },
           publicSnapshotStore: this.publicSnapshotStore,
           deleteCheckpoint: (key) => deleteSyncPageCheckpoint(this.syncCheckpoints, key),
-          setCheckpoint: (key, offset) => this.syncCheckpoints.set(key, offset),
+          setCheckpoint: (key, offset, responderSessionOffset) => this.syncCheckpoints.set(
+            key,
+            offset,
+            Date.now(),
+            responderSessionOffset,
+          ),
           ensureOwnedMap: (contextGraphId) => {
             if (!this.workspaceOwnedEntities.has(contextGraphId)) {
               this.workspaceOwnedEntities.set(contextGraphId, new Map());

--- a/packages/agent/src/sync-verify-worker-impl.ts
+++ b/packages/agent/src/sync-verify-worker-impl.ts
@@ -96,10 +96,22 @@ function verifySyncedDataImpl(
 function parseAndFilterNQuads(text: string, graphUri: string, contextGraphId: string): SyncParseResult {
   const rawQuads = parseNQuads(text);
   const cgUriPrefix = `did:dkg:context-graph:${contextGraphId}/`;
+  // Graph-backed SWM snapshots encode the complete CG identifier as one path
+  // segment. Real public CG IDs contain `/` (contract/name), so their transport
+  // graph starts with `contract%2Fname` and does NOT match cgUriPrefix above.
+  // Admit that sibling family only for a shared-memory DATA request; descriptor
+  // validation later binds the exact graph, count and digest before storage.
+  const graphBackedSwmPrefix = `did:dkg:context-graph:${encodeURIComponent(contextGraphId)}`
+    + '/_shared_memory_snapshots/';
+  const acceptsGraphBackedSwm = graphUri.endsWith('/_shared_memory');
   const quads: Quad[] = [];
   const sourceIndexes: number[] = [];
   for (const [index, quad] of rawQuads.entries()) {
-    if (quad.graph !== graphUri && !quad.graph.startsWith(cgUriPrefix)) continue;
+    if (
+      quad.graph !== graphUri
+      && !quad.graph.startsWith(cgUriPrefix)
+      && !(acceptsGraphBackedSwm && quad.graph.startsWith(graphBackedSwmPrefix))
+    ) continue;
     quads.push(quad);
     sourceIndexes.push(index);
   }

--- a/packages/agent/src/sync-verify-worker-impl.ts
+++ b/packages/agent/src/sync-verify-worker-impl.ts
@@ -1,6 +1,7 @@
 import { parentPort } from 'node:worker_threads';
 import { validateSubGraphName } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
+import { parseGraphBackedSwmSnapshotGraph } from './sync/graph-scoped-swm-recovery.js';
 import type { SyncVerifyResult, SyncVerifyLogEntry, SyncParseResult, SharedMemoryProcessResult, DurableBatchProcessResult, DurableBatchProcessWireResult, DurableBatchVerificationMode, SharedMemoryBatchProcessResult } from './sync-verify-worker.js';
 import { isSharedMemoryBucketDescendantDataGraph } from './sync/shared-memory-graphs.js';
 import {
@@ -101,8 +102,6 @@ function parseAndFilterNQuads(text: string, graphUri: string, contextGraphId: st
   // graph starts with `contract%2Fname` and does NOT match cgUriPrefix above.
   // Admit that sibling family only for a shared-memory DATA request; descriptor
   // validation later binds the exact graph, count and digest before storage.
-  const graphBackedSwmPrefix = `did:dkg:context-graph:${encodeURIComponent(contextGraphId)}`
-    + '/_shared_memory_snapshots/';
   const acceptsGraphBackedSwm = graphUri.endsWith('/_shared_memory');
   const quads: Quad[] = [];
   const sourceIndexes: number[] = [];
@@ -110,7 +109,10 @@ function parseAndFilterNQuads(text: string, graphUri: string, contextGraphId: st
     if (
       quad.graph !== graphUri
       && !quad.graph.startsWith(cgUriPrefix)
-      && !(acceptsGraphBackedSwm && quad.graph.startsWith(graphBackedSwmPrefix))
+      && !(
+        acceptsGraphBackedSwm
+        && parseGraphBackedSwmSnapshotGraph(quad.graph)?.contextGraphId === contextGraphId
+      )
     ) continue;
     quads.push(quad);
     sourceIndexes.push(index);

--- a/packages/agent/src/sync/auth/request-build.ts
+++ b/packages/agent/src/sync/auth/request-build.ts
@@ -191,8 +191,7 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
   // and a NEW responder treats a request WITHOUT meta pageMode as non-negotiated
   // (plain meta serializer). The signed `limit` still rides the 500-row legacy
   // cap below, so digests stay wire-compatible.
-  const useByteBudgetPage = !includeSharedMemory
-    && (phase === 'data' || phase === 'meta')
+  const useByteBudgetPage = (phase === 'data' || (!includeSharedMemory && phase === 'meta'))
     && (
       requestedLimit > SYNC_PAGE_SIZE
       // Exact DATA must remain on the responder's bounded page-only path after

--- a/packages/agent/src/sync/checkpoint/state.ts
+++ b/packages/agent/src/sync/checkpoint/state.ts
@@ -33,6 +33,8 @@ export type SyncCheckpointScope =
 
 /** Runtime-distinct namespace owned only by retained selected-SWM metadata. */
 export type SelectedSwmMetaRetentionScope = `selected-swm-meta:retained:${string}`;
+/** Runtime-distinct namespace owned only by selected SWM DATA replay. */
+export type SelectedSwmDataCheckpointScope = `selected-swm-data:${string}`;
 
 export interface SyncCheckpointStore {
   /**

--- a/packages/agent/src/sync/checkpoint/state.ts
+++ b/packages/agent/src/sync/checkpoint/state.ts
@@ -28,6 +28,7 @@ export {
  */
 export type SyncCheckpointScope =
   | `selected-swm-meta:${string}`
+  | `selected-swm-data:${string}`
   | `durable-recovery-meta:${string}`;
 
 /** Runtime-distinct namespace owned only by retained selected-SWM metadata. */

--- a/packages/agent/src/sync/graph-scoped-swm-recovery.ts
+++ b/packages/agent/src/sync/graph-scoped-swm-recovery.ts
@@ -489,13 +489,58 @@ function subGraphForMetaGraph(contextGraphId: string, metaGraph: string): string
   return name;
 }
 
-function knowledgeAssetSnapshotGraph(
+export interface GraphBackedSwmSnapshotGraphIdentity {
+  readonly contextGraphId: string;
+  readonly shareOperationId: string;
+  readonly subGraphName?: string;
+}
+
+/** Canonical immutable transport graph for one graph-scoped SWM operation. */
+export function knowledgeAssetSnapshotGraph(
   contextGraphId: string,
   shareOperationId: string,
   subGraphName?: string,
 ): string {
   const parts = [contextGraphId, subGraphName ?? '_', shareOperationId].map(encodeURIComponent);
   return `did:dkg:context-graph:${parts[0]}/_shared_memory_snapshots/${parts[1]}/${parts[2]}/ka`;
+}
+
+/**
+ * Parse the canonical graph-backed SWM transport identity. Returning null is
+ * deliberately fail-closed: callers must not treat a merely similar URI as an
+ * immutable snapshot graph.
+ */
+export function parseGraphBackedSwmSnapshotGraph(
+  graph: string,
+): GraphBackedSwmSnapshotGraphIdentity | null {
+  const prefix = 'did:dkg:context-graph:';
+  const marker = '/_shared_memory_snapshots/';
+  if (!graph.startsWith(prefix) || !graph.endsWith('/ka')) return null;
+  const markerIndex = graph.indexOf(marker, prefix.length);
+  if (markerIndex < 0) return null;
+  const encodedContextGraphId = graph.slice(prefix.length, markerIndex);
+  const tail = graph.slice(markerIndex + marker.length, -3);
+  const parts = tail.split('/');
+  if (!encodedContextGraphId || parts.length !== 2 || parts.some((part) => !part)) return null;
+  try {
+    const contextGraphId = decodeURIComponent(encodedContextGraphId);
+    const encodedSubGraphName = parts[0]!;
+    const shareOperationId = decodeURIComponent(parts[1]!);
+    const subGraphName = encodedSubGraphName === '_'
+      ? undefined
+      : decodeURIComponent(encodedSubGraphName);
+    if (
+      !contextGraphId
+      || !shareOperationId
+      || (subGraphName !== undefined && !validateSubGraphName(subGraphName).valid)
+    ) return null;
+    const identity = { contextGraphId, shareOperationId, ...(subGraphName ? { subGraphName } : {}) };
+    return knowledgeAssetSnapshotGraph(contextGraphId, shareOperationId, subGraphName) === graph
+      ? identity
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 function groupByGraphAndSubject(quads: readonly Quad[]): Map<string, Quad[]> {

--- a/packages/agent/src/sync/requester/graph-backed-swm-data-replay.ts
+++ b/packages/agent/src/sync/requester/graph-backed-swm-data-replay.ts
@@ -1,0 +1,157 @@
+import type { Quad } from '@origintrail-official/dkg-storage';
+import type { GraphScopedSwmRecoveryDescriptor } from '../graph-scoped-swm-recovery.js';
+
+const PUBLIC_SNAPSHOT_GRAPH = 'http://dkg.io/ontology/publicSnapshotGraph';
+
+export interface BoundedGraphBackedSwmDataPage {
+  readonly completeGraphs: ReadonlySet<string>;
+  readonly safeNextOffset: number;
+  readonly safeRawNextOffset: number;
+  readonly rewound: boolean;
+}
+
+export interface IndexedGraphBackedSwmDataPage {
+  readonly dataByGraph: Map<string, Quad[]>;
+  readonly rawStartByGraph: ReadonlyMap<string, number>;
+}
+
+/**
+ * Raw advertisement terms are used only to partition aggregate DATA away from
+ * the permissive legacy-root verifier. Descriptor parsing remains the sole
+ * authority for identity, materialization, and completion.
+ */
+export function collectAdvertisedGraphBackedSnapshotGraphs(
+  metaQuads: readonly Quad[],
+): ReadonlySet<string> {
+  return new Set(
+    metaQuads
+      .filter((quad) => quad.predicate === PUBLIC_SNAPSHOT_GRAPH)
+      .map((quad) => stripLiteral(quad.object)?.trim())
+      .filter((graph): graph is string => Boolean(graph)),
+  );
+}
+
+/** Index one aggregate DATA page once, preserving its responder coordinates. */
+export function indexGraphBackedSwmDataPage(params: {
+  readonly quads: readonly Quad[];
+  readonly advertisedGraphs: ReadonlySet<string>;
+  readonly resumedFromOffset: number;
+  readonly rawResumedFromOffset?: number;
+  readonly quadRawOffsets?: readonly number[];
+}): IndexedGraphBackedSwmDataPage {
+  const dataByGraph = new Map<string, Quad[]>();
+  const rawStartByGraph = new Map<string, number>();
+  const rawStart = params.rawResumedFromOffset ?? params.resumedFromOffset;
+  for (const [quadIndex, quad] of params.quads.entries()) {
+    if (!params.advertisedGraphs.has(quad.graph)) continue;
+    if (!rawStartByGraph.has(quad.graph)) {
+      rawStartByGraph.set(
+        quad.graph,
+        params.quadRawOffsets?.[quadIndex] ?? rawStart + quadIndex,
+      );
+    }
+    const rows = dataByGraph.get(quad.graph);
+    if (rows) rows.push(quad);
+    else dataByGraph.set(quad.graph, [quad]);
+  }
+  return { dataByGraph, rawStartByGraph };
+}
+
+/**
+ * Project a possibly interrupted aggregate SWM DATA response onto whole
+ * immutable snapshot graphs. The responder emits graph-backed snapshots as
+ * contiguous graph groups before legacy root data; only a full count-bound
+ * group may be materialized or skipped by the next requester cursor.
+ */
+export function planBoundedGraphBackedSwmDataPage(params: {
+  readonly quads: readonly Quad[];
+  readonly descriptors: readonly GraphScopedSwmRecoveryDescriptor[];
+  readonly resumedFromOffset: number;
+  readonly rawResumedFromOffset?: number;
+  readonly nextOffset: number;
+  readonly rawNextOffset?: number;
+  readonly quadRawOffsets?: readonly number[];
+  readonly completed: boolean;
+}): BoundedGraphBackedSwmDataPage | null {
+  const expectedByGraph = new Map<string, number>();
+  for (const descriptor of params.descriptors) {
+    const graph = descriptor.publicSnapshotGraph;
+    if (!graph) continue;
+    const existing = expectedByGraph.get(graph);
+    if (existing !== undefined && existing !== descriptor.publicQuadsCount) return null;
+    expectedByGraph.set(graph, descriptor.publicQuadsCount);
+  }
+  const rawResumed = params.rawResumedFromOffset ?? params.resumedFromOffset;
+  const rawNext = params.rawNextOffset ?? params.nextOffset;
+  if (expectedByGraph.size === 0) {
+    return {
+      completeGraphs: new Set(),
+      safeNextOffset: params.nextOffset,
+      safeRawNextOffset: rawNext,
+      rewound: false,
+    };
+  }
+  const rawOffsets = params.quadRawOffsets === undefined
+    ? rawNext - rawResumed === params.quads.length
+      ? params.quads.map((_, index) => rawResumed + index)
+      : null
+    : [...params.quadRawOffsets];
+  if (
+    rawOffsets === null
+    || rawOffsets.length !== params.quads.length
+    || rawOffsets.some((offset, index) => !Number.isSafeInteger(offset)
+      || offset < rawResumed
+      || offset >= rawNext
+      || (index > 0 && offset <= rawOffsets[index - 1]!))
+  ) return null;
+
+  const completeGraphs = new Set<string>();
+  const seenGraphs = new Set<string>();
+  let index = 0;
+  let sawLegacyRows = false;
+  while (index < params.quads.length) {
+    const graph = params.quads[index]!.graph;
+    const expected = expectedByGraph.get(graph);
+    if (expected === undefined) {
+      sawLegacyRows = true;
+      index += 1;
+      continue;
+    }
+    if (sawLegacyRows || seenGraphs.has(graph)) return null;
+    seenGraphs.add(graph);
+    const groupStart = index;
+    while (index < params.quads.length && params.quads[index]!.graph === graph) index += 1;
+    const observed = index - groupStart;
+    if (observed > expected) return null;
+    if (observed === expected) {
+      completeGraphs.add(graph);
+      continue;
+    }
+    if (params.completed || index !== params.quads.length) return null;
+    const safeRawNextOffset = rawOffsets[groupStart]!;
+    return {
+      completeGraphs,
+      safeNextOffset: safeRawNextOffset,
+      safeRawNextOffset,
+      rewound: safeRawNextOffset < rawNext,
+    };
+  }
+  return {
+    completeGraphs,
+    safeNextOffset: params.nextOffset,
+    safeRawNextOffset: rawNext,
+    rewound: false,
+  };
+}
+
+function stripLiteral(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const match = value.match(/^"((?:[^"\\]|\\.)*)"(?:@[-A-Za-z0-9]+|\^\^<[^>]+>)?$/);
+  if (!match) return value;
+  return match[1]
+    .replace(/\\n/g, '\n')
+    .replace(/\\r/g, '\r')
+    .replace(/\\t/g, '\t')
+    .replace(/\\"/g, '"')
+    .replace(/\\\\/g, '\\');
+}

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -9,7 +9,7 @@ import type { Quad } from '@origintrail-official/dkg-storage';
 import type { SwmSnapshotCoverage } from '../../dkg-agent-types.js';
 import { workspacePublicQuadsDigest, type WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
 import type { SyncPhase } from '../auth/request-build.js';
-import type { SyncCheckpointScope } from '../checkpoint/state.js';
+import type { SelectedSwmDataCheckpointScope } from '../checkpoint/state.js';
 import { didSyncPeerRespond, isSyncBackoffWorthyError, isSyncPermanentRejection, isSyncTransportFailure } from '../error-tags.js';
 import { isSharedMemoryBucketDescendantDataGraph } from '../shared-memory-graphs.js';
 import {
@@ -19,10 +19,16 @@ import {
 import {
   canonicalizeGraphScopedSwmHeadRows,
   materializeGraphScopedSwmRecoveryAsset,
+  parseGraphBackedSwmSnapshotGraph,
   parseGraphScopedSwmRecoveryDescriptors,
   type GraphScopedSwmRecoveryDescriptor,
 } from '../graph-scoped-swm-recovery.js';
 import type { SharedMemorySnapshotMaterializer } from './swm-snapshot-materializer.js';
+import {
+  collectAdvertisedGraphBackedSnapshotGraphs,
+  indexGraphBackedSwmDataPage,
+  planBoundedGraphBackedSwmDataPage,
+} from './graph-backed-swm-data-replay.js';
 
 const DKG = 'http://dkg.io/ontology/';
 
@@ -389,7 +395,7 @@ interface SharedMemorySyncContext {
    */
   snapshotRecoveryOrder?: 'manifest' | 'recent-balanced';
   /** Versioned cursor namespace for callers that own selected SWM DATA replay. */
-  dataRequesterScope?: SyncCheckpointScope;
+  dataRequesterScope?: SelectedSwmDataCheckpointScope;
   deleteCheckpoint: (key: string) => void;
   setCheckpoint: (key: string, offset: number, responderSessionOffset?: number) => void;
   ensureOwnedMap: (ownershipKey: string) => Map<string, string>;
@@ -411,106 +417,6 @@ function storedVersionOutranksDescriptor(stored: string, descriptorVersion: stri
   } catch {
     return true;
   }
-}
-
-export interface BoundedGraphBackedSwmDataPage {
-  readonly completeGraphs: ReadonlySet<string>;
-  readonly safeNextOffset: number;
-  readonly safeRawNextOffset: number;
-  readonly rewound: boolean;
-}
-
-/**
- * Project a possibly interrupted aggregate SWM DATA response onto whole
- * immutable snapshot graphs. The responder emits graph-backed snapshots as
- * contiguous graph groups before legacy root data; only a full count-bound
- * group may be materialized or skipped by the next requester cursor.
- */
-export function planBoundedGraphBackedSwmDataPage(params: {
-  readonly quads: readonly Quad[];
-  readonly descriptors: readonly GraphScopedSwmRecoveryDescriptor[];
-  readonly resumedFromOffset: number;
-  readonly rawResumedFromOffset?: number;
-  readonly nextOffset: number;
-  readonly rawNextOffset?: number;
-  readonly quadRawOffsets?: readonly number[];
-  readonly completed: boolean;
-}): BoundedGraphBackedSwmDataPage | null {
-  const expectedByGraph = new Map<string, number>();
-  for (const descriptor of params.descriptors) {
-    const graph = descriptor.publicSnapshotGraph;
-    if (!graph) continue;
-    const existing = expectedByGraph.get(graph);
-    if (existing !== undefined && existing !== descriptor.publicQuadsCount) return null;
-    expectedByGraph.set(graph, descriptor.publicQuadsCount);
-  }
-  const rawResumed = params.rawResumedFromOffset ?? params.resumedFromOffset;
-  const rawNext = params.rawNextOffset ?? params.nextOffset;
-  if (expectedByGraph.size === 0) {
-    return {
-      completeGraphs: new Set(),
-      safeNextOffset: params.nextOffset,
-      safeRawNextOffset: rawNext,
-      rewound: false,
-    };
-  }
-  const rawOffsets = params.quadRawOffsets === undefined
-    ? rawNext - rawResumed === params.quads.length
-      ? params.quads.map((_, index) => rawResumed + index)
-      : null
-    : [...params.quadRawOffsets];
-  if (
-    rawOffsets === null
-    || rawOffsets.length !== params.quads.length
-    || rawOffsets.some((offset, index) => !Number.isSafeInteger(offset)
-      || offset < rawResumed
-      || offset >= rawNext
-      || (index > 0 && offset <= rawOffsets[index - 1]!))
-  ) return null;
-
-  const completeGraphs = new Set<string>();
-  const seenGraphs = new Set<string>();
-  let index = 0;
-  let sawLegacyRows = false;
-  while (index < params.quads.length) {
-    const graph = params.quads[index]!.graph;
-    const expected = expectedByGraph.get(graph);
-    if (expected === undefined) {
-      sawLegacyRows = true;
-      index += 1;
-      continue;
-    }
-    // Graph-backed groups precede legacy root rows and are contiguous. A graph
-    // after legacy data, or the same graph in two groups, is not safely
-    // checkpointable against this responder generation.
-    if (sawLegacyRows || seenGraphs.has(graph)) return null;
-    seenGraphs.add(graph);
-    const groupStart = index;
-    while (index < params.quads.length && params.quads[index]!.graph === graph) index += 1;
-    const observed = index - groupStart;
-    if (observed > expected) return null;
-    if (observed === expected) {
-      completeGraphs.add(graph);
-      continue;
-    }
-    // A short immutable graph is only a valid timeout prefix when it is the
-    // final group returned. Rewind both verified and responder coordinates to
-    // its first row so the next pass reconstructs the whole graph.
-    if (params.completed || index !== params.quads.length) return null;
-    const safeRawNextOffset = rawOffsets[groupStart]!;
-    return {
-      completeGraphs,
-      safeNextOffset: safeRawNextOffset,
-      safeRawNextOffset,
-      rewound: safeRawNextOffset < rawNext,
-    };
-  }
-  return {
-    completeGraphs,
-    safeNextOffset: params.nextOffset,
-    safeRawNextOffset: rawNext,
-    rewound: false,
-  };
 }
 
 export async function runSharedMemorySync(context: SharedMemorySyncContext): Promise<SharedMemorySyncSummary> {
@@ -748,7 +654,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       // This prefilter uses raw metadata only to REMOVE data from the permissive
       // legacy path; verified metadata remains the sole authority for adding or
       // completing anything.
-      const rawAdvertisedGraphBackedSnapshots = collectAdvertisedGraphBackedSnapshots(
+      const rawAdvertisedGraphBackedSnapshots = collectAdvertisedGraphBackedSnapshotGraphs(
         wsMetaResult.quads,
       );
       const processed = await processSharedMemoryBatch(
@@ -848,28 +754,27 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       // queryable as ordinary SWM data or inflate insertion counters. The
       // parser remains the authority for which of these advertisements can be
       // materialized and counted toward terminal coverage.
-      const advertisedGraphBackedSnapshotGraphs = collectAdvertisedGraphBackedSnapshots(
+      const advertisedGraphBackedSnapshotGraphs = collectAdvertisedGraphBackedSnapshotGraphs(
         processed.verifiedMeta,
       );
+      // Preserve the advertised denominator independently of descriptor
+      // parsing. A malformed graph-backed operation must remain incomplete;
+      // clearing the materializable set below must never turn it into vacuous
+      // 0/0 completion.
+      graphBackedTotalForCg = advertisedGraphBackedSnapshotGraphs.size;
       // Index the aggregate page once. Filtering the complete 250k-quad page
       // once per KA would make recovery O(KAs * quads); the per-graph buckets
       // keep verification linear while retaining the materializer's own exact
       // graph/count/digest checks.
-      const graphBackedDataByGraph = new Map<string, Quad[]>();
-      const graphBackedRawStartByGraph = new Map<string, number>();
-      for (const [quadIndex, quad] of wsDataResult.quads.entries()) {
-        if (!advertisedGraphBackedSnapshotGraphs.has(quad.graph)) continue;
-        if (!graphBackedRawStartByGraph.has(quad.graph)) {
-          graphBackedRawStartByGraph.set(
-            quad.graph,
-            wsDataResult.quadRawOffsets?.[quadIndex]
-              ?? (wsDataResult.rawResumedFromOffset ?? wsDataResult.resumedFromOffset) + quadIndex,
-          );
-        }
-        const rows = graphBackedDataByGraph.get(quad.graph);
-        if (rows) rows.push(quad);
-        else graphBackedDataByGraph.set(quad.graph, [quad]);
-      }
+      const graphBackedDataPage = indexGraphBackedSwmDataPage({
+        quads: wsDataResult.quads,
+        advertisedGraphs: advertisedGraphBackedSnapshotGraphs,
+        resumedFromOffset: wsDataResult.resumedFromOffset,
+        rawResumedFromOffset: wsDataResult.rawResumedFromOffset,
+        quadRawOffsets: wsDataResult.quadRawOffsets,
+      });
+      const graphBackedDataByGraph = graphBackedDataPage.dataByGraph;
+      const graphBackedRawStartByGraph = graphBackedDataPage.rawStartByGraph;
       validWsQuads = validWsQuads.filter(
         (quad) => !advertisedGraphBackedSnapshotGraphs.has(quad.graph),
       );
@@ -938,11 +843,11 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
               rawNextOffset: boundedGraphBackedPage.safeRawNextOffset,
               completed: false,
             };
-            for (const graph of [...graphBackedDataByGraph.keys()]) {
-              if (!boundedGraphBackedPage.completeGraphs.has(graph)) {
-                graphBackedDataByGraph.delete(graph);
-              }
+          for (const graph of [...graphBackedDataByGraph.keys()]) {
+            if (!boundedGraphBackedPage.completeGraphs.has(graph)) {
+              graphBackedDataByGraph.delete(graph);
             }
+          }
             if (boundedGraphBackedPage.safeNextOffset === 0) {
               // setCheckpoint(0) would retain page-fetch's process-local token
               // at the raw end of the discarded suffix. Delete both halves so
@@ -1338,7 +1243,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       // rather than a decision input.
       recordSnapshotCoverage(
         snapshotSync,
-        graphBackedSnapshotGraphs.size,
+        graphBackedTotalForCg,
         wsMetaResult.completed,
         descriptorsAuthoritativeForCg,
         materializationFailures,
@@ -1380,16 +1285,16 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       const snapshotEvidenceAccepted = snapshotEvidencePolicy?.accepts({
         verifiedMetadataTriples: processed.verifiedMeta.length,
         snapshotReferences: snapshotSync.totalSnapshots,
-        graphBackedOperations: countGraphBackedSnapshotOperations(processed.verifiedMeta),
+        graphBackedOperations: countGraphBackedSnapshotOperations(processed.verifiedMeta, pid),
       }) ?? true;
       const snapshotPhaseUsable = snapshotSync.completed
         && materializationFailures === 0
         && (
           descriptorsAuthoritativeForCg
-          || snapshotSync.totalSnapshots + graphBackedSnapshotGraphs.size === 0
+          || snapshotSync.totalSnapshots + graphBackedTotalForCg === 0
         )
         && materializedRefs.size
-          === snapshotSync.totalSnapshots + graphBackedSnapshotGraphs.size
+          === snapshotSync.totalSnapshots + graphBackedTotalForCg
         && snapshotEvidenceAccepted;
       if (materializationFailures > 0) {
         logWarn(ctx, `SWM sync for "${pid}": ${materializationFailures} snapshot(s) verified but `
@@ -1415,11 +1320,15 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
           await storeInsert(validWsQuads);
           summary.insertedTriples += validWsQuads.length;
           summary.insertedDataTriples += validWsQuads.length;
-          recordPhaseOutcome(effectiveWsDataResult, {
-            updateCheckpoint: !suppressDataCheckpointUpdate,
-          });
           hydrateOwnership();
         }
+        // Graph-backed DATA can be the entire response. Its safe rewind cursor
+        // is still evidence even when there are no legacy rows to insert; tying
+        // checkpoint persistence to `validWsQuads.length` discarded that cursor
+        // and restarted every failed immutable graph from an unrelated offset.
+        recordPhaseOutcome(effectiveWsDataResult, {
+          updateCheckpoint: !suppressDataCheckpointUpdate,
+        });
         if (snapshotSync.timedOutPhases > 0 && shouldStopAfterBackoffWorthyFailure(pid, 'snapshot timeout')) {
           break;
         }
@@ -1954,19 +1863,23 @@ export function orderPublicSnapshotsForBalancedRecency(
  * deliberately excluded: the selected lane then sees no supported immutable
  * commitment and remains incomplete instead of falsely treating them as KAs.
  */
-function countGraphBackedSnapshotOperations(metaQuads: readonly Quad[]): number {
+function countGraphBackedSnapshotOperations(
+  metaQuads: readonly Quad[],
+  contextGraphId: string,
+): number {
   const bySubject = new Map<string, {
-    hasSnapshotGraph: boolean;
+    snapshotGraph?: string;
     isWorkspaceOperation: boolean;
     graphScoped: boolean;
   }>();
   for (const quad of metaQuads) {
     const entry = bySubject.get(quad.subject) ?? {
-      hasSnapshotGraph: false,
       isWorkspaceOperation: false,
       graphScoped: false,
     };
-    if (quad.predicate === `${DKG}publicSnapshotGraph`) entry.hasSnapshotGraph = true;
+    if (quad.predicate === `${DKG}publicSnapshotGraph`) {
+      entry.snapshotGraph = stripLiteral(quad.object)?.trim();
+    }
     if (
       quad.predicate === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
       && quad.object === `${DKG}WorkspaceOperation`
@@ -1978,17 +1891,11 @@ function countGraphBackedSnapshotOperations(metaQuads: readonly Quad[]): number 
     bySubject.set(quad.subject, entry);
   }
   return [...bySubject.values()].filter((entry) => (
-    entry.hasSnapshotGraph && entry.isWorkspaceOperation && entry.graphScoped
+    entry.snapshotGraph !== undefined
+    && parseGraphBackedSwmSnapshotGraph(entry.snapshotGraph)?.contextGraphId === contextGraphId
+    && entry.isWorkspaceOperation
+    && entry.graphScoped
   )).length;
-}
-
-function collectAdvertisedGraphBackedSnapshots(metaQuads: readonly Quad[]): Set<string> {
-  return new Set(
-    metaQuads
-      .filter((quad) => quad.predicate === `${DKG}publicSnapshotGraph`)
-      .map((quad) => stripLiteral(quad.object)?.trim())
-      .filter((graph): graph is string => Boolean(graph)),
-  );
 }
 
 async function hasValidSnapshot(

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -1,9 +1,15 @@
-import { contextGraphWorkspaceGraphUri, contextGraphWorkspaceMetaGraphUri, validateSubGraphName } from '@origintrail-official/dkg-core';
+import {
+  contextGraphWorkspaceGraphUri,
+  contextGraphWorkspaceMetaGraphUri,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  validateSubGraphName,
+} from '@origintrail-official/dkg-core';
 import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { SwmSnapshotCoverage } from '../../dkg-agent-types.js';
 import { workspacePublicQuadsDigest, type WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
 import type { SyncPhase } from '../auth/request-build.js';
+import type { SyncCheckpointScope } from '../checkpoint/state.js';
 import { didSyncPeerRespond, isSyncBackoffWorthyError, isSyncPermanentRejection, isSyncTransportFailure } from '../error-tags.js';
 import { isSharedMemoryBucketDescendantDataGraph } from '../shared-memory-graphs.js';
 import {
@@ -382,8 +388,10 @@ interface SharedMemorySyncContext {
    * oldest outstanding history. Ordinary sync preserves manifest order.
    */
   snapshotRecoveryOrder?: 'manifest' | 'recent-balanced';
+  /** Versioned cursor namespace for callers that own selected SWM DATA replay. */
+  dataRequesterScope?: SyncCheckpointScope;
   deleteCheckpoint: (key: string) => void;
-  setCheckpoint: (key: string, offset: number) => void;
+  setCheckpoint: (key: string, offset: number, responderSessionOffset?: number) => void;
   ensureOwnedMap: (ownershipKey: string) => Map<string, string>;
   logInfo: (ctx: OperationContext, message: string) => void;
   logWarn: (ctx: OperationContext, message: string) => void;
@@ -405,6 +413,106 @@ function storedVersionOutranksDescriptor(stored: string, descriptorVersion: stri
   }
 }
 
+export interface BoundedGraphBackedSwmDataPage {
+  readonly completeGraphs: ReadonlySet<string>;
+  readonly safeNextOffset: number;
+  readonly safeRawNextOffset: number;
+  readonly rewound: boolean;
+}
+
+/**
+ * Project a possibly interrupted aggregate SWM DATA response onto whole
+ * immutable snapshot graphs. The responder emits graph-backed snapshots as
+ * contiguous graph groups before legacy root data; only a full count-bound
+ * group may be materialized or skipped by the next requester cursor.
+ */
+export function planBoundedGraphBackedSwmDataPage(params: {
+  readonly quads: readonly Quad[];
+  readonly descriptors: readonly GraphScopedSwmRecoveryDescriptor[];
+  readonly resumedFromOffset: number;
+  readonly rawResumedFromOffset?: number;
+  readonly nextOffset: number;
+  readonly rawNextOffset?: number;
+  readonly quadRawOffsets?: readonly number[];
+  readonly completed: boolean;
+}): BoundedGraphBackedSwmDataPage | null {
+  const expectedByGraph = new Map<string, number>();
+  for (const descriptor of params.descriptors) {
+    const graph = descriptor.publicSnapshotGraph;
+    if (!graph) continue;
+    const existing = expectedByGraph.get(graph);
+    if (existing !== undefined && existing !== descriptor.publicQuadsCount) return null;
+    expectedByGraph.set(graph, descriptor.publicQuadsCount);
+  }
+  const rawResumed = params.rawResumedFromOffset ?? params.resumedFromOffset;
+  const rawNext = params.rawNextOffset ?? params.nextOffset;
+  if (expectedByGraph.size === 0) {
+    return {
+      completeGraphs: new Set(),
+      safeNextOffset: params.nextOffset,
+      safeRawNextOffset: rawNext,
+      rewound: false,
+    };
+  }
+  const rawOffsets = params.quadRawOffsets === undefined
+    ? rawNext - rawResumed === params.quads.length
+      ? params.quads.map((_, index) => rawResumed + index)
+      : null
+    : [...params.quadRawOffsets];
+  if (
+    rawOffsets === null
+    || rawOffsets.length !== params.quads.length
+    || rawOffsets.some((offset, index) => !Number.isSafeInteger(offset)
+      || offset < rawResumed
+      || offset >= rawNext
+      || (index > 0 && offset <= rawOffsets[index - 1]!))
+  ) return null;
+
+  const completeGraphs = new Set<string>();
+  const seenGraphs = new Set<string>();
+  let index = 0;
+  let sawLegacyRows = false;
+  while (index < params.quads.length) {
+    const graph = params.quads[index]!.graph;
+    const expected = expectedByGraph.get(graph);
+    if (expected === undefined) {
+      sawLegacyRows = true;
+      index += 1;
+      continue;
+    }
+    // Graph-backed groups precede legacy root rows and are contiguous. A graph
+    // after legacy data, or the same graph in two groups, is not safely
+    // checkpointable against this responder generation.
+    if (sawLegacyRows || seenGraphs.has(graph)) return null;
+    seenGraphs.add(graph);
+    const groupStart = index;
+    while (index < params.quads.length && params.quads[index]!.graph === graph) index += 1;
+    const observed = index - groupStart;
+    if (observed > expected) return null;
+    if (observed === expected) {
+      completeGraphs.add(graph);
+      continue;
+    }
+    // A short immutable graph is only a valid timeout prefix when it is the
+    // final group returned. Rewind both verified and responder coordinates to
+    // its first row so the next pass reconstructs the whole graph.
+    if (params.completed || index !== params.quads.length) return null;
+    const safeRawNextOffset = rawOffsets[groupStart]!;
+    return {
+      completeGraphs,
+      safeNextOffset: safeRawNextOffset,
+      safeRawNextOffset,
+      rewound: safeRawNextOffset < rawNext,
+    };
+  }
+  return {
+    completeGraphs,
+    safeNextOffset: params.nextOffset,
+    safeRawNextOffset: rawNext,
+    rewound: false,
+  };
+}
+
 export async function runSharedMemorySync(context: SharedMemorySyncContext): Promise<SharedMemorySyncSummary> {
   const {
     ctx,
@@ -424,6 +532,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
     snapshotEvidencePolicy,
     metadataFetcher,
     snapshotRecoveryOrder = 'manifest',
+    dataRequesterScope,
     deleteCheckpoint,
     setCheckpoint,
     ensureOwnedMap,
@@ -480,7 +589,11 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
     }
     if (result.completed) deleteCheckpoint(result.checkpointKey);
     else if (result.nextOffset > 0 || result.resumedFromOffset > 0) {
-      setCheckpoint(result.checkpointKey, result.nextOffset);
+      setCheckpoint(
+        result.checkpointKey,
+        result.nextOffset,
+        result.rawNextOffset ?? result.nextOffset,
+      );
     }
   };
 
@@ -501,6 +614,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
    */
   const recordSnapshotCoverage = (
     walk: PublicSnapshotWalkProgress,
+    graphBackedTotal: number,
     manifestComplete: boolean,
     descriptorsAuthoritative: boolean,
     materializationFailures: number,
@@ -513,7 +627,8 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
     // is not part of this snapshot walk. Do not turn that into terminal 0/0
     // evidence. The genuinely empty two-phase response has its own explicit
     // builder below.
-    if (walk.totalSnapshots <= 0) return;
+    const totalSnapshots = walk.totalSnapshots + graphBackedTotal;
+    if (totalSnapshots <= 0) return;
     // RESOLVED MEANS LOCALLY MATERIALIZED, not fetched.
     //
     // `walk.readySnapshots` counts refs retrieved and digest-valid in the blob
@@ -529,15 +644,15 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
     // `resolved + missing === total` true by construction, and makes it cover
     // both never-fetched and fetched-but-unwritten refs without either being
     // tracked twice.
-    const snapshotsResolved = Math.min(materializedRefCount, walk.totalSnapshots);
+    const snapshotsResolved = Math.min(materializedRefCount, totalSnapshots);
     summary.swmCoverage = selectSwmSnapshotCoverage(summary.swmCoverage, {
       contextGraphId,
       peerIdSuffix: remotePeerId.slice(-8),
       snapshotsResolved,
-      snapshotsTotal: walk.totalSnapshots,
+      snapshotsTotal: totalSnapshots,
       manifestComplete,
       descriptorsAuthoritative,
-      missingCount: walk.totalSnapshots - snapshotsResolved,
+      missingCount: totalSnapshots - snapshotsResolved,
       // Never-retrieved refs first, then retrieved-but-unwritten ones. Deduped
       // across BOTH sources so the sample can never exceed `missingCount`, which
       // is what the renderer subtracts it from to size its "(+N more)" suffix.
@@ -557,6 +672,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
     // must reach the coverage record, not be lost with the stack.
     let materializedFailuresForCg = 0;
     let materializedRefsForCg = 0;
+    let graphBackedTotalForCg = 0;
     let descriptorsAuthoritativeForCg = true;
     const unresolvedRefSampleForCg: string[] = [];
     try {
@@ -603,7 +719,18 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         recordPhaseOutcome(wsMetaResult, { updateCheckpoint: false });
         break;
       }
-      const wsDataResult = await fetchSyncPages(ctx, remotePeerId, pid, true, 'data', wsGraph, deadline);
+      const wsDataResult = await fetchSyncPages(
+        ctx,
+        remotePeerId,
+        pid,
+        true,
+        'data',
+        wsGraph,
+        deadline,
+        dataRequesterScope ? { requesterScope: dataRequesterScope } : undefined,
+      );
+      let effectiveWsDataResult = wsDataResult;
+      let suppressDataCheckpointUpdate = false;
       peerRespondedForContextGraph = true;
       const fetchDurationMs = Date.now() - fetchStartedAt;
 
@@ -614,8 +741,20 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       const excludedSubGraphNames = getExcludedSubGraphNames
         ? await getExcludedSubGraphNames(pid)
         : undefined;
+      // Immutable graph-backed snapshots are a separate integrity plane. Keep
+      // them out of the legacy root-entity verifier (which would correctly but
+      // noisily classify every rootless snapshot quad as dropped), while the
+      // descriptor-bound materializer below still receives the original page.
+      // This prefilter uses raw metadata only to REMOVE data from the permissive
+      // legacy path; verified metadata remains the sole authority for adding or
+      // completing anything.
+      const rawAdvertisedGraphBackedSnapshots = collectAdvertisedGraphBackedSnapshots(
+        wsMetaResult.quads,
+      );
       const processed = await processSharedMemoryBatch(
-        wsDataResult.quads,
+        wsDataResult.quads.filter(
+          (quad) => !rawAdvertisedGraphBackedSnapshots.has(quad.graph),
+        ),
         wsMetaResult.quads,
         pid,
         registeredSubGraphNames,
@@ -672,7 +811,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         continue;
       }
 
-      const validWsQuads = processed.verifiedData;
+      let validWsQuads = processed.verifiedData;
       const dropped = processed.droppedDataTriples;
       const hydrateOwnership = () => {
         for (const { dataGraph, entity, creator } of processed.entityCreators) {
@@ -701,7 +840,39 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       // otherwise abort the whole CG fanout. A parse failure here must degrade to
       // "no materialization this round" — never take down the sync.
       const snapshotDescriptorsByRef = new Map<string, GraphScopedSwmRecoveryDescriptor[]>();
+      const graphBackedSnapshotGraphs = new Set<string>();
       let verifiedMetaForInsert = processed.verifiedMeta;
+      // Never union-insert an immutable graph-backed transport graph, even if
+      // descriptor parsing fails below. A malformed sibling descriptor must
+      // leave this round incomplete, but it must not make the transport copy
+      // queryable as ordinary SWM data or inflate insertion counters. The
+      // parser remains the authority for which of these advertisements can be
+      // materialized and counted toward terminal coverage.
+      const advertisedGraphBackedSnapshotGraphs = collectAdvertisedGraphBackedSnapshots(
+        processed.verifiedMeta,
+      );
+      // Index the aggregate page once. Filtering the complete 250k-quad page
+      // once per KA would make recovery O(KAs * quads); the per-graph buckets
+      // keep verification linear while retaining the materializer's own exact
+      // graph/count/digest checks.
+      const graphBackedDataByGraph = new Map<string, Quad[]>();
+      const graphBackedRawStartByGraph = new Map<string, number>();
+      for (const [quadIndex, quad] of wsDataResult.quads.entries()) {
+        if (!advertisedGraphBackedSnapshotGraphs.has(quad.graph)) continue;
+        if (!graphBackedRawStartByGraph.has(quad.graph)) {
+          graphBackedRawStartByGraph.set(
+            quad.graph,
+            wsDataResult.quadRawOffsets?.[quadIndex]
+              ?? (wsDataResult.rawResumedFromOffset ?? wsDataResult.resumedFromOffset) + quadIndex,
+          );
+        }
+        const rows = graphBackedDataByGraph.get(quad.graph);
+        if (rows) rows.push(quad);
+        else graphBackedDataByGraph.set(quad.graph, [quad]);
+      }
+      validWsQuads = validWsQuads.filter(
+        (quad) => !advertisedGraphBackedSnapshotGraphs.has(quad.graph),
+      );
       // Whether the descriptor map is an AUTHORITATIVE statement about this
       // round's metadata, i.e. whether "this ref has no descriptor" may be read
       // as "this ref has nothing to materialize".
@@ -713,7 +884,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       // descriptors never parsed is a third state, distinct both from a
       // truncated meta phase and from a genuine entity-share manifest that has
       // no head rows to describe.
-      if (snapshotMaterializer && publicSnapshotStore && wsMetaResult.completed) {
+      if (snapshotMaterializer && wsMetaResult.completed) {
         try {
           const descriptors = parseGraphScopedSwmRecoveryDescriptors({
             contextGraphId: pid,
@@ -731,16 +902,64 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
             descriptors,
           });
           for (const descriptor of descriptors) {
-            const ref = descriptor.publicSnapshotRef;
-            if (!ref) continue; // no immutable snapshot for this KA
+            const ref = descriptor.publicSnapshotRef ?? descriptor.publicSnapshotGraph;
+            if (!ref) continue;
+            if (descriptor.publicSnapshotGraph) {
+              graphBackedSnapshotGraphs.add(descriptor.publicSnapshotGraph);
+            }
             const list = snapshotDescriptorsByRef.get(ref) ?? [];
             list.push(descriptor);
             snapshotDescriptorsByRef.set(ref, list);
+          }
+          graphBackedTotalForCg = graphBackedSnapshotGraphs.size;
+
+          const boundedGraphBackedPage = planBoundedGraphBackedSwmDataPage({
+            quads: wsDataResult.quads,
+            descriptors,
+            resumedFromOffset: wsDataResult.resumedFromOffset,
+            rawResumedFromOffset: wsDataResult.rawResumedFromOffset,
+            nextOffset: wsDataResult.nextOffset,
+            rawNextOffset: wsDataResult.rawNextOffset,
+            quadRawOffsets: wsDataResult.quadRawOffsets,
+            completed: wsDataResult.completed,
+          });
+          if (!boundedGraphBackedPage) {
+            deleteCheckpoint(wsDataResult.checkpointKey);
+            suppressDataCheckpointUpdate = true;
+            throw Object.assign(
+              new Error(`Discarding graph-backed SWM response for "${pid}": immutable graph groups cannot be reconciled with the DATA cursor`),
+              { code: 'SYNC_SWM_GRAPH_CHECKPOINT_UNMAPPABLE' },
+            );
+          }
+          if (boundedGraphBackedPage.rewound) {
+            effectiveWsDataResult = {
+              ...wsDataResult,
+              nextOffset: boundedGraphBackedPage.safeNextOffset,
+              rawNextOffset: boundedGraphBackedPage.safeRawNextOffset,
+              completed: false,
+            };
+            for (const graph of [...graphBackedDataByGraph.keys()]) {
+              if (!boundedGraphBackedPage.completeGraphs.has(graph)) {
+                graphBackedDataByGraph.delete(graph);
+              }
+            }
+            if (boundedGraphBackedPage.safeNextOffset === 0) {
+              // setCheckpoint(0) would retain page-fetch's process-local token
+              // at the raw end of the discarded suffix. Delete both halves so
+              // a retry really starts the immutable response at zero.
+              deleteCheckpoint(wsDataResult.checkpointKey);
+              suppressDataCheckpointUpdate = true;
+            }
+            logInfo(ctx, `SWM sync for "${pid}": rewound DATA checkpoint to immutable graph boundary `
+              + `${boundedGraphBackedPage.safeNextOffset} (raw ${boundedGraphBackedPage.safeRawNextOffset})`);
           }
         } catch (err) {
           logWarn(ctx, `SWM sync could not parse graph-scoped snapshot descriptors for "${pid}": `
             + `${err instanceof Error ? err.message : String(err)}`);
           snapshotDescriptorsByRef.clear();
+          graphBackedSnapshotGraphs.clear();
+          deleteCheckpoint(wsDataResult.checkpointKey);
+          suppressDataCheckpointUpdate = true;
           // The map is now empty because parsing FAILED, not because there was
           // nothing to describe. Without this the vacuity rule would read every
           // manifest ref as "nothing to write" and report the graph fully
@@ -753,6 +972,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       let materializedGraphs = 0;
       let materializationFailures = 0;
       let materializedQuads = 0;
+      let graphBackedFailureRewindOffset: number | undefined;
       const materializedKeys = new Set<string>();
       /** Snapshot refs whose every descriptor is locally present. */
       const materializedRefs = new Set<string>();
@@ -821,7 +1041,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         // Missing WIRING means nothing CAN be written, so the ref stays
         // UNRESOLVED: a fetched-but-unwritten ref must never look like progress
         // to the continuation loop.
-        if (!snapshotMaterializer || !publicSnapshotStore) return;
+        if (!snapshotMaterializer) return;
         // No descriptors is a DIFFERENT case, and collapsing the two made a
         // fully-synced peer permanently capable.
         //
@@ -918,7 +1138,9 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
                 }
                 const asset = await materializeGraphScopedSwmRecoveryAsset({
                   descriptor,
-                  fetchedDataQuads: [],
+                  fetchedDataQuads: descriptor.publicSnapshotGraph
+                    ? (graphBackedDataByGraph.get(descriptor.publicSnapshotGraph) ?? [])
+                    : [],
                   publicSnapshotStore,
                 });
                 await ensureContextGraphOnce();
@@ -999,6 +1221,14 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
             }
             // Mirrored outside the `try` so a later throw cannot lose it.
             materializedFailuresForCg = materializationFailures;
+            if (descriptor.publicSnapshotGraph) {
+              const rewindOffset = graphBackedRawStartByGraph.get(descriptor.publicSnapshotGraph);
+              if (rewindOffset !== undefined) {
+                graphBackedFailureRewindOffset = graphBackedFailureRewindOffset === undefined
+                  ? rewindOffset
+                  : Math.min(graphBackedFailureRewindOffset, rewindOffset);
+              }
+            }
             logWarn(ctx, `SWM sync failed to materialize snapshot ${snapshotRef} for "${pid}": `
               + `${err instanceof Error ? err.message : String(err)}`);
           }
@@ -1057,6 +1287,26 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         // absent, so this costs nothing when there is genuinely no wiring.
         onSnapshotReady: (snapshot: PublicSnapshotMetadata) => materializeReadySnapshot(snapshot.ref),
       });
+      // Graph-backed immutable snapshots travel in the aggregate data phase,
+      // not through the blob-store snapshot protocol. They share the exact same
+      // atomic materializer and signed count/digest checks as store-backed refs.
+      for (const graph of graphBackedSnapshotGraphs) {
+        await materializeReadySnapshot(graph);
+      }
+      if (graphBackedFailureRewindOffset !== undefined) {
+        effectiveWsDataResult = {
+          ...wsDataResult,
+          nextOffset: graphBackedFailureRewindOffset,
+          rawNextOffset: graphBackedFailureRewindOffset,
+          completed: false,
+        };
+        if (graphBackedFailureRewindOffset === 0) {
+          deleteCheckpoint(wsDataResult.checkpointKey);
+          suppressDataCheckpointUpdate = true;
+        }
+        logInfo(ctx, `SWM sync for "${pid}": retained DATA cursor at failed immutable graph boundary `
+          + `${graphBackedFailureRewindOffset}`);
+      }
       if (materializedGraphs > 0) {
         // Reporting only — the counters were already added per KA, inside the
         // write lock, so they survive a snapshot-phase throw. Adding them again
@@ -1088,6 +1338,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       // rather than a decision input.
       recordSnapshotCoverage(
         snapshotSync,
+        graphBackedSnapshotGraphs.size,
         wsMetaResult.completed,
         descriptorsAuthoritativeForCg,
         materializationFailures,
@@ -1133,7 +1384,12 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       }) ?? true;
       const snapshotPhaseUsable = snapshotSync.completed
         && materializationFailures === 0
-        && (descriptorsAuthoritativeForCg || snapshotSync.totalSnapshots === 0)
+        && (
+          descriptorsAuthoritativeForCg
+          || snapshotSync.totalSnapshots + graphBackedSnapshotGraphs.size === 0
+        )
+        && materializedRefs.size
+          === snapshotSync.totalSnapshots + graphBackedSnapshotGraphs.size
         && snapshotEvidenceAccepted;
       if (materializationFailures > 0) {
         logWarn(ctx, `SWM sync for "${pid}": ${materializationFailures} snapshot(s) verified but `
@@ -1159,7 +1415,9 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
           await storeInsert(validWsQuads);
           summary.insertedTriples += validWsQuads.length;
           summary.insertedDataTriples += validWsQuads.length;
-          recordPhaseOutcome(wsDataResult);
+          recordPhaseOutcome(effectiveWsDataResult, {
+            updateCheckpoint: !suppressDataCheckpointUpdate,
+          });
           hydrateOwnership();
         }
         if (snapshotSync.timedOutPhases > 0 && shouldStopAfterBackoffWorthyFailure(pid, 'snapshot timeout')) {
@@ -1210,7 +1468,9 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         summary.insertedMetaTriples += newlyCountedMeta;
       }
       recordPhaseOutcome(wsMetaResult);
-      recordPhaseOutcome(wsDataResult);
+      recordPhaseOutcome(effectiveWsDataResult, {
+        updateCheckpoint: !suppressDataCheckpointUpdate,
+      });
       metadataFetcher?.release(pid);
       if ((wsMetaResult.timedOut || wsDataResult.timedOut) && shouldStopAfterBackoffWorthyFailure(pid, 'phase timeout')) {
         break;
@@ -1238,6 +1498,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         // group attached by the walk, never reassembled here.
         recordSnapshotCoverage(
           thrownProgress,
+          graphBackedTotalForCg,
           manifestComplete,
           descriptorsAuthoritativeForCg,
           materializedFailuresForCg,
@@ -1688,16 +1949,46 @@ export function orderPublicSnapshotsForBalancedRecency(
 }
 
 /**
- * Count graph-backed share operations whose content is outside the immutable
- * snapshot-store walk. The selected SWM lane must fail closed while this
- * aggregate requester cannot prove those transport graphs by count and digest.
+ * Count graph-scoped KA operations whose graph-backed content this requester
+ * can prove and materialize. Legacy root-slice graph advertisements are
+ * deliberately excluded: the selected lane then sees no supported immutable
+ * commitment and remains incomplete instead of falsely treating them as KAs.
  */
 function countGraphBackedSnapshotOperations(metaQuads: readonly Quad[]): number {
+  const bySubject = new Map<string, {
+    hasSnapshotGraph: boolean;
+    isWorkspaceOperation: boolean;
+    graphScoped: boolean;
+  }>();
+  for (const quad of metaQuads) {
+    const entry = bySubject.get(quad.subject) ?? {
+      hasSnapshotGraph: false,
+      isWorkspaceOperation: false,
+      graphScoped: false,
+    };
+    if (quad.predicate === `${DKG}publicSnapshotGraph`) entry.hasSnapshotGraph = true;
+    if (
+      quad.predicate === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
+      && quad.object === `${DKG}WorkspaceOperation`
+    ) entry.isWorkspaceOperation = true;
+    if (
+      quad.predicate === `${DKG}contentScopeVersion`
+      && parseIntegerLiteral(quad.object) === GRAPH_KA_CONTENT_SCOPE_VERSION
+    ) entry.graphScoped = true;
+    bySubject.set(quad.subject, entry);
+  }
+  return [...bySubject.values()].filter((entry) => (
+    entry.hasSnapshotGraph && entry.isWorkspaceOperation && entry.graphScoped
+  )).length;
+}
+
+function collectAdvertisedGraphBackedSnapshots(metaQuads: readonly Quad[]): Set<string> {
   return new Set(
     metaQuads
       .filter((quad) => quad.predicate === `${DKG}publicSnapshotGraph`)
-      .map((quad) => quad.subject),
-  ).size;
+      .map((quad) => stripLiteral(quad.object)?.trim())
+      .filter((graph): graph is string => Boolean(graph)),
+  );
 }
 
 async function hasValidSnapshot(

--- a/packages/agent/src/sync/responder/data-request-policy.ts
+++ b/packages/agent/src/sync/responder/data-request-policy.ts
@@ -4,32 +4,33 @@ import {
   SYNC_REQUEST_SAFE_PAGE_SIZE,
 } from '../../dkg-agent-constants.js';
 
-export type DurableDataCacheMode = 'session-snapshot' | 'page-only';
+export type DataRequestCacheMode = 'session-snapshot' | 'page-only';
 export type ExactGraphReadMode = 'snapshot-or-page' | 'page-only';
 
-export interface DurableDataRequestPolicy {
+export interface DataRequestPolicy {
   usesByteBudgetPage: boolean;
   limit: number;
-  cacheMode: DurableDataCacheMode;
+  cacheMode: DataRequestCacheMode;
   exactGraphReadMode: ExactGraphReadMode;
 }
 
 /**
  * Resolve responder resource policy from authenticated request semantics only.
  *
- * Signature fields are deliberately absent: public-graph authorization may
- * accept a request before validating them, so their presence is not proof that
- * a caller is authenticated. Every negotiated exact-asset read therefore uses
- * the conservative store-page path and 64-row floor.
+ * This boundary is shared by durable and SWM DATA. Signature fields are
+ * deliberately absent: public-graph authorization may accept a request before
+ * validating them, so their presence is not proof that a caller is
+ * authenticated. Negotiated exact-asset reads therefore use the conservative
+ * store-page path and 64-row floor.
  */
-export function resolveDurableDataRequestPolicy(params: {
+export function resolveDataRequestPolicy(params: {
   legacyLimit: number;
   includeSharedMemory: boolean;
   phase: string;
   pageMode?: string;
   pageRowsHint?: number;
   hasExactAssetFilter: boolean;
-}): DurableDataRequestPolicy {
+}): DataRequestPolicy {
   const hintedPageRows = typeof params.pageRowsHint === 'number' &&
     Number.isSafeInteger(params.pageRowsHint)
     ? Math.max(1, Math.min(params.pageRowsHint, SYNC_BYTE_BUDGET_MAX_ROWS))

--- a/packages/agent/src/sync/responder/durable-data-request-policy.ts
+++ b/packages/agent/src/sync/responder/durable-data-request-policy.ts
@@ -34,12 +34,13 @@ export function resolveDurableDataRequestPolicy(params: {
     Number.isSafeInteger(params.pageRowsHint)
     ? Math.max(1, Math.min(params.pageRowsHint, SYNC_BYTE_BUDGET_MAX_ROWS))
     : 0;
-  const usesByteBudgetPage = !params.includeSharedMemory &&
-    params.phase === 'data' &&
+  const usesByteBudgetPage = params.phase === 'data' &&
     params.pageMode === SYNC_BYTE_BUDGET_PAGE_MODE &&
     hintedPageRows > 0 &&
     (hintedPageRows > params.legacyLimit || params.hasExactAssetFilter);
-  const pageOnlyExactFetch = usesByteBudgetPage && params.hasExactAssetFilter;
+  const pageOnlyExactFetch = usesByteBudgetPage
+    && !params.includeSharedMemory
+    && params.hasExactAssetFilter;
 
   return {
     usesByteBudgetPage,

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -3595,6 +3595,7 @@ async function readFreshSwmDataRowsPageFromPlan(
       : `VALUES ?root { ${graphValues(entry.roots)} }
         GRAPH <${assertSafeIri(entry.graph)}> { ?s ?p ?o }
         FILTER(?s = ?root || STRSTARTS(STR(?s), CONCAT(STR(?root), "/.well-known/genid/")))`;
+    // sparql-scan-allow: R3 -- the session plan maps the corpus cursor to one pre-counted concrete graph; graph-backed entries are immutable per-KA graphs and the root-scoped branch retains its existing bounded-plan pagination
     const result = await store.query(`
       SELECT DISTINCT ?s ?p ?o WHERE {
         ${selection}

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -35,7 +35,8 @@ import type { ChangelogSyncResponse, ChangelogDeltaRecord } from '../changelog/w
 import { durableMetaDelegationSubjectAdmissionExpression } from './durable-meta-admission.js';
 import { exactAssetFilterKey } from '../exact-assets.js';
 import { isIriTerm } from '../iri-term.js';
-import type { ExactGraphReadMode } from './durable-data-request-policy.js';
+import type { ExactGraphReadMode } from './data-request-policy.js';
+import { parseGraphBackedSwmSnapshotGraph } from '../graph-scoped-swm-recovery.js';
 
 export {
   createResponderSyncRowListMemo,
@@ -91,12 +92,18 @@ export interface SubGraphNameMemo {
   }): Promise<readonly string[]>;
 }
 
-interface FreshSwmDataGraphPlanEntry {
-  graph: string;
-  /** Empty for an immutable graph-backed KA snapshot, whose whole graph is served. */
-  roots: readonly string[];
-  rowCount: number;
-}
+type FreshSwmDataGraphPlanEntry =
+  | {
+    readonly kind: 'root-scoped';
+    readonly graph: string;
+    readonly roots: readonly string[];
+    readonly rowCount: number;
+  }
+  | {
+    readonly kind: 'graph-backed';
+    readonly graph: string;
+    readonly rowCount: number;
+  };
 
 interface FreshSwmDataGraphPlan {
   entries: readonly FreshSwmDataGraphPlanEntry[];
@@ -918,6 +925,8 @@ export async function readSwmDataPage(params: {
   refreshGeneration?: string;
   freshGraphPlanMemo?: FreshSwmDataGraphPlanMemo;
   exactGraphPlanMemo?: ExactGraphPagePlanMemo;
+  /** Keep the immutable row snapshot until explicit empty-page EOF. */
+  releaseCacheOnShortPage?: boolean;
 }): Promise<SyncRow[]> {
   const dataGraphs = swmGraphsForRegisteredSubGraphs(params.contextGraphId, params.registeredSubGraphNames, false);
   const graphSet = new Set(params.graphList);
@@ -930,6 +939,7 @@ export async function readSwmDataPage(params: {
       key: params.rowListCacheKey,
       refresh: params.refreshRowList,
       refreshGeneration: params.refreshGeneration,
+      releaseOnShortPage: params.releaseCacheOnShortPage,
       expiredMessage: 'Shared-memory data sync session snapshot expired before page completion',
     }
     : undefined;
@@ -3440,8 +3450,13 @@ async function buildFreshSwmDataGraphPlan(
     }
   }
 
-  const entries = admitted
-    .map(({ graph, roots }) => ({ graph, roots, rowCount: countsByGraph.get(graph) ?? 0 }))
+  const entries: FreshSwmDataGraphPlanEntry[] = admitted
+    .map(({ graph, roots }) => ({
+      kind: 'root-scoped' as const,
+      graph,
+      roots,
+      rowCount: countsByGraph.get(graph) ?? 0,
+    }))
     .filter((entry) => entry.rowCount > 0);
   const graphBackedEntries = await readFreshGraphBackedSwmSnapshotEntries(
     store,
@@ -3486,7 +3501,10 @@ async function readFreshGraphBackedSwmSnapshotEntries(
     const result = await store.query(`
       SELECT DISTINCT ?snapshotGraph ?count ?ts WHERE {
         GRAPH <${assertSafeIri(metaGraph)}> {
+          ?head <${DKG_SHARE_OPERATION_ID}> ?shareOperationId .
+          FILTER(STRENDS(STR(?head), "#dkg-swm-head"))
           ?op <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_WORKSPACE_OPERATION}> ;
+              <${DKG_SHARE_OPERATION_ID}> ?shareOperationId ;
               <${DKG_CONTENT_SCOPE_VERSION}> ${GRAPH_KA_CONTENT_SCOPE_VERSION} ;
               <${DKG_PUBLIC_SNAPSHOT_GRAPH}> ?snapshotGraph ;
               <${DKG_PUBLIC_QUADS_COUNT}> ?count ;
@@ -3549,11 +3567,11 @@ async function readFreshGraphBackedSwmSnapshotEntries(
           + `metadata=${evidence.expectedCount}, store=${actualCount}`,
         );
       }
-      return { graph, roots: [], rowCount: actualCount, publishedAtMs: evidence.publishedAtMs };
+      return { kind: 'graph-backed' as const, graph, rowCount: actualCount, publishedAtMs: evidence.publishedAtMs };
     })
     .sort((left, right) => right.publishedAtMs - left.publishedAtMs
       || compareCodePoint(left.graph, right.graph))
-    .map(({ graph, roots, rowCount }) => ({ graph, roots, rowCount }));
+    .map(({ kind, graph, rowCount }) => ({ kind, graph, rowCount }));
 }
 
 function isGraphBackedSwmSnapshotGraph(
@@ -3561,17 +3579,14 @@ function isGraphBackedSwmSnapshotGraph(
   contextGraphId: string,
   dataGraph: string,
 ): boolean {
+  const identity = parseGraphBackedSwmSnapshotGraph(graph);
+  if (!identity || identity.contextGraphId !== contextGraphId) return false;
   const suffix = '/_shared_memory';
   const base = dataGraph.endsWith(suffix) ? dataGraph.slice(0, -suffix.length) : dataGraph;
-  const contextPrefix = 'did:dkg:context-graph:';
-  const contextBase = `${contextPrefix}${contextGraphId}`;
-  if (base !== contextBase && !base.startsWith(`${contextBase}/`)) return false;
-  const subGraphName = base === contextBase ? '_' : base.slice(contextBase.length + 1);
-  if (subGraphName !== '_' && !validateSubGraphName(subGraphName).valid) return false;
-  const prefix = `${contextPrefix}${encodeURIComponent(contextGraphId)}/_shared_memory_snapshots/`
-    + `${encodeURIComponent(subGraphName)}/`;
-  const tail = graph.startsWith(prefix) ? graph.slice(prefix.length) : '';
-  return tail.endsWith('/ka') && tail.slice(0, -3).length > 0 && !tail.slice(0, -3).includes('/');
+  const contextBase = `did:dkg:context-graph:${contextGraphId}`;
+  if (base === contextBase) return identity.subGraphName === undefined;
+  if (!base.startsWith(`${contextBase}/`)) return false;
+  return identity.subGraphName === base.slice(contextBase.length + 1);
 }
 
 async function readFreshSwmDataRowsPageFromPlan(
@@ -3590,7 +3605,7 @@ async function readFreshSwmDataRowsPageFromPlan(
       skip -= entry.rowCount;
       continue;
     }
-    const selection = entry.roots.length === 0
+    const selection = entry.kind === 'graph-backed'
       ? `GRAPH <${assertSafeIri(entry.graph)}> { ?s ?p ?o }`
       : `VALUES ?root { ${graphValues(entry.roots)} }
         GRAPH <${assertSafeIri(entry.graph)}> { ?s ?p ?o }

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -49,6 +49,8 @@ const DKG_SUB_GRAPH = `${DKG}SubGraph`;
 const DKG_WORKSPACE_OPERATION = `${DKG}WorkspaceOperation`;
 const DKG_PUBLISHED_AT = `${DKG}publishedAt`;
 const DKG_ROOT_ENTITY = `${DKG}rootEntity`;
+const DKG_PUBLIC_SNAPSHOT_GRAPH = `${DKG}publicSnapshotGraph`;
+const DKG_PUBLIC_QUADS_COUNT = `${DKG}publicQuadsCount`;
 const DKG_CONTENT_SCOPE_VERSION = `${DKG}contentScopeVersion`;
 const DKG_KA_UAL = `${DKG}kaUal`;
 const DKG_ASSERTION_VERSION = `${DKG}assertionVersion`;
@@ -91,6 +93,7 @@ export interface SubGraphNameMemo {
 
 interface FreshSwmDataGraphPlanEntry {
   graph: string;
+  /** Empty for an immutable graph-backed KA snapshot, whose whole graph is served. */
   roots: readonly string[];
   rowCount: number;
 }
@@ -948,6 +951,7 @@ export async function readSwmDataPage(params: {
   const loadStoreBoundedPage: StorePageLoader = async (offset, limit, signal) => {
     const loadPlan = () => buildFreshSwmDataGraphPlan(
       params.store,
+      params.contextGraphId,
       dataGraphs,
       graphSet,
       candidateGraphsFor,
@@ -3354,6 +3358,7 @@ function parseSparqlInteger(value: string | undefined): number {
  */
 async function buildFreshSwmDataGraphPlan(
   store: TripleStore,
+  contextGraphId: string,
   dataGraphs: readonly string[],
   graphSet: ReadonlySet<string>,
   candidateGraphsFor: (graph: string) => string[],
@@ -3373,7 +3378,6 @@ async function buildFreshSwmDataGraphPlan(
   const uniqueCandidates = [...new Map(
     candidates.map((candidate) => [candidate.graph, candidate]),
   ).values()].sort((a, b) => compareCodePoint(a.graph, b.graph));
-  if (uniqueCandidates.length === 0) return { entries: [], totalRows: 0 };
 
   const rootsByGraph = new Map<string, Set<string>>();
   for (const chunk of chunkValues(uniqueCandidates, FRESH_SWM_PLAN_QUERY_GRAPH_CHUNK)) {
@@ -3439,10 +3443,135 @@ async function buildFreshSwmDataGraphPlan(
   const entries = admitted
     .map(({ graph, roots }) => ({ graph, roots, rowCount: countsByGraph.get(graph) ?? 0 }))
     .filter((entry) => entry.rowCount > 0);
+  const graphBackedEntries = await readFreshGraphBackedSwmSnapshotEntries(
+    store,
+    contextGraphId,
+    dataGraphs,
+    graphSet,
+    cutoffIso,
+    signal,
+  );
   return {
-    entries,
-    totalRows: entries.reduce((sum, entry) => sum + entry.rowCount, 0),
+    // Recent graph-backed KAs go first so a selected receiver can keep up with
+    // live publication while the same immutable plan continues through older
+    // root-scoped history. Completeness still requires the entire plan.
+    entries: [...graphBackedEntries, ...entries],
+    totalRows: [...graphBackedEntries, ...entries]
+      .reduce((sum, entry) => sum + entry.rowCount, 0),
   };
+}
+
+/**
+ * Discover fresh content-scope-v2 SWM snapshots from their authenticated
+ * operation metadata, then bind every planned graph to its actual row count.
+ *
+ * These graphs are siblings of `_shared_memory`, not descendants of it. The
+ * legacy root planner therefore cannot discover them through
+ * `isSharedMemoryBucketDescendantDataGraph`; omitting them leaves a cold
+ * receiver with verified heads but no payload. The requester independently
+ * verifies the advertised count and digest before materialization.
+ */
+async function readFreshGraphBackedSwmSnapshotEntries(
+  store: TripleStore,
+  contextGraphId: string,
+  dataGraphs: readonly string[],
+  graphSet: ReadonlySet<string>,
+  cutoffIso: string,
+  signal?: AbortSignal,
+): Promise<FreshSwmDataGraphPlanEntry[]> {
+  const discovered = new Map<string, { expectedCount: number; publishedAtMs: number }>();
+  for (const dataGraph of dataGraphs) {
+    const metaGraph = `${dataGraph}_meta`;
+    if (!graphSet.has(metaGraph)) continue;
+    const result = await store.query(`
+      SELECT DISTINCT ?snapshotGraph ?count ?ts WHERE {
+        GRAPH <${assertSafeIri(metaGraph)}> {
+          ?op <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_WORKSPACE_OPERATION}> ;
+              <${DKG_CONTENT_SCOPE_VERSION}> ${GRAPH_KA_CONTENT_SCOPE_VERSION} ;
+              <${DKG_PUBLIC_SNAPSHOT_GRAPH}> ?snapshotGraph ;
+              <${DKG_PUBLIC_QUADS_COUNT}> ?count ;
+              <${DKG_PUBLISHED_AT}> ?ts .
+          FILTER(?ts >= ${sparqlString(cutoffIso)}^^<http://www.w3.org/2001/XMLSchema#dateTime>)
+        }
+      }
+      ORDER BY DESC(?ts) ?snapshotGraph
+    `, syncResponderStoreOptions(signal, 'sync.responder.readFreshGraphBackedSwmSnapshots'));
+    if (result.type !== 'bindings') continue;
+    for (const row of result.bindings) {
+      const graph = row['snapshotGraph'];
+      const expectedCount = parseSparqlInteger(row['count']);
+      const publishedAtMs = Date.parse(stripLiteral(row['ts']));
+      if (
+        !graph
+        || !isGraphBackedSwmSnapshotGraph(graph, contextGraphId, dataGraph)
+        || !graphSet.has(graph)
+        || expectedCount <= 0
+        || !Number.isFinite(publishedAtMs)
+      ) continue;
+      const previous = discovered.get(graph);
+      if (previous && previous.expectedCount !== expectedCount) {
+        throw new Error(`Conflicting graph-backed SWM snapshot counts for ${graph}`);
+      }
+      if (!previous || publishedAtMs > previous.publishedAtMs) {
+        discovered.set(graph, { expectedCount, publishedAtMs });
+      }
+    }
+  }
+  if (discovered.size === 0) return [];
+
+  const actualCounts = new Map<string, number>();
+  for (const graphs of chunkValues([...discovered.keys()], FRESH_SWM_PLAN_QUERY_GRAPH_CHUNK)) {
+    const unions = graphs.map((graph) => `
+      {
+        SELECT (<${assertSafeIri(graph)}> AS ?g) (COUNT(*) AS ?count) WHERE {
+          GRAPH <${assertSafeIri(graph)}> { ?s ?p ?o }
+        }
+      }`);
+    const result = await store.query(`
+      SELECT ?g ?count WHERE {
+        ${unions.join('\n        UNION')}
+      }
+      ORDER BY ?g
+    `, syncResponderStoreOptions(signal, 'sync.responder.countFreshGraphBackedSwmSnapshotRows'));
+    if (result.type !== 'bindings') continue;
+    for (const row of result.bindings) {
+      const graph = row['g'];
+      if (graph) actualCounts.set(graph, parseSparqlInteger(row['count']));
+    }
+  }
+
+  return [...discovered.entries()]
+    .map(([graph, evidence]) => {
+      const actualCount = actualCounts.get(graph) ?? 0;
+      if (actualCount !== evidence.expectedCount) {
+        throw new Error(
+          `Graph-backed SWM snapshot ${graph} count mismatch: `
+          + `metadata=${evidence.expectedCount}, store=${actualCount}`,
+        );
+      }
+      return { graph, roots: [], rowCount: actualCount, publishedAtMs: evidence.publishedAtMs };
+    })
+    .sort((left, right) => right.publishedAtMs - left.publishedAtMs
+      || compareCodePoint(left.graph, right.graph))
+    .map(({ graph, roots, rowCount }) => ({ graph, roots, rowCount }));
+}
+
+function isGraphBackedSwmSnapshotGraph(
+  graph: string,
+  contextGraphId: string,
+  dataGraph: string,
+): boolean {
+  const suffix = '/_shared_memory';
+  const base = dataGraph.endsWith(suffix) ? dataGraph.slice(0, -suffix.length) : dataGraph;
+  const contextPrefix = 'did:dkg:context-graph:';
+  const contextBase = `${contextPrefix}${contextGraphId}`;
+  if (base !== contextBase && !base.startsWith(`${contextBase}/`)) return false;
+  const subGraphName = base === contextBase ? '_' : base.slice(contextBase.length + 1);
+  if (subGraphName !== '_' && !validateSubGraphName(subGraphName).valid) return false;
+  const prefix = `${contextPrefix}${encodeURIComponent(contextGraphId)}/_shared_memory_snapshots/`
+    + `${encodeURIComponent(subGraphName)}/`;
+  const tail = graph.startsWith(prefix) ? graph.slice(prefix.length) : '';
+  return tail.endsWith('/ka') && tail.slice(0, -3).length > 0 && !tail.slice(0, -3).includes('/');
 }
 
 async function readFreshSwmDataRowsPageFromPlan(
@@ -3461,11 +3590,14 @@ async function readFreshSwmDataRowsPageFromPlan(
       skip -= entry.rowCount;
       continue;
     }
+    const selection = entry.roots.length === 0
+      ? `GRAPH <${assertSafeIri(entry.graph)}> { ?s ?p ?o }`
+      : `VALUES ?root { ${graphValues(entry.roots)} }
+        GRAPH <${assertSafeIri(entry.graph)}> { ?s ?p ?o }
+        FILTER(?s = ?root || STRSTARTS(STR(?s), CONCAT(STR(?root), "/.well-known/genid/")))`;
     const result = await store.query(`
       SELECT DISTINCT ?s ?p ?o WHERE {
-        VALUES ?root { ${graphValues(entry.roots)} }
-        GRAPH <${assertSafeIri(entry.graph)}> { ?s ?p ?o }
-        FILTER(?s = ?root || STRSTARTS(STR(?s), CONCAT(STR(?root), "/.well-known/genid/")))
+        ${selection}
       }
       ORDER BY ?s ?p ?o
       OFFSET ${skip}

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -55,7 +55,7 @@ import {
   PriorityAdmissionQueue,
   type PriorityAdmission,
 } from '../priority-admission-queue.js';
-import { resolveDurableDataRequestPolicy } from './durable-data-request-policy.js';
+import { resolveDataRequestPolicy } from './data-request-policy.js';
 
 const MAX_SYNC_SESSION_TOKENS = 256;
 
@@ -556,7 +556,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     const assetSelectionKey = assetUals === undefined
       ? 'full'
       : exactAssetFilterKey(assetUals);
-    const durableDataPolicy = resolveDurableDataRequestPolicy({
+    const dataRequestPolicy = resolveDataRequestPolicy({
       legacyLimit: limit,
       includeSharedMemory: isWorkspace,
       phase,
@@ -564,7 +564,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       pageRowsHint: request.pageRowsHint,
       hasExactAssetFilter: assetUals !== undefined,
     });
-    const usesByteBudgetPage = durableDataPolicy.usesByteBudgetPage;
+    const usesByteBudgetPage = dataRequestPolicy.usesByteBudgetPage;
     // Durable meta negotiated its byte-budget page mode on the wire (#1916 /
     // #1923). The subject-atomic byte-fit in readDurableMetaPage already bounds
     // the page ≤ budget for BOTH modes, so this only selects the belt-and-
@@ -735,7 +735,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
             contextGraphId,
             cutoffIso: cutoff,
             offset,
-            limit: durableDataPolicy.limit,
+            limit: dataRequestPolicy.limit,
             signal,
             rowListMemo: session ? swmRowsMemo : undefined,
             rowListCacheKey: session?.rowListCacheKey,
@@ -743,6 +743,10 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
             refreshGeneration: session?.refreshGeneration,
             freshGraphPlanMemo: freshSwmDataGraphPlanMemo,
             exactGraphPlanMemo: swmDataExactGraphPlanMemo,
+            // A byte-bounded response may serialize only a prefix of the
+            // loaded row slice. Keep the session until an explicit empty page
+            // proves EOF, matching the durable DATA lane below.
+            releaseCacheOnShortPage: !usesByteBudgetPage,
           });
           const queryDurationMs = Date.now() - queryStartedAt;
           const serializeStartedAt = Date.now();
@@ -853,12 +857,12 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           contextGraphId,
           sinceBatchId,
           offset,
-          limit: durableDataPolicy.limit,
+          limit: dataRequestPolicy.limit,
           signal,
-          rowListMemo: session && durableDataPolicy.cacheMode === 'session-snapshot'
+          rowListMemo: session && dataRequestPolicy.cacheMode === 'session-snapshot'
             ? durableDataRowsMemo
             : undefined,
-          rowListCacheScope: session && durableDataPolicy.cacheMode === 'session-snapshot'
+          rowListCacheScope: session && dataRequestPolicy.cacheMode === 'session-snapshot'
             ? peerId
             : undefined,
           refreshRowList: session?.refreshRowList,
@@ -869,7 +873,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           // because that slice was short; the explicit empty request is EOF.
           releaseCacheOnShortPage: !usesByteBudgetPage,
           assetUals,
-          exactGraphReadMode: durableDataPolicy.exactGraphReadMode,
+          exactGraphReadMode: dataRequestPolicy.exactGraphReadMode,
         });
         const queryDurationMs = Date.now() - queryStartedAt;
         const serializeStartedAt = Date.now();

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -735,7 +735,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
             contextGraphId,
             cutoffIso: cutoff,
             offset,
-            limit,
+            limit: durableDataPolicy.limit,
             signal,
             rowListMemo: session ? swmRowsMemo : undefined,
             rowListCacheKey: session?.rowListCacheKey,
@@ -746,7 +746,9 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           });
           const queryDurationMs = Date.now() - queryStartedAt;
           const serializeStartedAt = Date.now();
-          const serialized = serializeResponderRows(rows);
+          const serialized = usesByteBudgetPage
+            ? serializeResponderRowsWithinByteBudget(rows, SYNC_BYTE_BUDGET_RESPONSE_BYTES)
+            : serializeResponderRows(rows);
           if (serialized) nquads.push(serialized);
           const serializeDurationMs = Date.now() - serializeStartedAt;
           logFirstPageDetail(() => `Sync responder SWM data for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);

--- a/packages/agent/test/graph-backed-swm-page-boundary.test.ts
+++ b/packages/agent/test/graph-backed-swm-page-boundary.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import type { Quad } from '@origintrail-official/dkg-storage';
+import type { GraphScopedSwmRecoveryDescriptor } from '../src/sync/graph-scoped-swm-recovery.js';
+import { planBoundedGraphBackedSwmDataPage } from '../src/sync/requester/shared-memory-sync.js';
+
+const quad = (graph: string, index: number): Quad => ({
+  subject: `urn:subject:${index}`,
+  predicate: 'http://schema.org/value',
+  object: `"${index}"`,
+  graph,
+});
+
+const descriptor = (graph: string, count: number): GraphScopedSwmRecoveryDescriptor => ({
+  metaGraph: 'urn:meta',
+  headSubject: `urn:head:${graph}`,
+  operationSubject: `urn:op:${graph}`,
+  kaUal: `did:dkg:test:1/${encodeURIComponent(graph)}`,
+  assertionVersion: '1',
+  assertionGraph: `urn:assertion:${graph}`,
+  shareOperationId: `op-${graph}`,
+  publicQuadsDigest: `urn:digest:${graph}`,
+  publicQuadsCount: count,
+  privateTripleCount: 0,
+  publicSnapshotGraph: graph,
+  publisherPeerId: 'peer',
+  metadataQuads: [],
+});
+
+describe('graph-backed SWM DATA graph boundaries', () => {
+  it('rewinds a timed-out suffix to the first row of its partial immutable graph', () => {
+    const graphA = 'urn:snapshot:a';
+    const graphB = 'urn:snapshot:b';
+    const result = planBoundedGraphBackedSwmDataPage({
+      quads: [quad(graphA, 0), quad(graphA, 1), quad(graphB, 0)],
+      descriptors: [descriptor(graphA, 2), descriptor(graphB, 2)],
+      resumedFromOffset: 100,
+      rawResumedFromOffset: 100,
+      nextOffset: 103,
+      rawNextOffset: 103,
+      quadRawOffsets: [100, 101, 102],
+      completed: false,
+    });
+
+    expect(result).not.toBeNull();
+    expect([...result!.completeGraphs]).toEqual([graphA]);
+    expect(result).toMatchObject({ safeNextOffset: 102, safeRawNextOffset: 102, rewound: true });
+  });
+
+  it('advances across whole graphs and subsequent legacy rows', () => {
+    const graphA = 'urn:snapshot:a';
+    const result = planBoundedGraphBackedSwmDataPage({
+      quads: [quad(graphA, 0), quad(graphA, 1), quad('urn:legacy', 0)],
+      descriptors: [descriptor(graphA, 2)],
+      resumedFromOffset: 0,
+      nextOffset: 3,
+      completed: false,
+    });
+
+    expect(result).not.toBeNull();
+    expect([...result!.completeGraphs]).toEqual([graphA]);
+    expect(result).toMatchObject({ safeNextOffset: 3, safeRawNextOffset: 3, rewound: false });
+  });
+
+  it('rejects a terminal short graph as an integrity mismatch', () => {
+    const graphA = 'urn:snapshot:a';
+    expect(planBoundedGraphBackedSwmDataPage({
+      quads: [quad(graphA, 0)],
+      descriptors: [descriptor(graphA, 2)],
+      resumedFromOffset: 0,
+      nextOffset: 1,
+      completed: true,
+    })).toBeNull();
+  });
+
+  it('rejects non-contiguous graph-backed groups', () => {
+    const graphA = 'urn:snapshot:a';
+    expect(planBoundedGraphBackedSwmDataPage({
+      quads: [quad(graphA, 0), quad('urn:legacy', 0), quad(graphA, 1)],
+      descriptors: [descriptor(graphA, 2)],
+      resumedFromOffset: 0,
+      nextOffset: 3,
+      completed: false,
+    })).toBeNull();
+  });
+});

--- a/packages/agent/test/graph-backed-swm-page-boundary.test.ts
+++ b/packages/agent/test/graph-backed-swm-page-boundary.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { GraphScopedSwmRecoveryDescriptor } from '../src/sync/graph-scoped-swm-recovery.js';
-import { planBoundedGraphBackedSwmDataPage } from '../src/sync/requester/shared-memory-sync.js';
+import { planBoundedGraphBackedSwmDataPage } from '../src/sync/requester/graph-backed-swm-data-replay.js';
 
 const quad = (graph: string, index: number): Quad => ({
   subject: `urn:subject:${index}`,

--- a/packages/agent/test/selected-swm-lifecycle-core.test.ts
+++ b/packages/agent/test/selected-swm-lifecycle-core.test.ts
@@ -153,6 +153,7 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
       contextGraphs: { public: publicCg },
       manifest: graphBackedManifest(publicCg),
       clock: { now: () => 1_000, deadline: () => 61_000 },
+      dataPage: { quads: [], completed: true, timedOut: false },
     });
 
     try {
@@ -173,7 +174,12 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
       expect(selected.shared.fetchedMetaTriples).toBeGreaterThan(0);
       expect(selected.shared.insertedMetaTriples).toBe(0);
       expect(selected.shared.failedPhases).toBeGreaterThan(0);
-      expect(selected.shared.swmCoverage).toBeUndefined();
+      expect(selected.shared.swmCoverage).toMatchObject({
+        snapshotsResolved: 0,
+        snapshotsTotal: 1,
+        missingCount: 1,
+        materializationFailures: 1,
+      });
       expect(selected.selectedScopeComplete).toBe(false);
       expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(true);
     } finally {
@@ -181,16 +187,12 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
     }
   });
 
-  it('keeps mixed store-backed and graph-backed metadata incomplete until every operation is proven', async () => {
-    const publicCg = 'selected-mixed-snapshot-evidence';
-    const storeBacked = snapshotManifest(publicCg, 1);
-    const graphBacked = graphBackedManifest(publicCg);
+  it('completes selected graph-backed SWM after count/digest-bound materialization', async () => {
+    const publicCg = 'selected-graph-backed-materialized';
+    const manifest = graphBackedManifest(publicCg);
     const harness = createSelectedSwmLifecycleHarness({
       contextGraphs: { public: publicCg },
-      manifest: {
-        meta: [...storeBacked.meta, ...graphBacked.meta],
-        payloadByRef: storeBacked.payloadByRef,
-      },
+      manifest,
       clock: { now: () => 1_000, deadline: () => 61_000 },
     });
 
@@ -214,11 +216,108 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
         snapshotsResolved: 1,
         snapshotsTotal: 1,
         missingCount: 0,
+        materializationFailures: 0,
       });
-      expect(selected.shared.insertedMetaTriples).toBe(0);
-      expect(selected.shared.failedPhases).toBeGreaterThan(0);
+      expect(selected.shared.insertedDataTriples).toBe(manifest.dataQuads.length);
+      expect(selected.shared.droppedDataTriples).toBe(0);
+      expect(selected.shared.failedPhases).toBe(0);
+      expect(selected.selectedScopeComplete).toBe(true);
+      expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(false);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it('keeps legacy root-slice graph advertisements fail-closed in the selected KA lane', async () => {
+    const publicCg = 'selected-legacy-graph-backed-root-slice';
+    const manifest = snapshotManifest(publicCg, 1);
+    const subject = manifest.meta[0]!.subject;
+    const transportGraph = `did:dkg:context-graph:${encodeURIComponent(publicCg)}`
+      + '/_shared_memory_snapshots/_/legacy-op/root/_shared_memory';
+    manifest.meta.push({
+      subject,
+      predicate: `${DKG}publicSnapshotGraph`,
+      object: transportGraph,
+      graph: manifest.meta[0]!.graph,
+    });
+    manifest.dataQuads = [{
+      subject: 'urn:legacy-root',
+      predicate: 'http://schema.org/value',
+      object: '"legacy"',
+      graph: transportGraph,
+    }];
+    const harness = createSelectedSwmLifecycleHarness({
+      contextGraphs: { public: publicCg },
+      manifest,
+      clock: { now: () => 1_000, deadline: () => 61_000 },
+    });
+
+    try {
+      const selected = await callSelectedSharedMemoryFromPeerDetailed(
+        harness.agent,
+        [publicCg],
+        {
+          selectedSwmPriority: true,
+          priority: 2_000,
+          sharedMemorySyncPlan: {
+            publicContextGraphIds: [publicCg],
+            privateRecoverFromCurator: [],
+            eligibleContextGraphIds: [publicCg],
+          },
+        },
+      );
+
+      expect(selected.shared.swmCoverage).toBeUndefined();
+      expect(selected.shared.insertedDataTriples).toBe(0);
+      // The lane-level contract is the fail-closed evidence: this unsupported
+      // legacy advertisement must stay incomplete and retryable even when the
+      // ordinary SWM summary has no transport/store phase failure to count.
       expect(selected.selectedScopeComplete).toBe(false);
       expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(true);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it('completes mixed store-backed and graph-backed metadata after every operation is proven', async () => {
+    const publicCg = 'selected-mixed-snapshot-evidence';
+    const storeBacked = snapshotManifest(publicCg, 1);
+    const graphBacked = graphBackedManifest(publicCg);
+    const harness = createSelectedSwmLifecycleHarness({
+      contextGraphs: { public: publicCg },
+      manifest: {
+        meta: [...storeBacked.meta, ...graphBacked.meta],
+        payloadByRef: storeBacked.payloadByRef,
+        dataQuads: graphBacked.dataQuads,
+      },
+      clock: { now: () => 1_000, deadline: () => 61_000 },
+    });
+
+    try {
+      const selected = await callSelectedSharedMemoryFromPeerDetailed(
+        harness.agent,
+        [publicCg],
+        {
+          selectedSwmPriority: true,
+          priority: 2_000,
+          sharedMemorySyncPlan: {
+            publicContextGraphIds: [publicCg],
+            privateRecoverFromCurator: [],
+            eligibleContextGraphIds: [publicCg],
+          },
+        },
+      );
+
+      expect(selected.shared.swmCoverage).toMatchObject({
+        contextGraphId: publicCg,
+        snapshotsResolved: 2,
+        snapshotsTotal: 2,
+        missingCount: 0,
+      });
+      expect(selected.shared.insertedMetaTriples).toBeGreaterThan(0);
+      expect(selected.shared.failedPhases).toBe(0);
+      expect(selected.selectedScopeComplete).toBe(true);
+      expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(false);
     } finally {
       await harness.close();
     }

--- a/packages/agent/test/selected-swm-lifecycle-core.test.ts
+++ b/packages/agent/test/selected-swm-lifecycle-core.test.ts
@@ -222,7 +222,97 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
       expect(selected.shared.droppedDataTriples).toBe(0);
       expect(selected.shared.failedPhases).toBe(0);
       expect(selected.selectedScopeComplete).toBe(true);
+      expect(harness.probes.dataRequesterScopes).toEqual(['selected-swm-data:graph-v1']);
       expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(false);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it('fails closed when graph-backed metadata advertises a malformed transport graph', async () => {
+    const publicCg = 'selected-malformed-graph-backed';
+    const manifest = graphBackedManifest(publicCg);
+    const malformedGraph = 'did:dkg:context-graph:not-the-selected-cg/_shared_memory_snapshots/_/bad/ka';
+    manifest.meta = manifest.meta.map((quad) => (
+      quad.predicate === `${DKG}publicSnapshotGraph`
+        ? { ...quad, object: malformedGraph }
+        : quad
+    ));
+    const harness = createSelectedSwmLifecycleHarness({
+      contextGraphs: { public: publicCg },
+      manifest,
+      clock: { now: () => 1_000, deadline: () => 61_000 },
+      dataPage: { quads: [], completed: true, timedOut: false },
+    });
+
+    try {
+      const selected = await callSelectedSharedMemoryFromPeerDetailed(
+        harness.agent,
+        [publicCg],
+        {
+          selectedSwmPriority: true,
+          priority: 2_000,
+          sharedMemorySyncPlan: {
+            publicContextGraphIds: [publicCg],
+            privateRecoverFromCurator: [],
+            eligibleContextGraphIds: [publicCg],
+          },
+        },
+      );
+
+      expect(selected.shared.swmCoverage).toMatchObject({
+        snapshotsResolved: 0,
+        snapshotsTotal: 1,
+        descriptorsAuthoritative: false,
+        missingCount: 1,
+      });
+      expect(selected.shared.insertedMetaTriples).toBe(0);
+      expect(selected.shared.failedPhases).toBeGreaterThan(0);
+      expect(selected.selectedScopeComplete).toBe(false);
+      expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(true);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it('rewinds a failed graph-backed materialization to its DATA graph boundary', async () => {
+    const publicCg = 'selected-graph-backed-failed-rewind';
+    const manifest = graphBackedManifest(publicCg);
+    const corruptData = manifest.dataQuads.map((quad) => ({ ...quad, object: '"corrupt"' }));
+    const harness = createSelectedSwmLifecycleHarness({
+      contextGraphs: { public: publicCg },
+      manifest,
+      clock: { now: () => 1_000, deadline: () => 61_000 },
+      dataPage: {
+        quads: corruptData,
+        completed: true,
+        timedOut: false,
+        resumedFromOffset: 10,
+        nextOffset: 11,
+        rawResumedFromOffset: 10,
+        rawNextOffset: 11,
+        quadRawOffsets: [10],
+      },
+    });
+
+    try {
+      const selected = await callSelectedSharedMemoryFromPeerDetailed(
+        harness.agent,
+        [publicCg],
+        {
+          selectedSwmPriority: true,
+          priority: 2_000,
+          sharedMemorySyncPlan: {
+            publicContextGraphIds: [publicCg],
+            privateRecoverFromCurator: [],
+            eligibleContextGraphIds: [publicCg],
+          },
+        },
+      );
+
+      expect(selected.shared.failedPhases).toBeGreaterThan(0);
+      expect(selected.selectedScopeComplete).toBe(false);
+      expect(harness.agent.syncCheckpoints.get(`${publicCg}:data`)).toBe(10);
     } finally {
       await harness.close();
     }

--- a/packages/agent/test/selected-swm-test-helpers.ts
+++ b/packages/agent/test/selected-swm-test-helpers.ts
@@ -374,6 +374,11 @@ export interface SelectedSwmLifecycleHarnessOptions {
     readonly quads?: readonly Quad[];
     readonly completed: boolean;
     readonly timedOut: boolean;
+    readonly resumedFromOffset?: number;
+    readonly nextOffset?: number;
+    readonly rawResumedFromOffset?: number;
+    readonly rawNextOffset?: number;
+    readonly quadRawOffsets?: readonly number[];
   };
 }
 
@@ -454,6 +459,7 @@ export interface SelectedSwmLifecycleHarness {
     readonly processedMetaBatches: readonly Quad[][];
     readonly dataFetches: () => number;
     readonly metaRequesterScopes: readonly (string | undefined)[];
+    readonly dataRequesterScopes: readonly (string | undefined)[];
     readonly metaSinceBatchIds: readonly (string | undefined)[];
     readonly metaReturnAcceptedPrefixOnRetryableTransportFailure: readonly boolean[];
     readonly maxActiveAdmissions: () => number;
@@ -526,6 +532,7 @@ export function createSelectedSwmLifecycleHarness(
   let metaFetches = 0;
   let dataFetches = 0;
   const metaRequesterScopes: Array<string | undefined> = [];
+  const dataRequesterScopes: Array<string | undefined> = [];
   const metaSinceBatchIds: Array<string | undefined> = [];
   const metaReturnAcceptedPrefixOnRetryableTransportFailure: boolean[] = [];
   const processedMetaBatches: Quad[][] = [];
@@ -644,15 +651,28 @@ export function createSelectedSwmLifecycleHarness(
       }
       if (phase === 'data') {
         dataFetches += 1;
+        dataRequesterScopes.push(requesterScope);
         if (dataFetches <= (options.dataFailuresBeforeSuccess ?? 0)) {
           throw new Error('simulated aggregate-data transport failure');
         }
         if (options.dataPage) {
+          const resumedFromOffset = options.dataPage.resumedFromOffset ?? 0;
+          const nextOffset = options.dataPage.nextOffset
+            ?? resumedFromOffset + (options.dataPage.quads?.length ?? 0);
           return {
             quads: [...(options.dataPage.quads ?? [])],
             bytesReceived: options.dataPage.quads?.length ?? 0,
-            resumedFromOffset: 0,
-            nextOffset: options.dataPage.quads?.length ?? 0,
+            resumedFromOffset,
+            nextOffset,
+            ...(options.dataPage.rawResumedFromOffset !== undefined
+              ? { rawResumedFromOffset: options.dataPage.rawResumedFromOffset }
+              : {}),
+            ...(options.dataPage.rawNextOffset !== undefined
+              ? { rawNextOffset: options.dataPage.rawNextOffset }
+              : {}),
+            ...(options.dataPage.quadRawOffsets !== undefined
+              ? { quadRawOffsets: [...options.dataPage.quadRawOffsets] }
+              : {}),
             checkpointKey: `${contextGraphId}:${phase}`,
             completed: options.dataPage.completed,
             timedOut: options.dataPage.timedOut,
@@ -752,6 +772,7 @@ export function createSelectedSwmLifecycleHarness(
       processedMetaBatches,
       dataFetches: () => dataFetches,
       metaRequesterScopes,
+      dataRequesterScopes,
       metaSinceBatchIds,
       metaReturnAcceptedPrefixOnRetryableTransportFailure,
       maxActiveAdmissions: () => maxActiveAdmissions,

--- a/packages/agent/test/selected-swm-test-helpers.ts
+++ b/packages/agent/test/selected-swm-test-helpers.ts
@@ -35,6 +35,7 @@ export const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
 export function snapshotManifest(contextGraphId: string, count: number): {
   meta: Quad[];
   payloadByRef: Map<string, Quad[]>;
+  dataQuads: Quad[];
 } {
   const metaGraph = contextGraphWorkspaceMetaGraphUri(contextGraphId);
   const meta: Quad[] = [];
@@ -64,7 +65,7 @@ export function snapshotManifest(contextGraphId: string, count: number): {
     );
     payloadByRef.set(digest, payload);
   }
-  return { meta, payloadByRef };
+  return { meta, payloadByRef, dataQuads: [] };
 }
 
 export function graphBackedManifest(contextGraphId: string): ReturnType<typeof snapshotManifest> {
@@ -132,7 +133,11 @@ export function graphBackedManifest(contextGraphId: string): ReturnType<typeof s
       graph: metaGraph,
     },
   ];
-  return { meta, payloadByRef: new Map() };
+  return {
+    meta,
+    payloadByRef: new Map(),
+    dataQuads: payload.map((quad) => ({ ...quad, graph: snapshotGraph })),
+  };
 }
 
 export function cleanDurableResult(): SharedMemorySyncResult {
@@ -656,6 +661,8 @@ export function createSelectedSwmLifecycleHarness(
       }
       const quads = phase === 'meta' && contextGraphId === options.contextGraphs.public
         ? options.manifest.meta
+        : phase === 'data' && contextGraphId === options.contextGraphs.public
+          ? options.manifest.dataQuads
         : [];
       return {
         quads,

--- a/packages/agent/test/shared-memory-sync-ownership.test.ts
+++ b/packages/agent/test/shared-memory-sync-ownership.test.ts
@@ -271,6 +271,31 @@ describe('runSharedMemorySync ownership hydration', () => {
     }
   });
 
+  it('admits encoded graph-backed snapshots only for shared-memory data', async () => {
+    const worker = new SyncVerifyWorker();
+    const contextGraphId = '0x1111111111111111111111111111111111111111/public-cg';
+    const workspaceGraph = contextGraphSharedMemoryUri(contextGraphId);
+    const snapshotGraph = `did:dkg:context-graph:${encodeURIComponent(contextGraphId)}`
+      + '/_shared_memory_snapshots/_/operation/ka';
+    const nquads = `<urn:s> <urn:p> "value" <${snapshotGraph}> .`;
+
+    try {
+      const workspace = await worker.parseAndFilter(nquads, workspaceGraph, contextGraphId);
+      expect(workspace.quads).toHaveLength(1);
+      expect(workspace.quads[0]?.graph).toBe(snapshotGraph);
+
+      const durable = await worker.parseAndFilter(
+        nquads,
+        `did:dkg:context-graph:${contextGraphId}`,
+        contextGraphId,
+      );
+      expect(durable.quads).toHaveLength(0);
+      expect(durable.totalQuads).toBe(1);
+    } finally {
+      await worker.close();
+    }
+  });
+
   it('rejects forged replicated registrations with noncanonical subjects', async () => {
     const worker = new SyncVerifyWorker();
     const inserted: Quad[] = [];

--- a/packages/agent/test/shared-memory-sync-ownership.test.ts
+++ b/packages/agent/test/shared-memory-sync-ownership.test.ts
@@ -284,6 +284,13 @@ describe('runSharedMemorySync ownership hydration', () => {
       expect(workspace.quads).toHaveLength(1);
       expect(workspace.quads[0]?.graph).toBe(snapshotGraph);
 
+      const malformed = await worker.parseAndFilter(
+        '<urn:s> <urn:p> "value" <did:dkg:context-graph:0x1111111111111111111111111111111111111111%2Fpublic-cg/_shared_memory_snapshots/_/operation/extra/ka> .',
+        workspaceGraph,
+        contextGraphId,
+      );
+      expect(malformed.quads).toHaveLength(0);
+
       const durable = await worker.parseAndFilter(
         nquads,
         `did:dkg:context-graph:${contextGraphId}`,

--- a/packages/agent/test/sync-byte-budget-pages.test.ts
+++ b/packages/agent/test/sync-byte-budget-pages.test.ts
@@ -25,7 +25,7 @@ import {
   serializeResponderRowsWithinByteBudget,
   type SyncRow,
 } from '../src/sync/responder/graph-plan.js';
-import { resolveDurableDataRequestPolicy } from '../src/sync/responder/durable-data-request-policy.js';
+import { resolveDataRequestPolicy } from '../src/sync/responder/data-request-policy.js';
 import {
   linesFromNquads,
   registerTestSyncHandler,
@@ -179,7 +179,7 @@ describe('byte-budget sync pagination', () => {
       pageRowsHint: SYNC_REQUEST_SAFE_PAGE_SIZE,
       assetUals: [exactUal],
     });
-    expect(resolveDurableDataRequestPolicy({
+    expect(resolveDataRequestPolicy({
       legacyLimit: request.limit,
       includeSharedMemory: false,
       phase: request.phase,
@@ -578,6 +578,43 @@ describe('byte-budget sync pagination', () => {
     await store.close();
   });
 
+  it('keeps an oversized SWM byte-budget session alive for the serialized continuation', async () => {
+    const store = new OxigraphStore();
+    const graph = `did:dkg:context-graph:${CG_ID}/_shared_memory`;
+    const totalRows = 900;
+    await store.insert(Array.from({ length: totalRows }, (_, i) => ({
+      graph,
+      subject: 'urn:shared-memory-oversized-root',
+      predicate: `urn:predicate:${i.toString().padStart(4, '0')}`,
+      object: `"${'x'.repeat(6_000)}-${i}"`,
+    })));
+    const cap = registerTestSyncHandler(store, { syncPageSize: SYNC_PAGE_SIZE });
+    const request = {
+      contextGraphId: CG_ID,
+      limit: SYNC_PAGE_SIZE,
+      includeSharedMemory: true,
+      phase: 'data' as const,
+      syncSessionId: 'byte-budget-swm-oversized-session',
+      pageMode: SYNC_BYTE_BUDGET_PAGE_MODE,
+      pageRowsHint: SYNC_REQUEST_PAGE_SIZE,
+    };
+
+    const first = await cap.invoke({ ...request, offset: 0 });
+    const firstRows = linesFromNquads(first);
+    expect(firstRows.length).toBeGreaterThan(0);
+    expect(firstRows.length).toBeLessThan(totalRows);
+    expect(new TextEncoder().encode(first).byteLength)
+      .toBeLessThanOrEqual(SYNC_BYTE_BUDGET_RESPONSE_BYTES);
+
+    // The store-loaded slice was short (900 < 8192), but the byte serializer
+    // exposed only a prefix. The same responder session must still own the
+    // suffix addressed by this continuation offset.
+    const second = await cap.invoke({ ...request, offset: firstRows.length });
+    expect(linesFromNquads(second)).toHaveLength(totalRows - firstRows.length);
+
+    await store.close();
+  });
+
   it('honours the negotiated row hint for durable meta while legacy meta remains capped', async () => {
     const store = new OxigraphStore();
     const contextGraphId = 'byte-budget-meta-cg';
@@ -692,7 +729,7 @@ describe('byte-budget sync pagination', () => {
   });
 
   it('derives exact-fetch resource policy without trusting signature fields', () => {
-    expect(resolveDurableDataRequestPolicy({
+    expect(resolveDataRequestPolicy({
       legacyLimit: SYNC_PAGE_SIZE,
       includeSharedMemory: false,
       phase: 'data',
@@ -706,7 +743,7 @@ describe('byte-budget sync pagination', () => {
       exactGraphReadMode: 'page-only',
     });
 
-    expect(resolveDurableDataRequestPolicy({
+    expect(resolveDataRequestPolicy({
       legacyLimit: SYNC_PAGE_SIZE,
       includeSharedMemory: false,
       phase: 'data',
@@ -720,7 +757,7 @@ describe('byte-budget sync pagination', () => {
       exactGraphReadMode: 'snapshot-or-page',
     });
 
-    expect(resolveDurableDataRequestPolicy({
+    expect(resolveDataRequestPolicy({
       legacyLimit: SYNC_PAGE_SIZE,
       includeSharedMemory: true,
       phase: 'data',

--- a/packages/agent/test/sync-byte-budget-pages.test.ts
+++ b/packages/agent/test/sync-byte-budget-pages.test.ts
@@ -104,6 +104,26 @@ describe('byte-budget sync pagination', () => {
     );
   });
 
+  it('advertises byte-budget paging for public shared-memory data', async () => {
+    const encoded = await buildSyncRequestEnvelope({
+      contextGraphId: CG_ID,
+      offset: 0,
+      limit: SYNC_REQUEST_PAGE_SIZE,
+      includeSharedMemory: true,
+      targetPeerId: REMOTE_PEER_ID,
+      requesterPeerId: LOCAL_PEER_ID,
+      phase: 'data',
+      needsAuth: false,
+      computeSyncDigest: () => new Uint8Array(32),
+      getIdentityId: async () => 0n,
+    });
+
+    expect(new TextDecoder().decode(encoded)).toBe(
+      `workspace:${CG_ID}|0|${SYNC_REQUEST_PAGE_SIZE}|data`
+      + `|page-mode|${SYNC_BYTE_BUDGET_PAGE_MODE}|page-rows|${SYNC_REQUEST_PAGE_SIZE}`,
+    );
+  });
+
   it('keeps the authenticated legacy limit signed while adding the larger hint', async () => {
     const wallet = ethers.Wallet.createRandom();
     const signedLimits: number[] = [];
@@ -520,6 +540,44 @@ describe('byte-budget sync pagination', () => {
     await store.close();
   });
 
+  it('lets negotiated shared-memory data use the larger byte-bounded page', async () => {
+    const store = new OxigraphStore();
+    const graph = `did:dkg:context-graph:${CG_ID}/_shared_memory`;
+    await store.insert(Array.from({ length: 1_200 }, (_, i) => ({
+      graph,
+      subject: 'urn:shared-memory-root',
+      predicate: `urn:predicate:${i.toString().padStart(4, '0')}`,
+      object: `"value-${i}"`,
+    })));
+    const cap = registerTestSyncHandler(store, { syncPageSize: SYNC_PAGE_SIZE });
+
+    const legacy = await cap.invoke({
+      contextGraphId: CG_ID,
+      offset: 0,
+      limit: SYNC_PAGE_SIZE,
+      includeSharedMemory: true,
+      phase: 'data',
+      syncSessionId: 'legacy-swm-data-session',
+    });
+    expect(linesFromNquads(legacy)).toHaveLength(SYNC_PAGE_SIZE);
+
+    const upgraded = await cap.invoke({
+      contextGraphId: CG_ID,
+      offset: 0,
+      limit: SYNC_PAGE_SIZE,
+      includeSharedMemory: true,
+      phase: 'data',
+      syncSessionId: 'byte-budget-swm-data-session',
+      pageMode: SYNC_BYTE_BUDGET_PAGE_MODE,
+      pageRowsHint: SYNC_REQUEST_PAGE_SIZE,
+    });
+    expect(linesFromNquads(upgraded)).toHaveLength(1_200);
+    expect(new TextEncoder().encode(upgraded).byteLength)
+      .toBeLessThanOrEqual(SYNC_BYTE_BUDGET_RESPONSE_BYTES);
+
+    await store.close();
+  });
+
   it('honours the negotiated row hint for durable meta while legacy meta remains capped', async () => {
     const store = new OxigraphStore();
     const contextGraphId = 'byte-budget-meta-cg';
@@ -651,6 +709,20 @@ describe('byte-budget sync pagination', () => {
     expect(resolveDurableDataRequestPolicy({
       legacyLimit: SYNC_PAGE_SIZE,
       includeSharedMemory: false,
+      phase: 'data',
+      pageMode: SYNC_BYTE_BUDGET_PAGE_MODE,
+      pageRowsHint: SYNC_REQUEST_PAGE_SIZE,
+      hasExactAssetFilter: false,
+    })).toEqual({
+      usesByteBudgetPage: true,
+      limit: SYNC_REQUEST_PAGE_SIZE,
+      cacheMode: 'session-snapshot',
+      exactGraphReadMode: 'snapshot-or-page',
+    });
+
+    expect(resolveDurableDataRequestPolicy({
+      legacyLimit: SYNC_PAGE_SIZE,
+      includeSharedMemory: true,
       phase: 'data',
       pageMode: SYNC_BYTE_BUDGET_PAGE_MODE,
       pageRowsHint: SYNC_REQUEST_PAGE_SIZE,

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -864,7 +864,7 @@ describe('sync requester progress accounting', () => {
     expect(summary.deniedPhases).toBe(1);
     expect(summary.failedPeers).toBe(0);
     expect(summary.completedPhases).toBe(2);
-    expect(fetchSyncPages.calls).toContainEqual([ctx, 'peer-a', 'open-swm', true, 'data', expect.any(String), expect.any(Number)]);
+    expect(fetchSyncPages.calls).toContainEqual([ctx, 'peer-a', 'open-swm', true, 'data', expect.any(String), expect.any(Number), undefined]);
   });
 
   it('counts multiple shared-memory context-graph failures as one failed peer', async () => {
@@ -900,7 +900,7 @@ describe('sync requester progress accounting', () => {
     expect(summary.failedPhases).toBe(0);
     expect(summary.deniedPhases).toBe(0);
     expect(summary.completedPhases).toBe(2);
-    expect(fetchSyncPages.calls).toContainEqual([ctx, 'peer-a', 'open-swm', true, 'data', expect.any(String), expect.any(Number)]);
+    expect(fetchSyncPages.calls).toContainEqual([ctx, 'peer-a', 'open-swm', true, 'data', expect.any(String), expect.any(Number), undefined]);
   });
 
   it('continues shared-memory sync after a post-response verifier failure without marking the peer unreachable', async () => {
@@ -939,7 +939,7 @@ describe('sync requester progress accounting', () => {
     expect(summary.failedPeers).toBe(0);
     expect(summary.failedPhases).toBe(1);
     expect(summary.completedPhases).toBe(2);
-    expect(fetchSyncPages.calls).toContainEqual([ctx, 'peer-a', 'open-swm', true, 'data', expect.any(String), expect.any(Number)]);
+    expect(fetchSyncPages.calls).toContainEqual([ctx, 'peer-a', 'open-swm', true, 'data', expect.any(String), expect.any(Number), undefined]);
   });
 
   it('counts shared-memory snapshot validation failures as phase failures after the peer responded', async () => {
@@ -1005,7 +1005,7 @@ describe('sync requester progress accounting', () => {
     expect(summary.failedPeers).toBe(0);
     expect(summary.failedPhases).toBe(1);
     expect(summary.completedPhases).toBe(2);
-    expect(fetchSyncPages.calls).toContainEqual([ctx, 'peer-a', 'open-swm', true, 'data', expect.any(String), expect.any(Number)]);
+    expect(fetchSyncPages.calls).toContainEqual([ctx, 'peer-a', 'open-swm', true, 'data', expect.any(String), expect.any(Number), undefined]);
   });
 
   it('counts both clean zero-offset empty shared-memory phases as complete', async () => {
@@ -1239,7 +1239,7 @@ describe('sync requester progress accounting', () => {
     expect(storeInsert.calls).toHaveLength(1);
     expect(storeInsert.calls).toContainEqual([[dataQuad]]);
     expect(setCheckpoint.calls).not.toContainEqual(['large-swm:snapshot:snapshot-ref', expect.any(Number)]);
-    expect(setCheckpoint.calls).toContainEqual(['large-swm:data', 7]);
+    expect(setCheckpoint.calls).toContainEqual(['large-swm:data', 7, 7]);
     expect(setCheckpoint.calls).not.toContainEqual(['large-swm:meta', expect.any(Number)]);
     expect(deleteCheckpoint.calls).toContainEqual(['large-swm:snapshot:snapshot-ref']);
   });

--- a/packages/agent/test/sync-responder-graph-backed-swm.test.ts
+++ b/packages/agent/test/sync-responder-graph-backed-swm.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import { OxigraphStore, type TripleStore } from '@origintrail-official/dkg-storage';
+import { readSwmDataPage } from '../src/sync/responder/graph-plan.js';
+
+describe('graph-backed shared-memory responder planning', () => {
+  const contextGraphId = 'test/graph-backed-cg';
+  const dataGraph = `did:dkg:context-graph:${contextGraphId}/_shared_memory`;
+  const metaGraph = `${dataGraph}_meta`;
+  const snapshotGraph = `did:dkg:context-graph:${encodeURIComponent(contextGraphId)}`
+    + '/_shared_memory_snapshots/_/share-op-1/ka';
+  const rows = [0, 1, 2].map((index) => ({
+    s: `urn:graph-backed:${index}`,
+    p: 'http://schema.org/value',
+    o: `"${index}"`,
+    g: snapshotGraph,
+  }));
+
+  function storeWithActualCount(actualCount = rows.length): TripleStore {
+    return {
+      async query(sparql: string) {
+        if (sparql.includes('SELECT DISTINCT ?g ?root')) {
+          return { type: 'bindings' as const, bindings: [] };
+        }
+        if (sparql.includes('SELECT DISTINCT ?snapshotGraph ?count ?ts')) {
+          return {
+            type: 'bindings' as const,
+            bindings: [{
+              snapshotGraph,
+              count: `"${rows.length}"^^<http://www.w3.org/2001/XMLSchema#integer>`,
+              ts: '"2026-08-15T00:00:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>',
+            }],
+          };
+        }
+        if (sparql.includes(`SELECT (<${snapshotGraph}> AS ?g) (COUNT(*) AS ?count)`)) {
+          return {
+            type: 'bindings' as const,
+            bindings: [{ g: snapshotGraph, count: String(actualCount) }],
+          };
+        }
+        if (sparql.includes(`GRAPH <${snapshotGraph}> { ?s ?p ?o }`)) {
+          const offset = Number(/OFFSET (\d+)/.exec(sparql)?.[1] ?? 0);
+          const limit = Number(/LIMIT (\d+)/.exec(sparql)?.[1] ?? rows.length);
+          return {
+            type: 'bindings' as const,
+            bindings: rows.slice(offset, offset + limit),
+          };
+        }
+        return { type: 'bindings' as const, bindings: [] };
+      },
+    } as unknown as TripleStore;
+  }
+
+  it('serves a fresh immutable snapshot graph as one paged batch plan', async () => {
+    const first = await readSwmDataPage({
+      store: storeWithActualCount(),
+      graphList: [dataGraph, metaGraph, snapshotGraph],
+      registeredSubGraphNames: [],
+      contextGraphId,
+      cutoffIso: '2026-08-14T00:00:00.000Z',
+      offset: 0,
+      limit: 2,
+    });
+    const second = await readSwmDataPage({
+      store: storeWithActualCount(),
+      graphList: [dataGraph, metaGraph, snapshotGraph],
+      registeredSubGraphNames: [],
+      contextGraphId,
+      cutoffIso: '2026-08-14T00:00:00.000Z',
+      offset: 2,
+      limit: 2,
+    });
+
+    expect([...first, ...second]).toEqual(rows);
+  });
+
+  it('fails closed when operation metadata and stored graph count disagree', async () => {
+    await expect(readSwmDataPage({
+      store: storeWithActualCount(rows.length - 1),
+      graphList: [dataGraph, metaGraph, snapshotGraph],
+      registeredSubGraphNames: [],
+      contextGraphId,
+      cutoffIso: '2026-08-14T00:00:00.000Z',
+      offset: 0,
+      limit: 2,
+    })).rejects.toThrow('count mismatch');
+  });
+
+  it('executes the graph-backed discovery and count plan against Oxigraph', async () => {
+    const store = new OxigraphStore();
+    const operation = 'urn:dkg:share:graph-backed-real-store';
+    await store.insert([
+      {
+        graph: metaGraph,
+        subject: operation,
+        predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+        object: 'http://dkg.io/ontology/WorkspaceOperation',
+      },
+      {
+        graph: metaGraph,
+        subject: operation,
+        predicate: 'http://dkg.io/ontology/contentScopeVersion',
+        object: '"2"^^<http://www.w3.org/2001/XMLSchema#integer>',
+      },
+      {
+        graph: metaGraph,
+        subject: operation,
+        predicate: 'http://dkg.io/ontology/publicSnapshotGraph',
+        object: snapshotGraph,
+      },
+      {
+        graph: metaGraph,
+        subject: operation,
+        predicate: 'http://dkg.io/ontology/publicQuadsCount',
+        object: `"${rows.length}"^^<http://www.w3.org/2001/XMLSchema#integer>`,
+      },
+      {
+        graph: metaGraph,
+        subject: operation,
+        predicate: 'http://dkg.io/ontology/publishedAt',
+        object: '"2026-08-15T00:00:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>',
+      },
+      ...rows.map((row) => ({
+        graph: row.g,
+        subject: row.s,
+        predicate: row.p,
+        object: row.o,
+      })),
+    ]);
+
+    const actual = await readSwmDataPage({
+      store,
+      graphList: [dataGraph, metaGraph, snapshotGraph],
+      registeredSubGraphNames: [],
+      contextGraphId,
+      cutoffIso: '2026-08-14T00:00:00.000Z',
+      offset: 0,
+      limit: 10,
+    });
+
+    expect(actual).toEqual(rows);
+    await store.close();
+  });
+});

--- a/packages/agent/test/sync-responder-graph-backed-swm.test.ts
+++ b/packages/agent/test/sync-responder-graph-backed-swm.test.ts
@@ -88,12 +88,29 @@ describe('graph-backed shared-memory responder planning', () => {
   it('executes the graph-backed discovery and count plan against Oxigraph', async () => {
     const store = new OxigraphStore();
     const operation = 'urn:dkg:share:graph-backed-real-store';
+    const head = 'did:dkg:test/graph-backed/1#dkg-swm-head';
+    const shareOperationId = 'share-op-1';
+    const staleOperation = 'urn:dkg:share:graph-backed-stale';
+    const staleSnapshotGraph = `did:dkg:context-graph:${encodeURIComponent(contextGraphId)}`
+      + '/_shared_memory_snapshots/_/stale-share-op/ka';
     await store.insert([
+      {
+        graph: metaGraph,
+        subject: head,
+        predicate: 'http://dkg.io/ontology/shareOperationId',
+        object: `"${shareOperationId}"`,
+      },
       {
         graph: metaGraph,
         subject: operation,
         predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
         object: 'http://dkg.io/ontology/WorkspaceOperation',
+      },
+      {
+        graph: metaGraph,
+        subject: operation,
+        predicate: 'http://dkg.io/ontology/shareOperationId',
+        object: `"${shareOperationId}"`,
       },
       {
         graph: metaGraph,
@@ -119,6 +136,45 @@ describe('graph-backed shared-memory responder planning', () => {
         predicate: 'http://dkg.io/ontology/publishedAt',
         object: '"2026-08-15T00:00:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>',
       },
+      // Superseded operations remain in metadata history. This intentionally
+      // advertises a missing graph/count mismatch and must be ignored because
+      // no canonical head references its shareOperationId.
+      {
+        graph: metaGraph,
+        subject: staleOperation,
+        predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+        object: 'http://dkg.io/ontology/WorkspaceOperation',
+      },
+      {
+        graph: metaGraph,
+        subject: staleOperation,
+        predicate: 'http://dkg.io/ontology/shareOperationId',
+        object: '"stale-share-op"',
+      },
+      {
+        graph: metaGraph,
+        subject: staleOperation,
+        predicate: 'http://dkg.io/ontology/contentScopeVersion',
+        object: '"2"^^<http://www.w3.org/2001/XMLSchema#integer>',
+      },
+      {
+        graph: metaGraph,
+        subject: staleOperation,
+        predicate: 'http://dkg.io/ontology/publicSnapshotGraph',
+        object: staleSnapshotGraph,
+      },
+      {
+        graph: metaGraph,
+        subject: staleOperation,
+        predicate: 'http://dkg.io/ontology/publicQuadsCount',
+        object: '"999"^^<http://www.w3.org/2001/XMLSchema#integer>',
+      },
+      {
+        graph: metaGraph,
+        subject: staleOperation,
+        predicate: 'http://dkg.io/ontology/publishedAt',
+        object: '"2026-08-15T00:01:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>',
+      },
       ...rows.map((row) => ({
         graph: row.g,
         subject: row.s,
@@ -138,6 +194,56 @@ describe('graph-backed shared-memory responder planning', () => {
     });
 
     expect(actual).toEqual(rows);
+    await store.close();
+  });
+
+  it('emits graph-backed groups before legacy root-scoped rows across pages', async () => {
+    const store = new OxigraphStore();
+    const operation = 'urn:dkg:share:graph-backed-mixed';
+    const head = 'did:dkg:test/graph-backed/mixed#dkg-swm-head';
+    const legacyOperation = 'urn:dkg:share:legacy-mixed';
+    const legacyRoot = 'urn:legacy:root';
+    const legacyRows = [
+      { subject: legacyRoot, predicate: 'http://schema.org/name', object: '"root"' },
+      { subject: `${legacyRoot}/.well-known/genid/1`, predicate: 'http://schema.org/value', object: '"child"' },
+    ];
+    await store.insert([
+      { graph: metaGraph, subject: head, predicate: 'http://dkg.io/ontology/shareOperationId', object: '"share-op-1"' },
+      { graph: metaGraph, subject: operation, predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/WorkspaceOperation' },
+      { graph: metaGraph, subject: operation, predicate: 'http://dkg.io/ontology/shareOperationId', object: '"share-op-1"' },
+      { graph: metaGraph, subject: operation, predicate: 'http://dkg.io/ontology/contentScopeVersion', object: '"2"^^<http://www.w3.org/2001/XMLSchema#integer>' },
+      { graph: metaGraph, subject: operation, predicate: 'http://dkg.io/ontology/publicSnapshotGraph', object: snapshotGraph },
+      { graph: metaGraph, subject: operation, predicate: 'http://dkg.io/ontology/publicQuadsCount', object: `"${rows.length}"^^<http://www.w3.org/2001/XMLSchema#integer>` },
+      { graph: metaGraph, subject: operation, predicate: 'http://dkg.io/ontology/publishedAt', object: '"2026-08-15T00:00:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>' },
+      { graph: metaGraph, subject: legacyOperation, predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/WorkspaceOperation' },
+      { graph: metaGraph, subject: legacyOperation, predicate: 'http://dkg.io/ontology/rootEntity', object: legacyRoot },
+      { graph: metaGraph, subject: legacyOperation, predicate: 'http://dkg.io/ontology/publishedAt', object: '"2026-08-15T00:00:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>' },
+      ...rows.map((row) => ({ graph: row.g, subject: row.s, predicate: row.p, object: row.o })),
+      ...legacyRows.map((row) => ({ graph: dataGraph, ...row })),
+    ]);
+
+    const page1 = await readSwmDataPage({
+      store,
+      graphList: [dataGraph, metaGraph, snapshotGraph],
+      registeredSubGraphNames: [],
+      contextGraphId,
+      cutoffIso: '2026-08-14T00:00:00.000Z',
+      offset: 0,
+      limit: 4,
+    });
+    const page2 = await readSwmDataPage({
+      store,
+      graphList: [dataGraph, metaGraph, snapshotGraph],
+      registeredSubGraphNames: [],
+      contextGraphId,
+      cutoffIso: '2026-08-14T00:00:00.000Z',
+      offset: 4,
+      limit: 4,
+    });
+    const actual = [...page1, ...page2];
+    expect(actual.slice(0, rows.length).every((row) => row.g === snapshotGraph)).toBe(true);
+    expect(actual.slice(rows.length).every((row) => row.g === dataGraph)).toBe(true);
+    expect(actual).toHaveLength(rows.length + legacyRows.length);
     await store.close();
   });
 });

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -79,6 +79,8 @@ export default defineConfig({
       "test/sync-responder-oversized-fallback.test.ts",
       "test/sync-responder-swm-meta-ceiling.test.ts",
       "test/sync-responder-large-graph-stack-overflow.test.ts",
+      "test/sync-responder-graph-backed-swm.test.ts",
+      "test/graph-backed-swm-page-boundary.test.ts",
       "test/sync-page-frame-budget.test.ts",
       "test/sync-byte-budget-pages.test.ts",
       "test/sync-append-in-place.test.ts",
@@ -175,6 +177,7 @@ export default defineConfig({
       "test/workspace-crypto-delegatee-filter.test.ts",
       "test/swm-public-snapshot-materialization.test.ts",
       "test/swm-public-cg-plaintext.test.ts",
+      "test/shared-memory-sync-ownership.test.ts",
       "test/swm-snapshot-materializer.test.ts",
       // #2079 — the already-materialized witness: the warm-path win, the count
       // gate that keeps it self-healing, and the digest binding that makes an


### PR DESCRIPTION
## Impact

Selected RFC-64 public SWM recovery can now recover the immutable graph-backed form of a Knowledge Asset, not only snapshot-store references. A responder discovers the graph-backed operations from verified SWM metadata, serves their immutable payload graphs in whole graph groups, and a receiver independently verifies each advertised count and digest before atomically materializing it.

This also enables the already-negotiated byte-bounded 8,192-row page contract for public SWM DATA. Large pages remain capped by the existing 4 MiB transport frame budget, while incomplete pages rewind to the first row of the partial immutable graph so a checkpoint can never skip unverified content.

The change is fail-closed. Unsupported legacy root-slice graph advertisements, malformed descriptors, non-contiguous groups, count/digest mismatches, and store failures all keep the selected scope incomplete and retryable.

## Before

```mermaid
sequenceDiagram
    participant Receiver
    participant Provider
    participant Store
    Receiver->>Provider: Request selected public SWM metadata
    Provider-->>Receiver: KA descriptor with publicSnapshotGraph
    Receiver->>Provider: Request aggregate SWM DATA
    Provider-->>Receiver: Base SWM rows only
    Receiver->>Receiver: No count-and-digest-bound payload
    Receiver-->>Receiver: Keep selected scope incomplete
```

## After

```mermaid
sequenceDiagram
    participant Receiver
    participant Provider
    participant Store
    Receiver->>Provider: Request selected public SWM metadata
    Provider-->>Receiver: Verified KA descriptors and immutable graph commitments
    Receiver->>Provider: Request byte-bounded SWM DATA page
    Provider->>Store: Plan recent immutable graphs and legacy rows
    Store-->>Provider: Whole graph groups within row and byte caps
    Provider-->>Receiver: Immutable graph payloads
    Receiver->>Receiver: Verify graph, count, digest, and page boundary
    Receiver->>Store: Atomically replace assertion graph and head metadata
    Receiver-->>Receiver: Mark scope complete only at exact coverage
```

## Safety boundaries

- The transport graph is never union-inserted as ordinary SWM data.
- Only content-scope-v2 WorkspaceOperation descriptors can authorize graph-backed materialization.
- The responder count-checks every planned immutable graph; the requester rechecks count and digest independently.
- A partial final graph rewinds the durable cursor to its first row. A failed graph is retried from its boundary.
- The selected SWM DATA checkpoint has a versioned namespace, so older cursor semantics cannot be reused accidentally.
- Existing snapshot-store recovery remains unchanged; this adds the missing graph-backed compatibility path.

## Validation

- Agent build, type tests, and package-root test: pass.
- Focused requester progress suite: 59/59 pass.
- Full agent unit lane: 202/202 files; 2,916 passed, 5 skipped, 0 failed.
- Oxigraph-backed responder integration proves discovery, count validation, and payload serving.
- Boundary tests prove whole-graph advance, partial rewind, terminal-short rejection, and non-contiguous rejection.
- `git diff --check`: clean.

## Runtime validation

The exact commit will be deployed to Testnet as a validation candidate and exercised by a fresh Blackbox v3 500 SWM + 500 VM run with both local and remote receivers. This PR does not claim that runtime gate until the archived harness evidence reaches exact parity on every admitted receiver.
