### PR TITLE
fix(sync): admit independent SWM and VM responder lanes

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -1608,13 +1608,7 @@ export class DKGAgentBase {
    * so denied peers must remain eligible on the next reconciler cadence.
    */
   protected readonly lastSyncProgressAt = new Map<string, number>();
-  /**
-   * Per-peer timestamp of the most recent graph-complete selected-SWM pass.
-   * Kept separate from `lastSuccessfulSyncAt` because selected refresh proves
-   * neither durable state nor unrelated Context Graphs on the same peer.
-   */
-  protected readonly lastSelectedSwmSyncAt = new Map<string, number>();
-  /** Peer + selected-CG scoped seed/retry/terminal state for RFC-64 SWM. */
+  /** Peer + selected-CG scoped seed/retry/terminal/freshness state for RFC-64 SWM. */
   protected readonly selectedSwmBootstrapAdmission = new SelectedSwmBootstrapAdmission();
   /**
    * Per-peer sync-reconciler backoff. `failures` is the count of

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -1608,6 +1608,12 @@ export class DKGAgentBase {
    * so denied peers must remain eligible on the next reconciler cadence.
    */
   protected readonly lastSyncProgressAt = new Map<string, number>();
+  /**
+   * Per-peer timestamp of the most recent graph-complete selected-SWM pass.
+   * Kept separate from `lastSuccessfulSyncAt` because selected refresh proves
+   * neither durable state nor unrelated Context Graphs on the same peer.
+   */
+  protected readonly lastSelectedSwmSyncAt = new Map<string, number>();
   /** Peer + selected-CG scoped seed/retry/terminal state for RFC-64 SWM. */
   protected readonly selectedSwmBootstrapAdmission = new SelectedSwmBootstrapAdmission();
   /**

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -4179,7 +4179,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.lastSyncDisconnectedAt.delete(remotePeer);
     this.lastSuccessfulSyncAt.delete(remotePeer);
     this.lastSyncProgressAt.delete(remotePeer);
-    this.lastSelectedSwmSyncAt.delete(remotePeer);
     this.selectedSwmBootstrapAdmission.clear(remotePeer);
     this.syncReconcilerBackoff.delete(remotePeer);
     this.warmedCores.delete(remotePeer);
@@ -4630,9 +4629,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         if (outcome?.progress) {
           this.lastSyncProgressAt.set(peerId, progressAt);
         }
-        if (outcome?.fresh) {
-          this.lastSelectedSwmSyncAt.set(peerId, progressAt);
-        }
         // A selected-only retry never stamps the whole peer fresh; durable and
         // unrelated CG lanes were deliberately outside this invocation.
         this.skippedNoSyncPeers.delete(peerId);
@@ -4906,11 +4902,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         || lastSyncCooldown <= lastDisconnected
         || (now - lastSyncCooldown) >= SYNC_STALENESS_THRESHOLD_MS);
       const selectedContextGraphIds = this.selectedSwmBootstrapContextGraphIdsForPeer(peerId);
-      const lastSelectedSwmSync = this.lastSelectedSwmSyncAt.get(peerId);
-      const selectedSwmStale = selectedContextGraphIds.length > 0 && (
-        lastSelectedSwmSync == null
-        || lastSelectedSwmSync <= lastDisconnected
-        || (now - lastSelectedSwmSync) >= SYNC_STALENESS_THRESHOLD_MS
+      const selectedSwmStale = this.selectedSwmBootstrapAdmission.shouldRefresh(
+        peerId,
+        selectedContextGraphIds,
+        {
+          now,
+          disconnectBoundary: lastDisconnected,
+          staleAfterMs: SYNC_STALENESS_THRESHOLD_MS,
+        },
       );
       if (!broadSyncStale && !selectedSwmStale) continue;
       // Per-peer exponential backoff: a peer that can never be synced
@@ -4935,8 +4934,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         // this selected graph again. Re-open only this peer/scope after the
         // bounded freshness window; the broad sync kill switch and unselected
         // graphs remain untouched.
-        this.selectedSwmBootstrapAdmission.clear(peerId);
-        this.selectedSwmBootstrapAdmission.request(peerId, selectedContextGraphIds);
+        this.selectedSwmBootstrapAdmission.requestRefresh(peerId, selectedContextGraphIds);
         this.log.info(
           ctx,
           `Sync reconciler refreshing ${selectedContextGraphIds.length} selected shared-memory Context Graph(s) from ${shortPeer}`,
@@ -4984,11 +4982,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         this.lastSyncProgressAt.delete(peerId);
       }
     }
-    for (const [peerId, ts] of this.lastSelectedSwmSyncAt) {
-      if (!connected.has(peerId) && now - ts >= SYNC_STALENESS_THRESHOLD_MS) {
-        this.lastSelectedSwmSyncAt.delete(peerId);
-      }
-    }
+    this.selectedSwmBootstrapAdmission.pruneDisconnected(
+      connected,
+      now,
+      SYNC_STALENESS_THRESHOLD_MS,
+    );
     for (const [peerId, backoff] of this.syncReconcilerBackoff) {
       if (!connected.has(peerId) && now >= backoff.nextRetryAt + SYNC_STALENESS_THRESHOLD_MS) {
         this.syncReconcilerBackoff.delete(peerId);
@@ -7249,7 +7247,6 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         && continuationExecution.incompleteContextGraphIds.length === 0;
       if (selectedScopeComplete) {
         this.selectedSwmBootstrapAdmission.markTransferTerminal(selectedBootstrapOwner!);
-        this.lastSelectedSwmSyncAt.set(remotePeerId, Date.now());
       }
       // Preserve the raw historical yield/failure counters for diagnostics;
       // the canonical freshness helper bounds the selected continuation's

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -1291,6 +1291,14 @@ interface RecoverContextGraphSwmFromPeerDependencies {
 
 type SyncReconcilerAttemptOutcome = SyncOnConnectOutcome | 'not-started' | 'deferred-backpressure';
 
+type SyncReconcilerAttemptPlan =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'broad' }
+  | {
+    readonly kind: 'selected-swm';
+    readonly contextGraphIds: readonly string[];
+  };
+
 export interface ContextGraphCatchupOptions {
   includeSharedMemory?: boolean;
   maxPeers?: number;
@@ -4883,6 +4891,40 @@ export class LifecycleSyncMethods extends DKGAgentBase {
    * Designed to be safe to call concurrently with the event-driven path
    * — `runSyncOnConnect` itself is idempotent via `syncingPeers`.
    */
+  planSyncReconcilerAttempt(
+    this: DKGAgent,
+    peerId: string,
+    options: {
+      readonly broadSyncEnabled: boolean;
+      readonly now: number;
+      readonly disconnectBoundary: number;
+      readonly lastSyncCooldown: number;
+    },
+  ): SyncReconcilerAttemptPlan {
+    const broadSyncStale = options.broadSyncEnabled && (
+      options.lastSyncCooldown === 0
+      || options.lastSyncCooldown <= options.disconnectBoundary
+      || (options.now - options.lastSyncCooldown) >= SYNC_STALENESS_THRESHOLD_MS
+    );
+    // Broad sync owns the attempt whenever it is due. Selected-SWM refresh is
+    // an independent fallback for deployments that disable broad sync, not a
+    // second transfer to schedule beside the same peer attempt.
+    if (broadSyncStale) return { kind: 'broad' };
+
+    const contextGraphIds = this.selectedSwmBootstrapContextGraphIdsForPeer(peerId);
+    if (!this.selectedSwmBootstrapAdmission.shouldRefresh(
+      peerId,
+      contextGraphIds,
+      {
+        now: options.now,
+        disconnectBoundary: options.disconnectBoundary,
+        staleAfterMs: SYNC_STALENESS_THRESHOLD_MS,
+      },
+    )) return { kind: 'none' };
+
+    return { kind: 'selected-swm', contextGraphIds };
+  }
+
   async reconcileSyncFromConnectedPeers(this: DKGAgent): Promise<void> {
     if (!this.started) return;
     if (!syncReconcilerEnabled(this.config)) return;
@@ -4898,20 +4940,16 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       const lastDisconnected = this.syncOnConnectDisconnectBoundary(peerId, now);
       const lastProgress = this.lastSyncProgressAt.get(peerId);
       const lastSyncCooldown = Math.max(lastOk ?? 0, lastProgress ?? 0);
-      const broadSyncStale = broadSyncEnabled && (lastSyncCooldown === 0
-        || lastSyncCooldown <= lastDisconnected
-        || (now - lastSyncCooldown) >= SYNC_STALENESS_THRESHOLD_MS);
-      const selectedContextGraphIds = this.selectedSwmBootstrapContextGraphIdsForPeer(peerId);
-      const selectedSwmStale = this.selectedSwmBootstrapAdmission.shouldRefresh(
+      const attemptPlan = this.planSyncReconcilerAttempt(
         peerId,
-        selectedContextGraphIds,
         {
+          broadSyncEnabled,
           now,
           disconnectBoundary: lastDisconnected,
-          staleAfterMs: SYNC_STALENESS_THRESHOLD_MS,
+          lastSyncCooldown,
         },
       );
-      if (!broadSyncStale && !selectedSwmStale) continue;
+      if (attemptPlan.kind === 'none') continue;
       // Per-peer exponential backoff: a peer that can never be synced
       // (dead / NAT-stuck / persistently stream-resetting) never stamps
       // `lastSuccessfulSyncAt`, so it reads as perpetually stale. Without
@@ -4929,20 +4967,20 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       }
       if (!(await this.ensurePeerAdmittedForRecovery(peerId, ctx, 'Sync reconciler'))) continue;
       const shortPeer = peerId.slice(-8);
-      if (selectedSwmStale && !broadSyncStale) {
+      if (attemptPlan.kind === 'selected-swm') {
         // Terminal means complete at the last observed head, not never refresh
         // this selected graph again. Re-open only this peer/scope after the
         // bounded freshness window; the broad sync kill switch and unselected
         // graphs remain untouched.
-        this.selectedSwmBootstrapAdmission.requestRefresh(peerId, selectedContextGraphIds);
+        this.selectedSwmBootstrapAdmission.requestRefresh(peerId, attemptPlan.contextGraphIds);
         this.log.info(
           ctx,
-          `Sync reconciler refreshing ${selectedContextGraphIds.length} selected shared-memory Context Graph(s) from ${shortPeer}`,
+          `Sync reconciler refreshing ${attemptPlan.contextGraphIds.length} selected shared-memory Context Graph(s) from ${shortPeer}`,
         );
       } else {
         this.log.info(ctx, `Sync reconciler retrying ${shortPeer} (last success: ${lastOk == null ? 'never' : `${Math.round((now - lastOk) / 1000)}s ago`}${backoff ? `, prior failures: ${backoff.failures}` : ''})`);
       }
-      const attempt = selectedSwmStale && !broadSyncStale
+      const attempt = attemptPlan.kind === 'selected-swm'
         ? this.attemptSelectedSwmRetryWithReconcilerAccounting(peerId, probe, 'reconcile')
         : this.attemptSyncFromPeerWithReconcilerAccounting(peerId, probe, 'reconcile');
       attempt

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -6983,23 +6983,23 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           stopOnBackoffWorthyFailure,
           snapshotEvidencePolicy: selectedSwmEnabled
             ? {
-              // Any graph-backed operation sits outside the immutable snapshot
-              // walk, including when other operations in the same manifest do
-              // have store-backed refs. Until this requester has count/digest-
-              // bound transport evidence for every such operation, the selected
-              // lane must fail closed.
+              // A selected non-empty scope is complete only when it exposes at
+              // least one immutable content commitment. Store-backed refs use
+              // the snapshot protocol; graph-backed operations use the batched
+              // aggregate data plan and the same count/digest materializer.
               accepts: ({
                 verifiedMetadataTriples,
                 snapshotReferences,
                 graphBackedOperations,
               }) => (
                 verifiedMetadataTriples === 0
-                || (snapshotReferences > 0 && graphBackedOperations === 0)
+                || snapshotReferences + graphBackedOperations > 0
               ),
             }
             : undefined,
           metadataFetcher: selectedMetaFetcher?.strategy,
           snapshotRecoveryOrder: selectedSwmEnabled ? 'recent-balanced' : 'manifest',
+          dataRequesterScope: selectedSwmEnabled ? 'selected-swm-data:graph-v1' : undefined,
           ensureContextGraph: async (contextGraphId) => {
             const graphManager = new GraphManager(this.store);
             await graphManager.ensureContextGraph(contextGraphId);
@@ -7059,7 +7059,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           },
           publicSnapshotStore: this.publicSnapshotStore,
           deleteCheckpoint: (key) => deleteSyncPageCheckpoint(this.syncCheckpoints, key),
-          setCheckpoint: (key, offset) => this.syncCheckpoints.set(key, offset),
+          setCheckpoint: (key, offset, responderSessionOffset) => this.syncCheckpoints.set(
+            key,
+            offset,
+            Date.now(),
+            responderSessionOffset,
+          ),
           ensureOwnedMap: (contextGraphId) => {
             if (!this.workspaceOwnedEntities.has(contextGraphId)) {
               this.workspaceOwnedEntities.set(contextGraphId, new Map());

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -4179,6 +4179,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.lastSyncDisconnectedAt.delete(remotePeer);
     this.lastSuccessfulSyncAt.delete(remotePeer);
     this.lastSyncProgressAt.delete(remotePeer);
+    this.lastSelectedSwmSyncAt.delete(remotePeer);
     this.selectedSwmBootstrapAdmission.clear(remotePeer);
     this.syncReconcilerBackoff.delete(remotePeer);
     this.warmedCores.delete(remotePeer);
@@ -4629,6 +4630,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         if (outcome?.progress) {
           this.lastSyncProgressAt.set(peerId, progressAt);
         }
+        if (outcome?.fresh) {
+          this.lastSelectedSwmSyncAt.set(peerId, progressAt);
+        }
         // A selected-only retry never stamps the whole peer fresh; durable and
         // unrelated CG lanes were deliberately outside this invocation.
         this.skippedNoSyncPeers.delete(peerId);
@@ -4885,7 +4889,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
    */
   async reconcileSyncFromConnectedPeers(this: DKGAgent): Promise<void> {
     if (!this.started) return;
-    if (!syncReconcilerEnabled(this.config) || !syncOnConnectEnabled(this.config)) return;
+    if (!syncReconcilerEnabled(this.config)) return;
+    const broadSyncEnabled = syncOnConnectEnabled(this.config);
     const now = Date.now();
     const ctx = createOperationContext('sync');
     this.pruneSyncReconcilerState(now);
@@ -4897,10 +4902,17 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       const lastDisconnected = this.syncOnConnectDisconnectBoundary(peerId, now);
       const lastProgress = this.lastSyncProgressAt.get(peerId);
       const lastSyncCooldown = Math.max(lastOk ?? 0, lastProgress ?? 0);
-      const stale = lastSyncCooldown === 0
+      const broadSyncStale = broadSyncEnabled && (lastSyncCooldown === 0
         || lastSyncCooldown <= lastDisconnected
-        || (now - lastSyncCooldown) >= SYNC_STALENESS_THRESHOLD_MS;
-      if (!stale) continue;
+        || (now - lastSyncCooldown) >= SYNC_STALENESS_THRESHOLD_MS);
+      const selectedContextGraphIds = this.selectedSwmBootstrapContextGraphIdsForPeer(peerId);
+      const lastSelectedSwmSync = this.lastSelectedSwmSyncAt.get(peerId);
+      const selectedSwmStale = selectedContextGraphIds.length > 0 && (
+        lastSelectedSwmSync == null
+        || lastSelectedSwmSync <= lastDisconnected
+        || (now - lastSelectedSwmSync) >= SYNC_STALENESS_THRESHOLD_MS
+      );
+      if (!broadSyncStale && !selectedSwmStale) continue;
       // Per-peer exponential backoff: a peer that can never be synced
       // (dead / NAT-stuck / persistently stream-resetting) never stamps
       // `lastSuccessfulSyncAt`, so it reads as perpetually stale. Without
@@ -4918,8 +4930,24 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       }
       if (!(await this.ensurePeerAdmittedForRecovery(peerId, ctx, 'Sync reconciler'))) continue;
       const shortPeer = peerId.slice(-8);
-      this.log.info(ctx, `Sync reconciler retrying ${shortPeer} (last success: ${lastOk == null ? 'never' : `${Math.round((now - lastOk) / 1000)}s ago`}${backoff ? `, prior failures: ${backoff.failures}` : ''})`);
-      this.attemptSyncFromPeerWithReconcilerAccounting(peerId, probe, 'reconcile')
+      if (selectedSwmStale && !broadSyncStale) {
+        // Terminal means complete at the last observed head, not never refresh
+        // this selected graph again. Re-open only this peer/scope after the
+        // bounded freshness window; the broad sync kill switch and unselected
+        // graphs remain untouched.
+        this.selectedSwmBootstrapAdmission.clear(peerId);
+        this.selectedSwmBootstrapAdmission.request(peerId, selectedContextGraphIds);
+        this.log.info(
+          ctx,
+          `Sync reconciler refreshing ${selectedContextGraphIds.length} selected shared-memory Context Graph(s) from ${shortPeer}`,
+        );
+      } else {
+        this.log.info(ctx, `Sync reconciler retrying ${shortPeer} (last success: ${lastOk == null ? 'never' : `${Math.round((now - lastOk) / 1000)}s ago`}${backoff ? `, prior failures: ${backoff.failures}` : ''})`);
+      }
+      const attempt = selectedSwmStale && !broadSyncStale
+        ? this.attemptSelectedSwmRetryWithReconcilerAccounting(peerId, probe, 'reconcile')
+        : this.attemptSyncFromPeerWithReconcilerAccounting(peerId, probe, 'reconcile');
+      attempt
         .then(() => undefined)
         .catch((err: unknown) => {
           const message = err instanceof Error ? err.message : String(err);
@@ -4954,6 +4982,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     for (const [peerId, ts] of this.lastSyncProgressAt) {
       if (!connected.has(peerId) && now - ts >= SYNC_STALENESS_THRESHOLD_MS) {
         this.lastSyncProgressAt.delete(peerId);
+      }
+    }
+    for (const [peerId, ts] of this.lastSelectedSwmSyncAt) {
+      if (!connected.has(peerId) && now - ts >= SYNC_STALENESS_THRESHOLD_MS) {
+        this.lastSelectedSwmSyncAt.delete(peerId);
       }
     }
     for (const [peerId, backoff] of this.syncReconcilerBackoff) {
@@ -7216,6 +7249,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         && continuationExecution.incompleteContextGraphIds.length === 0;
       if (selectedScopeComplete) {
         this.selectedSwmBootstrapAdmission.markTransferTerminal(selectedBootstrapOwner!);
+        this.lastSelectedSwmSyncAt.set(remotePeerId, Date.now());
       }
       // Preserve the raw historical yield/failure counters for diagnostics;
       // the canonical freshness helper bounds the selected continuation's

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -4998,6 +4998,7 @@ export class PublishMethods extends DKGAgentBase {
           );
           const candidate = await this.store.query(
             `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${vmGraph}> { ?s ?p ?o } }`,
+            { source: 'agent.asyncVmPublish.recoveredVmCandidate' },
           );
           recoveredVmCandidate = candidate.type === 'quads'
             && candidate.quads.length === request.publicTripleCount;

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -4968,18 +4968,53 @@ export class PublishMethods extends DKGAgentBase {
           publicSnapshotStore: this.publicSnapshotStore,
         });
       } catch (error) {
-        if (
-          !(error instanceof KnowledgeAssetOperationPublicSnapshotNotFoundError)
-          || request.clearSharedMemoryAfter !== true
-        ) {
+        if (!(error instanceof KnowledgeAssetOperationPublicSnapshotNotFoundError)) {
           throw error;
         }
-        // Explicit post-publish cleanup may remove the redundant snapshot. The
-        // signed seal plus immutable queued counts still verifies exact VM.
+
+        // RFC-64 reconciliation may observe the finalized chain receipt and
+        // retire the byte-identical SWM twin before the async publisher records
+        // its own receipt. In that race the operation snapshot is intentionally
+        // gone even when the original request did not ask for cleanup. Admit
+        // only a public, count-complete VM candidate here; handleChainReconciledKC
+        // below still recomputes and verifies its Merkle root against the chain
+        // before any receipt or lifecycle state is repaired.
+        let recoveredVmCandidate = false;
+        if (
+          request.clearSharedMemoryAfter !== true
+          && request.accessPolicy === 'public'
+          && request.publicTripleCount > 0
+        ) {
+          const scope = createGraphKnowledgeAssetScope(
+            request.kaUal,
+            request.assertionVersion,
+          );
+          const vmGraph = contextGraphLayerUri(
+            request.contextGraphId,
+            MemoryLayer.VerifiableMemory,
+            scope.agentAddress,
+            BigInt(scope.kaNumber),
+            request.subGraphName,
+          );
+          const candidate = await this.store.query(
+            `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${vmGraph}> { ?s ?p ?o } }`,
+          );
+          recoveredVmCandidate = candidate.type === 'quads'
+            && candidate.quads.length === request.publicTripleCount;
+        }
+        if (request.clearSharedMemoryAfter !== true && !recoveredVmCandidate) {
+          throw error;
+        }
+
+        // Explicit cleanup, or an RFC-64-retired SWM twin with a complete VM
+        // candidate, may remove the redundant snapshot. The signed seal,
+        // immutable queued counts and chain-root verification below remain the
+        // authority for exact VM recovery.
         this.log.info(
           ctx,
           `Named KA recovery for "${request.name}" has no durable public snapshot; `
-            + `using the immutable seal envelope: ${error instanceof Error ? error.message : String(error)}`,
+            + `${recoveredVmCandidate ? 'verifying the materialized VM candidate' : 'using the immutable seal envelope'}: `
+            + `${error instanceof Error ? error.message : String(error)}`,
         );
       }
       if (snapshot) {

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -4976,32 +4976,28 @@ export class PublishMethods extends DKGAgentBase {
         // retire the byte-identical SWM twin before the async publisher records
         // its own receipt. In that race the operation snapshot is intentionally
         // gone even when the original request did not ask for cleanup. Admit
-        // only a public, count-complete VM candidate here; handleChainReconciledKC
-        // below still recomputes and verifies its Merkle root against the chain
-        // before any receipt or lifecycle state is repaired.
+        // only an exact public VM candidate here, through the finalization
+        // layer's canonical count/root verifier. handleChainReconciledKC below
+        // re-verifies it at the mutation boundary before any receipt or
+        // lifecycle state is repaired.
         let recoveredVmCandidate = false;
         if (
           request.clearSharedMemoryAfter !== true
           && request.accessPolicy === 'public'
           && request.publicTripleCount > 0
         ) {
-          const scope = createGraphKnowledgeAssetScope(
-            request.kaUal,
-            request.assertionVersion,
-          );
-          const vmGraph = contextGraphLayerUri(
-            request.contextGraphId,
-            MemoryLayer.VerifiableMemory,
-            scope.agentAddress,
-            BigInt(scope.kaNumber),
-            request.subGraphName,
-          );
-          const candidate = await this.store.query(
-            `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${vmGraph}> { ?s ?p ?o } }`,
-            { source: 'agent.asyncVmPublish.recoveredVmCandidate' },
-          );
-          recoveredVmCandidate = candidate.type === 'quads'
-            && candidate.quads.length === request.publicTripleCount;
+          recoveredVmCandidate = await this.getOrCreateFinalizationHandler()
+            .verifyRecoveredGraphScopedVmCandidate({
+              contextGraphId: request.contextGraphId,
+              ual: request.kaUal,
+              assertionVersion: request.assertionVersion,
+              publicTripleCount: request.publicTripleCount,
+              expectedMerkleRoot: ethers.getBytes(recovered.materialization.merkleRoot),
+              ...(request.privateMerkleRoot
+                ? { privateMerkleRoot: request.privateMerkleRoot }
+                : {}),
+              ...(request.subGraphName ? { subGraphName: request.subGraphName } : {}),
+            });
         }
         if (request.clearSharedMemoryAfter !== true && !recoveredVmCandidate) {
           throw error;

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -1373,6 +1373,51 @@ export class FinalizationHandler {
     return outcome;
   }
 
+  /**
+   * Admit snapshot-retirement recovery only through the canonical exact-layer
+   * verifier. A missing/wrong-count VM graph is not a recovery candidate; a
+   * count-complete but byte-different graph is an inconsistent confirmed state
+   * and must fail closed instead of being mistaken for an absent snapshot.
+   */
+  async verifyRecoveredGraphScopedVmCandidate(input: {
+    contextGraphId: string;
+    ual: string;
+    assertionVersion: string;
+    publicTripleCount: number;
+    privateMerkleRoot?: string;
+    expectedMerkleRoot: Uint8Array;
+    subGraphName?: string;
+  }): Promise<boolean> {
+    let privateMerkleRoot: Uint8Array | undefined;
+    try {
+      privateMerkleRoot = input.privateMerkleRoot
+        ? ethers.getBytes(input.privateMerkleRoot)
+        : undefined;
+    } catch {
+      throw Object.assign(
+        new Error(`Invalid private commitment for recovered graph-scoped KA ${input.ual}`),
+        { code: 'KA_VM_RECOVERY_INCONSISTENT' },
+      );
+    }
+    const verification = await this.verifyExactGraphScopedLayer({
+      contextGraphId: input.contextGraphId,
+      scope: createGraphKnowledgeAssetScope(input.ual, input.assertionVersion),
+      layer: MemoryLayer.VerifiableMemory,
+      publicTripleCount: input.publicTripleCount,
+      expectedMerkleRoot: input.expectedMerkleRoot,
+      ...(privateMerkleRoot ? { privateMerkleRoot } : {}),
+      ...(input.subGraphName ? { subGraphName: input.subGraphName } : {}),
+    });
+    if (verification.status === 'verified') return true;
+    if (verification.status === 'count-mismatch') return false;
+    throw Object.assign(
+      new Error(
+        `Recovered exact VM candidate for ${input.ual} failed ${verification.status}`,
+      ),
+      { code: 'KA_VM_RECOVERY_INCONSISTENT' },
+    );
+  }
+
   /** Load and verify one exact graph-scoped layer using the shared count/root rules. */
   private async verifyExactGraphScopedLayer(input: {
     contextGraphId: string;

--- a/packages/agent/src/sync-verify-worker-impl.ts
+++ b/packages/agent/src/sync-verify-worker-impl.ts
@@ -96,10 +96,22 @@ function verifySyncedDataImpl(
 function parseAndFilterNQuads(text: string, graphUri: string, contextGraphId: string): SyncParseResult {
   const rawQuads = parseNQuads(text);
   const cgUriPrefix = `did:dkg:context-graph:${contextGraphId}/`;
+  // Graph-backed SWM snapshots encode the complete CG identifier as one path
+  // segment. Real public CG IDs contain `/` (contract/name), so their transport
+  // graph starts with `contract%2Fname` and does NOT match cgUriPrefix above.
+  // Admit that sibling family only for a shared-memory DATA request; descriptor
+  // validation later binds the exact graph, count and digest before storage.
+  const graphBackedSwmPrefix = `did:dkg:context-graph:${encodeURIComponent(contextGraphId)}`
+    + '/_shared_memory_snapshots/';
+  const acceptsGraphBackedSwm = graphUri.endsWith('/_shared_memory');
   const quads: Quad[] = [];
   const sourceIndexes: number[] = [];
   for (const [index, quad] of rawQuads.entries()) {
-    if (quad.graph !== graphUri && !quad.graph.startsWith(cgUriPrefix)) continue;
+    if (
+      quad.graph !== graphUri
+      && !quad.graph.startsWith(cgUriPrefix)
+      && !(acceptsGraphBackedSwm && quad.graph.startsWith(graphBackedSwmPrefix))
+    ) continue;
     quads.push(quad);
     sourceIndexes.push(index);
   }

--- a/packages/agent/src/sync-verify-worker-impl.ts
+++ b/packages/agent/src/sync-verify-worker-impl.ts
@@ -1,6 +1,7 @@
 import { parentPort } from 'node:worker_threads';
 import { validateSubGraphName } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
+import { parseGraphBackedSwmSnapshotGraph } from './sync/graph-scoped-swm-recovery.js';
 import type { SyncVerifyResult, SyncVerifyLogEntry, SyncParseResult, SharedMemoryProcessResult, DurableBatchProcessResult, DurableBatchProcessWireResult, DurableBatchVerificationMode, SharedMemoryBatchProcessResult } from './sync-verify-worker.js';
 import { isSharedMemoryBucketDescendantDataGraph } from './sync/shared-memory-graphs.js';
 import {
@@ -101,8 +102,6 @@ function parseAndFilterNQuads(text: string, graphUri: string, contextGraphId: st
   // graph starts with `contract%2Fname` and does NOT match cgUriPrefix above.
   // Admit that sibling family only for a shared-memory DATA request; descriptor
   // validation later binds the exact graph, count and digest before storage.
-  const graphBackedSwmPrefix = `did:dkg:context-graph:${encodeURIComponent(contextGraphId)}`
-    + '/_shared_memory_snapshots/';
   const acceptsGraphBackedSwm = graphUri.endsWith('/_shared_memory');
   const quads: Quad[] = [];
   const sourceIndexes: number[] = [];
@@ -110,7 +109,10 @@ function parseAndFilterNQuads(text: string, graphUri: string, contextGraphId: st
     if (
       quad.graph !== graphUri
       && !quad.graph.startsWith(cgUriPrefix)
-      && !(acceptsGraphBackedSwm && quad.graph.startsWith(graphBackedSwmPrefix))
+      && !(
+        acceptsGraphBackedSwm
+        && parseGraphBackedSwmSnapshotGraph(quad.graph)?.contextGraphId === contextGraphId
+      )
     ) continue;
     quads.push(quad);
     sourceIndexes.push(index);

--- a/packages/agent/src/sync/auth/request-build.ts
+++ b/packages/agent/src/sync/auth/request-build.ts
@@ -191,8 +191,7 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
   // and a NEW responder treats a request WITHOUT meta pageMode as non-negotiated
   // (plain meta serializer). The signed `limit` still rides the 500-row legacy
   // cap below, so digests stay wire-compatible.
-  const useByteBudgetPage = !includeSharedMemory
-    && (phase === 'data' || phase === 'meta')
+  const useByteBudgetPage = (phase === 'data' || (!includeSharedMemory && phase === 'meta'))
     && (
       requestedLimit > SYNC_PAGE_SIZE
       // Exact DATA must remain on the responder's bounded page-only path after

--- a/packages/agent/src/sync/checkpoint/state.ts
+++ b/packages/agent/src/sync/checkpoint/state.ts
@@ -33,6 +33,8 @@ export type SyncCheckpointScope =
 
 /** Runtime-distinct namespace owned only by retained selected-SWM metadata. */
 export type SelectedSwmMetaRetentionScope = `selected-swm-meta:retained:${string}`;
+/** Runtime-distinct namespace owned only by selected SWM DATA replay. */
+export type SelectedSwmDataCheckpointScope = `selected-swm-data:${string}`;
 
 export interface SyncCheckpointStore {
   /**

--- a/packages/agent/src/sync/checkpoint/state.ts
+++ b/packages/agent/src/sync/checkpoint/state.ts
@@ -28,6 +28,7 @@ export {
  */
 export type SyncCheckpointScope =
   | `selected-swm-meta:${string}`
+  | `selected-swm-data:${string}`
   | `durable-recovery-meta:${string}`;
 
 /** Runtime-distinct namespace owned only by retained selected-SWM metadata. */

--- a/packages/agent/src/sync/graph-scoped-swm-recovery.ts
+++ b/packages/agent/src/sync/graph-scoped-swm-recovery.ts
@@ -489,13 +489,58 @@ function subGraphForMetaGraph(contextGraphId: string, metaGraph: string): string
   return name;
 }
 
-function knowledgeAssetSnapshotGraph(
+export interface GraphBackedSwmSnapshotGraphIdentity {
+  readonly contextGraphId: string;
+  readonly shareOperationId: string;
+  readonly subGraphName?: string;
+}
+
+/** Canonical immutable transport graph for one graph-scoped SWM operation. */
+export function knowledgeAssetSnapshotGraph(
   contextGraphId: string,
   shareOperationId: string,
   subGraphName?: string,
 ): string {
   const parts = [contextGraphId, subGraphName ?? '_', shareOperationId].map(encodeURIComponent);
   return `did:dkg:context-graph:${parts[0]}/_shared_memory_snapshots/${parts[1]}/${parts[2]}/ka`;
+}
+
+/**
+ * Parse the canonical graph-backed SWM transport identity. Returning null is
+ * deliberately fail-closed: callers must not treat a merely similar URI as an
+ * immutable snapshot graph.
+ */
+export function parseGraphBackedSwmSnapshotGraph(
+  graph: string,
+): GraphBackedSwmSnapshotGraphIdentity | null {
+  const prefix = 'did:dkg:context-graph:';
+  const marker = '/_shared_memory_snapshots/';
+  if (!graph.startsWith(prefix) || !graph.endsWith('/ka')) return null;
+  const markerIndex = graph.indexOf(marker, prefix.length);
+  if (markerIndex < 0) return null;
+  const encodedContextGraphId = graph.slice(prefix.length, markerIndex);
+  const tail = graph.slice(markerIndex + marker.length, -3);
+  const parts = tail.split('/');
+  if (!encodedContextGraphId || parts.length !== 2 || parts.some((part) => !part)) return null;
+  try {
+    const contextGraphId = decodeURIComponent(encodedContextGraphId);
+    const encodedSubGraphName = parts[0]!;
+    const shareOperationId = decodeURIComponent(parts[1]!);
+    const subGraphName = encodedSubGraphName === '_'
+      ? undefined
+      : decodeURIComponent(encodedSubGraphName);
+    if (
+      !contextGraphId
+      || !shareOperationId
+      || (subGraphName !== undefined && !validateSubGraphName(subGraphName).valid)
+    ) return null;
+    const identity = { contextGraphId, shareOperationId, ...(subGraphName ? { subGraphName } : {}) };
+    return knowledgeAssetSnapshotGraph(contextGraphId, shareOperationId, subGraphName) === graph
+      ? identity
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 function groupByGraphAndSubject(quads: readonly Quad[]): Map<string, Quad[]> {

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -369,6 +369,15 @@ interface ManifestSettlementCheckpoint {
   readonly numericAdvance: boolean;
 }
 
+type RootlessDataCheckpointRepair =
+  | { readonly kind: 'none' }
+  | {
+      readonly kind: 'rewind';
+      readonly offset: number;
+      readonly responderSessionOffset: number;
+    }
+  | { readonly kind: 'reset-stranded-session' };
+
 /**
  * Advance only across a contiguous prefix of graph descriptors whose exact
  * assets have finished the chain-authentication + atomic-materialization
@@ -906,8 +915,7 @@ async function runDurableSyncWithBudget(
 
       let effectiveDataResult = dataResult;
       let dataForVerification = dataResult.quads;
-      let rewoundDiscardedDataSuffix = false;
-      let resetStrandedDataSession = false;
+      let dataCheckpointRepair: RootlessDataCheckpointRepair = { kind: 'none' };
       let verificationMode: DurableBatchVerificationMode = sinceBatchId === undefined
         ? { kind: 'fullSnapshot' }
         : { kind: 'sinceBatchId', sinceBatchId };
@@ -1002,18 +1010,27 @@ async function runDurableSyncWithBudget(
           // projection deliberately drops that unusable suffix. Rebind the
           // same responder token to the last complete raw graph boundary so a
           // retry replays the dropped rows instead of skipping them forever.
-          rewoundDiscardedDataSuffix = rawNextOffset > bounded.safeRawNextOffset;
+          const rewoundDiscardedDataSuffix = rawNextOffset > bounded.safeRawNextOffset;
           // Repair checkpoints written by older code that already reached raw
           // EOF while their verified cursor remained behind. With no rows in
           // this response there is no raw-offset mapping from which to rewind,
           // so discard the paired token/checkpoint and let the next attempt
           // obtain a fresh immutable responder generation from offset zero.
-          resetStrandedDataSession = dataResult.completed
+          const resetStrandedDataSession = dataResult.completed
             && bounded.safeNextOffset < bounded.manifestRowCount
             && bounded.safeNextOffset === dataResult.resumedFromOffset
             && bounded.completedGraphCount === 0
             && rawResumedFromOffset > dataResult.resumedFromOffset
             && rawNextOffset === rawResumedFromOffset;
+          dataCheckpointRepair = resetStrandedDataSession
+            ? { kind: 'reset-stranded-session' }
+            : rewoundDiscardedDataSuffix
+              ? {
+                  kind: 'rewind',
+                  offset: bounded.safeNextOffset,
+                  responderSessionOffset: bounded.safeRawNextOffset,
+                }
+              : { kind: 'none' };
           dataForVerification = bounded.dataQuads;
           effectiveDataResult = {
             ...dataResult,
@@ -1084,54 +1101,6 @@ async function runDurableSyncWithBudget(
       if (graphScopedManifest && processed.dataRejectedMissingMeta !== 0) {
         deleteCheckpoint(rawDataResult.checkpointKey);
       }
-      if (
-        graphScopedManifest
-        && batchVerifiedCleanly
-        && processed.dataRejectedMissingMeta === 0
-        && resetStrandedDataSession
-      ) {
-        deleteCheckpoint(rawDataResult.checkpointKey);
-        logWarn(
-          ctx,
-          `Reset stranded rootless durable session for "${pid}": raw cursor `
-            + `${rawDataResult.rawResumedFromOffset ?? rawDataResult.resumedFromOffset} `
-            + `was ahead of verified graph boundary ${effectiveDataResult.resumedFromOffset}`,
-        );
-      } else if (
-        graphScopedManifest
-        && batchVerifiedCleanly
-        && processed.dataRejectedMissingMeta === 0
-        && rewoundDiscardedDataSuffix
-      ) {
-        const prefix = graphScopedDurableManifestPrefixAtOffset(
-          graphScopedManifest,
-          effectiveDataResult.nextOffset,
-        );
-        if (!prefix) {
-          deleteCheckpoint(rawDataResult.checkpointKey);
-          throw new Error(
-            `Refusing to rewind durable DATA cursor ${effectiveDataResult.nextOffset}: `
-              + 'the completed META manifest has no matching graph boundary',
-          );
-        }
-        setCheckpoint(rawDataResult.checkpointKey, {
-          offset: effectiveDataResult.nextOffset,
-          responderSessionOffset: effectiveDataResult.rawNextOffset,
-          binding: {
-            manifestDigest: graphScopedManifest.manifestDigest,
-            manifestPrefixDigest: prefix.prefixDigest,
-            terminal: false,
-          },
-        });
-        logInfo(
-          ctx,
-          `Rewound rootless durable responder cursor for "${pid}" to complete graph `
-            + `boundary ${effectiveDataResult.nextOffset} `
-            + `(raw ${rawDataResult.rawNextOffset ?? rawDataResult.nextOffset}`
-            + `->${effectiveDataResult.rawNextOffset})`,
-        );
-      }
-
       const notifyVerifiedFullSnapshot = async (): Promise<void> => {
         if (
           !onVerifiedFullSnapshot
@@ -1192,6 +1161,56 @@ async function runDurableSyncWithBudget(
         && !metaResult.timedOut
         && effectiveDataResult.completed
         && !effectiveDataResult.timedOut;
+      const settleZeroProgressDataCheckpointRepair = () => {
+        if (
+          !graphScopedManifest
+          || !batchVerifiedCleanly
+          || processed.dataRejectedMissingMeta !== 0
+          || dataCheckpointRepair.kind === 'none'
+        ) return;
+        if (dataCheckpointRepair.kind === 'reset-stranded-session') {
+          deleteCheckpoint(rawDataResult.checkpointKey);
+          logWarn(
+            ctx,
+            `Reset stranded rootless durable session for "${pid}": raw cursor `
+              + `${rawDataResult.rawResumedFromOffset ?? rawDataResult.resumedFromOffset} `
+              + `was ahead of verified graph boundary ${effectiveDataResult.resumedFromOffset}`,
+          );
+          return;
+        }
+        // A zero-length verified prefix has no store side effect to await, so
+        // it is safe to repair the raw responder cursor at the empty-response
+        // checkpoint boundary. Non-empty prefixes are deliberately left to
+        // the normal post-materialization settlement/checkpoint path below.
+        if (dataCheckpointRepair.offset !== effectiveDataResult.resumedFromOffset) return;
+        const prefix = graphScopedDurableManifestPrefixAtOffset(
+          graphScopedManifest,
+          dataCheckpointRepair.offset,
+        );
+        if (!prefix) {
+          deleteCheckpoint(rawDataResult.checkpointKey);
+          throw new Error(
+            `Refusing to rewind durable DATA cursor ${dataCheckpointRepair.offset}: `
+              + 'the completed META manifest has no matching graph boundary',
+          );
+        }
+        setCheckpoint(rawDataResult.checkpointKey, {
+          offset: dataCheckpointRepair.offset,
+          responderSessionOffset: dataCheckpointRepair.responderSessionOffset,
+          binding: {
+            manifestDigest: graphScopedManifest.manifestDigest,
+            manifestPrefixDigest: prefix.prefixDigest,
+            terminal: false,
+          },
+        });
+        logInfo(
+          ctx,
+          `Rewound rootless durable responder cursor for "${pid}" to complete graph `
+            + `boundary ${dataCheckpointRepair.offset} `
+            + `(raw ${rawDataResult.rawNextOffset ?? rawDataResult.nextOffset}`
+            + `->${dataCheckpointRepair.responderSessionOffset})`,
+        );
+      };
       const settledExactDisposition = (): ExactDurableFetchDisposition => (
         classifyExactDurableFetch({
           requestedAssetCount: exactAssetUals?.length ?? 0,
@@ -1212,6 +1231,7 @@ async function runDurableSyncWithBudget(
       ) {
         await notifyVerifiedFullSnapshot();
         throwIfOperationAborted();
+        settleZeroProgressDataCheckpointRepair();
         // The verifier reports an empty batch only when both fetched phase
         // payloads are empty. Record each phase independently: a completed
         // zero-offset phase is a real clean-empty response, while a sibling

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -906,6 +906,8 @@ async function runDurableSyncWithBudget(
 
       let effectiveDataResult = dataResult;
       let dataForVerification = dataResult.quads;
+      let rewoundDiscardedDataSuffix = false;
+      let resetStrandedDataSession = false;
       let verificationMode: DurableBatchVerificationMode = sinceBatchId === undefined
         ? { kind: 'fullSnapshot' }
         : { kind: 'sinceBatchId', sinceBatchId };
@@ -991,6 +993,27 @@ async function runDurableSyncWithBudget(
           );
         }
         if (bounded) {
+          const rawResumedFromOffset = dataResult.rawResumedFromOffset
+            ?? dataResult.resumedFromOffset;
+          const rawNextOffset = dataResult.rawNextOffset ?? dataResult.nextOffset;
+          // page-fetch owns a raw immutable responder cursor, while this layer
+          // owns the verified complete-graph cursor. A timeout may accept part
+          // of the next graph and persist the RAW cursor before this bounded
+          // projection deliberately drops that unusable suffix. Rebind the
+          // same responder token to the last complete raw graph boundary so a
+          // retry replays the dropped rows instead of skipping them forever.
+          rewoundDiscardedDataSuffix = rawNextOffset > bounded.safeRawNextOffset;
+          // Repair checkpoints written by older code that already reached raw
+          // EOF while their verified cursor remained behind. With no rows in
+          // this response there is no raw-offset mapping from which to rewind,
+          // so discard the paired token/checkpoint and let the next attempt
+          // obtain a fresh immutable responder generation from offset zero.
+          resetStrandedDataSession = dataResult.completed
+            && bounded.safeNextOffset < bounded.manifestRowCount
+            && bounded.safeNextOffset === dataResult.resumedFromOffset
+            && bounded.completedGraphCount === 0
+            && rawResumedFromOffset > dataResult.resumedFromOffset
+            && rawNextOffset === rawResumedFromOffset;
           dataForVerification = bounded.dataQuads;
           effectiveDataResult = {
             ...dataResult,
@@ -1060,6 +1083,53 @@ async function runDurableSyncWithBudget(
       }
       if (graphScopedManifest && processed.dataRejectedMissingMeta !== 0) {
         deleteCheckpoint(rawDataResult.checkpointKey);
+      }
+      if (
+        graphScopedManifest
+        && batchVerifiedCleanly
+        && processed.dataRejectedMissingMeta === 0
+        && resetStrandedDataSession
+      ) {
+        deleteCheckpoint(rawDataResult.checkpointKey);
+        logWarn(
+          ctx,
+          `Reset stranded rootless durable session for "${pid}": raw cursor `
+            + `${rawDataResult.rawResumedFromOffset ?? rawDataResult.resumedFromOffset} `
+            + `was ahead of verified graph boundary ${effectiveDataResult.resumedFromOffset}`,
+        );
+      } else if (
+        graphScopedManifest
+        && batchVerifiedCleanly
+        && processed.dataRejectedMissingMeta === 0
+        && rewoundDiscardedDataSuffix
+      ) {
+        const prefix = graphScopedDurableManifestPrefixAtOffset(
+          graphScopedManifest,
+          effectiveDataResult.nextOffset,
+        );
+        if (!prefix) {
+          deleteCheckpoint(rawDataResult.checkpointKey);
+          throw new Error(
+            `Refusing to rewind durable DATA cursor ${effectiveDataResult.nextOffset}: `
+              + 'the completed META manifest has no matching graph boundary',
+          );
+        }
+        setCheckpoint(rawDataResult.checkpointKey, {
+          offset: effectiveDataResult.nextOffset,
+          responderSessionOffset: effectiveDataResult.rawNextOffset,
+          binding: {
+            manifestDigest: graphScopedManifest.manifestDigest,
+            manifestPrefixDigest: prefix.prefixDigest,
+            terminal: false,
+          },
+        });
+        logInfo(
+          ctx,
+          `Rewound rootless durable responder cursor for "${pid}" to complete graph `
+            + `boundary ${effectiveDataResult.nextOffset} `
+            + `(raw ${rawDataResult.rawNextOffset ?? rawDataResult.nextOffset}`
+            + `->${effectiveDataResult.rawNextOffset})`,
+        );
       }
 
       const notifyVerifiedFullSnapshot = async (): Promise<void> => {

--- a/packages/agent/src/sync/requester/graph-backed-swm-data-replay.ts
+++ b/packages/agent/src/sync/requester/graph-backed-swm-data-replay.ts
@@ -1,0 +1,157 @@
+import type { Quad } from '@origintrail-official/dkg-storage';
+import type { GraphScopedSwmRecoveryDescriptor } from '../graph-scoped-swm-recovery.js';
+
+const PUBLIC_SNAPSHOT_GRAPH = 'http://dkg.io/ontology/publicSnapshotGraph';
+
+export interface BoundedGraphBackedSwmDataPage {
+  readonly completeGraphs: ReadonlySet<string>;
+  readonly safeNextOffset: number;
+  readonly safeRawNextOffset: number;
+  readonly rewound: boolean;
+}
+
+export interface IndexedGraphBackedSwmDataPage {
+  readonly dataByGraph: Map<string, Quad[]>;
+  readonly rawStartByGraph: ReadonlyMap<string, number>;
+}
+
+/**
+ * Raw advertisement terms are used only to partition aggregate DATA away from
+ * the permissive legacy-root verifier. Descriptor parsing remains the sole
+ * authority for identity, materialization, and completion.
+ */
+export function collectAdvertisedGraphBackedSnapshotGraphs(
+  metaQuads: readonly Quad[],
+): ReadonlySet<string> {
+  return new Set(
+    metaQuads
+      .filter((quad) => quad.predicate === PUBLIC_SNAPSHOT_GRAPH)
+      .map((quad) => stripLiteral(quad.object)?.trim())
+      .filter((graph): graph is string => Boolean(graph)),
+  );
+}
+
+/** Index one aggregate DATA page once, preserving its responder coordinates. */
+export function indexGraphBackedSwmDataPage(params: {
+  readonly quads: readonly Quad[];
+  readonly advertisedGraphs: ReadonlySet<string>;
+  readonly resumedFromOffset: number;
+  readonly rawResumedFromOffset?: number;
+  readonly quadRawOffsets?: readonly number[];
+}): IndexedGraphBackedSwmDataPage {
+  const dataByGraph = new Map<string, Quad[]>();
+  const rawStartByGraph = new Map<string, number>();
+  const rawStart = params.rawResumedFromOffset ?? params.resumedFromOffset;
+  for (const [quadIndex, quad] of params.quads.entries()) {
+    if (!params.advertisedGraphs.has(quad.graph)) continue;
+    if (!rawStartByGraph.has(quad.graph)) {
+      rawStartByGraph.set(
+        quad.graph,
+        params.quadRawOffsets?.[quadIndex] ?? rawStart + quadIndex,
+      );
+    }
+    const rows = dataByGraph.get(quad.graph);
+    if (rows) rows.push(quad);
+    else dataByGraph.set(quad.graph, [quad]);
+  }
+  return { dataByGraph, rawStartByGraph };
+}
+
+/**
+ * Project a possibly interrupted aggregate SWM DATA response onto whole
+ * immutable snapshot graphs. The responder emits graph-backed snapshots as
+ * contiguous graph groups before legacy root data; only a full count-bound
+ * group may be materialized or skipped by the next requester cursor.
+ */
+export function planBoundedGraphBackedSwmDataPage(params: {
+  readonly quads: readonly Quad[];
+  readonly descriptors: readonly GraphScopedSwmRecoveryDescriptor[];
+  readonly resumedFromOffset: number;
+  readonly rawResumedFromOffset?: number;
+  readonly nextOffset: number;
+  readonly rawNextOffset?: number;
+  readonly quadRawOffsets?: readonly number[];
+  readonly completed: boolean;
+}): BoundedGraphBackedSwmDataPage | null {
+  const expectedByGraph = new Map<string, number>();
+  for (const descriptor of params.descriptors) {
+    const graph = descriptor.publicSnapshotGraph;
+    if (!graph) continue;
+    const existing = expectedByGraph.get(graph);
+    if (existing !== undefined && existing !== descriptor.publicQuadsCount) return null;
+    expectedByGraph.set(graph, descriptor.publicQuadsCount);
+  }
+  const rawResumed = params.rawResumedFromOffset ?? params.resumedFromOffset;
+  const rawNext = params.rawNextOffset ?? params.nextOffset;
+  if (expectedByGraph.size === 0) {
+    return {
+      completeGraphs: new Set(),
+      safeNextOffset: params.nextOffset,
+      safeRawNextOffset: rawNext,
+      rewound: false,
+    };
+  }
+  const rawOffsets = params.quadRawOffsets === undefined
+    ? rawNext - rawResumed === params.quads.length
+      ? params.quads.map((_, index) => rawResumed + index)
+      : null
+    : [...params.quadRawOffsets];
+  if (
+    rawOffsets === null
+    || rawOffsets.length !== params.quads.length
+    || rawOffsets.some((offset, index) => !Number.isSafeInteger(offset)
+      || offset < rawResumed
+      || offset >= rawNext
+      || (index > 0 && offset <= rawOffsets[index - 1]!))
+  ) return null;
+
+  const completeGraphs = new Set<string>();
+  const seenGraphs = new Set<string>();
+  let index = 0;
+  let sawLegacyRows = false;
+  while (index < params.quads.length) {
+    const graph = params.quads[index]!.graph;
+    const expected = expectedByGraph.get(graph);
+    if (expected === undefined) {
+      sawLegacyRows = true;
+      index += 1;
+      continue;
+    }
+    if (sawLegacyRows || seenGraphs.has(graph)) return null;
+    seenGraphs.add(graph);
+    const groupStart = index;
+    while (index < params.quads.length && params.quads[index]!.graph === graph) index += 1;
+    const observed = index - groupStart;
+    if (observed > expected) return null;
+    if (observed === expected) {
+      completeGraphs.add(graph);
+      continue;
+    }
+    if (params.completed || index !== params.quads.length) return null;
+    const safeRawNextOffset = rawOffsets[groupStart]!;
+    return {
+      completeGraphs,
+      safeNextOffset: safeRawNextOffset,
+      safeRawNextOffset,
+      rewound: safeRawNextOffset < rawNext,
+    };
+  }
+  return {
+    completeGraphs,
+    safeNextOffset: params.nextOffset,
+    safeRawNextOffset: rawNext,
+    rewound: false,
+  };
+}
+
+function stripLiteral(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const match = value.match(/^"((?:[^"\\]|\\.)*)"(?:@[-A-Za-z0-9]+|\^\^<[^>]+>)?$/);
+  if (!match) return value;
+  return match[1]
+    .replace(/\\n/g, '\n')
+    .replace(/\\r/g, '\r')
+    .replace(/\\t/g, '\t')
+    .replace(/\\"/g, '"')
+    .replace(/\\\\/g, '\\');
+}

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -9,7 +9,7 @@ import type { Quad } from '@origintrail-official/dkg-storage';
 import type { SwmSnapshotCoverage } from '../../dkg-agent-types.js';
 import { workspacePublicQuadsDigest, type WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
 import type { SyncPhase } from '../auth/request-build.js';
-import type { SyncCheckpointScope } from '../checkpoint/state.js';
+import type { SelectedSwmDataCheckpointScope } from '../checkpoint/state.js';
 import { didSyncPeerRespond, isSyncBackoffWorthyError, isSyncPermanentRejection, isSyncTransportFailure } from '../error-tags.js';
 import { isSharedMemoryBucketDescendantDataGraph } from '../shared-memory-graphs.js';
 import {
@@ -19,10 +19,16 @@ import {
 import {
   canonicalizeGraphScopedSwmHeadRows,
   materializeGraphScopedSwmRecoveryAsset,
+  parseGraphBackedSwmSnapshotGraph,
   parseGraphScopedSwmRecoveryDescriptors,
   type GraphScopedSwmRecoveryDescriptor,
 } from '../graph-scoped-swm-recovery.js';
 import type { SharedMemorySnapshotMaterializer } from './swm-snapshot-materializer.js';
+import {
+  collectAdvertisedGraphBackedSnapshotGraphs,
+  indexGraphBackedSwmDataPage,
+  planBoundedGraphBackedSwmDataPage,
+} from './graph-backed-swm-data-replay.js';
 
 const DKG = 'http://dkg.io/ontology/';
 
@@ -389,7 +395,7 @@ interface SharedMemorySyncContext {
    */
   snapshotRecoveryOrder?: 'manifest' | 'recent-balanced';
   /** Versioned cursor namespace for callers that own selected SWM DATA replay. */
-  dataRequesterScope?: SyncCheckpointScope;
+  dataRequesterScope?: SelectedSwmDataCheckpointScope;
   deleteCheckpoint: (key: string) => void;
   setCheckpoint: (key: string, offset: number, responderSessionOffset?: number) => void;
   ensureOwnedMap: (ownershipKey: string) => Map<string, string>;
@@ -411,106 +417,6 @@ function storedVersionOutranksDescriptor(stored: string, descriptorVersion: stri
   } catch {
     return true;
   }
-}
-
-export interface BoundedGraphBackedSwmDataPage {
-  readonly completeGraphs: ReadonlySet<string>;
-  readonly safeNextOffset: number;
-  readonly safeRawNextOffset: number;
-  readonly rewound: boolean;
-}
-
-/**
- * Project a possibly interrupted aggregate SWM DATA response onto whole
- * immutable snapshot graphs. The responder emits graph-backed snapshots as
- * contiguous graph groups before legacy root data; only a full count-bound
- * group may be materialized or skipped by the next requester cursor.
- */
-export function planBoundedGraphBackedSwmDataPage(params: {
-  readonly quads: readonly Quad[];
-  readonly descriptors: readonly GraphScopedSwmRecoveryDescriptor[];
-  readonly resumedFromOffset: number;
-  readonly rawResumedFromOffset?: number;
-  readonly nextOffset: number;
-  readonly rawNextOffset?: number;
-  readonly quadRawOffsets?: readonly number[];
-  readonly completed: boolean;
-}): BoundedGraphBackedSwmDataPage | null {
-  const expectedByGraph = new Map<string, number>();
-  for (const descriptor of params.descriptors) {
-    const graph = descriptor.publicSnapshotGraph;
-    if (!graph) continue;
-    const existing = expectedByGraph.get(graph);
-    if (existing !== undefined && existing !== descriptor.publicQuadsCount) return null;
-    expectedByGraph.set(graph, descriptor.publicQuadsCount);
-  }
-  const rawResumed = params.rawResumedFromOffset ?? params.resumedFromOffset;
-  const rawNext = params.rawNextOffset ?? params.nextOffset;
-  if (expectedByGraph.size === 0) {
-    return {
-      completeGraphs: new Set(),
-      safeNextOffset: params.nextOffset,
-      safeRawNextOffset: rawNext,
-      rewound: false,
-    };
-  }
-  const rawOffsets = params.quadRawOffsets === undefined
-    ? rawNext - rawResumed === params.quads.length
-      ? params.quads.map((_, index) => rawResumed + index)
-      : null
-    : [...params.quadRawOffsets];
-  if (
-    rawOffsets === null
-    || rawOffsets.length !== params.quads.length
-    || rawOffsets.some((offset, index) => !Number.isSafeInteger(offset)
-      || offset < rawResumed
-      || offset >= rawNext
-      || (index > 0 && offset <= rawOffsets[index - 1]!))
-  ) return null;
-
-  const completeGraphs = new Set<string>();
-  const seenGraphs = new Set<string>();
-  let index = 0;
-  let sawLegacyRows = false;
-  while (index < params.quads.length) {
-    const graph = params.quads[index]!.graph;
-    const expected = expectedByGraph.get(graph);
-    if (expected === undefined) {
-      sawLegacyRows = true;
-      index += 1;
-      continue;
-    }
-    // Graph-backed groups precede legacy root rows and are contiguous. A graph
-    // after legacy data, or the same graph in two groups, is not safely
-    // checkpointable against this responder generation.
-    if (sawLegacyRows || seenGraphs.has(graph)) return null;
-    seenGraphs.add(graph);
-    const groupStart = index;
-    while (index < params.quads.length && params.quads[index]!.graph === graph) index += 1;
-    const observed = index - groupStart;
-    if (observed > expected) return null;
-    if (observed === expected) {
-      completeGraphs.add(graph);
-      continue;
-    }
-    // A short immutable graph is only a valid timeout prefix when it is the
-    // final group returned. Rewind both verified and responder coordinates to
-    // its first row so the next pass reconstructs the whole graph.
-    if (params.completed || index !== params.quads.length) return null;
-    const safeRawNextOffset = rawOffsets[groupStart]!;
-    return {
-      completeGraphs,
-      safeNextOffset: safeRawNextOffset,
-      safeRawNextOffset,
-      rewound: safeRawNextOffset < rawNext,
-    };
-  }
-  return {
-    completeGraphs,
-    safeNextOffset: params.nextOffset,
-    safeRawNextOffset: rawNext,
-    rewound: false,
-  };
 }
 
 export async function runSharedMemorySync(context: SharedMemorySyncContext): Promise<SharedMemorySyncSummary> {
@@ -748,7 +654,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       // This prefilter uses raw metadata only to REMOVE data from the permissive
       // legacy path; verified metadata remains the sole authority for adding or
       // completing anything.
-      const rawAdvertisedGraphBackedSnapshots = collectAdvertisedGraphBackedSnapshots(
+      const rawAdvertisedGraphBackedSnapshots = collectAdvertisedGraphBackedSnapshotGraphs(
         wsMetaResult.quads,
       );
       const processed = await processSharedMemoryBatch(
@@ -848,28 +754,27 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       // queryable as ordinary SWM data or inflate insertion counters. The
       // parser remains the authority for which of these advertisements can be
       // materialized and counted toward terminal coverage.
-      const advertisedGraphBackedSnapshotGraphs = collectAdvertisedGraphBackedSnapshots(
+      const advertisedGraphBackedSnapshotGraphs = collectAdvertisedGraphBackedSnapshotGraphs(
         processed.verifiedMeta,
       );
+      // Preserve the advertised denominator independently of descriptor
+      // parsing. A malformed graph-backed operation must remain incomplete;
+      // clearing the materializable set below must never turn it into vacuous
+      // 0/0 completion.
+      graphBackedTotalForCg = advertisedGraphBackedSnapshotGraphs.size;
       // Index the aggregate page once. Filtering the complete 250k-quad page
       // once per KA would make recovery O(KAs * quads); the per-graph buckets
       // keep verification linear while retaining the materializer's own exact
       // graph/count/digest checks.
-      const graphBackedDataByGraph = new Map<string, Quad[]>();
-      const graphBackedRawStartByGraph = new Map<string, number>();
-      for (const [quadIndex, quad] of wsDataResult.quads.entries()) {
-        if (!advertisedGraphBackedSnapshotGraphs.has(quad.graph)) continue;
-        if (!graphBackedRawStartByGraph.has(quad.graph)) {
-          graphBackedRawStartByGraph.set(
-            quad.graph,
-            wsDataResult.quadRawOffsets?.[quadIndex]
-              ?? (wsDataResult.rawResumedFromOffset ?? wsDataResult.resumedFromOffset) + quadIndex,
-          );
-        }
-        const rows = graphBackedDataByGraph.get(quad.graph);
-        if (rows) rows.push(quad);
-        else graphBackedDataByGraph.set(quad.graph, [quad]);
-      }
+      const graphBackedDataPage = indexGraphBackedSwmDataPage({
+        quads: wsDataResult.quads,
+        advertisedGraphs: advertisedGraphBackedSnapshotGraphs,
+        resumedFromOffset: wsDataResult.resumedFromOffset,
+        rawResumedFromOffset: wsDataResult.rawResumedFromOffset,
+        quadRawOffsets: wsDataResult.quadRawOffsets,
+      });
+      const graphBackedDataByGraph = graphBackedDataPage.dataByGraph;
+      const graphBackedRawStartByGraph = graphBackedDataPage.rawStartByGraph;
       validWsQuads = validWsQuads.filter(
         (quad) => !advertisedGraphBackedSnapshotGraphs.has(quad.graph),
       );
@@ -938,11 +843,11 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
               rawNextOffset: boundedGraphBackedPage.safeRawNextOffset,
               completed: false,
             };
-            for (const graph of [...graphBackedDataByGraph.keys()]) {
-              if (!boundedGraphBackedPage.completeGraphs.has(graph)) {
-                graphBackedDataByGraph.delete(graph);
-              }
+          for (const graph of [...graphBackedDataByGraph.keys()]) {
+            if (!boundedGraphBackedPage.completeGraphs.has(graph)) {
+              graphBackedDataByGraph.delete(graph);
             }
+          }
             if (boundedGraphBackedPage.safeNextOffset === 0) {
               // setCheckpoint(0) would retain page-fetch's process-local token
               // at the raw end of the discarded suffix. Delete both halves so
@@ -1338,7 +1243,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       // rather than a decision input.
       recordSnapshotCoverage(
         snapshotSync,
-        graphBackedSnapshotGraphs.size,
+        graphBackedTotalForCg,
         wsMetaResult.completed,
         descriptorsAuthoritativeForCg,
         materializationFailures,
@@ -1380,16 +1285,16 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       const snapshotEvidenceAccepted = snapshotEvidencePolicy?.accepts({
         verifiedMetadataTriples: processed.verifiedMeta.length,
         snapshotReferences: snapshotSync.totalSnapshots,
-        graphBackedOperations: countGraphBackedSnapshotOperations(processed.verifiedMeta),
+        graphBackedOperations: countGraphBackedSnapshotOperations(processed.verifiedMeta, pid),
       }) ?? true;
       const snapshotPhaseUsable = snapshotSync.completed
         && materializationFailures === 0
         && (
           descriptorsAuthoritativeForCg
-          || snapshotSync.totalSnapshots + graphBackedSnapshotGraphs.size === 0
+          || snapshotSync.totalSnapshots + graphBackedTotalForCg === 0
         )
         && materializedRefs.size
-          === snapshotSync.totalSnapshots + graphBackedSnapshotGraphs.size
+          === snapshotSync.totalSnapshots + graphBackedTotalForCg
         && snapshotEvidenceAccepted;
       if (materializationFailures > 0) {
         logWarn(ctx, `SWM sync for "${pid}": ${materializationFailures} snapshot(s) verified but `
@@ -1415,11 +1320,15 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
           await storeInsert(validWsQuads);
           summary.insertedTriples += validWsQuads.length;
           summary.insertedDataTriples += validWsQuads.length;
-          recordPhaseOutcome(effectiveWsDataResult, {
-            updateCheckpoint: !suppressDataCheckpointUpdate,
-          });
           hydrateOwnership();
         }
+        // Graph-backed DATA can be the entire response. Its safe rewind cursor
+        // is still evidence even when there are no legacy rows to insert; tying
+        // checkpoint persistence to `validWsQuads.length` discarded that cursor
+        // and restarted every failed immutable graph from an unrelated offset.
+        recordPhaseOutcome(effectiveWsDataResult, {
+          updateCheckpoint: !suppressDataCheckpointUpdate,
+        });
         if (snapshotSync.timedOutPhases > 0 && shouldStopAfterBackoffWorthyFailure(pid, 'snapshot timeout')) {
           break;
         }
@@ -1954,19 +1863,23 @@ export function orderPublicSnapshotsForBalancedRecency(
  * deliberately excluded: the selected lane then sees no supported immutable
  * commitment and remains incomplete instead of falsely treating them as KAs.
  */
-function countGraphBackedSnapshotOperations(metaQuads: readonly Quad[]): number {
+function countGraphBackedSnapshotOperations(
+  metaQuads: readonly Quad[],
+  contextGraphId: string,
+): number {
   const bySubject = new Map<string, {
-    hasSnapshotGraph: boolean;
+    snapshotGraph?: string;
     isWorkspaceOperation: boolean;
     graphScoped: boolean;
   }>();
   for (const quad of metaQuads) {
     const entry = bySubject.get(quad.subject) ?? {
-      hasSnapshotGraph: false,
       isWorkspaceOperation: false,
       graphScoped: false,
     };
-    if (quad.predicate === `${DKG}publicSnapshotGraph`) entry.hasSnapshotGraph = true;
+    if (quad.predicate === `${DKG}publicSnapshotGraph`) {
+      entry.snapshotGraph = stripLiteral(quad.object)?.trim();
+    }
     if (
       quad.predicate === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
       && quad.object === `${DKG}WorkspaceOperation`
@@ -1978,17 +1891,11 @@ function countGraphBackedSnapshotOperations(metaQuads: readonly Quad[]): number 
     bySubject.set(quad.subject, entry);
   }
   return [...bySubject.values()].filter((entry) => (
-    entry.hasSnapshotGraph && entry.isWorkspaceOperation && entry.graphScoped
+    entry.snapshotGraph !== undefined
+    && parseGraphBackedSwmSnapshotGraph(entry.snapshotGraph)?.contextGraphId === contextGraphId
+    && entry.isWorkspaceOperation
+    && entry.graphScoped
   )).length;
-}
-
-function collectAdvertisedGraphBackedSnapshots(metaQuads: readonly Quad[]): Set<string> {
-  return new Set(
-    metaQuads
-      .filter((quad) => quad.predicate === `${DKG}publicSnapshotGraph`)
-      .map((quad) => stripLiteral(quad.object)?.trim())
-      .filter((graph): graph is string => Boolean(graph)),
-  );
 }
 
 async function hasValidSnapshot(

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -1,9 +1,15 @@
-import { contextGraphWorkspaceGraphUri, contextGraphWorkspaceMetaGraphUri, validateSubGraphName } from '@origintrail-official/dkg-core';
+import {
+  contextGraphWorkspaceGraphUri,
+  contextGraphWorkspaceMetaGraphUri,
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  validateSubGraphName,
+} from '@origintrail-official/dkg-core';
 import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { SwmSnapshotCoverage } from '../../dkg-agent-types.js';
 import { workspacePublicQuadsDigest, type WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
 import type { SyncPhase } from '../auth/request-build.js';
+import type { SyncCheckpointScope } from '../checkpoint/state.js';
 import { didSyncPeerRespond, isSyncBackoffWorthyError, isSyncPermanentRejection, isSyncTransportFailure } from '../error-tags.js';
 import { isSharedMemoryBucketDescendantDataGraph } from '../shared-memory-graphs.js';
 import {
@@ -382,8 +388,10 @@ interface SharedMemorySyncContext {
    * oldest outstanding history. Ordinary sync preserves manifest order.
    */
   snapshotRecoveryOrder?: 'manifest' | 'recent-balanced';
+  /** Versioned cursor namespace for callers that own selected SWM DATA replay. */
+  dataRequesterScope?: SyncCheckpointScope;
   deleteCheckpoint: (key: string) => void;
-  setCheckpoint: (key: string, offset: number) => void;
+  setCheckpoint: (key: string, offset: number, responderSessionOffset?: number) => void;
   ensureOwnedMap: (ownershipKey: string) => Map<string, string>;
   logInfo: (ctx: OperationContext, message: string) => void;
   logWarn: (ctx: OperationContext, message: string) => void;
@@ -405,6 +413,106 @@ function storedVersionOutranksDescriptor(stored: string, descriptorVersion: stri
   }
 }
 
+export interface BoundedGraphBackedSwmDataPage {
+  readonly completeGraphs: ReadonlySet<string>;
+  readonly safeNextOffset: number;
+  readonly safeRawNextOffset: number;
+  readonly rewound: boolean;
+}
+
+/**
+ * Project a possibly interrupted aggregate SWM DATA response onto whole
+ * immutable snapshot graphs. The responder emits graph-backed snapshots as
+ * contiguous graph groups before legacy root data; only a full count-bound
+ * group may be materialized or skipped by the next requester cursor.
+ */
+export function planBoundedGraphBackedSwmDataPage(params: {
+  readonly quads: readonly Quad[];
+  readonly descriptors: readonly GraphScopedSwmRecoveryDescriptor[];
+  readonly resumedFromOffset: number;
+  readonly rawResumedFromOffset?: number;
+  readonly nextOffset: number;
+  readonly rawNextOffset?: number;
+  readonly quadRawOffsets?: readonly number[];
+  readonly completed: boolean;
+}): BoundedGraphBackedSwmDataPage | null {
+  const expectedByGraph = new Map<string, number>();
+  for (const descriptor of params.descriptors) {
+    const graph = descriptor.publicSnapshotGraph;
+    if (!graph) continue;
+    const existing = expectedByGraph.get(graph);
+    if (existing !== undefined && existing !== descriptor.publicQuadsCount) return null;
+    expectedByGraph.set(graph, descriptor.publicQuadsCount);
+  }
+  const rawResumed = params.rawResumedFromOffset ?? params.resumedFromOffset;
+  const rawNext = params.rawNextOffset ?? params.nextOffset;
+  if (expectedByGraph.size === 0) {
+    return {
+      completeGraphs: new Set(),
+      safeNextOffset: params.nextOffset,
+      safeRawNextOffset: rawNext,
+      rewound: false,
+    };
+  }
+  const rawOffsets = params.quadRawOffsets === undefined
+    ? rawNext - rawResumed === params.quads.length
+      ? params.quads.map((_, index) => rawResumed + index)
+      : null
+    : [...params.quadRawOffsets];
+  if (
+    rawOffsets === null
+    || rawOffsets.length !== params.quads.length
+    || rawOffsets.some((offset, index) => !Number.isSafeInteger(offset)
+      || offset < rawResumed
+      || offset >= rawNext
+      || (index > 0 && offset <= rawOffsets[index - 1]!))
+  ) return null;
+
+  const completeGraphs = new Set<string>();
+  const seenGraphs = new Set<string>();
+  let index = 0;
+  let sawLegacyRows = false;
+  while (index < params.quads.length) {
+    const graph = params.quads[index]!.graph;
+    const expected = expectedByGraph.get(graph);
+    if (expected === undefined) {
+      sawLegacyRows = true;
+      index += 1;
+      continue;
+    }
+    // Graph-backed groups precede legacy root rows and are contiguous. A graph
+    // after legacy data, or the same graph in two groups, is not safely
+    // checkpointable against this responder generation.
+    if (sawLegacyRows || seenGraphs.has(graph)) return null;
+    seenGraphs.add(graph);
+    const groupStart = index;
+    while (index < params.quads.length && params.quads[index]!.graph === graph) index += 1;
+    const observed = index - groupStart;
+    if (observed > expected) return null;
+    if (observed === expected) {
+      completeGraphs.add(graph);
+      continue;
+    }
+    // A short immutable graph is only a valid timeout prefix when it is the
+    // final group returned. Rewind both verified and responder coordinates to
+    // its first row so the next pass reconstructs the whole graph.
+    if (params.completed || index !== params.quads.length) return null;
+    const safeRawNextOffset = rawOffsets[groupStart]!;
+    return {
+      completeGraphs,
+      safeNextOffset: safeRawNextOffset,
+      safeRawNextOffset,
+      rewound: safeRawNextOffset < rawNext,
+    };
+  }
+  return {
+    completeGraphs,
+    safeNextOffset: params.nextOffset,
+    safeRawNextOffset: rawNext,
+    rewound: false,
+  };
+}
+
 export async function runSharedMemorySync(context: SharedMemorySyncContext): Promise<SharedMemorySyncSummary> {
   const {
     ctx,
@@ -424,6 +532,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
     snapshotEvidencePolicy,
     metadataFetcher,
     snapshotRecoveryOrder = 'manifest',
+    dataRequesterScope,
     deleteCheckpoint,
     setCheckpoint,
     ensureOwnedMap,
@@ -480,7 +589,11 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
     }
     if (result.completed) deleteCheckpoint(result.checkpointKey);
     else if (result.nextOffset > 0 || result.resumedFromOffset > 0) {
-      setCheckpoint(result.checkpointKey, result.nextOffset);
+      setCheckpoint(
+        result.checkpointKey,
+        result.nextOffset,
+        result.rawNextOffset ?? result.nextOffset,
+      );
     }
   };
 
@@ -501,6 +614,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
    */
   const recordSnapshotCoverage = (
     walk: PublicSnapshotWalkProgress,
+    graphBackedTotal: number,
     manifestComplete: boolean,
     descriptorsAuthoritative: boolean,
     materializationFailures: number,
@@ -513,7 +627,8 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
     // is not part of this snapshot walk. Do not turn that into terminal 0/0
     // evidence. The genuinely empty two-phase response has its own explicit
     // builder below.
-    if (walk.totalSnapshots <= 0) return;
+    const totalSnapshots = walk.totalSnapshots + graphBackedTotal;
+    if (totalSnapshots <= 0) return;
     // RESOLVED MEANS LOCALLY MATERIALIZED, not fetched.
     //
     // `walk.readySnapshots` counts refs retrieved and digest-valid in the blob
@@ -529,15 +644,15 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
     // `resolved + missing === total` true by construction, and makes it cover
     // both never-fetched and fetched-but-unwritten refs without either being
     // tracked twice.
-    const snapshotsResolved = Math.min(materializedRefCount, walk.totalSnapshots);
+    const snapshotsResolved = Math.min(materializedRefCount, totalSnapshots);
     summary.swmCoverage = selectSwmSnapshotCoverage(summary.swmCoverage, {
       contextGraphId,
       peerIdSuffix: remotePeerId.slice(-8),
       snapshotsResolved,
-      snapshotsTotal: walk.totalSnapshots,
+      snapshotsTotal: totalSnapshots,
       manifestComplete,
       descriptorsAuthoritative,
-      missingCount: walk.totalSnapshots - snapshotsResolved,
+      missingCount: totalSnapshots - snapshotsResolved,
       // Never-retrieved refs first, then retrieved-but-unwritten ones. Deduped
       // across BOTH sources so the sample can never exceed `missingCount`, which
       // is what the renderer subtracts it from to size its "(+N more)" suffix.
@@ -557,6 +672,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
     // must reach the coverage record, not be lost with the stack.
     let materializedFailuresForCg = 0;
     let materializedRefsForCg = 0;
+    let graphBackedTotalForCg = 0;
     let descriptorsAuthoritativeForCg = true;
     const unresolvedRefSampleForCg: string[] = [];
     try {
@@ -603,7 +719,18 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         recordPhaseOutcome(wsMetaResult, { updateCheckpoint: false });
         break;
       }
-      const wsDataResult = await fetchSyncPages(ctx, remotePeerId, pid, true, 'data', wsGraph, deadline);
+      const wsDataResult = await fetchSyncPages(
+        ctx,
+        remotePeerId,
+        pid,
+        true,
+        'data',
+        wsGraph,
+        deadline,
+        dataRequesterScope ? { requesterScope: dataRequesterScope } : undefined,
+      );
+      let effectiveWsDataResult = wsDataResult;
+      let suppressDataCheckpointUpdate = false;
       peerRespondedForContextGraph = true;
       const fetchDurationMs = Date.now() - fetchStartedAt;
 
@@ -614,8 +741,20 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       const excludedSubGraphNames = getExcludedSubGraphNames
         ? await getExcludedSubGraphNames(pid)
         : undefined;
+      // Immutable graph-backed snapshots are a separate integrity plane. Keep
+      // them out of the legacy root-entity verifier (which would correctly but
+      // noisily classify every rootless snapshot quad as dropped), while the
+      // descriptor-bound materializer below still receives the original page.
+      // This prefilter uses raw metadata only to REMOVE data from the permissive
+      // legacy path; verified metadata remains the sole authority for adding or
+      // completing anything.
+      const rawAdvertisedGraphBackedSnapshots = collectAdvertisedGraphBackedSnapshots(
+        wsMetaResult.quads,
+      );
       const processed = await processSharedMemoryBatch(
-        wsDataResult.quads,
+        wsDataResult.quads.filter(
+          (quad) => !rawAdvertisedGraphBackedSnapshots.has(quad.graph),
+        ),
         wsMetaResult.quads,
         pid,
         registeredSubGraphNames,
@@ -672,7 +811,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         continue;
       }
 
-      const validWsQuads = processed.verifiedData;
+      let validWsQuads = processed.verifiedData;
       const dropped = processed.droppedDataTriples;
       const hydrateOwnership = () => {
         for (const { dataGraph, entity, creator } of processed.entityCreators) {
@@ -701,7 +840,39 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       // otherwise abort the whole CG fanout. A parse failure here must degrade to
       // "no materialization this round" — never take down the sync.
       const snapshotDescriptorsByRef = new Map<string, GraphScopedSwmRecoveryDescriptor[]>();
+      const graphBackedSnapshotGraphs = new Set<string>();
       let verifiedMetaForInsert = processed.verifiedMeta;
+      // Never union-insert an immutable graph-backed transport graph, even if
+      // descriptor parsing fails below. A malformed sibling descriptor must
+      // leave this round incomplete, but it must not make the transport copy
+      // queryable as ordinary SWM data or inflate insertion counters. The
+      // parser remains the authority for which of these advertisements can be
+      // materialized and counted toward terminal coverage.
+      const advertisedGraphBackedSnapshotGraphs = collectAdvertisedGraphBackedSnapshots(
+        processed.verifiedMeta,
+      );
+      // Index the aggregate page once. Filtering the complete 250k-quad page
+      // once per KA would make recovery O(KAs * quads); the per-graph buckets
+      // keep verification linear while retaining the materializer's own exact
+      // graph/count/digest checks.
+      const graphBackedDataByGraph = new Map<string, Quad[]>();
+      const graphBackedRawStartByGraph = new Map<string, number>();
+      for (const [quadIndex, quad] of wsDataResult.quads.entries()) {
+        if (!advertisedGraphBackedSnapshotGraphs.has(quad.graph)) continue;
+        if (!graphBackedRawStartByGraph.has(quad.graph)) {
+          graphBackedRawStartByGraph.set(
+            quad.graph,
+            wsDataResult.quadRawOffsets?.[quadIndex]
+              ?? (wsDataResult.rawResumedFromOffset ?? wsDataResult.resumedFromOffset) + quadIndex,
+          );
+        }
+        const rows = graphBackedDataByGraph.get(quad.graph);
+        if (rows) rows.push(quad);
+        else graphBackedDataByGraph.set(quad.graph, [quad]);
+      }
+      validWsQuads = validWsQuads.filter(
+        (quad) => !advertisedGraphBackedSnapshotGraphs.has(quad.graph),
+      );
       // Whether the descriptor map is an AUTHORITATIVE statement about this
       // round's metadata, i.e. whether "this ref has no descriptor" may be read
       // as "this ref has nothing to materialize".
@@ -713,7 +884,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       // descriptors never parsed is a third state, distinct both from a
       // truncated meta phase and from a genuine entity-share manifest that has
       // no head rows to describe.
-      if (snapshotMaterializer && publicSnapshotStore && wsMetaResult.completed) {
+      if (snapshotMaterializer && wsMetaResult.completed) {
         try {
           const descriptors = parseGraphScopedSwmRecoveryDescriptors({
             contextGraphId: pid,
@@ -731,16 +902,64 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
             descriptors,
           });
           for (const descriptor of descriptors) {
-            const ref = descriptor.publicSnapshotRef;
-            if (!ref) continue; // no immutable snapshot for this KA
+            const ref = descriptor.publicSnapshotRef ?? descriptor.publicSnapshotGraph;
+            if (!ref) continue;
+            if (descriptor.publicSnapshotGraph) {
+              graphBackedSnapshotGraphs.add(descriptor.publicSnapshotGraph);
+            }
             const list = snapshotDescriptorsByRef.get(ref) ?? [];
             list.push(descriptor);
             snapshotDescriptorsByRef.set(ref, list);
+          }
+          graphBackedTotalForCg = graphBackedSnapshotGraphs.size;
+
+          const boundedGraphBackedPage = planBoundedGraphBackedSwmDataPage({
+            quads: wsDataResult.quads,
+            descriptors,
+            resumedFromOffset: wsDataResult.resumedFromOffset,
+            rawResumedFromOffset: wsDataResult.rawResumedFromOffset,
+            nextOffset: wsDataResult.nextOffset,
+            rawNextOffset: wsDataResult.rawNextOffset,
+            quadRawOffsets: wsDataResult.quadRawOffsets,
+            completed: wsDataResult.completed,
+          });
+          if (!boundedGraphBackedPage) {
+            deleteCheckpoint(wsDataResult.checkpointKey);
+            suppressDataCheckpointUpdate = true;
+            throw Object.assign(
+              new Error(`Discarding graph-backed SWM response for "${pid}": immutable graph groups cannot be reconciled with the DATA cursor`),
+              { code: 'SYNC_SWM_GRAPH_CHECKPOINT_UNMAPPABLE' },
+            );
+          }
+          if (boundedGraphBackedPage.rewound) {
+            effectiveWsDataResult = {
+              ...wsDataResult,
+              nextOffset: boundedGraphBackedPage.safeNextOffset,
+              rawNextOffset: boundedGraphBackedPage.safeRawNextOffset,
+              completed: false,
+            };
+            for (const graph of [...graphBackedDataByGraph.keys()]) {
+              if (!boundedGraphBackedPage.completeGraphs.has(graph)) {
+                graphBackedDataByGraph.delete(graph);
+              }
+            }
+            if (boundedGraphBackedPage.safeNextOffset === 0) {
+              // setCheckpoint(0) would retain page-fetch's process-local token
+              // at the raw end of the discarded suffix. Delete both halves so
+              // a retry really starts the immutable response at zero.
+              deleteCheckpoint(wsDataResult.checkpointKey);
+              suppressDataCheckpointUpdate = true;
+            }
+            logInfo(ctx, `SWM sync for "${pid}": rewound DATA checkpoint to immutable graph boundary `
+              + `${boundedGraphBackedPage.safeNextOffset} (raw ${boundedGraphBackedPage.safeRawNextOffset})`);
           }
         } catch (err) {
           logWarn(ctx, `SWM sync could not parse graph-scoped snapshot descriptors for "${pid}": `
             + `${err instanceof Error ? err.message : String(err)}`);
           snapshotDescriptorsByRef.clear();
+          graphBackedSnapshotGraphs.clear();
+          deleteCheckpoint(wsDataResult.checkpointKey);
+          suppressDataCheckpointUpdate = true;
           // The map is now empty because parsing FAILED, not because there was
           // nothing to describe. Without this the vacuity rule would read every
           // manifest ref as "nothing to write" and report the graph fully
@@ -753,6 +972,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       let materializedGraphs = 0;
       let materializationFailures = 0;
       let materializedQuads = 0;
+      let graphBackedFailureRewindOffset: number | undefined;
       const materializedKeys = new Set<string>();
       /** Snapshot refs whose every descriptor is locally present. */
       const materializedRefs = new Set<string>();
@@ -821,7 +1041,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         // Missing WIRING means nothing CAN be written, so the ref stays
         // UNRESOLVED: a fetched-but-unwritten ref must never look like progress
         // to the continuation loop.
-        if (!snapshotMaterializer || !publicSnapshotStore) return;
+        if (!snapshotMaterializer) return;
         // No descriptors is a DIFFERENT case, and collapsing the two made a
         // fully-synced peer permanently capable.
         //
@@ -918,7 +1138,9 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
                 }
                 const asset = await materializeGraphScopedSwmRecoveryAsset({
                   descriptor,
-                  fetchedDataQuads: [],
+                  fetchedDataQuads: descriptor.publicSnapshotGraph
+                    ? (graphBackedDataByGraph.get(descriptor.publicSnapshotGraph) ?? [])
+                    : [],
                   publicSnapshotStore,
                 });
                 await ensureContextGraphOnce();
@@ -999,6 +1221,14 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
             }
             // Mirrored outside the `try` so a later throw cannot lose it.
             materializedFailuresForCg = materializationFailures;
+            if (descriptor.publicSnapshotGraph) {
+              const rewindOffset = graphBackedRawStartByGraph.get(descriptor.publicSnapshotGraph);
+              if (rewindOffset !== undefined) {
+                graphBackedFailureRewindOffset = graphBackedFailureRewindOffset === undefined
+                  ? rewindOffset
+                  : Math.min(graphBackedFailureRewindOffset, rewindOffset);
+              }
+            }
             logWarn(ctx, `SWM sync failed to materialize snapshot ${snapshotRef} for "${pid}": `
               + `${err instanceof Error ? err.message : String(err)}`);
           }
@@ -1057,6 +1287,26 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         // absent, so this costs nothing when there is genuinely no wiring.
         onSnapshotReady: (snapshot: PublicSnapshotMetadata) => materializeReadySnapshot(snapshot.ref),
       });
+      // Graph-backed immutable snapshots travel in the aggregate data phase,
+      // not through the blob-store snapshot protocol. They share the exact same
+      // atomic materializer and signed count/digest checks as store-backed refs.
+      for (const graph of graphBackedSnapshotGraphs) {
+        await materializeReadySnapshot(graph);
+      }
+      if (graphBackedFailureRewindOffset !== undefined) {
+        effectiveWsDataResult = {
+          ...wsDataResult,
+          nextOffset: graphBackedFailureRewindOffset,
+          rawNextOffset: graphBackedFailureRewindOffset,
+          completed: false,
+        };
+        if (graphBackedFailureRewindOffset === 0) {
+          deleteCheckpoint(wsDataResult.checkpointKey);
+          suppressDataCheckpointUpdate = true;
+        }
+        logInfo(ctx, `SWM sync for "${pid}": retained DATA cursor at failed immutable graph boundary `
+          + `${graphBackedFailureRewindOffset}`);
+      }
       if (materializedGraphs > 0) {
         // Reporting only — the counters were already added per KA, inside the
         // write lock, so they survive a snapshot-phase throw. Adding them again
@@ -1088,6 +1338,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       // rather than a decision input.
       recordSnapshotCoverage(
         snapshotSync,
+        graphBackedSnapshotGraphs.size,
         wsMetaResult.completed,
         descriptorsAuthoritativeForCg,
         materializationFailures,
@@ -1133,7 +1384,12 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       }) ?? true;
       const snapshotPhaseUsable = snapshotSync.completed
         && materializationFailures === 0
-        && (descriptorsAuthoritativeForCg || snapshotSync.totalSnapshots === 0)
+        && (
+          descriptorsAuthoritativeForCg
+          || snapshotSync.totalSnapshots + graphBackedSnapshotGraphs.size === 0
+        )
+        && materializedRefs.size
+          === snapshotSync.totalSnapshots + graphBackedSnapshotGraphs.size
         && snapshotEvidenceAccepted;
       if (materializationFailures > 0) {
         logWarn(ctx, `SWM sync for "${pid}": ${materializationFailures} snapshot(s) verified but `
@@ -1159,7 +1415,9 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
           await storeInsert(validWsQuads);
           summary.insertedTriples += validWsQuads.length;
           summary.insertedDataTriples += validWsQuads.length;
-          recordPhaseOutcome(wsDataResult);
+          recordPhaseOutcome(effectiveWsDataResult, {
+            updateCheckpoint: !suppressDataCheckpointUpdate,
+          });
           hydrateOwnership();
         }
         if (snapshotSync.timedOutPhases > 0 && shouldStopAfterBackoffWorthyFailure(pid, 'snapshot timeout')) {
@@ -1210,7 +1468,9 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         summary.insertedMetaTriples += newlyCountedMeta;
       }
       recordPhaseOutcome(wsMetaResult);
-      recordPhaseOutcome(wsDataResult);
+      recordPhaseOutcome(effectiveWsDataResult, {
+        updateCheckpoint: !suppressDataCheckpointUpdate,
+      });
       metadataFetcher?.release(pid);
       if ((wsMetaResult.timedOut || wsDataResult.timedOut) && shouldStopAfterBackoffWorthyFailure(pid, 'phase timeout')) {
         break;
@@ -1238,6 +1498,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         // group attached by the walk, never reassembled here.
         recordSnapshotCoverage(
           thrownProgress,
+          graphBackedTotalForCg,
           manifestComplete,
           descriptorsAuthoritativeForCg,
           materializedFailuresForCg,
@@ -1688,16 +1949,46 @@ export function orderPublicSnapshotsForBalancedRecency(
 }
 
 /**
- * Count graph-backed share operations whose content is outside the immutable
- * snapshot-store walk. The selected SWM lane must fail closed while this
- * aggregate requester cannot prove those transport graphs by count and digest.
+ * Count graph-scoped KA operations whose graph-backed content this requester
+ * can prove and materialize. Legacy root-slice graph advertisements are
+ * deliberately excluded: the selected lane then sees no supported immutable
+ * commitment and remains incomplete instead of falsely treating them as KAs.
  */
 function countGraphBackedSnapshotOperations(metaQuads: readonly Quad[]): number {
+  const bySubject = new Map<string, {
+    hasSnapshotGraph: boolean;
+    isWorkspaceOperation: boolean;
+    graphScoped: boolean;
+  }>();
+  for (const quad of metaQuads) {
+    const entry = bySubject.get(quad.subject) ?? {
+      hasSnapshotGraph: false,
+      isWorkspaceOperation: false,
+      graphScoped: false,
+    };
+    if (quad.predicate === `${DKG}publicSnapshotGraph`) entry.hasSnapshotGraph = true;
+    if (
+      quad.predicate === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
+      && quad.object === `${DKG}WorkspaceOperation`
+    ) entry.isWorkspaceOperation = true;
+    if (
+      quad.predicate === `${DKG}contentScopeVersion`
+      && parseIntegerLiteral(quad.object) === GRAPH_KA_CONTENT_SCOPE_VERSION
+    ) entry.graphScoped = true;
+    bySubject.set(quad.subject, entry);
+  }
+  return [...bySubject.values()].filter((entry) => (
+    entry.hasSnapshotGraph && entry.isWorkspaceOperation && entry.graphScoped
+  )).length;
+}
+
+function collectAdvertisedGraphBackedSnapshots(metaQuads: readonly Quad[]): Set<string> {
   return new Set(
     metaQuads
       .filter((quad) => quad.predicate === `${DKG}publicSnapshotGraph`)
-      .map((quad) => quad.subject),
-  ).size;
+      .map((quad) => stripLiteral(quad.object)?.trim())
+      .filter((graph): graph is string => Boolean(graph)),
+  );
 }
 
 async function hasValidSnapshot(

--- a/packages/agent/src/sync/responder/data-request-policy.ts
+++ b/packages/agent/src/sync/responder/data-request-policy.ts
@@ -4,32 +4,33 @@ import {
   SYNC_REQUEST_SAFE_PAGE_SIZE,
 } from '../../dkg-agent-constants.js';
 
-export type DurableDataCacheMode = 'session-snapshot' | 'page-only';
+export type DataRequestCacheMode = 'session-snapshot' | 'page-only';
 export type ExactGraphReadMode = 'snapshot-or-page' | 'page-only';
 
-export interface DurableDataRequestPolicy {
+export interface DataRequestPolicy {
   usesByteBudgetPage: boolean;
   limit: number;
-  cacheMode: DurableDataCacheMode;
+  cacheMode: DataRequestCacheMode;
   exactGraphReadMode: ExactGraphReadMode;
 }
 
 /**
  * Resolve responder resource policy from authenticated request semantics only.
  *
- * Signature fields are deliberately absent: public-graph authorization may
- * accept a request before validating them, so their presence is not proof that
- * a caller is authenticated. Every negotiated exact-asset read therefore uses
- * the conservative store-page path and 64-row floor.
+ * This boundary is shared by durable and SWM DATA. Signature fields are
+ * deliberately absent: public-graph authorization may accept a request before
+ * validating them, so their presence is not proof that a caller is
+ * authenticated. Negotiated exact-asset reads therefore use the conservative
+ * store-page path and 64-row floor.
  */
-export function resolveDurableDataRequestPolicy(params: {
+export function resolveDataRequestPolicy(params: {
   legacyLimit: number;
   includeSharedMemory: boolean;
   phase: string;
   pageMode?: string;
   pageRowsHint?: number;
   hasExactAssetFilter: boolean;
-}): DurableDataRequestPolicy {
+}): DataRequestPolicy {
   const hintedPageRows = typeof params.pageRowsHint === 'number' &&
     Number.isSafeInteger(params.pageRowsHint)
     ? Math.max(1, Math.min(params.pageRowsHint, SYNC_BYTE_BUDGET_MAX_ROWS))

--- a/packages/agent/src/sync/responder/durable-data-request-policy.ts
+++ b/packages/agent/src/sync/responder/durable-data-request-policy.ts
@@ -34,12 +34,13 @@ export function resolveDurableDataRequestPolicy(params: {
     Number.isSafeInteger(params.pageRowsHint)
     ? Math.max(1, Math.min(params.pageRowsHint, SYNC_BYTE_BUDGET_MAX_ROWS))
     : 0;
-  const usesByteBudgetPage = !params.includeSharedMemory &&
-    params.phase === 'data' &&
+  const usesByteBudgetPage = params.phase === 'data' &&
     params.pageMode === SYNC_BYTE_BUDGET_PAGE_MODE &&
     hintedPageRows > 0 &&
     (hintedPageRows > params.legacyLimit || params.hasExactAssetFilter);
-  const pageOnlyExactFetch = usesByteBudgetPage && params.hasExactAssetFilter;
+  const pageOnlyExactFetch = usesByteBudgetPage
+    && !params.includeSharedMemory
+    && params.hasExactAssetFilter;
 
   return {
     usesByteBudgetPage,

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -3595,6 +3595,7 @@ async function readFreshSwmDataRowsPageFromPlan(
       : `VALUES ?root { ${graphValues(entry.roots)} }
         GRAPH <${assertSafeIri(entry.graph)}> { ?s ?p ?o }
         FILTER(?s = ?root || STRSTARTS(STR(?s), CONCAT(STR(?root), "/.well-known/genid/")))`;
+    // sparql-scan-allow: R3 -- the session plan maps the corpus cursor to one pre-counted concrete graph; graph-backed entries are immutable per-KA graphs and the root-scoped branch retains its existing bounded-plan pagination
     const result = await store.query(`
       SELECT DISTINCT ?s ?p ?o WHERE {
         ${selection}

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -35,7 +35,8 @@ import type { ChangelogSyncResponse, ChangelogDeltaRecord } from '../changelog/w
 import { durableMetaDelegationSubjectAdmissionExpression } from './durable-meta-admission.js';
 import { exactAssetFilterKey } from '../exact-assets.js';
 import { isIriTerm } from '../iri-term.js';
-import type { ExactGraphReadMode } from './durable-data-request-policy.js';
+import type { ExactGraphReadMode } from './data-request-policy.js';
+import { parseGraphBackedSwmSnapshotGraph } from '../graph-scoped-swm-recovery.js';
 
 export {
   createResponderSyncRowListMemo,
@@ -91,12 +92,18 @@ export interface SubGraphNameMemo {
   }): Promise<readonly string[]>;
 }
 
-interface FreshSwmDataGraphPlanEntry {
-  graph: string;
-  /** Empty for an immutable graph-backed KA snapshot, whose whole graph is served. */
-  roots: readonly string[];
-  rowCount: number;
-}
+type FreshSwmDataGraphPlanEntry =
+  | {
+    readonly kind: 'root-scoped';
+    readonly graph: string;
+    readonly roots: readonly string[];
+    readonly rowCount: number;
+  }
+  | {
+    readonly kind: 'graph-backed';
+    readonly graph: string;
+    readonly rowCount: number;
+  };
 
 interface FreshSwmDataGraphPlan {
   entries: readonly FreshSwmDataGraphPlanEntry[];
@@ -918,6 +925,8 @@ export async function readSwmDataPage(params: {
   refreshGeneration?: string;
   freshGraphPlanMemo?: FreshSwmDataGraphPlanMemo;
   exactGraphPlanMemo?: ExactGraphPagePlanMemo;
+  /** Keep the immutable row snapshot until explicit empty-page EOF. */
+  releaseCacheOnShortPage?: boolean;
 }): Promise<SyncRow[]> {
   const dataGraphs = swmGraphsForRegisteredSubGraphs(params.contextGraphId, params.registeredSubGraphNames, false);
   const graphSet = new Set(params.graphList);
@@ -930,6 +939,7 @@ export async function readSwmDataPage(params: {
       key: params.rowListCacheKey,
       refresh: params.refreshRowList,
       refreshGeneration: params.refreshGeneration,
+      releaseOnShortPage: params.releaseCacheOnShortPage,
       expiredMessage: 'Shared-memory data sync session snapshot expired before page completion',
     }
     : undefined;
@@ -3440,8 +3450,13 @@ async function buildFreshSwmDataGraphPlan(
     }
   }
 
-  const entries = admitted
-    .map(({ graph, roots }) => ({ graph, roots, rowCount: countsByGraph.get(graph) ?? 0 }))
+  const entries: FreshSwmDataGraphPlanEntry[] = admitted
+    .map(({ graph, roots }) => ({
+      kind: 'root-scoped' as const,
+      graph,
+      roots,
+      rowCount: countsByGraph.get(graph) ?? 0,
+    }))
     .filter((entry) => entry.rowCount > 0);
   const graphBackedEntries = await readFreshGraphBackedSwmSnapshotEntries(
     store,
@@ -3486,7 +3501,10 @@ async function readFreshGraphBackedSwmSnapshotEntries(
     const result = await store.query(`
       SELECT DISTINCT ?snapshotGraph ?count ?ts WHERE {
         GRAPH <${assertSafeIri(metaGraph)}> {
+          ?head <${DKG_SHARE_OPERATION_ID}> ?shareOperationId .
+          FILTER(STRENDS(STR(?head), "#dkg-swm-head"))
           ?op <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_WORKSPACE_OPERATION}> ;
+              <${DKG_SHARE_OPERATION_ID}> ?shareOperationId ;
               <${DKG_CONTENT_SCOPE_VERSION}> ${GRAPH_KA_CONTENT_SCOPE_VERSION} ;
               <${DKG_PUBLIC_SNAPSHOT_GRAPH}> ?snapshotGraph ;
               <${DKG_PUBLIC_QUADS_COUNT}> ?count ;
@@ -3549,11 +3567,11 @@ async function readFreshGraphBackedSwmSnapshotEntries(
           + `metadata=${evidence.expectedCount}, store=${actualCount}`,
         );
       }
-      return { graph, roots: [], rowCount: actualCount, publishedAtMs: evidence.publishedAtMs };
+      return { kind: 'graph-backed' as const, graph, rowCount: actualCount, publishedAtMs: evidence.publishedAtMs };
     })
     .sort((left, right) => right.publishedAtMs - left.publishedAtMs
       || compareCodePoint(left.graph, right.graph))
-    .map(({ graph, roots, rowCount }) => ({ graph, roots, rowCount }));
+    .map(({ kind, graph, rowCount }) => ({ kind, graph, rowCount }));
 }
 
 function isGraphBackedSwmSnapshotGraph(
@@ -3561,17 +3579,14 @@ function isGraphBackedSwmSnapshotGraph(
   contextGraphId: string,
   dataGraph: string,
 ): boolean {
+  const identity = parseGraphBackedSwmSnapshotGraph(graph);
+  if (!identity || identity.contextGraphId !== contextGraphId) return false;
   const suffix = '/_shared_memory';
   const base = dataGraph.endsWith(suffix) ? dataGraph.slice(0, -suffix.length) : dataGraph;
-  const contextPrefix = 'did:dkg:context-graph:';
-  const contextBase = `${contextPrefix}${contextGraphId}`;
-  if (base !== contextBase && !base.startsWith(`${contextBase}/`)) return false;
-  const subGraphName = base === contextBase ? '_' : base.slice(contextBase.length + 1);
-  if (subGraphName !== '_' && !validateSubGraphName(subGraphName).valid) return false;
-  const prefix = `${contextPrefix}${encodeURIComponent(contextGraphId)}/_shared_memory_snapshots/`
-    + `${encodeURIComponent(subGraphName)}/`;
-  const tail = graph.startsWith(prefix) ? graph.slice(prefix.length) : '';
-  return tail.endsWith('/ka') && tail.slice(0, -3).length > 0 && !tail.slice(0, -3).includes('/');
+  const contextBase = `did:dkg:context-graph:${contextGraphId}`;
+  if (base === contextBase) return identity.subGraphName === undefined;
+  if (!base.startsWith(`${contextBase}/`)) return false;
+  return identity.subGraphName === base.slice(contextBase.length + 1);
 }
 
 async function readFreshSwmDataRowsPageFromPlan(
@@ -3590,7 +3605,7 @@ async function readFreshSwmDataRowsPageFromPlan(
       skip -= entry.rowCount;
       continue;
     }
-    const selection = entry.roots.length === 0
+    const selection = entry.kind === 'graph-backed'
       ? `GRAPH <${assertSafeIri(entry.graph)}> { ?s ?p ?o }`
       : `VALUES ?root { ${graphValues(entry.roots)} }
         GRAPH <${assertSafeIri(entry.graph)}> { ?s ?p ?o }

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -49,6 +49,8 @@ const DKG_SUB_GRAPH = `${DKG}SubGraph`;
 const DKG_WORKSPACE_OPERATION = `${DKG}WorkspaceOperation`;
 const DKG_PUBLISHED_AT = `${DKG}publishedAt`;
 const DKG_ROOT_ENTITY = `${DKG}rootEntity`;
+const DKG_PUBLIC_SNAPSHOT_GRAPH = `${DKG}publicSnapshotGraph`;
+const DKG_PUBLIC_QUADS_COUNT = `${DKG}publicQuadsCount`;
 const DKG_CONTENT_SCOPE_VERSION = `${DKG}contentScopeVersion`;
 const DKG_KA_UAL = `${DKG}kaUal`;
 const DKG_ASSERTION_VERSION = `${DKG}assertionVersion`;
@@ -91,6 +93,7 @@ export interface SubGraphNameMemo {
 
 interface FreshSwmDataGraphPlanEntry {
   graph: string;
+  /** Empty for an immutable graph-backed KA snapshot, whose whole graph is served. */
   roots: readonly string[];
   rowCount: number;
 }
@@ -948,6 +951,7 @@ export async function readSwmDataPage(params: {
   const loadStoreBoundedPage: StorePageLoader = async (offset, limit, signal) => {
     const loadPlan = () => buildFreshSwmDataGraphPlan(
       params.store,
+      params.contextGraphId,
       dataGraphs,
       graphSet,
       candidateGraphsFor,
@@ -3354,6 +3358,7 @@ function parseSparqlInteger(value: string | undefined): number {
  */
 async function buildFreshSwmDataGraphPlan(
   store: TripleStore,
+  contextGraphId: string,
   dataGraphs: readonly string[],
   graphSet: ReadonlySet<string>,
   candidateGraphsFor: (graph: string) => string[],
@@ -3373,7 +3378,6 @@ async function buildFreshSwmDataGraphPlan(
   const uniqueCandidates = [...new Map(
     candidates.map((candidate) => [candidate.graph, candidate]),
   ).values()].sort((a, b) => compareCodePoint(a.graph, b.graph));
-  if (uniqueCandidates.length === 0) return { entries: [], totalRows: 0 };
 
   const rootsByGraph = new Map<string, Set<string>>();
   for (const chunk of chunkValues(uniqueCandidates, FRESH_SWM_PLAN_QUERY_GRAPH_CHUNK)) {
@@ -3439,10 +3443,135 @@ async function buildFreshSwmDataGraphPlan(
   const entries = admitted
     .map(({ graph, roots }) => ({ graph, roots, rowCount: countsByGraph.get(graph) ?? 0 }))
     .filter((entry) => entry.rowCount > 0);
+  const graphBackedEntries = await readFreshGraphBackedSwmSnapshotEntries(
+    store,
+    contextGraphId,
+    dataGraphs,
+    graphSet,
+    cutoffIso,
+    signal,
+  );
   return {
-    entries,
-    totalRows: entries.reduce((sum, entry) => sum + entry.rowCount, 0),
+    // Recent graph-backed KAs go first so a selected receiver can keep up with
+    // live publication while the same immutable plan continues through older
+    // root-scoped history. Completeness still requires the entire plan.
+    entries: [...graphBackedEntries, ...entries],
+    totalRows: [...graphBackedEntries, ...entries]
+      .reduce((sum, entry) => sum + entry.rowCount, 0),
   };
+}
+
+/**
+ * Discover fresh content-scope-v2 SWM snapshots from their authenticated
+ * operation metadata, then bind every planned graph to its actual row count.
+ *
+ * These graphs are siblings of `_shared_memory`, not descendants of it. The
+ * legacy root planner therefore cannot discover them through
+ * `isSharedMemoryBucketDescendantDataGraph`; omitting them leaves a cold
+ * receiver with verified heads but no payload. The requester independently
+ * verifies the advertised count and digest before materialization.
+ */
+async function readFreshGraphBackedSwmSnapshotEntries(
+  store: TripleStore,
+  contextGraphId: string,
+  dataGraphs: readonly string[],
+  graphSet: ReadonlySet<string>,
+  cutoffIso: string,
+  signal?: AbortSignal,
+): Promise<FreshSwmDataGraphPlanEntry[]> {
+  const discovered = new Map<string, { expectedCount: number; publishedAtMs: number }>();
+  for (const dataGraph of dataGraphs) {
+    const metaGraph = `${dataGraph}_meta`;
+    if (!graphSet.has(metaGraph)) continue;
+    const result = await store.query(`
+      SELECT DISTINCT ?snapshotGraph ?count ?ts WHERE {
+        GRAPH <${assertSafeIri(metaGraph)}> {
+          ?op <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_WORKSPACE_OPERATION}> ;
+              <${DKG_CONTENT_SCOPE_VERSION}> ${GRAPH_KA_CONTENT_SCOPE_VERSION} ;
+              <${DKG_PUBLIC_SNAPSHOT_GRAPH}> ?snapshotGraph ;
+              <${DKG_PUBLIC_QUADS_COUNT}> ?count ;
+              <${DKG_PUBLISHED_AT}> ?ts .
+          FILTER(?ts >= ${sparqlString(cutoffIso)}^^<http://www.w3.org/2001/XMLSchema#dateTime>)
+        }
+      }
+      ORDER BY DESC(?ts) ?snapshotGraph
+    `, syncResponderStoreOptions(signal, 'sync.responder.readFreshGraphBackedSwmSnapshots'));
+    if (result.type !== 'bindings') continue;
+    for (const row of result.bindings) {
+      const graph = row['snapshotGraph'];
+      const expectedCount = parseSparqlInteger(row['count']);
+      const publishedAtMs = Date.parse(stripLiteral(row['ts']));
+      if (
+        !graph
+        || !isGraphBackedSwmSnapshotGraph(graph, contextGraphId, dataGraph)
+        || !graphSet.has(graph)
+        || expectedCount <= 0
+        || !Number.isFinite(publishedAtMs)
+      ) continue;
+      const previous = discovered.get(graph);
+      if (previous && previous.expectedCount !== expectedCount) {
+        throw new Error(`Conflicting graph-backed SWM snapshot counts for ${graph}`);
+      }
+      if (!previous || publishedAtMs > previous.publishedAtMs) {
+        discovered.set(graph, { expectedCount, publishedAtMs });
+      }
+    }
+  }
+  if (discovered.size === 0) return [];
+
+  const actualCounts = new Map<string, number>();
+  for (const graphs of chunkValues([...discovered.keys()], FRESH_SWM_PLAN_QUERY_GRAPH_CHUNK)) {
+    const unions = graphs.map((graph) => `
+      {
+        SELECT (<${assertSafeIri(graph)}> AS ?g) (COUNT(*) AS ?count) WHERE {
+          GRAPH <${assertSafeIri(graph)}> { ?s ?p ?o }
+        }
+      }`);
+    const result = await store.query(`
+      SELECT ?g ?count WHERE {
+        ${unions.join('\n        UNION')}
+      }
+      ORDER BY ?g
+    `, syncResponderStoreOptions(signal, 'sync.responder.countFreshGraphBackedSwmSnapshotRows'));
+    if (result.type !== 'bindings') continue;
+    for (const row of result.bindings) {
+      const graph = row['g'];
+      if (graph) actualCounts.set(graph, parseSparqlInteger(row['count']));
+    }
+  }
+
+  return [...discovered.entries()]
+    .map(([graph, evidence]) => {
+      const actualCount = actualCounts.get(graph) ?? 0;
+      if (actualCount !== evidence.expectedCount) {
+        throw new Error(
+          `Graph-backed SWM snapshot ${graph} count mismatch: `
+          + `metadata=${evidence.expectedCount}, store=${actualCount}`,
+        );
+      }
+      return { graph, roots: [], rowCount: actualCount, publishedAtMs: evidence.publishedAtMs };
+    })
+    .sort((left, right) => right.publishedAtMs - left.publishedAtMs
+      || compareCodePoint(left.graph, right.graph))
+    .map(({ graph, roots, rowCount }) => ({ graph, roots, rowCount }));
+}
+
+function isGraphBackedSwmSnapshotGraph(
+  graph: string,
+  contextGraphId: string,
+  dataGraph: string,
+): boolean {
+  const suffix = '/_shared_memory';
+  const base = dataGraph.endsWith(suffix) ? dataGraph.slice(0, -suffix.length) : dataGraph;
+  const contextPrefix = 'did:dkg:context-graph:';
+  const contextBase = `${contextPrefix}${contextGraphId}`;
+  if (base !== contextBase && !base.startsWith(`${contextBase}/`)) return false;
+  const subGraphName = base === contextBase ? '_' : base.slice(contextBase.length + 1);
+  if (subGraphName !== '_' && !validateSubGraphName(subGraphName).valid) return false;
+  const prefix = `${contextPrefix}${encodeURIComponent(contextGraphId)}/_shared_memory_snapshots/`
+    + `${encodeURIComponent(subGraphName)}/`;
+  const tail = graph.startsWith(prefix) ? graph.slice(prefix.length) : '';
+  return tail.endsWith('/ka') && tail.slice(0, -3).length > 0 && !tail.slice(0, -3).includes('/');
 }
 
 async function readFreshSwmDataRowsPageFromPlan(
@@ -3461,11 +3590,14 @@ async function readFreshSwmDataRowsPageFromPlan(
       skip -= entry.rowCount;
       continue;
     }
+    const selection = entry.roots.length === 0
+      ? `GRAPH <${assertSafeIri(entry.graph)}> { ?s ?p ?o }`
+      : `VALUES ?root { ${graphValues(entry.roots)} }
+        GRAPH <${assertSafeIri(entry.graph)}> { ?s ?p ?o }
+        FILTER(?s = ?root || STRSTARTS(STR(?s), CONCAT(STR(?root), "/.well-known/genid/")))`;
     const result = await store.query(`
       SELECT DISTINCT ?s ?p ?o WHERE {
-        VALUES ?root { ${graphValues(entry.roots)} }
-        GRAPH <${assertSafeIri(entry.graph)}> { ?s ?p ?o }
-        FILTER(?s = ?root || STRSTARTS(STR(?s), CONCAT(STR(?root), "/.well-known/genid/")))
+        ${selection}
       }
       ORDER BY ?s ?p ?o
       OFFSET ${skip}

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -130,7 +130,10 @@ const SYNC_RESPONDER_PER_PEER_CONCURRENCY = 2;
 const SYNC_RESPONDER_PER_PEER_PLANE_CONCURRENCY = 1;
 const SYNC_RESPONDER_QUEUE_LIMIT = 64;
 export const SYNC_RESPONDER_PER_PEER_QUEUE_LIMIT = 4;
-const SYNC_RESPONDER_MAX_QUEUE_WAIT_MS = 10_000;
+// Store-backed graph planning routinely takes tens of seconds for large CGs.
+// Keep bounded admission, but do not reject a healthy queued page before one
+// legitimate predecessor can finish. Request aborts still remove stale work.
+const SYNC_RESPONDER_MAX_QUEUE_WAIT_MS = 60_000;
 export const SYNC_RESPONDER_DURABLE_DATA_SNAPSHOT_LIMIT = 128;
 export const SYNC_RESPONDER_DURABLE_META_SNAPSHOT_LIMIT = 64;
 export const SYNC_RESPONDER_SHARED_MEMORY_SNAPSHOT_LIMIT = 64;

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -55,7 +55,7 @@ import {
   PriorityAdmissionQueue,
   type PriorityAdmission,
 } from '../priority-admission-queue.js';
-import { resolveDurableDataRequestPolicy } from './durable-data-request-policy.js';
+import { resolveDataRequestPolicy } from './data-request-policy.js';
 
 const MAX_SYNC_SESSION_TOKENS = 256;
 
@@ -556,7 +556,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     const assetSelectionKey = assetUals === undefined
       ? 'full'
       : exactAssetFilterKey(assetUals);
-    const durableDataPolicy = resolveDurableDataRequestPolicy({
+    const dataRequestPolicy = resolveDataRequestPolicy({
       legacyLimit: limit,
       includeSharedMemory: isWorkspace,
       phase,
@@ -564,7 +564,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       pageRowsHint: request.pageRowsHint,
       hasExactAssetFilter: assetUals !== undefined,
     });
-    const usesByteBudgetPage = durableDataPolicy.usesByteBudgetPage;
+    const usesByteBudgetPage = dataRequestPolicy.usesByteBudgetPage;
     // Durable meta negotiated its byte-budget page mode on the wire (#1916 /
     // #1923). The subject-atomic byte-fit in readDurableMetaPage already bounds
     // the page ≤ budget for BOTH modes, so this only selects the belt-and-
@@ -735,7 +735,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
             contextGraphId,
             cutoffIso: cutoff,
             offset,
-            limit: durableDataPolicy.limit,
+            limit: dataRequestPolicy.limit,
             signal,
             rowListMemo: session ? swmRowsMemo : undefined,
             rowListCacheKey: session?.rowListCacheKey,
@@ -743,6 +743,10 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
             refreshGeneration: session?.refreshGeneration,
             freshGraphPlanMemo: freshSwmDataGraphPlanMemo,
             exactGraphPlanMemo: swmDataExactGraphPlanMemo,
+            // A byte-bounded response may serialize only a prefix of the
+            // loaded row slice. Keep the session until an explicit empty page
+            // proves EOF, matching the durable DATA lane below.
+            releaseCacheOnShortPage: !usesByteBudgetPage,
           });
           const queryDurationMs = Date.now() - queryStartedAt;
           const serializeStartedAt = Date.now();
@@ -853,12 +857,12 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           contextGraphId,
           sinceBatchId,
           offset,
-          limit: durableDataPolicy.limit,
+          limit: dataRequestPolicy.limit,
           signal,
-          rowListMemo: session && durableDataPolicy.cacheMode === 'session-snapshot'
+          rowListMemo: session && dataRequestPolicy.cacheMode === 'session-snapshot'
             ? durableDataRowsMemo
             : undefined,
-          rowListCacheScope: session && durableDataPolicy.cacheMode === 'session-snapshot'
+          rowListCacheScope: session && dataRequestPolicy.cacheMode === 'session-snapshot'
             ? peerId
             : undefined,
           refreshRowList: session?.refreshRowList,
@@ -869,7 +873,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           // because that slice was short; the explicit empty request is EOF.
           releaseCacheOnShortPage: !usesByteBudgetPage,
           assetUals,
-          exactGraphReadMode: durableDataPolicy.exactGraphReadMode,
+          exactGraphReadMode: dataRequestPolicy.exactGraphReadMode,
         });
         const queryDurationMs = Date.now() - queryStartedAt;
         const serializeStartedAt = Date.now();

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -735,7 +735,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
             contextGraphId,
             cutoffIso: cutoff,
             offset,
-            limit,
+            limit: durableDataPolicy.limit,
             signal,
             rowListMemo: session ? swmRowsMemo : undefined,
             rowListCacheKey: session?.rowListCacheKey,
@@ -746,7 +746,9 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           });
           const queryDurationMs = Date.now() - queryStartedAt;
           const serializeStartedAt = Date.now();
-          const serialized = serializeResponderRows(rows);
+          const serialized = usesByteBudgetPage
+            ? serializeResponderRowsWithinByteBudget(rows, SYNC_BYTE_BUDGET_RESPONSE_BYTES)
+            : serializeResponderRows(rows);
           if (serialized) nquads.push(serialized);
           const serializeDurationMs = Date.now() - serializeStartedAt;
           logFirstPageDetail(() => `Sync responder SWM data for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -121,7 +121,13 @@ interface RegisterSyncHandlerParams {
 }
 
 const SYNC_RESPONDER_GLOBAL_CONCURRENCY = 3;
-const SYNC_RESPONDER_PER_PEER_CONCURRENCY = 1;
+// A selected public CG may recover SWM and VM from the same provider at the
+// same time. Reserve one bounded slot for each plane so a long SWM graph-plan
+// query cannot make the VM request (or vice versa) expire in the responder
+// queue. Each individual plane remains serialized per peer, and the global
+// limit still leaves capacity for another peer.
+const SYNC_RESPONDER_PER_PEER_CONCURRENCY = 2;
+const SYNC_RESPONDER_PER_PEER_PLANE_CONCURRENCY = 1;
 const SYNC_RESPONDER_QUEUE_LIMIT = 64;
 export const SYNC_RESPONDER_PER_PEER_QUEUE_LIMIT = 4;
 const SYNC_RESPONDER_MAX_QUEUE_WAIT_MS = 10_000;
@@ -246,10 +252,12 @@ class SyncResponderBusyError extends Error {
 
 interface SyncResponderQueuePayload {
   peerId: string;
+  plane: 'shared_memory' | 'durable';
   contextGraphId?: string;
 }
 
 type SyncResponderScheduling = {
+  plane: 'shared_memory' | 'durable';
   contextGraphId?: string;
   lane: Extract<SyncSchedulerLane, 'pre_authorization' | 'responder'>;
   priority: number;
@@ -259,20 +267,32 @@ type SyncResponderScheduling = {
 function createSyncResponderLimiter() {
   let running = 0;
   const runningByPeer = new Map<string, number>();
+  const runningByPeerPlane = new Map<string, number>();
+  const peerPlaneKey = (peerId: string, plane: SyncResponderQueuePayload['plane']) => (
+    `${peerId}\u0000${plane}`
+  );
   const queue = new PriorityAdmissionQueue<SyncResponderQueuePayload>({
-    canRun: (entry) => (
-      running < SYNC_RESPONDER_GLOBAL_CONCURRENCY
-      && (runningByPeer.get(entry.payload.peerId) ?? 0) < SYNC_RESPONDER_PER_PEER_CONCURRENCY
-    ),
+    canRun: (entry) => {
+      const { peerId, plane } = entry.payload;
+      return running < SYNC_RESPONDER_GLOBAL_CONCURRENCY
+        && (runningByPeer.get(peerId) ?? 0) < SYNC_RESPONDER_PER_PEER_CONCURRENCY
+        && (runningByPeerPlane.get(peerPlaneKey(peerId, plane)) ?? 0)
+          < SYNC_RESPONDER_PER_PEER_PLANE_CONCURRENCY;
+    },
     onStart: (entry) => {
-      const { peerId } = entry.payload;
+      const { peerId, plane } = entry.payload;
+      const planeKey = peerPlaneKey(peerId, plane);
       running += 1;
       runningByPeer.set(peerId, (runningByPeer.get(peerId) ?? 0) + 1);
+      runningByPeerPlane.set(planeKey, (runningByPeerPlane.get(planeKey) ?? 0) + 1);
       return () => {
         running = Math.max(0, running - 1);
         const peerRunning = (runningByPeer.get(peerId) ?? 1) - 1;
         if (peerRunning <= 0) runningByPeer.delete(peerId);
         else runningByPeer.set(peerId, peerRunning);
+        const peerPlaneRunning = (runningByPeerPlane.get(planeKey) ?? 1) - 1;
+        if (peerPlaneRunning <= 0) runningByPeerPlane.delete(planeKey);
+        else runningByPeerPlane.set(planeKey, peerPlaneRunning);
       };
     },
   });
@@ -282,7 +302,11 @@ function createSyncResponderLimiter() {
     scheduling: SyncResponderScheduling,
     signal?: AbortSignal,
   ) => ({
-    payload: { peerId, contextGraphId: scheduling.contextGraphId },
+    payload: {
+      peerId,
+      plane: scheduling.plane,
+      contextGraphId: scheduling.contextGraphId,
+    },
     lane: scheduling.lane,
     priority: scheduling.priority,
     priorityClass: scheduling.priorityClass,
@@ -893,6 +917,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     };
 
     const preAuthorizationScheduling: SyncResponderScheduling = {
+      plane: isWorkspace ? 'shared_memory' : 'durable',
       lane: 'pre_authorization',
       priority: 0,
       priorityClass: 'default',
@@ -908,6 +933,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
             const priority = contextGraphPriority(contextGraphPriorities, contextGraphId);
             return {
               scheduling: {
+                plane: isWorkspace ? 'shared_memory' : 'durable',
                 contextGraphId,
                 lane: 'responder' as const,
                 priority,
@@ -924,7 +950,13 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       : limiter.run(
           peerId,
           signal,
-          { contextGraphId, lane: 'responder', priority: 0, priorityClass: 'default' },
+          {
+            plane: isWorkspace ? 'shared_memory' : 'durable',
+            contextGraphId,
+            lane: 'responder',
+            priority: 0,
+            priorityClass: 'default',
+          },
           async () => {
             const prepared = await prepareResponderStage();
             return prepared.kind === 'respond'

--- a/packages/agent/src/sync/selected-swm-bootstrap-admission.ts
+++ b/packages/agent/src/sync/selected-swm-bootstrap-admission.ts
@@ -5,6 +5,7 @@ export type SelectedSwmBootstrapPhase = 'retry-required' | 'terminal';
 export interface SelectedSwmBootstrapAdmissionSnapshot {
   readonly contextGraphIds: readonly string[];
   readonly phase: SelectedSwmBootstrapPhase;
+  readonly freshAtMs: number | null;
 }
 
 export interface SelectedSwmBootstrapTransferOwner {
@@ -15,6 +16,13 @@ export interface SelectedSwmBootstrapTransferOwner {
 
 interface SelectedSwmBootstrapAdmissionState extends SelectedSwmBootstrapAdmissionSnapshot {
   readonly generation: number;
+  readonly updatedAtMs: number;
+}
+
+export interface SelectedSwmRefreshOptions {
+  readonly now: number;
+  readonly disconnectBoundary: number;
+  readonly staleAfterMs: number;
 }
 
 function canonicalScope(contextGraphIds: readonly string[]): readonly string[] {
@@ -41,11 +49,15 @@ export class SelectedSwmBootstrapAdmission {
     remotePeer: string,
     contextGraphIds: readonly string[],
     phase: SelectedSwmBootstrapPhase,
+    freshAtMs: number | null = null,
+    updatedAtMs = Date.now(),
   ): SelectedSwmBootstrapAdmissionState {
     const state = Object.freeze({
       contextGraphIds: canonicalScope(contextGraphIds),
       phase,
+      freshAtMs,
       generation: this.#nextGeneration += 1,
+      updatedAtMs,
     });
     this.#byPeer.set(remotePeer, state);
     return state;
@@ -90,7 +102,10 @@ export class SelectedSwmBootstrapAdmission {
     });
   }
 
-  markTransferTerminal(owner: SelectedSwmBootstrapTransferOwner): boolean {
+  markTransferTerminal(
+    owner: SelectedSwmBootstrapTransferOwner,
+    freshAtMs = Date.now(),
+  ): boolean {
     const current = this.#byPeer.get(owner.remotePeer);
     if (
       current === undefined
@@ -100,7 +115,32 @@ export class SelectedSwmBootstrapAdmission {
     this.#byPeer.set(owner.remotePeer, Object.freeze({
       ...current,
       phase: 'terminal',
+      freshAtMs,
+      updatedAtMs: freshAtMs,
     }));
+    return true;
+  }
+
+  shouldRefresh(
+    remotePeer: string,
+    contextGraphIds: readonly string[],
+    options: SelectedSwmRefreshOptions,
+  ): boolean {
+    const scope = canonicalScope(contextGraphIds);
+    if (scope.length === 0) return false;
+    const current = this.#byPeer.get(remotePeer);
+    if (current === undefined || !sameScope(current.contextGraphIds, scope)) return true;
+    if (current.phase === 'retry-required') return true;
+    const freshAtMs = current.freshAtMs;
+    return freshAtMs === null
+      || freshAtMs <= options.disconnectBoundary
+      || options.now - freshAtMs >= options.staleAfterMs;
+  }
+
+  requestRefresh(remotePeer: string, contextGraphIds: readonly string[]): boolean {
+    const scope = canonicalScope(contextGraphIds);
+    if (scope.length === 0) return false;
+    this.#replace(remotePeer, scope, 'retry-required');
     return true;
   }
 
@@ -114,7 +154,20 @@ export class SelectedSwmBootstrapAdmission {
     return Object.freeze({
       contextGraphIds: state.contextGraphIds,
       phase: state.phase,
+      freshAtMs: state.freshAtMs,
     });
+  }
+
+  pruneDisconnected(
+    connectedPeers: ReadonlySet<string>,
+    now: number,
+    staleAfterMs: number,
+  ): void {
+    for (const [remotePeer, state] of this.#byPeer) {
+      if (!connectedPeers.has(remotePeer) && now - state.updatedAtMs >= staleAfterMs) {
+        this.#byPeer.delete(remotePeer);
+      }
+    }
   }
 
   clear(remotePeer: string): void {

--- a/packages/agent/test/durable-sync-graph-scoped-materialization.test.ts
+++ b/packages/agent/test/durable-sync-graph-scoped-materialization.test.ts
@@ -1149,7 +1149,14 @@ describe('durable graph-scoped KA materialization', () => {
       });
       expect(materialize).not.toHaveBeenCalled();
       expect(deleteCheckpoint).not.toHaveBeenCalled();
-      expect(setCheckpoint).not.toHaveBeenCalled();
+      expect(setCheckpoint).toHaveBeenCalledWith(
+        `${contextGraphId}:data`,
+        expect.objectContaining({
+          offset: 0,
+          responderSessionOffset: 0,
+          binding: expect.objectContaining({ terminal: false }),
+        }),
+      );
       expect(await graphQuads(requesterStore, assertionGraph)).toEqual([]);
 
       const complete = run(fieldSizedData, true);

--- a/packages/agent/test/e2e-memory-layers.test.ts
+++ b/packages/agent/test/e2e-memory-layers.test.ts
@@ -864,10 +864,23 @@ describe('rootless graph-scoped KA lifecycle', () => {
     snapshotQuery.mockRestore();
 
     const operationSubject = `urn:dkg:share:${CG_ID}:${intent.shareOperationId}`;
+    const recoveryVmGraph = contextGraphLayerUri(
+      CG_ID,
+      MemoryLayer.VerifiableMemory,
+      queuedScope.agentAddress,
+      BigInt(queuedScope.kaNumber),
+    );
+    const recoveryVmRows = await store.query(
+      `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${recoveryVmGraph}> { ?s ?p ?o } }`,
+    );
+    if (recoveryVmRows.type !== 'quads' || recoveryVmRows.quads.length === 0) {
+      throw new Error('expected exact VM candidate before snapshot-retirement recovery');
+    }
     await store.deleteByPattern({
       graph: contextGraphSharedMemoryMetaUri(CG_ID),
       subject: operationSubject,
     });
+    await store.deleteByPattern({ graph: recoveryVmGraph });
     await expect(agent.finalizeRecoveredQueuedKnowledgeAssetVmPublish({
       ...recoveryInput,
       request: { ...recoveryInput.request, clearSharedMemoryAfter: false },
@@ -875,8 +888,22 @@ describe('rootless graph-scoped KA lifecycle', () => {
       code: 'KA_OPERATION_PUBLIC_SNAPSHOT_NOT_FOUND',
     });
 
-    await agent.finalizeRecoveredQueuedKnowledgeAssetVmPublish(recoveryInput as any);
-    await agent.finalizeRecoveredQueuedKnowledgeAssetVmPublish(recoveryInput as any);
+    await store.insert(recoveryVmRows.quads.map((quad) => ({
+      ...quad,
+      graph: recoveryVmGraph,
+    })));
+    // RFC-64 may retire the redundant SWM snapshot after independently
+    // materializing exact VM but before the async publisher records its receipt.
+    // Recovery must accept that already-verified public VM candidate even when
+    // the original publish did not request SWM cleanup.
+    await agent.finalizeRecoveredQueuedKnowledgeAssetVmPublish({
+      ...recoveryInput,
+      request: { ...recoveryInput.request, clearSharedMemoryAfter: false },
+    } as any);
+    await agent.finalizeRecoveredQueuedKnowledgeAssetVmPublish({
+      ...recoveryInput,
+      request: { ...recoveryInput.request, clearSharedMemoryAfter: false },
+    } as any);
     expect(recoveryCleanup).not.toHaveBeenCalled();
 
     const history = await agent.assertion.history(CG_ID, name);

--- a/packages/agent/test/e2e-memory-layers.test.ts
+++ b/packages/agent/test/e2e-memory-layers.test.ts
@@ -888,6 +888,23 @@ describe('rootless graph-scoped KA lifecycle', () => {
       code: 'KA_OPERATION_PUBLIC_SNAPSHOT_NOT_FOUND',
     });
 
+    const wrongVmRows = recoveryVmRows.quads.map((quad, index) => ({
+      ...quad,
+      ...(index === 0 ? { object: '"tampered-recovery-vm"' } : {}),
+      graph: recoveryVmGraph,
+    }));
+    await store.insert(wrongVmRows);
+    await expect(agent.finalizeRecoveredQueuedKnowledgeAssetVmPublish({
+      ...recoveryInput,
+      request: { ...recoveryInput.request, clearSharedMemoryAfter: false },
+    } as any)).rejects.toMatchObject({ code: 'KA_VM_RECOVERY_INCONSISTENT' });
+    expect((await agent.assertion.history(CG_ID, name))?.state).toBe('promoted');
+    const rejectedCandidateReceipt = await store.query(`ASK { GRAPH <${metaGraph}> {
+      <${assertionUri}> <${ASSERTION_PUBLISH_RECEIPT_PREDICATES.PUBLISHED_AT_TX}> ?tx .
+    } }`);
+    expect(rejectedCandidateReceipt).toMatchObject({ type: 'boolean', value: false });
+
+    await store.deleteByPattern({ graph: recoveryVmGraph });
     await store.insert(recoveryVmRows.quads.map((quad) => ({
       ...quad,
       graph: recoveryVmGraph,

--- a/packages/agent/test/graph-backed-swm-page-boundary.test.ts
+++ b/packages/agent/test/graph-backed-swm-page-boundary.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import type { Quad } from '@origintrail-official/dkg-storage';
+import type { GraphScopedSwmRecoveryDescriptor } from '../src/sync/graph-scoped-swm-recovery.js';
+import { planBoundedGraphBackedSwmDataPage } from '../src/sync/requester/shared-memory-sync.js';
+
+const quad = (graph: string, index: number): Quad => ({
+  subject: `urn:subject:${index}`,
+  predicate: 'http://schema.org/value',
+  object: `"${index}"`,
+  graph,
+});
+
+const descriptor = (graph: string, count: number): GraphScopedSwmRecoveryDescriptor => ({
+  metaGraph: 'urn:meta',
+  headSubject: `urn:head:${graph}`,
+  operationSubject: `urn:op:${graph}`,
+  kaUal: `did:dkg:test:1/${encodeURIComponent(graph)}`,
+  assertionVersion: '1',
+  assertionGraph: `urn:assertion:${graph}`,
+  shareOperationId: `op-${graph}`,
+  publicQuadsDigest: `urn:digest:${graph}`,
+  publicQuadsCount: count,
+  privateTripleCount: 0,
+  publicSnapshotGraph: graph,
+  publisherPeerId: 'peer',
+  metadataQuads: [],
+});
+
+describe('graph-backed SWM DATA graph boundaries', () => {
+  it('rewinds a timed-out suffix to the first row of its partial immutable graph', () => {
+    const graphA = 'urn:snapshot:a';
+    const graphB = 'urn:snapshot:b';
+    const result = planBoundedGraphBackedSwmDataPage({
+      quads: [quad(graphA, 0), quad(graphA, 1), quad(graphB, 0)],
+      descriptors: [descriptor(graphA, 2), descriptor(graphB, 2)],
+      resumedFromOffset: 100,
+      rawResumedFromOffset: 100,
+      nextOffset: 103,
+      rawNextOffset: 103,
+      quadRawOffsets: [100, 101, 102],
+      completed: false,
+    });
+
+    expect(result).not.toBeNull();
+    expect([...result!.completeGraphs]).toEqual([graphA]);
+    expect(result).toMatchObject({ safeNextOffset: 102, safeRawNextOffset: 102, rewound: true });
+  });
+
+  it('advances across whole graphs and subsequent legacy rows', () => {
+    const graphA = 'urn:snapshot:a';
+    const result = planBoundedGraphBackedSwmDataPage({
+      quads: [quad(graphA, 0), quad(graphA, 1), quad('urn:legacy', 0)],
+      descriptors: [descriptor(graphA, 2)],
+      resumedFromOffset: 0,
+      nextOffset: 3,
+      completed: false,
+    });
+
+    expect(result).not.toBeNull();
+    expect([...result!.completeGraphs]).toEqual([graphA]);
+    expect(result).toMatchObject({ safeNextOffset: 3, safeRawNextOffset: 3, rewound: false });
+  });
+
+  it('rejects a terminal short graph as an integrity mismatch', () => {
+    const graphA = 'urn:snapshot:a';
+    expect(planBoundedGraphBackedSwmDataPage({
+      quads: [quad(graphA, 0)],
+      descriptors: [descriptor(graphA, 2)],
+      resumedFromOffset: 0,
+      nextOffset: 1,
+      completed: true,
+    })).toBeNull();
+  });
+
+  it('rejects non-contiguous graph-backed groups', () => {
+    const graphA = 'urn:snapshot:a';
+    expect(planBoundedGraphBackedSwmDataPage({
+      quads: [quad(graphA, 0), quad('urn:legacy', 0), quad(graphA, 1)],
+      descriptors: [descriptor(graphA, 2)],
+      resumedFromOffset: 0,
+      nextOffset: 3,
+      completed: false,
+    })).toBeNull();
+  });
+});

--- a/packages/agent/test/graph-backed-swm-page-boundary.test.ts
+++ b/packages/agent/test/graph-backed-swm-page-boundary.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { GraphScopedSwmRecoveryDescriptor } from '../src/sync/graph-scoped-swm-recovery.js';
-import { planBoundedGraphBackedSwmDataPage } from '../src/sync/requester/shared-memory-sync.js';
+import { planBoundedGraphBackedSwmDataPage } from '../src/sync/requester/graph-backed-swm-data-replay.js';
 
 const quad = (graph: string, index: number): Quad => ({
   subject: `urn:subject:${index}`,

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -1192,6 +1192,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     expect((receiver as any).selectedSwmBootstrapAdmission.snapshot(providerPeerId)).toEqual({
       contextGraphIds: [CONTEXT_GRAPH_ID, secondContextGraphId].sort(),
       phase: 'retry-required',
+      freshAtMs: null,
     });
   });
 

--- a/packages/agent/test/rootless-durable-bounded-progress.test.ts
+++ b/packages/agent/test/rootless-durable-bounded-progress.test.ts
@@ -226,7 +226,11 @@ describe('bounded rootless durable progress', () => {
       ...fixtures[2]!.payload,
     ];
     const materialized: string[] = [];
-    const checkpoints: Array<[string, number]> = [];
+    const checkpoints: Array<{
+      key: string;
+      offset: number;
+      responderSessionOffset?: number;
+    }> = [];
 
     const summary = await runDurableSync({
       ctx,
@@ -359,7 +363,9 @@ describe('bounded rootless durable progress', () => {
           })
           : pageResult('data', {
             quads: rawData,
+            quadRawOffsets: [1, 2, 3, 4, 6, 7, 8, 9, 11, 12],
             nextOffset: rawData.length,
+            rawNextOffset: 13,
             completed: false,
             timedOut: true,
           });
@@ -375,7 +381,13 @@ describe('bounded rootless durable progress', () => {
         return 'applied';
       },
       deleteCheckpoint: () => {},
-      setCheckpoint: (key, checkpoint) => { checkpoints.push([key, checkpoint.offset]); },
+      setCheckpoint: (key, checkpoint) => {
+        checkpoints.push({
+          key,
+          offset: checkpoint.offset,
+          responderSessionOffset: checkpoint.responderSessionOffset,
+        });
+      },
       logInfo: () => {},
       logWarn: () => {},
       logDebug: () => {},
@@ -385,8 +397,12 @@ describe('bounded rootless durable progress', () => {
     expect(summary.complete).toBe(false);
     expect(summary.timedOutPhases).toBe(1);
     expect(summary.insertedDataTriples).toBe(8);
-    expect(checkpoints).toContainEqual([`${CONTEXT_GRAPH_ID}:data`, 8]);
-    expect(checkpoints.some(([key]) => key === `${CONTEXT_GRAPH_ID}:meta`)).toBe(false);
+    expect(checkpoints).toContainEqual({
+      key: `${CONTEXT_GRAPH_ID}:data`,
+      offset: 8,
+      responderSessionOffset: 10,
+    });
+    expect(checkpoints.some(({ key }) => key === `${CONTEXT_GRAPH_ID}:meta`)).toBe(false);
     expect(freshSessions).toEqual([
       ['meta', true],
       ['data', false],
@@ -398,6 +414,51 @@ describe('bounded rootless durable progress', () => {
     expect(materialized.flatMap((entry) => entry.dataQuads)
       .some((quad) => quad.graph === fixtures[2]!.graph)).toBe(false);
     expect(inserted.flat().some((quad) => fixtures.some((entry) => entry.graph === quad.graph))).toBe(false);
+  });
+
+  it('does not rebind a partial responder cursor before its verified prefix is stored', async () => {
+    const fixtures = orderedAssets();
+    const selected = fixtures.slice(0, 2);
+    const meta = selected.flatMap((entry) => entry.meta);
+    const rawData = [
+      ...selected[0]!.payload,
+      ...selected[1]!.payload.slice(0, 2),
+    ];
+    const checkpoints: Array<{ key: string; offset: number }> = [];
+
+    const summary = await runDurableSync({
+      ctx,
+      remotePeerId: 'peer-store-fails-before-rewind',
+      contextGraphIds: [CONTEXT_GRAPH_ID],
+      durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
+      fetchSyncPages: async ({ phase }: DurableSyncFetchRequest) => phase === 'meta'
+        ? pageResult('meta', { quads: meta, nextOffset: meta.length })
+        : pageResult('data', {
+            quads: rawData,
+            quadRawOffsets: [1, 2, 3, 4, 6, 7],
+            nextOffset: rawData.length,
+            rawNextOffset: 8,
+            completed: false,
+            timedOut: true,
+          }),
+      processDurableBatchInWorker: processBatch,
+      storeInsert: async () => {},
+      storeGraphScopedAsset: async () => {
+        throw new Error('simulated atomic store failure before commit');
+      },
+      deleteCheckpoint: () => {},
+      setCheckpoint: (key, checkpoint) => {
+        checkpoints.push({ key, offset: checkpoint.offset });
+      },
+      logInfo: () => {},
+      logWarn: () => {},
+      logDebug: () => {},
+    });
+
+    expect(summary.complete).toBe(false);
+    expect(summary.failedPhases).toBe(1);
+    expect(summary.insertedDataTriples).toBe(0);
+    expect(checkpoints).toEqual([]);
   });
 
   it('rewinds a responder cursor when a timeout leaves only a partial graph', async () => {

--- a/packages/agent/test/rootless-durable-bounded-progress.test.ts
+++ b/packages/agent/test/rootless-durable-bounded-progress.test.ts
@@ -400,6 +400,100 @@ describe('bounded rootless durable progress', () => {
     expect(inserted.flat().some((quad) => fixtures.some((entry) => entry.graph === quad.graph))).toBe(false);
   });
 
+  it('rewinds a responder cursor when a timeout leaves only a partial graph', async () => {
+    const [fixture] = orderedAssets();
+    const partialData = fixture!.payload.slice(0, 2);
+    const checkpoints: Array<{
+      offset: number;
+      responderSessionOffset?: number;
+      manifestDigest?: string;
+      terminal?: boolean;
+    }> = [];
+    const deleted: string[] = [];
+
+    const summary = await runDurableSync({
+      ctx,
+      remotePeerId: 'peer-partial-graph-timeout',
+      contextGraphIds: [CONTEXT_GRAPH_ID],
+      durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
+      fetchSyncPages: async ({ phase }: DurableSyncFetchRequest) => phase === 'meta'
+        ? pageResult('meta', { quads: fixture!.meta, nextOffset: fixture!.meta.length })
+        : pageResult('data', {
+            quads: partialData,
+            nextOffset: partialData.length,
+            rawNextOffset: partialData.length,
+            completed: false,
+            timedOut: true,
+          }),
+      processDurableBatchInWorker: processBatch,
+      storeInsert: async () => {},
+      storeGraphScopedAsset: async () => 'applied',
+      deleteCheckpoint: (key) => { deleted.push(key); },
+      setCheckpoint: (_key, checkpoint) => {
+        checkpoints.push({
+          offset: checkpoint.offset,
+          responderSessionOffset: checkpoint.responderSessionOffset,
+          manifestDigest: checkpoint.binding?.manifestDigest,
+          terminal: checkpoint.binding?.terminal,
+        });
+      },
+      logInfo: () => {},
+      logWarn: () => {},
+      logDebug: () => {},
+    });
+
+    expect(summary.complete).toBe(false);
+    expect(summary.insertedDataTriples).toBe(0);
+    expect(deleted).not.toContain(`${CONTEXT_GRAPH_ID}:data`);
+    expect(checkpoints).toContainEqual({
+      offset: 0,
+      responderSessionOffset: 0,
+      manifestDigest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
+      terminal: false,
+    });
+  });
+
+  it('self-heals a raw EOF checkpoint stranded ahead of its verified graph boundary', async () => {
+    const [fixture] = orderedAssets();
+    const manifestDigest = manifest(fixture!.meta).manifestDigest;
+    const deleted: string[] = [];
+    const dataCheckpoints: number[] = [];
+
+    const summary = await runDurableSync({
+      ctx,
+      remotePeerId: 'peer-stranded-raw-eof',
+      contextGraphIds: [CONTEXT_GRAPH_ID],
+      durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 60_000),
+      fetchSyncPages: async ({ phase }: DurableSyncFetchRequest) => phase === 'meta'
+        ? pageResult('meta', { quads: fixture!.meta, nextOffset: fixture!.meta.length })
+        : pageResult('data', {
+            quads: [],
+            resumedFromOffset: 0,
+            rawResumedFromOffset: fixture!.payload.length,
+            nextOffset: fixture!.payload.length,
+            rawNextOffset: fixture!.payload.length,
+            manifestDigest,
+            completed: true,
+            timedOut: false,
+          }),
+      processDurableBatchInWorker: processBatch,
+      storeInsert: async () => {},
+      storeGraphScopedAsset: async () => 'applied',
+      deleteCheckpoint: (key) => { deleted.push(key); },
+      setCheckpoint: (key, checkpoint) => {
+        if (key.endsWith(':data')) dataCheckpoints.push(checkpoint.offset);
+      },
+      logInfo: () => {},
+      logWarn: () => {},
+      logDebug: () => {},
+    });
+
+    expect(summary.complete).toBe(false);
+    expect(summary.insertedDataTriples).toBe(0);
+    expect(deleted).toContain(`${CONTEXT_GRAPH_ID}:data`);
+    expect(dataCheckpoints).toEqual([]);
+  });
+
   it('persists an authenticated asset prefix before a later authentication deadline', async () => {
     const fixtures = orderedAssets();
     const selected = fixtures.slice(0, 2);

--- a/packages/agent/test/selected-swm-bootstrap-admission.test.ts
+++ b/packages/agent/test/selected-swm-bootstrap-admission.test.ts
@@ -6,9 +6,10 @@ const PEER = '12D3KooWScopeAwareSelectedSwmProvider';
 function completeScope(
   admission: SelectedSwmBootstrapAdmission,
   contextGraphIds: readonly string[],
+  freshAtMs = 1_000,
 ): void {
   const owner = admission.beginTransfer(PEER, contextGraphIds);
-  expect(admission.markTransferTerminal(owner)).toBe(true);
+  expect(admission.markTransferTerminal(owner, freshAtMs)).toBe(true);
 }
 
 describe('SelectedSwmBootstrapAdmission', () => {
@@ -22,6 +23,7 @@ describe('SelectedSwmBootstrapAdmission', () => {
     expect(admission.snapshot(PEER)).toEqual({
       contextGraphIds: ['cg-a', 'cg-b'],
       phase: 'terminal',
+      freshAtMs: 1_000,
     });
   });
 
@@ -35,6 +37,7 @@ describe('SelectedSwmBootstrapAdmission', () => {
     expect(admission.snapshot(PEER)).toEqual({
       contextGraphIds: ['cg-a', 'cg-b'],
       phase: 'retry-required',
+      freshAtMs: null,
     });
   });
 
@@ -48,6 +51,7 @@ describe('SelectedSwmBootstrapAdmission', () => {
     expect(admission.snapshot(PEER)).toEqual({
       contextGraphIds: ['cg-a', 'cg-b'],
       phase: 'retry-required',
+      freshAtMs: null,
     });
   });
 
@@ -69,6 +73,38 @@ describe('SelectedSwmBootstrapAdmission', () => {
     expect(admission.snapshot(PEER)).toEqual({
       contextGraphIds: [],
       phase: 'terminal',
+      freshAtMs: null,
+    });
+  });
+
+  it('plans refreshes from peer, scope, completion, and disconnect freshness', () => {
+    const admission = new SelectedSwmBootstrapAdmission();
+    const now = 20_000;
+    const options = { now, disconnectBoundary: 0, staleAfterMs: 5_000 };
+
+    expect(admission.shouldRefresh(PEER, ['cg-a'], options)).toBe(true);
+    completeScope(admission, ['cg-a'], 18_000);
+    expect(admission.shouldRefresh(PEER, ['cg-a'], options)).toBe(false);
+    expect(admission.shouldRefresh(PEER, ['cg-b'], options)).toBe(true);
+    expect(admission.shouldRefresh(PEER, ['cg-a'], {
+      ...options,
+      disconnectBoundary: 19_000,
+    })).toBe(true);
+    expect(admission.shouldRefresh(PEER, ['cg-a'], {
+      ...options,
+      now: 23_000,
+    })).toBe(true);
+  });
+
+  it('reopens a stale terminal scope without lifecycle-owned timestamp state', () => {
+    const admission = new SelectedSwmBootstrapAdmission();
+    completeScope(admission, ['cg-a'], 1_000);
+
+    expect(admission.requestRefresh(PEER, ['cg-a'])).toBe(true);
+    expect(admission.snapshot(PEER)).toEqual({
+      contextGraphIds: ['cg-a'],
+      phase: 'retry-required',
+      freshAtMs: null,
     });
   });
 });

--- a/packages/agent/test/selected-swm-lifecycle-core.test.ts
+++ b/packages/agent/test/selected-swm-lifecycle-core.test.ts
@@ -153,6 +153,7 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
       contextGraphs: { public: publicCg },
       manifest: graphBackedManifest(publicCg),
       clock: { now: () => 1_000, deadline: () => 61_000 },
+      dataPage: { quads: [], completed: true, timedOut: false },
     });
 
     try {
@@ -173,7 +174,12 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
       expect(selected.shared.fetchedMetaTriples).toBeGreaterThan(0);
       expect(selected.shared.insertedMetaTriples).toBe(0);
       expect(selected.shared.failedPhases).toBeGreaterThan(0);
-      expect(selected.shared.swmCoverage).toBeUndefined();
+      expect(selected.shared.swmCoverage).toMatchObject({
+        snapshotsResolved: 0,
+        snapshotsTotal: 1,
+        missingCount: 1,
+        materializationFailures: 1,
+      });
       expect(selected.selectedScopeComplete).toBe(false);
       expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(true);
     } finally {
@@ -181,16 +187,12 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
     }
   });
 
-  it('keeps mixed store-backed and graph-backed metadata incomplete until every operation is proven', async () => {
-    const publicCg = 'selected-mixed-snapshot-evidence';
-    const storeBacked = snapshotManifest(publicCg, 1);
-    const graphBacked = graphBackedManifest(publicCg);
+  it('completes selected graph-backed SWM after count/digest-bound materialization', async () => {
+    const publicCg = 'selected-graph-backed-materialized';
+    const manifest = graphBackedManifest(publicCg);
     const harness = createSelectedSwmLifecycleHarness({
       contextGraphs: { public: publicCg },
-      manifest: {
-        meta: [...storeBacked.meta, ...graphBacked.meta],
-        payloadByRef: storeBacked.payloadByRef,
-      },
+      manifest,
       clock: { now: () => 1_000, deadline: () => 61_000 },
     });
 
@@ -214,11 +216,108 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
         snapshotsResolved: 1,
         snapshotsTotal: 1,
         missingCount: 0,
+        materializationFailures: 0,
       });
-      expect(selected.shared.insertedMetaTriples).toBe(0);
-      expect(selected.shared.failedPhases).toBeGreaterThan(0);
+      expect(selected.shared.insertedDataTriples).toBe(manifest.dataQuads.length);
+      expect(selected.shared.droppedDataTriples).toBe(0);
+      expect(selected.shared.failedPhases).toBe(0);
+      expect(selected.selectedScopeComplete).toBe(true);
+      expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(false);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it('keeps legacy root-slice graph advertisements fail-closed in the selected KA lane', async () => {
+    const publicCg = 'selected-legacy-graph-backed-root-slice';
+    const manifest = snapshotManifest(publicCg, 1);
+    const subject = manifest.meta[0]!.subject;
+    const transportGraph = `did:dkg:context-graph:${encodeURIComponent(publicCg)}`
+      + '/_shared_memory_snapshots/_/legacy-op/root/_shared_memory';
+    manifest.meta.push({
+      subject,
+      predicate: `${DKG}publicSnapshotGraph`,
+      object: transportGraph,
+      graph: manifest.meta[0]!.graph,
+    });
+    manifest.dataQuads = [{
+      subject: 'urn:legacy-root',
+      predicate: 'http://schema.org/value',
+      object: '"legacy"',
+      graph: transportGraph,
+    }];
+    const harness = createSelectedSwmLifecycleHarness({
+      contextGraphs: { public: publicCg },
+      manifest,
+      clock: { now: () => 1_000, deadline: () => 61_000 },
+    });
+
+    try {
+      const selected = await callSelectedSharedMemoryFromPeerDetailed(
+        harness.agent,
+        [publicCg],
+        {
+          selectedSwmPriority: true,
+          priority: 2_000,
+          sharedMemorySyncPlan: {
+            publicContextGraphIds: [publicCg],
+            privateRecoverFromCurator: [],
+            eligibleContextGraphIds: [publicCg],
+          },
+        },
+      );
+
+      expect(selected.shared.swmCoverage).toBeUndefined();
+      expect(selected.shared.insertedDataTriples).toBe(0);
+      // The lane-level contract is the fail-closed evidence: this unsupported
+      // legacy advertisement must stay incomplete and retryable even when the
+      // ordinary SWM summary has no transport/store phase failure to count.
       expect(selected.selectedScopeComplete).toBe(false);
       expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(true);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it('completes mixed store-backed and graph-backed metadata after every operation is proven', async () => {
+    const publicCg = 'selected-mixed-snapshot-evidence';
+    const storeBacked = snapshotManifest(publicCg, 1);
+    const graphBacked = graphBackedManifest(publicCg);
+    const harness = createSelectedSwmLifecycleHarness({
+      contextGraphs: { public: publicCg },
+      manifest: {
+        meta: [...storeBacked.meta, ...graphBacked.meta],
+        payloadByRef: storeBacked.payloadByRef,
+        dataQuads: graphBacked.dataQuads,
+      },
+      clock: { now: () => 1_000, deadline: () => 61_000 },
+    });
+
+    try {
+      const selected = await callSelectedSharedMemoryFromPeerDetailed(
+        harness.agent,
+        [publicCg],
+        {
+          selectedSwmPriority: true,
+          priority: 2_000,
+          sharedMemorySyncPlan: {
+            publicContextGraphIds: [publicCg],
+            privateRecoverFromCurator: [],
+            eligibleContextGraphIds: [publicCg],
+          },
+        },
+      );
+
+      expect(selected.shared.swmCoverage).toMatchObject({
+        contextGraphId: publicCg,
+        snapshotsResolved: 2,
+        snapshotsTotal: 2,
+        missingCount: 0,
+      });
+      expect(selected.shared.insertedMetaTriples).toBeGreaterThan(0);
+      expect(selected.shared.failedPhases).toBe(0);
+      expect(selected.selectedScopeComplete).toBe(true);
+      expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(false);
     } finally {
       await harness.close();
     }

--- a/packages/agent/test/selected-swm-lifecycle-core.test.ts
+++ b/packages/agent/test/selected-swm-lifecycle-core.test.ts
@@ -137,6 +137,11 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
       expect(summary.continuationPasses).toBe(0);
       expect(harness.probes.publicAdmissions()).toBe(1);
       expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(false);
+      expect(harness.agent.selectedSwmBootstrapAdmission.snapshot(PEER)).toMatchObject({
+        contextGraphIds: [publicCg],
+        phase: 'terminal',
+        freshAtMs: expect.any(Number),
+      });
     } finally {
       await harness.close();
     }

--- a/packages/agent/test/selected-swm-lifecycle-core.test.ts
+++ b/packages/agent/test/selected-swm-lifecycle-core.test.ts
@@ -222,7 +222,97 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
       expect(selected.shared.droppedDataTriples).toBe(0);
       expect(selected.shared.failedPhases).toBe(0);
       expect(selected.selectedScopeComplete).toBe(true);
+      expect(harness.probes.dataRequesterScopes).toEqual(['selected-swm-data:graph-v1']);
       expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(false);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it('fails closed when graph-backed metadata advertises a malformed transport graph', async () => {
+    const publicCg = 'selected-malformed-graph-backed';
+    const manifest = graphBackedManifest(publicCg);
+    const malformedGraph = 'did:dkg:context-graph:not-the-selected-cg/_shared_memory_snapshots/_/bad/ka';
+    manifest.meta = manifest.meta.map((quad) => (
+      quad.predicate === `${DKG}publicSnapshotGraph`
+        ? { ...quad, object: malformedGraph }
+        : quad
+    ));
+    const harness = createSelectedSwmLifecycleHarness({
+      contextGraphs: { public: publicCg },
+      manifest,
+      clock: { now: () => 1_000, deadline: () => 61_000 },
+      dataPage: { quads: [], completed: true, timedOut: false },
+    });
+
+    try {
+      const selected = await callSelectedSharedMemoryFromPeerDetailed(
+        harness.agent,
+        [publicCg],
+        {
+          selectedSwmPriority: true,
+          priority: 2_000,
+          sharedMemorySyncPlan: {
+            publicContextGraphIds: [publicCg],
+            privateRecoverFromCurator: [],
+            eligibleContextGraphIds: [publicCg],
+          },
+        },
+      );
+
+      expect(selected.shared.swmCoverage).toMatchObject({
+        snapshotsResolved: 0,
+        snapshotsTotal: 1,
+        descriptorsAuthoritative: false,
+        missingCount: 1,
+      });
+      expect(selected.shared.insertedMetaTriples).toBe(0);
+      expect(selected.shared.failedPhases).toBeGreaterThan(0);
+      expect(selected.selectedScopeComplete).toBe(false);
+      expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(true);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it('rewinds a failed graph-backed materialization to its DATA graph boundary', async () => {
+    const publicCg = 'selected-graph-backed-failed-rewind';
+    const manifest = graphBackedManifest(publicCg);
+    const corruptData = manifest.dataQuads.map((quad) => ({ ...quad, object: '"corrupt"' }));
+    const harness = createSelectedSwmLifecycleHarness({
+      contextGraphs: { public: publicCg },
+      manifest,
+      clock: { now: () => 1_000, deadline: () => 61_000 },
+      dataPage: {
+        quads: corruptData,
+        completed: true,
+        timedOut: false,
+        resumedFromOffset: 10,
+        nextOffset: 11,
+        rawResumedFromOffset: 10,
+        rawNextOffset: 11,
+        quadRawOffsets: [10],
+      },
+    });
+
+    try {
+      const selected = await callSelectedSharedMemoryFromPeerDetailed(
+        harness.agent,
+        [publicCg],
+        {
+          selectedSwmPriority: true,
+          priority: 2_000,
+          sharedMemorySyncPlan: {
+            publicContextGraphIds: [publicCg],
+            privateRecoverFromCurator: [],
+            eligibleContextGraphIds: [publicCg],
+          },
+        },
+      );
+
+      expect(selected.shared.failedPhases).toBeGreaterThan(0);
+      expect(selected.selectedScopeComplete).toBe(false);
+      expect(harness.agent.syncCheckpoints.get(`${publicCg}:data`)).toBe(10);
     } finally {
       await harness.close();
     }

--- a/packages/agent/test/selected-swm-test-helpers.ts
+++ b/packages/agent/test/selected-swm-test-helpers.ts
@@ -381,7 +381,6 @@ export interface SelectedSwmLifecycleAgentFixture {
     };
   };
   selectedSwmBootstrapAdmission: SelectedSwmBootstrapAdmission;
-  lastSelectedSwmSyncAt: Map<string, number>;
   store: OxigraphStore;
   writeLocks: Map<string, Promise<void>>;
   publicSnapshotStore: {
@@ -552,7 +551,6 @@ export function createSelectedSwmLifecycleHarness(
         : {}),
     },
     selectedSwmBootstrapAdmission: new SelectedSwmBootstrapAdmission(),
-    lastSelectedSwmSyncAt: new Map(),
     store,
     writeLocks: new Map(),
     publicSnapshotStore: {

--- a/packages/agent/test/selected-swm-test-helpers.ts
+++ b/packages/agent/test/selected-swm-test-helpers.ts
@@ -374,6 +374,11 @@ export interface SelectedSwmLifecycleHarnessOptions {
     readonly quads?: readonly Quad[];
     readonly completed: boolean;
     readonly timedOut: boolean;
+    readonly resumedFromOffset?: number;
+    readonly nextOffset?: number;
+    readonly rawResumedFromOffset?: number;
+    readonly rawNextOffset?: number;
+    readonly quadRawOffsets?: readonly number[];
   };
 }
 
@@ -454,6 +459,7 @@ export interface SelectedSwmLifecycleHarness {
     readonly processedMetaBatches: readonly Quad[][];
     readonly dataFetches: () => number;
     readonly metaRequesterScopes: readonly (string | undefined)[];
+    readonly dataRequesterScopes: readonly (string | undefined)[];
     readonly metaSinceBatchIds: readonly (string | undefined)[];
     readonly metaReturnAcceptedPrefixOnRetryableTransportFailure: readonly boolean[];
     readonly maxActiveAdmissions: () => number;
@@ -526,6 +532,7 @@ export function createSelectedSwmLifecycleHarness(
   let metaFetches = 0;
   let dataFetches = 0;
   const metaRequesterScopes: Array<string | undefined> = [];
+  const dataRequesterScopes: Array<string | undefined> = [];
   const metaSinceBatchIds: Array<string | undefined> = [];
   const metaReturnAcceptedPrefixOnRetryableTransportFailure: boolean[] = [];
   const processedMetaBatches: Quad[][] = [];
@@ -644,15 +651,28 @@ export function createSelectedSwmLifecycleHarness(
       }
       if (phase === 'data') {
         dataFetches += 1;
+        dataRequesterScopes.push(requesterScope);
         if (dataFetches <= (options.dataFailuresBeforeSuccess ?? 0)) {
           throw new Error('simulated aggregate-data transport failure');
         }
         if (options.dataPage) {
+          const resumedFromOffset = options.dataPage.resumedFromOffset ?? 0;
+          const nextOffset = options.dataPage.nextOffset
+            ?? resumedFromOffset + (options.dataPage.quads?.length ?? 0);
           return {
             quads: [...(options.dataPage.quads ?? [])],
             bytesReceived: options.dataPage.quads?.length ?? 0,
-            resumedFromOffset: 0,
-            nextOffset: options.dataPage.quads?.length ?? 0,
+            resumedFromOffset,
+            nextOffset,
+            ...(options.dataPage.rawResumedFromOffset !== undefined
+              ? { rawResumedFromOffset: options.dataPage.rawResumedFromOffset }
+              : {}),
+            ...(options.dataPage.rawNextOffset !== undefined
+              ? { rawNextOffset: options.dataPage.rawNextOffset }
+              : {}),
+            ...(options.dataPage.quadRawOffsets !== undefined
+              ? { quadRawOffsets: [...options.dataPage.quadRawOffsets] }
+              : {}),
             checkpointKey: `${contextGraphId}:${phase}`,
             completed: options.dataPage.completed,
             timedOut: options.dataPage.timedOut,
@@ -752,6 +772,7 @@ export function createSelectedSwmLifecycleHarness(
       processedMetaBatches,
       dataFetches: () => dataFetches,
       metaRequesterScopes,
+      dataRequesterScopes,
       metaSinceBatchIds,
       metaReturnAcceptedPrefixOnRetryableTransportFailure,
       maxActiveAdmissions: () => maxActiveAdmissions,

--- a/packages/agent/test/selected-swm-test-helpers.ts
+++ b/packages/agent/test/selected-swm-test-helpers.ts
@@ -35,6 +35,7 @@ export const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
 export function snapshotManifest(contextGraphId: string, count: number): {
   meta: Quad[];
   payloadByRef: Map<string, Quad[]>;
+  dataQuads: Quad[];
 } {
   const metaGraph = contextGraphWorkspaceMetaGraphUri(contextGraphId);
   const meta: Quad[] = [];
@@ -64,7 +65,7 @@ export function snapshotManifest(contextGraphId: string, count: number): {
     );
     payloadByRef.set(digest, payload);
   }
-  return { meta, payloadByRef };
+  return { meta, payloadByRef, dataQuads: [] };
 }
 
 export function graphBackedManifest(contextGraphId: string): ReturnType<typeof snapshotManifest> {
@@ -132,7 +133,11 @@ export function graphBackedManifest(contextGraphId: string): ReturnType<typeof s
       graph: metaGraph,
     },
   ];
-  return { meta, payloadByRef: new Map() };
+  return {
+    meta,
+    payloadByRef: new Map(),
+    dataQuads: payload.map((quad) => ({ ...quad, graph: snapshotGraph })),
+  };
 }
 
 export function cleanDurableResult(): SharedMemorySyncResult {
@@ -656,6 +661,8 @@ export function createSelectedSwmLifecycleHarness(
       }
       const quads = phase === 'meta' && contextGraphId === options.contextGraphs.public
         ? options.manifest.meta
+        : phase === 'data' && contextGraphId === options.contextGraphs.public
+          ? options.manifest.dataQuads
         : [];
       return {
         quads,

--- a/packages/agent/test/selected-swm-test-helpers.ts
+++ b/packages/agent/test/selected-swm-test-helpers.ts
@@ -381,6 +381,7 @@ export interface SelectedSwmLifecycleAgentFixture {
     };
   };
   selectedSwmBootstrapAdmission: SelectedSwmBootstrapAdmission;
+  lastSelectedSwmSyncAt: Map<string, number>;
   store: OxigraphStore;
   writeLocks: Map<string, Promise<void>>;
   publicSnapshotStore: {
@@ -551,6 +552,7 @@ export function createSelectedSwmLifecycleHarness(
         : {}),
     },
     selectedSwmBootstrapAdmission: new SelectedSwmBootstrapAdmission(),
+    lastSelectedSwmSyncAt: new Map(),
     store,
     writeLocks: new Map(),
     publicSnapshotStore: {

--- a/packages/agent/test/shared-memory-sync-ownership.test.ts
+++ b/packages/agent/test/shared-memory-sync-ownership.test.ts
@@ -271,6 +271,31 @@ describe('runSharedMemorySync ownership hydration', () => {
     }
   });
 
+  it('admits encoded graph-backed snapshots only for shared-memory data', async () => {
+    const worker = new SyncVerifyWorker();
+    const contextGraphId = '0x1111111111111111111111111111111111111111/public-cg';
+    const workspaceGraph = contextGraphSharedMemoryUri(contextGraphId);
+    const snapshotGraph = `did:dkg:context-graph:${encodeURIComponent(contextGraphId)}`
+      + '/_shared_memory_snapshots/_/operation/ka';
+    const nquads = `<urn:s> <urn:p> "value" <${snapshotGraph}> .`;
+
+    try {
+      const workspace = await worker.parseAndFilter(nquads, workspaceGraph, contextGraphId);
+      expect(workspace.quads).toHaveLength(1);
+      expect(workspace.quads[0]?.graph).toBe(snapshotGraph);
+
+      const durable = await worker.parseAndFilter(
+        nquads,
+        `did:dkg:context-graph:${contextGraphId}`,
+        contextGraphId,
+      );
+      expect(durable.quads).toHaveLength(0);
+      expect(durable.totalQuads).toBe(1);
+    } finally {
+      await worker.close();
+    }
+  });
+
   it('rejects forged replicated registrations with noncanonical subjects', async () => {
     const worker = new SyncVerifyWorker();
     const inserted: Quad[] = [];

--- a/packages/agent/test/shared-memory-sync-ownership.test.ts
+++ b/packages/agent/test/shared-memory-sync-ownership.test.ts
@@ -284,6 +284,13 @@ describe('runSharedMemorySync ownership hydration', () => {
       expect(workspace.quads).toHaveLength(1);
       expect(workspace.quads[0]?.graph).toBe(snapshotGraph);
 
+      const malformed = await worker.parseAndFilter(
+        '<urn:s> <urn:p> "value" <did:dkg:context-graph:0x1111111111111111111111111111111111111111%2Fpublic-cg/_shared_memory_snapshots/_/operation/extra/ka> .',
+        workspaceGraph,
+        contextGraphId,
+      );
+      expect(malformed.quads).toHaveLength(0);
+
       const durable = await worker.parseAndFilter(
         nquads,
         `did:dkg:context-graph:${contextGraphId}`,

--- a/packages/agent/test/sync-byte-budget-pages.test.ts
+++ b/packages/agent/test/sync-byte-budget-pages.test.ts
@@ -25,7 +25,7 @@ import {
   serializeResponderRowsWithinByteBudget,
   type SyncRow,
 } from '../src/sync/responder/graph-plan.js';
-import { resolveDurableDataRequestPolicy } from '../src/sync/responder/durable-data-request-policy.js';
+import { resolveDataRequestPolicy } from '../src/sync/responder/data-request-policy.js';
 import {
   linesFromNquads,
   registerTestSyncHandler,
@@ -179,7 +179,7 @@ describe('byte-budget sync pagination', () => {
       pageRowsHint: SYNC_REQUEST_SAFE_PAGE_SIZE,
       assetUals: [exactUal],
     });
-    expect(resolveDurableDataRequestPolicy({
+    expect(resolveDataRequestPolicy({
       legacyLimit: request.limit,
       includeSharedMemory: false,
       phase: request.phase,
@@ -578,6 +578,43 @@ describe('byte-budget sync pagination', () => {
     await store.close();
   });
 
+  it('keeps an oversized SWM byte-budget session alive for the serialized continuation', async () => {
+    const store = new OxigraphStore();
+    const graph = `did:dkg:context-graph:${CG_ID}/_shared_memory`;
+    const totalRows = 900;
+    await store.insert(Array.from({ length: totalRows }, (_, i) => ({
+      graph,
+      subject: 'urn:shared-memory-oversized-root',
+      predicate: `urn:predicate:${i.toString().padStart(4, '0')}`,
+      object: `"${'x'.repeat(6_000)}-${i}"`,
+    })));
+    const cap = registerTestSyncHandler(store, { syncPageSize: SYNC_PAGE_SIZE });
+    const request = {
+      contextGraphId: CG_ID,
+      limit: SYNC_PAGE_SIZE,
+      includeSharedMemory: true,
+      phase: 'data' as const,
+      syncSessionId: 'byte-budget-swm-oversized-session',
+      pageMode: SYNC_BYTE_BUDGET_PAGE_MODE,
+      pageRowsHint: SYNC_REQUEST_PAGE_SIZE,
+    };
+
+    const first = await cap.invoke({ ...request, offset: 0 });
+    const firstRows = linesFromNquads(first);
+    expect(firstRows.length).toBeGreaterThan(0);
+    expect(firstRows.length).toBeLessThan(totalRows);
+    expect(new TextEncoder().encode(first).byteLength)
+      .toBeLessThanOrEqual(SYNC_BYTE_BUDGET_RESPONSE_BYTES);
+
+    // The store-loaded slice was short (900 < 8192), but the byte serializer
+    // exposed only a prefix. The same responder session must still own the
+    // suffix addressed by this continuation offset.
+    const second = await cap.invoke({ ...request, offset: firstRows.length });
+    expect(linesFromNquads(second)).toHaveLength(totalRows - firstRows.length);
+
+    await store.close();
+  });
+
   it('honours the negotiated row hint for durable meta while legacy meta remains capped', async () => {
     const store = new OxigraphStore();
     const contextGraphId = 'byte-budget-meta-cg';
@@ -692,7 +729,7 @@ describe('byte-budget sync pagination', () => {
   });
 
   it('derives exact-fetch resource policy without trusting signature fields', () => {
-    expect(resolveDurableDataRequestPolicy({
+    expect(resolveDataRequestPolicy({
       legacyLimit: SYNC_PAGE_SIZE,
       includeSharedMemory: false,
       phase: 'data',
@@ -706,7 +743,7 @@ describe('byte-budget sync pagination', () => {
       exactGraphReadMode: 'page-only',
     });
 
-    expect(resolveDurableDataRequestPolicy({
+    expect(resolveDataRequestPolicy({
       legacyLimit: SYNC_PAGE_SIZE,
       includeSharedMemory: false,
       phase: 'data',
@@ -720,7 +757,7 @@ describe('byte-budget sync pagination', () => {
       exactGraphReadMode: 'snapshot-or-page',
     });
 
-    expect(resolveDurableDataRequestPolicy({
+    expect(resolveDataRequestPolicy({
       legacyLimit: SYNC_PAGE_SIZE,
       includeSharedMemory: true,
       phase: 'data',

--- a/packages/agent/test/sync-byte-budget-pages.test.ts
+++ b/packages/agent/test/sync-byte-budget-pages.test.ts
@@ -104,6 +104,26 @@ describe('byte-budget sync pagination', () => {
     );
   });
 
+  it('advertises byte-budget paging for public shared-memory data', async () => {
+    const encoded = await buildSyncRequestEnvelope({
+      contextGraphId: CG_ID,
+      offset: 0,
+      limit: SYNC_REQUEST_PAGE_SIZE,
+      includeSharedMemory: true,
+      targetPeerId: REMOTE_PEER_ID,
+      requesterPeerId: LOCAL_PEER_ID,
+      phase: 'data',
+      needsAuth: false,
+      computeSyncDigest: () => new Uint8Array(32),
+      getIdentityId: async () => 0n,
+    });
+
+    expect(new TextDecoder().decode(encoded)).toBe(
+      `workspace:${CG_ID}|0|${SYNC_REQUEST_PAGE_SIZE}|data`
+      + `|page-mode|${SYNC_BYTE_BUDGET_PAGE_MODE}|page-rows|${SYNC_REQUEST_PAGE_SIZE}`,
+    );
+  });
+
   it('keeps the authenticated legacy limit signed while adding the larger hint', async () => {
     const wallet = ethers.Wallet.createRandom();
     const signedLimits: number[] = [];
@@ -520,6 +540,44 @@ describe('byte-budget sync pagination', () => {
     await store.close();
   });
 
+  it('lets negotiated shared-memory data use the larger byte-bounded page', async () => {
+    const store = new OxigraphStore();
+    const graph = `did:dkg:context-graph:${CG_ID}/_shared_memory`;
+    await store.insert(Array.from({ length: 1_200 }, (_, i) => ({
+      graph,
+      subject: 'urn:shared-memory-root',
+      predicate: `urn:predicate:${i.toString().padStart(4, '0')}`,
+      object: `"value-${i}"`,
+    })));
+    const cap = registerTestSyncHandler(store, { syncPageSize: SYNC_PAGE_SIZE });
+
+    const legacy = await cap.invoke({
+      contextGraphId: CG_ID,
+      offset: 0,
+      limit: SYNC_PAGE_SIZE,
+      includeSharedMemory: true,
+      phase: 'data',
+      syncSessionId: 'legacy-swm-data-session',
+    });
+    expect(linesFromNquads(legacy)).toHaveLength(SYNC_PAGE_SIZE);
+
+    const upgraded = await cap.invoke({
+      contextGraphId: CG_ID,
+      offset: 0,
+      limit: SYNC_PAGE_SIZE,
+      includeSharedMemory: true,
+      phase: 'data',
+      syncSessionId: 'byte-budget-swm-data-session',
+      pageMode: SYNC_BYTE_BUDGET_PAGE_MODE,
+      pageRowsHint: SYNC_REQUEST_PAGE_SIZE,
+    });
+    expect(linesFromNquads(upgraded)).toHaveLength(1_200);
+    expect(new TextEncoder().encode(upgraded).byteLength)
+      .toBeLessThanOrEqual(SYNC_BYTE_BUDGET_RESPONSE_BYTES);
+
+    await store.close();
+  });
+
   it('honours the negotiated row hint for durable meta while legacy meta remains capped', async () => {
     const store = new OxigraphStore();
     const contextGraphId = 'byte-budget-meta-cg';
@@ -651,6 +709,20 @@ describe('byte-budget sync pagination', () => {
     expect(resolveDurableDataRequestPolicy({
       legacyLimit: SYNC_PAGE_SIZE,
       includeSharedMemory: false,
+      phase: 'data',
+      pageMode: SYNC_BYTE_BUDGET_PAGE_MODE,
+      pageRowsHint: SYNC_REQUEST_PAGE_SIZE,
+      hasExactAssetFilter: false,
+    })).toEqual({
+      usesByteBudgetPage: true,
+      limit: SYNC_REQUEST_PAGE_SIZE,
+      cacheMode: 'session-snapshot',
+      exactGraphReadMode: 'snapshot-or-page',
+    });
+
+    expect(resolveDurableDataRequestPolicy({
+      legacyLimit: SYNC_PAGE_SIZE,
+      includeSharedMemory: true,
       phase: 'data',
       pageMode: SYNC_BYTE_BUDGET_PAGE_MODE,
       pageRowsHint: SYNC_REQUEST_PAGE_SIZE,

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -1263,6 +1263,82 @@ describe('DKGAgent sync retry — event-driven via peer:update', () => {
 });
 
 describe('DKGAgent sync retry — periodic reconciler', () => {
+  it('refreshes only selected RFC-64 SWM when broad sync-on-connect is disabled', async () => {
+    const agent = await DKGAgent.create({
+      name: 'ReconcilerSelectedSwmIndependent',
+      listenHost: '127.0.0.1',
+      chainAdapter: new MockChainAdapter(),
+      syncOnConnectEnabled: false,
+    });
+    try {
+      await agent.start();
+      allowAllNetworkAdmission(agent);
+
+      const peerA = freshPeerIdString();
+      (agent.node.libp2p as any).getPeers = recorder(() => [peerIdFromString(peerA)]);
+      (agent as any).selectedSwmBootstrapContextGraphIdsForPeer = recorder(
+        () => ['selected-public-cg'],
+      );
+      (agent as any).lastSelectedSwmSyncAt.set(peerA, Date.now() - 20 * 60_000);
+      const owner = (agent as any).selectedSwmBootstrapAdmission.beginTransfer(
+        peerA,
+        ['selected-public-cg'],
+      );
+      (agent as any).selectedSwmBootstrapAdmission.markTransferTerminal(owner);
+
+      const selectedCalls: string[] = [];
+      (agent as any).trySelectedSwmRetryFromPeer = async (
+        peerId: string,
+        onSyncAccounting?: (outcome: SyncOnConnectPeerOutcome) => void,
+      ) => {
+        selectedCalls.push(peerId);
+        onSyncAccounting?.({ progress: false, fresh: true });
+        return 'synced';
+      };
+      const broadSync = recorder(async () => 'synced');
+      (agent as any).trySyncFromPeer = broadSync;
+
+      await (agent as any).reconcileSyncFromConnectedPeers();
+      await flushMicrotasks();
+
+      expect(selectedCalls).toEqual([peerA]);
+      expect(broadSync.calls).toEqual([]);
+      expect((agent as any).selectedSwmBootstrapAdmission.isRetryRequired(peerA)).toBe(true);
+      expect((agent as any).lastSuccessfulSyncAt.has(peerA)).toBe(false);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('does not refresh a recently completed selected RFC-64 SWM scope', async () => {
+    const agent = await DKGAgent.create({
+      name: 'ReconcilerSelectedSwmFresh',
+      listenHost: '127.0.0.1',
+      chainAdapter: new MockChainAdapter(),
+      syncOnConnectEnabled: false,
+    });
+    try {
+      await agent.start();
+      allowAllNetworkAdmission(agent);
+
+      const peerA = freshPeerIdString();
+      (agent.node.libp2p as any).getPeers = recorder(() => [peerIdFromString(peerA)]);
+      (agent as any).selectedSwmBootstrapContextGraphIdsForPeer = recorder(
+        () => ['selected-public-cg'],
+      );
+      (agent as any).lastSelectedSwmSyncAt.set(peerA, Date.now());
+      const selectedRetry = recorder(async () => 'synced');
+      (agent as any).trySelectedSwmRetryFromPeer = selectedRetry;
+
+      await (agent as any).reconcileSyncFromConnectedPeers();
+      await flushMicrotasks();
+
+      expect(selectedRetry.calls).toEqual([]);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
   it('retries connected peers with no successful sync on record', async () => {
     const agent = await DKGAgent.create({
       name: 'ReconcilerNeverSynced',

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -1279,12 +1279,14 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
       (agent as any).selectedSwmBootstrapContextGraphIdsForPeer = recorder(
         () => ['selected-public-cg'],
       );
-      (agent as any).lastSelectedSwmSyncAt.set(peerA, Date.now() - 20 * 60_000);
       const owner = (agent as any).selectedSwmBootstrapAdmission.beginTransfer(
         peerA,
         ['selected-public-cg'],
       );
-      (agent as any).selectedSwmBootstrapAdmission.markTransferTerminal(owner);
+      (agent as any).selectedSwmBootstrapAdmission.markTransferTerminal(
+        owner,
+        Date.now() - 20 * 60_000,
+      );
 
       const selectedCalls: string[] = [];
       (agent as any).trySelectedSwmRetryFromPeer = async (
@@ -1326,7 +1328,11 @@ describe('DKGAgent sync retry — periodic reconciler', () => {
       (agent as any).selectedSwmBootstrapContextGraphIdsForPeer = recorder(
         () => ['selected-public-cg'],
       );
-      (agent as any).lastSelectedSwmSyncAt.set(peerA, Date.now());
+      const owner = (agent as any).selectedSwmBootstrapAdmission.beginTransfer(
+        peerA,
+        ['selected-public-cg'],
+      );
+      (agent as any).selectedSwmBootstrapAdmission.markTransferTerminal(owner, Date.now());
       const selectedRetry = recorder(async () => 'synced');
       (agent as any).trySelectedSwmRetryFromPeer = selectedRetry;
 
@@ -2006,6 +2012,14 @@ describe('DKGAgent sync state lifecycle', () => {
         nextRetryAt: now - 20 * 60_000,
       });
       (agent as any).lastSyncDisconnectedAt.set(remotePeer, now - 20 * 60_000);
+      const selectedOwner = (agent as any).selectedSwmBootstrapAdmission.beginTransfer(
+        remotePeer,
+        ['selected-public-cg'],
+      );
+      (agent as any).selectedSwmBootstrapAdmission.markTransferTerminal(
+        selectedOwner,
+        now - 20 * 60_000,
+      );
       (agent.node.libp2p as any).getPeers = recorder(() => []);
 
       (agent as any).pruneSyncReconcilerState(now);
@@ -2015,6 +2029,7 @@ describe('DKGAgent sync state lifecycle', () => {
       expect((agent as any).lastSyncProgressAt.has(remotePeer)).toBe(false);
       expect((agent as any).syncReconcilerBackoff.has(remotePeer)).toBe(false);
       expect((agent as any).lastSyncDisconnectedAt.has(remotePeer)).toBe(false);
+      expect((agent as any).selectedSwmBootstrapAdmission.snapshot(remotePeer)).toBeNull();
     } finally {
       await agent.stop().catch(() => {});
     }

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -864,7 +864,7 @@ describe('sync requester progress accounting', () => {
     expect(summary.deniedPhases).toBe(1);
     expect(summary.failedPeers).toBe(0);
     expect(summary.completedPhases).toBe(2);
-    expect(fetchSyncPages.calls).toContainEqual([ctx, 'peer-a', 'open-swm', true, 'data', expect.any(String), expect.any(Number)]);
+    expect(fetchSyncPages.calls).toContainEqual([ctx, 'peer-a', 'open-swm', true, 'data', expect.any(String), expect.any(Number), undefined]);
   });
 
   it('counts multiple shared-memory context-graph failures as one failed peer', async () => {
@@ -900,7 +900,7 @@ describe('sync requester progress accounting', () => {
     expect(summary.failedPhases).toBe(0);
     expect(summary.deniedPhases).toBe(0);
     expect(summary.completedPhases).toBe(2);
-    expect(fetchSyncPages.calls).toContainEqual([ctx, 'peer-a', 'open-swm', true, 'data', expect.any(String), expect.any(Number)]);
+    expect(fetchSyncPages.calls).toContainEqual([ctx, 'peer-a', 'open-swm', true, 'data', expect.any(String), expect.any(Number), undefined]);
   });
 
   it('continues shared-memory sync after a post-response verifier failure without marking the peer unreachable', async () => {
@@ -939,7 +939,7 @@ describe('sync requester progress accounting', () => {
     expect(summary.failedPeers).toBe(0);
     expect(summary.failedPhases).toBe(1);
     expect(summary.completedPhases).toBe(2);
-    expect(fetchSyncPages.calls).toContainEqual([ctx, 'peer-a', 'open-swm', true, 'data', expect.any(String), expect.any(Number)]);
+    expect(fetchSyncPages.calls).toContainEqual([ctx, 'peer-a', 'open-swm', true, 'data', expect.any(String), expect.any(Number), undefined]);
   });
 
   it('counts shared-memory snapshot validation failures as phase failures after the peer responded', async () => {
@@ -1005,7 +1005,7 @@ describe('sync requester progress accounting', () => {
     expect(summary.failedPeers).toBe(0);
     expect(summary.failedPhases).toBe(1);
     expect(summary.completedPhases).toBe(2);
-    expect(fetchSyncPages.calls).toContainEqual([ctx, 'peer-a', 'open-swm', true, 'data', expect.any(String), expect.any(Number)]);
+    expect(fetchSyncPages.calls).toContainEqual([ctx, 'peer-a', 'open-swm', true, 'data', expect.any(String), expect.any(Number), undefined]);
   });
 
   it('counts both clean zero-offset empty shared-memory phases as complete', async () => {
@@ -1239,7 +1239,7 @@ describe('sync requester progress accounting', () => {
     expect(storeInsert.calls).toHaveLength(1);
     expect(storeInsert.calls).toContainEqual([[dataQuad]]);
     expect(setCheckpoint.calls).not.toContainEqual(['large-swm:snapshot:snapshot-ref', expect.any(Number)]);
-    expect(setCheckpoint.calls).toContainEqual(['large-swm:data', 7]);
+    expect(setCheckpoint.calls).toContainEqual(['large-swm:data', 7, 7]);
     expect(setCheckpoint.calls).not.toContainEqual(['large-swm:meta', expect.any(Number)]);
     expect(deleteCheckpoint.calls).toContainEqual(['large-swm:snapshot:snapshot-ref']);
   });

--- a/packages/agent/test/sync-responder-graph-backed-swm.test.ts
+++ b/packages/agent/test/sync-responder-graph-backed-swm.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import { OxigraphStore, type TripleStore } from '@origintrail-official/dkg-storage';
+import { readSwmDataPage } from '../src/sync/responder/graph-plan.js';
+
+describe('graph-backed shared-memory responder planning', () => {
+  const contextGraphId = 'test/graph-backed-cg';
+  const dataGraph = `did:dkg:context-graph:${contextGraphId}/_shared_memory`;
+  const metaGraph = `${dataGraph}_meta`;
+  const snapshotGraph = `did:dkg:context-graph:${encodeURIComponent(contextGraphId)}`
+    + '/_shared_memory_snapshots/_/share-op-1/ka';
+  const rows = [0, 1, 2].map((index) => ({
+    s: `urn:graph-backed:${index}`,
+    p: 'http://schema.org/value',
+    o: `"${index}"`,
+    g: snapshotGraph,
+  }));
+
+  function storeWithActualCount(actualCount = rows.length): TripleStore {
+    return {
+      async query(sparql: string) {
+        if (sparql.includes('SELECT DISTINCT ?g ?root')) {
+          return { type: 'bindings' as const, bindings: [] };
+        }
+        if (sparql.includes('SELECT DISTINCT ?snapshotGraph ?count ?ts')) {
+          return {
+            type: 'bindings' as const,
+            bindings: [{
+              snapshotGraph,
+              count: `"${rows.length}"^^<http://www.w3.org/2001/XMLSchema#integer>`,
+              ts: '"2026-08-15T00:00:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>',
+            }],
+          };
+        }
+        if (sparql.includes(`SELECT (<${snapshotGraph}> AS ?g) (COUNT(*) AS ?count)`)) {
+          return {
+            type: 'bindings' as const,
+            bindings: [{ g: snapshotGraph, count: String(actualCount) }],
+          };
+        }
+        if (sparql.includes(`GRAPH <${snapshotGraph}> { ?s ?p ?o }`)) {
+          const offset = Number(/OFFSET (\d+)/.exec(sparql)?.[1] ?? 0);
+          const limit = Number(/LIMIT (\d+)/.exec(sparql)?.[1] ?? rows.length);
+          return {
+            type: 'bindings' as const,
+            bindings: rows.slice(offset, offset + limit),
+          };
+        }
+        return { type: 'bindings' as const, bindings: [] };
+      },
+    } as unknown as TripleStore;
+  }
+
+  it('serves a fresh immutable snapshot graph as one paged batch plan', async () => {
+    const first = await readSwmDataPage({
+      store: storeWithActualCount(),
+      graphList: [dataGraph, metaGraph, snapshotGraph],
+      registeredSubGraphNames: [],
+      contextGraphId,
+      cutoffIso: '2026-08-14T00:00:00.000Z',
+      offset: 0,
+      limit: 2,
+    });
+    const second = await readSwmDataPage({
+      store: storeWithActualCount(),
+      graphList: [dataGraph, metaGraph, snapshotGraph],
+      registeredSubGraphNames: [],
+      contextGraphId,
+      cutoffIso: '2026-08-14T00:00:00.000Z',
+      offset: 2,
+      limit: 2,
+    });
+
+    expect([...first, ...second]).toEqual(rows);
+  });
+
+  it('fails closed when operation metadata and stored graph count disagree', async () => {
+    await expect(readSwmDataPage({
+      store: storeWithActualCount(rows.length - 1),
+      graphList: [dataGraph, metaGraph, snapshotGraph],
+      registeredSubGraphNames: [],
+      contextGraphId,
+      cutoffIso: '2026-08-14T00:00:00.000Z',
+      offset: 0,
+      limit: 2,
+    })).rejects.toThrow('count mismatch');
+  });
+
+  it('executes the graph-backed discovery and count plan against Oxigraph', async () => {
+    const store = new OxigraphStore();
+    const operation = 'urn:dkg:share:graph-backed-real-store';
+    await store.insert([
+      {
+        graph: metaGraph,
+        subject: operation,
+        predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+        object: 'http://dkg.io/ontology/WorkspaceOperation',
+      },
+      {
+        graph: metaGraph,
+        subject: operation,
+        predicate: 'http://dkg.io/ontology/contentScopeVersion',
+        object: '"2"^^<http://www.w3.org/2001/XMLSchema#integer>',
+      },
+      {
+        graph: metaGraph,
+        subject: operation,
+        predicate: 'http://dkg.io/ontology/publicSnapshotGraph',
+        object: snapshotGraph,
+      },
+      {
+        graph: metaGraph,
+        subject: operation,
+        predicate: 'http://dkg.io/ontology/publicQuadsCount',
+        object: `"${rows.length}"^^<http://www.w3.org/2001/XMLSchema#integer>`,
+      },
+      {
+        graph: metaGraph,
+        subject: operation,
+        predicate: 'http://dkg.io/ontology/publishedAt',
+        object: '"2026-08-15T00:00:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>',
+      },
+      ...rows.map((row) => ({
+        graph: row.g,
+        subject: row.s,
+        predicate: row.p,
+        object: row.o,
+      })),
+    ]);
+
+    const actual = await readSwmDataPage({
+      store,
+      graphList: [dataGraph, metaGraph, snapshotGraph],
+      registeredSubGraphNames: [],
+      contextGraphId,
+      cutoffIso: '2026-08-14T00:00:00.000Z',
+      offset: 0,
+      limit: 10,
+    });
+
+    expect(actual).toEqual(rows);
+    await store.close();
+  });
+});

--- a/packages/agent/test/sync-responder-graph-backed-swm.test.ts
+++ b/packages/agent/test/sync-responder-graph-backed-swm.test.ts
@@ -88,12 +88,29 @@ describe('graph-backed shared-memory responder planning', () => {
   it('executes the graph-backed discovery and count plan against Oxigraph', async () => {
     const store = new OxigraphStore();
     const operation = 'urn:dkg:share:graph-backed-real-store';
+    const head = 'did:dkg:test/graph-backed/1#dkg-swm-head';
+    const shareOperationId = 'share-op-1';
+    const staleOperation = 'urn:dkg:share:graph-backed-stale';
+    const staleSnapshotGraph = `did:dkg:context-graph:${encodeURIComponent(contextGraphId)}`
+      + '/_shared_memory_snapshots/_/stale-share-op/ka';
     await store.insert([
+      {
+        graph: metaGraph,
+        subject: head,
+        predicate: 'http://dkg.io/ontology/shareOperationId',
+        object: `"${shareOperationId}"`,
+      },
       {
         graph: metaGraph,
         subject: operation,
         predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
         object: 'http://dkg.io/ontology/WorkspaceOperation',
+      },
+      {
+        graph: metaGraph,
+        subject: operation,
+        predicate: 'http://dkg.io/ontology/shareOperationId',
+        object: `"${shareOperationId}"`,
       },
       {
         graph: metaGraph,
@@ -119,6 +136,45 @@ describe('graph-backed shared-memory responder planning', () => {
         predicate: 'http://dkg.io/ontology/publishedAt',
         object: '"2026-08-15T00:00:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>',
       },
+      // Superseded operations remain in metadata history. This intentionally
+      // advertises a missing graph/count mismatch and must be ignored because
+      // no canonical head references its shareOperationId.
+      {
+        graph: metaGraph,
+        subject: staleOperation,
+        predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+        object: 'http://dkg.io/ontology/WorkspaceOperation',
+      },
+      {
+        graph: metaGraph,
+        subject: staleOperation,
+        predicate: 'http://dkg.io/ontology/shareOperationId',
+        object: '"stale-share-op"',
+      },
+      {
+        graph: metaGraph,
+        subject: staleOperation,
+        predicate: 'http://dkg.io/ontology/contentScopeVersion',
+        object: '"2"^^<http://www.w3.org/2001/XMLSchema#integer>',
+      },
+      {
+        graph: metaGraph,
+        subject: staleOperation,
+        predicate: 'http://dkg.io/ontology/publicSnapshotGraph',
+        object: staleSnapshotGraph,
+      },
+      {
+        graph: metaGraph,
+        subject: staleOperation,
+        predicate: 'http://dkg.io/ontology/publicQuadsCount',
+        object: '"999"^^<http://www.w3.org/2001/XMLSchema#integer>',
+      },
+      {
+        graph: metaGraph,
+        subject: staleOperation,
+        predicate: 'http://dkg.io/ontology/publishedAt',
+        object: '"2026-08-15T00:01:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>',
+      },
       ...rows.map((row) => ({
         graph: row.g,
         subject: row.s,
@@ -138,6 +194,56 @@ describe('graph-backed shared-memory responder planning', () => {
     });
 
     expect(actual).toEqual(rows);
+    await store.close();
+  });
+
+  it('emits graph-backed groups before legacy root-scoped rows across pages', async () => {
+    const store = new OxigraphStore();
+    const operation = 'urn:dkg:share:graph-backed-mixed';
+    const head = 'did:dkg:test/graph-backed/mixed#dkg-swm-head';
+    const legacyOperation = 'urn:dkg:share:legacy-mixed';
+    const legacyRoot = 'urn:legacy:root';
+    const legacyRows = [
+      { subject: legacyRoot, predicate: 'http://schema.org/name', object: '"root"' },
+      { subject: `${legacyRoot}/.well-known/genid/1`, predicate: 'http://schema.org/value', object: '"child"' },
+    ];
+    await store.insert([
+      { graph: metaGraph, subject: head, predicate: 'http://dkg.io/ontology/shareOperationId', object: '"share-op-1"' },
+      { graph: metaGraph, subject: operation, predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/WorkspaceOperation' },
+      { graph: metaGraph, subject: operation, predicate: 'http://dkg.io/ontology/shareOperationId', object: '"share-op-1"' },
+      { graph: metaGraph, subject: operation, predicate: 'http://dkg.io/ontology/contentScopeVersion', object: '"2"^^<http://www.w3.org/2001/XMLSchema#integer>' },
+      { graph: metaGraph, subject: operation, predicate: 'http://dkg.io/ontology/publicSnapshotGraph', object: snapshotGraph },
+      { graph: metaGraph, subject: operation, predicate: 'http://dkg.io/ontology/publicQuadsCount', object: `"${rows.length}"^^<http://www.w3.org/2001/XMLSchema#integer>` },
+      { graph: metaGraph, subject: operation, predicate: 'http://dkg.io/ontology/publishedAt', object: '"2026-08-15T00:00:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>' },
+      { graph: metaGraph, subject: legacyOperation, predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/WorkspaceOperation' },
+      { graph: metaGraph, subject: legacyOperation, predicate: 'http://dkg.io/ontology/rootEntity', object: legacyRoot },
+      { graph: metaGraph, subject: legacyOperation, predicate: 'http://dkg.io/ontology/publishedAt', object: '"2026-08-15T00:00:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>' },
+      ...rows.map((row) => ({ graph: row.g, subject: row.s, predicate: row.p, object: row.o })),
+      ...legacyRows.map((row) => ({ graph: dataGraph, ...row })),
+    ]);
+
+    const page1 = await readSwmDataPage({
+      store,
+      graphList: [dataGraph, metaGraph, snapshotGraph],
+      registeredSubGraphNames: [],
+      contextGraphId,
+      cutoffIso: '2026-08-14T00:00:00.000Z',
+      offset: 0,
+      limit: 4,
+    });
+    const page2 = await readSwmDataPage({
+      store,
+      graphList: [dataGraph, metaGraph, snapshotGraph],
+      registeredSubGraphNames: [],
+      contextGraphId,
+      cutoffIso: '2026-08-14T00:00:00.000Z',
+      offset: 4,
+      limit: 4,
+    });
+    const actual = [...page1, ...page2];
+    expect(actual.slice(0, rows.length).every((row) => row.g === snapshotGraph)).toBe(true);
+    expect(actual.slice(rows.length).every((row) => row.g === dataGraph)).toBe(true);
+    expect(actual).toHaveLength(rows.length + legacyRows.length);
     await store.close();
   });
 });

--- a/packages/agent/test/sync-responder-protection.test.ts
+++ b/packages/agent/test/sync-responder-protection.test.ts
@@ -357,7 +357,7 @@ describe('sync responder protection', () => {
     expect(served).toBe(1);
   });
 
-  it('caps durable page computation at three globally and one per peer', async () => {
+  it('caps durable page computation at three globally and one per peer per plane', async () => {
     const releases: Array<() => void> = [];
     let completed = 0;
     let inFlight = 0;
@@ -404,6 +404,36 @@ describe('sync responder protection', () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     }
     await Promise.all(requests);
+  });
+
+  it('admits SWM and VM together from one peer while serializing each plane', async () => {
+    const authGates: Array<ReturnType<typeof deferred<boolean>>> = [];
+    const startedPlanes: string[] = [];
+    const cap = captureHandler(baseStore(), {
+      authorizeSyncRequest: async (request) => {
+        startedPlanes.push(request.includeSharedMemory ? 'swm' : 'vm');
+        const gate = deferred<boolean>();
+        authGates.push(gate);
+        return gate.promise;
+      },
+    });
+
+    const firstVm = cap.invoke(makeEnvelope(), REMOTE_A);
+    const swm = cap.invoke({ ...makeEnvelope(), includeSharedMemory: true }, REMOTE_A);
+    const secondVm = cap.invoke(makeEnvelope(), REMOTE_A);
+    while (startedPlanes.length < 2) await new Promise((resolve) => setTimeout(resolve, 0));
+    for (let i = 0; i < 3; i++) await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(startedPlanes).toEqual(['vm', 'swm']);
+
+    authGates[0]?.resolve(false);
+    await firstVm;
+    while (startedPlanes.length < 3) await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(startedPlanes).toEqual(['vm', 'swm', 'vm']);
+
+    authGates[1]?.resolve(false);
+    authGates[2]?.resolve(false);
+    await Promise.all([swm, secondVm]);
   });
 
   it('applies per-peer backpressure before authorization work starts', async () => {

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -79,6 +79,8 @@ export default defineConfig({
       "test/sync-responder-oversized-fallback.test.ts",
       "test/sync-responder-swm-meta-ceiling.test.ts",
       "test/sync-responder-large-graph-stack-overflow.test.ts",
+      "test/sync-responder-graph-backed-swm.test.ts",
+      "test/graph-backed-swm-page-boundary.test.ts",
       "test/sync-page-frame-budget.test.ts",
       "test/sync-byte-budget-pages.test.ts",
       "test/sync-append-in-place.test.ts",
@@ -175,6 +177,7 @@ export default defineConfig({
       "test/workspace-crypto-delegatee-filter.test.ts",
       "test/swm-public-snapshot-materialization.test.ts",
       "test/swm-public-cg-plaintext.test.ts",
+      "test/shared-memory-sync-ownership.test.ts",
       "test/swm-snapshot-materializer.test.ts",
       // #2079 — the already-materialized witness: the warm-path win, the count
       // gate that keeps it self-healing, and the digest binding that makes an

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -1333,6 +1333,11 @@ export class ApiClient {
     return this.post('/api/publisher/retry', { status });
   }
 
+  async publisherRetryJob(jobId: string): Promise<{ retried: number }> {
+    if (!jobId) throw new Error('jobId must be a non-empty string');
+    return this.post('/api/publisher/retry', { status: 'failed', jobId });
+  }
+
   async publisherClear(status: 'failed' | 'finalized'): Promise<{ cleared: number; status: 'failed' | 'finalized' }> {
     return this.post('/api/publisher/clear', { status });
   }

--- a/packages/cli/src/daemon/routes/publisher.ts
+++ b/packages/cli/src/daemon/routes/publisher.ts
@@ -536,7 +536,13 @@ export async function handlePublisherRoutes(ctx: RequestContext): Promise<void> 
       return jsonResponse(res, 400, {
         error: "Only status=failed is supported",
       });
-    const count = await publisherControl.retry({ status: "failed" });
+    const jobId = parsed.jobId;
+    if (jobId !== undefined && (typeof jobId !== "string" || jobId.length === 0)) {
+      return jsonResponse(res, 400, { error: "jobId must be a non-empty string when supplied" });
+    }
+    const count = typeof jobId === "string"
+      ? await publisherControl.retryFailedJob(jobId)
+      : await publisherControl.retry({ status: "failed" });
     return jsonResponse(res, 200, { retried: count });
   }
 

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -1275,6 +1275,17 @@ describe('ApiClient — GitHub-shaped knowledge-assets SDK (OT-RFC-43 §10.5)', 
     expect(JSON.parse(calls[0].opts.body as string)).toEqual({ jobId: 'lift job 7' });
   });
 
+  it('publisherRetryJob serializes an exact job selection and rejects an empty id before HTTP', async () => {
+    const calls = track({ retried: 1 });
+    await client.publisherRetryJob('lift job 7');
+    expect(calls[0].url).toBe(`${base}/api/publisher/retry`);
+    expect(calls[0].opts.method).toBe('POST');
+    expect(JSON.parse(calls[0].opts.body as string)).toEqual({ status: 'failed', jobId: 'lift job 7' });
+
+    await expect(client.publisherRetryJob('')).rejects.toThrow('jobId must be a non-empty string');
+    expect(calls).toHaveLength(1);
+  });
+
   it('knowledgeAssetShareAsync rejects unsupported sync-only options before HTTP serialization', async () => {
     const calls = track({ jobId: 'should-not-reach', state: 'queued' });
     await expect(client.knowledgeAssetShareAsync('cg', 'f', {

--- a/packages/cli/test/publisher-admin-body-boundary.test.ts
+++ b/packages/cli/test/publisher-admin-body-boundary.test.ts
@@ -15,6 +15,7 @@ describe('#1890 publisher admin POST body boundary', () => {
     return {
       cancel: async () => {},
       retry: async () => 3,
+      retryFailedJob: async (jobId) => jobId === 'j1' ? 1 : 0,
       clear: async () => 2,
       clearTerminalJob: async () => ({ outcome: 'already_absent' as const }),
     } as unknown as RequestContext['publisherControl'];
@@ -90,6 +91,15 @@ describe('#1890 publisher admin POST body boundary', () => {
     });
     it('unsupported status → 400', async () => {
       expect(await post('/api/publisher/retry', JSON.stringify({ status: 'queued' }))).toEqual({ status: 400, body: { error: 'Only status=failed is supported' } });
+    });
+    it('exact jobId → retries only the selected job', async () => {
+      expect(await post('/api/publisher/retry', JSON.stringify({ status: 'failed', jobId: 'j1' }))).toEqual({ status: 200, body: { retried: 1 } });
+    });
+    it('invalid jobId → 400', async () => {
+      expect(await post('/api/publisher/retry', JSON.stringify({ status: 'failed', jobId: 42 }))).toEqual({ status: 400, body: { error: 'jobId must be a non-empty string when supplied' } });
+    });
+    it('empty jobId → 400 without broadening to retry-all', async () => {
+      expect(await post('/api/publisher/retry', JSON.stringify({ status: 'failed', jobId: '' }))).toEqual({ status: 400, body: { error: 'jobId must be a non-empty string when supplied' } });
     });
     it('null body → 200 (hardened, not a 500)', async () => {
       expect(await post('/api/publisher/retry', 'null')).toEqual({ status: 200, body: { retried: 3 } });

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -39,6 +39,7 @@ import type {
   JournalReadResult,
   VmPublishIntentRecoveryPublisher,
   VmPublishIntentIndexBackfiller,
+  VmPublishFailedJobRetrier,
   VmPublishAdmissionJournalReader,
   VmPublishTerminalJobClearer,
 } from './async-lift-publisher-types.js';
@@ -213,7 +214,7 @@ function resolveKnowledgeAssetVmPublishHandler(
 }
 
 export class TripleStoreAsyncLiftPublisher
-  implements VmPublishIntentRecoveryPublisher, VmPublishIntentIndexBackfiller, VmPublishAdmissionJournalReader, VmPublishTerminalJobClearer {
+  implements VmPublishIntentRecoveryPublisher, VmPublishIntentIndexBackfiller, VmPublishAdmissionJournalReader, VmPublishTerminalJobClearer, VmPublishFailedJobRetrier {
   private static readonly claimQueues = new Map<string, Promise<void>>();
   // #1829 — dedicated per-lineageKey journal mutex, SEPARATE from claimQueues, so the
   // read-modify-write seq allocation is atomic without touching the claim lock (lock
@@ -1035,7 +1036,16 @@ export class TripleStoreAsyncLiftPublisher
   async retry(filter: { status?: 'failed' } = {}): Promise<number> {
     await this.ensureGraph();
     if (filter.status && filter.status !== 'failed') return 0;
+    return this.retryFailedJobs();
+  }
 
+  async retryFailedJob(jobId: string): Promise<number> {
+    await this.ensureGraph();
+    if (!jobId) throw new Error('jobId must be a non-empty string');
+    return this.retryFailedJobs(jobId);
+  }
+
+  private async retryFailedJobs(jobId?: string): Promise<number> {
     // #1837 — reaccept (failed→accepted) is a terminal→active transition; it MUST be
     // serialized with claimNext/enqueue AND with clearTerminalJob (which also runs under
     // withClaimLock) so a by-id clear that read a job as clearable-failed cannot be swept
@@ -1043,7 +1053,10 @@ export class TripleStoreAsyncLiftPublisher
     // swept" guarantee does not hold.
     return this.withClaimLock(async () => {
       let retried = 0;
-      for (const job of (await this.list({ status: 'failed' })).filter(isFailedJob)) {
+      const failedJobs = (await this.list({ status: 'failed' }))
+        .filter(isFailedJob)
+        .filter((job) => jobId === undefined || job.jobId === jobId);
+      for (const job of failedJobs) {
         if (!job.failure.retryable || job.retries.retryCount >= job.retries.maxRetries) continue;
         // Jobs that failed with a recovery-phase resolution must go through recover(),
         // not retry(), to avoid double-publishing if the original tx eventually lands.

--- a/packages/publisher/src/async-lift-publisher-types.ts
+++ b/packages/publisher/src/async-lift-publisher-types.ts
@@ -148,6 +148,11 @@ export interface VmPublishIntentIndexBackfiller {
   ensureVmPublishIntentIndex(): Promise<number>;
 }
 
+/** Daemon/admin-only exact failed-job retry; intentionally absent from the base runtime queue contract. */
+export interface VmPublishFailedJobRetrier {
+  retryFailedJob(jobId: string): Promise<number>;
+}
+
 /**
  * #1889 — the composite VM-publisher control surface returned by the daemon factory
  * (`createPublisherControlFromStore`) and held by `RequestContext.publisherControl`. Names
@@ -160,7 +165,8 @@ export interface VmPublisherControl
   extends VmPublishIntentRecoveryPublisher,
     VmPublishIntentIndexBackfiller,
     VmPublishAdmissionJournalReader,
-    VmPublishTerminalJobClearer {}
+    VmPublishTerminalJobClearer,
+    VmPublishFailedJobRetrier {}
 
 export interface AsyncLiftPublisherRecoveryResult {
   inclusion: LiftJobInclusionMetadata;

--- a/packages/publisher/src/async-lift-publisher.ts
+++ b/packages/publisher/src/async-lift-publisher.ts
@@ -13,6 +13,7 @@ export type {
   AsyncLiftPublisherRecoveryResult,
   VmPublishIntentRecoveryPublisher,
   VmPublishIntentIndexBackfiller,
+  VmPublishFailedJobRetrier,
   VmPublishAdmissionJournalReader,
   VmPublishTerminalJobClearer,
   VmPublisherControl,

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -269,6 +269,7 @@ export {
   type AsyncLiftPublisherRecoveryResolver,
   type VmPublishIntentRecoveryPublisher,
   type VmPublishIntentIndexBackfiller,
+  type VmPublishFailedJobRetrier,
   type VmPublishAdmissionJournalReader,
   type VmPublishTerminalJobClearer,
   type VmPublisherControl,

--- a/packages/publisher/test/async-lift-runner.test.ts
+++ b/packages/publisher/test/async-lift-runner.test.ts
@@ -15,25 +15,30 @@ async function waitFor(assertion: () => void, timeout = 5000): Promise<void> {
   }
 }
 
-function createPublisher(overrides: Partial<AsyncLiftPublisher> = {}): AsyncLiftPublisher {
-  return {
-    lift: async () => {},
+const basePublisher = {
+    enqueueKnowledgeAssetVmPublish: async () => 'job-id',
     claimNext: async () => null,
     update: async () => {},
     getStatus: async () => null,
     list: async () => [],
+    inspectPreparedPayload: async () => null,
     processNext: async () => null,
-    recordPublishResult: async () => {},
-    recordPublishFailure: async () => {},
+    recordPublishResult: async () => ({} as LiftJob),
+    recordPublishFailure: async () => ({} as LiftJob),
     recover: async () => 0,
-    getStats: () => ({}),
-    pause: () => {},
-    resume: () => {},
+    getStats: async () => ({} as Awaited<ReturnType<AsyncLiftPublisher['getStats']>>),
+    pause: async () => {},
+    resume: async () => {},
     cancel: async () => {},
-    retry: async () => {},
-    clear: async () => {},
+    retry: async () => 0,
+    clear: async () => 0,
+} satisfies AsyncLiftPublisher;
+
+function createPublisher(overrides: Partial<AsyncLiftPublisher> = {}): AsyncLiftPublisher {
+  return {
+    ...basePublisher,
     ...overrides,
-  } as unknown as AsyncLiftPublisher;
+  };
 }
 
 describe('AsyncLiftRunner', () => {

--- a/packages/publisher/test/e2e-publisher-queue.test.ts
+++ b/packages/publisher/test/e2e-publisher-queue.test.ts
@@ -426,4 +426,34 @@ describe('Async Lift Publisher Queue — Recovery', () => {
     const afterRetry = await pub.list({ status: 'accepted' });
     expect(afterRetry.length).toBeGreaterThanOrEqual(1);
   });
+
+  it('retry can re-queue one exact failed job without touching other failures', async () => {
+    const pub = create();
+    const selectedJobId = await pub.seedLegacyRawLift(makeLiftRequest({
+      contextGraphId: 'selected-retry',
+    }));
+    const untouchedJobId = await pub.seedLegacyRawLift(makeLiftRequest({
+      contextGraphId: 'untouched-retry',
+    }));
+
+    for (const jobId of [selectedJobId, untouchedJobId]) {
+      await pub.claimNext('wallet-1');
+      await pub.update(jobId, 'failed', {
+        failure: {
+          failedFromState: 'claimed',
+          code: 'workspace_unavailable',
+          message: 'Store temporarily unavailable',
+          errorPayloadRef: `urn:error:${jobId}`,
+          phase: 'validation',
+          mode: 'retryable',
+          retryable: true,
+          resolution: 'reset_to_accepted',
+        },
+      } as any);
+    }
+
+    await expect(pub.retryFailedJob(selectedJobId)).resolves.toBe(1);
+    await expect(pub.getStatus(selectedJobId)).resolves.toMatchObject({ status: 'accepted' });
+    await expect(pub.getStatus(untouchedJobId)).resolves.toMatchObject({ status: 'failed' });
+  });
 });

--- a/packages/storage/src/atomic-replace-failure.ts
+++ b/packages/storage/src/atomic-replace-failure.ts
@@ -1,0 +1,25 @@
+import { StoreSchedulerBusyError } from './store-priority-scheduler.js';
+import {
+  UnsupportedTripleStoreCapabilityError,
+  type TripleStoreCapability,
+} from './unsupported-capability-error.js';
+
+export type AtomicReplaceCapability = Extract<
+  TripleStoreCapability,
+  'replaceGraph' | 'replaceGraphAndSubject' | 'replaceSubject'
+>;
+
+/**
+ * True only when the storage contract proves an atomic replace body never ran.
+ * Every other rejection is indeterminate: it may have committed before its
+ * response was lost and therefore requires cache/log reconciliation.
+ */
+export function isAtomicReplaceOperationNotStarted(
+  error: unknown,
+  capability: AtomicReplaceCapability,
+): boolean {
+  return error instanceof StoreSchedulerBusyError || (
+    error instanceof UnsupportedTripleStoreCapabilityError
+    && error.capability === capability
+  );
+}

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -10,11 +10,9 @@ import type {
 } from './triple-store.js';
 import {
   UnsupportedTripleStoreCapabilityError,
-  isReplaceGraphAndSubjectCapabilityRefusal,
-  isReplaceGraphCapabilityRefusal,
-  isReplaceSubjectCapabilityRefusal,
 } from './unsupported-capability-error.js';
 import { isAtomicGraphReplaceStagingGraph } from './atomic-graph-replace.js';
+import { isAtomicReplaceOperationNotStarted } from './atomic-replace-failure.js';
 
 /**
  * ChangelogStore — an append-only per-node change log maintained on the write
@@ -342,8 +340,8 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
       try {
         await this.inner.replaceGraph!(graphUri, quads, options);
       } catch (err) {
-        if (isReplaceGraphCapabilityRefusal(err)) {
-          // A capability refusal is a clean preflight result: no mutation was
+        if (isAtomicReplaceOperationNotStarted(err, 'replaceGraph')) {
+          // A clean preflight or scheduler admission refusal means no mutation
           // started, so there is no gap to reconcile.
           throw err;
         }
@@ -398,7 +396,7 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
           options,
         );
       } catch (error) {
-        if (!isReplaceGraphAndSubjectCapabilityRefusal(error)) {
+        if (!isAtomicReplaceOperationNotStarted(error, 'replaceGraphAndSubject')) {
           this.flagReconcile('replaceGraphAndSubject(indeterminate-failure)');
         }
         throw error;
@@ -427,8 +425,8 @@ export class ChangelogStore implements TripleStore, ChangelogReader {
       try {
         await this.inner.replaceSubject!(graphUri, subject, quads, options);
       } catch (error) {
-        if (isReplaceSubjectCapabilityRefusal(error)) {
-          // Clean preflight refusal: no mutation started, nothing to reconcile.
+        if (isAtomicReplaceOperationNotStarted(error, 'replaceSubject')) {
+          // Clean preflight or scheduler refusal: no mutation started, nothing to reconcile.
           throw error;
         }
         this.flagReconcile('replaceSubject(indeterminate-failure)');

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -12,11 +12,9 @@ import type {
 import { storeWorkPriorityRank } from './store-priority-scheduler.js';
 import {
   UnsupportedTripleStoreCapabilityError,
-  isReplaceGraphAndSubjectCapabilityRefusal,
-  isReplaceGraphCapabilityRefusal,
-  isReplaceSubjectCapabilityRefusal,
 } from './unsupported-capability-error.js';
 import { isAtomicGraphReplaceStagingGraph } from './atomic-graph-replace.js';
+import { isAtomicReplaceOperationNotStarted } from './atomic-replace-failure.js';
 
 export const DEFAULT_GRAPH_SET_REVALIDATE_MS = 30_000;
 export const DEFAULT_GRAPH_SET_REVALIDATE_FAILURE_MAX_BACKOFF_MS = 5 * 60_000;
@@ -382,8 +380,10 @@ export class GraphSetIndexStore implements TripleStore {
       // complete new graph (or dropped the old one). Serving the cached graph
       // set would then hide a committed KA graph from enumeration, so mark the
       // index dirty for a lazy rebuild — unless this was a clean preflight
-      // capability refusal, where nothing was mutated.
-      if (!isReplaceGraphCapabilityRefusal(error)) {
+      // capability refusal or scheduler admission rejection. A
+      // StoreSchedulerBusyError is raised while the closure is still queued,
+      // so the store operation provably never started and cannot have mutated.
+      if (!isAtomicReplaceOperationNotStarted(error, 'replaceGraph')) {
         this.scheduleFullRefresh('replaceGraph');
       }
       throw error;
@@ -416,7 +416,7 @@ export class GraphSetIndexStore implements TripleStore {
         options,
       );
     } catch (error) {
-      if (!isReplaceGraphAndSubjectCapabilityRefusal(error)) {
+      if (!isAtomicReplaceOperationNotStarted(error, 'replaceGraphAndSubject')) {
         this.scheduleFullRefresh('replaceGraphAndSubject');
       }
       throw error;
@@ -449,7 +449,7 @@ export class GraphSetIndexStore implements TripleStore {
       // A committed subject replace could add/remove the graph's first/last row;
       // dirty the index so a lazy rebuild re-derives membership — unless this was
       // a clean preflight capability refusal, where nothing was mutated.
-      if (!isReplaceSubjectCapabilityRefusal(error)) {
+      if (!isAtomicReplaceOperationNotStarted(error, 'replaceSubject')) {
         this.scheduleFullRefresh('replaceSubject');
       }
       throw error;

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -41,6 +41,10 @@ export {
   type TripleStoreCapability,
 } from './unsupported-capability-error.js';
 export {
+  isAtomicReplaceOperationNotStarted,
+  type AtomicReplaceCapability,
+} from './atomic-replace-failure.js';
+export {
   StorePriorityScheduler,
   StoreSchedulerBusyError,
   externalStorePriorityScheduler,

--- a/packages/storage/test/changelog-store.test.ts
+++ b/packages/storage/test/changelog-store.test.ts
@@ -23,6 +23,7 @@ import { BlazegraphStore } from '../src/adapters/blazegraph.js';
 import { ChangelogStore, CHANGELOG_GRAPH, asChangelogReader, type ChangelogEraGuard } from '../src/changelog-store.js';
 import { createTripleStore } from '../src/triple-store.js';
 import type { Quad, QueryOptions, QueryResult, TripleStore, UpdateOptions } from '../src/triple-store.js';
+import { StoreSchedulerBusyError } from '../src/store-priority-scheduler.js';
 
 const G1 = 'http://ex.org/g1';
 const G2 = 'http://ex.org/g2';
@@ -61,6 +62,42 @@ class SpyStore implements TripleStore {
   countQuads(g?: string, options?: QueryOptions) { return this.inner.countQuads(g, options); }
   close() { return this.inner.close(); }
 }
+
+class BusyAtomicReplaceStore extends SpyStore {
+  async replaceGraph(): Promise<void> {
+    throw new StoreSchedulerBusyError('queue_wait_timeout', 'normal', 'test.replaceGraph');
+  }
+
+  async replaceGraphAndSubject(): Promise<void> {
+    throw new StoreSchedulerBusyError('queue_wait_timeout', 'normal', 'test.replaceGraphAndSubject');
+  }
+
+  async replaceSubject(): Promise<void> {
+    throw new StoreSchedulerBusyError('queue_wait_timeout', 'normal', 'test.replaceSubject');
+  }
+}
+
+describe('ChangelogStore — pre-execution atomic replace rejection', () => {
+  it('does not request reconciliation when scheduler admission proves no mutation started', async () => {
+    const base = new OxigraphStore();
+    const log = new ChangelogStore(new BusyAtomicReplaceStore(base));
+
+    await expect(log.replaceGraph(G1, [q('http://ex.org/a', G1)]))
+      .rejects.toBeInstanceOf(StoreSchedulerBusyError);
+    await expect(log.replaceGraphAndSubject(
+      G1,
+      [q('http://ex.org/a', G1)],
+      G2,
+      'http://ex.org/meta',
+      [q('http://ex.org/meta', G2)],
+    )).rejects.toBeInstanceOf(StoreSchedulerBusyError);
+    await expect(log.replaceSubject(G1, 'http://ex.org/a', [q('http://ex.org/a', G1)]))
+      .rejects.toBeInstanceOf(StoreSchedulerBusyError);
+
+    expect(log.needsReconcile).toBe(false);
+    await base.close();
+  });
+});
 
 describe('ChangelogStore — upsert marker atomicity', () => {
   it('appends the marker in the SAME inner.insert() call as the data (one transaction)', async () => {

--- a/packages/storage/test/graph-set-index-store.test.ts
+++ b/packages/storage/test/graph-set-index-store.test.ts
@@ -6,11 +6,13 @@ import { describe, expect, it } from 'vitest';
 import {
   GraphSetIndexStore,
   OxigraphStore,
+  StoreSchedulerBusyError,
   StorePriorityScheduler,
   createTripleStore,
   registerTripleStoreAdapter,
   type GraphSetIndexStoreOptions,
   type GraphSetMutationEvent,
+  type Quad,
   type QueryOptions,
   type StoreWorkPriority,
 } from '../src/index.js';
@@ -28,6 +30,54 @@ class FailingMaintenanceStore extends CountingStore {
   async hasGraph(graphUri: string, options?: QueryOptions): Promise<boolean> {
     if (this.failHasGraph) throw new Error('hasGraph failed');
     return super.hasGraph(graphUri, options);
+  }
+}
+
+class ScheduledAtomicReplaceStore extends CountingStore {
+  readonly started: string[] = [];
+
+  constructor(inner: OxigraphStore, private readonly scheduler: StorePriorityScheduler) {
+    super(inner);
+  }
+
+  replaceGraph(graphUri: string, quads: Quad[], options?: QueryOptions): Promise<void> {
+    return this.scheduler.run(options?.priority, 'sparql-http.replaceGraph', async () => {
+      this.started.push('replaceGraph');
+      await this.inner.replaceGraph?.(graphUri, quads, options);
+    });
+  }
+
+  async replaceGraphAndSubject(
+    graphUri: string,
+    graphQuads: Quad[],
+    metaGraphUri: string,
+    metadataSubject: string,
+    metadataQuads: Quad[],
+    options?: QueryOptions,
+  ): Promise<void> {
+    return this.scheduler.run(options?.priority, 'sparql-http.replaceGraphAndSubject', async () => {
+      this.started.push('replaceGraphAndSubject');
+      await this.inner.replaceGraphAndSubject?.(
+        graphUri,
+        graphQuads,
+        metaGraphUri,
+        metadataSubject,
+        metadataQuads,
+        options,
+      );
+    });
+  }
+
+  async replaceSubject(
+    graphUri: string,
+    subject: string,
+    quads: Quad[],
+    options?: QueryOptions,
+  ): Promise<void> {
+    return this.scheduler.run(options?.priority, 'sparql-http.replaceSubject', async () => {
+      this.started.push('replaceSubject');
+      await this.inner.replaceSubject?.(graphUri, subject, quads, options);
+    });
   }
 }
 
@@ -82,6 +132,57 @@ async function exhaustTouchedGraphProbeRetries(
 }
 
 describe('GraphSetIndexStore', () => {
+  it('does not dirty a warm index when scheduler admission rejects an atomic replace before execution', async () => {
+    const inner = new OxigraphStore();
+    await inner.insert([q('did:dkg:context-graph:existing')]);
+    const scheduler = new StorePriorityScheduler({
+      maxConcurrent: 1,
+      ackReservedSlots: 0,
+      healthReservedSlots: 0,
+      backgroundReservedSlots: 0,
+      queueLimits: 1,
+      queueWaitTimeoutMs: 10,
+    });
+    let releaseBlocker!: () => void;
+    let blockerStarted = false;
+    const blocker = scheduler.run('normal', 'test.atomic-replace-blocker', async () => {
+      blockerStarted = true;
+      await new Promise<void>((resolve) => { releaseBlocker = resolve; });
+    });
+    await Promise.resolve();
+    expect(blockerStarted).toBe(true);
+
+    const counting = new ScheduledAtomicReplaceStore(inner, scheduler);
+    const diagnostics: unknown[] = [];
+    const store = new GraphSetIndexStore(counting, {
+      revalidateMs: 100_000,
+      now: () => 1_000,
+      onDiagnostic: (event) => diagnostics.push(event),
+    } as GraphSetIndexStoreOptions);
+
+    try {
+      await expect(store.listGraphs()).resolves.toEqual(['did:dkg:context-graph:existing']);
+      expect(counting.listGraphsCalls).toBe(1);
+
+      await expect(store.replaceGraph('urn:graph', [q('urn:graph')]))
+        .rejects.toBeInstanceOf(StoreSchedulerBusyError);
+      await expect(store.replaceGraphAndSubject(
+        'urn:graph', [q('urn:graph')], 'urn:meta', 'urn:subject', [q('urn:meta')],
+      )).rejects.toBeInstanceOf(StoreSchedulerBusyError);
+      await expect(store.replaceSubject('urn:graph', 'urn:subject', [q('urn:graph')]))
+        .rejects.toBeInstanceOf(StoreSchedulerBusyError);
+
+      expect(counting.started).toEqual([]);
+
+      await expect(store.listGraphs()).resolves.toEqual(['did:dkg:context-graph:existing']);
+      expect(counting.listGraphsCalls).toBe(1);
+      expect(diagnostics).toEqual([]);
+    } finally {
+      releaseBlocker();
+      await blocker;
+    }
+  });
+
   it('seeds from one listGraphs scan and serves prefix lookups from memory', async () => {
     const inner = new OxigraphStore();
     await inner.insert([


### PR DESCRIPTION
## User impact

A node serving a large SWM catch-up no longer blocks unrelated VM recovery behind the same responder slot. SWM and VM keep separate bounded admission lanes, while expensive plan construction gets a bounded allowance instead of being mistaken for an immediate transport failure.

## Before

```mermaid
sequenceDiagram
    participant SWM as SWM receiver
    participant VM as VM receiver
    participant R as Provider responder
    participant S as Store
    SWM->>R: Large selected SWM request
    R->>S: Build and read plan
    VM->>R: Exact VM request
    Note over VM,R: Waits behind the SWM lane
    R-->>VM: Timeout or late response
```

## After

```mermaid
sequenceDiagram
    participant SWM as SWM receiver
    participant VM as VM receiver
    participant R as Provider responder
    participant S as Store
    SWM->>R: Selected SWM request
    VM->>R: Exact VM request
    par Bounded SWM lane
        R->>S: Build and read SWM plan
    and Bounded VM lane
        R->>S: Build and read exact VM plan
    end
    R-->>SWM: Paged response
    R-->>VM: Exact response
```

## Safety

- Admission remains bounded; this does not create unbounded worker fan-out.
- Payload limits and authentication are unchanged.
- Existing overload rejection remains fail-closed.

## Validation

Focused responder protection tests cover lane independence and bounded planning. The complete stack was also exercised by the Testnet Blackbox 500 SWM + 500 VM recovery run; final distributed evidence will be attached to the top PR.