### PR TITLE
fix(publisher): retry one exact failed lift job

### DIFF
--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -1333,6 +1333,11 @@ export class ApiClient {
     return this.post('/api/publisher/retry', { status });
   }
 
+  async publisherRetryJob(jobId: string): Promise<{ retried: number }> {
+    if (!jobId) throw new Error('jobId must be a non-empty string');
+    return this.post('/api/publisher/retry', { status: 'failed', jobId });
+  }
+
   async publisherClear(status: 'failed' | 'finalized'): Promise<{ cleared: number; status: 'failed' | 'finalized' }> {
     return this.post('/api/publisher/clear', { status });
   }

--- a/packages/cli/src/daemon/routes/publisher.ts
+++ b/packages/cli/src/daemon/routes/publisher.ts
@@ -536,7 +536,13 @@ export async function handlePublisherRoutes(ctx: RequestContext): Promise<void> 
       return jsonResponse(res, 400, {
         error: "Only status=failed is supported",
       });
-    const count = await publisherControl.retry({ status: "failed" });
+    const jobId = parsed.jobId;
+    if (jobId !== undefined && (typeof jobId !== "string" || jobId.length === 0)) {
+      return jsonResponse(res, 400, { error: "jobId must be a non-empty string when supplied" });
+    }
+    const count = typeof jobId === "string"
+      ? await publisherControl.retryFailedJob(jobId)
+      : await publisherControl.retry({ status: "failed" });
     return jsonResponse(res, 200, { retried: count });
   }
 

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -1275,6 +1275,17 @@ describe('ApiClient — GitHub-shaped knowledge-assets SDK (OT-RFC-43 §10.5)', 
     expect(JSON.parse(calls[0].opts.body as string)).toEqual({ jobId: 'lift job 7' });
   });
 
+  it('publisherRetryJob serializes an exact job selection and rejects an empty id before HTTP', async () => {
+    const calls = track({ retried: 1 });
+    await client.publisherRetryJob('lift job 7');
+    expect(calls[0].url).toBe(`${base}/api/publisher/retry`);
+    expect(calls[0].opts.method).toBe('POST');
+    expect(JSON.parse(calls[0].opts.body as string)).toEqual({ status: 'failed', jobId: 'lift job 7' });
+
+    await expect(client.publisherRetryJob('')).rejects.toThrow('jobId must be a non-empty string');
+    expect(calls).toHaveLength(1);
+  });
+
   it('knowledgeAssetShareAsync rejects unsupported sync-only options before HTTP serialization', async () => {
     const calls = track({ jobId: 'should-not-reach', state: 'queued' });
     await expect(client.knowledgeAssetShareAsync('cg', 'f', {

--- a/packages/cli/test/publisher-admin-body-boundary.test.ts
+++ b/packages/cli/test/publisher-admin-body-boundary.test.ts
@@ -15,6 +15,7 @@ describe('#1890 publisher admin POST body boundary', () => {
     return {
       cancel: async () => {},
       retry: async () => 3,
+      retryFailedJob: async (jobId) => jobId === 'j1' ? 1 : 0,
       clear: async () => 2,
       clearTerminalJob: async () => ({ outcome: 'already_absent' as const }),
     } as unknown as RequestContext['publisherControl'];
@@ -90,6 +91,15 @@ describe('#1890 publisher admin POST body boundary', () => {
     });
     it('unsupported status → 400', async () => {
       expect(await post('/api/publisher/retry', JSON.stringify({ status: 'queued' }))).toEqual({ status: 400, body: { error: 'Only status=failed is supported' } });
+    });
+    it('exact jobId → retries only the selected job', async () => {
+      expect(await post('/api/publisher/retry', JSON.stringify({ status: 'failed', jobId: 'j1' }))).toEqual({ status: 200, body: { retried: 1 } });
+    });
+    it('invalid jobId → 400', async () => {
+      expect(await post('/api/publisher/retry', JSON.stringify({ status: 'failed', jobId: 42 }))).toEqual({ status: 400, body: { error: 'jobId must be a non-empty string when supplied' } });
+    });
+    it('empty jobId → 400 without broadening to retry-all', async () => {
+      expect(await post('/api/publisher/retry', JSON.stringify({ status: 'failed', jobId: '' }))).toEqual({ status: 400, body: { error: 'jobId must be a non-empty string when supplied' } });
     });
     it('null body → 200 (hardened, not a 500)', async () => {
       expect(await post('/api/publisher/retry', 'null')).toEqual({ status: 200, body: { retried: 3 } });

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -39,6 +39,7 @@ import type {
   JournalReadResult,
   VmPublishIntentRecoveryPublisher,
   VmPublishIntentIndexBackfiller,
+  VmPublishFailedJobRetrier,
   VmPublishAdmissionJournalReader,
   VmPublishTerminalJobClearer,
 } from './async-lift-publisher-types.js';
@@ -213,7 +214,7 @@ function resolveKnowledgeAssetVmPublishHandler(
 }
 
 export class TripleStoreAsyncLiftPublisher
-  implements VmPublishIntentRecoveryPublisher, VmPublishIntentIndexBackfiller, VmPublishAdmissionJournalReader, VmPublishTerminalJobClearer {
+  implements VmPublishIntentRecoveryPublisher, VmPublishIntentIndexBackfiller, VmPublishAdmissionJournalReader, VmPublishTerminalJobClearer, VmPublishFailedJobRetrier {
   private static readonly claimQueues = new Map<string, Promise<void>>();
   // #1829 — dedicated per-lineageKey journal mutex, SEPARATE from claimQueues, so the
   // read-modify-write seq allocation is atomic without touching the claim lock (lock
@@ -1035,7 +1036,16 @@ export class TripleStoreAsyncLiftPublisher
   async retry(filter: { status?: 'failed' } = {}): Promise<number> {
     await this.ensureGraph();
     if (filter.status && filter.status !== 'failed') return 0;
+    return this.retryFailedJobs();
+  }
 
+  async retryFailedJob(jobId: string): Promise<number> {
+    await this.ensureGraph();
+    if (!jobId) throw new Error('jobId must be a non-empty string');
+    return this.retryFailedJobs(jobId);
+  }
+
+  private async retryFailedJobs(jobId?: string): Promise<number> {
     // #1837 — reaccept (failed→accepted) is a terminal→active transition; it MUST be
     // serialized with claimNext/enqueue AND with clearTerminalJob (which also runs under
     // withClaimLock) so a by-id clear that read a job as clearable-failed cannot be swept
@@ -1043,7 +1053,10 @@ export class TripleStoreAsyncLiftPublisher
     // swept" guarantee does not hold.
     return this.withClaimLock(async () => {
       let retried = 0;
-      for (const job of (await this.list({ status: 'failed' })).filter(isFailedJob)) {
+      const failedJobs = (await this.list({ status: 'failed' }))
+        .filter(isFailedJob)
+        .filter((job) => jobId === undefined || job.jobId === jobId);
+      for (const job of failedJobs) {
         if (!job.failure.retryable || job.retries.retryCount >= job.retries.maxRetries) continue;
         // Jobs that failed with a recovery-phase resolution must go through recover(),
         // not retry(), to avoid double-publishing if the original tx eventually lands.

--- a/packages/publisher/src/async-lift-publisher-types.ts
+++ b/packages/publisher/src/async-lift-publisher-types.ts
@@ -148,6 +148,11 @@ export interface VmPublishIntentIndexBackfiller {
   ensureVmPublishIntentIndex(): Promise<number>;
 }
 
+/** Daemon/admin-only exact failed-job retry; intentionally absent from the base runtime queue contract. */
+export interface VmPublishFailedJobRetrier {
+  retryFailedJob(jobId: string): Promise<number>;
+}
+
 /**
  * #1889 — the composite VM-publisher control surface returned by the daemon factory
  * (`createPublisherControlFromStore`) and held by `RequestContext.publisherControl`. Names
@@ -160,7 +165,8 @@ export interface VmPublisherControl
   extends VmPublishIntentRecoveryPublisher,
     VmPublishIntentIndexBackfiller,
     VmPublishAdmissionJournalReader,
-    VmPublishTerminalJobClearer {}
+    VmPublishTerminalJobClearer,
+    VmPublishFailedJobRetrier {}
 
 export interface AsyncLiftPublisherRecoveryResult {
   inclusion: LiftJobInclusionMetadata;

--- a/packages/publisher/src/async-lift-publisher.ts
+++ b/packages/publisher/src/async-lift-publisher.ts
@@ -13,6 +13,7 @@ export type {
   AsyncLiftPublisherRecoveryResult,
   VmPublishIntentRecoveryPublisher,
   VmPublishIntentIndexBackfiller,
+  VmPublishFailedJobRetrier,
   VmPublishAdmissionJournalReader,
   VmPublishTerminalJobClearer,
   VmPublisherControl,

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -269,6 +269,7 @@ export {
   type AsyncLiftPublisherRecoveryResolver,
   type VmPublishIntentRecoveryPublisher,
   type VmPublishIntentIndexBackfiller,
+  type VmPublishFailedJobRetrier,
   type VmPublishAdmissionJournalReader,
   type VmPublishTerminalJobClearer,
   type VmPublisherControl,

--- a/packages/publisher/test/async-lift-runner.test.ts
+++ b/packages/publisher/test/async-lift-runner.test.ts
@@ -15,25 +15,30 @@ async function waitFor(assertion: () => void, timeout = 5000): Promise<void> {
   }
 }
 
-function createPublisher(overrides: Partial<AsyncLiftPublisher> = {}): AsyncLiftPublisher {
-  return {
-    lift: async () => {},
+const basePublisher = {
+    enqueueKnowledgeAssetVmPublish: async () => 'job-id',
     claimNext: async () => null,
     update: async () => {},
     getStatus: async () => null,
     list: async () => [],
+    inspectPreparedPayload: async () => null,
     processNext: async () => null,
-    recordPublishResult: async () => {},
-    recordPublishFailure: async () => {},
+    recordPublishResult: async () => ({} as LiftJob),
+    recordPublishFailure: async () => ({} as LiftJob),
     recover: async () => 0,
-    getStats: () => ({}),
-    pause: () => {},
-    resume: () => {},
+    getStats: async () => ({} as Awaited<ReturnType<AsyncLiftPublisher['getStats']>>),
+    pause: async () => {},
+    resume: async () => {},
     cancel: async () => {},
-    retry: async () => {},
-    clear: async () => {},
+    retry: async () => 0,
+    clear: async () => 0,
+} satisfies AsyncLiftPublisher;
+
+function createPublisher(overrides: Partial<AsyncLiftPublisher> = {}): AsyncLiftPublisher {
+  return {
+    ...basePublisher,
     ...overrides,
-  } as unknown as AsyncLiftPublisher;
+  };
 }
 
 describe('AsyncLiftRunner', () => {

--- a/packages/publisher/test/e2e-publisher-queue.test.ts
+++ b/packages/publisher/test/e2e-publisher-queue.test.ts
@@ -426,4 +426,34 @@ describe('Async Lift Publisher Queue — Recovery', () => {
     const afterRetry = await pub.list({ status: 'accepted' });
     expect(afterRetry.length).toBeGreaterThanOrEqual(1);
   });
+
+  it('retry can re-queue one exact failed job without touching other failures', async () => {
+    const pub = create();
+    const selectedJobId = await pub.seedLegacyRawLift(makeLiftRequest({
+      contextGraphId: 'selected-retry',
+    }));
+    const untouchedJobId = await pub.seedLegacyRawLift(makeLiftRequest({
+      contextGraphId: 'untouched-retry',
+    }));
+
+    for (const jobId of [selectedJobId, untouchedJobId]) {
+      await pub.claimNext('wallet-1');
+      await pub.update(jobId, 'failed', {
+        failure: {
+          failedFromState: 'claimed',
+          code: 'workspace_unavailable',
+          message: 'Store temporarily unavailable',
+          errorPayloadRef: `urn:error:${jobId}`,
+          phase: 'validation',
+          mode: 'retryable',
+          retryable: true,
+          resolution: 'reset_to_accepted',
+        },
+      } as any);
+    }
+
+    await expect(pub.retryFailedJob(selectedJobId)).resolves.toBe(1);
+    await expect(pub.getStatus(selectedJobId)).resolves.toMatchObject({ status: 'accepted' });
+    await expect(pub.getStatus(untouchedJobId)).resolves.toMatchObject({ status: 'failed' });
+  });
 });


### PR DESCRIPTION
## Impact

The async publisher admin boundary can now retry exactly one failed lift job by `jobId`. This lets the Blackbox harness recover a retryable VM publication without sweeping unrelated historical failures or submitting a second publish request.

## Before

```mermaid
sequenceDiagram
    participant Harness
    participant Job as Failed VM job
    participant Publisher
    Harness->>Job: Poll status
    Job-->>Harness: failed and retryable
    Harness->>Harness: Keep polling until timeout
    Note over Publisher: Bulk retry selects every failed job
```

## After

```mermaid
sequenceDiagram
    participant Harness
    participant API as Publisher API
    participant Job as Exact VM job
    Harness->>Job: Poll status
    Job-->>Harness: failed and retryable
    Harness->>API: Retry failed jobId only
    API->>Job: Reset exact job to accepted
    Job-->>Harness: finalized
```

## Validation

- Publisher queue E2E: 14 passed
- CLI publisher boundary: 18 passed
- Publisher dependency build: passed
- CLI dependency build: passed
- Diff check: passed

## Live trigger

The Testnet 500/500 diagnostic run exposed a retryable VM job in `failed` state. The harness recognized it as retryable but had no safe exact-job retry endpoint, so it polled until timeout. The only existing API retried all failed jobs; this PR closes that safety gap.
