### PR TITLE
fix(publisher): fail closed on multi-valued SWM heads and classify as retryable (GH#2273 1/3)

### DIFF
--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -1593,6 +1593,18 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         if (err?.code === "PUBLISH_NOT_FULL_SHARE" || err?.code === "PUBLISH_INTENT_STALE") {
           return jsonResponse(res, 409, { code: err.code, error: err.message ?? String(err) });
         }
+        // GH#2273 — a multi-valued SWM head now fails closed in the resolver. That is
+        // transient SERVER-side corruption the sync repair heals, not a stale client
+        // intent, so it must not read as the 409 above (the client would re-share for
+        // nothing) or fall through to a generic 500: 503 + retryable tells the caller to
+        // retry the same enqueue after catch-up converges the head.
+        if (err?.code === "KA_WORKSPACE_HEAD_CORRUPT") {
+          return jsonResponse(res, 503, {
+            code: err.code,
+            error: err.message ?? String(err),
+            retryable: true,
+          });
+        }
         // GH#1778 — several authors share this KA name; the caller must
         // disambiguate. Surface the candidate authors so the UI/CLI can pick.
         if (respondAmbiguousAssertionAuthor(res, err)) return;

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -73,7 +73,7 @@ import {
   isSameAgentAddress,
   scopedTokenPromoteLane,
 } from "./shared-assertion-helpers.js";
-import { AsyncLiftJobConflictError, PromoteJobConflictError } from "@origintrail-official/dkg-publisher";
+import { AsyncLiftJobConflictError, PromoteJobConflictError, isKnowledgeAssetWorkspaceHeadCorruptError } from "@origintrail-official/dkg-publisher";
 import { deriveStatus } from "@origintrail-official/dkg-publisher";
 import {
   validateAssertionName,
@@ -1598,7 +1598,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         // intent, so it must not read as the 409 above (the client would re-share for
         // nothing) or fall through to a generic 500: 503 + retryable tells the caller to
         // retry the same enqueue after catch-up converges the head.
-        if (err?.code === "KA_WORKSPACE_HEAD_CORRUPT") {
+        if (isKnowledgeAssetWorkspaceHeadCorruptError(err)) {
           return jsonResponse(res, 503, {
             code: err.code,
             error: err.message ?? String(err),

--- a/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
+++ b/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
@@ -447,6 +447,36 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
     expect(enqueueCalls).toBe(0);
   });
 
+  it('vm/publish-async: KA_WORKSPACE_HEAD_CORRUPT → 503 { code, error, retryable }', async () => {
+    // GH#2273 — a multi-valued SWM head now fails closed in the resolver during the
+    // enqueue-time intent resolution. That is transient SERVER-side corruption the sync
+    // repair heals, not a stale client intent: a 409 would tell the caller to re-share
+    // for nothing, and pre-fix the code matched no catch branch and surfaced as a
+    // generic 500. The 503 + retryable tells the caller to retry the SAME enqueue after
+    // catch-up converges the head.
+    let enqueueCalls = 0;
+    await startWith({}, {
+      resolveFinalizedAssertionVmPublishIntent: async () => {
+        throw Object.assign(
+          new Error('Corrupt graph-scoped SWM head for did:dkg:test/1: head carries 2 shareOperationId values (op-a, storage-ack-b)'),
+          { code: 'KA_WORKSPACE_HEAD_CORRUPT' },
+        );
+      },
+    }, {}, {
+      enqueueKnowledgeAssetVmPublish: async () => {
+        enqueueCalls += 1;
+        return 'job-should-not-exist';
+      },
+    });
+
+    const res = await post('vm/publish-async', { contextGraphId: CG_ID });
+    expect(res.status).toBe(503);
+    expect(res.body.code).toBe('KA_WORKSPACE_HEAD_CORRUPT');
+    expect(res.body.retryable).toBe(true);
+    expect(String(res.body.error)).toContain('shareOperationId');
+    expect(enqueueCalls).toBe(0);
+  });
+
   // GH#1778 — the disambiguation error surfaces as a 409 with the candidate
   // author list so UI/CLI consumers can pick an author.
   const AMBIGUOUS_AUTHORS = [

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -841,7 +841,14 @@ export class TripleStoreAsyncLiftPublisher
     if (
       anyError?.code === 'PUBLISH_NOT_FULL_SHARE' ||
       anyError?.code === 'PUBLISH_INTENT_STALE' ||
-      anyError?.code === 'CG_NOT_REGISTERED'
+      anyError?.code === 'CG_NOT_REGISTERED' ||
+      // GH#2273 — the pre-execute preflight re-resolves the SWM head and the resolver now
+      // fails closed on a multi-valued head. Raised strictly before any transaction is
+      // built, so the job must fail from 'validated', not 'broadcast': from 'broadcast' the
+      // second classifier's message sniffing lands corrupt-head text containing 'mismatch'
+      // on terminal `confirmation_mismatch`, and `workspace_unavailable` is not even
+      // recordable there (allowed states exclude 'broadcast').
+      anyError?.code === 'KA_WORKSPACE_HEAD_CORRUPT'
     ) {
       return true;
     }
@@ -1503,6 +1510,14 @@ export class TripleStoreAsyncLiftPublisher
           ? 'authority_forbidden'
         : errorCode === 'PUBLISH_INTENT_STALE'
           ? 'publish_intent_stale'
+        // GH#2273 — a multi-valued SWM head (catch-up union residue) is transient local
+        // corruption that the sync repair heals, NOT a stale intent: the queued request may
+        // still be byte-identical to what the head certified at admission. Matched by CODE
+        // before the message chain below, whose keywords ('Corrupt graph-scoped SWM head…')
+        // would otherwise land on terminal `canonicalization_failed` and kill a job that a
+        // later retry could finalize unchanged.
+        : errorCode === 'KA_WORKSPACE_HEAD_CORRUPT'
+          ? 'workspace_unavailable'
           : lower.includes('timeout') || lower.includes('timed out') || lower.includes('unavailable') || lower.includes('query') || lower.includes('store')
           ? 'workspace_unavailable'
           : lower.includes('authority')

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -57,7 +57,7 @@ import { prepareAsyncPublishPayload, type AsyncPreparedPublishPayload, type Lift
 import { validateLiftPublishPayload } from './async-lift-validation.js';
 import { computePrivateRootV10 } from './merkle.js';
 import { subtractFinalizedExactQuads } from './async-lift-subtraction.js';
-import { resolveLiftWorkspaceSlice } from './workspace-resolution.js';
+import { isKnowledgeAssetWorkspaceHeadCorruptError, resolveLiftWorkspaceSlice } from './workspace-resolution.js';
 import {
   CONTROL_CLAIM_TOKEN,
   CONTROL_LOCKED_JOB,
@@ -848,7 +848,7 @@ export class TripleStoreAsyncLiftPublisher
       // second classifier's message sniffing lands corrupt-head text containing 'mismatch'
       // on terminal `confirmation_mismatch`, and `workspace_unavailable` is not even
       // recordable there (allowed states exclude 'broadcast').
-      anyError?.code === 'KA_WORKSPACE_HEAD_CORRUPT'
+      isKnowledgeAssetWorkspaceHeadCorruptError(error)
     ) {
       return true;
     }
@@ -1512,11 +1512,12 @@ export class TripleStoreAsyncLiftPublisher
           ? 'publish_intent_stale'
         // GH#2273 — a multi-valued SWM head (catch-up union residue) is transient local
         // corruption that the sync repair heals, NOT a stale intent: the queued request may
-        // still be byte-identical to what the head certified at admission. Matched by CODE
-        // before the message chain below, whose keywords ('Corrupt graph-scoped SWM head…')
-        // would otherwise land on terminal `canonicalization_failed` and kill a job that a
-        // later retry could finalize unchanged.
-        : errorCode === 'KA_WORKSPACE_HEAD_CORRUPT'
+        // still be byte-identical to what the head certified at admission. Recognized by
+        // the shared boundary predicate before the message chain below, whose keywords
+        // ('Corrupt graph-scoped SWM head…') would otherwise land on terminal
+        // `canonicalization_failed` and kill a job that a later retry could finalize
+        // unchanged.
+        : isKnowledgeAssetWorkspaceHeadCorruptError(error)
           ? 'workspace_unavailable'
           : lower.includes('timeout') || lower.includes('timed out') || lower.includes('unavailable') || lower.includes('query') || lower.includes('store')
           ? 'workspace_unavailable'

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -12,6 +12,7 @@ import {
   createLiftJobFailureMetadata,
   getLiftJobFailurePolicy,
   type LiftJob,
+  type LiftJobFailureCode,
   type LiftJobAccepted,
   type LiftJobBroadcast,
   type LiftJobBroadcastMetadata,
@@ -836,29 +837,42 @@ export class TripleStoreAsyncLiftPublisher
     return this.reacceptFailedJob(job);
   }
 
+  /**
+   * The ONE registration point for STRUCTURED (typed) KA VM-publish
+   * precondition failures: a non-null result simultaneously (a) forces the
+   * failure to be recorded from the pre-send 'validated' state — from
+   * 'broadcast' the publish-side classifier's message sniffing lands e.g.
+   * corrupt-head text containing 'mismatch' on terminal `confirmation_mismatch`,
+   * and codes like `workspace_unavailable` are not even recordable there — and
+   * (b) IS the persisted failure code. Registering a future structured
+   * preflight error here cannot desynchronize state and code, which was
+   * previously possible because the two decisions lived in independent
+   * condition chains. Message-keyed legacy failures still flow through the
+   * message chains below and in `recordExecutionFailure` (their consolidation
+   * is #1974's scope).
+   */
+  private classifyKnowledgeAssetVmPublishPreconditionCode(error: unknown): LiftJobFailureCode | null {
+    // GH#1786 — permanent author-capability refusal; no transaction was ever sent.
+    if (isPermanentAuthorCapabilityFailure(error)) return 'authority_forbidden';
+    if ((error as { code?: unknown } | null | undefined)?.code === 'PUBLISH_INTENT_STALE') {
+      return 'publish_intent_stale';
+    }
+    // GH#2273 — multi-valued SWM head: transient local corruption the sync
+    // repair heals, NOT a stale intent; the queued request may still be
+    // byte-identical to what the head certified at admission.
+    if (isKnowledgeAssetWorkspaceHeadCorruptError(error)) return 'workspace_unavailable';
+    return null;
+  }
+
   private isKnowledgeAssetPublishPreconditionFailure(error: unknown): boolean {
+    if (this.classifyKnowledgeAssetVmPublishPreconditionCode(error) !== null) return true;
     const anyError = error as { code?: unknown; message?: unknown };
     if (
       anyError?.code === 'PUBLISH_NOT_FULL_SHARE' ||
-      anyError?.code === 'PUBLISH_INTENT_STALE' ||
-      anyError?.code === 'CG_NOT_REGISTERED' ||
-      // GH#2273 — the pre-execute preflight re-resolves the SWM head and the resolver now
-      // fails closed on a multi-valued head. Raised strictly before any transaction is
-      // built, so the job must fail from 'validated', not 'broadcast': from 'broadcast' the
-      // second classifier's message sniffing lands corrupt-head text containing 'mismatch'
-      // on terminal `confirmation_mismatch`, and `workspace_unavailable` is not even
-      // recordable there (allowed states exclude 'broadcast').
-      isKnowledgeAssetWorkspaceHeadCorruptError(error)
+      anyError?.code === 'CG_NOT_REGISTERED'
     ) {
       return true;
     }
-    // GH#1786 — the node cannot re-sign the selected author's UpdateAuthorAttestation.
-    // Raised while BUILDING the attestation, strictly before onPhase reaches
-    // recordDurableBroadcastBeforeSend, so no transaction was ever sent: the job is still
-    // 'validated' and recording 'broadcast' would publish a false claim that a broadcast
-    // occurred (and mislabel the phase with it). Shared predicate — the same one decides the
-    // failure CODE on both the validated and broadcast paths.
-    if (isPermanentAuthorCapabilityFailure(error)) return true;
     const message = String(anyError?.message ?? error);
     return /is not finalized/i.test(message)
       || /No quads in shared memory/i.test(message)
@@ -1498,34 +1512,19 @@ export class TripleStoreAsyncLiftPublisher
     if (failedFromState === 'claimed' || failedFromState === 'validated') {
       const message = error instanceof Error ? error.message : String(error);
       const lower = message.toLowerCase();
-      const errorCode = (error as { code?: unknown })?.code;
       const code =
-        // GH#1786 — a no-send author-capability refusal, recognized by CODE (with the shared
-        // marker fallback for a re-wrap that lost it) BEFORE the message chain below. That
-        // chain would otherwise reach `canonicalization_failed`: this message contains none
-        // of its keywords, and not even 'authority' — "UpdateAuthorAttestation" carries
-        // "author", not "authority". Terminal either way, but the code is what clients
-        // branch on and what tells an operator the publish is unfixable by retrying.
-        isPermanentAuthorCapabilityFailure(error)
-          ? 'authority_forbidden'
-        : errorCode === 'PUBLISH_INTENT_STALE'
-          ? 'publish_intent_stale'
-        // GH#2273 — a multi-valued SWM head (catch-up union residue) is transient local
-        // corruption that the sync repair heals, NOT a stale intent: the queued request may
-        // still be byte-identical to what the head certified at admission. Recognized by
-        // the shared boundary predicate before the message chain below, whose keywords
-        // ('Corrupt graph-scoped SWM head…') would otherwise land on terminal
-        // `canonicalization_failed` and kill a job that a later retry could finalize
-        // unchanged.
-        : isKnowledgeAssetWorkspaceHeadCorruptError(error)
-          ? 'workspace_unavailable'
-          : lower.includes('timeout') || lower.includes('timed out') || lower.includes('unavailable') || lower.includes('query') || lower.includes('store')
+        // Structured precondition failures (author capability / stale intent /
+        // corrupt head) come from the SAME classifier that routed the failure
+        // to this pre-send branch, so their state and code cannot drift apart.
+        // Everything message-keyed stays in the legacy chain below (#1974).
+        this.classifyKnowledgeAssetVmPublishPreconditionCode(error)
+          ?? (lower.includes('timeout') || lower.includes('timed out') || lower.includes('unavailable') || lower.includes('query') || lower.includes('store')
           ? 'workspace_unavailable'
           : lower.includes('authority')
           ? 'authority_forbidden'
           : lower.includes('workspace') || lower.includes('root')
             ? 'workspace_slice_not_found'
-            : 'canonicalization_failed';
+            : 'canonicalization_failed');
       const failure = createLiftJobFailureMetadata({
         failedFromState,
         code,

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -854,25 +854,33 @@ export class TripleStoreAsyncLiftPublisher
   private classifyKnowledgeAssetVmPublishPreconditionCode(error: unknown): LiftJobFailureCode | null {
     // GH#1786 — permanent author-capability refusal; no transaction was ever sent.
     if (isPermanentAuthorCapabilityFailure(error)) return 'authority_forbidden';
-    if ((error as { code?: unknown } | null | undefined)?.code === 'PUBLISH_INTENT_STALE') {
-      return 'publish_intent_stale';
+    let structuredCode: unknown;
+    try {
+      structuredCode = (error as { code?: unknown } | null | undefined)?.code;
+    } catch {
+      structuredCode = undefined;
     }
+    if (structuredCode === 'PUBLISH_INTENT_STALE') return 'publish_intent_stale';
     // GH#2273 — multi-valued SWM head: transient local corruption the sync
     // repair heals, NOT a stale intent; the queued request may still be
     // byte-identical to what the head certified at admission.
     if (isKnowledgeAssetWorkspaceHeadCorruptError(error)) return 'workspace_unavailable';
+    // Structured admission/registration preconditions. Their persisted code
+    // PRESERVES the pre-existing effective mapping: neither message ("is not
+    // registered on-chain", "not a complete full share") matches any keyword
+    // in the legacy chain, so both always fell through to
+    // `canonicalization_failed`. Re-taxonomizing them is #1974's call — what
+    // this helper guarantees is only that the code that ROUTES the failure to
+    // the pre-send state is also the code that decides what gets persisted.
+    if (structuredCode === 'PUBLISH_NOT_FULL_SHARE' || structuredCode === 'CG_NOT_REGISTERED') {
+      return 'canonicalization_failed';
+    }
     return null;
   }
 
   private isKnowledgeAssetPublishPreconditionFailure(error: unknown): boolean {
     if (this.classifyKnowledgeAssetVmPublishPreconditionCode(error) !== null) return true;
     const anyError = error as { code?: unknown; message?: unknown };
-    if (
-      anyError?.code === 'PUBLISH_NOT_FULL_SHARE' ||
-      anyError?.code === 'CG_NOT_REGISTERED'
-    ) {
-      return true;
-    }
     const message = String(anyError?.message ?? error);
     return /is not finalized/i.test(message)
       || /No quads in shared memory/i.test(message)

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -67,12 +67,11 @@ import {
   type OnChainProvenance,
 } from './metadata.js';
 import {
-  isKnowledgeAssetWorkspaceHeadCorruptError,
   resolveKnowledgeAssetWorkspaceHead,
   storeKnowledgeAssetOperationPublicQuads,
   storeKnowledgeAssetWorkspaceHead,
   storeWorkspaceOperationPublicQuads,
-  type KnowledgeAssetWorkspaceHead,
+  tryResolveKnowledgeAssetWorkspaceHead,
 } from './workspace-resolution.js';
 import type { WorkspacePublicSnapshotStore } from './workspace-snapshot-store.js';
 import { ethers } from 'ethers';
@@ -8971,27 +8970,23 @@ export class DKGPublisher implements Publisher {
         // the live SWM content, so fail toward RETENTION: archive the seal (benign extra
         // storage) rather than risk destroying the only recovery artifact for content that
         // is genuinely resident.
-        let head: KnowledgeAssetWorkspaceHead | undefined;
-        let headCorrupt = false;
-        try {
-          head = await resolveKnowledgeAssetWorkspaceHead({
-            store: this.store,
-            graphManager: this.graphManager,
-            contextGraphId,
-            kaUal: seal.kaUal,
-            subGraphName,
-          });
-        } catch (err) {
-          if (!isKnowledgeAssetWorkspaceHeadCorruptError(err)) throw err;
+        const headResolution = await tryResolveKnowledgeAssetWorkspaceHead({
+          store: this.store,
+          graphManager: this.graphManager,
+          contextGraphId,
+          kaUal: seal.kaUal,
+          subGraphName,
+        });
+        if (headResolution.status === 'corrupt') {
           this.log.warn(
             createOperationContext('system'),
-            `assertionDiscard: SWM head for ${seal.kaUal} is corrupt; retaining recovery seal (${err instanceof Error ? err.message : String(err)})`,
+            `assertionDiscard: SWM head for ${seal.kaUal} is corrupt; retaining recovery seal (${headResolution.error.message})`,
           );
-          headCorrupt = true;
         }
-        preserveSwmRecoverySeal = headCorrupt
-          || (head?.kaUal === seal.kaUal
-            && head.assertionVersion === seal.assertionVersion);
+        preserveSwmRecoverySeal = headResolution.status === 'corrupt'
+          || (headResolution.status === 'resolved'
+            && headResolution.head.kaUal === seal.kaUal
+            && headResolution.head.assertionVersion === seal.assertionVersion);
         if (preserveSwmRecoverySeal) {
           await this.archiveAssertionSeal(
             contextGraphId,

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -67,10 +67,12 @@ import {
   type OnChainProvenance,
 } from './metadata.js';
 import {
+  KnowledgeAssetWorkspaceHeadCorruptError,
   resolveKnowledgeAssetWorkspaceHead,
   storeKnowledgeAssetOperationPublicQuads,
   storeKnowledgeAssetWorkspaceHead,
   storeWorkspaceOperationPublicQuads,
+  type KnowledgeAssetWorkspaceHead,
 } from './workspace-resolution.js';
 import type { WorkspacePublicSnapshotStore } from './workspace-snapshot-store.js';
 import { ethers } from 'ethers';
@@ -8962,15 +8964,34 @@ export class DKGPublisher implements Publisher {
           || !seal.kaUal
           || !seal.assertionVersion
         ) continue;
-        const head = await resolveKnowledgeAssetWorkspaceHead({
-          store: this.store,
-          graphManager: this.graphManager,
-          contextGraphId,
-          kaUal: seal.kaUal,
-          subGraphName,
-        });
-        preserveSwmRecoverySeal = head?.kaUal === seal.kaUal
-          && head.assertionVersion === seal.assertionVersion;
+        // GH#2273 — the resolver fails closed on a multi-valued head. The head here feeds
+        // only the advisory keep-the-recovery-seal decision, and discard is a plausible
+        // operator remedy for a KA whose head is exactly in that corrupt state — so a throw
+        // must not abort the discard. On corruption we cannot prove the seal does NOT match
+        // the live SWM content, so fail toward RETENTION: archive the seal (benign extra
+        // storage) rather than risk destroying the only recovery artifact for content that
+        // is genuinely resident.
+        let head: KnowledgeAssetWorkspaceHead | undefined;
+        let headCorrupt = false;
+        try {
+          head = await resolveKnowledgeAssetWorkspaceHead({
+            store: this.store,
+            graphManager: this.graphManager,
+            contextGraphId,
+            kaUal: seal.kaUal,
+            subGraphName,
+          });
+        } catch (err) {
+          if (!(err instanceof KnowledgeAssetWorkspaceHeadCorruptError)) throw err;
+          this.log.warn(
+            createOperationContext('system'),
+            `assertionDiscard: SWM head for ${seal.kaUal} is corrupt; retaining recovery seal (${err.message})`,
+          );
+          headCorrupt = true;
+        }
+        preserveSwmRecoverySeal = headCorrupt
+          || (head?.kaUal === seal.kaUal
+            && head.assertionVersion === seal.assertionVersion);
         if (preserveSwmRecoverySeal) {
           await this.archiveAssertionSeal(
             contextGraphId,

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -67,7 +67,7 @@ import {
   type OnChainProvenance,
 } from './metadata.js';
 import {
-  KnowledgeAssetWorkspaceHeadCorruptError,
+  isKnowledgeAssetWorkspaceHeadCorruptError,
   resolveKnowledgeAssetWorkspaceHead,
   storeKnowledgeAssetOperationPublicQuads,
   storeKnowledgeAssetWorkspaceHead,
@@ -8982,10 +8982,10 @@ export class DKGPublisher implements Publisher {
             subGraphName,
           });
         } catch (err) {
-          if (!(err instanceof KnowledgeAssetWorkspaceHeadCorruptError)) throw err;
+          if (!isKnowledgeAssetWorkspaceHeadCorruptError(err)) throw err;
           this.log.warn(
             createOperationContext('system'),
-            `assertionDiscard: SWM head for ${seal.kaUal} is corrupt; retaining recovery seal (${err.message})`,
+            `assertionDiscard: SWM head for ${seal.kaUal} is corrupt; retaining recovery seal (${err instanceof Error ? err.message : String(err)})`,
           );
           headCorrupt = true;
         }

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -51,6 +51,7 @@ export {
   storeKnowledgeAssetOperationPublicQuads,
   KnowledgeAssetOperationPublicSnapshotNotFoundError,
   KnowledgeAssetWorkspaceHeadCorruptError,
+  isKnowledgeAssetWorkspaceHeadCorruptError,
   type KnowledgeAssetWorkspaceHead,
   type PublishedKnowledgeAssetWorkspaceHead,
   type ResolveKnowledgeAssetWorkspaceHeadParams,

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -52,6 +52,8 @@ export {
   KnowledgeAssetOperationPublicSnapshotNotFoundError,
   KnowledgeAssetWorkspaceHeadCorruptError,
   isKnowledgeAssetWorkspaceHeadCorruptError,
+  tryResolveKnowledgeAssetWorkspaceHead,
+  type KnowledgeAssetWorkspaceHeadResolution,
   type KnowledgeAssetWorkspaceHead,
   type PublishedKnowledgeAssetWorkspaceHead,
   type ResolveKnowledgeAssetWorkspaceHeadParams,

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -52,8 +52,6 @@ export {
   KnowledgeAssetOperationPublicSnapshotNotFoundError,
   KnowledgeAssetWorkspaceHeadCorruptError,
   isKnowledgeAssetWorkspaceHeadCorruptError,
-  tryResolveKnowledgeAssetWorkspaceHead,
-  type KnowledgeAssetWorkspaceHeadResolution,
   type KnowledgeAssetWorkspaceHead,
   type PublishedKnowledgeAssetWorkspaceHead,
   type ResolveKnowledgeAssetWorkspaceHeadParams,

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -1636,7 +1636,8 @@ export class SharedMemoryHandler {
       // collapses the multi-valued head, and the sender's budget-bounded
       // outbox must keep the payload queued rather than record a terminal
       // drop of a share that will apply once the head heals).
-      switch (decision.kind) {
+      const rejectionKind = decision.kind;
+      switch (rejectionKind) {
         case 'corrupt-head':
           return rejectedSharedMemoryOutcome(
             verifiedFields,
@@ -1651,13 +1652,20 @@ export class SharedMemoryHandler {
             true,
             true,
           );
-        default:
+        case 'validation':
           return rejectedSharedMemoryOutcome(
             verifiedFields,
             decision.reason ?? 'validation rejected graph-scoped KA payload (permanent)',
             false,
             true,
           );
+        default: {
+          // Compile-time exhaustiveness: a future SwmWriteDecision kind fails
+          // HERE instead of silently inheriting the permanent validation
+          // policy.
+          const unreachable: never = rejectionKind;
+          return unreachable;
+        }
       }
     } catch (err) {
       // PR-C codex R3: classify the catch path as `retryable: true`.

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -37,7 +37,7 @@ import {
 } from './metadata.js';
 import { parseSimpleNQuads } from './publish-handler.js';
 import {
-  KnowledgeAssetWorkspaceHeadCorruptError,
+  isKnowledgeAssetWorkspaceHeadCorruptError,
   resolveKnowledgeAssetWorkspaceHead,
   storeKnowledgeAssetOperationPublicQuads,
   storeKnowledgeAssetWorkspaceHead,
@@ -1454,8 +1454,8 @@ export class SharedMemoryHandler {
             subGraphName,
           });
         } catch (err) {
-          if (!(err instanceof KnowledgeAssetWorkspaceHeadCorruptError)) throw err;
-          validationRejectionReason = `CORRUPT_SWM_HEAD: ${err.message}`;
+          if (!isKnowledgeAssetWorkspaceHeadCorruptError(err)) throw err;
+          validationRejectionReason = `CORRUPT_SWM_HEAD: ${err instanceof Error ? err.message : String(err)}`;
           this.log.warn(ctx, `SWM validation rejected: ${validationRejectionReason}`);
           withWriteLocksRejection = 'validation';
           return false;

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -967,10 +967,20 @@ export class SharedMemoryHandler {
     // reasons — validation rejection (deterministic, payload
     // can never apply) and CAS-not-met (TRANSIENT when SWM
     // writes arrive out of order). Hoisted here so the closure
-    // can signal which branch fired; the post-closure code
-    // maps `cas` → retryable and `validation` → permanent.
-    let withWriteLocksRejection: 'validation' | 'cas' | 'corrupt-head' | undefined;
-    let validationRejectionReason: string | undefined;
+    // can signal which branch fired; the post-closure code maps
+    // the kind to retryability in ONE place. Kind and reason are
+    // one object set by one call, so no rejection path can set
+    // half its state and silently fall into the wrong branch.
+    let withWriteLocksRejection:
+      | { readonly kind: 'validation' | 'cas' | 'corrupt-head'; readonly reason?: string }
+      | undefined;
+    const rejectWithinLocks = (
+      kind: 'validation' | 'cas' | 'corrupt-head',
+      reason?: string,
+    ): false => {
+      withWriteLocksRejection = { kind, ...(reason === undefined ? {} : { reason }) };
+      return false;
+    };
     let verifiedLifecycleFields: SharedMemoryLifecycleFields | undefined;
     try {
       const { envelope, signedPayload } = decoded;
@@ -1389,9 +1399,7 @@ export class SharedMemoryHandler {
             reason,
             validationErrorCount: validation.errors.length,
           }, 'warn');
-          withWriteLocksRejection = 'validation';
-          validationRejectionReason = reason;
-          return false;
+          return rejectWithinLocks('validation', reason);
         }
         this.logSwmLifecycleEvent(ctx, 'swm_validation_passed', {
           ...verifiedFields,
@@ -1407,10 +1415,9 @@ export class SharedMemoryHandler {
         );
         const operationTimestamp = new Date(Number(timestampMs));
         if (Number.isNaN(operationTimestamp.getTime())) {
-          validationRejectionReason = `invalid timestampMs ${String(timestampMs)}`;
-          this.log.warn(ctx, `SWM validation rejected: ${validationRejectionReason}`);
-          withWriteLocksRejection = 'validation';
-          return false;
+          const reason = `invalid timestampMs ${String(timestampMs)}`;
+          this.log.warn(ctx, `SWM validation rejected: ${reason}`);
+          return rejectWithinLocks('validation', reason);
         }
         const persistLocallyTrustedControls = async (): Promise<void> => {
           const merkleRoot = computeFlatKCRootV10(
@@ -1451,21 +1458,19 @@ export class SharedMemoryHandler {
           subGraphName,
         });
         if (headResolution.status === 'corrupt') {
-          validationRejectionReason = `CORRUPT_SWM_HEAD: ${headResolution.error.message}`;
-          this.log.warn(ctx, `SWM share deferred: ${validationRejectionReason}`);
-          withWriteLocksRejection = 'corrupt-head';
-          return false;
+          const reason = `CORRUPT_SWM_HEAD: ${headResolution.error.message}`;
+          this.log.warn(ctx, `SWM share deferred: ${reason}`);
+          return rejectWithinLocks('corrupt-head', reason);
         }
         const currentHead = headResolution.status === 'resolved' ? headResolution.head : undefined;
         if (currentHead) {
           const incomingVersion = BigInt(contentScope.assertionVersion);
           const currentVersion = BigInt(currentHead.assertionVersion);
           if (incomingVersion < currentVersion) {
-            validationRejectionReason =
+            const reason =
               `STALE_KA_ASSERTION_VERSION: incoming=${incomingVersion}, current=${currentVersion}`;
-            this.log.warn(ctx, `SWM validation rejected: ${validationRejectionReason}`);
-            withWriteLocksRejection = 'validation';
-            return false;
+            this.log.warn(ctx, `SWM validation rejected: ${reason}`);
+            return rejectWithinLocks('validation', reason);
           }
           if (incomingVersion === currentVersion) {
             const sameAssertion =
@@ -1486,20 +1491,18 @@ export class SharedMemoryHandler {
               await persistLocallyTrustedControls();
               return true;
             }
-            validationRejectionReason =
+            const reason =
               `CONFLICTING_KA_ASSERTION_VERSION: ${contentScope.ual} version ${incomingVersion} ` +
               'is already bound to a different operation or content digest';
-            this.log.warn(ctx, `SWM validation rejected: ${validationRejectionReason}`);
-            withWriteLocksRejection = 'validation';
-            return false;
+            this.log.warn(ctx, `SWM validation rejected: ${reason}`);
+            return rejectWithinLocks('validation', reason);
           }
           if (currentHead.publisherPeerId !== publisherPeerId) {
-            validationRejectionReason =
+            const reason =
               `KA_PUBLISHER_MISMATCH: ${contentScope.ual} is owned in SWM by ` +
               `${currentHead.publisherPeerId}, not ${publisherPeerId}`;
-            this.log.warn(ctx, `SWM validation rejected: ${validationRejectionReason}`);
-            withWriteLocksRejection = 'validation';
-            return false;
+            this.log.warn(ctx, `SWM validation rejected: ${reason}`);
+            return rejectWithinLocks('validation', reason);
           }
         }
 
@@ -1512,8 +1515,7 @@ export class SharedMemoryHandler {
             // replays missed writes on reconnect, converging replicas eventually.
             // Accepting stale-CAS writes would silently corrupt local state.
             this.log.info(ctx, `Skipping SWM write ${shareOperationId} — remote CAS conditions not met`);
-            withWriteLocksRejection = 'cas';
-            return false;
+            return rejectWithinLocks('cas');
           }
         }
 
@@ -1627,40 +1629,38 @@ export class SharedMemoryHandler {
         });
         return appliedSharedMemoryOutcome(verifiedFields, quads.length);
       }
-      // `applied === false` from the withWriteLocks closure. PR-C
-      // codex R4: validation rejection is deterministic (retry
-      // produces the same outcome), but CAS-not-met is
-      // TRANSIENT — the missed write upstream might still arrive
-      // via gossip and bring local state up to where the CAS
-      // condition would pass. Keep retrying so the sender's
-      // outbox doesn't drop a payload that would apply after
-      // out-of-order delivery converges.
-      // GH#2273 — same shape as the CAS case below: the blocking condition is
-      // LOCAL and convergent (sync repair collapses the multi-valued head), so
-      // the sender's outbox must keep retrying rather than record a terminal
-      // drop of a payload that will apply once the head heals.
-      if (withWriteLocksRejection === 'corrupt-head') {
-        return rejectedSharedMemoryOutcome(
-          verifiedFields,
-          `${validationRejectionReason ?? 'CORRUPT_SWM_HEAD'} (transient: may apply after sync repair converges the head)`,
-          true,
-          true,
-        );
+      // `applied === false` from the withWriteLocks closure. The kind ->
+      // outcome policy lives HERE, in one table adjacent to the channels:
+      // 'validation' is deterministic (retry produces the same outcome, so
+      // permanent); 'cas' is TRANSIENT (PR-C codex R4 — the missed upstream
+      // write might still arrive and make the condition pass); 'corrupt-head'
+      // is TRANSIENT for the same convergent-local-state reason (GH#2273 —
+      // sync repair collapses the multi-valued head, and the sender's
+      // budget-bounded outbox must keep the payload queued rather than record
+      // a terminal drop of a share that will apply once the head heals).
+      switch (withWriteLocksRejection?.kind) {
+        case 'corrupt-head':
+          return rejectedSharedMemoryOutcome(
+            verifiedFields,
+            `${withWriteLocksRejection.reason ?? 'CORRUPT_SWM_HEAD'} (transient: may apply after sync repair converges the head)`,
+            true,
+            true,
+          );
+        case 'cas':
+          return rejectedSharedMemoryOutcome(
+            verifiedFields,
+            'CAS pre-conditions not met against current SWM state (transient: may apply after upstream writes converge)',
+            true,
+            true,
+          );
+        default:
+          return rejectedSharedMemoryOutcome(
+            verifiedFields,
+            withWriteLocksRejection?.reason ?? 'validation rejected graph-scoped KA payload (permanent)',
+            false,
+            true,
+          );
       }
-      if (withWriteLocksRejection === 'cas') {
-        return rejectedSharedMemoryOutcome(
-          verifiedFields,
-          'CAS pre-conditions not met against current SWM state (transient: may apply after upstream writes converge)',
-          true,
-          true,
-        );
-      }
-      return rejectedSharedMemoryOutcome(
-        verifiedFields,
-        validationRejectionReason ?? 'validation rejected graph-scoped KA payload (permanent)',
-        false,
-        true,
-      );
     } catch (err) {
       // PR-C codex R3: classify the catch path as `retryable: true`.
       // The dominant production case here is `workspaceSenderKeyDecryptor`

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -37,9 +37,11 @@ import {
 } from './metadata.js';
 import { parseSimpleNQuads } from './publish-handler.js';
 import {
+  KnowledgeAssetWorkspaceHeadCorruptError,
   resolveKnowledgeAssetWorkspaceHead,
   storeKnowledgeAssetOperationPublicQuads,
   storeKnowledgeAssetWorkspaceHead,
+  type KnowledgeAssetWorkspaceHead,
 } from './workspace-resolution.js';
 import type { WorkspacePublicSnapshotStore } from './workspace-snapshot-store.js';
 import { workspacePublicQuadsDigest } from './workspace-snapshot-store.js';
@@ -1434,13 +1436,30 @@ export class SharedMemoryHandler {
         const incomingPrivateRootHex = privateMerkleRoot?.length
           ? ethers.hexlify(privateMerkleRoot).toLowerCase()
           : undefined;
-        const currentHead = await resolveKnowledgeAssetWorkspaceHead({
-          store: this.store,
-          graphManager: this.graphManager,
-          contextGraphId,
-          kaUal: contentScope.ual,
-          subGraphName,
-        });
+        // GH#2273 — the resolver fails closed on a multi-valued head (catch-up union
+        // residue). That corruption lives in OUR meta graph, so it must be a PERMANENT
+        // rejection: the outer catch classifies as `retryable: true`, and a retryable
+        // outcome would put the sender's substrate outbox into an infinite redelivery loop
+        // against local state identical bytes can never fix. The sync lane's
+        // identity-preserving repair is the sanctioned healer; this path deliberately
+        // forgoes its own delete-then-insert head rewrite, which would otherwise adopt
+        // whatever the inbound share claims over a head we cannot even read.
+        let currentHead: KnowledgeAssetWorkspaceHead | undefined;
+        try {
+          currentHead = await resolveKnowledgeAssetWorkspaceHead({
+            store: this.store,
+            graphManager: this.graphManager,
+            contextGraphId,
+            kaUal: contentScope.ual,
+            subGraphName,
+          });
+        } catch (err) {
+          if (!(err instanceof KnowledgeAssetWorkspaceHeadCorruptError)) throw err;
+          validationRejectionReason = `CORRUPT_SWM_HEAD: ${err.message}`;
+          this.log.warn(ctx, `SWM validation rejected: ${validationRejectionReason}`);
+          withWriteLocksRejection = 'validation';
+          return false;
+        }
         if (currentHead) {
           const incomingVersion = BigInt(contentScope.assertionVersion);
           const currentVersion = BigInt(currentHead.assertionVersion);

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -966,21 +966,19 @@ export class SharedMemoryHandler {
     // try, `withWriteLocks` returns false for TWO distinct
     // reasons — validation rejection (deterministic, payload
     // can never apply) and CAS-not-met (TRANSIENT when SWM
-    // writes arrive out of order). Hoisted here so the closure
-    // can signal which branch fired; the post-closure code maps
-    // the kind to retryability in ONE place. Kind and reason are
-    // one object set by one call, so no rejection path can set
-    // half its state and silently fall into the wrong branch.
-    let withWriteLocksRejection:
-      | { readonly kind: 'validation' | 'cas' | 'corrupt-head'; readonly reason?: string }
-      | undefined;
+    // writes arrive out of order). The locked closure RETURNS its
+    // decision as data — applied, or rejected with a kind — so the
+    // impossible state "returned false with no rejection kind" is
+    // unrepresentable, and the kind -> retryability policy is one
+    // switch after the lock.
+    type SwmWriteDecision =
+      | { readonly applied: true }
+      | { readonly applied: false; readonly kind: 'validation' | 'cas' | 'corrupt-head'; readonly reason?: string };
+    const swmWriteApplied: SwmWriteDecision = { applied: true };
     const rejectWithinLocks = (
       kind: 'validation' | 'cas' | 'corrupt-head',
       reason?: string,
-    ): false => {
-      withWriteLocksRejection = { kind, ...(reason === undefined ? {} : { reason }) };
-      return false;
-    };
+    ): SwmWriteDecision => ({ applied: false, kind, ...(reason === undefined ? {} : { reason }) });
     let verifiedLifecycleFields: SharedMemoryLifecycleFields | undefined;
     try {
       const { envelope, signedPayload } = decoded;
@@ -1381,7 +1379,7 @@ export class SharedMemoryHandler {
       const lockKeys = [swmKaWriteLockKey(contextGraphId, subGraphName, contentScope.ual)];
 
       onPhase?.('store', 'start');
-      const applied = await this.withWriteLocks(lockKeys, async (): Promise<boolean> => {
+      const decision = await this.withWriteLocks(lockKeys, async (): Promise<SwmWriteDecision> => {
         onPhase?.('validate', 'start');
         const validation = validateCanonicalGraphScopedKnowledgeAssetPayload(
           quads,
@@ -1489,7 +1487,7 @@ export class SharedMemoryHandler {
               // graph or immutable operation snapshot. Refresh the local-only
               // controls too, so a retry completes a prior head/sidecar tear.
               await persistLocallyTrustedControls();
-              return true;
+              return swmWriteApplied;
             }
             const reason =
               `CONFLICTING_KA_ASSERTION_VERSION: ${contentScope.ual} version ${incomingVersion} ` +
@@ -1600,11 +1598,11 @@ export class SharedMemoryHandler {
         // head has committed. Receipt recovery must fail closed without them.
         await persistLocallyTrustedControls();
 
-        return true;
+        return swmWriteApplied;
       });
 
       onPhase?.('store', 'end');
-      if (applied) {
+      if (decision.applied) {
         // PR-A R1: only record the observation after the apply actually
         // succeeded — passing allowlist + sub-graph validation + CAS +
         // the durable store insert. Recording earlier would let
@@ -1629,20 +1627,20 @@ export class SharedMemoryHandler {
         });
         return appliedSharedMemoryOutcome(verifiedFields, quads.length);
       }
-      // `applied === false` from the withWriteLocks closure. The kind ->
-      // outcome policy lives HERE, in one table adjacent to the channels:
-      // 'validation' is deterministic (retry produces the same outcome, so
-      // permanent); 'cas' is TRANSIENT (PR-C codex R4 — the missed upstream
-      // write might still arrive and make the condition pass); 'corrupt-head'
-      // is TRANSIENT for the same convergent-local-state reason (GH#2273 —
-      // sync repair collapses the multi-valued head, and the sender's
-      // budget-bounded outbox must keep the payload queued rather than record
-      // a terminal drop of a share that will apply once the head heals).
-      switch (withWriteLocksRejection?.kind) {
+      // Rejected by the locked closure. The kind -> outcome policy lives
+      // HERE, in one switch adjacent to the channel docs: 'validation' is
+      // deterministic (retry produces the same outcome, so permanent); 'cas'
+      // is TRANSIENT (PR-C codex R4 — the missed upstream write might still
+      // arrive and make the condition pass); 'corrupt-head' is TRANSIENT for
+      // the same convergent-local-state reason (GH#2273 — sync repair
+      // collapses the multi-valued head, and the sender's budget-bounded
+      // outbox must keep the payload queued rather than record a terminal
+      // drop of a share that will apply once the head heals).
+      switch (decision.kind) {
         case 'corrupt-head':
           return rejectedSharedMemoryOutcome(
             verifiedFields,
-            `${withWriteLocksRejection.reason ?? 'CORRUPT_SWM_HEAD'} (transient: may apply after sync repair converges the head)`,
+            `${decision.reason ?? 'CORRUPT_SWM_HEAD'} (transient: may apply after sync repair converges the head)`,
             true,
             true,
           );
@@ -1656,7 +1654,7 @@ export class SharedMemoryHandler {
         default:
           return rejectedSharedMemoryOutcome(
             verifiedFields,
-            withWriteLocksRejection?.reason ?? 'validation rejected graph-scoped KA payload (permanent)',
+            decision.reason ?? 'validation rejected graph-scoped KA payload (permanent)',
             false,
             true,
           );

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -969,7 +969,7 @@ export class SharedMemoryHandler {
     // writes arrive out of order). Hoisted here so the closure
     // can signal which branch fired; the post-closure code
     // maps `cas` → retryable and `validation` → permanent.
-    let withWriteLocksRejection: 'validation' | 'cas' | undefined;
+    let withWriteLocksRejection: 'validation' | 'cas' | 'corrupt-head' | undefined;
     let validationRejectionReason: string | undefined;
     let verifiedLifecycleFields: SharedMemoryLifecycleFields | undefined;
     try {
@@ -1435,13 +1435,14 @@ export class SharedMemoryHandler {
           ? ethers.hexlify(privateMerkleRoot).toLowerCase()
           : undefined;
         // GH#2273 — the resolver fails closed on a multi-valued head (catch-up union
-        // residue). That corruption lives in OUR meta graph, so it must be a PERMANENT
-        // rejection: the outer catch classifies as `retryable: true`, and a retryable
-        // outcome would put the sender's substrate outbox into an infinite redelivery loop
-        // against local state identical bytes can never fix. The sync lane's
-        // identity-preserving repair is the sanctioned healer; this path deliberately
-        // forgoes its own delete-then-insert head rewrite, which would otherwise adopt
-        // whatever the inbound share claims over a head we cannot even read.
+        // residue). The monotonicity gate cannot read such a head, so NOTHING is written
+        // (fail closed), and this path deliberately forgoes its own delete-then-insert
+        // head rewrite, which would otherwise adopt whatever the inbound share claims
+        // over a head we cannot even read. The rejection is TRANSIENT ('corrupt-head'
+        // channel below): the corruption is local state the sync lane's
+        // identity-preserving repair heals, so the sender's budget-bounded outbox must
+        // keep the payload queued — a permanent drop would lose a valid newer share
+        // that becomes applicable the moment the head converges.
         const headResolution = await tryResolveKnowledgeAssetWorkspaceHead({
           store: this.store,
           graphManager: this.graphManager,
@@ -1451,8 +1452,8 @@ export class SharedMemoryHandler {
         });
         if (headResolution.status === 'corrupt') {
           validationRejectionReason = `CORRUPT_SWM_HEAD: ${headResolution.error.message}`;
-          this.log.warn(ctx, `SWM validation rejected: ${validationRejectionReason}`);
-          withWriteLocksRejection = 'validation';
+          this.log.warn(ctx, `SWM share deferred: ${validationRejectionReason}`);
+          withWriteLocksRejection = 'corrupt-head';
           return false;
         }
         const currentHead = headResolution.status === 'resolved' ? headResolution.head : undefined;
@@ -1634,6 +1635,18 @@ export class SharedMemoryHandler {
       // condition would pass. Keep retrying so the sender's
       // outbox doesn't drop a payload that would apply after
       // out-of-order delivery converges.
+      // GH#2273 — same shape as the CAS case below: the blocking condition is
+      // LOCAL and convergent (sync repair collapses the multi-valued head), so
+      // the sender's outbox must keep retrying rather than record a terminal
+      // drop of a payload that will apply once the head heals.
+      if (withWriteLocksRejection === 'corrupt-head') {
+        return rejectedSharedMemoryOutcome(
+          verifiedFields,
+          `${validationRejectionReason ?? 'CORRUPT_SWM_HEAD'} (transient: may apply after sync repair converges the head)`,
+          true,
+          true,
+        );
+      }
       if (withWriteLocksRejection === 'cas') {
         return rejectedSharedMemoryOutcome(
           verifiedFields,

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -37,11 +37,9 @@ import {
 } from './metadata.js';
 import { parseSimpleNQuads } from './publish-handler.js';
 import {
-  isKnowledgeAssetWorkspaceHeadCorruptError,
-  resolveKnowledgeAssetWorkspaceHead,
   storeKnowledgeAssetOperationPublicQuads,
   storeKnowledgeAssetWorkspaceHead,
-  type KnowledgeAssetWorkspaceHead,
+  tryResolveKnowledgeAssetWorkspaceHead,
 } from './workspace-resolution.js';
 import type { WorkspacePublicSnapshotStore } from './workspace-snapshot-store.js';
 import { workspacePublicQuadsDigest } from './workspace-snapshot-store.js';
@@ -1444,22 +1442,20 @@ export class SharedMemoryHandler {
         // identity-preserving repair is the sanctioned healer; this path deliberately
         // forgoes its own delete-then-insert head rewrite, which would otherwise adopt
         // whatever the inbound share claims over a head we cannot even read.
-        let currentHead: KnowledgeAssetWorkspaceHead | undefined;
-        try {
-          currentHead = await resolveKnowledgeAssetWorkspaceHead({
-            store: this.store,
-            graphManager: this.graphManager,
-            contextGraphId,
-            kaUal: contentScope.ual,
-            subGraphName,
-          });
-        } catch (err) {
-          if (!isKnowledgeAssetWorkspaceHeadCorruptError(err)) throw err;
-          validationRejectionReason = `CORRUPT_SWM_HEAD: ${err instanceof Error ? err.message : String(err)}`;
+        const headResolution = await tryResolveKnowledgeAssetWorkspaceHead({
+          store: this.store,
+          graphManager: this.graphManager,
+          contextGraphId,
+          kaUal: contentScope.ual,
+          subGraphName,
+        });
+        if (headResolution.status === 'corrupt') {
+          validationRejectionReason = `CORRUPT_SWM_HEAD: ${headResolution.error.message}`;
           this.log.warn(ctx, `SWM validation rejected: ${validationRejectionReason}`);
           withWriteLocksRejection = 'validation';
           return false;
         }
+        const currentHead = headResolution.status === 'resolved' ? headResolution.head : undefined;
         if (currentHead) {
           const incomingVersion = BigInt(contentScope.assertionVersion);
           const currentVersion = BigInt(currentHead.assertionVersion);

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -142,6 +142,67 @@ export interface ResolveKnowledgeAssetWorkspaceHeadParams {
 }
 
 /**
+ * Distinct object values per predicate for one subject's rows — the resolver's
+ * one row-collection shape, shared by the head and operation phases so their
+ * cardinality handling cannot drift apart.
+ */
+function collectSubjectValues(
+  bindings: readonly Record<string, string | undefined>[],
+): Map<string, string[]> {
+  const values = new Map<string, string[]>();
+  for (const binding of bindings) {
+    const predicate = binding['p'] ?? '';
+    const object = binding['o'] ?? '';
+    const list = values.get(predicate) ?? [];
+    if (!list.includes(object)) list.push(object);
+    values.set(predicate, list);
+  }
+  return values;
+}
+
+/**
+ * Declared-cardinality accessors over one subject's collected values. Every
+ * singleton predicate goes through `required`/`optional` — a duplicate is the
+ * union-residue corruption class and fails closed with the offending values
+ * named. Set-valued (`allowedPeer`) and canonicalized (`publishedAt`)
+ * predicates are read from the map directly by the resolver, which owns those
+ * two declared exceptions.
+ */
+function makeSingletonReader(
+  values: Map<string, string[]>,
+  ual: string,
+  subjectNoun: 'head' | 'operation',
+): {
+  required: (predicate: string, label: string) => string;
+  optional: (predicate: string, label: string) => string | undefined;
+} {
+  const read = (predicate: string, label: string, required: boolean): string | undefined => {
+    const list = values.get(predicate);
+    if (!list || list.length === 0) {
+      if (!required) return undefined;
+      throw new KnowledgeAssetWorkspaceHeadCorruptError(
+        `Corrupt graph-scoped SWM head for ${ual}: incomplete head or operation metadata`,
+      );
+    }
+    if (list.length > 1) {
+      const rendered = list
+        .map((value) => stripLiteral(value)?.trim())
+        .filter((value): value is string => Boolean(value))
+        .sort();
+      throw new KnowledgeAssetWorkspaceHeadCorruptError(
+        `Corrupt graph-scoped SWM head for ${ual}: ${subjectNoun} carries ` +
+        `${list.length} ${label} values (${rendered.join(', ')})`,
+      );
+    }
+    return list[0];
+  };
+  return {
+    required: (predicate, label) => read(predicate, label, true)!,
+    optional: (predicate, label) => read(predicate, label, false),
+  };
+}
+
+/**
  * Resolve the latest complete graph-scoped assertion accepted into SWM.
  * Missing means this node has not accepted this KA yet; malformed rows fail
  * closed so a corrupt head cannot allow an older assertion to overwrite data.
@@ -178,33 +239,9 @@ export async function resolveKnowledgeAssetWorkspaceHead(
     );
   }
   if (headResult.bindings.length === 0) return undefined;
-  const headValues = new Map<string, string[]>();
-  for (const binding of headResult.bindings) {
-    const predicate = binding['p'] ?? '';
-    const object = binding['o'] ?? '';
-    const values = headValues.get(predicate) ?? [];
-    if (!values.includes(object)) values.push(object);
-    headValues.set(predicate, values);
-  }
-  const requiredHeadValue = (predicate: string, label: string): string => {
-    const values = headValues.get(predicate);
-    if (!values || values.length === 0) {
-      throw new KnowledgeAssetWorkspaceHeadCorruptError(
-        `Corrupt graph-scoped SWM head for ${scope.ual}: incomplete head or operation metadata`,
-      );
-    }
-    if (values.length > 1) {
-      const rendered = values
-        .map((value) => stripLiteral(value)?.trim())
-        .filter((value): value is string => Boolean(value))
-        .sort();
-      throw new KnowledgeAssetWorkspaceHeadCorruptError(
-        `Corrupt graph-scoped SWM head for ${scope.ual}: head carries ` +
-        `${values.length} ${label} values (${rendered.join(', ')})`,
-      );
-    }
-    return values[0]!;
-  };
+  const headValues = collectSubjectValues(headResult.bindings);
+  const head = makeSingletonReader(headValues, scope.ual, 'head');
+  const requiredHeadValue = head.required;
   if (parseIntegerLiteral(requiredHeadValue(`${DKG}contentScopeVersion`, 'contentScopeVersion'))
     !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
     throw new KnowledgeAssetWorkspaceHeadCorruptError(
@@ -274,34 +311,13 @@ export async function resolveKnowledgeAssetWorkspaceHead(
       `Unexpected graph-scoped SWM operation query result for ${scope.ual}: ${operationResult.type}`,
     );
   }
-  const operationValues = new Map<string, string[]>();
-  for (const binding of operationResult.bindings) {
-    const predicate = binding['p'] ?? '';
-    const object = binding['o'] ?? '';
-    const values = operationValues.get(predicate) ?? [];
-    if (!values.includes(object)) values.push(object);
-    operationValues.set(predicate, values);
-  }
+  const operationValues = collectSubjectValues(operationResult.bindings);
+  const operation = makeSingletonReader(operationValues, scope.ual, 'operation');
   const singletonOperationValue = (
     predicate: string,
     label: string,
     required: boolean,
-  ): string | undefined => {
-    const values = operationValues.get(predicate);
-    if (!values || values.length === 0) {
-      if (!required) return undefined;
-      throw new KnowledgeAssetWorkspaceHeadCorruptError(
-        `Corrupt graph-scoped SWM head for ${scope.ual}: incomplete head or operation metadata`,
-      );
-    }
-    if (values.length > 1) {
-      throw new KnowledgeAssetWorkspaceHeadCorruptError(
-        `Corrupt graph-scoped SWM head for ${scope.ual}: operation carries ` +
-        `${values.length} ${label} values`,
-      );
-    }
-    return values[0];
-  };
+  ): string | undefined => (required ? operation.required(predicate, label) : operation.optional(predicate, label));
   // Id echo — the operation must itself carry the head's id (mirrors the
   // previous join). Multiple id rows on the operation subject were tolerated
   // by the join (only the matching one bound) and remain tolerated here.

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -134,19 +134,17 @@ export async function tryResolveKnowledgeAssetWorkspaceHead(
     const head = await resolveKnowledgeAssetWorkspaceHead(params);
     return head === undefined ? { status: 'missing' } : { status: 'resolved', head };
   } catch (error) {
-    // Same recognition rule as the boolean predicate — the resolver itself only
-    // throws the local class, but a store decorator or wrapper that preserved
-    // `.code` while losing class identity must land on the SAME corrupt path in
-    // both APIs, coerced into the concrete class the result type promises.
-    if (isKnowledgeAssetWorkspaceHeadCorruptError(error)) {
-      return {
-        status: 'corrupt',
-        error: error instanceof KnowledgeAssetWorkspaceHeadCorruptError
-          ? error
-          : new KnowledgeAssetWorkspaceHeadCorruptError(
-            error instanceof Error ? error.message : String(error),
-          ),
-      };
+    // instanceof ONLY, deliberately narrower than the exported boundary
+    // predicate: within this module the resolver is the sole authority on
+    // corruption and always throws the concrete class, so anything else —
+    // including a lower storage layer that happens to throw a code-colliding
+    // error before the resolver ever inspected head rows — is a STORE failure
+    // and must keep propagating as one. The loose code-based predicate exists
+    // for boundaries the error crosses AFTER propagation, where class identity
+    // can be lost; no such boundary sits between the resolver and this
+    // wrapper.
+    if (error instanceof KnowledgeAssetWorkspaceHeadCorruptError) {
+      return { status: 'corrupt', error };
     }
     throw error;
   }
@@ -258,6 +256,28 @@ export async function resolveKnowledgeAssetWorkspaceHead(
     subGraphName,
   );
   const subject = workspaceKnowledgeAssetHeadSubject(scope.ual);
+  // ONE query acquires every row the resolver will normalize — the head
+  // subject's own rows plus the rows of every operation subject the head
+  // references — so both phases below read one store snapshot and no head
+  // swap between two reads can interleave a stale id with fresh metadata.
+  const acquisition = await params.store.query(
+    `SELECT ?s ?p ?o WHERE { GRAPH <${assertSafeIri(metaGraph)}> { ` +
+    `{ <${assertSafeIri(subject)}> ?p ?o . BIND(<${assertSafeIri(subject)}> AS ?s) } UNION ` +
+    `{ <${assertSafeIri(subject)}> <${DKG}shareOperationId> ?id . ` +
+    `?op <${DKG}shareOperationId> ?id ; ?p ?o . BIND(?op AS ?s) } } }`,
+  );
+  if (acquisition.type !== 'bindings') {
+    throw new Error(
+      `Unexpected graph-scoped SWM head query result for ${scope.ual}: ${acquisition.type}`,
+    );
+  }
+  const rowsBySubject = new Map<string, { p?: string; o?: string }[]>();
+  for (const binding of acquisition.bindings) {
+    const rowSubject = binding['s'] ?? '';
+    const rows = rowsBySubject.get(rowSubject) ?? [];
+    rows.push({ p: binding['p'], o: binding['o'] });
+    rowsBySubject.set(rowSubject, rows);
+  }
   // Phase 1 — the head subject's OWN rows. GH#2273: sync's bulk verified-meta
   // write is a bare set-union with no per-subject delete, so a peer's head row
   // for the same KA can land BESIDE the local one; a joined LIMIT-1 read over
@@ -270,17 +290,9 @@ export async function resolveKnowledgeAssetWorkspaceHead(
   // subject (two cores ACKing the same content stamp their own clocks onto
   // the same deterministic operation subject) stay healthy — they never touch
   // the head subject this phase inspects.
-  const headResult = await params.store.query(
-    `SELECT ?p ?o WHERE { GRAPH <${assertSafeIri(metaGraph)}> { ` +
-    `<${assertSafeIri(subject)}> ?p ?o } }`,
-  );
-  if (headResult.type !== 'bindings') {
-    throw new Error(
-      `Unexpected graph-scoped SWM head query result for ${scope.ual}: ${headResult.type}`,
-    );
-  }
-  if (headResult.bindings.length === 0) return undefined;
-  const headValues = collectSubjectValues(headResult.bindings);
+  const headBindings = rowsBySubject.get(subject) ?? [];
+  if (headBindings.length === 0) return undefined;
+  const headValues = collectSubjectValues(headBindings);
   const head = makeSingletonReader(headValues, scope.ual, 'head');
   const requiredHeadValue = head.required;
   if (parseIntegerLiteral(requiredHeadValue(`${DKG}contentScopeVersion`, 'contentScopeVersion'))
@@ -343,16 +355,7 @@ export async function resolveKnowledgeAssetWorkspaceHead(
   // stamp their own clocks onto the same deterministic operation subject —
   // and canonicalizes to the EARLIEST stamp, which stays stable when a later
   // union adds more re-stamps (this timestamp orders RFC64 inventory).
-  const operationResult = await params.store.query(
-    `SELECT ?p ?o WHERE { GRAPH <${assertSafeIri(metaGraph)}> { ` +
-    `<${assertSafeIri(operationSubject)}> ?p ?o } }`,
-  );
-  if (operationResult.type !== 'bindings') {
-    throw new Error(
-      `Unexpected graph-scoped SWM operation query result for ${scope.ual}: ${operationResult.type}`,
-    );
-  }
-  const operationValues = collectSubjectValues(operationResult.bindings);
+  const operationValues = collectSubjectValues(rowsBySubject.get(operationSubject) ?? []);
   const operation = makeSingletonReader(operationValues, scope.ual, 'operation');
   // Id echo — the operation must itself carry the head's id (mirrors the
   // previous join). Multiple id rows on the operation subject were tolerated

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -241,6 +241,184 @@ function makeSingletonReader(
   };
 }
 
+/** Everything the head subject's rows certify, decoded and validated. */
+interface DecodedWorkspaceHead {
+  readonly scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
+  readonly assertionGraph: string;
+  readonly shareOperationId: string;
+  readonly operationSubject: string;
+}
+
+/**
+ * Focused decoder for the HEAD subject's rows. Every head predicate is a
+ * fail-closed singleton (`makeSingletonReader`); the decoded fields are
+ * validated against the expected scope so a mismatched UAL, scope version or
+ * derived assertion graph is corruption, never a silently different KA.
+ */
+function decodeWorkspaceHeadRows(input: {
+  readonly headValues: Map<string, string[]>;
+  readonly expectedUal: string;
+  readonly contextGraphId: string;
+  readonly subGraphName: string | undefined;
+}): DecodedWorkspaceHead {
+  const head = makeSingletonReader(input.headValues, input.expectedUal, 'head');
+  if (parseIntegerLiteral(head.required(`${DKG}contentScopeVersion`, 'contentScopeVersion'))
+    !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+    throw new KnowledgeAssetWorkspaceHeadCorruptError(
+      `Corrupt graph-scoped SWM head for ${input.expectedUal}: invalid scope version`,
+    );
+  }
+  const actualUal = head.required(`${DKG}kaUal`, 'kaUal');
+  let scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
+  try {
+    scope = createGraphKnowledgeAssetScope(
+      actualUal ?? '',
+      parsePositiveBigIntLiteral(head.required(`${DKG}assertionVersion`, 'assertionVersion')),
+    );
+  } catch (error) {
+    if (error instanceof KnowledgeAssetWorkspaceHeadCorruptError) throw error;
+    throw new KnowledgeAssetWorkspaceHeadCorruptError(
+      `Corrupt graph-scoped SWM head for ${input.expectedUal}: invalid assertion identity ` +
+      `(${error instanceof Error ? error.message : String(error)})`,
+    );
+  }
+  if (scope.ual !== input.expectedUal) {
+    throw new KnowledgeAssetWorkspaceHeadCorruptError(
+      `Corrupt graph-scoped SWM head for ${input.expectedUal}: UAL mismatch`,
+    );
+  }
+  const assertionGraph = head.required(`${DKG}assertionGraph`, 'assertionGraph');
+  const expectedGraph = knowledgeAssetLayerGraphUri(
+    input.contextGraphId,
+    MemoryLayer.SharedWorkingMemory,
+    scope,
+    input.subGraphName,
+  );
+  if (assertionGraph !== expectedGraph) {
+    throw new KnowledgeAssetWorkspaceHeadCorruptError(
+      `Corrupt graph-scoped SWM head for ${input.expectedUal}: assertion graph mismatch`,
+    );
+  }
+  const shareOperationId = stripLiteral(head.required(`${DKG}shareOperationId`, 'shareOperationId'))?.trim() ?? '';
+  if (!shareOperationId) {
+    throw new KnowledgeAssetWorkspaceHeadCorruptError(
+      `Corrupt graph-scoped SWM head for ${input.expectedUal}: incomplete head or operation metadata`,
+    );
+  }
+  let operationSubject = '';
+  try {
+    operationSubject = workspaceOperationSubject(input.contextGraphId, shareOperationId);
+  } catch (error) {
+    throw new KnowledgeAssetWorkspaceHeadCorruptError(
+      `Corrupt graph-scoped SWM head for ${input.expectedUal}: invalid share operation ` +
+      `(${error instanceof Error ? error.message : String(error)})`,
+    );
+  }
+  return { scope, assertionGraph, shareOperationId, operationSubject };
+}
+
+/** The operation subject's commitment + access envelope, decoded and validated. */
+interface DecodedWorkspaceOperation {
+  readonly publicQuadsDigest: string;
+  readonly publicTripleCount: number;
+  readonly privateMerkleRoot: string | undefined;
+  readonly privateTripleCount: number;
+  readonly publisherPeerId: string;
+  readonly publishedAtMs: number | undefined;
+  readonly accessPolicy: 'public' | 'ownerOnly' | 'allowList' | undefined;
+  readonly allowedPeers: string[];
+}
+
+/**
+ * Focused decoder for the OPERATION subject's rows. The cardinality model is
+ * exactly three rules: commitment/envelope predicates are fail-closed
+ * singletons; `allowedPeer` is set-valued; `publishedAt` tolerates duplicates
+ * (two cores ACKing the same content stamp their own clocks onto the same
+ * deterministic operation subject) and canonicalizes to the EARLIEST stamp,
+ * which stays stable when a later union adds more re-stamps (this timestamp
+ * orders RFC64 inventory). The operation must echo the head's id (mirrors the
+ * pre-refactor join); extra id rows on the operation stay tolerated.
+ */
+function decodeWorkspaceOperationRows(input: {
+  readonly operationValues: Map<string, string[]>;
+  readonly scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
+  readonly shareOperationId: string;
+}): DecodedWorkspaceOperation {
+  const ual = input.scope.ual;
+  const operation = makeSingletonReader(input.operationValues, ual, 'operation');
+  const echoedIds = (input.operationValues.get(`${DKG}shareOperationId`) ?? [])
+    .map((value) => stripLiteral(value)?.trim());
+  if (!echoedIds.includes(input.shareOperationId)) {
+    throw new KnowledgeAssetWorkspaceHeadCorruptError(
+      `Corrupt graph-scoped SWM head for ${ual}: incomplete head or operation metadata`,
+    );
+  }
+  const publicQuadsDigest = stripLiteral(operation.required(`${DKG}publicQuadsDigest`, 'publicQuadsDigest'))?.trim() ?? '';
+  const publicTripleCount = parseIntegerLiteral(operation.required(`${DKG}publicQuadsCount`, 'publicQuadsCount'));
+  const privateTripleCount = parseIntegerLiteral(operation.required(`${DKG}privateTripleCount`, 'privateTripleCount'));
+  const publisherPeerId = stripLiteral(operation.required(`${DKG}publisherPeerId`, 'publisherPeerId'))?.trim() ?? '';
+  const operationUal = operation.required(`${DKG}kaUal`, 'kaUal') ?? '';
+  const privateMerkleRoot = stripLiteral(operation.optional(`${DKG}privateMerkleRoot`, 'privateMerkleRoot'))?.trim();
+  const rawAccessPolicy = stripLiteral(operation.optional(`${DKG}accessPolicy`, 'accessPolicy'))?.trim();
+  const accessPolicy = rawAccessPolicy === 'public'
+    || rawAccessPolicy === 'ownerOnly'
+    || rawAccessPolicy === 'allowList'
+    ? rawAccessPolicy
+    : undefined;
+  const publishedAtStamps = (input.operationValues.get(`${DKG}publishedAt`) ?? [])
+    .map((value) => Date.parse(stripLiteral(value)?.trim() ?? ''));
+  const publishedAtMs = publishedAtStamps.length === 0
+    ? undefined
+    : publishedAtStamps.reduce((min, ms) => Math.min(min, ms), Number.POSITIVE_INFINITY);
+  let operationVersion: bigint;
+  try {
+    operationVersion = parsePositiveBigIntLiteral(operation.required(`${DKG}assertionVersion`, 'assertionVersion'));
+  } catch (error) {
+    if (error instanceof KnowledgeAssetWorkspaceHeadCorruptError) throw error;
+    throw new KnowledgeAssetWorkspaceHeadCorruptError(
+      `Corrupt graph-scoped SWM head for ${ual}: invalid operation version ` +
+      `(${error instanceof Error ? error.message : String(error)})`,
+    );
+  }
+  if (
+    !publicQuadsDigest ||
+    !Number.isSafeInteger(publicTripleCount) || publicTripleCount < 0 ||
+    !Number.isSafeInteger(privateTripleCount) || privateTripleCount < 0 ||
+    !publisherPeerId ||
+    publishedAtStamps.some((ms) => !Number.isSafeInteger(ms) || ms < 0) ||
+    operationUal !== ual ||
+    operationVersion.toString() !== input.scope.assertionVersion ||
+    (privateTripleCount > 0 && !/^0x[0-9a-f]{64}$/i.test(privateMerkleRoot ?? '')) ||
+    (privateTripleCount === 0 && privateMerkleRoot !== undefined)
+    || (rawAccessPolicy !== undefined && accessPolicy === undefined)
+  ) {
+    throw new KnowledgeAssetWorkspaceHeadCorruptError(
+      `Corrupt graph-scoped SWM head for ${ual}: incomplete commitment metadata`,
+    );
+  }
+  const allowedPeers = [...new Set((input.operationValues.get(`${DKG}allowedPeer`) ?? [])
+    .map((value) => stripLiteral(value)?.trim())
+    .filter((peer): peer is string => Boolean(peer)))];
+  if (
+    (accessPolicy === 'allowList' && allowedPeers.length === 0)
+    || (accessPolicy !== 'allowList' && allowedPeers.length > 0)
+  ) {
+    throw new KnowledgeAssetWorkspaceHeadCorruptError(
+      `Corrupt graph-scoped SWM head for ${ual}: invalid access envelope`,
+    );
+  }
+  return {
+    publicQuadsDigest,
+    publicTripleCount,
+    privateMerkleRoot,
+    privateTripleCount,
+    publisherPeerId,
+    publishedAtMs,
+    accessPolicy,
+    allowedPeers,
+  };
+}
+
 /**
  * Resolve the latest complete graph-scoped assertion accepted into SWM.
  * Missing means this node has not accepted this KA yet; malformed rows fail
@@ -292,154 +470,37 @@ export async function resolveKnowledgeAssetWorkspaceHead(
   // the head subject this phase inspects.
   const headBindings = rowsBySubject.get(subject) ?? [];
   if (headBindings.length === 0) return undefined;
-  const headValues = collectSubjectValues(headBindings);
-  const head = makeSingletonReader(headValues, scope.ual, 'head');
-  const requiredHeadValue = head.required;
-  if (parseIntegerLiteral(requiredHeadValue(`${DKG}contentScopeVersion`, 'contentScopeVersion'))
-    !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
-    throw new KnowledgeAssetWorkspaceHeadCorruptError(
-      `Corrupt graph-scoped SWM head for ${scope.ual}: invalid scope version`,
-    );
-  }
-  const actualUal = requiredHeadValue(`${DKG}kaUal`, 'kaUal');
-  let assertionVersion: bigint;
-  let actualScope: ReturnType<typeof createGraphKnowledgeAssetScope>;
-  try {
-    assertionVersion = parsePositiveBigIntLiteral(requiredHeadValue(`${DKG}assertionVersion`, 'assertionVersion'));
-    actualScope = createGraphKnowledgeAssetScope(actualUal ?? '', assertionVersion);
-  } catch (error) {
-    if (error instanceof KnowledgeAssetWorkspaceHeadCorruptError) throw error;
-    throw new KnowledgeAssetWorkspaceHeadCorruptError(
-      `Corrupt graph-scoped SWM head for ${scope.ual}: invalid assertion identity ` +
-      `(${error instanceof Error ? error.message : String(error)})`,
-    );
-  }
-  if (actualScope.ual !== scope.ual) {
-    throw new KnowledgeAssetWorkspaceHeadCorruptError(
-      `Corrupt graph-scoped SWM head for ${scope.ual}: UAL mismatch`,
-    );
-  }
-  const assertionGraph = requiredHeadValue(`${DKG}assertionGraph`, 'assertionGraph');
-  const expectedGraph = knowledgeAssetLayerGraphUri(
-    params.contextGraphId,
-    MemoryLayer.SharedWorkingMemory,
-    actualScope,
+  // Phase 1 — decode + validate the head subject's rows (fail-closed
+  // singletons; GH#2273: a multi-valued shareOperationId is the sync
+  // union-insert residue that previously made LIMIT-1 readers arbitrary).
+  const decodedHead = decodeWorkspaceHeadRows({
+    headValues: collectSubjectValues(headBindings),
+    expectedUal: scope.ual,
+    contextGraphId: params.contextGraphId,
     subGraphName,
-  );
-  if (assertionGraph !== expectedGraph) {
-    throw new KnowledgeAssetWorkspaceHeadCorruptError(
-      `Corrupt graph-scoped SWM head for ${scope.ual}: assertion graph mismatch`,
-    );
-  }
-  const shareOperationId = stripLiteral(requiredHeadValue(`${DKG}shareOperationId`, 'shareOperationId'))?.trim() ?? '';
-  if (!shareOperationId) {
-    throw new KnowledgeAssetWorkspaceHeadCorruptError(
-      `Corrupt graph-scoped SWM head for ${scope.ual}: incomplete head or operation metadata`,
-    );
-  }
-  let operationSubject = '';
-  try {
-    operationSubject = workspaceOperationSubject(params.contextGraphId, shareOperationId);
-  } catch (error) {
-    throw new KnowledgeAssetWorkspaceHeadCorruptError(
-      `Corrupt graph-scoped SWM head for ${scope.ual}: invalid share operation ` +
-      `(${error instanceof Error ? error.message : String(error)})`,
-    );
-  }
-
-  // Phase 2 — the single validated operation, read as its OWN rows and
-  // normalized under DECLARED cardinality rules (no LIMIT-1 first-binding
-  // policy anywhere in the resolver): every commitment/envelope predicate must
-  // carry exactly one distinct value; `allowedPeer` is set-valued by design;
-  // `publishedAt` tolerates duplicates — two cores ACKing the same content
-  // stamp their own clocks onto the same deterministic operation subject —
-  // and canonicalizes to the EARLIEST stamp, which stays stable when a later
-  // union adds more re-stamps (this timestamp orders RFC64 inventory).
-  const operationValues = collectSubjectValues(rowsBySubject.get(operationSubject) ?? []);
-  const operation = makeSingletonReader(operationValues, scope.ual, 'operation');
-  // Id echo — the operation must itself carry the head's id (mirrors the
-  // previous join). Multiple id rows on the operation subject were tolerated
-  // by the join (only the matching one bound) and remain tolerated here.
-  const echoedIds = (operationValues.get(`${DKG}shareOperationId`) ?? [])
-    .map((value) => stripLiteral(value)?.trim());
-  if (!echoedIds.includes(shareOperationId)) {
-    throw new KnowledgeAssetWorkspaceHeadCorruptError(
-      `Corrupt graph-scoped SWM head for ${scope.ual}: incomplete head or operation metadata`,
-    );
-  }
-  const publicQuadsDigest = stripLiteral(operation.required(`${DKG}publicQuadsDigest`, 'publicQuadsDigest'))?.trim() ?? '';
-  const publicTripleCount = parseIntegerLiteral(operation.required(`${DKG}publicQuadsCount`, 'publicQuadsCount'));
-  const privateTripleCount = parseIntegerLiteral(operation.required(`${DKG}privateTripleCount`, 'privateTripleCount'));
-  const publisherPeerId = stripLiteral(operation.required(`${DKG}publisherPeerId`, 'publisherPeerId'))?.trim() ?? '';
-  const operationUal = operation.required(`${DKG}kaUal`, 'kaUal') ?? '';
-  const privateMerkleRoot = stripLiteral(operation.optional(`${DKG}privateMerkleRoot`, 'privateMerkleRoot'))?.trim();
-  const rawAccessPolicy = stripLiteral(operation.optional(`${DKG}accessPolicy`, 'accessPolicy'))?.trim();
-  const accessPolicy = rawAccessPolicy === 'public'
-    || rawAccessPolicy === 'ownerOnly'
-    || rawAccessPolicy === 'allowList'
-    ? rawAccessPolicy
-    : undefined;
-  const publishedAtStamps = (operationValues.get(`${DKG}publishedAt`) ?? [])
-    .map((value) => {
-      const lexical = stripLiteral(value)?.trim() ?? '';
-      return { lexical, ms: Date.parse(lexical) };
-    });
-  const publishedAtMs = publishedAtStamps.length === 0
-    ? undefined
-    : publishedAtStamps.reduce((min, stamp) => Math.min(min, stamp.ms), Number.POSITIVE_INFINITY);
-  let operationVersion: bigint;
-  try {
-    operationVersion = parsePositiveBigIntLiteral(operation.required(`${DKG}assertionVersion`, 'assertionVersion'));
-  } catch (error) {
-    if (error instanceof KnowledgeAssetWorkspaceHeadCorruptError) throw error;
-    throw new KnowledgeAssetWorkspaceHeadCorruptError(
-      `Corrupt graph-scoped SWM head for ${scope.ual}: invalid operation version ` +
-      `(${error instanceof Error ? error.message : String(error)})`,
-    );
-  }
-  if (
-    !publicQuadsDigest ||
-    !Number.isSafeInteger(publicTripleCount) || publicTripleCount < 0 ||
-    !Number.isSafeInteger(privateTripleCount) || privateTripleCount < 0 ||
-    !publisherPeerId ||
-    publishedAtStamps.some((stamp) => !Number.isSafeInteger(stamp.ms) || stamp.ms < 0) ||
-    operationUal !== actualScope.ual ||
-    operationVersion.toString() !== actualScope.assertionVersion ||
-    (privateTripleCount > 0 && !/^0x[0-9a-f]{64}$/i.test(privateMerkleRoot ?? '')) ||
-    (privateTripleCount === 0 && privateMerkleRoot !== undefined)
-    || (rawAccessPolicy !== undefined && accessPolicy === undefined)
-  ) {
-    throw new KnowledgeAssetWorkspaceHeadCorruptError(
-      `Corrupt graph-scoped SWM head for ${scope.ual}: incomplete commitment metadata`,
-    );
-  }
-
-  const allowedPeers = [...new Set((operationValues.get(`${DKG}allowedPeer`) ?? [])
-    .map((value) => stripLiteral(value)?.trim())
-    .filter((peer): peer is string => Boolean(peer)))];
-  if (
-    (accessPolicy === 'allowList' && allowedPeers.length === 0)
-    || (accessPolicy !== 'allowList' && allowedPeers.length > 0)
-  ) {
-    throw new KnowledgeAssetWorkspaceHeadCorruptError(
-      `Corrupt graph-scoped SWM head for ${scope.ual}: invalid access envelope`,
-    );
-  }
+  });
+  // Phase 2 — decode + validate the single referenced operation's rows from
+  // the same acquisition snapshot.
+  const decodedOperation = decodeWorkspaceOperationRows({
+    operationValues: collectSubjectValues(rowsBySubject.get(decodedHead.operationSubject) ?? []),
+    scope: decodedHead.scope,
+    shareOperationId: decodedHead.shareOperationId,
+  });
   return {
-    kaUal: actualScope.ual,
-    assertionVersion: actualScope.assertionVersion,
-    assertionGraph,
-    publicQuadsDigest,
-    publicTripleCount,
-    privateMerkleRoot,
-    privateTripleCount,
-    shareOperationId,
-    ...(publishedAtMs === undefined
+    kaUal: decodedHead.scope.ual,
+    assertionVersion: decodedHead.scope.assertionVersion,
+    assertionGraph: decodedHead.assertionGraph,
+    publicQuadsDigest: decodedOperation.publicQuadsDigest,
+    publicTripleCount: decodedOperation.publicTripleCount,
+    privateMerkleRoot: decodedOperation.privateMerkleRoot,
+    privateTripleCount: decodedOperation.privateTripleCount,
+    shareOperationId: decodedHead.shareOperationId,
+    ...(decodedOperation.publishedAtMs === undefined
       ? {}
-      : { publishedAt: publishedAtMs.toString() as TimestampMsV1 }),
-    publisherPeerId,
-    ...(accessPolicy ? { accessPolicy } : {}),
-    allowedPeers,
+      : { publishedAt: decodedOperation.publishedAtMs.toString() as TimestampMsV1 }),
+    publisherPeerId: decodedOperation.publisherPeerId,
+    ...(decodedOperation.accessPolicy ? { accessPolicy: decodedOperation.accessPolicy } : {}),
+    allowedPeers: decodedOperation.allowedPeers,
   };
 }
 

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -134,8 +134,19 @@ export async function tryResolveKnowledgeAssetWorkspaceHead(
     const head = await resolveKnowledgeAssetWorkspaceHead(params);
     return head === undefined ? { status: 'missing' } : { status: 'resolved', head };
   } catch (error) {
-    if (error instanceof KnowledgeAssetWorkspaceHeadCorruptError) {
-      return { status: 'corrupt', error };
+    // Same recognition rule as the boolean predicate — the resolver itself only
+    // throws the local class, but a store decorator or wrapper that preserved
+    // `.code` while losing class identity must land on the SAME corrupt path in
+    // both APIs, coerced into the concrete class the result type promises.
+    if (isKnowledgeAssetWorkspaceHeadCorruptError(error)) {
+      return {
+        status: 'corrupt',
+        error: error instanceof KnowledgeAssetWorkspaceHeadCorruptError
+          ? error
+          : new KnowledgeAssetWorkspaceHeadCorruptError(
+            error instanceof Error ? error.message : String(error),
+          ),
+      };
     }
     throw error;
   }
@@ -343,11 +354,6 @@ export async function resolveKnowledgeAssetWorkspaceHead(
   }
   const operationValues = collectSubjectValues(operationResult.bindings);
   const operation = makeSingletonReader(operationValues, scope.ual, 'operation');
-  const singletonOperationValue = (
-    predicate: string,
-    label: string,
-    required: boolean,
-  ): string | undefined => (required ? operation.required(predicate, label) : operation.optional(predicate, label));
   // Id echo — the operation must itself carry the head's id (mirrors the
   // previous join). Multiple id rows on the operation subject were tolerated
   // by the join (only the matching one bound) and remain tolerated here.
@@ -358,13 +364,13 @@ export async function resolveKnowledgeAssetWorkspaceHead(
       `Corrupt graph-scoped SWM head for ${scope.ual}: incomplete head or operation metadata`,
     );
   }
-  const publicQuadsDigest = stripLiteral(singletonOperationValue(`${DKG}publicQuadsDigest`, 'publicQuadsDigest', true))?.trim() ?? '';
-  const publicTripleCount = parseIntegerLiteral(singletonOperationValue(`${DKG}publicQuadsCount`, 'publicQuadsCount', true));
-  const privateTripleCount = parseIntegerLiteral(singletonOperationValue(`${DKG}privateTripleCount`, 'privateTripleCount', true));
-  const publisherPeerId = stripLiteral(singletonOperationValue(`${DKG}publisherPeerId`, 'publisherPeerId', true))?.trim() ?? '';
-  const operationUal = singletonOperationValue(`${DKG}kaUal`, 'kaUal', true) ?? '';
-  const privateMerkleRoot = stripLiteral(singletonOperationValue(`${DKG}privateMerkleRoot`, 'privateMerkleRoot', false))?.trim();
-  const rawAccessPolicy = stripLiteral(singletonOperationValue(`${DKG}accessPolicy`, 'accessPolicy', false))?.trim();
+  const publicQuadsDigest = stripLiteral(operation.required(`${DKG}publicQuadsDigest`, 'publicQuadsDigest'))?.trim() ?? '';
+  const publicTripleCount = parseIntegerLiteral(operation.required(`${DKG}publicQuadsCount`, 'publicQuadsCount'));
+  const privateTripleCount = parseIntegerLiteral(operation.required(`${DKG}privateTripleCount`, 'privateTripleCount'));
+  const publisherPeerId = stripLiteral(operation.required(`${DKG}publisherPeerId`, 'publisherPeerId'))?.trim() ?? '';
+  const operationUal = operation.required(`${DKG}kaUal`, 'kaUal') ?? '';
+  const privateMerkleRoot = stripLiteral(operation.optional(`${DKG}privateMerkleRoot`, 'privateMerkleRoot'))?.trim();
+  const rawAccessPolicy = stripLiteral(operation.optional(`${DKG}accessPolicy`, 'accessPolicy'))?.trim();
   const accessPolicy = rawAccessPolicy === 'public'
     || rawAccessPolicy === 'ownerOnly'
     || rawAccessPolicy === 'allowList'
@@ -380,7 +386,7 @@ export async function resolveKnowledgeAssetWorkspaceHead(
     : publishedAtStamps.reduce((min, stamp) => Math.min(min, stamp.ms), Number.POSITIVE_INFINITY);
   let operationVersion: bigint;
   try {
-    operationVersion = parsePositiveBigIntLiteral(singletonOperationValue(`${DKG}assertionVersion`, 'assertionVersion', true));
+    operationVersion = parsePositiveBigIntLiteral(operation.required(`${DKG}assertionVersion`, 'assertionVersion'));
   } catch (error) {
     if (error instanceof KnowledgeAssetWorkspaceHeadCorruptError) throw error;
     throw new KnowledgeAssetWorkspaceHeadCorruptError(

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -111,6 +111,36 @@ export function isKnowledgeAssetWorkspaceHeadCorruptError(
   }
 }
 
+/**
+ * Typed outcome boundary over `resolveKnowledgeAssetWorkspaceHead` for callers
+ * whose local POLICY on corruption differs (discard archives, gossip receive
+ * permanently rejects) — they switch on the result instead of each hand-rolling
+ * a try/catch + flag around the thrown resolver error. Non-corrupt errors
+ * (store failures etc.) still throw. Callers that consume the error AFTER
+ * cross-package propagation (the async classifier, the daemon route) stay on
+ * the thrown-error path deliberately: the throw is the carrier across those
+ * boundaries and `isKnowledgeAssetWorkspaceHeadCorruptError` is their
+ * recognition point.
+ */
+export type KnowledgeAssetWorkspaceHeadResolution =
+  | { readonly status: 'missing' }
+  | { readonly status: 'resolved'; readonly head: KnowledgeAssetWorkspaceHead }
+  | { readonly status: 'corrupt'; readonly error: KnowledgeAssetWorkspaceHeadCorruptError };
+
+export async function tryResolveKnowledgeAssetWorkspaceHead(
+  params: ResolveKnowledgeAssetWorkspaceHeadParams,
+): Promise<KnowledgeAssetWorkspaceHeadResolution> {
+  try {
+    const head = await resolveKnowledgeAssetWorkspaceHead(params);
+    return head === undefined ? { status: 'missing' } : { status: 'resolved', head };
+  } catch (error) {
+    if (error instanceof KnowledgeAssetWorkspaceHeadCorruptError) {
+      return { status: 'corrupt', error };
+    }
+    throw error;
+  }
+}
+
 /** Durable last-applied state for one graph-scoped KA in SWM. */
 export interface KnowledgeAssetWorkspaceHead {
   readonly kaUal: string;

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -177,6 +177,40 @@ export async function resolveKnowledgeAssetWorkspaceHead(
     return undefined;
   }
 
+  // GH#2273 — a head subject must carry exactly ONE shareOperationId. Sync's
+  // bulk verified-meta write is a bare set-union with no per-subject delete,
+  // so a peer's head row for the same KA can land BESIDE the local one; under
+  // `LIMIT 1` every consumer (gossip monotonicity, finalization, access
+  // decisions, the queued VM-publish preflight) then received an arbitrary
+  // answer that could change between calls. Cardinality is measured on the
+  // HEAD ROWS, not as `result.bindings.length`: the main query's OPTIONALs
+  // multiply bindings when ONE operation subject carries duplicate
+  // publishedAt/accessPolicy rows (two cores ACKing the same content stamp
+  // their own clocks onto the same deterministic operation subject), and a
+  // dangling second id whose operation subject is absent contributes no
+  // binding at all — both polarities need the head-row count. Checked only
+  // when a binding exists: with zero bindings the existence branch above
+  // already fails closed on any partial head.
+  const headOperationIds = await params.store.query(
+    `SELECT DISTINCT ?op WHERE { GRAPH <${assertSafeIri(metaGraph)}> { ` +
+    `<${assertSafeIri(subject)}> <${DKG}shareOperationId> ?op } }`,
+  );
+  if (headOperationIds.type !== 'bindings') {
+    throw new Error(
+      `Unexpected graph-scoped SWM head cardinality result for ${scope.ual}: ${headOperationIds.type}`,
+    );
+  }
+  if (headOperationIds.bindings.length > 1) {
+    const ids = headOperationIds.bindings
+      .map((binding) => stripLiteral(binding['op'])?.trim())
+      .filter((value): value is string => Boolean(value))
+      .sort();
+    throw new KnowledgeAssetWorkspaceHeadCorruptError(
+      `Corrupt graph-scoped SWM head for ${scope.ual}: head carries ` +
+      `${headOperationIds.bindings.length} shareOperationId values (${ids.join(', ')})`,
+    );
+  }
+
   const row = result.bindings[0];
   if (parseIntegerLiteral(row?.['scopeVersion']) !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
     throw new KnowledgeAssetWorkspaceHeadCorruptError(

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -88,6 +88,21 @@ export class KnowledgeAssetWorkspaceHeadCorruptError extends Error {
   }
 }
 
+/**
+ * The ONE way to recognize a corrupt-head outcome at any boundary. Matches by
+ * `code` as well as `instanceof` deliberately: the error crosses package
+ * boundaries (agent preflight -> publisher classifier -> CLI route), where a
+ * re-wrap or a dual package instance can preserve `.code` while losing class
+ * identity — and each consumer choosing its own raw check is how a single
+ * boundary contract drifts. Callers pick only their local response policy.
+ */
+export function isKnowledgeAssetWorkspaceHeadCorruptError(
+  error: unknown,
+): boolean {
+  if (error instanceof KnowledgeAssetWorkspaceHeadCorruptError) return true;
+  return (error as { code?: unknown } | null | undefined)?.code === 'KA_WORKSPACE_HEAD_CORRUPT';
+}
+
 /** Durable last-applied state for one graph-scoped KA in SWM. */
 export interface KnowledgeAssetWorkspaceHead {
   readonly kaUal: string;
@@ -133,97 +148,69 @@ export async function resolveKnowledgeAssetWorkspaceHead(
     subGraphName,
   );
   const subject = workspaceKnowledgeAssetHeadSubject(scope.ual);
-  const result = await params.store.query(
-    `SELECT ?scopeVersion ?kaUal ?assertionVersion ?assertionGraph ?shareOperationId ?operation ?operationUal ?operationVersion ?digest ?publicCount ?privateRoot ?privateCount ?publisherPeerId ?publishedAt ?accessPolicy WHERE {
-      GRAPH <${assertSafeIri(metaGraph)}> {
-        <${assertSafeIri(subject)}> <${DKG}contentScopeVersion> ?scopeVersion ;
-          <${DKG}kaUal> ?kaUal ;
-          <${DKG}assertionVersion> ?assertionVersion ;
-          <${DKG}assertionGraph> ?assertionGraph ;
-          <${DKG}shareOperationId> ?shareOperationId .
-        ?operation <${DKG}shareOperationId> ?shareOperationId ;
-          <${DKG}kaUal> ?operationUal ;
-          <${DKG}assertionVersion> ?operationVersion ;
-          <${DKG}publicQuadsDigest> ?digest ;
-          <${DKG}publicQuadsCount> ?publicCount ;
-          <${DKG}privateTripleCount> ?privateCount ;
-          <${DKG}publisherPeerId> ?publisherPeerId .
-        OPTIONAL { ?operation <${DKG}privateMerkleRoot> ?privateRoot }
-        OPTIONAL { ?operation <${DKG}publishedAt> ?publishedAt }
-        OPTIONAL { ?operation <${DKG}accessPolicy> ?accessPolicy }
-      }
-    } LIMIT 1`,
+  // Phase 1 — the head subject's OWN rows. GH#2273: sync's bulk verified-meta
+  // write is a bare set-union with no per-subject delete, so a peer's head row
+  // for the same KA can land BESIDE the local one; a joined LIMIT-1 read over
+  // that state handed every consumer (gossip monotonicity, finalization,
+  // access decisions, the queued VM-publish preflight) an arbitrary answer
+  // that could change between calls. Reading the head rows first makes the
+  // exactly-one invariant primary: each required head predicate must carry
+  // exactly ONE distinct value, and only a single validated operation id ever
+  // reaches the operation lookup below. Duplicate rows on the OPERATION
+  // subject (two cores ACKing the same content stamp their own clocks onto
+  // the same deterministic operation subject) stay healthy — they never touch
+  // the head subject this phase inspects.
+  const headResult = await params.store.query(
+    `SELECT ?p ?o WHERE { GRAPH <${assertSafeIri(metaGraph)}> { ` +
+    `<${assertSafeIri(subject)}> ?p ?o } }`,
   );
-  if (result.type !== 'bindings') {
+  if (headResult.type !== 'bindings') {
     throw new Error(
-      `Unexpected graph-scoped SWM head query result for ${scope.ual}: ${result.type}`,
+      `Unexpected graph-scoped SWM head query result for ${scope.ual}: ${headResult.type}`,
     );
   }
-  if (result.bindings.length === 0) {
-    const existence = await params.store.query(
-      `ASK { GRAPH <${assertSafeIri(metaGraph)}> { ` +
-      `<${assertSafeIri(subject)}> ?predicate ?object } }`,
-    );
-    if (existence.type !== 'boolean') {
-      throw new Error(
-        `Unexpected graph-scoped SWM head existence result for ${scope.ual}: ${existence.type}`,
-      );
-    }
-    if (existence.value) {
+  if (headResult.bindings.length === 0) return undefined;
+  const headValues = new Map<string, string[]>();
+  for (const binding of headResult.bindings) {
+    const predicate = binding['p'] ?? '';
+    const object = binding['o'] ?? '';
+    const values = headValues.get(predicate) ?? [];
+    if (!values.includes(object)) values.push(object);
+    headValues.set(predicate, values);
+  }
+  const requiredHeadValue = (predicate: string, label: string): string => {
+    const values = headValues.get(predicate);
+    if (!values || values.length === 0) {
       throw new KnowledgeAssetWorkspaceHeadCorruptError(
         `Corrupt graph-scoped SWM head for ${scope.ual}: incomplete head or operation metadata`,
       );
     }
-    return undefined;
-  }
-
-  // GH#2273 — a head subject must carry exactly ONE shareOperationId. Sync's
-  // bulk verified-meta write is a bare set-union with no per-subject delete,
-  // so a peer's head row for the same KA can land BESIDE the local one; under
-  // `LIMIT 1` every consumer (gossip monotonicity, finalization, access
-  // decisions, the queued VM-publish preflight) then received an arbitrary
-  // answer that could change between calls. Cardinality is measured on the
-  // HEAD ROWS, not as `result.bindings.length`: the main query's OPTIONALs
-  // multiply bindings when ONE operation subject carries duplicate
-  // publishedAt/accessPolicy rows (two cores ACKing the same content stamp
-  // their own clocks onto the same deterministic operation subject), and a
-  // dangling second id whose operation subject is absent contributes no
-  // binding at all — both polarities need the head-row count. Checked only
-  // when a binding exists: with zero bindings the existence branch above
-  // already fails closed on any partial head.
-  const headOperationIds = await params.store.query(
-    `SELECT DISTINCT ?op WHERE { GRAPH <${assertSafeIri(metaGraph)}> { ` +
-    `<${assertSafeIri(subject)}> <${DKG}shareOperationId> ?op } }`,
-  );
-  if (headOperationIds.type !== 'bindings') {
-    throw new Error(
-      `Unexpected graph-scoped SWM head cardinality result for ${scope.ual}: ${headOperationIds.type}`,
-    );
-  }
-  if (headOperationIds.bindings.length > 1) {
-    const ids = headOperationIds.bindings
-      .map((binding) => stripLiteral(binding['op'])?.trim())
-      .filter((value): value is string => Boolean(value))
-      .sort();
-    throw new KnowledgeAssetWorkspaceHeadCorruptError(
-      `Corrupt graph-scoped SWM head for ${scope.ual}: head carries ` +
-      `${headOperationIds.bindings.length} shareOperationId values (${ids.join(', ')})`,
-    );
-  }
-
-  const row = result.bindings[0];
-  if (parseIntegerLiteral(row?.['scopeVersion']) !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
+    if (values.length > 1) {
+      const rendered = values
+        .map((value) => stripLiteral(value)?.trim())
+        .filter((value): value is string => Boolean(value))
+        .sort();
+      throw new KnowledgeAssetWorkspaceHeadCorruptError(
+        `Corrupt graph-scoped SWM head for ${scope.ual}: head carries ` +
+        `${values.length} ${label} values (${rendered.join(', ')})`,
+      );
+    }
+    return values[0]!;
+  };
+  if (parseIntegerLiteral(requiredHeadValue(`${DKG}contentScopeVersion`, 'contentScopeVersion'))
+    !== GRAPH_KA_CONTENT_SCOPE_VERSION) {
     throw new KnowledgeAssetWorkspaceHeadCorruptError(
       `Corrupt graph-scoped SWM head for ${scope.ual}: invalid scope version`,
     );
   }
-  const actualUal = row?.['kaUal'];
+  const actualUal = requiredHeadValue(`${DKG}kaUal`, 'kaUal');
   let assertionVersion: bigint;
   let actualScope: ReturnType<typeof createGraphKnowledgeAssetScope>;
   try {
-    assertionVersion = parsePositiveBigIntLiteral(row?.['assertionVersion']);
+    assertionVersion = parsePositiveBigIntLiteral(requiredHeadValue(`${DKG}assertionVersion`, 'assertionVersion'));
     actualScope = createGraphKnowledgeAssetScope(actualUal ?? '', assertionVersion);
   } catch (error) {
+    if (error instanceof KnowledgeAssetWorkspaceHeadCorruptError) throw error;
     throw new KnowledgeAssetWorkspaceHeadCorruptError(
       `Corrupt graph-scoped SWM head for ${scope.ual}: invalid assertion identity ` +
       `(${error instanceof Error ? error.message : String(error)})`,
@@ -234,7 +221,7 @@ export async function resolveKnowledgeAssetWorkspaceHead(
       `Corrupt graph-scoped SWM head for ${scope.ual}: UAL mismatch`,
     );
   }
-  const assertionGraph = row?.['assertionGraph'] ?? '';
+  const assertionGraph = requiredHeadValue(`${DKG}assertionGraph`, 'assertionGraph');
   const expectedGraph = knowledgeAssetLayerGraphUri(
     params.contextGraphId,
     MemoryLayer.SharedWorkingMemory,
@@ -246,11 +233,57 @@ export async function resolveKnowledgeAssetWorkspaceHead(
       `Corrupt graph-scoped SWM head for ${scope.ual}: assertion graph mismatch`,
     );
   }
+  const shareOperationId = stripLiteral(requiredHeadValue(`${DKG}shareOperationId`, 'shareOperationId'))?.trim() ?? '';
+  if (!shareOperationId) {
+    throw new KnowledgeAssetWorkspaceHeadCorruptError(
+      `Corrupt graph-scoped SWM head for ${scope.ual}: incomplete head or operation metadata`,
+    );
+  }
+  let operationSubject = '';
+  try {
+    operationSubject = workspaceOperationSubject(params.contextGraphId, shareOperationId);
+  } catch (error) {
+    throw new KnowledgeAssetWorkspaceHeadCorruptError(
+      `Corrupt graph-scoped SWM head for ${scope.ual}: invalid share operation ` +
+      `(${error instanceof Error ? error.message : String(error)})`,
+    );
+  }
+
+  // Phase 2 — the single validated operation, looked up by its OWN subject.
+  // The id echo pattern mirrors the previous join (the operation must itself
+  // carry the head's id); LIMIT 1 here only collapses duplicate OPTIONAL rows
+  // on one already-identified subject, never a choice between operations.
+  const result = await params.store.query(
+    `SELECT ?operationUal ?operationVersion ?digest ?publicCount ?privateRoot ?privateCount ?publisherPeerId ?publishedAt ?accessPolicy WHERE {
+      GRAPH <${assertSafeIri(metaGraph)}> {
+        <${assertSafeIri(operationSubject)}> <${DKG}shareOperationId> ${JSON.stringify(shareOperationId)} ;
+          <${DKG}kaUal> ?operationUal ;
+          <${DKG}assertionVersion> ?operationVersion ;
+          <${DKG}publicQuadsDigest> ?digest ;
+          <${DKG}publicQuadsCount> ?publicCount ;
+          <${DKG}privateTripleCount> ?privateCount ;
+          <${DKG}publisherPeerId> ?publisherPeerId .
+        OPTIONAL { <${assertSafeIri(operationSubject)}> <${DKG}privateMerkleRoot> ?privateRoot }
+        OPTIONAL { <${assertSafeIri(operationSubject)}> <${DKG}publishedAt> ?publishedAt }
+        OPTIONAL { <${assertSafeIri(operationSubject)}> <${DKG}accessPolicy> ?accessPolicy }
+      }
+    } LIMIT 1`,
+  );
+  if (result.type !== 'bindings') {
+    throw new Error(
+      `Unexpected graph-scoped SWM operation query result for ${scope.ual}: ${result.type}`,
+    );
+  }
+  if (result.bindings.length === 0) {
+    throw new KnowledgeAssetWorkspaceHeadCorruptError(
+      `Corrupt graph-scoped SWM head for ${scope.ual}: incomplete head or operation metadata`,
+    );
+  }
+  const row = result.bindings[0];
   const publicQuadsDigest = stripLiteral(row?.['digest'])?.trim() ?? '';
   const publicTripleCount = parseIntegerLiteral(row?.['publicCount']);
   const privateTripleCount = parseIntegerLiteral(row?.['privateCount']);
   const privateMerkleRoot = stripLiteral(row?.['privateRoot'])?.trim();
-  const shareOperationId = stripLiteral(row?.['shareOperationId'])?.trim() ?? '';
   const publisherPeerId = stripLiteral(row?.['publisherPeerId'])?.trim() ?? '';
   const publishedAtLexical = stripLiteral(row?.['publishedAt'])?.trim();
   const publishedAtMs = publishedAtLexical === undefined
@@ -262,17 +295,6 @@ export async function resolveKnowledgeAssetWorkspaceHead(
     || rawAccessPolicy === 'allowList'
     ? rawAccessPolicy
     : undefined;
-  let expectedOperationSubject = '';
-  try {
-    expectedOperationSubject = shareOperationId
-      ? workspaceOperationSubject(params.contextGraphId, shareOperationId)
-      : '';
-  } catch (error) {
-    throw new KnowledgeAssetWorkspaceHeadCorruptError(
-      `Corrupt graph-scoped SWM head for ${scope.ual}: invalid share operation ` +
-      `(${error instanceof Error ? error.message : String(error)})`,
-    );
-  }
   const operationUal = row?.['operationUal'] ?? '';
   let operationVersion: bigint;
   try {
@@ -287,13 +309,11 @@ export async function resolveKnowledgeAssetWorkspaceHead(
     !publicQuadsDigest ||
     !Number.isSafeInteger(publicTripleCount) || publicTripleCount < 0 ||
     !Number.isSafeInteger(privateTripleCount) || privateTripleCount < 0 ||
-    !shareOperationId ||
     !publisherPeerId ||
     (publishedAtLexical !== undefined && (
       !Number.isSafeInteger(publishedAtMs)
       || publishedAtMs! < 0
     )) ||
-    row?.['operation'] !== expectedOperationSubject ||
     operationUal !== actualScope.ual ||
     operationVersion.toString() !== actualScope.assertionVersion ||
     (privateTripleCount > 0 && !/^0x[0-9a-f]{64}$/i.test(privateMerkleRoot ?? '')) ||
@@ -304,9 +324,10 @@ export async function resolveKnowledgeAssetWorkspaceHead(
       `Corrupt graph-scoped SWM head for ${scope.ual}: incomplete commitment metadata`,
     );
   }
+
   const peersResult = await params.store.query(
     `SELECT ?peer WHERE { GRAPH <${assertSafeIri(metaGraph)}> { ` +
-      `<${assertSafeIri(expectedOperationSubject)}> <${DKG}allowedPeer> ?peer } }`,
+      `<${assertSafeIri(operationSubject)}> <${DKG}allowedPeer> ?peer } }`,
   );
   if (peersResult.type !== 'bindings') {
     throw new Error(

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -257,57 +257,86 @@ export async function resolveKnowledgeAssetWorkspaceHead(
     );
   }
 
-  // Phase 2 — the single validated operation, looked up by its OWN subject.
-  // The id echo pattern mirrors the previous join (the operation must itself
-  // carry the head's id); LIMIT 1 here only collapses duplicate OPTIONAL rows
-  // on one already-identified subject, never a choice between operations.
-  const result = await params.store.query(
-    `SELECT ?operationUal ?operationVersion ?digest ?publicCount ?privateRoot ?privateCount ?publisherPeerId ?publishedAt ?accessPolicy WHERE {
-      GRAPH <${assertSafeIri(metaGraph)}> {
-        <${assertSafeIri(operationSubject)}> <${DKG}shareOperationId> ${JSON.stringify(shareOperationId)} ;
-          <${DKG}kaUal> ?operationUal ;
-          <${DKG}assertionVersion> ?operationVersion ;
-          <${DKG}publicQuadsDigest> ?digest ;
-          <${DKG}publicQuadsCount> ?publicCount ;
-          <${DKG}privateTripleCount> ?privateCount ;
-          <${DKG}publisherPeerId> ?publisherPeerId .
-        OPTIONAL { <${assertSafeIri(operationSubject)}> <${DKG}privateMerkleRoot> ?privateRoot }
-        OPTIONAL { <${assertSafeIri(operationSubject)}> <${DKG}publishedAt> ?publishedAt }
-        OPTIONAL { <${assertSafeIri(operationSubject)}> <${DKG}accessPolicy> ?accessPolicy }
-      }
-    } LIMIT 1`,
+  // Phase 2 — the single validated operation, read as its OWN rows and
+  // normalized under DECLARED cardinality rules (no LIMIT-1 first-binding
+  // policy anywhere in the resolver): every commitment/envelope predicate must
+  // carry exactly one distinct value; `allowedPeer` is set-valued by design;
+  // `publishedAt` tolerates duplicates — two cores ACKing the same content
+  // stamp their own clocks onto the same deterministic operation subject —
+  // and canonicalizes to the EARLIEST stamp, which stays stable when a later
+  // union adds more re-stamps (this timestamp orders RFC64 inventory).
+  const operationResult = await params.store.query(
+    `SELECT ?p ?o WHERE { GRAPH <${assertSafeIri(metaGraph)}> { ` +
+    `<${assertSafeIri(operationSubject)}> ?p ?o } }`,
   );
-  if (result.type !== 'bindings') {
+  if (operationResult.type !== 'bindings') {
     throw new Error(
-      `Unexpected graph-scoped SWM operation query result for ${scope.ual}: ${result.type}`,
+      `Unexpected graph-scoped SWM operation query result for ${scope.ual}: ${operationResult.type}`,
     );
   }
-  if (result.bindings.length === 0) {
+  const operationValues = new Map<string, string[]>();
+  for (const binding of operationResult.bindings) {
+    const predicate = binding['p'] ?? '';
+    const object = binding['o'] ?? '';
+    const values = operationValues.get(predicate) ?? [];
+    if (!values.includes(object)) values.push(object);
+    operationValues.set(predicate, values);
+  }
+  const singletonOperationValue = (
+    predicate: string,
+    label: string,
+    required: boolean,
+  ): string | undefined => {
+    const values = operationValues.get(predicate);
+    if (!values || values.length === 0) {
+      if (!required) return undefined;
+      throw new KnowledgeAssetWorkspaceHeadCorruptError(
+        `Corrupt graph-scoped SWM head for ${scope.ual}: incomplete head or operation metadata`,
+      );
+    }
+    if (values.length > 1) {
+      throw new KnowledgeAssetWorkspaceHeadCorruptError(
+        `Corrupt graph-scoped SWM head for ${scope.ual}: operation carries ` +
+        `${values.length} ${label} values`,
+      );
+    }
+    return values[0];
+  };
+  // Id echo — the operation must itself carry the head's id (mirrors the
+  // previous join). Multiple id rows on the operation subject were tolerated
+  // by the join (only the matching one bound) and remain tolerated here.
+  const echoedIds = (operationValues.get(`${DKG}shareOperationId`) ?? [])
+    .map((value) => stripLiteral(value)?.trim());
+  if (!echoedIds.includes(shareOperationId)) {
     throw new KnowledgeAssetWorkspaceHeadCorruptError(
       `Corrupt graph-scoped SWM head for ${scope.ual}: incomplete head or operation metadata`,
     );
   }
-  const row = result.bindings[0];
-  const publicQuadsDigest = stripLiteral(row?.['digest'])?.trim() ?? '';
-  const publicTripleCount = parseIntegerLiteral(row?.['publicCount']);
-  const privateTripleCount = parseIntegerLiteral(row?.['privateCount']);
-  const privateMerkleRoot = stripLiteral(row?.['privateRoot'])?.trim();
-  const publisherPeerId = stripLiteral(row?.['publisherPeerId'])?.trim() ?? '';
-  const publishedAtLexical = stripLiteral(row?.['publishedAt'])?.trim();
-  const publishedAtMs = publishedAtLexical === undefined
-    ? undefined
-    : Date.parse(publishedAtLexical);
-  const rawAccessPolicy = stripLiteral(row?.['accessPolicy'])?.trim();
+  const publicQuadsDigest = stripLiteral(singletonOperationValue(`${DKG}publicQuadsDigest`, 'publicQuadsDigest', true))?.trim() ?? '';
+  const publicTripleCount = parseIntegerLiteral(singletonOperationValue(`${DKG}publicQuadsCount`, 'publicQuadsCount', true));
+  const privateTripleCount = parseIntegerLiteral(singletonOperationValue(`${DKG}privateTripleCount`, 'privateTripleCount', true));
+  const publisherPeerId = stripLiteral(singletonOperationValue(`${DKG}publisherPeerId`, 'publisherPeerId', true))?.trim() ?? '';
+  const operationUal = singletonOperationValue(`${DKG}kaUal`, 'kaUal', true) ?? '';
+  const privateMerkleRoot = stripLiteral(singletonOperationValue(`${DKG}privateMerkleRoot`, 'privateMerkleRoot', false))?.trim();
+  const rawAccessPolicy = stripLiteral(singletonOperationValue(`${DKG}accessPolicy`, 'accessPolicy', false))?.trim();
   const accessPolicy = rawAccessPolicy === 'public'
     || rawAccessPolicy === 'ownerOnly'
     || rawAccessPolicy === 'allowList'
     ? rawAccessPolicy
     : undefined;
-  const operationUal = row?.['operationUal'] ?? '';
+  const publishedAtStamps = (operationValues.get(`${DKG}publishedAt`) ?? [])
+    .map((value) => {
+      const lexical = stripLiteral(value)?.trim() ?? '';
+      return { lexical, ms: Date.parse(lexical) };
+    });
+  const publishedAtMs = publishedAtStamps.length === 0
+    ? undefined
+    : publishedAtStamps.reduce((min, stamp) => Math.min(min, stamp.ms), Number.POSITIVE_INFINITY);
   let operationVersion: bigint;
   try {
-    operationVersion = parsePositiveBigIntLiteral(row?.['operationVersion']);
+    operationVersion = parsePositiveBigIntLiteral(singletonOperationValue(`${DKG}assertionVersion`, 'assertionVersion', true));
   } catch (error) {
+    if (error instanceof KnowledgeAssetWorkspaceHeadCorruptError) throw error;
     throw new KnowledgeAssetWorkspaceHeadCorruptError(
       `Corrupt graph-scoped SWM head for ${scope.ual}: invalid operation version ` +
       `(${error instanceof Error ? error.message : String(error)})`,
@@ -318,10 +347,7 @@ export async function resolveKnowledgeAssetWorkspaceHead(
     !Number.isSafeInteger(publicTripleCount) || publicTripleCount < 0 ||
     !Number.isSafeInteger(privateTripleCount) || privateTripleCount < 0 ||
     !publisherPeerId ||
-    (publishedAtLexical !== undefined && (
-      !Number.isSafeInteger(publishedAtMs)
-      || publishedAtMs! < 0
-    )) ||
+    publishedAtStamps.some((stamp) => !Number.isSafeInteger(stamp.ms) || stamp.ms < 0) ||
     operationUal !== actualScope.ual ||
     operationVersion.toString() !== actualScope.assertionVersion ||
     (privateTripleCount > 0 && !/^0x[0-9a-f]{64}$/i.test(privateMerkleRoot ?? '')) ||
@@ -333,17 +359,8 @@ export async function resolveKnowledgeAssetWorkspaceHead(
     );
   }
 
-  const peersResult = await params.store.query(
-    `SELECT ?peer WHERE { GRAPH <${assertSafeIri(metaGraph)}> { ` +
-      `<${assertSafeIri(operationSubject)}> <${DKG}allowedPeer> ?peer } }`,
-  );
-  if (peersResult.type !== 'bindings') {
-    throw new Error(
-      `Unexpected graph-scoped SWM access query result for ${scope.ual}: ${peersResult.type}`,
-    );
-  }
-  const allowedPeers = [...new Set(peersResult.bindings
-    .map((binding) => stripLiteral(binding['peer'])?.trim())
+  const allowedPeers = [...new Set((operationValues.get(`${DKG}allowedPeer`) ?? [])
+    .map((value) => stripLiteral(value)?.trim())
     .filter((peer): peer is string => Boolean(peer)))];
   if (
     (accessPolicy === 'allowList' && allowedPeers.length === 0)

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -100,7 +100,15 @@ export function isKnowledgeAssetWorkspaceHeadCorruptError(
   error: unknown,
 ): boolean {
   if (error instanceof KnowledgeAssetWorkspaceHeadCorruptError) return true;
-  return (error as { code?: unknown } | null | undefined)?.code === 'KA_WORKSPACE_HEAD_CORRUPT';
+  // Throw-safe by contract: this predicate runs inside catch/failure-recording
+  // paths against arbitrary cross-package thrown values, so inspecting the
+  // value must never itself throw (a Proxy or a throwing `code` getter would
+  // otherwise detonate mid-classification and mask the original failure).
+  try {
+    return (error as { code?: unknown } | null | undefined)?.code === 'KA_WORKSPACE_HEAD_CORRUPT';
+  } catch {
+    return false;
+  }
 }
 
 /** Durable last-applied state for one graph-scoped KA in SWM. */

--- a/packages/publisher/test/async-lift-publisher.test.ts
+++ b/packages/publisher/test/async-lift-publisher.test.ts
@@ -675,6 +675,90 @@ describe('TripleStoreAsyncLiftPublisher', () => {
     expect(processed?.failure?.code).toBe('publish_intent_stale');
   });
 
+  it('fails a corrupt-head preflight as retryable workspace_unavailable, not a terminal code', async () => {
+    // GH#2273 — a multi-valued SWM head (catch-up union residue) is transient local
+    // corruption that sync repair heals; the queued request may still be byte-identical
+    // to what the head certified at admission. Pre-fix the corrupt-head message fell
+    // through the classification chain's keyword sniffing to terminal
+    // `canonicalization_failed`, killing a job a later retry could have finalized.
+    let executorCalls = 0;
+    const publisher = createPublisher({
+      config: {
+        knowledgeAssetVmPublishHandler: {
+          preflight: async () => {
+            throw Object.assign(
+              new Error('Corrupt graph-scoped SWM head for did:dkg:test/1: head carries 2 shareOperationId values (op-a, storage-ack-b)'),
+              { code: 'KA_WORKSPACE_HEAD_CORRUPT' },
+            );
+          },
+          execute: async () => {
+            executorCalls++;
+            throw new Error('executor should not run for corrupt-head preflight');
+          },
+        },
+      },
+    });
+    const shareOperationId = 'rootless-corrupt-head-op';
+    await stageRootlessSnapshot(shareOperationId);
+
+    const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest({
+      shareOperationId,
+    }));
+    const processed = await publisher.processNext('wallet-1');
+
+    expect(executorCalls).toBe(0);
+    expect(processed?.jobId).toBe(jobId);
+    expect(processed?.status).toBe('failed');
+    expect(processed?.failure?.failedFromState).toBe('claimed');
+    expect(processed?.failure?.code).toBe('workspace_unavailable');
+    expect(processed?.failure?.retryable).toBe(true);
+  });
+
+  it('classifies a corrupt head at the pre-execute preflight from validated, not broadcast', async () => {
+    // GH#2273 — the preflight runs TWICE per attempt: once on claim and once immediately
+    // before execute. The second invocation's throw lands in the broadcast-path catch,
+    // where the failed-from state is decided by `isKnowledgeAssetPublishPreconditionFailure`.
+    // Pre-fix that predicate did not recognize KA_WORKSPACE_HEAD_CORRUPT, so the job
+    // failed from 'broadcast' and the SECOND classifier defaulted the corrupt-head
+    // message to `rpc_unavailable` — this row pins the site-B path specifically, which
+    // the single-preflight row above cannot reach.
+    let preflightCalls = 0;
+    let executorCalls = 0;
+    const publisher = createPublisher({
+      config: {
+        knowledgeAssetVmPublishHandler: {
+          preflight: async () => {
+            preflightCalls += 1;
+            if (preflightCalls === 1) return undefined;
+            throw Object.assign(
+              new Error('Corrupt graph-scoped SWM head for did:dkg:test/1: head carries 2 shareOperationId values (op-a, storage-ack-b)'),
+              { code: 'KA_WORKSPACE_HEAD_CORRUPT' },
+            );
+          },
+          execute: async () => {
+            executorCalls++;
+            throw new Error('executor should not run when the pre-execute preflight rejects');
+          },
+        },
+      },
+    });
+    const shareOperationId = 'rootless-corrupt-head-presend-op';
+    await stageRootlessSnapshot(shareOperationId);
+
+    const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest({
+      shareOperationId,
+    }));
+    const processed = await publisher.processNext('wallet-1');
+
+    expect(preflightCalls).toBe(2);
+    expect(executorCalls).toBe(0);
+    expect(processed?.jobId).toBe(jobId);
+    expect(processed?.status).toBe('failed');
+    expect(processed?.failure?.failedFromState).toBe('validated');
+    expect(processed?.failure?.code).toBe('workspace_unavailable');
+    expect(processed?.failure?.retryable).toBe(true);
+  });
+
   it('exposes the SWM share operation contract', async () => {
     const publisherContract: Publisher = makeTestPublisher({
       store,

--- a/packages/publisher/test/async-lift-publisher.test.ts
+++ b/packages/publisher/test/async-lift-publisher.test.ts
@@ -759,6 +759,50 @@ describe('TripleStoreAsyncLiftPublisher', () => {
     expect(processed?.failure?.retryable).toBe(true);
   });
 
+  it('classifies a code-only precondition by its structured code, not its message text', async () => {
+    // Behavior-INVARIANCE pin for the consolidated precondition classifier:
+    // the code that routes a failure to the pre-send 'validated' state is the
+    // same decision that persists the failure code. The message here is
+    // deliberately keyword-free, so a regression back to message-keyed
+    // classification (which would still route the state via the code list)
+    // could not reproduce the expected pairing from the message alone.
+    let executorCalls = 0;
+    let preflightCalls = 0;
+    const publisher = createPublisher({
+      config: {
+        knowledgeAssetVmPublishHandler: {
+          preflight: async () => {
+            preflightCalls += 1;
+            if (preflightCalls === 1) return undefined;
+            throw Object.assign(
+              new Error('zzz keyword-free precondition zzz'),
+              { code: 'CG_NOT_REGISTERED' },
+            );
+          },
+          execute: async () => {
+            executorCalls++;
+            throw new Error('executor should not run for an unregistered CG precondition');
+          },
+        },
+      },
+    });
+    const shareOperationId = 'rootless-code-only-precondition-op';
+    await stageRootlessSnapshot(shareOperationId);
+
+    const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest({
+      shareOperationId,
+    }));
+    const processed = await publisher.processNext('wallet-1');
+
+    expect(executorCalls).toBe(0);
+    expect(processed?.jobId).toBe(jobId);
+    expect(processed?.status).toBe('failed');
+    expect(processed?.failure?.failedFromState).toBe('validated');
+    // Preserves the pre-existing effective mapping for this code (the legacy
+    // chain never matched its real messages either); re-taxonomizing is #1974.
+    expect(processed?.failure?.code).toBe('canonicalization_failed');
+  });
+
   it('exposes the SWM share operation contract', async () => {
     const publisherContract: Publisher = makeTestPublisher({
       store,

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -8,6 +8,7 @@ import {
   contextGraphDataUri,
   contextGraphMetaUri,
   contextGraphLayerUri,
+  contextGraphPrivateUri,
   MemoryLayer,
   ASSERTION_SEAL_PREDICATES,
   assertionLifecycleUri,
@@ -2500,6 +2501,40 @@ describe('Working Memory Assertion Lifecycle', () => {
       const count = Number(String(preservedSwm.bindings[0]?.['c'] ?? '0').match(/\d+/)?.[0] ?? 0);
       expect(count).toBe(3);
     }
+  });
+
+  it('discard proceeds and archives the recovery seal when the SWM head is corrupt (GH#2273)', async () => {
+    // GH#2273 — the resolver fails closed on a corrupt SWM head, and the discard path
+    // resolves the head only to decide the advisory keep-the-recovery-seal boolean.
+    // Discard is a plausible operator remedy for a KA whose head is exactly in that
+    // corrupt state, so the throw must not abort it (pre-fix it did: the resolve had no
+    // catch, so this discard rejected with KA_WORKSPACE_HEAD_CORRUPT and the operator
+    // had no API-level way to clear the assertion). On corruption we cannot prove the
+    // seal does NOT match live SWM content, so the decision fails toward RETENTION: the
+    // seal is archived to the recovery subject rather than dropped.
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    const finalized = await finalizeAssertion();
+
+    // One dangling shareOperationId row with none of the other required head rows is
+    // the resolver's pre-existing "incomplete head or operation metadata" corrupt case
+    // — the cheapest corrupt-head shape to fabricate, and the catch under test treats
+    // every KnowledgeAssetWorkspaceHeadCorruptError alike.
+    await store.insert([{
+      subject: `${finalized.kaUal}#dkg-swm-head`,
+      predicate: SHARE_OPERATION_ID_PREDICATE,
+      object: '"phantom-op"',
+      graph: SWM_META_GRAPH,
+    }]);
+
+    await publisher.assertionDiscard(CG_ID, ASSERTION_NAME, AGENT);
+
+    expect(await publisher.assertionQuery(CG_ID, ASSERTION_NAME, AGENT)).toHaveLength(0);
+    const recoverySubject = `${contextGraphAssertionUri(CG_ID, AGENT, ASSERTION_NAME)}/_recovery_seal`;
+    const archived = await store.query(
+      `ASK { GRAPH <${contextGraphPrivateUri(CG_ID)}> { <${recoverySubject}> ?p ?o } }`,
+    );
+    expect(archived).toEqual({ type: 'boolean', value: true });
   });
 });
 

--- a/packages/publisher/test/ka-graph-workspace-receiver.test.ts
+++ b/packages/publisher/test/ka-graph-workspace-receiver.test.ts
@@ -542,7 +542,7 @@ describe('SharedMemoryHandler graph-scoped KA receiver', () => {
     }
   });
 
-  it('permanently rejects an inbound share while the local head is multi-valued (GH#2273)', async () => {
+  it('defers a retryable inbound share while the local head is multi-valued (GH#2273)', async () => {
     const store = new OxigraphStore();
     const graphManager = new GraphManager(store);
     const handler = new SharedMemoryHandler(store, new TypedEventBus());

--- a/packages/publisher/test/ka-graph-workspace-receiver.test.ts
+++ b/packages/publisher/test/ka-graph-workspace-receiver.test.ts
@@ -560,20 +560,22 @@ describe('SharedMemoryHandler graph-scoped KA receiver', () => {
       graph: metaGraph,
     }]);
 
-    // The monotonicity gate cannot read a multi-valued head, and the corruption is
-    // LOCAL: identical bytes redelivered by the sender can never fix it, so the
-    // rejection must be PERMANENT (retryable: false). A retryable outcome here would
-    // put the sender's substrate outbox into an infinite redelivery loop. Pre-fix the
-    // resolver answered arbitrarily and this share was applied on top of the corrupt
-    // head; the sync lane's identity-preserving repair is the sanctioned healer.
-    const outcome = await handler.handle(v2Request({
+    // The monotonicity gate cannot read a multi-valued head, so NOTHING is written
+    // (fail closed) — but the rejection is TRANSIENT: the corruption is local state
+    // the sync lane's identity-preserving repair heals, and the sender's outbox
+    // retries are budget-bounded, so a permanent drop would lose a valid newer
+    // share that becomes applicable the moment the head converges. Pre-fix the
+    // resolver answered arbitrarily and this share was applied on top of the
+    // corrupt head.
+    const inbound = v2Request({
       nquads: new TextEncoder().encode(nquad('urn:entity:2', 'two')),
       shareOperationId: 'rootless-op-2',
       assertionVersion: '2',
-    }), PEER_ID);
+    });
+    const outcome = await handler.handle(inbound, PEER_ID);
     expect(outcome.applied).toBe(false);
     if (outcome.applied) throw new Error('unreachable');
-    expect(outcome.retryable).toBe(false);
+    expect(outcome.retryable).toBe(true);
     expect(outcome.reason).toContain('CORRUPT_SWM_HEAD');
 
     // The corrupt head must be left byte-untouched for the repair lane: still exactly
@@ -600,5 +602,18 @@ describe('SharedMemoryHandler graph-scoped KA receiver', () => {
     expect(contentRows.type).toBe('bindings');
     if (contentRows.type !== 'bindings') throw new Error('expected bindings');
     expect(contentRows.bindings).toEqual([{ s: 'urn:entity:1', o: '"one"' }]);
+
+    // The transient contract's second half: after the head is repaired (here by
+    // removing the union residue the way the sync lane's identity-preserving
+    // repair does), the SAME deferred payload applies cleanly — proving the
+    // sender's kept-queued delivery was worth keeping.
+    await store.delete([{
+      subject: `${UAL}#dkg-swm-head`,
+      predicate: 'http://dkg.io/ontology/shareOperationId',
+      object: '"storage-ack-2273"',
+      graph: metaGraph,
+    }]);
+    const replay = await handler.handle(inbound, PEER_ID);
+    expect(replay.applied).toBe(true);
   });
 });

--- a/packages/publisher/test/ka-graph-workspace-receiver.test.ts
+++ b/packages/publisher/test/ka-graph-workspace-receiver.test.ts
@@ -577,12 +577,28 @@ describe('SharedMemoryHandler graph-scoped KA receiver', () => {
     expect(outcome.reason).toContain('CORRUPT_SWM_HEAD');
 
     // The corrupt head must be left byte-untouched for the repair lane: still exactly
-    // two shareOperationId rows, and the rejected share's graph write never happened.
+    // two shareOperationId rows.
     const headIds = await store.query(
       `SELECT DISTINCT ?op WHERE { GRAPH <${metaGraph}> { <${UAL}#dkg-swm-head> <http://dkg.io/ontology/shareOperationId> ?op } }`,
     );
     expect(headIds.type).toBe('bindings');
     if (headIds.type !== 'bindings') throw new Error('expected bindings');
     expect(headIds.bindings).toHaveLength(2);
+
+    // And the rejected share must not have mutated SWM CONTENT either — the
+    // fail-closed decision fires BEFORE any graph write. A regression that
+    // replaced the assertion graph and then reported the rejection would pass
+    // the two assertions above while local data silently changed.
+    const swmGraph = knowledgeAssetLayerGraphUri(
+      CONTEXT_GRAPH,
+      MemoryLayer.SharedWorkingMemory,
+      createGraphKnowledgeAssetScope(UAL, 1),
+    );
+    const contentRows = await store.query(
+      `SELECT ?s ?o WHERE { GRAPH <${swmGraph}> { ?s <urn:predicate:value> ?o } }`,
+    );
+    expect(contentRows.type).toBe('bindings');
+    if (contentRows.type !== 'bindings') throw new Error('expected bindings');
+    expect(contentRows.bindings).toEqual([{ s: 'urn:entity:1', o: '"one"' }]);
   });
 });

--- a/packages/publisher/test/ka-graph-workspace-receiver.test.ts
+++ b/packages/publisher/test/ka-graph-workspace-receiver.test.ts
@@ -541,4 +541,48 @@ describe('SharedMemoryHandler graph-scoped KA receiver', () => {
       expect(outcome.reason, name).toContain(expectedReason);
     }
   });
+
+  it('permanently rejects an inbound share while the local head is multi-valued (GH#2273)', async () => {
+    const store = new OxigraphStore();
+    const graphManager = new GraphManager(store);
+    const handler = new SharedMemoryHandler(store, new TypedEventBus());
+
+    const applied = await handler.handle(v2Request({}), PEER_ID);
+    expect(applied.applied).toBe(true);
+
+    // Fabricate the GH#2273 corruption exactly the way sync produces it: a bare
+    // set-union of a second shareOperationId row onto the head subject.
+    const metaGraph = graphManager.sharedMemoryMetaUri(CONTEXT_GRAPH);
+    await store.insert([{
+      subject: `${UAL}#dkg-swm-head`,
+      predicate: 'http://dkg.io/ontology/shareOperationId',
+      object: '"storage-ack-2273"',
+      graph: metaGraph,
+    }]);
+
+    // The monotonicity gate cannot read a multi-valued head, and the corruption is
+    // LOCAL: identical bytes redelivered by the sender can never fix it, so the
+    // rejection must be PERMANENT (retryable: false). A retryable outcome here would
+    // put the sender's substrate outbox into an infinite redelivery loop. Pre-fix the
+    // resolver answered arbitrarily and this share was applied on top of the corrupt
+    // head; the sync lane's identity-preserving repair is the sanctioned healer.
+    const outcome = await handler.handle(v2Request({
+      nquads: new TextEncoder().encode(nquad('urn:entity:2', 'two')),
+      shareOperationId: 'rootless-op-2',
+      assertionVersion: '2',
+    }), PEER_ID);
+    expect(outcome.applied).toBe(false);
+    if (outcome.applied) throw new Error('unreachable');
+    expect(outcome.retryable).toBe(false);
+    expect(outcome.reason).toContain('CORRUPT_SWM_HEAD');
+
+    // The corrupt head must be left byte-untouched for the repair lane: still exactly
+    // two shareOperationId rows, and the rejected share's graph write never happened.
+    const headIds = await store.query(
+      `SELECT DISTINCT ?op WHERE { GRAPH <${metaGraph}> { <${UAL}#dkg-swm-head> <http://dkg.io/ontology/shareOperationId> ?op } }`,
+    );
+    expect(headIds.type).toBe('bindings');
+    if (headIds.type !== 'bindings') throw new Error('expected bindings');
+    expect(headIds.bindings).toHaveLength(2);
+  });
 });

--- a/packages/publisher/test/workspace-head-cardinality.test.ts
+++ b/packages/publisher/test/workspace-head-cardinality.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+import { GraphManager, OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import {
+  KnowledgeAssetWorkspaceHeadCorruptError,
+  resolveKnowledgeAssetWorkspaceHead,
+  storeKnowledgeAssetOperationPublicQuads,
+  storeKnowledgeAssetWorkspaceHead,
+} from '../src/index.js';
+
+// GH#2273: SWM catch-up union-inserts a peer's head `shareOperationId` row
+// beside the local one (shared-memory-sync bulk insert holds no lock and
+// performs no delete), leaving ONE head subject carrying TWO operation ids.
+// `resolveKnowledgeAssetWorkspaceHead` was `LIMIT 1` over that state, so every
+// consumer — gossip monotonicity, finalization, access decisions, and the
+// async VM-publish preflight — received an ARBITRARY answer that could change
+// between calls. These rows pin the corrected contract: head-id cardinality
+// is measured as COUNT(DISTINCT shareOperationId) ON THE HEAD SUBJECT, and
+// more than one distinct id fails closed as KA_WORKSPACE_HEAD_CORRUPT.
+//
+// The predicate is deliberately NOT `bindings.length` of the main resolver
+// query: that query carries three OPTIONALs on the operation subject
+// (privateMerkleRoot / publishedAt / accessPolicy), so binding count is a
+// cross-product. Two `publishedAt` rows on ONE operation subject — reachable
+// in production when two cores ACK the same content with different clocks and
+// a third node unions both via sync — must keep resolving (see the
+// duplicate-publishedAt row below, which kills a bindings.length
+// implementation).
+
+const CONTEXT_GRAPH = 'head-cardinality';
+const UAL = 'did:dkg:base:8453/0x70997970c51812dc3a010c7d01b50e0d17dc79c8/7';
+// Format contract with workspace-resolution.ts (module-private helpers):
+// head subject = `<ual>#dkg-swm-head`, operation subject =
+// `urn:dkg:share:<contextGraphId>:<shareOperationId>`.
+const HEAD_SUBJECT = `${UAL}#dkg-swm-head`;
+const DKG = 'http://dkg.io/ontology/';
+const XSD = 'http://www.w3.org/2001/XMLSchema#';
+
+const LOCAL_OP = 'op-a';
+// The realistic foreign id shape: deterministic storage-ACK mint on a
+// receiving core (storage-ack-handler.ts), served back to the author by the
+// SWM responder after a restart.
+const REMOTE_OP = 'storage-ack-2273b';
+
+const CONTENT: Quad[] = [
+  { subject: 'urn:entity:1', predicate: 'urn:predicate:value', object: '"one"', graph: '' },
+  { subject: 'urn:entity:2', predicate: 'urn:predicate:value', object: '"two"', graph: '' },
+];
+
+interface Harness {
+  store: OxigraphStore;
+  graphManager: GraphManager;
+  metaGraph: string;
+}
+
+function makeHarness(): Harness {
+  const store = new OxigraphStore();
+  const graphManager = new GraphManager(store);
+  return { store, graphManager, metaGraph: graphManager.sharedMemoryMetaUri(CONTEXT_GRAPH) };
+}
+
+async function seedOperation(h: Harness, shareOperationId: string): Promise<void> {
+  await storeKnowledgeAssetOperationPublicQuads({
+    store: h.store,
+    graphManager: h.graphManager,
+    contextGraphId: CONTEXT_GRAPH,
+    shareOperationId,
+    kaUal: UAL,
+    assertionVersion: 1,
+    quads: CONTENT,
+    publisherPeerId: 'peer-1',
+    timestamp: new Date('2026-08-16T00:00:00.000Z'),
+  });
+}
+
+async function seedHealthyHead(h: Harness): Promise<void> {
+  await seedOperation(h, LOCAL_OP);
+  await storeKnowledgeAssetWorkspaceHead({
+    store: h.store,
+    graphManager: h.graphManager,
+    contextGraphId: CONTEXT_GRAPH,
+    kaUal: UAL,
+    assertionVersion: 1,
+    shareOperationId: LOCAL_OP,
+  });
+}
+
+/**
+ * The corruption is fabricated with a RAW insert because that is exactly what
+ * produces it in production: `storeKnowledgeAssetWorkspaceHead` is
+ * delete-then-insert (cannot stack), while the sync bulk insert is a bare
+ * set-union onto the same subject.
+ */
+async function unionInsertSecondHeadId(h: Harness): Promise<void> {
+  await h.store.insert([{
+    subject: HEAD_SUBJECT,
+    predicate: `${DKG}shareOperationId`,
+    object: JSON.stringify(REMOTE_OP),
+    graph: h.metaGraph,
+  }]);
+}
+
+function resolveHead(h: Harness) {
+  return resolveKnowledgeAssetWorkspaceHead({
+    store: h.store,
+    graphManager: h.graphManager,
+    contextGraphId: CONTEXT_GRAPH,
+    kaUal: UAL,
+  });
+}
+
+describe('graph-scoped SWM head shareOperationId cardinality', () => {
+  it('resolves a healthy single-operation head (guard polarity control)', async () => {
+    const h = makeHarness();
+    await seedHealthyHead(h);
+    const head = await resolveHead(h);
+    expect(head?.shareOperationId).toBe(LOCAL_OP);
+    expect(head?.assertionVersion).toBe('1');
+  });
+
+  it('fails closed when the head carries two operation ids and both operation subjects exist', async () => {
+    const h = makeHarness();
+    await seedHealthyHead(h);
+    await seedOperation(h, REMOTE_OP);
+    await unionInsertSecondHeadId(h);
+    // Pre-fix: LIMIT 1 resolved to whichever of the two full solutions the
+    // store returned first — an answer that could differ between calls on the
+    // same state. The queued VM-publish preflight compared that arbitrary id
+    // against its admission-time id and terminally failed the job as
+    // publish_intent_stale (GH#2273's reported death).
+    await expect(resolveHead(h)).rejects.toThrow(KnowledgeAssetWorkspaceHeadCorruptError);
+    await expect(resolveHead(h)).rejects.toThrow(/shareOperationId/);
+  });
+
+  it('fails closed when the head carries two operation ids even if the second operation subject is absent', async () => {
+    const h = makeHarness();
+    await seedHealthyHead(h);
+    await unionInsertSecondHeadId(h);
+    // Pre-fix this state silently resolved to the SURVIVING operation: the
+    // main query joins head→operation on the id, so the danging second id
+    // contributed no binding and LIMIT 1 saw exactly one solution. The head
+    // row set is corrupt all the same — a later arrival of the second
+    // operation subject would flip the resolver's answer — so cardinality
+    // must be measured on the HEAD ROWS, not on the join result.
+    await expect(resolveHead(h)).rejects.toThrow(KnowledgeAssetWorkspaceHeadCorruptError);
+  });
+
+  it('still resolves when one operation subject carries duplicate optional rows (kills a bindings-length guard)', async () => {
+    const h = makeHarness();
+    await seedHealthyHead(h);
+    // Two cores ACKing the same content mint the SAME deterministic operation
+    // subject but stamp their own clocks; a node that unions both peers' meta
+    // ends with two publishedAt rows on ONE operation. The resolver's main
+    // query then yields TWO bindings for a head with exactly ONE operation
+    // id. A guard on bindings.length would fail this healthy head closed;
+    // the cardinality guard must not.
+    const operationSubject = `urn:dkg:share:${CONTEXT_GRAPH}:${LOCAL_OP}`;
+    await h.store.insert([{
+      subject: operationSubject,
+      predicate: `${DKG}publishedAt`,
+      object: `"2026-08-16T00:00:05.000Z"^^<${XSD}dateTime>`,
+      graph: h.metaGraph,
+    }]);
+    const head = await resolveHead(h);
+    expect(head?.shareOperationId).toBe(LOCAL_OP);
+  });
+});

--- a/packages/publisher/test/workspace-head-cardinality.test.ts
+++ b/packages/publisher/test/workspace-head-cardinality.test.ts
@@ -144,6 +144,25 @@ describe('graph-scoped SWM head shareOperationId cardinality', () => {
     await expect(resolveHead(h)).rejects.toThrow(KnowledgeAssetWorkspaceHeadCorruptError);
   });
 
+  it('fails closed when the head carries two assertionVersion values (same corruption class)', async () => {
+    const h = makeHarness();
+    await seedHealthyHead(h);
+    // Union residue can stack a second VERSION row just as it stacks a second
+    // operation id (the materializer's needsRepair flags versions > 1 for the
+    // same reason). Pre-refactor the joined LIMIT-1 read picked one version
+    // arbitrarily — the overwrite-with-older hazard for the gossip
+    // monotonicity gate. The phased resolver requires exactly one distinct
+    // value per REQUIRED head predicate, so this is the same corrupt outcome.
+    await h.store.insert([{
+      subject: HEAD_SUBJECT,
+      predicate: `${DKG}assertionVersion`,
+      object: `"2"^^<${XSD}integer>`,
+      graph: h.metaGraph,
+    }]);
+    await expect(resolveHead(h)).rejects.toThrow(KnowledgeAssetWorkspaceHeadCorruptError);
+    await expect(resolveHead(h)).rejects.toThrow(/assertionVersion/);
+  });
+
   it('still resolves when one operation subject carries duplicate optional rows (kills a bindings-length guard)', async () => {
     const h = makeHarness();
     await seedHealthyHead(h);

--- a/packages/publisher/test/workspace-head-cardinality.test.ts
+++ b/packages/publisher/test/workspace-head-cardinality.test.ts
@@ -6,6 +6,7 @@ import {
   resolveKnowledgeAssetWorkspaceHead,
   storeKnowledgeAssetOperationPublicQuads,
   storeKnowledgeAssetWorkspaceHead,
+  tryResolveKnowledgeAssetWorkspaceHead,
 } from '../src/index.js';
 
 // GH#2273: SWM catch-up union-inserts a peer's head `shareOperationId` row
@@ -132,6 +133,76 @@ describe('isKnowledgeAssetWorkspaceHeadCorruptError boundary predicate', () => {
       get() { throw new Error('inspection trap'); },
     });
     expect(isKnowledgeAssetWorkspaceHeadCorruptError(hostile)).toBe(false);
+  });
+});
+
+describe('tryResolveKnowledgeAssetWorkspaceHead typed boundary', () => {
+  it('maps missing, resolved and corrupt onto the discriminated result', async () => {
+    const h = makeHarness();
+    expect(await tryResolveKnowledgeAssetWorkspaceHead({
+      store: h.store, graphManager: h.graphManager, contextGraphId: CONTEXT_GRAPH, kaUal: UAL,
+    })).toEqual({ status: 'missing' });
+    await seedHealthyHead(h);
+    const resolved = await tryResolveKnowledgeAssetWorkspaceHead({
+      store: h.store, graphManager: h.graphManager, contextGraphId: CONTEXT_GRAPH, kaUal: UAL,
+    });
+    expect(resolved.status).toBe('resolved');
+    if (resolved.status !== 'resolved') throw new Error('unreachable');
+    expect(resolved.head.shareOperationId).toBe(LOCAL_OP);
+    await unionInsertSecondHeadId(h);
+    const corrupt = await tryResolveKnowledgeAssetWorkspaceHead({
+      store: h.store, graphManager: h.graphManager, contextGraphId: CONTEXT_GRAPH, kaUal: UAL,
+    });
+    expect(corrupt.status).toBe('corrupt');
+    if (corrupt.status !== 'corrupt') throw new Error('unreachable');
+    expect(corrupt.error).toBeInstanceOf(KnowledgeAssetWorkspaceHeadCorruptError);
+  });
+
+  it('recognizes a code-preserving wrapped error the same way the boolean predicate does', async () => {
+    // ONE recognition rule across both boundary APIs: a store decorator that
+    // re-wraps the corrupt error preserving `.code` but losing class identity
+    // must land on the corrupt result, coerced into the concrete class the
+    // result type promises — not rethrown while the boolean predicate would
+    // have said corrupt. Non-corrupt store failures must still throw.
+    const h = makeHarness();
+    const throwingStore = new Proxy(h.store, {
+      get(target, prop, receiver) {
+        if (prop === 'query') {
+          return async () => {
+            throw Object.assign(
+              new Error('re-wrapped by a store decorator'),
+              { code: 'KA_WORKSPACE_HEAD_CORRUPT' },
+            );
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+    const outcome = await tryResolveKnowledgeAssetWorkspaceHead({
+      store: throwingStore as never,
+      graphManager: h.graphManager,
+      contextGraphId: CONTEXT_GRAPH,
+      kaUal: UAL,
+    });
+    expect(outcome.status).toBe('corrupt');
+    if (outcome.status !== 'corrupt') throw new Error('unreachable');
+    expect(outcome.error).toBeInstanceOf(KnowledgeAssetWorkspaceHeadCorruptError);
+    expect(outcome.error.message).toContain('re-wrapped');
+
+    const failingStore = new Proxy(h.store, {
+      get(target, prop, receiver) {
+        if (prop === 'query') {
+          return async () => { throw new Error('store outage'); };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+    await expect(tryResolveKnowledgeAssetWorkspaceHead({
+      store: failingStore as never,
+      graphManager: h.graphManager,
+      contextGraphId: CONTEXT_GRAPH,
+      kaUal: UAL,
+    })).rejects.toThrow('store outage');
   });
 });
 

--- a/packages/publisher/test/workspace-head-cardinality.test.ts
+++ b/packages/publisher/test/workspace-head-cardinality.test.ts
@@ -158,19 +158,22 @@ describe('tryResolveKnowledgeAssetWorkspaceHead typed boundary', () => {
     expect(corrupt.error).toBeInstanceOf(KnowledgeAssetWorkspaceHeadCorruptError);
   });
 
-  it('recognizes a code-preserving wrapped error the same way the boolean predicate does', async () => {
-    // ONE recognition rule across both boundary APIs: a store decorator that
-    // re-wraps the corrupt error preserving `.code` but losing class identity
-    // must land on the corrupt result, coerced into the concrete class the
-    // result type promises — not rethrown while the boolean predicate would
-    // have said corrupt. Non-corrupt store failures must still throw.
+  it('classifies only resolver-proven corruption; store failures propagate — even code-colliding ones', async () => {
+    // The typed wrapper is deliberately NARROWER than the exported boundary
+    // predicate: within this module the resolver is the sole authority on
+    // corruption and always throws the concrete class, so a lower storage
+    // layer that throws a code-colliding error BEFORE the resolver ever
+    // inspected head rows is a STORE failure and must keep propagating as
+    // one — treating it as domain corruption would misreport an outage as
+    // malformed workspace-head data. The loose `.code` predicate remains the
+    // recognition rule for boundaries the error crosses AFTER propagation.
     const h = makeHarness();
-    const throwingStore = new Proxy(h.store, {
+    const codeCollidingStore = new Proxy(h.store, {
       get(target, prop, receiver) {
         if (prop === 'query') {
           return async () => {
             throw Object.assign(
-              new Error('re-wrapped by a store decorator'),
+              new Error('storage layer failure that happens to collide on code'),
               { code: 'KA_WORKSPACE_HEAD_CORRUPT' },
             );
           };
@@ -178,16 +181,12 @@ describe('tryResolveKnowledgeAssetWorkspaceHead typed boundary', () => {
         return Reflect.get(target, prop, receiver);
       },
     });
-    const outcome = await tryResolveKnowledgeAssetWorkspaceHead({
-      store: throwingStore as never,
+    await expect(tryResolveKnowledgeAssetWorkspaceHead({
+      store: codeCollidingStore as never,
       graphManager: h.graphManager,
       contextGraphId: CONTEXT_GRAPH,
       kaUal: UAL,
-    });
-    expect(outcome.status).toBe('corrupt');
-    if (outcome.status !== 'corrupt') throw new Error('unreachable');
-    expect(outcome.error).toBeInstanceOf(KnowledgeAssetWorkspaceHeadCorruptError);
-    expect(outcome.error.message).toContain('re-wrapped');
+    })).rejects.toThrow('collide on code');
 
     const failingStore = new Proxy(h.store, {
       get(target, prop, receiver) {

--- a/packages/publisher/test/workspace-head-cardinality.test.ts
+++ b/packages/publisher/test/workspace-head-cardinality.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { GraphManager, OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import {
   KnowledgeAssetWorkspaceHeadCorruptError,
+  isKnowledgeAssetWorkspaceHeadCorruptError,
   resolveKnowledgeAssetWorkspaceHead,
   storeKnowledgeAssetOperationPublicQuads,
   storeKnowledgeAssetWorkspaceHead,
@@ -107,6 +108,32 @@ function resolveHead(h: Harness) {
     kaUal: UAL,
   });
 }
+
+describe('isKnowledgeAssetWorkspaceHeadCorruptError boundary predicate', () => {
+  it('recognizes the class, a code-preserving re-wrap, and survives hostile inspection', () => {
+    expect(isKnowledgeAssetWorkspaceHeadCorruptError(
+      new KnowledgeAssetWorkspaceHeadCorruptError('x'),
+    )).toBe(true);
+    // A re-wrap that kept the code but lost class identity (the dual-package /
+    // wrapper case the predicate exists for).
+    expect(isKnowledgeAssetWorkspaceHeadCorruptError(
+      Object.assign(new Error('wrapped'), { code: 'KA_WORKSPACE_HEAD_CORRUPT' }),
+    )).toBe(true);
+    expect(isKnowledgeAssetWorkspaceHeadCorruptError(
+      Object.assign(new Error('other'), { code: 'PUBLISH_INTENT_STALE' }),
+    )).toBe(false);
+    expect(isKnowledgeAssetWorkspaceHeadCorruptError(null)).toBe(false);
+    expect(isKnowledgeAssetWorkspaceHeadCorruptError(undefined)).toBe(false);
+    // The predicate runs inside catch paths against arbitrary thrown values;
+    // inspecting the value must never itself throw and mask the original
+    // failure — a throwing `code` getter is the hostile shape.
+    const hostile = {};
+    Object.defineProperty(hostile, 'code', {
+      get() { throw new Error('inspection trap'); },
+    });
+    expect(isKnowledgeAssetWorkspaceHeadCorruptError(hostile)).toBe(false);
+  });
+});
 
 describe('graph-scoped SWM head shareOperationId cardinality', () => {
   it('resolves a healthy single-operation head (guard polarity control)', async () => {

--- a/packages/publisher/test/workspace-head-cardinality.test.ts
+++ b/packages/publisher/test/workspace-head-cardinality.test.ts
@@ -6,8 +6,11 @@ import {
   resolveKnowledgeAssetWorkspaceHead,
   storeKnowledgeAssetOperationPublicQuads,
   storeKnowledgeAssetWorkspaceHead,
-  tryResolveKnowledgeAssetWorkspaceHead,
 } from '../src/index.js';
+// Deliberately imported from the MODULE, not the package barrel: the typed
+// resolution wrapper is intra-package API (each internal caller owns its own
+// corruption policy) and is not exported for external consumers.
+import { tryResolveKnowledgeAssetWorkspaceHead } from '../src/workspace-resolution.js';
 
 // GH#2273: SWM catch-up union-inserts a peer's head `shareOperationId` row
 // beside the local one (shared-memory-sync bulk insert holds no lock and

--- a/packages/publisher/test/workspace-head-cardinality.test.ts
+++ b/packages/publisher/test/workspace-head-cardinality.test.ts
@@ -208,5 +208,26 @@ describe('graph-scoped SWM head shareOperationId cardinality', () => {
     }]);
     const head = await resolveHead(h);
     expect(head?.shareOperationId).toBe(LOCAL_OP);
+    // The tolerated duplicate canonicalizes to the EARLIEST stamp — stable
+    // under later re-stamp unions (this timestamp orders RFC64 inventory), and
+    // an explicit rule rather than whichever binding the store returned first.
+    expect(head?.publishedAt).toBe(Date.parse('2026-08-16T00:00:00.000Z').toString());
+  });
+
+  it('fails closed when the operation carries duplicate singleton metadata (accessPolicy)', async () => {
+    // The envelope predicates are declared SINGLETON: two accessPolicy rows on
+    // one operation are the same union-residue corruption class as two head
+    // ids, and an arbitrary pick here would drive an ACCESS decision. Only
+    // publishedAt (canonicalized) and allowedPeer (set-valued) tolerate
+    // duplicates.
+    const h = makeHarness();
+    await seedHealthyHead(h);
+    const operationSubject = `urn:dkg:share:${CONTEXT_GRAPH}:${LOCAL_OP}`;
+    await h.store.insert([
+      { subject: operationSubject, predicate: `${DKG}accessPolicy`, object: '"public"', graph: h.metaGraph },
+      { subject: operationSubject, predicate: `${DKG}accessPolicy`, object: '"ownerOnly"', graph: h.metaGraph },
+    ]);
+    await expect(resolveHead(h)).rejects.toThrow(KnowledgeAssetWorkspaceHeadCorruptError);
+    await expect(resolveHead(h)).rejects.toThrow(/accessPolicy/);
   });
 });

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
       'test/storage-ack-priority-lane.test.ts',
       'test/swm-slice-ack-unbounded.test.ts',
       'test/workspace-snapshot-store.test.ts',
+      'test/workspace-head-cardinality.test.ts',
     ],
     testTimeout: 60_000,
     maxWorkers: 1,


### PR DESCRIPTION
## Summary

- **Part 1/3 of the #2273 fix chain.** SWM catch-up's bulk verified-meta write is a bare set-union with no per-subject delete, so a peer's head row for the same KA can land beside the local one — leaving one workspace-head subject carrying **two** `shareOperationId` values. `resolveKnowledgeAssetWorkspaceHead` was `LIMIT 1` over that state, so every consumer (gossip monotonicity, finalization, access decisions, the async VM-publish preflight) received an **arbitrary answer that could change between calls**. For a queued VM-publish job, that arbitrary answer terminally killed the job as `publish_intent_stale` even when its request was still byte-identical to what the head certified at admission — the #2273 reported death.
- **Detection** (shape per review round 1): the resolver now reads the **head subject's own rows first**, requires exactly ONE distinct value per required head predicate, and only then resolves that single validated operation subject directly — no joined `LIMIT 1` choice between operations remains. More than one `shareOperationId` (or any other required head predicate) throws `KnowledgeAssetWorkspaceHeadCorruptError` with the offending values named. Cardinality is measured on the HEAD ROWS, never on result-binding counts: duplicate `publishedAt` rows on one operation subject (two cores ACKing the same content stamp their own clocks onto the same deterministic `storage-ack-…` subject) are a healthy state that must keep resolving, while a dangling second head id with no operation subject must still fail closed. Dedicated test rows pin both polarities, including one that kills a bindings-count implementation.
- **Every consumer made safe** (fail-closed without new failure modes):
  - **Gossip receive** (`SharedMemoryHandler`): corrupt local head ⇒ fail-closed **transient** deferral (`CORRUPT_SWM_HEAD`, `retryable: true`, nothing written) — the corruption is local convergent state that sync repair heals, and the sender's outbox retries are budget-bounded, so the payload stays queued and applies once the head converges (review round 6 corrected an earlier permanent-rejection shape that created a propagation-loss window). The test proves both halves: rejection leaves head rows AND content byte-untouched, and the same payload applies after repair.
  - **Queued execution**: `KA_WORKSPACE_HEAD_CORRUPT` ⇒ retryable `workspace_unavailable` from **both** preflight invocation sites. Added to `isKnowledgeAssetPublishPreconditionFailure` so the pre-execute site fails from `'validated'` (where the code is recordable) instead of `'broadcast'`, where the second classifier's message sniffing would land the corrupt-head text on terminal codes.
  - **`assertionDiscard`**: a corrupt head no longer aborts the discard (discard is a plausible operator remedy for exactly this state); the advisory keep-the-recovery-seal decision fails toward **retention** (seal archived).
  - **Daemon route `vm/publish-async`**: `KA_WORKSPACE_HEAD_CORRUPT` ⇒ **503 + retryable** (transient server-side state — not a 409 stale-intent, which would tell the client to re-share for nothing, and not a generic 500).
- **Deployment note**: this PR alone converts the #2273 death into a retryable wait but does **not** heal existing multi-valued heads and deliberately forgoes the gossip path's incidental head rewrite. Parts 2–3 (agent sync lanes preserve operation identity for semantically identical heads, and repair heals toward the stored identity) deliver the healing; **the chain should be released together**.
- Second-order effect worth knowing: `workspace_unavailable` is retryable, so re-enqueueing a matching request now re-accepts the failed job where `canonicalization_failed` previously refused — desirable, but user-visible.

## Related

- #2273 (this chain, part 1/3; parts 2–3 follow on this branch's base)
- #2270 (retry breadth — deliberately untouched: no new `autoRetry` flags; `workspace_unavailable` remains manual-retry)
- #2050 G7 (prior head-invisibility fix; untouched by this PR, load-bearing for parts 2–3)

## Diagrams

### Queued VM-publish retry over a corrupted head

Before:

```mermaid
sequenceDiagram
    participant Job as Queued VM-publish job
    participant PF as Preflight
    participant R as Head resolver
    participant Store as SWM meta store
    Job->>PF: retry attempt with admission id op-A
    PF->>R: resolve workspace head
    R->>Store: joined query with LIMIT 1 over two head ids
    Store-->>R: arbitrary pick, op-B this time
    R-->>PF: head id is op-B
    PF-->>Job: publish_intent_stale, TERMINAL
```

After:

```mermaid
sequenceDiagram
    participant Job as Queued VM-publish job
    participant PF as Preflight
    participant R as Head resolver
    participant Store as SWM meta store
    Job->>PF: retry attempt with admission id op-A
    PF->>R: resolve workspace head
    R->>Store: read head subject rows first
    Store-->>R: two distinct head ids found
    R-->>PF: throw KA_WORKSPACE_HEAD_CORRUPT naming both ids
    PF-->>Job: workspace_unavailable, RETRYABLE, job preserved
```

### Inbound gossip share while the local head is corrupt

Before:

```mermaid
sequenceDiagram
    participant Peer as Sender outbox
    participant H as SharedMemoryHandler
    participant R as Head resolver
    Peer->>H: WorkspacePublishRequest
    H->>R: resolve current head for monotonicity gate
    R-->>H: arbitrary pick, possibly the older version
    H-->>Peer: applied on top of the corrupt head
```

After:

```mermaid
sequenceDiagram
    participant Peer as Sender outbox
    participant H as SharedMemoryHandler
    participant R as Head resolver
    Peer->>H: WorkspacePublishRequest
    H->>R: resolve current head for monotonicity gate
    R-->>H: corrupt result from the typed boundary
    H-->>Peer: TRANSIENT deferral, retryable true, nothing written
    Note over H: sender keeps the payload queued and it applies after sync repair converges the head
```

## Files changed

| File | What |
|------|------|
| `packages/publisher/src/workspace-resolution.ts` | Resolver split into phases (review round 1): head rows read + exactly-one validation first, then the single validated operation resolved by its own subject; multi-valued required head predicates throw `KnowledgeAssetWorkspaceHeadCorruptError` with the values named. New shared `isKnowledgeAssetWorkspaceHeadCorruptError` boundary predicate |
| `packages/publisher/src/workspace-handler.ts` | Gossip receive: corrupt head ⇒ fail-closed TRANSIENT deferral via a dedicated `corrupt-head` rejection channel (same convergent-local-state shape as the CAS-transient precedent), consuming the typed resolver boundary |
| `packages/publisher/src/async-lift-publisher-impl.ts` | ONE structured-precondition classifier (`classifyKnowledgeAssetVmPublishPreconditionCode`) owns state routing AND persisted code for every code-keyed preflight failure (corrupt-head ⇒ retryable `workspace_unavailable`; stale ⇒ `publish_intent_stale`; author-capability ⇒ `authority_forbidden`; NOT_FULL_SHARE / CG_NOT_REGISTERED keep their pre-existing effective mapping) |
| `packages/publisher/src/dkg-publisher.ts` | `assertionDiscard`: local catch on corrupt head; keep-the-recovery-seal decision fails toward retention (archive) with a warn log |
| `packages/cli/src/daemon/routes/knowledge-assets.ts` | `vm/publish-async`: `KA_WORKSPACE_HEAD_CORRUPT` ⇒ 503 `{ code, error, retryable: true }` |
| `packages/publisher/test/workspace-head-cardinality.test.ts` | NEW — 4 rows: healthy control; two ids + both ops ⇒ corrupt; two ids + dangling second id ⇒ corrupt; duplicate `publishedAt` on one op subject ⇒ still resolves (kills a `bindings.length` guard) |
| `packages/publisher/test/ka-graph-workspace-receiver.test.ts` | Gossip row: corrupt head ⇒ `{applied: false, retryable: true}`, head rows AND SWM content byte-untouched, and the SAME payload applies after the head is repaired |
| `packages/publisher/test/async-lift-publisher.test.ts` | 2 classification rows: claim-time preflight site ⇒ `workspace_unavailable` from `claimed`; pre-execute site ⇒ `workspace_unavailable` from `validated` (pins the `isKnowledgeAssetPublishPreconditionFailure` path specifically) |
| `packages/publisher/test/draft-lifecycle.test.ts` | Discard row: corrupt head ⇒ discard proceeds, recovery seal archived |
| `packages/cli/test/knowledge-assets-1116-share-errors.test.ts` | Route row: `KA_WORKSPACE_HEAD_CORRUPT` ⇒ 503 with `retryable: true`, enqueue never called |
| `packages/publisher/vitest.unit.config.ts` | Register the new test file in the Hardhat-free unit lane |

## Test plan

Every new behavior has **fail-before evidence** captured against the unpatched source (reverted src, ran the rows, restored):

- [x] Cardinality rows: pre-fix the two corruption rows RESOLVE (arbitrary pick) — post-fix they throw; the duplicate-`publishedAt` row passes in both states (it exists to kill a `bindings.length` implementation)
- [x] Gossip row: pre-fix the share is APPLIED on top of the corrupt head — post-fix permanent rejection, store untouched
- [x] Classification rows: pre-fix site A lands on terminal `canonicalization_failed`, site B fails from `'broadcast'` — post-fix both give retryable `workspace_unavailable`
- [x] Route row: pre-fix generic 500 — post-fix typed 503
- [x] Discard row: pre-fix `assertionDiscard` rejects with `KnowledgeAssetWorkspaceHeadCorruptError` — post-fix discard proceeds and archives the seal
- [x] Full publisher Hardhat lane: **127 files / 1831 tests green** post-fix
- [x] Publisher unit lane (Hardhat-free): 50 files / 570 tests green
- [x] `knowledge-assets-1116-share-errors.test.ts`: 64/64 green
- [x] `pnpm build:packages` (turbo, includes tsc typecheck of all changed src): green
- [x] Review round 1 (phased resolver + shared corrupt-head predicate): publisher unit lane re-run green (570 tests), Hardhat consumer rows re-run green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
