### PR TITLE
fix(storage): keep graph index warm on admission rejection

### DIFF
--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -76,6 +76,12 @@ operation rejected before dispatch receives `StoreSchedulerBusyError` with
 the operation closure starts, retrying it cannot duplicate a write that might
 already have reached the store.
 
+Each external adapter supplies the canonical store operation as queue-entry
+metadata, and the scheduler binds it when creating either admission rejection.
+Decorators validate that tagged operation-outcome contract rather than the
+error class alone: a rejected nested read does not imply that an enclosing
+replace failed before mutation.
+
 | Environment variable | Default | Purpose |
 |---|---:|---|
 | `DKG_STORE_MAX_CONCURRENT` | `8` | Maximum external-store operations in flight. |

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -24,7 +24,10 @@ import {
   getMetrics,
   JAVA_WRITE_UTF_MAX_BYTES,
 } from '@origintrail-official/dkg-core';
-import { externalStorePriorityScheduler } from '../store-priority-scheduler.js';
+import {
+  externalStorePriorityScheduler,
+  type StorePriorityScheduler,
+} from '../store-priority-scheduler.js';
 import {
   buildAtomicGraphAndSubjectReplaceUpdate,
   buildAtomicGraphReplaceUpdate,
@@ -35,6 +38,7 @@ import { quadToNQuad } from '../bounded-rdf.js';
 import { readResponseTextBounded } from '../http-response-limit.js';
 import { scanNQuadLines, type NQuadLineScan } from '../nquads-text.js';
 import { StoreOperationTimeoutError } from '../store-operation-timeout.js';
+import type { StoreOperation, StoreOperationOutcome } from '../store-operation-outcome.js';
 
 export const DEFAULT_BLAZEGRAPH_OPERATION_TIMEOUT_MS = 30_000;
 
@@ -79,10 +83,13 @@ const SERVER_QUERY_DEADLINE_FACTOR = 4;
 export interface BlazegraphStoreOptions {
   /** End-to-end timeout including scheduler wait, HTTP work, and response decoding. */
   timeout?: number;
+  /** Optional scheduler injection for embedded callers and adapter-boundary tests. */
+  scheduler?: StorePriorityScheduler;
 }
 
 interface StoreOperationDeadline {
   readonly signal: AbortSignal;
+  markStarted(): void;
   waitFor<T>(work: Promise<T>): Promise<T>;
   check(): void;
   dispose(): void;
@@ -116,19 +123,19 @@ function abortError(signal: AbortSignal): Error {
 function createStoreOperationDeadline(
   timeoutMs: number,
   callerSignal?: AbortSignal,
-  operation = 'operation',
-  outcome: () => 'not_started' | 'indeterminate' = () => 'indeterminate',
+  operation: StoreOperation = 'query',
 ): StoreOperationDeadline {
   const controller = new AbortController();
   const deadlineAt = performance.now() + timeoutMs;
   let timer: ReturnType<typeof setTimeout> | undefined;
   let callerAttached = false;
+  let outcome: StoreOperationOutcome = 'not_started';
 
   const timeoutError = () => new StoreOperationTimeoutError({
     backend: 'blazegraph',
     operation,
     timeoutMs,
-    outcome: outcome(),
+    outcome,
   });
   const detachCaller = () => {
     if (!callerAttached) return;
@@ -186,6 +193,7 @@ function createStoreOperationDeadline(
 
   return {
     signal: controller.signal,
+    markStarted: () => { outcome = 'indeterminate'; },
     waitFor,
     check,
     dispose: () => {
@@ -211,54 +219,51 @@ export class BlazegraphStore implements TripleStore {
 
   private readonly url: string;
   private readonly operationTimeoutMs: number;
+  private readonly scheduler: StorePriorityScheduler;
 
   constructor(url: string, options: BlazegraphStoreOptions = {}) {
     this.url = url.replace(/\/$/, '');
     this.operationTimeoutMs = resolveOperationTimeout(options.timeout);
+    this.scheduler = options.scheduler ?? externalStorePriorityScheduler;
   }
 
   private runStoreWork<T>(
-    operation: string,
+    operation: StoreOperation,
     options: QueryOptions | undefined,
     work: (deadline: StoreOperationDeadline) => Promise<T>,
   ): Promise<T> {
-    let admitted = false;
     const deadline = createStoreOperationDeadline(
       this.operationTimeoutMs,
       options?.signal,
       operation,
-      () => admitted ? 'indeterminate' : 'not_started',
     );
     const source = options?.source ?? `blazegraph.${operation}`;
-    const scheduled = externalStorePriorityScheduler.run(
+    const scheduled = this.scheduler.run(
       options?.priority,
       source,
       async () => {
-        admitted = true;
-        deadline.check();
-        const result = await work(deadline);
-        deadline.check();
-        return result;
+        deadline.markStarted();
+        try {
+          deadline.check();
+          const result = await work(deadline);
+          deadline.check();
+          return result;
+        } finally {
+          // The admitted transport/body promise has settled before this metric
+          // and before the scheduler releases its slot.
+          if (deadline.signal.aborted) {
+            getMetrics().storeCancellationCompletedTotal.add(1, { operation, source });
+          }
+        }
       },
       deadline.signal,
+      { storeOperation: operation },
     );
-    return scheduled
-      .catch((error) => {
-        // This runs only after the admitted work promise has settled. Combined
-        // with StoreOperationDeadline.waitFor awaiting the real fetch/body
-        // promise, the metric means transport cleanup completed before the
-        // caller can launch a retry. Queued work that expired before admission
-        // is intentionally excluded.
-        if (admitted && deadline.signal.aborted) {
-          getMetrics().storeCancellationCompletedTotal.add(1, { operation, source });
-        }
-        throw error;
-      })
-      .finally(deadline.dispose);
+    return scheduled.finally(deadline.dispose);
   }
 
   getPressureSnapshot(): StorePressureSnapshot {
-    return externalStorePriorityScheduler.snapshot;
+    return this.scheduler.snapshot;
   }
 
   // -------------------------------------------------------------------
@@ -393,7 +398,7 @@ export class BlazegraphStore implements TripleStore {
         await this.sparqlUpdate(
           plan.cleanup,
           { ...options, source: 'blazegraph.replaceGraph.cleanup' },
-          'replaceGraphCleanup',
+          'replaceGraph',
         ).catch(() => undefined);
       }
       throw error;
@@ -429,7 +434,7 @@ export class BlazegraphStore implements TripleStore {
       await this.sparqlUpdate(
         plan.cleanup,
         { ...options, source: 'blazegraph.replaceGraphAndSubject.cleanup' },
-        'replaceGraphAndSubjectCleanup',
+        'replaceGraphAndSubject',
       ).catch(() => undefined);
       throw error;
     }
@@ -460,11 +465,22 @@ export class BlazegraphStore implements TripleStore {
   // -------------------------------------------------------------------
 
   async query(sparql: string, options?: TripleStoreQueryOptions): Promise<QueryResult> {
+    return this.queryWithOperation(sparql, options);
+  }
+
+  private async queryWithOperation(
+    sparql: string,
+    options: TripleStoreQueryOptions | undefined,
+    storeOperation?: StoreOperation,
+  ): Promise<QueryResult> {
     const trimmed = sparql.trim();
     const upper = trimmed.toUpperCase();
     const isAsk = upper.startsWith('ASK');
     const isConstruct = upper.startsWith('CONSTRUCT') || upper.startsWith('DESCRIBE');
-    return this.runStoreWork(isConstruct ? 'construct' : 'query', options, async (deadline) => {
+    return this.runStoreWork(
+      storeOperation ?? (isConstruct ? 'construct' : 'query'),
+      options,
+      async (deadline) => {
 
       if (isConstruct) {
         return this.queryConstruct(trimmed, deadline, options);
@@ -500,7 +516,8 @@ export class BlazegraphStore implements TripleStore {
 
       const bindings = formatSparqlJsonBindings(json as AdapterSparqlJsonSelectResponse);
       return { type: 'bindings', bindings } satisfies SelectResult;
-    });
+      },
+    );
   }
 
   /**
@@ -570,9 +587,10 @@ export class BlazegraphStore implements TripleStore {
   // -------------------------------------------------------------------
 
   async hasGraph(graphUri: string, options?: QueryOptions): Promise<boolean> {
-    const r = await this.query(
+    const r = await this.queryWithOperation(
       `ASK { GRAPH <${escapeUri(graphUri)}> { ?s ?p ?o } }`,
       { ...options, source: options?.source ?? 'blazegraph.hasGraph' },
+      'hasGraph',
     );
     return r.type === 'boolean' && r.value;
   }
@@ -590,9 +608,10 @@ export class BlazegraphStore implements TripleStore {
   }
 
   async listGraphs(options?: TripleStoreQueryOptions): Promise<string[]> {
-    const r = await this.query(
+    const r = await this.queryWithOperation(
       'SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }',
       options,
+      'listGraphs',
     );
     if (r.type !== 'bindings') return [];
     return r.bindings
@@ -608,10 +627,14 @@ export class BlazegraphStore implements TripleStore {
     const sparql = graphUri
       ? `SELECT (COUNT(*) AS ?c) WHERE { GRAPH <${escapeUri(graphUri)}> { ?s ?p ?o } }`
       : `SELECT (COUNT(*) AS ?c) WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } } }`;
-    const r = await this.query(sparql, {
-      ...options,
-      source: options?.source ?? 'blazegraph.countQuads',
-    });
+    const r = await this.queryWithOperation(
+      sparql,
+      {
+        ...options,
+        source: options?.source ?? 'blazegraph.countQuads',
+      },
+      'countQuads',
+    );
     if (r.type === 'bindings' && r.bindings.length > 0) {
       const cell = r.bindings[0].c ?? '';
       const digits = cell.match(/\d+/)?.[0];
@@ -635,7 +658,7 @@ export class BlazegraphStore implements TripleStore {
   private async sparqlUpdate(
     update: string,
     options?: QueryOptions,
-    operation = 'update',
+    operation: StoreOperation = 'update',
   ): Promise<void> {
     // Direct POST (W3C SPARQL 1.1 Protocol): send the update as the raw
     // request body with `application/sparql-update` rather than URL-encoded

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -38,7 +38,10 @@ import {
   formatSparqlJsonBindings,
   type AdapterSparqlJsonSelectResponse,
 } from './sparql-json-results.js';
-import { externalStorePriorityScheduler } from '../store-priority-scheduler.js';
+import {
+  externalStorePriorityScheduler,
+  type StorePriorityScheduler,
+} from '../store-priority-scheduler.js';
 import {
   GraphWriteGenTracker,
   type GraphWriteLifecycle,
@@ -67,6 +70,7 @@ import {
   StoreOperationTimeoutError,
 } from '../store-operation-timeout.js';
 import { readSparqlResponseText } from './sparql-response-policy.js';
+import type { StoreOperation } from '../store-operation-outcome.js';
 
 function throwIfAborted(signal: AbortSignal | undefined): void {
   if (!signal?.aborted) return;
@@ -225,6 +229,8 @@ export interface SparqlHttpStoreOptions {
   slowQuerySampleRate?: number;
   /** Optional sink for sampled slow-query events; defaults to a compact console warning. */
   onSlowQuery?: (event: SparqlHttpSlowQueryEvent) => void;
+  /** Optional scheduler injection for embedded callers and adapter-boundary tests. */
+  scheduler?: StorePriorityScheduler;
   /**
    * Monotonic clock for slow-query telemetry. Graph-list revalidation clocks
    * are owned by GraphSetIndexStore.
@@ -244,6 +250,7 @@ export class SparqlHttpStore implements TripleStore {
   private readonly onClientTimeout?: (operation: string) => void;
   private readonly getRecoveryState?: () => SparqlHttpRecoveryState;
   private readonly atomicUpdates: boolean;
+  private readonly scheduler: StorePriorityScheduler;
 
   private readonly now: () => number;
   private readonly slowQueryThresholdMs: number;
@@ -271,6 +278,7 @@ export class SparqlHttpStore implements TripleStore {
     this.onClientTimeout = options.onClientTimeout;
     this.getRecoveryState = options.getRecoveryState;
     this.atomicUpdates = options.atomicUpdates === true || this.managedOxigraph;
+    this.scheduler = options.scheduler ?? externalStorePriorityScheduler;
     this.now = options.now ?? monotonicNow;
     this.slowQueryThresholdMs = normalizeNonNegativeNumber(
       options.slowQueryThresholdMs,
@@ -291,7 +299,7 @@ export class SparqlHttpStore implements TripleStore {
   }
 
   private runStoreWork<T>(
-    operation: string,
+    operation: StoreOperation,
     options: QueryOptions | undefined,
     work: (signal: AbortSignal | undefined) => Promise<T>,
   ): Promise<T> {
@@ -301,12 +309,15 @@ export class SparqlHttpStore implements TripleStore {
     }
     return this.workLifecycle.run(
       options?.signal,
-      (signal) => externalStorePriorityScheduler.run(
-        options?.priority,
-        options?.source ?? `sparql-http.${operation}`,
-        () => work(signal),
-        signal,
-      ),
+      (signal) => {
+        return this.scheduler.run(
+          options?.priority,
+          options?.source ?? `sparql-http.${operation}`,
+          () => work(signal),
+          signal,
+          { storeOperation: operation },
+        );
+      },
     );
   }
 
@@ -326,7 +337,7 @@ export class SparqlHttpStore implements TripleStore {
   }
 
   private recoveryError(
-    operation: string,
+    operation: StoreOperation,
     outcome: 'not_started' | 'indeterminate',
     cause?: unknown,
   ): StoreOperationTimeoutError {
@@ -351,7 +362,7 @@ export class SparqlHttpStore implements TripleStore {
     );
   }
 
-  private notifyClientTimeout(operation: string): void {
+  private notifyClientTimeout(operation: StoreOperation): void {
     try {
       this.onClientTimeout?.(operation);
     } catch {
@@ -360,7 +371,7 @@ export class SparqlHttpStore implements TripleStore {
   }
 
   getPressureSnapshot(): StorePressureSnapshot {
-    return externalStorePriorityScheduler.snapshot;
+    return this.scheduler.snapshot;
   }
 
   /** {@link GraphWriteGenSource} capability (#1609) — see graph-write-gen.ts. */
@@ -376,12 +387,13 @@ export class SparqlHttpStore implements TripleStore {
     sparql: string,
     accept: string,
     operation: 'query' | 'construct',
+    storeOperation: StoreOperation,
     options: SparqlHttpQueryOptions | undefined,
     consume: (response: Response) => Promise<T>,
   ): Promise<T> {
     const recoveryAtStart = this.readRecoveryState();
     if (recoveryAtStart?.recovering) {
-      throw this.recoveryError(operation, 'not_started');
+      throw this.recoveryError(storeOperation, 'not_started');
     }
     // Direct POST (W3C SPARQL 1.1 Protocol §2.1.3): the query is the raw
     // request body with `application/sparql-query`, not URL-encoded form
@@ -420,12 +432,13 @@ export class SparqlHttpStore implements TripleStore {
         throw new StoreOperationTimeoutError({
           backend: this.managedOxigraph ? 'oxigraph-server' : 'sparql-http',
           operation,
+          storeOperation,
           timeoutMs: this.timeout,
           cause: error,
         });
       }
       if (this.recoveryInterrupted(recoveryAtStart)) {
-        throw this.recoveryError(operation, 'indeterminate', error);
+        throw this.recoveryError(storeOperation, 'indeterminate', error);
       }
       throw error;
     } finally {
@@ -437,7 +450,7 @@ export class SparqlHttpStore implements TripleStore {
   private async postCleanupUpdate(
     update: string,
     options?: QueryOptions,
-    operation = 'update',
+    operation: StoreOperation = 'update',
   ): Promise<void> {
     // Direct POST (W3C SPARQL 1.1 Protocol §2.2.2): the update is the raw
     // request body with `application/sparql-update`, not URL-encoded form
@@ -731,11 +744,11 @@ export class SparqlHttpStore implements TripleStore {
     scope: GraphWriteScope;
     update: string;
     options?: QueryOptions;
-    operation: string;
+    operation: StoreOperation;
     cleanup?: {
       update: string;
       options?: QueryOptions;
-      operation: string;
+      operation: StoreOperation;
     };
   }): Promise<void> {
     let lifecycle: GraphWriteLifecycle | undefined;
@@ -815,34 +828,44 @@ export class SparqlHttpStore implements TripleStore {
   }
 
   async query(sparql: string, options?: SparqlHttpQueryOptions): Promise<QueryResult> {
-    return this.runStoreWork('query', options, async (lifecycleSignal) => {
+    return this.queryWithOperation(sparql, options);
+  }
+
+  private async queryWithOperation(
+    sparql: string,
+    options: SparqlHttpQueryOptions | undefined,
+    storeOperation?: StoreOperation,
+  ): Promise<QueryResult> {
+    const trimmed = sparql.trim();
+    const upper = trimmed.toUpperCase();
+    const isAsk = upper.startsWith('ASK');
+    const isConstruct = upper.startsWith('CONSTRUCT') || upper.startsWith('DESCRIBE');
+    const canonicalOperation = storeOperation ?? (isConstruct ? 'construct' : 'query');
+    return this.runStoreWork(canonicalOperation, options, async (lifecycleSignal) => {
       const effectiveOptions: SparqlHttpQueryOptions = {
         ...options,
         signal: lifecycleSignal,
       };
       const startedAt = this.now();
       throwIfAborted(lifecycleSignal);
-      const trimmed = sparql.trim();
-      const upper = trimmed.toUpperCase();
-      const isAsk = upper.startsWith('ASK');
-      const isConstruct = upper.startsWith('CONSTRUCT') || upper.startsWith('DESCRIBE');
 
       try {
         if (isConstruct) {
-          return await this.queryConstruct(trimmed, effectiveOptions);
+          return await this.queryConstruct(trimmed, effectiveOptions, canonicalOperation);
         }
 
         return await this.postQuery(
           trimmed,
           'application/sparql-results+json',
           'query',
+          canonicalOperation,
           effectiveOptions,
           async (res) => {
             if (!res.ok) {
               const text = await readSparqlResponseText(res, {
                 maxResponseBytes: effectiveOptions.maxResponseBytes,
                 managedOxigraph: this.managedOxigraph,
-                operation: 'query',
+                operation: canonicalOperation,
                 tolerateReadFailure: true,
               });
               throw new SparqlHttpResponseError('query', res.status, text.slice(0, 300));
@@ -851,7 +874,7 @@ export class SparqlHttpStore implements TripleStore {
             const text = await readSparqlResponseText(res, {
               maxResponseBytes: effectiveOptions.maxResponseBytes,
               managedOxigraph: this.managedOxigraph,
-              operation: 'query',
+              operation: canonicalOperation,
             });
             const json = JSON.parse(text) as AdapterSparqlJsonSelectResponse | W3CAskResponse;
 
@@ -876,18 +899,23 @@ export class SparqlHttpStore implements TripleStore {
     });
   }
 
-  private async queryConstruct(sparql: string, options?: SparqlHttpQueryOptions): Promise<ConstructResult> {
+  private async queryConstruct(
+    sparql: string,
+    options: SparqlHttpQueryOptions | undefined,
+    storeOperation: StoreOperation,
+  ): Promise<ConstructResult> {
     return this.postQuery(
       sparql,
       'application/n-quads, text/n-quads',
       'construct',
+      storeOperation,
       options,
       async (res) => {
         if (!res.ok) {
           const text = await readSparqlResponseText(res, {
             maxResponseBytes: options?.maxResponseBytes,
             managedOxigraph: this.managedOxigraph,
-            operation: 'construct',
+            operation: storeOperation,
             tolerateReadFailure: true,
           });
           throw new SparqlHttpResponseError('construct', res.status, text.slice(0, 300));
@@ -895,7 +923,7 @@ export class SparqlHttpStore implements TripleStore {
         const text = await readSparqlResponseText(res, {
           maxResponseBytes: options?.maxResponseBytes,
           managedOxigraph: this.managedOxigraph,
-          operation: 'construct',
+          operation: storeOperation,
         });
         const quads = parseNQuadsTextTolerant(text);
         return { type: 'quads', quads };
@@ -904,9 +932,10 @@ export class SparqlHttpStore implements TripleStore {
   }
 
   async hasGraph(graphUri: string, options?: QueryOptions): Promise<boolean> {
-    const r = await this.query(
+    const r = await this.queryWithOperation(
       `ASK { GRAPH <${escapeUri(graphUri)}> { ?s ?p ?o } }`,
       { ...options, source: options?.source ?? 'sparql-http.hasGraph' },
+      'hasGraph',
     );
     return r.type === 'boolean' && r.value;
   }
@@ -951,9 +980,10 @@ export class SparqlHttpStore implements TripleStore {
     // Index-read enumeration shared with OxigraphStore — see the rationale on
     // NON_EMPTY_NAMED_GRAPH_ENUMERATION_QUERY (O(#graphs) vs the legacy O(#quads)
     // scan; FILTER EXISTS preserves the non-empty-only contract).
-    const r = await this.query(
+    const r = await this.queryWithOperation(
       NON_EMPTY_NAMED_GRAPH_ENUMERATION_QUERY,
       { ...options, source: options?.source ?? 'sparql-http.listGraphs' },
+      'listGraphs',
     );
     return r.type === 'bindings'
       ? r.bindings
@@ -992,10 +1022,14 @@ export class SparqlHttpStore implements TripleStore {
     const sparql = graphUri
       ? `SELECT (COUNT(*) AS ?c) WHERE { GRAPH <${escapeUri(graphUri)}> { ?s ?p ?o } }`
       : `SELECT (COUNT(*) AS ?c) WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } } }`;
-    const r = await this.query(sparql, {
-      ...options,
-      source: options?.source ?? 'sparql-http.countQuads',
-    });
+    const r = await this.queryWithOperation(
+      sparql,
+      {
+        ...options,
+        source: options?.source ?? 'sparql-http.countQuads',
+      },
+      'countQuads',
+    );
     if (r.type === 'bindings' && r.bindings.length > 0) {
       const c = String(r.bindings[0].c ?? '');
       const stripped = c.replace(/^"|"$/g, '');

--- a/packages/storage/src/adapters/sparql-response-policy.ts
+++ b/packages/storage/src/adapters/sparql-response-policy.ts
@@ -1,5 +1,6 @@
 import { readResponseTextBounded } from '../http-response-limit.js';
 import { StoreOperationTimeoutError } from '../store-operation-timeout.js';
+import type { StoreOperation } from '../store-operation-outcome.js';
 
 // Oxigraph 0.5.x appends this evaluator error to an already-started
 // SELECT/CONSTRUCT response when `serve --timeout-s` cancels the query.
@@ -8,7 +9,7 @@ const MANAGED_OXIGRAPH_CANCELLATION_SUFFIX = 'The SPARQL operation has been canc
 export interface SparqlResponseTextOptions {
   maxResponseBytes?: number;
   managedOxigraph?: boolean;
-  operation: string;
+  operation: StoreOperation;
   tolerateReadFailure?: boolean;
 }
 

--- a/packages/storage/src/atomic-replace-failure.ts
+++ b/packages/storage/src/atomic-replace-failure.ts
@@ -1,0 +1,19 @@
+import { hasStoreOperationOutcome } from './store-operation-outcome.js';
+import type { TripleStoreCapability } from './unsupported-capability-error.js';
+
+export type AtomicReplaceCapability = Extract<
+  TripleStoreCapability,
+  'replaceGraph' | 'replaceGraphAndSubject' | 'replaceSubject'
+>;
+
+/**
+ * True only when the storage contract proves an atomic replace body never ran.
+ * Every other rejection is indeterminate: it may have committed before its
+ * response was lost and therefore requires cache/log reconciliation.
+ */
+export function isAtomicReplaceOperationNotStarted(
+  error: unknown,
+  capability: AtomicReplaceCapability,
+): boolean {
+  return hasStoreOperationOutcome(error, capability, 'not_started');
+}

--- a/packages/storage/src/atomic-replace-failure.ts
+++ b/packages/storage/src/atomic-replace-failure.ts
@@ -1,0 +1,25 @@
+import { StoreSchedulerBusyError } from './store-priority-scheduler.js';
+import {
+  UnsupportedTripleStoreCapabilityError,
+  type TripleStoreCapability,
+} from './unsupported-capability-error.js';
+
+export type AtomicReplaceCapability = Extract<
+  TripleStoreCapability,
+  'replaceGraph' | 'replaceGraphAndSubject' | 'replaceSubject'
+>;
+
+/**
+ * True only when the storage contract proves an atomic replace body never ran.
+ * Every other rejection is indeterminate: it may have committed before its
+ * response was lost and therefore requires cache/log reconciliation.
+ */
+export function isAtomicReplaceOperationNotStarted(
+  error: unknown,
+  capability: AtomicReplaceCapability,
+): boolean {
+  return error instanceof StoreSchedulerBusyError || (
+    error instanceof UnsupportedTripleStoreCapabilityError
+    && error.capability === capability
+  );
+}

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -12,11 +12,9 @@ import type {
 } from './triple-store.js';
 import {
   UnsupportedTripleStoreCapabilityError,
-  isReplaceGraphAndSubjectCapabilityRefusal,
-  isReplaceGraphCapabilityRefusal,
-  isReplaceSubjectCapabilityRefusal,
 } from './unsupported-capability-error.js';
 import { isAtomicGraphReplaceStagingGraph } from './atomic-graph-replace.js';
+import { isAtomicReplaceOperationNotStarted } from './atomic-replace-failure.js';
 
 /**
  * ChangelogStore — an append-only per-node change log maintained on the write
@@ -346,9 +344,9 @@ export class ChangelogStore implements TripleStoreDecorator, ChangelogReader {
       try {
         await this.inner.replaceGraph!(graphUri, quads, options);
       } catch (err) {
-        if (isReplaceGraphCapabilityRefusal(err)) {
-          // A capability refusal is a clean preflight result: no mutation was
-          // started, so there is no gap to reconcile.
+        if (isAtomicReplaceOperationNotStarted(err, 'replaceGraph')) {
+          // A clean preflight or admission refusal explicitly bound to this
+          // replace means no mutation started, so there is no gap to reconcile.
           throw err;
         }
         // The replaceGraph contract allows a rejected call to have left either
@@ -402,7 +400,7 @@ export class ChangelogStore implements TripleStoreDecorator, ChangelogReader {
           options,
         );
       } catch (error) {
-        if (!isReplaceGraphAndSubjectCapabilityRefusal(error)) {
+        if (!isAtomicReplaceOperationNotStarted(error, 'replaceGraphAndSubject')) {
           this.flagReconcile('replaceGraphAndSubject(indeterminate-failure)');
         }
         throw error;
@@ -431,8 +429,9 @@ export class ChangelogStore implements TripleStoreDecorator, ChangelogReader {
       try {
         await this.inner.replaceSubject!(graphUri, subject, quads, options);
       } catch (error) {
-        if (isReplaceSubjectCapabilityRefusal(error)) {
-          // Clean preflight refusal: no mutation started, nothing to reconcile.
+        if (isAtomicReplaceOperationNotStarted(error, 'replaceSubject')) {
+          // Clean preflight or replace-bound admission refusal: no mutation
+          // started, so there is nothing to reconcile.
           throw error;
         }
         this.flagReconcile('replaceSubject(indeterminate-failure)');

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -10,11 +10,9 @@ import type {
 } from './triple-store.js';
 import {
   UnsupportedTripleStoreCapabilityError,
-  isReplaceGraphAndSubjectCapabilityRefusal,
-  isReplaceGraphCapabilityRefusal,
-  isReplaceSubjectCapabilityRefusal,
 } from './unsupported-capability-error.js';
 import { isAtomicGraphReplaceStagingGraph } from './atomic-graph-replace.js';
+import { isAtomicReplaceOperationNotStarted } from './atomic-replace-failure.js';
 
 /**
  * ChangelogStore — an append-only per-node change log maintained on the write
@@ -342,8 +340,8 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
       try {
         await this.inner.replaceGraph!(graphUri, quads, options);
       } catch (err) {
-        if (isReplaceGraphCapabilityRefusal(err)) {
-          // A capability refusal is a clean preflight result: no mutation was
+        if (isAtomicReplaceOperationNotStarted(err, 'replaceGraph')) {
+          // A clean preflight or scheduler admission refusal means no mutation
           // started, so there is no gap to reconcile.
           throw err;
         }
@@ -398,7 +396,7 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
           options,
         );
       } catch (error) {
-        if (!isReplaceGraphAndSubjectCapabilityRefusal(error)) {
+        if (!isAtomicReplaceOperationNotStarted(error, 'replaceGraphAndSubject')) {
           this.flagReconcile('replaceGraphAndSubject(indeterminate-failure)');
         }
         throw error;
@@ -427,8 +425,8 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
       try {
         await this.inner.replaceSubject!(graphUri, subject, quads, options);
       } catch (error) {
-        if (isReplaceSubjectCapabilityRefusal(error)) {
-          // Clean preflight refusal: no mutation started, nothing to reconcile.
+        if (isAtomicReplaceOperationNotStarted(error, 'replaceSubject')) {
+          // Clean preflight or scheduler refusal: no mutation started, nothing to reconcile.
           throw error;
         }
         this.flagReconcile('replaceSubject(indeterminate-failure)');

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -12,11 +12,9 @@ import type {
 import { storeWorkPriorityRank } from './store-priority-scheduler.js';
 import {
   UnsupportedTripleStoreCapabilityError,
-  isReplaceGraphAndSubjectCapabilityRefusal,
-  isReplaceGraphCapabilityRefusal,
-  isReplaceSubjectCapabilityRefusal,
 } from './unsupported-capability-error.js';
 import { isAtomicGraphReplaceStagingGraph } from './atomic-graph-replace.js';
+import { isAtomicReplaceOperationNotStarted } from './atomic-replace-failure.js';
 
 export const DEFAULT_GRAPH_SET_REVALIDATE_MS = 30_000;
 export const DEFAULT_GRAPH_SET_REVALIDATE_FAILURE_MAX_BACKOFF_MS = 5 * 60_000;
@@ -382,8 +380,10 @@ export class GraphSetIndexStore implements TripleStore {
       // complete new graph (or dropped the old one). Serving the cached graph
       // set would then hide a committed KA graph from enumeration, so mark the
       // index dirty for a lazy rebuild — unless this was a clean preflight
-      // capability refusal, where nothing was mutated.
-      if (!isReplaceGraphCapabilityRefusal(error)) {
+      // capability refusal or scheduler admission rejection. A
+      // StoreSchedulerBusyError is raised while the closure is still queued,
+      // so the store operation provably never started and cannot have mutated.
+      if (!isAtomicReplaceOperationNotStarted(error, 'replaceGraph')) {
         this.scheduleFullRefresh('replaceGraph');
       }
       throw error;
@@ -416,7 +416,7 @@ export class GraphSetIndexStore implements TripleStore {
         options,
       );
     } catch (error) {
-      if (!isReplaceGraphAndSubjectCapabilityRefusal(error)) {
+      if (!isAtomicReplaceOperationNotStarted(error, 'replaceGraphAndSubject')) {
         this.scheduleFullRefresh('replaceGraphAndSubject');
       }
       throw error;
@@ -449,7 +449,7 @@ export class GraphSetIndexStore implements TripleStore {
       // A committed subject replace could add/remove the graph's first/last row;
       // dirty the index so a lazy rebuild re-derives membership — unless this was
       // a clean preflight capability refusal, where nothing was mutated.
-      if (!isReplaceSubjectCapabilityRefusal(error)) {
+      if (!isAtomicReplaceOperationNotStarted(error, 'replaceSubject')) {
         this.scheduleFullRefresh('replaceSubject');
       }
       throw error;

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -13,11 +13,9 @@ import type {
 import { storeWorkPriorityRank } from './store-priority-scheduler.js';
 import {
   UnsupportedTripleStoreCapabilityError,
-  isReplaceGraphAndSubjectCapabilityRefusal,
-  isReplaceGraphCapabilityRefusal,
-  isReplaceSubjectCapabilityRefusal,
 } from './unsupported-capability-error.js';
 import { isAtomicGraphReplaceStagingGraph } from './atomic-graph-replace.js';
+import { isAtomicReplaceOperationNotStarted } from './atomic-replace-failure.js';
 
 export const DEFAULT_GRAPH_SET_REVALIDATE_MS = 30_000;
 export const DEFAULT_GRAPH_SET_REVALIDATE_FAILURE_MAX_BACKOFF_MS = 5 * 60_000;
@@ -385,8 +383,11 @@ export class GraphSetIndexStore implements TripleStoreDecorator {
       // complete new graph (or dropped the old one). Serving the cached graph
       // set would then hide a committed KA graph from enumeration, so mark the
       // index dirty for a lazy rebuild — unless this was a clean preflight
-      // capability refusal, where nothing was mutated.
-      if (!isReplaceGraphCapabilityRefusal(error)) {
+      // capability refusal or an admission rejection explicitly bound to this
+      // replace dispatch. A nested post-commit probe can also be rejected by
+      // the scheduler, but its storeOperation does not match replaceGraph and
+      // therefore still dirties this index.
+      if (!isAtomicReplaceOperationNotStarted(error, 'replaceGraph')) {
         this.scheduleFullRefresh('replaceGraph');
       }
       throw error;
@@ -419,7 +420,7 @@ export class GraphSetIndexStore implements TripleStoreDecorator {
         options,
       );
     } catch (error) {
-      if (!isReplaceGraphAndSubjectCapabilityRefusal(error)) {
+      if (!isAtomicReplaceOperationNotStarted(error, 'replaceGraphAndSubject')) {
         this.scheduleFullRefresh('replaceGraphAndSubject');
       }
       throw error;
@@ -452,7 +453,7 @@ export class GraphSetIndexStore implements TripleStoreDecorator {
       // A committed subject replace could add/remove the graph's first/last row;
       // dirty the index so a lazy rebuild re-derives membership — unless this was
       // a clean preflight capability refusal, where nothing was mutated.
-      if (!isReplaceSubjectCapabilityRefusal(error)) {
+      if (!isAtomicReplaceOperationNotStarted(error, 'replaceSubject')) {
         this.scheduleFullRefresh('replaceSubject');
       }
       throw error;

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -53,6 +53,8 @@ export {
   type StorePrioritySchedulerOptions,
   type StorePriorityQueueLimits,
   type StoreSchedulerBusyReason,
+  type StoreSchedulerOperationMetadata,
+  type StoreSchedulerBusyErrorOptions,
 } from './store-priority-scheduler.js';
 export {
   STORE_OPERATION_TIMEOUT_CODE,
@@ -60,8 +62,17 @@ export {
   isStoreOperationTimeoutError,
   type StoreOperationTimeoutErrorOptions,
   type StoreOperationTimeoutErrorLike,
-  type StoreOperationOutcome,
 } from './store-operation-timeout.js';
+export {
+  STORE_OPERATION_OUTCOME_TAG,
+  STORE_OPERATIONS,
+  hasStoreOperationOutcome,
+  isStoreOperation,
+  type StoreOperation,
+  type StoreOperationOutcome,
+  type StoreOperationOutcomeTagged,
+  type StoreOperationOutcomeErrorLike,
+} from './store-operation-outcome.js';
 export {
   EXTERNAL_LITERAL_REF_DATATYPE,
   SHARED_MEMORY_GRAPH_SUFFIX,

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -41,6 +41,10 @@ export {
   type TripleStoreCapability,
 } from './unsupported-capability-error.js';
 export {
+  isAtomicReplaceOperationNotStarted,
+  type AtomicReplaceCapability,
+} from './atomic-replace-failure.js';
+export {
   StorePriorityScheduler,
   StoreSchedulerBusyError,
   externalStorePriorityScheduler,

--- a/packages/storage/src/store-operation-outcome.ts
+++ b/packages/storage/src/store-operation-outcome.ts
@@ -1,0 +1,62 @@
+/** Stable protocol tag for failures that declare one store operation's outcome. */
+export const STORE_OPERATION_OUTCOME_TAG = 'dkg.store-operation-outcome.v1' as const;
+
+/** Public TripleStore operations that may be classified by the outcome protocol. */
+export const STORE_OPERATIONS = [
+  'insert',
+  'delete',
+  'deleteByPattern',
+  'query',
+  'construct',
+  'hasGraph',
+  'createGraph',
+  'dropGraph',
+  'replaceGraph',
+  'replaceGraphAndSubject',
+  'replaceSubject',
+  'listGraphs',
+  'listGraphsByPrefix',
+  'deleteBySubjectPrefix',
+  'update',
+  'countQuads',
+  'flush',
+  'close',
+] as const;
+
+export type StoreOperation = typeof STORE_OPERATIONS[number];
+export type StoreOperationOutcome = 'not_started' | 'indeterminate';
+
+const STORE_OPERATION_SET: ReadonlySet<string> = new Set(STORE_OPERATIONS);
+
+/** Runtime validator for public operation metadata crossing package boundaries. */
+export function isStoreOperation(value: unknown): value is StoreOperation {
+  return typeof value === 'string' && STORE_OPERATION_SET.has(value);
+}
+
+export interface StoreOperationOutcomeTagged {
+  readonly storeOperationOutcomeTag: typeof STORE_OPERATION_OUTCOME_TAG;
+  readonly storeOperation?: StoreOperation;
+  readonly outcome: StoreOperationOutcome;
+}
+
+/**
+ * Structural contract for failures whose effect on one canonical store
+ * operation is known. The operation binding is deliberately separate from a
+ * scheduler source label: a nested query can be rejected before dispatch even
+ * after its enclosing replace has committed.
+ */
+export interface StoreOperationOutcomeErrorLike extends StoreOperationOutcomeTagged {
+  readonly storeOperation: StoreOperation;
+}
+
+export function hasStoreOperationOutcome(
+  error: unknown,
+  storeOperation: StoreOperation,
+  outcome: StoreOperationOutcome,
+): error is StoreOperationOutcomeErrorLike {
+  if (!error || typeof error !== 'object') return false;
+  const shaped = error as Partial<StoreOperationOutcomeErrorLike>;
+  return shaped.storeOperationOutcomeTag === STORE_OPERATION_OUTCOME_TAG
+    && shaped.storeOperation === storeOperation
+    && shaped.outcome === outcome;
+}

--- a/packages/storage/src/store-operation-timeout.ts
+++ b/packages/storage/src/store-operation-timeout.ts
@@ -1,6 +1,12 @@
-export const STORE_OPERATION_TIMEOUT_CODE = 'STORE_OPERATION_TIMEOUT' as const;
+import {
+  isStoreOperation,
+  STORE_OPERATION_OUTCOME_TAG,
+  type StoreOperation,
+  type StoreOperationOutcome,
+  type StoreOperationOutcomeTagged,
+} from './store-operation-outcome.js';
 
-export type StoreOperationOutcome = 'not_started' | 'indeterminate';
+export const STORE_OPERATION_TIMEOUT_CODE = 'STORE_OPERATION_TIMEOUT' as const;
 
 /**
  * Structural timeout shape accepted across package/prototype boundaries.
@@ -14,13 +20,18 @@ export interface StoreOperationTimeoutErrorLike {
   message?: string;
   backend?: string;
   operation?: string;
+  storeOperation?: StoreOperation;
+  storeOperationOutcomeTag?: typeof STORE_OPERATION_OUTCOME_TAG;
   timeoutMs?: number;
   outcome?: StoreOperationOutcome;
 }
 
 export interface StoreOperationTimeoutErrorOptions {
   backend: string;
+  /** Backward-compatible diagnostic/transport label. */
   operation: string;
+  /** Canonical public store operation for the tagged outcome protocol. */
+  storeOperation?: StoreOperation;
   timeoutMs?: number;
   outcome?: StoreOperationOutcome;
   message?: string;
@@ -34,11 +45,13 @@ export interface StoreOperationTimeoutErrorOptions {
  * that already recognize the platform timeout shape; `code` is the stable DKG
  * contract used by HTTP routes and async job classifiers.
  */
-export class StoreOperationTimeoutError extends Error implements StoreOperationTimeoutErrorLike {
+export class StoreOperationTimeoutError extends Error implements StoreOperationTimeoutErrorLike, StoreOperationOutcomeTagged {
   readonly code = STORE_OPERATION_TIMEOUT_CODE;
   readonly retryable = true as const;
   readonly backend: string;
   readonly operation: string;
+  readonly storeOperation?: StoreOperation;
+  readonly storeOperationOutcomeTag = STORE_OPERATION_OUTCOME_TAG;
   readonly timeoutMs?: number;
   readonly outcome: StoreOperationOutcome;
 
@@ -52,6 +65,8 @@ export class StoreOperationTimeoutError extends Error implements StoreOperationT
     this.name = 'TimeoutError';
     this.backend = options.backend;
     this.operation = options.operation;
+    this.storeOperation = options.storeOperation
+      ?? (isStoreOperation(options.operation) ? options.operation : undefined);
     this.timeoutMs = options.timeoutMs;
     this.outcome = options.outcome ?? 'indeterminate';
   }
@@ -67,6 +82,11 @@ export function isStoreOperationTimeoutError(
     && (shaped.message === undefined || typeof shaped.message === 'string')
     && (shaped.backend === undefined || typeof shaped.backend === 'string')
     && (shaped.operation === undefined || typeof shaped.operation === 'string')
+    && (shaped.storeOperation === undefined || isStoreOperation(shaped.storeOperation))
+    && (
+      shaped.storeOperationOutcomeTag === undefined
+      || shaped.storeOperationOutcomeTag === STORE_OPERATION_OUTCOME_TAG
+    )
     && (shaped.timeoutMs === undefined || (
       typeof shaped.timeoutMs === 'number' && Number.isFinite(shaped.timeoutMs)
     ))

--- a/packages/storage/src/store-priority-scheduler.ts
+++ b/packages/storage/src/store-priority-scheduler.ts
@@ -8,6 +8,11 @@ import {
   type SchedulerPressureTicket,
 } from '@origintrail-official/dkg-core';
 import type { StorePressureSnapshot, StoreWorkPriority } from './triple-store.js';
+import {
+  STORE_OPERATION_OUTCOME_TAG,
+  type StoreOperation,
+  type StoreOperationOutcomeTagged,
+} from './store-operation-outcome.js';
 
 export interface StorePrioritySchedulerSnapshot extends StorePressureSnapshot {
   ackInflight: number;
@@ -32,21 +37,38 @@ export interface StorePrioritySchedulerSnapshot extends StorePressureSnapshot {
 
 export type StoreSchedulerBusyReason = 'queue_full' | 'queue_wait_timeout';
 
+export interface StoreSchedulerOperationMetadata {
+  /** Canonical public store operation; separate from the observability label. */
+  storeOperation: StoreOperation;
+}
+
+export interface StoreSchedulerBusyErrorOptions extends ErrorOptions {
+  storeOperation?: StoreOperation;
+}
+
 /**
  * A retry-safe overload rejection emitted only while work is still queued.
  * Callers may retry because the operation closure has not started.
  */
-export class StoreSchedulerBusyError extends Error {
+export class StoreSchedulerBusyError extends Error implements StoreOperationOutcomeTagged {
   readonly code = 'STORE_SCHEDULER_BUSY' as const;
   readonly retryable = true as const;
+  readonly outcome = 'not_started' as const;
+  readonly storeOperationOutcomeTag = STORE_OPERATION_OUTCOME_TAG;
+  readonly storeOperation?: StoreOperation;
 
   constructor(
     readonly reason: StoreSchedulerBusyReason,
     readonly priority: StoreWorkPriority,
     readonly operation: string,
+    options?: StoreSchedulerBusyErrorOptions,
   ) {
-    super(`Store scheduler ${reason.replaceAll('_', ' ')} (${priority}: ${operation || 'unknown'})`);
+    super(
+      `Store scheduler ${reason.replaceAll('_', ' ')} (${priority}: ${operation || 'unknown'})`,
+      options,
+    );
     this.name = 'StoreSchedulerBusyError';
+    this.storeOperation = options?.storeOperation;
   }
 }
 
@@ -66,6 +88,7 @@ export interface StorePrioritySchedulerOptions {
 interface QueueEntry<T> {
   priority: StoreWorkPriority;
   operation: string;
+  storeOperation?: StoreOperation;
   queuedAt: number;
   pressureTicket: SchedulerPressureTicket;
   work: () => Promise<T>;
@@ -384,6 +407,7 @@ export class StorePriorityScheduler extends ObservableScheduler {
     operation: string,
     work: () => Promise<T>,
     signal?: AbortSignal,
+    metadata?: StoreSchedulerOperationMetadata,
   ): Promise<T> {
     const normalizedPriority = priority ?? 'normal';
     if (signal?.aborted) {
@@ -391,7 +415,12 @@ export class StorePriorityScheduler extends ObservableScheduler {
       throw reason instanceof Error ? reason : new Error(String(reason ?? 'aborted'));
     }
     if (this.queues[normalizedPriority].length >= this.queueLimits[normalizedPriority]) {
-      const error = new StoreSchedulerBusyError('queue_full', normalizedPriority, operation);
+      const error = new StoreSchedulerBusyError(
+        'queue_full',
+        normalizedPriority,
+        operation,
+        metadata,
+      );
       this.pressureReject(
         { lane: normalizedPriority, operation },
         error.reason,
@@ -407,6 +436,7 @@ export class StorePriorityScheduler extends ObservableScheduler {
       const entry: QueueEntry<T> = {
         priority: normalizedPriority,
         operation,
+        storeOperation: metadata?.storeOperation,
         queuedAt: this.now(),
         pressureTicket,
         work,
@@ -434,6 +464,9 @@ export class StorePriorityScheduler extends ObservableScheduler {
           'queue_wait_timeout',
           normalizedPriority,
           operation,
+          entry.storeOperation === undefined
+            ? undefined
+            : { storeOperation: entry.storeOperation },
         );
         this.pressureRejectQueued(entry.pressureTicket, error.reason);
         this.observeRejection(error);

--- a/packages/storage/src/unsupported-capability-error.ts
+++ b/packages/storage/src/unsupported-capability-error.ts
@@ -1,3 +1,8 @@
+import {
+  STORE_OPERATION_OUTCOME_TAG,
+  type StoreOperationOutcomeErrorLike,
+} from './store-operation-outcome.js';
+
 /**
  * Optional TripleStore operations that a decorator may expose even when its
  * wrapped backend cannot perform them.
@@ -17,14 +22,18 @@ export type TripleStoreCapability =
  * treating a genuine execution failure as "unsupported". Implementations
  * must raise it before starting the operation so a caller can safely fall back.
  */
-export class UnsupportedTripleStoreCapabilityError extends Error {
+export class UnsupportedTripleStoreCapabilityError extends Error implements StoreOperationOutcomeErrorLike {
+  readonly storeOperationOutcomeTag = STORE_OPERATION_OUTCOME_TAG;
+  readonly outcome = 'not_started' as const;
   readonly capability: TripleStoreCapability;
+  readonly storeOperation: TripleStoreCapability;
   readonly storeName: string;
 
   constructor(capability: TripleStoreCapability, storeName: string) {
     super(`${storeName}: inner store does not support ${capability}()`);
     this.name = 'UnsupportedTripleStoreCapabilityError';
     this.capability = capability;
+    this.storeOperation = capability;
     this.storeName = storeName;
   }
 }

--- a/packages/storage/test/changelog-store.test.ts
+++ b/packages/storage/test/changelog-store.test.ts
@@ -23,6 +23,7 @@ import { BlazegraphStore } from '../src/adapters/blazegraph.js';
 import { ChangelogStore, CHANGELOG_GRAPH, asChangelogReader, type ChangelogEraGuard } from '../src/changelog-store.js';
 import { createTripleStore } from '../src/triple-store.js';
 import type { Quad, QueryOptions, QueryResult, TripleStore, UpdateOptions } from '../src/triple-store.js';
+import { StoreSchedulerBusyError } from '../src/store-priority-scheduler.js';
 
 const G1 = 'http://ex.org/g1';
 const G2 = 'http://ex.org/g2';
@@ -61,6 +62,42 @@ class SpyStore implements TripleStore {
   countQuads(g?: string, options?: QueryOptions) { return this.inner.countQuads(g, options); }
   close() { return this.inner.close(); }
 }
+
+class BusyAtomicReplaceStore extends SpyStore {
+  async replaceGraph(): Promise<void> {
+    throw new StoreSchedulerBusyError('queue_wait_timeout', 'normal', 'test.replaceGraph');
+  }
+
+  async replaceGraphAndSubject(): Promise<void> {
+    throw new StoreSchedulerBusyError('queue_wait_timeout', 'normal', 'test.replaceGraphAndSubject');
+  }
+
+  async replaceSubject(): Promise<void> {
+    throw new StoreSchedulerBusyError('queue_wait_timeout', 'normal', 'test.replaceSubject');
+  }
+}
+
+describe('ChangelogStore — pre-execution atomic replace rejection', () => {
+  it('does not request reconciliation when scheduler admission proves no mutation started', async () => {
+    const base = new OxigraphStore();
+    const log = new ChangelogStore(new BusyAtomicReplaceStore(base));
+
+    await expect(log.replaceGraph(G1, [q('http://ex.org/a', G1)]))
+      .rejects.toBeInstanceOf(StoreSchedulerBusyError);
+    await expect(log.replaceGraphAndSubject(
+      G1,
+      [q('http://ex.org/a', G1)],
+      G2,
+      'http://ex.org/meta',
+      [q('http://ex.org/meta', G2)],
+    )).rejects.toBeInstanceOf(StoreSchedulerBusyError);
+    await expect(log.replaceSubject(G1, 'http://ex.org/a', [q('http://ex.org/a', G1)]))
+      .rejects.toBeInstanceOf(StoreSchedulerBusyError);
+
+    expect(log.needsReconcile).toBe(false);
+    await base.close();
+  });
+});
 
 describe('ChangelogStore — upsert marker atomicity', () => {
   it('appends the marker in the SAME inner.insert() call as the data (one transaction)', async () => {

--- a/packages/storage/test/changelog-store.test.ts
+++ b/packages/storage/test/changelog-store.test.ts
@@ -13,16 +13,19 @@
  *    reordering hole). Enforced by the in-process write mutex.
  *  - seq reseeds from the durable high-water mark on restart → no reuse/rollback.
  */
-import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { createServer, type Server } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { OxigraphStore } from '../src/adapters/oxigraph.js';
 import { BlazegraphStore } from '../src/adapters/blazegraph.js';
+import { SparqlHttpStore } from '../src/adapters/sparql-http.js';
 import { ChangelogStore, CHANGELOG_GRAPH, asChangelogReader, type ChangelogEraGuard } from '../src/changelog-store.js';
 import { createTripleStore } from '../src/triple-store.js';
 import type { Quad, QueryOptions, QueryResult, TripleStore, UpdateOptions } from '../src/triple-store.js';
+import { StorePriorityScheduler } from '../src/store-priority-scheduler.js';
+import { StoreOperationTimeoutError } from '../src/store-operation-timeout.js';
 
 const G1 = 'http://ex.org/g1';
 const G2 = 'http://ex.org/g2';
@@ -61,6 +64,128 @@ class SpyStore implements TripleStore {
   countQuads(g?: string, options?: QueryOptions) { return this.inner.countQuads(g, options); }
   close() { return this.inner.close(); }
 }
+
+class NotStartedTimeoutAtomicReplaceStore extends SpyStore {
+  async replaceGraph(): Promise<void> {
+    throw this.notStarted('replaceGraph');
+  }
+
+  async replaceGraphAndSubject(): Promise<void> {
+    throw this.notStarted('replaceGraphAndSubject');
+  }
+
+  async replaceSubject(): Promise<void> {
+    throw this.notStarted('replaceSubject');
+  }
+
+  private notStarted(operation: string): StoreOperationTimeoutError {
+    return new StoreOperationTimeoutError({
+      backend: 'managed-test-store',
+      operation,
+      outcome: 'not_started',
+    });
+  }
+}
+
+describe('ChangelogStore — pre-execution atomic replace rejection', () => {
+  for (const adapter of [
+    {
+      name: 'BlazegraphStore',
+      create: (scheduler: StorePriorityScheduler): TripleStore => new BlazegraphStore(
+        'http://blazegraph.test/sparql',
+        { scheduler, timeout: 1_000 },
+      ),
+    },
+    {
+      name: 'SparqlHttpStore',
+      create: (scheduler: StorePriorityScheduler): TripleStore => new SparqlHttpStore({
+        queryEndpoint: 'http://sparql.test/query',
+        updateEndpoint: 'http://sparql.test/update',
+        atomicUpdates: true,
+        scheduler,
+        timeout: 1_000,
+      }),
+    },
+  ]) {
+    it(`does not request reconciliation for a real ${adapter.name} admission rejection`, async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+        new Error('adapter closure must not dispatch'),
+      );
+      const scheduler = new StorePriorityScheduler({
+        maxConcurrent: 1,
+        ackReservedSlots: 0,
+        healthReservedSlots: 0,
+        backgroundReservedSlots: 0,
+        queueLimits: 1,
+        queueWaitTimeoutMs: 10,
+      });
+      const inner = adapter.create(scheduler);
+      const log = new ChangelogStore(inner);
+      let releaseBlocker!: () => void;
+      let blocker: Promise<void> | undefined;
+
+      try {
+        blocker = scheduler.run('normal', 'test.atomic-replace-blocker', async () => {
+          await new Promise<void>((resolve) => { releaseBlocker = resolve; });
+        });
+        await Promise.resolve();
+
+        for (const [storeOperation, work] of [
+          ['replaceGraph', () => log.replaceGraph(G1, [q('http://ex.org/a', G1)])],
+          ['replaceGraphAndSubject', () => log.replaceGraphAndSubject(
+            G1,
+            [q('http://ex.org/a', G1)],
+            G2,
+            'http://ex.org/meta',
+            [q('http://ex.org/meta', G2)],
+          )],
+          ['replaceSubject', () => log.replaceSubject(
+            G1,
+            'http://ex.org/a',
+            [q('http://ex.org/a', G1)],
+          )],
+        ] as const) {
+          await expect(work()).rejects.toMatchObject({
+            code: 'STORE_SCHEDULER_BUSY',
+            outcome: 'not_started',
+            storeOperation,
+          });
+        }
+
+        expect(log.needsReconcile).toBe(false);
+        expect(fetchSpy).not.toHaveBeenCalled();
+      } finally {
+        releaseBlocker?.();
+        if (blocker) await blocker;
+        await inner.close();
+        fetchSpy.mockRestore();
+      }
+    });
+  }
+
+  it('uses the shared not-started outcome for managed-store refusals', async () => {
+    const base = new OxigraphStore();
+    const log = new ChangelogStore(new NotStartedTimeoutAtomicReplaceStore(base));
+
+    await expect(log.replaceGraph(G1, [q('http://ex.org/a', G1)]))
+      .rejects.toMatchObject({ outcome: 'not_started', storeOperation: 'replaceGraph' });
+    await expect(log.replaceGraphAndSubject(
+      G1,
+      [q('http://ex.org/a', G1)],
+      G2,
+      'http://ex.org/meta',
+      [q('http://ex.org/meta', G2)],
+    )).rejects.toMatchObject({
+      outcome: 'not_started',
+      storeOperation: 'replaceGraphAndSubject',
+    });
+    await expect(log.replaceSubject(G1, 'http://ex.org/a', [q('http://ex.org/a', G1)]))
+      .rejects.toMatchObject({ outcome: 'not_started', storeOperation: 'replaceSubject' });
+
+    expect(log.needsReconcile).toBe(false);
+    await base.close();
+  });
+});
 
 describe('ChangelogStore — upsert marker atomicity', () => {
   it('appends the marker in the SAME inner.insert() call as the data (one transaction)', async () => {

--- a/packages/storage/test/graph-set-index-store.test.ts
+++ b/packages/storage/test/graph-set-index-store.test.ts
@@ -2,17 +2,23 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { createServer } from 'node:http';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
+  ChangelogStore,
+  BlazegraphStore,
   GraphSetIndexStore,
   OxigraphStore,
+  SparqlHttpStore,
+  StoreSchedulerBusyError,
   StorePriorityScheduler,
   createTripleStore,
   registerTripleStoreAdapter,
   type GraphSetIndexStoreOptions,
   type GraphSetMutationEvent,
+  type Quad,
   type QueryOptions,
   type StoreWorkPriority,
+  type TripleStore,
 } from '../src/index.js';
 import {
   ControlledProbeStore,
@@ -27,6 +33,35 @@ class FailingMaintenanceStore extends CountingStore {
 
   async hasGraph(graphUri: string, options?: QueryOptions): Promise<boolean> {
     if (this.failHasGraph) throw new Error('hasGraph failed');
+    return super.hasGraph(graphUri, options);
+  }
+}
+
+class PostCommitProbeBusyStore extends CountingStore {
+  private rejectNextPresenceProbe = false;
+
+  async replaceGraph(
+    graphUri: string,
+    quads: Quad[],
+    options?: QueryOptions,
+  ): Promise<void> {
+    if (typeof this.inner.replaceGraph !== 'function') {
+      throw new Error('inner store does not support replaceGraph()');
+    }
+    await this.inner.replaceGraph(graphUri, quads, options);
+    this.rejectNextPresenceProbe = true;
+  }
+
+  override hasGraph(graphUri: string, options?: QueryOptions): Promise<boolean> {
+    if (this.rejectNextPresenceProbe) {
+      this.rejectNextPresenceProbe = false;
+      throw new StoreSchedulerBusyError(
+        'queue_wait_timeout',
+        'normal',
+        'sparql-http.hasGraph',
+        { storeOperation: 'hasGraph' },
+      );
+    }
     return super.hasGraph(graphUri, options);
   }
 }
@@ -82,6 +117,131 @@ async function exhaustTouchedGraphProbeRetries(
 }
 
 describe('GraphSetIndexStore', () => {
+  for (const adapter of [
+    {
+      name: 'BlazegraphStore',
+      create: (scheduler: StorePriorityScheduler): TripleStore => new BlazegraphStore(
+        'http://blazegraph.test/sparql',
+        { scheduler, timeout: 1_000 },
+      ),
+    },
+    {
+      name: 'SparqlHttpStore',
+      create: (scheduler: StorePriorityScheduler): TripleStore => new SparqlHttpStore({
+        queryEndpoint: 'http://sparql.test/query',
+        updateEndpoint: 'http://sparql.test/update',
+        atomicUpdates: true,
+        scheduler,
+        timeout: 1_000,
+      }),
+    },
+  ]) {
+    it(`keeps a warm index when the real ${adapter.name} boundary rejects before dispatch`, async () => {
+      const existing = 'did:dkg:context-graph:existing';
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(
+        JSON.stringify({
+          head: { vars: ['g'] },
+          results: { bindings: [{ g: { type: 'uri', value: existing } }] },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/sparql-results+json' } },
+      ));
+      const scheduler = new StorePriorityScheduler({
+        maxConcurrent: 1,
+        ackReservedSlots: 0,
+        healthReservedSlots: 0,
+        backgroundReservedSlots: 0,
+        queueLimits: 1,
+        queueWaitTimeoutMs: 10,
+      });
+      const inner = adapter.create(scheduler);
+      const diagnostics: unknown[] = [];
+      const store = new GraphSetIndexStore(inner, {
+        revalidateMs: 100_000,
+        now: () => 1_000,
+        onDiagnostic: (event) => diagnostics.push(event),
+      } as GraphSetIndexStoreOptions);
+      let releaseBlocker!: () => void;
+      let blockerStarted = false;
+      let blocker: Promise<void> | undefined;
+
+      try {
+        await expect(store.listGraphs()).resolves.toEqual([existing]);
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+        blocker = scheduler.run('normal', 'test.atomic-replace-blocker', async () => {
+          blockerStarted = true;
+          await new Promise<void>((resolve) => { releaseBlocker = resolve; });
+        });
+        await Promise.resolve();
+        expect(blockerStarted).toBe(true);
+
+        for (const [storeOperation, work] of [
+          ['replaceGraph', () => store.replaceGraph('urn:graph', [q('urn:graph')])],
+          ['replaceGraphAndSubject', () => store.replaceGraphAndSubject(
+            'urn:graph',
+            [q('urn:graph')],
+            'urn:meta',
+            'urn:subject',
+            [q('urn:meta', 'urn:subject')],
+          )],
+          ['replaceSubject', () => store.replaceSubject(
+            'urn:graph', 'urn:subject', [q('urn:graph', 'urn:subject')],
+          )],
+        ] as const) {
+          await expect(work()).rejects.toMatchObject({
+            code: 'STORE_SCHEDULER_BUSY',
+            outcome: 'not_started',
+            storeOperation,
+          });
+        }
+
+        for (const [storeOperation, read] of [
+          ['hasGraph', () => inner.hasGraph('urn:probe')],
+          ['listGraphs', () => inner.listGraphs()],
+          ['countQuads', () => inner.countQuads('urn:probe')],
+        ] as const) {
+          await expect(read()).rejects.toMatchObject({
+            code: 'STORE_SCHEDULER_BUSY',
+            outcome: 'not_started',
+            storeOperation,
+          });
+        }
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+        await expect(store.listGraphs()).resolves.toEqual([existing]);
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(diagnostics).toEqual([]);
+      } finally {
+        releaseBlocker?.();
+        if (blocker) await blocker;
+        await inner.close();
+        fetchSpy.mockRestore();
+      }
+    });
+  }
+
+  it('dirties the index when a nested post-commit probe is rejected before dispatch', async () => {
+    const inner = new OxigraphStore();
+    await inner.insert([q('did:dkg:context-graph:existing')]);
+    const backend = new PostCommitProbeBusyStore(inner);
+    const changelog = new ChangelogStore(backend);
+    const store = new GraphSetIndexStore(changelog, { revalidateMs: 100_000 });
+
+    await expect(store.listGraphs()).resolves.toEqual(['did:dkg:context-graph:existing']);
+    expect(backend.listGraphsCalls).toBe(1);
+
+    await expect(store.replaceGraph('urn:committed', [q('urn:committed')]))
+      .rejects.toBeInstanceOf(StoreSchedulerBusyError);
+    expect(changelog.needsReconcile).toBe(true);
+
+    await expect(store.listGraphs()).resolves.toEqual(expect.arrayContaining([
+      'did:dkg:context-graph:existing',
+      'urn:committed',
+    ]));
+    expect(backend.listGraphsCalls).toBe(2);
+    await inner.close();
+  });
+
   it('seeds from one listGraphs scan and serves prefix lookups from memory', async () => {
     const inner = new OxigraphStore();
     await inner.insert([

--- a/packages/storage/test/graph-set-index-store.test.ts
+++ b/packages/storage/test/graph-set-index-store.test.ts
@@ -6,11 +6,13 @@ import { describe, expect, it } from 'vitest';
 import {
   GraphSetIndexStore,
   OxigraphStore,
+  StoreSchedulerBusyError,
   StorePriorityScheduler,
   createTripleStore,
   registerTripleStoreAdapter,
   type GraphSetIndexStoreOptions,
   type GraphSetMutationEvent,
+  type Quad,
   type QueryOptions,
   type StoreWorkPriority,
 } from '../src/index.js';
@@ -28,6 +30,54 @@ class FailingMaintenanceStore extends CountingStore {
   async hasGraph(graphUri: string, options?: QueryOptions): Promise<boolean> {
     if (this.failHasGraph) throw new Error('hasGraph failed');
     return super.hasGraph(graphUri, options);
+  }
+}
+
+class ScheduledAtomicReplaceStore extends CountingStore {
+  readonly started: string[] = [];
+
+  constructor(inner: OxigraphStore, private readonly scheduler: StorePriorityScheduler) {
+    super(inner);
+  }
+
+  replaceGraph(graphUri: string, quads: Quad[], options?: QueryOptions): Promise<void> {
+    return this.scheduler.run(options?.priority, 'sparql-http.replaceGraph', async () => {
+      this.started.push('replaceGraph');
+      await this.inner.replaceGraph?.(graphUri, quads, options);
+    });
+  }
+
+  async replaceGraphAndSubject(
+    graphUri: string,
+    graphQuads: Quad[],
+    metaGraphUri: string,
+    metadataSubject: string,
+    metadataQuads: Quad[],
+    options?: QueryOptions,
+  ): Promise<void> {
+    return this.scheduler.run(options?.priority, 'sparql-http.replaceGraphAndSubject', async () => {
+      this.started.push('replaceGraphAndSubject');
+      await this.inner.replaceGraphAndSubject?.(
+        graphUri,
+        graphQuads,
+        metaGraphUri,
+        metadataSubject,
+        metadataQuads,
+        options,
+      );
+    });
+  }
+
+  async replaceSubject(
+    graphUri: string,
+    subject: string,
+    quads: Quad[],
+    options?: QueryOptions,
+  ): Promise<void> {
+    return this.scheduler.run(options?.priority, 'sparql-http.replaceSubject', async () => {
+      this.started.push('replaceSubject');
+      await this.inner.replaceSubject?.(graphUri, subject, quads, options);
+    });
   }
 }
 
@@ -82,6 +132,57 @@ async function exhaustTouchedGraphProbeRetries(
 }
 
 describe('GraphSetIndexStore', () => {
+  it('does not dirty a warm index when scheduler admission rejects an atomic replace before execution', async () => {
+    const inner = new OxigraphStore();
+    await inner.insert([q('did:dkg:context-graph:existing')]);
+    const scheduler = new StorePriorityScheduler({
+      maxConcurrent: 1,
+      ackReservedSlots: 0,
+      healthReservedSlots: 0,
+      backgroundReservedSlots: 0,
+      queueLimits: 1,
+      queueWaitTimeoutMs: 10,
+    });
+    let releaseBlocker!: () => void;
+    let blockerStarted = false;
+    const blocker = scheduler.run('normal', 'test.atomic-replace-blocker', async () => {
+      blockerStarted = true;
+      await new Promise<void>((resolve) => { releaseBlocker = resolve; });
+    });
+    await Promise.resolve();
+    expect(blockerStarted).toBe(true);
+
+    const counting = new ScheduledAtomicReplaceStore(inner, scheduler);
+    const diagnostics: unknown[] = [];
+    const store = new GraphSetIndexStore(counting, {
+      revalidateMs: 100_000,
+      now: () => 1_000,
+      onDiagnostic: (event) => diagnostics.push(event),
+    } as GraphSetIndexStoreOptions);
+
+    try {
+      await expect(store.listGraphs()).resolves.toEqual(['did:dkg:context-graph:existing']);
+      expect(counting.listGraphsCalls).toBe(1);
+
+      await expect(store.replaceGraph('urn:graph', [q('urn:graph')]))
+        .rejects.toBeInstanceOf(StoreSchedulerBusyError);
+      await expect(store.replaceGraphAndSubject(
+        'urn:graph', [q('urn:graph')], 'urn:meta', 'urn:subject', [q('urn:meta')],
+      )).rejects.toBeInstanceOf(StoreSchedulerBusyError);
+      await expect(store.replaceSubject('urn:graph', 'urn:subject', [q('urn:graph')]))
+        .rejects.toBeInstanceOf(StoreSchedulerBusyError);
+
+      expect(counting.started).toEqual([]);
+
+      await expect(store.listGraphs()).resolves.toEqual(['did:dkg:context-graph:existing']);
+      expect(counting.listGraphsCalls).toBe(1);
+      expect(diagnostics).toEqual([]);
+    } finally {
+      releaseBlocker();
+      await blocker;
+    }
+  });
+
   it('seeds from one listGraphs scan and serves prefix lookups from memory', async () => {
     const inner = new OxigraphStore();
     await inner.insert([

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -438,7 +438,7 @@ describe('SparqlHttpStore (test server)', () => {
     }
   });
 
-  it('notifies managed Oxigraph recovery when the client query deadline fires', async () => {
+  it('uses the transport label for recovery while retaining the canonical helper operation', async () => {
     const originalFetch = globalThis.fetch;
     const timedOutOperations: string[] = [];
     globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) =>
@@ -456,10 +456,11 @@ describe('SparqlHttpStore (test server)', () => {
         timeout: 5,
         onClientTimeout: (operation) => timedOutOperations.push(operation),
       });
-      await expect(store.query('SELECT ?s WHERE { ?s ?p ?o }')).rejects.toMatchObject({
+      await expect(store.hasGraph('urn:timed-out-graph')).rejects.toMatchObject({
         code: 'STORE_OPERATION_TIMEOUT',
         backend: 'oxigraph-server',
         operation: 'query',
+        storeOperation: 'hasGraph',
         timeoutMs: 5,
       });
       expect(timedOutOperations).toEqual(['query']);

--- a/packages/storage/test/store-operation-outcome.test.ts
+++ b/packages/storage/test/store-operation-outcome.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  STORE_OPERATION_OUTCOME_TAG,
+  StoreOperationTimeoutError,
+  StoreSchedulerBusyError,
+  UnsupportedTripleStoreCapabilityError,
+  hasStoreOperationOutcome,
+  isStoreOperation,
+  isStoreOperationTimeoutError,
+} from '../src/index.js';
+
+describe('store operation outcome protocol', () => {
+  it('recognizes the timeout, scheduler, and capability producers', () => {
+    const failures = [
+      new StoreOperationTimeoutError({
+        backend: 'test',
+        operation: 'replaceGraph',
+        outcome: 'not_started',
+      }),
+      new StoreSchedulerBusyError('queue_full', 'normal', 'adapter.replaceGraph', {
+        storeOperation: 'replaceGraph',
+      }),
+      new UnsupportedTripleStoreCapabilityError('replaceGraph', 'TestStore'),
+    ];
+
+    for (const failure of failures) {
+      expect(hasStoreOperationOutcome(failure, 'replaceGraph', 'not_started')).toBe(true);
+      expect(failure).toMatchObject({
+        storeOperationOutcomeTag: STORE_OPERATION_OUTCOME_TAG,
+        storeOperation: 'replaceGraph',
+        outcome: 'not_started',
+      });
+    }
+  });
+
+  it('rejects incidental matching properties without the stable protocol tag', () => {
+    const incidental = Object.assign(new Error('unrelated failure'), {
+      storeOperation: 'replaceGraph',
+      outcome: 'not_started',
+    });
+
+    expect(hasStoreOperationOutcome(incidental, 'replaceGraph', 'not_started')).toBe(false);
+  });
+
+  it('preserves arbitrary legacy timeout labels without inventing a canonical operation', () => {
+    const timeout = new StoreOperationTimeoutError({
+      backend: 'test',
+      operation: 'publish',
+    });
+
+    expect(timeout.operation).toBe('publish');
+    expect(timeout.storeOperation).toBeUndefined();
+    expect(isStoreOperationTimeoutError(timeout)).toBe(true);
+  });
+
+  it('validates canonical operation metadata rather than narrowing arbitrary strings', () => {
+    expect(isStoreOperation('replaceGraph')).toBe(true);
+    expect(isStoreOperation('replaceGrahp')).toBe(false);
+    expect(isStoreOperationTimeoutError({
+      code: 'STORE_OPERATION_TIMEOUT',
+      storeOperation: 'replaceGrahp',
+    })).toBe(false);
+    expect(isStoreOperationTimeoutError({
+      code: 'STORE_OPERATION_TIMEOUT',
+      operation: 'legacy-route-label',
+    })).toBe(true);
+  });
+});

--- a/packages/storage/test/store-priority-scheduler.test.ts
+++ b/packages/storage/test/store-priority-scheduler.test.ts
@@ -242,6 +242,71 @@ describe('StorePriorityScheduler', () => {
     });
   });
 
+  it('binds canonical operations at both scheduler-owned admission rejection sites', async () => {
+    const scheduler = new StorePriorityScheduler({
+      maxConcurrent: 1,
+      ackReservedSlots: 0,
+      healthReservedSlots: 0,
+      backgroundReservedSlots: 0,
+      queueLimits: 1,
+      queueWaitTimeoutMs: 10,
+    });
+    let release!: () => void;
+    const blocker = scheduler.run('normal', 'observability.blocker', async () => {
+      await new Promise<void>((resolve) => { release = resolve; });
+    });
+    const expires = scheduler.run(
+      'normal',
+      'observability.waiting',
+      async () => undefined,
+      undefined,
+      { storeOperation: 'replaceGraph' },
+    );
+
+    await expect(scheduler.run(
+      'normal',
+      'observability.rejected',
+      async () => undefined,
+      undefined,
+      { storeOperation: 'hasGraph' },
+    )).rejects.toMatchObject({
+      reason: 'queue_full',
+      operation: 'observability.rejected',
+      storeOperation: 'hasGraph',
+      outcome: 'not_started',
+    });
+
+    await expect(expires).rejects.toMatchObject({
+      reason: 'queue_wait_timeout',
+      operation: 'observability.waiting',
+      storeOperation: 'replaceGraph',
+      outcome: 'not_started',
+    });
+    release();
+    await blocker;
+  });
+
+  it('does not rewrite a busy error thrown by work after admission', async () => {
+    const scheduler = new StorePriorityScheduler({ maxConcurrent: 1, ackReservedSlots: 0 });
+    const nested = new StoreSchedulerBusyError(
+      'queue_wait_timeout',
+      'normal',
+      'nested.hasGraph',
+      { storeOperation: 'hasGraph' },
+    );
+
+    const outcome = scheduler.run(
+      'normal',
+      'outer.replaceGraph',
+      async () => { throw nested; },
+      undefined,
+      { storeOperation: 'replaceGraph' },
+    );
+
+    await expect(outcome).rejects.toBe(nested);
+    expect(nested.storeOperation).toBe('hasGraph');
+  });
+
   it('preserves queue admission settings in the deprecated positional constructor', async () => {
     vi.useFakeTimers();
     let releaseNormal1: (() => void) | undefined;


### PR DESCRIPTION
## Impact

A store scheduler queue rejection occurs before the operation closure starts. Atomic graph-replace wrappers now recognize that typed pre-execution outcome and keep their warm named-graph index instead of marking it dirty and forcing an O(store) rebuild on the next graph read.

This breaks a feedback loop observed during the Testnet 500/500 run: load caused an atomic replace to wait out its queue slot, the harmless admission rejection dirtied the index, the next read launched a full background scan, and that scan consumed capacity needed by the publication and synchronization workload.

## Before

```mermaid
sequenceDiagram
    participant Workload
    participant Scheduler
    participant Index as Graph-set index
    participant Store
    Workload->>Scheduler: Atomic replace
    Scheduler-->>Workload: Busy before execution
    Workload->>Index: Next graph read
    Index->>Store: Full named-graph rebuild
    Note over Scheduler,Store: Extra scan amplifies load
```

## After

```mermaid
sequenceDiagram
    participant Workload
    participant Scheduler
    participant Index as Graph-set index
    Workload->>Scheduler: Atomic replace
    Scheduler-->>Workload: Typed busy before execution
    Index->>Index: Preserve warm index
    Workload->>Index: Next graph read
    Index-->>Workload: Serve cached graph set
```

## Safety

`StoreSchedulerBusyError` is documented and enforced as retry-safe for its own queued closure. External adapters supply the canonical operation as scheduler-entry metadata, and the scheduler binds it only when constructing `queue_full` or `queue_wait_timeout`. A busy error thrown by already-started work is left untouched, so a nested post-commit read rejection remains indeterminate and forces index refresh plus changelog reconciliation.

The storage package exports one tagged operation-outcome contract for schedulers, timeouts, capability refusals, and third-party adapters. Decorators require its stable discriminator plus the exact operation/outcome pair; unrelated errors with coincidentally matching properties are rejected.

## Current target

Rebased onto `testnet-canary` at `f2a33f15fb99f0c694af3ac385d4ef0eb7092aff`.

## Validation

- Full storage suite: 550 passed, 27 skipped, 0 failed
- Focused outcome, scheduler, timeout, adapter, graph-index, and changelog suites: 166 passed, 0 failed
- Storage dependency/build lane: 3/3 tasks passed
- Lint and diff check: passed
- Exact-head GitHub CI at `c12645114b7cd811c5dd7fb2fc03c3932027940a`: 45 successful, 8 expected skipped, 0 failed
