### PR TITLE
perf(sync): bound selected SWM responder planning

### DIFF
--- a/packages/agent/src/sync/auth/request-build.ts
+++ b/packages/agent/src/sync/auth/request-build.ts
@@ -185,13 +185,16 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
     ? Math.max(1, Math.min(limit, SYNC_BYTE_BUDGET_MAX_ROWS))
     : SYNC_PAGE_SIZE;
   const assetUals = rawAssetUals === undefined ? undefined : requireExactAssetUals(rawAssetUals);
-  // Advertise byte-budget page mode for durable DATA and META (#1916/#1923).
+  // Advertise byte-budget page mode for DATA and META (#1916/#1923). SWM
+  // metadata uses the same additive hint so a retained RFC-64 manifest can
+  // grow beyond the legacy 500-row transport cap without changing its signed
+  // authorization boundary.
   // Additive/rolling-upgrade safe both directions: an OLD responder ignores the
   // meta pageMode (its meta path is not byte-budget-gated → serves legacy meta),
   // and a NEW responder treats a request WITHOUT meta pageMode as non-negotiated
   // (plain meta serializer). The signed `limit` still rides the 500-row legacy
   // cap below, so digests stay wire-compatible.
-  const useByteBudgetPage = (phase === 'data' || (!includeSharedMemory && phase === 'meta'))
+  const useByteBudgetPage = (phase === 'data' || phase === 'meta')
     && (
       requestedLimit > SYNC_PAGE_SIZE
       // Exact DATA must remain on the responder's bounded page-only path after

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -2794,6 +2794,10 @@ async function readSwmMetaRowsPage(
 }
 
 const FRESH_SWM_META_PLAN_SUBJECT_CHUNK = 100;
+// Count rows return only two small scalar bindings per subject. A wider batch
+// avoids dozens of store round trips during plan construction without raising
+// the payload-window response ceiling used for actual metadata rows.
+const FRESH_SWM_META_PLAN_COUNT_SUBJECT_CHUNK = 1_000;
 
 /**
  * Ceiling for one subject row-group in the fresh-SWM plan lane. Whole-subject
@@ -2828,10 +2832,10 @@ function freshSwmMetaPlanResponseByteLimit(): number {
 export const FRESH_SWM_META_PLAN_MAX_SUBJECTS = 32_000;
 
 /**
- * Discover the TTL-admitted subjects of one SWM meta graph with two
- * small-result queries (no payload rows, no sort, no OFFSET), each bounded by
- * construction: LIMIT (remaining subject allowance + 1 sentinel) and the fixed
- * plan response byte cap. Crossing either bound is a typed
+ * Discover the TTL-admitted subjects of one SWM meta graph with two bounded
+ * small-result queries (no payload rows, no sort, no OFFSET). Both carry a
+ * LIMIT (remaining subject allowance + 1 sentinel) and the fixed plan response
+ * byte cap. Crossing either bound is a typed
  * per-snapshot budget refusal — the plan lane's one remaining bounded refusal
  * besides the single-oversized-subject case.
  *
@@ -2839,10 +2843,11 @@ export const FRESH_SWM_META_PLAN_MAX_SUBJECTS = 32_000;
  *     {@link readFreshSwmRoots} shape, an indexed predicate probe whose result
  *     is the fresh subset, not the graph;
  *  2. graph-scoped SWM heads. Heads are current-state pointers and
- *     intentionally have no independent publishedAt row; they are admitted via
- *     the timestamped WorkspaceOperation they select (same six-predicate join
- *     the TTL lane has always used), so TTL recovery receives the head plus its
- *     immutable commitment atomically.
+ *     intentionally have no independent publishedAt row. The timestamped
+ *     WorkspaceOperation carries the canonical KA UAL from which the head IRI
+ *     is derived. Reading the operation directly avoids the old quadratic
+ *     operation-to-head self-join; the subsequently paged head rows still have
+ *     to satisfy the receiver's exact workspace validation.
  *
  * SWM meta subjects are IRIs by contract (workspace writers skolemize blank
  * nodes before storage); non-IRI subjects cannot appear in a VALUES clause and
@@ -2860,7 +2865,11 @@ async function readFreshSwmMetaSubjects(
     `FILTER(?ts >= ${sparqlString(cutoffIso)}^^<http://www.w3.org/2001/XMLSchema#dateTime>)`;
   const discoveryLimit = Math.max(1, Math.floor(maxSubjects)) + 1;
   const subjects = new Set<string>();
-  const runDiscovery = async (sparql: string, operation: string): Promise<void> => {
+  const runDiscovery = async (
+    sparql: string,
+    operation: string,
+    collect: (row: Record<string, string>) => string | undefined = (row) => row['s'],
+  ): Promise<void> => {
     let res;
     try {
       res = await store.query(sparql, {
@@ -2879,7 +2888,7 @@ async function readFreshSwmMetaSubjects(
     }
     if (res.type !== 'bindings') return;
     for (const row of res.bindings) {
-      const subject = row['s'];
+      const subject = collect(row);
       if (subject && isIriTerm(subject)) subjects.add(subject);
     }
     if (subjects.size > maxSubjects) {
@@ -2902,14 +2911,9 @@ async function readFreshSwmMetaSubjects(
     LIMIT ${discoveryLimit}
   `, 'sync.responder.readFreshSwmMetaSubjects');
   await runDiscovery(`
-    SELECT DISTINCT ?s WHERE {
+    SELECT DISTINCT ?s ?headUal WHERE {
       GRAPH <${assertSafeIri(graph)}> {
         ?s <${DKG_CONTENT_SCOPE_VERSION}> ${GRAPH_KA_CONTENT_SCOPE_VERSION} ;
-           <${DKG_KA_UAL}> ?headUal ;
-           <${DKG_ASSERTION_VERSION}> ?headVersion ;
-           <${DKG_SHARE_OPERATION_ID}> ?shareId .
-        ?headOperation <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_WORKSPACE_OPERATION}> ;
-           <${DKG_CONTENT_SCOPE_VERSION}> ${GRAPH_KA_CONTENT_SCOPE_VERSION} ;
            <${DKG_KA_UAL}> ?headUal ;
            <${DKG_ASSERTION_VERSION}> ?headVersion ;
            <${DKG_SHARE_OPERATION_ID}> ?shareId ;
@@ -2918,7 +2922,10 @@ async function readFreshSwmMetaSubjects(
       }
     }
     LIMIT ${discoveryLimit}
-  `, 'sync.responder.readFreshSwmMetaHeadSubjects');
+  `, 'sync.responder.readFreshSwmMetaHeadSubjects', (row) => {
+    const headUal = row['headUal'];
+    return headUal && isIriTerm(headUal) ? `${headUal}#dkg-swm-head` : undefined;
+  });
   return subjects;
 }
 
@@ -2934,7 +2941,7 @@ async function countFreshSwmMetaSubjectRows(
   signal?: AbortSignal,
 ): Promise<FreshSwmMetaSubjectEntry[]> {
   const countsBySubject = new Map<string, number>();
-  for (const chunk of chunkValues(subjects, FRESH_SWM_META_PLAN_SUBJECT_CHUNK)) {
+  for (const chunk of chunkValues(subjects, FRESH_SWM_META_PLAN_COUNT_SUBJECT_CHUNK)) {
     let res;
     try {
       res = await store.query(`
@@ -3398,18 +3405,23 @@ async function buildFreshSwmDataGraphPlan(
   const uniqueMetaGraphs = dedupeStrings(dataGraphs.map((graph) => `${graph}_meta`))
     .sort(compareCodePoint);
   for (const chunk of chunkValues(uniqueMetaGraphs, FRESH_SWM_PLAN_QUERY_GRAPH_CHUNK)) {
-    const values = graphValues(chunk);
-    const rootResult = await store.query(`
-      SELECT DISTINCT ?metaGraph ?root WHERE {
-        VALUES ?metaGraph { ${values} }
-        GRAPH ?metaGraph {
-          ?op <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_WORKSPACE_OPERATION}> ;
-              <${DKG_PUBLISHED_AT}> ?ts ;
-              <${DKG_ROOT_ENTITY}> ?root .
-          ${cutoffFilter}
-        }
+    // Keep every GRAPH operand concrete. Both Oxigraph and Blazegraph can turn
+    // `VALUES ?metaGraph { ... } GRAPH ?metaGraph` into a scan across all named
+    // graphs even when the VALUES set contains one IRI. A bounded UNION of the
+    // same literal-graph probes preserves batching while retaining the graph
+    // index lookup (0.1s rather than 10s+ on the 500-KA canary corpus).
+    const branches = chunk.map((metaGraph) => `{
+      GRAPH <${assertSafeIri(metaGraph)}> {
+        ?op <${DKG_ROOT_ENTITY}> ?root ;
+            <${DKG_PUBLISHED_AT}> ?ts .
+        ${cutoffFilter}
       }
-      ORDER BY ?metaGraph ?root
+      BIND(<${assertSafeIri(metaGraph)}> AS ?metaGraph)
+    }`).join('\nUNION\n');
+    const rootResult = await store.query(`
+      SELECT ?metaGraph ?root WHERE {
+        ${branches}
+      }
     `, syncResponderStoreOptions(signal, 'sync.responder.discoverFreshSwmMetaRoots'));
     if (rootResult.type !== 'bindings') continue;
     for (const row of rootResult.bindings) {

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -899,12 +899,21 @@ export async function readSwmMetaPage(params: {
     params.signal,
     {
       loadSnapshot: cache
-        ? async () => readBoundedFreshSwmMetaSnapshot(
-          params.store,
-          await getPlan(0, undefined),
-          cutoffIso,
-          cache,
-        )
+        ? async () => {
+          // Most selected-CG manifests fit comfortably inside the fixed
+          // snapshot ceiling. Reading that bounded graph once and applying the
+          // canonical TTL filter in process avoids paying the much more
+          // expensive subject-discovery/count plan before page zero. If the
+          // raw history is genuinely large, readResponderRowsPage translates
+          // the typed rows/bytes refusal into the existing bounded plan-paged
+          // lane below; the #1847 large-history guarantee is therefore kept.
+          const rawRows = await readBoundedSwmMetaSnapshot(
+            params.store,
+            candidateGraphs,
+            cache,
+          );
+          return filterSwmMetaSnapshotRows(rawRows, cutoffIso);
+        }
         : undefined,
       // The per-snapshot budget fallback MUST stay enabled here (#1847): it
       // degrades to the bounded plan-paged reader above, never to the deleted

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -902,37 +902,16 @@ export async function readSwmMetaPage(params: {
       budgetKey,
       signal,
     );
-  return readResponderRowsPage(
-    cache,
-    loadStoreBoundedPage,
+  // The verified subject plan is the immutable session boundary for TTL
+  // metadata. Page directly from it instead of materializing every admitted
+  // row before page zero: a few thousand ordinary graph-scoped operations are
+  // well below the snapshot memory ceiling but can still take longer than the
+  // transport deadline to serialize as one store response. The plan memo keeps
+  // offsets stable, and each page remains whole-subject verified.
+  return loadStoreBoundedPage(
     params.offset,
     params.limit,
     params.signal,
-    {
-      loadSnapshot: cache
-        ? async () => {
-          // Most selected-CG manifests fit comfortably inside the fixed
-          // snapshot ceiling. Reading that bounded graph once and applying the
-          // canonical TTL filter in process avoids paying the much more
-          // expensive subject-discovery/count plan before page zero. If the
-          // raw history is genuinely large, readResponderRowsPage translates
-          // the typed rows/bytes refusal into the existing bounded plan-paged
-          // lane below; the #1847 large-history guarantee is therefore kept.
-          const rawRows = await readBoundedSwmMetaSnapshot(
-            params.store,
-            candidateGraphs,
-            cache,
-          );
-          return filterSwmMetaSnapshotRows(rawRows, cutoffIso);
-        }
-        : undefined,
-      // The per-snapshot budget fallback MUST stay enabled here (#1847): it
-      // degrades to the bounded plan-paged reader above, never to the deleted
-      // global-sort query. This policy used to be a positional boolean, and
-      // passing `params.cutoffIso == null` in that position is the exact defect
-      // that made every 64,000-row `_meta` CG permanently unsyncable on mainnet.
-      fallbackOnPerSnapshotBudget: true,
-    },
   );
 }
 

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -73,7 +73,13 @@ const PROV_USED = 'http://www.w3.org/ns/prov#used';
 const DKG_JOIN_REQUEST_SUBJECT_PREFIX = 'did:dkg:join-request:';
 const COMPLETED_SYNC_RESPONDER_SESSION_GRACE_MS = 30_000;
 function syncResponderStoreOptions(signal: AbortSignal | undefined, source: string): QueryOptions {
-  return { signal, priority: 'background', source };
+  // An admitted sync response is latency-sensitive work for a remote node,
+  // not local maintenance.  Keeping these reads in the background lane lets
+  // an unrelated finalization/repair backlog occupy every normal slot while
+  // the remote stream sits on a hard deadline.  The responder already has
+  // bounded global/per-peer admission, so route the store work through the
+  // normal lane and let that outer limiter remain the abuse boundary.
+  return { signal, priority: 'normal', source };
 }
 
 export interface GraphListMemo {

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -812,7 +812,15 @@ export async function readSwmMetaPage(params: {
 }): Promise<SyncRow[]> {
   const graphs = swmGraphsForRegisteredSubGraphs(params.contextGraphId, params.registeredSubGraphNames, true);
   const graphSet = new Set(params.graphList);
-  const candidateGraphs = graphs.filter((graph) => graphSet.has(graph));
+  // A TTL-filtered RFC-64 request already names every admissible metadata
+  // graph exactly. Querying a missing named graph is an empty, bounded read;
+  // enumerating the node's complete graph inventory first is not. Large edge
+  // stores can spend tens of seconds rebuilding that inventory after ordinary
+  // writes, resetting the transport before page zero. Keep the inventory
+  // membership guard only for the legacy, unfiltered compatibility lane.
+  const candidateGraphs = params.cutoffIso == null
+    ? graphs.filter((graph) => graphSet.has(graph))
+    : graphs;
   const cache = params.rowListMemo && params.rowListCacheKey
     ? {
       memo: params.rowListMemo,
@@ -3399,18 +3407,6 @@ async function buildFreshSwmDataGraphPlan(
 ): Promise<FreshSwmDataGraphPlan> {
   const cutoffFilter =
     `FILTER(?ts >= ${sparqlString(cutoffIso)}^^<http://www.w3.org/2001/XMLSchema#dateTime>)`;
-  const candidates: FreshSwmCandidateGraph[] = [];
-  for (const graph of dataGraphs) {
-    const metaGraph = `${graph}_meta`;
-    if (!graphSet.has(metaGraph)) continue;
-    for (const candidate of candidateGraphsFor(graph)) {
-      candidates.push({ graph: candidate, metaGraph });
-    }
-  }
-  const uniqueCandidates = [...new Map(
-    candidates.map((candidate) => [candidate.graph, candidate]),
-  ).values()].sort((a, b) => compareCodePoint(a.graph, b.graph));
-
   // Modern content-scope-v2 SWM operations use detached snapshot references
   // (or immutable snapshot graphs) and intentionally do not carry
   // dkg:rootEntity. Probe the small metadata graphs once before constructing
@@ -3420,7 +3416,7 @@ async function buildFreshSwmDataGraphPlan(
   // result still follows the existing graph/root existence + exact-count path,
   // so no payload graph is admitted from metadata alone.
   const freshRootsByMetaGraph = new Map<string, Set<string>>();
-  const uniqueMetaGraphs = dedupeStrings(uniqueCandidates.map(({ metaGraph }) => metaGraph))
+  const uniqueMetaGraphs = dedupeStrings(dataGraphs.map((graph) => `${graph}_meta`))
     .sort(compareCodePoint);
   for (const chunk of chunkValues(uniqueMetaGraphs, FRESH_SWM_PLAN_QUERY_GRAPH_CHUNK)) {
     const values = graphValues(chunk);
@@ -3446,6 +3442,38 @@ async function buildFreshSwmDataGraphPlan(
       freshRootsByMetaGraph.set(metaGraph, roots);
     }
   }
+
+  // Do not enumerate payload graphs unless the small metadata preflight proved
+  // that this is a legacy root-scoped operation. Modern graph-scoped snapshot
+  // refs are transferred by the immutable snapshot phase, so their DATA page
+  // is intentionally empty. If a caller already supplied an inventory (unit
+  // callers and the legacy lane), reuse it; otherwise enumerate only the
+  // relevant data-graph prefixes rather than every named graph on the node.
+  const candidates: FreshSwmCandidateGraph[] = [];
+  for (const graph of dataGraphs) {
+    const metaGraph = `${graph}_meta`;
+    if ((freshRootsByMetaGraph.get(metaGraph)?.size ?? 0) === 0) continue;
+    const candidateGraphs = graphSet.size > 0
+      ? candidateGraphsFor(graph)
+      : store.listGraphsByPrefix
+        ? (await store.listGraphsByPrefix(
+          graph,
+          syncResponderStoreOptions(signal, 'sync.responder.listFreshSwmGraphPrefix'),
+        )).filter((candidate) => (
+          candidate === graph || isSharedMemoryBucketDescendantDataGraph(candidate, graph)
+        ))
+        : (await store.listGraphs(
+          syncResponderStoreOptions(signal, 'sync.responder.listFreshSwmGraphs'),
+        )).filter((candidate) => (
+          candidate === graph || isSharedMemoryBucketDescendantDataGraph(candidate, graph)
+        ));
+    for (const candidate of candidateGraphs.sort(compareCodePoint)) {
+      candidates.push({ graph: candidate, metaGraph });
+    }
+  }
+  const uniqueCandidates = [...new Map(
+    candidates.map((candidate) => [candidate.graph, candidate]),
+  ).values()].sort((a, b) => compareCodePoint(a.graph, b.graph));
 
   const rootScopedCandidates = uniqueCandidates.filter(
     ({ metaGraph }) => (freshRootsByMetaGraph.get(metaGraph)?.size ?? 0) > 0,

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -807,6 +807,8 @@ export async function readSwmMetaPage(params: {
   refreshRowList?: boolean;
   refreshGeneration?: string;
   freshMetaPlanMemo?: FreshSwmMetaPlanMemo;
+  /** Keep the immutable row snapshot until an explicit empty-page EOF. */
+  releaseCacheOnShortPage?: boolean;
 }): Promise<SyncRow[]> {
   const graphs = swmGraphsForRegisteredSubGraphs(params.contextGraphId, params.registeredSubGraphNames, true);
   const graphSet = new Set(params.graphList);
@@ -817,6 +819,7 @@ export async function readSwmMetaPage(params: {
       key: params.rowListCacheKey,
       refresh: params.refreshRowList,
       refreshGeneration: params.refreshGeneration,
+      releaseOnShortPage: params.releaseCacheOnShortPage,
       expiredMessage: 'Shared-memory meta sync session snapshot expired before page completion',
     }
     : undefined;

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -3373,12 +3373,16 @@ function parseSparqlInteger(value: string | undefined): number {
  * graph; on a 1 GiB workspace that exceeded the 30s HTTP query timeout on every
  * page. This planner inverts the work with backend-neutral SPARQL 1.1:
  *
- *  1. Join each concrete graph to its fresh metadata roots by the root subject
+ *  1. Discover fresh legacy `rootEntity` metadata before touching any payload
+ *     graph. Modern graph-scoped snapshots deliberately have no root entity;
+ *     without this preflight the old UNION planner probes every immutable KA
+ *     graph merely to prove the root-scoped lane is empty.
+ *  2. Join each concrete graph to its fresh metadata roots by the root subject
  *     (an indexed lookup and a DKG workspace invariant: `rootEntity` names an
  *     entity present in the shared payload).
- *  2. Count the exact root closures per concrete graph without returning their
+ *  3. Count the exact root closures per concrete graph without returning their
  *     large literal values.
- *  3. Cache only graph/root/count scalars for the responder session.
+ *  4. Cache only graph/root/count scalars for the responder session.
  *
  * Paging then touches one or two concrete graphs at a time with `VALUES ?root`,
  * preserving the exact root/skolem filter used by {@link readFreshSwmDataRows}
@@ -3407,17 +3411,52 @@ async function buildFreshSwmDataGraphPlan(
     candidates.map((candidate) => [candidate.graph, candidate]),
   ).values()].sort((a, b) => compareCodePoint(a.graph, b.graph));
 
+  // Modern content-scope-v2 SWM operations use detached snapshot references
+  // (or immutable snapshot graphs) and intentionally do not carry
+  // dkg:rootEntity. Probe the small metadata graphs once before constructing
+  // the graph-family UNION below. On a selected CG with hundreds of immutable
+  // KA graphs this turns the common rootless case from hundreds of expensive
+  // payload-graph probes into one bounded metadata lookup. A non-empty legacy
+  // result still follows the existing graph/root existence + exact-count path,
+  // so no payload graph is admitted from metadata alone.
+  const freshRootsByMetaGraph = new Map<string, Set<string>>();
+  const uniqueMetaGraphs = dedupeStrings(uniqueCandidates.map(({ metaGraph }) => metaGraph))
+    .sort(compareCodePoint);
+  for (const chunk of chunkValues(uniqueMetaGraphs, FRESH_SWM_PLAN_QUERY_GRAPH_CHUNK)) {
+    const values = graphValues(chunk);
+    const rootResult = await store.query(`
+      SELECT DISTINCT ?metaGraph ?root WHERE {
+        VALUES ?metaGraph { ${values} }
+        GRAPH ?metaGraph {
+          ?op <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_WORKSPACE_OPERATION}> ;
+              <${DKG_PUBLISHED_AT}> ?ts ;
+              <${DKG_ROOT_ENTITY}> ?root .
+          ${cutoffFilter}
+        }
+      }
+      ORDER BY ?metaGraph ?root
+    `, syncResponderStoreOptions(signal, 'sync.responder.discoverFreshSwmMetaRoots'));
+    if (rootResult.type !== 'bindings') continue;
+    for (const row of rootResult.bindings) {
+      const metaGraph = row['metaGraph'];
+      const root = row['root'];
+      if (!metaGraph || !root) continue;
+      const roots = freshRootsByMetaGraph.get(metaGraph) ?? new Set<string>();
+      roots.add(root);
+      freshRootsByMetaGraph.set(metaGraph, roots);
+    }
+  }
+
+  const rootScopedCandidates = uniqueCandidates.filter(
+    ({ metaGraph }) => (freshRootsByMetaGraph.get(metaGraph)?.size ?? 0) > 0,
+  );
+
   const rootsByGraph = new Map<string, Set<string>>();
-  for (const chunk of chunkValues(uniqueCandidates, FRESH_SWM_PLAN_QUERY_GRAPH_CHUNK)) {
+  for (const chunk of chunkValues(rootScopedCandidates, FRESH_SWM_PLAN_QUERY_GRAPH_CHUNK)) {
     const unions = chunk.map(({ graph, metaGraph }) => `
       {
         SELECT (<${assertSafeIri(graph)}> AS ?g) ?root WHERE {
-          GRAPH <${assertSafeIri(metaGraph)}> {
-            ?op <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_WORKSPACE_OPERATION}> ;
-                <${DKG_PUBLISHED_AT}> ?ts ;
-                <${DKG_ROOT_ENTITY}> ?root .
-            ${cutoffFilter}
-          }
+          VALUES ?root { ${graphValues([...(freshRootsByMetaGraph.get(metaGraph) ?? [])])} }
           GRAPH <${assertSafeIri(graph)}> { ?root ?rootPredicate ?rootObject }
         }
       }`);

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -702,21 +702,24 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
             request.syncSessionId,
             offset,
           );
-          const rows = await readSwmMetaPage({
-            store,
-            graphList: await graphListMemo.get({
+          const registeredSubGraphNames = await swmAdmissionMemo.get(
+            contextGraphId,
+            {
               refresh: session?.refreshRowList ?? offset === 0,
               refreshGeneration: offset === 0 ? session?.refreshGeneration : undefined,
               signal,
-            }),
-            registeredSubGraphNames: await swmAdmissionMemo.get(
-              contextGraphId,
-              {
+            },
+          );
+          const rows = await readSwmMetaPage({
+            store,
+            graphList: cutoff == null
+              ? await graphListMemo.get({
                 refresh: session?.refreshRowList ?? offset === 0,
                 refreshGeneration: offset === 0 ? session?.refreshGeneration : undefined,
                 signal,
-              },
-            ),
+              })
+              : [],
+            registeredSubGraphNames,
             contextGraphId,
             cutoffIso: cutoff,
             offset,
@@ -748,21 +751,24 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
             request.syncSessionId,
             offset,
           );
-          const rows = await readSwmDataPage({
-            store,
-            graphList: await graphListMemo.get({
+          const registeredSubGraphNames = await swmAdmissionMemo.get(
+            contextGraphId,
+            {
               refresh: session?.refreshRowList ?? offset === 0,
               refreshGeneration: offset === 0 ? session?.refreshGeneration : undefined,
               signal,
-            }),
-            registeredSubGraphNames: await swmAdmissionMemo.get(
-              contextGraphId,
-              {
+            },
+          );
+          const rows = await readSwmDataPage({
+            store,
+            graphList: cutoff == null
+              ? await graphListMemo.get({
                 refresh: session?.refreshRowList ?? offset === 0,
                 refreshGeneration: offset === 0 ? session?.refreshGeneration : undefined,
                 signal,
-              },
-            ),
+              })
+              : [],
+            registeredSubGraphNames,
             contextGraphId,
             cutoffIso: cutoff,
             offset,

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -592,19 +592,17 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       hasExactAssetFilter: assetUals !== undefined,
     });
     const usesByteBudgetPage = dataRequestPolicy.usesByteBudgetPage;
-    // Durable meta negotiated its byte-budget page mode on the wire (#1916 /
-    // #1923). The subject-atomic byte-fit in readDurableMetaPage already bounds
-    // the page ≤ budget for BOTH modes, so this only selects the belt-and-
-    // suspenders response serializer and records the explicit contract.
-    const usesMetaByteBudget = !isWorkspace &&
-      phase === 'meta' &&
+    // META negotiates byte-budget paging on the wire (#1916/#1923). Durable
+    // meta is subject-atomic; SWM meta is reassembled and verified as one
+    // retained manifest. Both remain bounded by the common response serializer.
+    const usesMetaByteBudget = phase === 'meta' &&
       request.pageMode === SYNC_BYTE_BUDGET_PAGE_MODE;
     // The authenticated `limit` deliberately remains capped at the legacy
     // responder size for rolling-upgrade signature compatibility. Upgraded
     // META requesters carry the larger row target in the additive hint, just
-    // like DATA. Honour it here: readDurableMetaPage and the serializer below
-    // still enforce the response byte budget and whole-subject boundaries.
-    const durableMetaLimit = usesMetaByteBudget &&
+    // like DATA. Honour it here; the serializer below still enforces the
+    // response byte budget, while durable meta also keeps whole-subject bounds.
+    const metaLimit = usesMetaByteBudget &&
       typeof request.pageRowsHint === 'number' &&
       Number.isSafeInteger(request.pageRowsHint)
       ? Math.max(1, Math.min(request.pageRowsHint, SYNC_BYTE_BUDGET_MAX_ROWS))
@@ -722,17 +720,23 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
             contextGraphId,
             cutoffIso: cutoff,
             offset,
-            limit,
+            limit: metaLimit,
             signal,
             rowListMemo: session ? swmRowsMemo : undefined,
             rowListCacheKey: session?.rowListCacheKey,
             refreshRowList: session?.refreshRowList,
             refreshGeneration: session?.refreshGeneration,
             freshMetaPlanMemo: freshSwmMetaPlanMemo,
+            // The byte-budget serializer may return only a prefix even when
+            // the loaded row slice is shorter than pageRowsHint. Retain the
+            // immutable session snapshot until the requester asks for EOF.
+            releaseCacheOnShortPage: !usesMetaByteBudget,
           });
           const queryDurationMs = Date.now() - queryStartedAt;
           const serializeStartedAt = Date.now();
-          const serialized = serializeResponderRows(rows);
+          const serialized = usesMetaByteBudget
+            ? serializeResponderRowsWithinByteBudget(rows, SYNC_BYTE_BUDGET_RESPONSE_BYTES)
+            : serializeResponderRows(rows);
           if (serialized) nquads.push(serialized);
           const serializeDurationMs = Date.now() - serializeStartedAt;
           logFirstPageDetail(() => `Sync responder SWM meta for "${contextGraphId}": auth=${authDurationMs}ms query=${queryDurationMs}ms serialize=${serializeDurationMs}ms`);
@@ -824,7 +828,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
               },
             ),
             offset,
-            limit: durableMetaLimit,
+            limit: metaLimit,
             signal,
             rowListMemo: session ? durableMetaRowsMemo : undefined,
             rowListCacheKey: session?.rowListCacheKey,

--- a/packages/agent/test/sync-byte-budget-pages.test.ts
+++ b/packages/agent/test/sync-byte-budget-pages.test.ts
@@ -229,6 +229,26 @@ describe('byte-budget sync pagination', () => {
     expect(request.pageRowsHint).toBe(SYNC_REQUEST_PAGE_SIZE);
   });
 
+  it('advertises byte-budget paging for public shared-memory metadata', async () => {
+    const encoded = await buildSyncRequestEnvelope({
+      contextGraphId: CG_ID,
+      offset: 0,
+      limit: SYNC_REQUEST_PAGE_SIZE,
+      includeSharedMemory: true,
+      targetPeerId: REMOTE_PEER_ID,
+      requesterPeerId: LOCAL_PEER_ID,
+      phase: 'meta',
+      needsAuth: false,
+      computeSyncDigest: () => new Uint8Array(32),
+      getIdentityId: async () => 0n,
+    });
+
+    expect(new TextDecoder().decode(encoded)).toBe(
+      `workspace:${CG_ID}|0|${SYNC_REQUEST_PAGE_SIZE}|meta`
+      + `|page-mode|${SYNC_BYTE_BUDGET_PAGE_MODE}|page-rows|${SYNC_REQUEST_PAGE_SIZE}`,
+    );
+  });
+
   it('does not advertise byte-budget paging for a durable meta request at the legacy cap', async () => {
     const wallet = ethers.Wallet.createRandom();
     const encoded = await buildSyncRequestEnvelope({
@@ -653,6 +673,90 @@ describe('byte-budget sync pagination', () => {
     });
     expect(linesFromNquads(upgraded)).toHaveLength(1_200);
     expect(new TextEncoder().encode(upgraded).byteLength)
+      .toBeLessThanOrEqual(SYNC_BYTE_BUDGET_RESPONSE_BYTES);
+
+    await store.close();
+  });
+
+  it('honours the negotiated row hint for shared-memory meta while legacy meta remains capped', async () => {
+    const store = new OxigraphStore();
+    const contextGraphId = 'byte-budget-swm-meta-cg';
+    const graph = `did:dkg:context-graph:${contextGraphId}/_shared_memory_meta`;
+    await store.insert(Array.from({ length: 1_200 }, (_, i) => ({
+      graph,
+      subject: `urn:swm-meta-subject-${i.toString().padStart(4, '0')}`,
+      predicate: 'urn:predicate',
+      object: `"value-${i}"`,
+    })));
+    const legacyPageSize = 128;
+    const cap = registerTestSyncHandler(store, {
+      syncPageSize: legacyPageSize,
+      sharedMemoryTtlMs: 0,
+    });
+
+    const legacy = await cap.invoke({
+      contextGraphId,
+      offset: 0,
+      limit: legacyPageSize,
+      includeSharedMemory: true,
+      phase: 'meta',
+      syncSessionId: 'legacy-swm-meta-session',
+    });
+    expect(linesFromNquads(legacy)).toHaveLength(legacyPageSize);
+
+    const upgraded = await cap.invoke({
+      contextGraphId,
+      offset: 0,
+      limit: legacyPageSize,
+      includeSharedMemory: true,
+      phase: 'meta',
+      syncSessionId: 'byte-budget-swm-meta-session',
+      pageMode: SYNC_BYTE_BUDGET_PAGE_MODE,
+      pageRowsHint: SYNC_REQUEST_PAGE_SIZE,
+    });
+    expect(linesFromNquads(upgraded)).toHaveLength(1_200);
+    expect(new TextEncoder().encode(upgraded).byteLength)
+      .toBeLessThanOrEqual(SYNC_BYTE_BUDGET_RESPONSE_BYTES);
+
+    await store.close();
+  });
+
+  it('continues a byte-truncated shared-memory meta page from the same session snapshot', async () => {
+    const store = new OxigraphStore();
+    const contextGraphId = 'byte-budget-swm-meta-continuation-cg';
+    const graph = `did:dkg:context-graph:${contextGraphId}/_shared_memory_meta`;
+    const totalRows = 900;
+    await store.insert(Array.from({ length: totalRows }, (_, i) => ({
+      graph,
+      subject: `urn:swm-meta-large-${i.toString().padStart(4, '0')}`,
+      predicate: 'urn:predicate',
+      object: `"${'x'.repeat(6_000)}-${i}"`,
+    })));
+    const cap = registerTestSyncHandler(store, {
+      syncPageSize: 128,
+      sharedMemoryTtlMs: 0,
+    });
+    const request = {
+      contextGraphId,
+      limit: 128,
+      includeSharedMemory: true,
+      phase: 'meta' as const,
+      syncSessionId: 'byte-budget-swm-meta-continuation-session',
+      pageMode: SYNC_BYTE_BUDGET_PAGE_MODE,
+      pageRowsHint: SYNC_REQUEST_PAGE_SIZE,
+    };
+
+    const first = await cap.invoke({ ...request, offset: 0 });
+    const firstRows = linesFromNquads(first);
+    expect(firstRows.length).toBeGreaterThan(0);
+    expect(firstRows.length).toBeLessThan(totalRows);
+    expect(new TextEncoder().encode(first).byteLength)
+      .toBeLessThanOrEqual(SYNC_BYTE_BUDGET_RESPONSE_BYTES);
+
+    const second = await cap.invoke({ ...request, offset: firstRows.length });
+    const secondRows = linesFromNquads(second);
+    expect(secondRows.length).toBe(totalRows - firstRows.length);
+    expect(new TextEncoder().encode(second).byteLength)
       .toBeLessThanOrEqual(SYNC_BYTE_BUDGET_RESPONSE_BYTES);
 
     await store.close();

--- a/packages/agent/test/sync-responder-snapshot-cache.test.ts
+++ b/packages/agent/test/sync-responder-snapshot-cache.test.ts
@@ -96,10 +96,15 @@ describe('sync responder snapshot budget defaults', () => {
     const contextGraphId = 'snapshot-cap-regression';
     const rawRowCount = 64_001;
     const querySources: string[] = [];
+    const queryPriorities: Array<string | undefined> = [];
     const store = {
-      query: vi.fn(async (_sparql: string, options?: { source?: string }) => {
+      query: vi.fn(async (
+        _sparql: string,
+        options?: { source?: string; priority?: string },
+      ) => {
         const source = options?.source ?? 'unknown';
         querySources.push(source);
+        queryPriorities.push(options?.priority);
         if (source === 'sync.responder.readDurableMetaGraphSnapshot') {
           return {
             type: 'bindings' as const,
@@ -135,6 +140,7 @@ describe('sync responder snapshot budget defaults', () => {
     await expect(readPage(0)).resolves.toHaveLength(500);
     await expect(readPage(500)).resolves.toHaveLength(500);
     expect(querySources).toEqual(['sync.responder.readDurableMetaGraphSnapshot']);
+    expect(queryPriorities).toEqual(['normal']);
   });
 
   it('allows operators to override every responder snapshot budget limit', () => {

--- a/packages/agent/test/sync-responder-swm-meta-ceiling.test.ts
+++ b/packages/agent/test/sync-responder-swm-meta-ceiling.test.ts
@@ -136,8 +136,8 @@ function forbidSwmMetaSortOrOffsetQueries(store: OxigraphStore) {
 }
 
 describe('SWM meta lane above the legacy 64,000-row snapshot ceiling (#1847)', () => {
-  it('uses the bounded raw-snapshot fast path for an ordinary TTL-filtered manifest', async () => {
-    const cgId = 'meta-bounded-fast-path';
+  it('uses the bounded fresh-subject plan for an ordinary TTL-filtered manifest', async () => {
+    const cgId = 'meta-bounded-plan-path';
     const metaGraph = `did:dkg:context-graph:${cgId}/_shared_memory_meta`;
     const store = new OxigraphStore();
     const quads: Quad[] = [];
@@ -162,17 +162,28 @@ describe('SWM meta lane above the legacy 64,000-row snapshot ceiling (#1847)', (
       phase: 'meta' as const,
       offset: 0,
       limit: 500,
-      syncSessionId: 'bounded-fast-session',
+      syncSessionId: 'bounded-plan-session',
     };
     const first = await cap.invoke(request);
     expect(linesFromNquads(first)).toHaveLength(40 * 5);
-    expect(sources.filter((source) => source === 'sync.responder.readSwmMetaGraphSnapshot')).toHaveLength(1);
-    expect(sources).not.toContain('sync.responder.readFreshSwmMetaSubjects');
-    expect(sources).not.toContain('sync.responder.countFreshSwmMetaSubjectRows');
+    expect(sources).not.toContain('sync.responder.readSwmMetaGraphSnapshot');
+    expect(sources).toContain('sync.responder.readFreshSwmMetaSubjects');
+    expect(sources).toContain('sync.responder.countFreshSwmMetaSubjectRows');
+    expect(sources).toContain('sync.responder.readFreshSwmMetaSubjectRows');
 
-    const queriesAfterFirst = sources.length;
+    const subjectDiscoveryAfterFirst = sources.filter(
+      (source) => source === 'sync.responder.readFreshSwmMetaSubjects',
+    ).length;
+    const subjectCountAfterFirst = sources.filter(
+      (source) => source === 'sync.responder.countFreshSwmMetaSubjectRows',
+    ).length;
     expect(await cap.invoke(request)).toBe(first);
-    expect(sources).toHaveLength(queriesAfterFirst);
+    expect(sources.filter(
+      (source) => source === 'sync.responder.readFreshSwmMetaSubjects',
+    )).toHaveLength(subjectDiscoveryAfterFirst);
+    expect(sources.filter(
+      (source) => source === 'sync.responder.countFreshSwmMetaSubjectRows',
+    )).toHaveLength(subjectCountAfterFirst);
     await store.close();
   });
 

--- a/packages/agent/test/sync-responder-swm-meta-ceiling.test.ts
+++ b/packages/agent/test/sync-responder-swm-meta-ceiling.test.ts
@@ -527,7 +527,7 @@ describe('SWM meta lane above the legacy 64,000-row snapshot ceiling (#1847)', (
     await store.close();
   });
 
-  it('degrades to plan paging when the STORE response byte cap fires during snapshot materialization (#1868 review: untyped escape)', async () => {
+  it('serves directly through bounded plan paging without attempting an oversized whole-subject snapshot', async () => {
     const cgId = 'meta-ceiling-storecap';
     const metaGraph = `did:dkg:context-graph:${cgId}/_shared_memory_meta`;
     const fresh = freshIso();
@@ -558,7 +558,8 @@ describe('SWM meta lane above the legacy 64,000-row snapshot ceiling (#1847)', (
       return originalQuery(sparql, options as never);
     }) as OxigraphStore['query'];
 
-    // DEFAULT budgets: the snapshot lane is attempted first and must degrade.
+    // DEFAULT budgets: the bounded subject plan is now the primary TTL lane,
+    // so it must never attempt the old whole-subject snapshot query.
     const cap = registerTestSyncHandler(store, { sharedMemoryTtlMs: TTL_MS, syncPageSize: 7 });
     const { lines } = await collectAllPages(
       cap,
@@ -566,7 +567,7 @@ describe('SWM meta lane above the legacy 64,000-row snapshot ceiling (#1847)', (
       7,
     );
     expect(lines.size).toBe(200);
-    expect(capThrows).toBeGreaterThan(0);
+    expect(capThrows).toBe(0);
     await store.close();
   });
 

--- a/packages/agent/test/sync-responder-swm-meta-ceiling.test.ts
+++ b/packages/agent/test/sync-responder-swm-meta-ceiling.test.ts
@@ -136,6 +136,46 @@ function forbidSwmMetaSortOrOffsetQueries(store: OxigraphStore) {
 }
 
 describe('SWM meta lane above the legacy 64,000-row snapshot ceiling (#1847)', () => {
+  it('uses the bounded raw-snapshot fast path for an ordinary TTL-filtered manifest', async () => {
+    const cgId = 'meta-bounded-fast-path';
+    const metaGraph = `did:dkg:context-graph:${cgId}/_shared_memory_meta`;
+    const store = new OxigraphStore();
+    const quads: Quad[] = [];
+    for (let index = 0; index < 40; index += 1) {
+      quads.push(...workspaceOpQuads(cgId, `fresh-${index}`, `urn:fresh:root:${index}`, metaGraph, freshIso()));
+      quads.push(...workspaceOpQuads(cgId, `stale-${index}`, `urn:stale:root:${index}`, metaGraph, staleIso()));
+    }
+    await store.insert(quads);
+
+    const sources: string[] = [];
+    const originalQuery = store.query.bind(store);
+    store.query = (async (sparql: string, options?: unknown) => {
+      const source = (options as { source?: string } | undefined)?.source;
+      if (source) sources.push(source);
+      return originalQuery(sparql, options as never);
+    }) as OxigraphStore['query'];
+
+    const cap = registerTestSyncHandler(store, { sharedMemoryTtlMs: TTL_MS, syncPageSize: 500 });
+    const request = {
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'meta' as const,
+      offset: 0,
+      limit: 500,
+      syncSessionId: 'bounded-fast-session',
+    };
+    const first = await cap.invoke(request);
+    expect(linesFromNquads(first)).toHaveLength(40 * 5);
+    expect(sources.filter((source) => source === 'sync.responder.readSwmMetaGraphSnapshot')).toHaveLength(1);
+    expect(sources).not.toContain('sync.responder.readFreshSwmMetaSubjects');
+    expect(sources).not.toContain('sync.responder.countFreshSwmMetaSubjectRows');
+
+    const queriesAfterFirst = sources.length;
+    expect(await cap.invoke(request)).toBe(first);
+    expect(sources).toHaveLength(queriesAfterFirst);
+    await store.close();
+  });
+
   it('keeps plan-only ceilings pinned below the snapshot materialization caps', () => {
     expect(FRESH_SWM_META_SUBJECT_WINDOW_MAX_ROWS).toBe(64_000);
     expect(FRESH_SWM_META_PLAN_MAX_BYTES_ESTIMATE).toBe(32 * 1024 * 1024);

--- a/packages/agent/test/sync-responder-swm-subgraphs.test.ts
+++ b/packages/agent/test/sync-responder-swm-subgraphs.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import { registerSyncHandler } from '../src/sync/responder/sync-handler.js';
 import type { SyncRequestEnvelope } from '../src/sync/auth/request-build.js';
@@ -348,6 +348,54 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
       const graphs = lineGraphsFromNquads(out);
       expect(graphs.has(ROOT_SWM)).toBe(true);
       expect(graphs.has(SUB_SWM)).toBe(true);
+    });
+
+    it('does not probe every payload graph when fresh metadata has no legacy root entities', async () => {
+      const modernStore = new OxigraphStore();
+      const modernCap = captureHandler();
+      const publishedAt = new Date(Date.now() - 1_000).toISOString();
+      const operation = 'urn:dkg:share:devnet-test:modern-rootless';
+      const payloadGraph = `${ROOT_SWM}/0x00000000000000000000000000000000000000ab/7`;
+      await modernStore.insert([
+        { graph: ROOT_SWM_META, subject: operation, predicate: RDF_TYPE, object: `${DKG_NS}WorkspaceOperation` },
+        { graph: ROOT_SWM_META, subject: operation, predicate: `${DKG_NS}publishedAt`, object: `"${publishedAt}"^^<http://www.w3.org/2001/XMLSchema#dateTime>` },
+        { graph: ROOT_SWM_META, subject: operation, predicate: `${DKG_NS}kaUal`, object: 'did:dkg:hardhat:31337/0x00000000000000000000000000000000000000ab/7' },
+        { graph: payloadGraph, subject: 'urn:modern:payload', predicate: 'http://schema.org/name', object: '"modern-rootless"' },
+      ]);
+
+      const querySources: string[] = [];
+      const query = modernStore.query.bind(modernStore);
+      vi.spyOn(modernStore, 'query').mockImplementation(async (sparql, options) => {
+        querySources.push(options?.source ?? 'unknown');
+        return query(sparql, options);
+      });
+      registerSyncHandler({
+        register: modernCap.register,
+        protocolSync: '/origintrail/dkg/sync/1.0.0',
+        syncDeniedResponse: 'sync-denied',
+        syncPageSize: 5000,
+        sharedMemoryTtlMs: 5_000,
+        store: modernStore,
+        peerId: 'self-peer',
+        parseSyncRequest: (data) => JSON.parse(new TextDecoder().decode(data)) as SyncRequestEnvelope,
+        authorizeSyncRequest: async () => true,
+        logWarn: noopLog,
+        logDebug: noopLog,
+      });
+
+      const out = await modernCap.invoke({
+        contextGraphId: CG_ID,
+        offset: 0,
+        limit: 5000,
+        includeSharedMemory: true,
+        phase: 'data',
+      });
+
+      expect(out).toBe('');
+      expect(querySources).toContain('sync.responder.discoverFreshSwmMetaRoots');
+      expect(querySources).not.toContain('sync.responder.planFreshSwmGraphRoots');
+      expect(querySources).not.toContain('sync.responder.countFreshSwmGraphRows');
+      await modernStore.close();
     });
   });
 

--- a/packages/agent/test/sync-responder-swm-subgraphs.test.ts
+++ b/packages/agent/test/sync-responder-swm-subgraphs.test.ts
@@ -365,6 +365,7 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
 
       const querySources: string[] = [];
       const query = modernStore.query.bind(modernStore);
+      const listGraphs = vi.spyOn(modernStore, 'listGraphs');
       vi.spyOn(modernStore, 'query').mockImplementation(async (sparql, options) => {
         querySources.push(options?.source ?? 'unknown');
         return query(sparql, options);
@@ -395,6 +396,8 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
       expect(querySources).toContain('sync.responder.discoverFreshSwmMetaRoots');
       expect(querySources).not.toContain('sync.responder.planFreshSwmGraphRoots');
       expect(querySources).not.toContain('sync.responder.countFreshSwmGraphRows');
+      expect(querySources).not.toContain('sync.responder.listFreshSwmGraphs');
+      expect(listGraphs).not.toHaveBeenCalled();
       await modernStore.close();
     });
   });

--- a/packages/agent/test/sync-responder-swm-subgraphs.test.ts
+++ b/packages/agent/test/sync-responder-swm-subgraphs.test.ts
@@ -364,10 +364,14 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
       ]);
 
       const querySources: string[] = [];
+      const rootDiscoveryQueries: string[] = [];
       const query = modernStore.query.bind(modernStore);
       const listGraphs = vi.spyOn(modernStore, 'listGraphs');
       vi.spyOn(modernStore, 'query').mockImplementation(async (sparql, options) => {
         querySources.push(options?.source ?? 'unknown');
+        if (options?.source === 'sync.responder.discoverFreshSwmMetaRoots') {
+          rootDiscoveryQueries.push(sparql.replace(/\s+/g, ' ').trim());
+        }
         return query(sparql, options);
       });
       registerSyncHandler({
@@ -397,6 +401,10 @@ describe('sync responder workspace branch — sub-graph SWM coverage', () => {
       expect(querySources).not.toContain('sync.responder.planFreshSwmGraphRoots');
       expect(querySources).not.toContain('sync.responder.countFreshSwmGraphRows');
       expect(querySources).not.toContain('sync.responder.listFreshSwmGraphs');
+      expect(rootDiscoveryQueries).toHaveLength(1);
+      expect(rootDiscoveryQueries[0]).toContain(`${DKG_NS}rootEntity`);
+      expect(rootDiscoveryQueries[0]).not.toContain(`${DKG_NS}WorkspaceOperation`);
+      expect(rootDiscoveryQueries[0]).not.toContain('ORDER BY');
       expect(listGraphs).not.toHaveBeenCalled();
       await modernStore.close();
     });

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -78,6 +78,7 @@ export default defineConfig({
       "test/sync-responder-cursor.test.ts",
       "test/sync-responder-oversized-fallback.test.ts",
       "test/sync-responder-swm-meta-ceiling.test.ts",
+      "test/sync-responder-swm-subgraphs.test.ts",
       "test/sync-responder-large-graph-stack-overflow.test.ts",
       "test/sync-responder-graph-backed-swm.test.ts",
       "test/graph-backed-swm-page-boundary.test.ts",


### PR DESCRIPTION
## User impact

A provider can serve large selected public context graphs without repeatedly scanning unrelated graphs or probing payload shapes that cannot contribute. Metadata is negotiated and paged by bytes, and selected-graph planning uses bounded subject and graph indexes.

## Before

```mermaid
sequenceDiagram
    participant R as Receiver
    participant P as Provider
    participant S as Store
    R->>P: Catch up selected CG
    loop Metadata and data pages
        P->>S: Global graph discovery
        P->>S: Rootless payload probes
        P->>S: Rebuild broad plan
    end
    Note over R,P: Store work grows with unrelated local data
```

## After

```mermaid
sequenceDiagram
    participant R as Receiver
    participant P as Provider
    participant I as Selected CG indexes
    participant S as Store
    R->>P: Catch up selected CG with byte budget
    P->>I: Resolve bounded subject and graph plan
    loop Byte-bounded pages
        P->>S: Read only planned selected graphs
        P-->>R: Bounded metadata or data page
    end
    Note over R,P: Work follows the selected CG, not the whole store
```

## Safety

- Page byte ceilings remain negotiated and enforced.
- No global sync-all behavior is introduced.
- Maintenance reads stay lower priority than already-admitted user sync work.
- Empty and rootless cases remain fail-closed.

## Validation

Focused byte-budget, metadata-ceiling, SWM-subgraph, and snapshot-cache suites cover the bounded path. The complete stack reached 500/500 SWM on Testnet without manual catch-up.