### PR TITLE
fix(sync): complete selected public VM catch-up efficiently

### DIFF
--- a/packages/agent/src/dkg-agent-constants.ts
+++ b/packages/agent/src/dkg-agent-constants.ts
@@ -61,6 +61,17 @@ export const SYNC_BYTE_BUDGET_MAX_ROWS = 8_192;
  * while bounding the first response.
  */
 export const SYNC_REQUEST_INITIAL_PAGE_SIZE = 512;
+/**
+ * Maximum store rows loaded by one negotiated exact-VM page.
+ *
+ * Exact reads stay page-only, so this is also their responder working-set
+ * bound. 256 worst-case 64 KiB literal rows are about 16 MiB before normal
+ * JS/store overhead; the responder's existing global concurrency of three
+ * keeps that bounded while the 4 MiB serializer cap still owns wire bytes.
+ * This is deliberately below the requester's 512-row cold-path hint and far
+ * below the 8,192-row retained-snapshot lane.
+ */
+export const SYNC_EXACT_PAGE_READ_MAX_ROWS = 256;
 /** Target serialized body. Six MiB of the 10 MiB router cap remains as headroom. */
 export const SYNC_BYTE_BUDGET_RESPONSE_BYTES = DEFAULT_MAX_READ_BYTES - SYNC_RESPONSE_FRAME_HEADROOM_BYTES;
 /** Maximum throughput-oriented row hint; the signed legacy limit remains 500. */

--- a/packages/agent/src/dkg-agent-constants.ts
+++ b/packages/agent/src/dkg-agent-constants.ts
@@ -65,13 +65,14 @@ export const SYNC_REQUEST_INITIAL_PAGE_SIZE = 512;
  * Maximum store rows loaded by one negotiated exact-VM page.
  *
  * Exact reads stay page-only, so this is also their responder working-set
- * bound. 256 worst-case 64 KiB literal rows are about 16 MiB before normal
+ * bound. 512 worst-case 64 KiB literal rows are about 32 MiB before normal
  * JS/store overhead; the responder's existing global concurrency of three
  * keeps that bounded while the 4 MiB serializer cap still owns wire bytes.
- * This is deliberately below the requester's 512-row cold-path hint and far
- * below the 8,192-row retained-snapshot lane.
+ * Matching the requester's cold-path hint lets an ordinary 100-750 triple KA
+ * cross in one or two streams while remaining far below the 8,192-row retained-
+ * snapshot lane.
  */
-export const SYNC_EXACT_PAGE_READ_MAX_ROWS = 256;
+export const SYNC_EXACT_PAGE_READ_MAX_ROWS = 512;
 /** Target serialized body. Six MiB of the 10 MiB router cap remains as headroom. */
 export const SYNC_BYTE_BUDGET_RESPONSE_BYTES = DEFAULT_MAX_READ_BYTES - SYNC_RESPONSE_FRAME_HEADROOM_BYTES;
 /** Maximum throughput-oriented row hint; the signed legacy limit remains 500. */

--- a/packages/agent/src/dkg-agent-constants.ts
+++ b/packages/agent/src/dkg-agent-constants.ts
@@ -64,17 +64,17 @@ export const SYNC_REQUEST_INITIAL_PAGE_SIZE = 512;
 /**
  * Maximum store rows loaded by one negotiated exact-VM page.
  *
- * Exact reads stay page-only, so this is also their responder working-set
- * bound. 512 worst-case 64 KiB literal rows are about 32 MiB before normal
- * JS/store overhead; the responder's existing global concurrency of three
- * keeps that bounded while the 4 MiB serializer cap still owns wire bytes.
- * Matching the requester's cold-path hint lets an ordinary 100-750 triple KA
- * cross in one or two streams while remaining far below the 8,192-row retained-
- * snapshot lane.
+ * Exact reads stay page-only. Their store adapter separately caps the SPARQL
+ * response body, while the 4 MiB serializer cap owns wire bytes. A 4,096-row
+ * ceiling lets a catalog-sized multi-KA batch that is known to fit the wire
+ * cross in one stream without permitting the retained 8,192-row snapshot lane.
+ * Path failures still fall back to the conservative frame-safe floor.
  */
-export const SYNC_EXACT_PAGE_READ_MAX_ROWS = 512;
+export const SYNC_EXACT_PAGE_READ_MAX_ROWS = 4_096;
 /** Target serialized body. Six MiB of the 10 MiB router cap remains as headroom. */
 export const SYNC_BYTE_BUDGET_RESPONSE_BYTES = DEFAULT_MAX_READ_BYTES - SYNC_RESPONSE_FRAME_HEADROOM_BYTES;
+/** Bound SPARQL JSON before parsing exact page-only payloads into JS objects. */
+export const SYNC_EXACT_PAGE_STORE_RESPONSE_MAX_BYTES = 2 * SYNC_BYTE_BUDGET_RESPONSE_BYTES;
 /** Maximum throughput-oriented row hint; the signed legacy limit remains 500. */
 export const SYNC_REQUEST_PAGE_SIZE = SYNC_BYTE_BUDGET_MAX_ROWS;
 /** Successful pages required before the requester doubles its learned size. */

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -620,7 +620,10 @@ import {
   deserializePendingSenderKeyEntry,
 } from './dkg-agent-swm-state.js';
 import { DKGAgentBase } from './dkg-agent-base.js';
-import { VmReconcileShutdownTimeoutError } from './vm-reconcile-service.js';
+import {
+  VmReconcileShutdownTimeoutError,
+  type ContextGraphReconcileResult,
+} from './vm-reconcile-service.js';
 import { ContextGraphMembershipPersistShutdownTimeoutError } from './context-graph-membership-persist-scheduler.js';
 import type { DKGAgent } from './dkg-agent.js';
 import { deterministicStartupJitterMs, scheduleAfterStartupJitter } from './startup-jitter.js';
@@ -1388,6 +1391,35 @@ type PhysicalDurableSyncResult = {
   readonly result: DurableSyncResult;
   readonly exactFetchDisposition?: ExactDurableFetchDisposition;
 };
+
+/**
+ * Adapt one chain-inventory reconciliation slice to the legacy durable-sync
+ * accounting shape consumed by reconnect and catch-up orchestration.
+ *
+ * RFC-64 catalogs are authoritative for SWM only. For an explicitly selected
+ * public CG, finalized VM completeness comes from the chain reconciler, so a
+ * legacy whole-graph transfer must not run beside it. The adapter reports
+ * bounded cursor/materialization progress without inventing transferred triple
+ * counts, and reaches the durable terminal boundary only when the chain lane is
+ * actually current with no unresolved ordinals.
+ */
+function vmReconcileSliceAsDurableResult(
+  result: ContextGraphReconcileResult,
+): DurableSyncResult {
+  const accumulator = createDurableSyncAccumulator();
+  if (
+    result.reconciledOrdinals > 0
+    || result.watermarkAfter > result.watermarkBefore
+  ) {
+    recordDurableSyncDiagnostics(accumulator, { checkpointAdvances: 1 });
+  }
+  markDurableTerminalBoundary(
+    accumulator,
+    result.status === 'current' && result.unresolvedOrdinals === 0,
+    { countCompletedPhase: true },
+  );
+  return finalizeDurableSyncCompletion(accumulator);
+}
 
 type LegacyDurableContextGraphOptions = {
   onPhase?: PhaseCallback;
@@ -7409,6 +7441,49 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     } = {},
   ): Promise<DurableRecoveryExecution> {
     const ctx = createOperationContext('sync');
+
+    // Selected public RFC-64 CGs have two deliberately separate inventories:
+    // the accepted RFC-64 catalog is authoritative for SWM, while finalized VM
+    // membership is authoritative on chain. Sending these graphs through the
+    // legacy whole-CG durable runner duplicates the chain reconciler, downloads
+    // every historical graph, and can monopolise the store long enough to
+    // invalidate the exact recovery lifecycle. Keep the existing method as the
+    // orchestration seam, but delegate its VM work to one bounded exact slice.
+    if (this.isRfc64SelectedVmReconcileContextGraph(contextGraphId)) {
+      let durableResult: DurableSyncResult;
+      let outcome: DurableRecoveryExecution['outcome'] = 'no-progress';
+      let safeOffset = 0;
+      try {
+        const reconcile = await this.runVmReconcileForCg(contextGraphId, 'manual');
+        durableResult = vmReconcileSliceAsDurableResult(reconcile);
+        safeOffset = reconcile.watermarkAfter;
+        outcome = durableResult.complete
+          ? 'terminal'
+          : (durableResult.checkpointAdvances ?? 0) > 0
+            ? 'partial-progress'
+            : 'no-progress';
+      } catch (error) {
+        durableResult = createIncompleteDurableSyncResult();
+        this.log.warn(
+          ctx,
+          `Chain-inventory VM recovery for selected public CG "${contextGraphId}" `
+            + `did not complete this slice: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      // The candidate is the trigger/accounting peer, not an assertion that it
+      // served VM bytes. Exact recovery owns provider selection internally and
+      // verifies every returned UAL against the chain before materialization.
+      const peerId = options.candidatePeerIds?.[0];
+      return {
+        outcome,
+        result: durableResult,
+        peerResults: peerId ? [{ peerId, result: durableResult }] : [],
+        slices: 1,
+        ...(peerId ? { peerId } : {}),
+        safeOffset,
+      };
+    }
+
     return durableRecoveryRunnerFor(this).run({
       contextGraphId,
       options,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -1407,15 +1407,19 @@ function vmReconcileSliceAsDurableResult(
   result: ContextGraphReconcileResult,
 ): DurableSyncResult {
   const accumulator = createDurableSyncAccumulator();
+  const terminal = result.status === 'current' && result.unresolvedOrdinals === 0;
   if (
     result.reconciledOrdinals > 0
     || result.watermarkAfter > result.watermarkBefore
   ) {
     recordDurableSyncDiagnostics(accumulator, { checkpointAdvances: 1 });
   }
+  if (terminal) {
+    recordDurableSyncDiagnostics(accumulator, { selectedVmTerminalCompletions: 1 });
+  }
   markDurableTerminalBoundary(
     accumulator,
-    result.status === 'current' && result.unresolvedOrdinals === 0,
+    terminal,
     { countCompletedPhase: true },
   );
   return finalizeDurableSyncCompletion(accumulator);
@@ -7826,6 +7830,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         emptyResponses: 0,
         metaOnlyResponses: 0,
         verifiedPrivateOnlyResponses: 0,
+        selectedVmTerminalCompletions: 0,
         dataRejectedMissingMeta: 0,
         rejectedKcs: 0,
         failedPeers: 0,
@@ -7992,6 +7997,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const accessDeniedPeers = new Set<string>();
     let cleanDurableDataSynced = 0;
     let cleanDurablePrivateOnlyCompletions = 0;
+    let cleanSelectedVmTerminalCompletions = 0;
     let cleanSharedMemoryDataSynced = 0;
     const peersSucceeded = new Set<string>();
     for (const [resultIndex, r] of results.entries()) {
@@ -8056,6 +8062,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         cleanDurableDataSynced += r.durable.insertedDataTriples;
         cleanDurablePrivateOnlyCompletions +=
           durableProgress.hasVerifiedPrivateOnlyResponse ? 1 : 0;
+        cleanSelectedVmTerminalCompletions +=
+          durableProgress.hasSelectedVmTerminalCompletion ? 1 : 0;
       }
       if (sharedMemoryCompletedCleanly) {
         cleanSharedMemoryDataSynced += r.shared!.insertedDataTriples;
@@ -8092,6 +8100,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       diagnostics.durable.metaOnlyResponses += r.durable.metaOnlyResponses;
       diagnostics.durable.verifiedPrivateOnlyResponses +=
         r.durable.verifiedPrivateOnlyResponses;
+      diagnostics.durable.selectedVmTerminalCompletions =
+        (diagnostics.durable.selectedVmTerminalCompletions ?? 0)
+        + (r.durable.selectedVmTerminalCompletions ?? 0);
       diagnostics.durable.dataRejectedMissingMeta += r.durable.dataRejectedMissingMeta;
       diagnostics.durable.rejectedKcs += r.durable.rejectedKcs;
       diagnostics.durable.failedPeers += r.durable.failedPeers;
@@ -8290,7 +8301,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // promote readiness — and cannot erase a clean snapshot another peer did
     // deliver.
     const durableCompletedCleanly =
-      cleanDurableDataSynced > 0 || cleanDurablePrivateOnlyCompletions > 0;
+      cleanDurableDataSynced > 0
+      || cleanDurablePrivateOnlyCompletions > 0
+      || cleanSelectedVmTerminalCompletions > 0;
     const sharedMemoryCompletedCleanly = cleanSharedMemoryDataSynced > 0;
     if (durableCompletedCleanly || sharedMemoryCompletedCleanly) {
       this.markContextGraphSubscriptionState(contextGraphId, {

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -854,6 +854,7 @@ function syncPageFetchCoalescingKey(params: {
   forceFreshSession?: boolean;
   manifestDigest?: SyncPageFetchOptions['manifestDigest'];
   assetUals?: readonly string[];
+  initialPageSizeHint?: number;
   returnAcceptedPrefixOnRetryableTransportFailure?: boolean;
   requesterScope?: SyncCheckpointScope;
   maxAcceptedQuads?: number;
@@ -871,6 +872,7 @@ function syncPageFetchCoalescingKey(params: {
     params.forceFreshSession === true,
     params.manifestDigest ?? null,
     params.assetUals === undefined ? null : exactAssetFilterKey(params.assetUals),
+    params.initialPageSizeHint ?? null,
     params.returnAcceptedPrefixOnRetryableTransportFailure === true,
     params.requesterScope ?? null,
     params.maxAcceptedQuads ?? null,
@@ -989,6 +991,7 @@ function durableSyncSingleFlightKey(params: {
   hasSignal: boolean;
   hasCurrentFence: boolean;
   exactAssetUals?: readonly string[];
+  exactInitialPageSizeHint?: number;
   settlementSliceTimeoutMs?: number;
   priority?: number;
 }): string | null {
@@ -1010,6 +1013,7 @@ function durableSyncSingleFlightKey(params: {
     authenticationTimeoutMs: params.authenticationTimeoutMs,
     syncAgentsMeta: params.syncAgentsMeta,
     exactAssetUals: params.exactAssetUals ?? null,
+    exactInitialPageSizeHint: params.exactInitialPageSizeHint ?? null,
     settlementSliceTimeoutMs: params.settlementSliceTimeoutMs ?? null,
     priority: params.priority ?? null,
   });
@@ -1363,6 +1367,8 @@ export type DurableSyncOptions = {
   onAtomicCommitStarted?: (contextGraphId: string, ual: string) => void;
   /** Internal VM-recovery filter; only these locally-missing KAs are stored. */
   exactAssetUals?: string[];
+  /** Verified catalog leaf estimate for the exact batch. */
+  exactInitialPageSizeHint?: number;
   /** Owner-private retained META prefix for bounded durable recovery. */
   durableMetaContinuation?: DurableMetaContinuation;
   /** Admission override for foreground VM recovery. */
@@ -1434,6 +1440,7 @@ type LegacyDurableContextGraphOptions = {
   onVerifiedFullSnapshot?: (snapshot: VerifiedFullSnapshot) => Promise<void>;
   fetchTimeoutMs?: number;
   exactAssetUals?: string[];
+  exactInitialPageSizeHint?: number;
   authenticationTimeoutMs?: number;
   operationFetchDeadline?: number;
   operationDeadline?: number;
@@ -5511,6 +5518,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
                 stopOnBackoffWorthyFailure,
                 fetchTimeoutMs,
                 exactAssetUals,
+                exactInitialPageSizeHint: options?.exactInitialPageSizeHint,
                 authenticationTimeoutMs,
                 operationFetchDeadline: operationBoundary.fetchDeadline,
                 operationDeadline: operationBoundary.deadline,
@@ -5605,6 +5613,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       hasSignal: Boolean(operationBoundary.signal),
       hasCurrentFence: Boolean(options?.isCurrent),
       exactAssetUals,
+      exactInitialPageSizeHint: options?.exactInitialPageSizeHint,
       settlementSliceTimeoutMs: options?.settlementSliceTimeoutMs,
       priority: options?.priority,
     });
@@ -5635,7 +5644,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     remotePeerId: string,
     contextGraphId: string,
     requestedAssetUals: string[],
-    options: { signal?: AbortSignal; isCurrent?: () => boolean } = {},
+    options: {
+      signal?: AbortSignal;
+      isCurrent?: () => boolean;
+      initialPageSizeHint?: number;
+    } = {},
   ): Promise<DurableSyncResult> {
     return (await this.syncExactKnowledgeAssetsFromPeerDetailed(
       remotePeerId,
@@ -5649,7 +5662,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     remotePeerId: string,
     contextGraphId: string,
     requestedAssetUals: string[],
-    options: { signal?: AbortSignal; isCurrent?: () => boolean } = {},
+    options: {
+      signal?: AbortSignal;
+      isCurrent?: () => boolean;
+      initialPageSizeHint?: number;
+    } = {},
   ): Promise<ExactKnowledgeAssetSyncResult> {
     const assetUals = requireExactAssetUals(requestedAssetUals);
     const ctx = createOperationContext('sync');
@@ -5662,6 +5679,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       undefined,
       {
         exactAssetUals: assetUals,
+        exactInitialPageSizeHint: options.initialPageSizeHint,
         stopOnBackoffWorthyFailure: true,
         priority: 1_000,
         source: 'vm-recovery',
@@ -5709,6 +5727,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       onVerifiedFullSnapshot,
       fetchTimeoutMs = SYNC_TOTAL_TIMEOUT_MS,
       exactAssetUals,
+      exactInitialPageSizeHint,
       authenticationTimeoutMs = fetchTimeoutMs,
       operationFetchDeadline,
       operationDeadline,
@@ -5824,6 +5843,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             manifestPrefixDigestAtOffset,
             shouldStopAfterPage,
             assetUals: exactAssetUals,
+            initialPageSizeHint: phase === 'data'
+              ? exactInitialPageSizeHint
+              : undefined,
             returnAcceptedPrefixOnRetryableTransportFailure,
             requesterScope,
           },
@@ -6452,6 +6474,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // Exact VM recovery filter. Included in checkpoint, coalescing, wire and
       // responder-session identities so offsets never cross asset batches.
       assetUals,
+      initialPageSizeHint,
       returnAcceptedPrefixOnRetryableTransportFailure,
       // Internal namespace for state whose retained prefix is unavailable to
       // ordinary coalesced callers.
@@ -6479,6 +6502,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         forceFreshSession,
         manifestDigest,
         assetUals,
+        initialPageSizeHint,
         returnAcceptedPrefixOnRetryableTransportFailure,
         requesterScope,
         maxAcceptedQuads,
@@ -6530,6 +6554,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       snapshotRef,
       sinceBatchId,
       assetUals,
+      initialPageSizeHint,
       returnAcceptedPrefixOnRetryableTransportFailure,
       requesterScope,
       maxAcceptedBytes: exactAccumulationLimits?.maxBytes,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -7464,13 +7464,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // behavior; the periodic/trailing owner continues durable progress.
       if (this.vmReconcileDispatcher?.isInFlight(contextGraphId)) {
         const result = createIncompleteDurableSyncResult();
-        const peerId = options.candidatePeerIds?.[0];
         return {
           outcome: 'no-progress',
           result,
-          peerResults: peerId ? [{ peerId, result }] : [],
+          // No physical peer attempt happened in this trigger. Keeping the
+          // list empty prevents outer catch-up accounting from mistaking a
+          // skipped self-reentry for a successful peer response.
+          peerResults: [],
           slices: 0,
-          ...(peerId ? { peerId } : {}),
           safeOffset: 0,
         };
       }

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -7450,6 +7450,26 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // invalidate the exact recovery lifecycle. Keep the existing method as the
     // orchestration seam, but delegate its VM work to one bounded exact slice.
     if (this.isRfc64SelectedVmReconcileContextGraph(contextGraphId)) {
+      // A reconcile slice can reach catch-up while repairing one missing
+      // ordinal. Re-entering the same keyed dispatcher from that catch-up
+      // would make the active promise await itself. Return a fail-closed
+      // no-progress durable result instead: runCatchupOverPeers still executes
+      // the independent SWM plane, while the active chain-inventory owner keeps
+      // responsibility for exact VM provider selection and materialization.
+      // External triggers racing an already-active slice use the same safe
+      // behavior; the periodic/trailing owner continues durable progress.
+      if (this.vmReconcileDispatcher?.isInFlight(contextGraphId)) {
+        const result = createIncompleteDurableSyncResult();
+        const peerId = options.candidatePeerIds?.[0];
+        return {
+          outcome: 'no-progress',
+          result,
+          peerResults: peerId ? [{ peerId, result }] : [],
+          slices: 0,
+          ...(peerId ? { peerId } : {}),
+          safeOffset: 0,
+        };
+      }
       let durableResult: DurableSyncResult;
       let outcome: DurableRecoveryExecution['outcome'] = 'no-progress';
       let safeOffset = 0;
@@ -7463,7 +7483,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             ? 'partial-progress'
             : 'no-progress';
       } catch (error) {
-        durableResult = createIncompleteDurableSyncResult();
+        // An exception is not an empty but otherwise healthy slice. Preserve
+        // the durable diagnostic contract so outer catch-up accounting cannot
+        // count the trigger peer as successful and suppress the next retry.
+        durableResult = createFailedPeerDurableSyncResult();
         this.log.warn(
           ctx,
           `Chain-inventory VM recovery for selected public CG "${contextGraphId}" `

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -372,6 +372,7 @@ import {
 } from './dkg-agent-utils.js';
 import {
   PRIVATE_DATA_ANCHOR,
+  SYNC_EXACT_PAGE_READ_MAX_ROWS,
   SYNC_PAGE_SIZE,
   SYNC_PAGE_RETRY_ATTEMPTS,
   SYNC_TOTAL_TIMEOUT_MS,
@@ -5215,6 +5216,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     attempts: readonly VmRecoveryBatchAttempt[];
     unavailablePeerIds: readonly string[];
     headBlock: number | undefined;
+    initialPageSizeHint?: number;
     signal?: AbortSignal;
     isRecoveryCurrent: () => boolean;
     revalidateTarget?: () => Promise<boolean>;
@@ -5227,6 +5229,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
       attempts,
       unavailablePeerIds,
       headBlock,
+      initialPageSizeHint,
       signal,
       isRecoveryCurrent,
       revalidateTarget,
@@ -5273,7 +5276,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         peerId,
         localCgId,
         attempts.map(({ entry }) => entry.target.ual),
-        { signal, isCurrent: isRecoveryCurrent },
+        { signal, isCurrent: isRecoveryCurrent, initialPageSizeHint },
       );
       const { result } = detailed;
       disposition = detailed.disposition;
@@ -5806,6 +5809,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         installedRecord,
         candidatePeerIds,
       }];
+      let batchInitialPageSizeHint: number | undefined;
 
       // The first exact request to a peer remains a single-KA probe. Once that
       // probe has proved the peer is a holder, pack a stable compatible prefix
@@ -5907,6 +5911,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
           continue;
         }
         batchAttempts = plan.targets.map(({ attempt }) => attempt);
+        batchInitialPageSizeHint = Number(
+          plan.estimatedLeaves > BigInt(SYNC_EXACT_PAGE_READ_MAX_ROWS)
+            ? BigInt(SYNC_EXACT_PAGE_READ_MAX_ROWS)
+            : plan.estimatedLeaves,
+        );
         this.log.info(
           ctx,
           `VM exact recovery plan for "${localCgId}" from ${peerId.slice(-8)}: `
@@ -5923,6 +5932,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
         attempts: batchAttempts,
         unavailablePeerIds: [...providerPolicy.unavailablePeerIds()],
         headBlock,
+        initialPageSizeHint: batchInitialPageSizeHint,
         signal,
         isRecoveryCurrent,
         revalidateTarget,

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -572,9 +572,9 @@ type VmReconcileOrdinalOptions = {
  */
 const HOST_MODE_PUBLISH_POLICY_MAX_CACHE_AGE_MS = 5_000;
 
-// Exact VM data responses are page-only and capped at 64 rows per page. Keep
-// one recovery microbatch near 64 non-empty pages so a single large graph does
-// not monopolize the global sync admission. This is a soft scheduling/fairness
+// Exact VM data responses are page-only and bounded independently of retained
+// snapshots. Keep one recovery microbatch near 4,096 leaves so a single large
+// graph does not monopolize the global sync admission. This is a soft scheduling/fairness
 // cap, not a wire or correctness limit: an individually larger KA is still
 // admitted alone and remains bounded by the exact executor's hard guards.
 const VM_EXACT_MICROBATCH_PAGE_FAIRNESS_LEAVES = 4_096n;

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -3483,7 +3483,14 @@ export class SwmHostModeMethods extends DKGAgentBase {
         && current.record.nameHash === target.nameHash;
     }
     const current = this.subscribedContextGraphs.get(localCgId);
-    return current === target.sub
+    // Subscription records are immutable snapshots and ordinary readiness
+    // updates replace the object in the map.  Object identity is therefore
+    // not a lifecycle fence: a concurrent SWM catch-up can set metaSynced or
+    // sharedMemorySynced without changing either membership or the VM binding.
+    // Keep the VM slice current across those harmless replacements, while the
+    // durable binding generation + cursor identity still fail closed on an
+    // unsubscribe, rebind, deletion, or cursor reset.
+    return (current?.subscribed === true || current?.coreHosted === true)
       && this.contextGraphBindingState.targetStillCurrent(localCgId, current, target)
       && this.reconcileCursors.get(localCgId) === expectedCursor;
   }
@@ -3789,12 +3796,19 @@ export class SwmHostModeMethods extends DKGAgentBase {
   ): Promise<RsHealPassResult> {
     try {
       const capturedOnChainId = target.onChainId;
+      const currentSubscription = () => (
+        this.subscribedContextGraphs instanceof Map
+          ? this.subscribedContextGraphs.get(localCgId)
+          : target.sub
+      );
       const canApply = () => isCurrent()
-        && (!(this.subscribedContextGraphs instanceof Map)
-          || this.subscribedContextGraphs.get(localCgId) === target.sub)
+        && (
+          currentSubscription()?.subscribed === true
+          || currentSubscription()?.coreHosted === true
+        )
         && this.contextGraphBindingState.targetStillCurrent(
           localCgId,
-          target.sub,
+          currentSubscription(),
           target,
         );
       if (!canApply()) {

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -3660,8 +3660,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
       });
       return;
     }
+    // Readiness bookkeeping replaces immutable subscription snapshots. The
+    // binding-generation/cursor fence above, not object identity, determines
+    // whether this watermark still belongs to the active target.
     const sub = this.subscribedContextGraphs.get(localCgId);
-    if (!sub || sub !== target.sub) return;
+    if (!sub || !this.contextGraphBindingState.targetStillCurrent(localCgId, sub, target)) return;
     if (target.bindingKind === 'reverse-name-hash') {
       // Reverse-derived progress is valid only for this process-local,
       // revalidated target. The live cursor advances after this returns; never
@@ -3682,7 +3685,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
       isTargetCurrent,
     );
     if (!isTargetCurrent()) return;
-    sub.lastReconciledOrdinal = watermark;
+    // A second harmless readiness replacement may race the durable write.
+    // Apply the in-memory watermark to the latest same-binding snapshot.
+    const latest = this.subscribedContextGraphs.get(localCgId);
+    if (!latest || !this.contextGraphBindingState.targetStillCurrent(localCgId, latest, target)) return;
+    latest.lastReconciledOrdinal = watermark;
     this.emitReplication({
       contextGraphId: localCgId,
       onChainCgId: target.onChainId,

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -1057,6 +1057,12 @@ export interface DurableSyncDiagnostics {
   metaOnlyResponses: number;
   /** Cryptographically verified V2 responses whose public graph is intentionally empty. */
   verifiedPrivateOnlyResponses: number;
+  /**
+   * Chain-inventory VM lanes that reached their finalized on-chain head with
+   * no unresolved ordinals. This is terminal readiness evidence without peer
+   * payload bytes; only the selected-public VM reconciler may emit it.
+   */
+  selectedVmTerminalCompletions?: number;
   dataRejectedMissingMeta: number;
   rejectedKcs: number;
   failedPeers: number;

--- a/packages/agent/src/sync/durable-progress.ts
+++ b/packages/agent/src/sync/durable-progress.ts
@@ -11,6 +11,7 @@ export interface DurableProgressSummary {
   readonly insertedMetaTriples?: number;
   readonly metaOnlyResponses?: number;
   readonly verifiedPrivateOnlyResponses?: number;
+  readonly selectedVmTerminalCompletions?: number;
   readonly dataRejectedMissingMeta?: number;
   readonly rejectedKcs?: number;
   readonly resumedPhases?: number;
@@ -35,6 +36,7 @@ export interface DurableProgressClassification {
   readonly hasInsertedData: boolean;
   readonly hasMetadataEvidence: boolean;
   readonly hasVerifiedPrivateOnlyResponse: boolean;
+  readonly hasSelectedVmTerminalCompletion: boolean;
   readonly hasCleanVerifiedPrivateOnlyCompletion: boolean;
   readonly integrityRejected: boolean;
   readonly metadataOnly: boolean;
@@ -68,6 +70,7 @@ export function classifyDurableProgress(
   const checkpointAdvances = progress?.checkpointAdvances ?? 0;
   const resumedPhases = progress?.resumedPhases ?? 0;
   const verifiedPrivateOnlyResponses = progress?.verifiedPrivateOnlyResponses ?? 0;
+  const selectedVmTerminalCompletions = progress?.selectedVmTerminalCompletions ?? 0;
 
   const timedOut = (progress?.timedOutPhases ?? 0) > 0;
   const transportFailed = (progress?.failedPeers ?? 0) > 0;
@@ -77,6 +80,7 @@ export function classifyDurableProgress(
   const integrityRejected = (progress?.dataRejectedMissingMeta ?? 0) > 0
     || (progress?.rejectedKcs ?? 0) > 0;
   const hasVerifiedPrivateOnlyResponse = verifiedPrivateOnlyResponses > 0;
+  const hasSelectedVmTerminalCompletion = selectedVmTerminalCompletions > 0;
   const hasMetadataEvidence = insertedMetaTriples > 0 || metaOnlyResponses > 0;
   const hasBlockingFailure = timedOut
     || transportFailed
@@ -112,6 +116,7 @@ export function classifyDurableProgress(
   const madeReconnectProgress = !integrityRejected && (
     hasInsertedData
     || hasCleanVerifiedPrivateOnlyCompletion
+    || hasSelectedVmTerminalCompletion
     || (!metadataOnly && (completedPhases > 0 || checkpointAdvances > 0))
   );
 
@@ -120,6 +125,7 @@ export function classifyDurableProgress(
   // caller silently changes semantics during this consolidation.
   const madeReadinessProgress = (progress?.insertedDataTriples ?? insertedTriples) > 0
     || hasVerifiedPrivateOnlyResponse
+    || hasSelectedVmTerminalCompletion
     || checkpointAdvances > 0
     || (completedPhases > 0 && resumedPhases > 0);
 
@@ -133,6 +139,7 @@ export function classifyDurableProgress(
     hasInsertedData,
     hasMetadataEvidence,
     hasVerifiedPrivateOnlyResponse,
+    hasSelectedVmTerminalCompletion,
     hasCleanVerifiedPrivateOnlyCompletion,
     integrityRejected,
     metadataOnly,
@@ -149,7 +156,11 @@ export function classifyDurableProgress(
     madeReadinessProgress,
     completedWithoutFailure,
     completedReadinessCleanly: completedWithoutFailure
-      && (hasInsertedData || hasVerifiedPrivateOnlyResponse),
+      && (
+        hasInsertedData
+        || hasVerifiedPrivateOnlyResponse
+        || hasSelectedVmTerminalCompletion
+      ),
     cleanNonMetadataResponse: !transportFailed
       && !phaseFailed
       && !timedOut
@@ -201,6 +212,7 @@ const DURABLE_SYNC_COUNTER_REDUCERS = {
   emptyResponses: 'sum',
   metaOnlyResponses: 'sum',
   verifiedPrivateOnlyResponses: 'sum',
+  selectedVmTerminalCompletions: 'sum',
   dataRejectedMissingMeta: 'sum',
   rejectedKcs: 'sum',
   failedPeers: 'max',
@@ -402,7 +414,7 @@ export function finalizeDurableSyncCompletion(
 
 export type InitializedDurableSyncResult = DurableSyncResult & Required<Pick<
   DurableSyncResult,
-  'backoffWorthyFailures' | 'deferredBackpressure'
+  'backoffWorthyFailures' | 'deferredBackpressure' | 'selectedVmTerminalCompletions'
 >>;
 
 export type InitializedDurableSyncDiagnostics = Omit<InitializedDurableSyncResult, 'complete'>;

--- a/packages/agent/src/sync/durable-recovery-runner.ts
+++ b/packages/agent/src/sync/durable-recovery-runner.ts
@@ -90,6 +90,7 @@ const PROGRESS_COUNTERS = [
   'emptyResponses',
   'metaOnlyResponses',
   'verifiedPrivateOnlyResponses',
+  'selectedVmTerminalCompletions',
 ] as const satisfies readonly (keyof DurableSyncResult)[];
 
 type ProgressTotals = Record<typeof PROGRESS_COUNTERS[number], number>;

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -554,6 +554,16 @@ function shouldReducePageSize(error: unknown): boolean {
   // Request construction can fail before a byte leaves this node (wallet,
   // chain RPC, signing). Only a send failure or an explicit responder-capacity
   // rejection is evidence that a smaller page could help.
+  //
+  // libp2p's explicit "during opening" failure is also pre-response evidence:
+  // the peer closed while negotiating a fresh stream, before it could inspect
+  // or serialize the requested page. Treating that connection-churn signal as
+  // an oversized page permanently collapsed an otherwise healthy 512-row path
+  // to 64 rows and multiplied exact-VM stream opens by eight.
+  if (
+    error instanceof Error
+    && error.message.toLowerCase().includes('during opening')
+  ) return false;
   return isSyncTransportFailure(error) || (
     isSyncValidationRejection(error) && isSyncBackoffWorthyError(error)
   );

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -305,12 +305,24 @@ class AdaptiveSyncPageSizer {
     private readonly usesByteBudgetPagination: boolean,
     preferredPageSize?: number,
     private readonly rememberPreferredPageSize?: (pageSize: number) => void,
+    initialPageSizeHint?: number,
   ) {
     this.safePageSize = Math.min(syncPageSize, SYNC_REQUEST_SAFE_PAGE_SIZE);
-    const initialPageSize = Math.min(syncPageSize, SYNC_REQUEST_INITIAL_PAGE_SIZE);
-    this.activePageSize = Number.isSafeInteger(preferredPageSize)
-      ? Math.max(this.safePageSize, Math.min(syncPageSize, preferredPageSize!))
-      : Math.max(this.safePageSize, initialPageSize);
+    const defaultInitialPageSize = Math.min(syncPageSize, SYNC_REQUEST_INITIAL_PAGE_SIZE);
+    const learnedPageSize = Number.isSafeInteger(preferredPageSize)
+      ? Math.max(1, Math.min(syncPageSize, preferredPageSize!))
+      : defaultInitialPageSize;
+    const hintedInitialPageSize = Number.isSafeInteger(initialPageSizeHint)
+      ? Math.max(1, Math.min(syncPageSize, initialPageSizeHint!))
+      : learnedPageSize;
+    // A chain/catalog-bound exact batch has a transfer-specific size proof.
+    // Let it escape a stale low profile learned by an unrelated whole-CG page;
+    // any real path failure still reduces this fetch to the safe floor.
+    this.activePageSize = Math.max(
+      this.safePageSize,
+      learnedPageSize,
+      hintedInitialPageSize,
+    );
   }
 
   current(): number {
@@ -391,6 +403,8 @@ export interface SyncPageFetchOptions {
     offset: number,
   ) => DurableManifestPrefixDigest | undefined;
   readonly assetUals?: string[];
+  /** Verified catalog row estimate for a bounded exact-VM batch. */
+  readonly initialPageSizeHint?: number;
   /**
    * Permit the selected-SWM transfer owner to retain a validated metadata
    * prefix after a retryable transport interruption. Checkpoint identity is
@@ -484,6 +498,8 @@ interface FetchSyncPagesParams {
   sinceBatchId?: string;
   /** Exact KAs requested by VM recovery. Undefined retains ordinary full sync. */
   assetUals?: string[];
+  /** Verified catalog row estimate for a bounded exact-VM batch. */
+  initialPageSizeHint?: number;
   /** Selected-SWM-only policy for returning a validated incomplete prefix. */
   returnAcceptedPrefixOnRetryableTransportFailure?: boolean;
   /** Isolates an internal requester whose retained prefix is not shareable. */
@@ -596,6 +612,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
     buildSyncRequest,
     sinceBatchId,
     assetUals,
+    initialPageSizeHint,
     returnAcceptedPrefixOnRetryableTransportFailure,
     requesterScope,
     maxAcceptedBytes,
@@ -759,6 +776,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
     pageSizeProfileCache
       ? (pageSize) => pageSizeProfileCache.remember(pageSizeProfileScope, pageSize)
       : undefined,
+    initialPageSizeHint,
   );
   let successfulPageSize = adaptivePageSizer.current();
   const syncSessionId = usesPageSession

--- a/packages/agent/src/sync/responder/data-request-policy.ts
+++ b/packages/agent/src/sync/responder/data-request-policy.ts
@@ -1,6 +1,7 @@
 import {
   SYNC_BYTE_BUDGET_MAX_ROWS,
   SYNC_BYTE_BUDGET_PAGE_MODE,
+  SYNC_EXACT_PAGE_READ_MAX_ROWS,
   SYNC_REQUEST_SAFE_PAGE_SIZE,
 } from '../../dkg-agent-constants.js';
 
@@ -20,8 +21,9 @@ export interface DataRequestPolicy {
  * This boundary is shared by durable and SWM DATA. Signature fields are
  * deliberately absent: public-graph authorization may accept a request before
  * validating them, so their presence is not proof that a caller is
- * authenticated. Negotiated exact-asset reads therefore use the conservative
- * store-page path and 64-row floor.
+ * authenticated. Negotiated exact-asset reads therefore stay on the bounded
+ * store-page path; their independent row cap limits responder working memory
+ * even when the requester advertises the larger retained-snapshot ceiling.
  */
 export function resolveDataRequestPolicy(params: {
   legacyLimit: number;
@@ -49,7 +51,7 @@ export function resolveDataRequestPolicy(params: {
       ? Math.min(
         hintedPageRows,
         pageOnlyExactFetch
-          ? SYNC_REQUEST_SAFE_PAGE_SIZE
+          ? SYNC_EXACT_PAGE_READ_MAX_ROWS
           : SYNC_BYTE_BUDGET_MAX_ROWS,
       )
       : params.legacyLimit,

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -232,7 +232,12 @@ export interface ExactGraphPagePlanMemo {
   get(
     key: string,
     load: () => Promise<ExactGraphPagePlan>,
-    options?: { refresh?: boolean; requireExisting?: boolean; signal?: AbortSignal },
+    options?: {
+      refresh?: boolean;
+      refreshGeneration?: string;
+      requireExisting?: boolean;
+      signal?: AbortSignal;
+    },
   ): Promise<ExactGraphPagePlan | null>;
 }
 
@@ -393,11 +398,24 @@ function createSessionPlanMemo<T>(
   get(
     key: string,
     load: () => Promise<T>,
-    options?: { refresh?: boolean; requireExisting?: boolean; signal?: AbortSignal },
+    options?: {
+      refresh?: boolean;
+      refreshGeneration?: string;
+      requireExisting?: boolean;
+      signal?: AbortSignal;
+    },
   ): Promise<T | null>;
 } {
-  const cached = new Map<string, { value: T; cachedAt: number; budgetEntryId?: symbol }>();
-  const inflight = new Map<string, Promise<T>>();
+  const cached = new Map<string, {
+    value: T;
+    cachedAt: number;
+    budgetEntryId?: symbol;
+    refreshGeneration?: string;
+  }>();
+  const inflight = new Map<string, {
+    promise: Promise<T>;
+    refreshGeneration?: string;
+  }>();
   const deleteEntry = (key: string, reason: 'expired' | 'released' | 'replaced') => {
     const entry = cached.get(key);
     if (!entry) return;
@@ -412,11 +430,34 @@ function createSessionPlanMemo<T>(
   return {
     async get(key, load, options) {
       throwIfAborted(options?.signal);
+      while (true) {
+        const pending = inflight.get(key);
+        if (!pending) break;
+        const supersedesPending = options?.refreshGeneration !== undefined
+          && options.refreshGeneration !== pending.refreshGeneration;
+        if (!supersedesPending) {
+          return raceAgainstAbort(pending.promise, options?.signal);
+        }
+        // A page-zero request from another server-derived session generation
+        // owns a new immutable plan boundary. Let the older load settle, then
+        // rebuild; never let the new session inherit its pending result.
+        try {
+          await raceAgainstAbort(pending.promise, options?.signal);
+        } catch {
+          throwIfAborted(options?.signal);
+        }
+      }
       const now = Date.now();
       prune(now);
-      const pending = inflight.get(key);
-      if (pending) return raceAgainstAbort(pending, options?.signal);
-      const existing = cached.get(key);
+      let existing = cached.get(key);
+      if (
+        existing
+        && options?.refreshGeneration !== undefined
+        && existing.refreshGeneration !== options.refreshGeneration
+      ) {
+        deleteEntry(key, 'replaced');
+        existing = undefined;
+      }
       if (!options?.refresh && existing) {
         cached.delete(key);
         cached.set(key, { ...existing, cachedAt: now });
@@ -456,11 +497,21 @@ function createSessionPlanMemo<T>(
             });
             accounting.budget.release(budgetEntryId);
           }
-          cached.set(key, { value, cachedAt: Date.now(), budgetEntryId });
+          cached.set(key, {
+            value,
+            cachedAt: Date.now(),
+            budgetEntryId,
+            refreshGeneration: options?.refreshGeneration,
+          });
           return value;
         })
-        .finally(() => inflight.delete(key));
-      inflight.set(key, pendingLoad);
+        .finally(() => {
+          if (inflight.get(key)?.promise === pendingLoad) inflight.delete(key);
+        });
+      inflight.set(key, {
+        promise: pendingLoad,
+        refreshGeneration: options?.refreshGeneration,
+      });
       return raceAgainstAbort(pendingLoad, options?.signal);
     },
   };
@@ -884,6 +935,7 @@ export async function readSwmMetaPage(params: {
     params.freshMetaPlanMemo,
     params.rowListCacheKey,
     params.refreshRowList === true,
+    params.refreshGeneration,
     (signal) => buildFreshSwmMetaPlan(
       params.store,
       candidateGraphs,
@@ -1658,7 +1710,11 @@ export async function readDurableDataPage(params: {
         );
       },
       params.exactGraphPlanCacheScope
-        ? { key: durableCacheKey, refresh: params.refreshRowList }
+        ? {
+          key: durableCacheKey,
+          refresh: params.refreshRowList,
+          refreshGeneration: params.refreshGeneration,
+        }
         : undefined,
     );
   }
@@ -1818,7 +1874,7 @@ async function readPagedRowsFromExactGraphPlanLoader(
   signal: AbortSignal | undefined,
   planMemo: ExactGraphPagePlanMemo | undefined,
   loadExactGraphPlan: (signal?: AbortSignal) => Promise<ExactGraphPagePlan>,
-  planCache?: { key: string; refresh?: boolean },
+  planCache?: { key: string; refresh?: boolean; refreshGeneration?: string },
 ): Promise<SyncRow[]> {
   const rowSnapshotLimits = cache?.memo.snapshotLoadLimits ?? {
     maxRows: SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS,
@@ -1829,6 +1885,7 @@ async function readPagedRowsFromExactGraphPlanLoader(
     planMemo,
     planCache?.key ?? cache?.key,
     planCache?.refresh ?? cache?.refresh === true,
+    planCache?.refreshGeneration ?? cache?.refreshGeneration,
     (planSignal) => loadExactGraphPlan(planSignal),
     'Sync session exact-graph plan expired before page completion',
   );
@@ -2186,11 +2243,17 @@ function createSessionPlanGetter<T>(
     get(
       key: string,
       load: () => Promise<T>,
-      options?: { refresh?: boolean; requireExisting?: boolean; signal?: AbortSignal },
+      options?: {
+        refresh?: boolean;
+        refreshGeneration?: string;
+        requireExisting?: boolean;
+        signal?: AbortSignal;
+      },
     ): Promise<T | null>;
   } | undefined,
   cacheKey: string | undefined,
   initialRefreshPending: boolean,
+  refreshGeneration: string | undefined,
   loadPlan: (signal?: AbortSignal) => Promise<T>,
   expiredMessage: string,
 ): (pageOffset: number, pageSignal: AbortSignal | undefined) => Promise<T> {
@@ -2201,6 +2264,7 @@ function createSessionPlanGetter<T>(
     const plan = memo && cacheKey
       ? await memo.get(cacheKey, () => loadPlan(pageSignal), {
         refresh: refreshPlan,
+        refreshGeneration,
         requireExisting: pageOffset > 0,
         signal: pageSignal,
       })

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -1203,6 +1203,9 @@ async function readGraphScopedVmManifest(
 ): Promise<GraphScopedVmManifest> {
   const metaGraph = contextGraphMetaGraphUri(contextGraphId);
   const contextGraph = contextGraphDataGraphUri(contextGraphId);
+  // Keep this restriction inside each named GRAPH block below. Oxigraph can
+  // otherwise plan the descriptor join as a graph-wide scan even when only one
+  // exact UAL was requested.
   const exactUalClause = assetUals === undefined
     ? ''
     : `VALUES ?ual { ${subjectValues(assetUals)} }`;
@@ -1248,8 +1251,8 @@ async function readGraphScopedVmManifest(
   // legacy compatibility lane.
   const markerBindings = await readBoundedBindings(`
     SELECT ?ual ?scopeVersion WHERE {
-      ${exactUalClause}
       GRAPH <${assertSafeIri(metaGraph)}> {
+        ${exactUalClause}
         ?ual <${DKG_CONTENT_SCOPE_VERSION}> ?scopeVersion .
       }
     }
@@ -1292,8 +1295,8 @@ async function readGraphScopedVmManifest(
       SELECT ?ual ?scopeVersion ?kaUal ?assertionVersion ?assertionGraph
              ?contextGraph ?publicTripleCount ?privateTripleCount ?status ?subGraphName
       WHERE {
-        ${exactUalClause}
         GRAPH <${assertSafeIri(metaGraph)}> {
+          ${exactUalClause}
           ?ual <${DKG_CONTENT_SCOPE_VERSION}> ?scopeVersion ;
                <${DKG_KA_UAL}> ?kaUal ;
                <${DKG_ASSERTION_VERSION}> ?assertionVersion ;

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -1598,6 +1598,12 @@ export async function readDurableDataPage(params: {
   refreshRowList?: boolean;
   refreshGeneration?: string;
   exactGraphPlanMemo?: ExactGraphPagePlanMemo;
+  /**
+   * Scope a lightweight exact-graph manifest plan to an authenticated sync
+   * session even when payload rows deliberately remain in page-only mode.
+   * This retains only graph IRIs and committed row counts, never payload rows.
+   */
+  exactGraphPlanCacheScope?: string;
   /** Keep the immutable row snapshot until an explicit empty-page EOF. */
   releaseCacheOnShortPage?: boolean;
   assetUals?: readonly string[];
@@ -1608,15 +1614,16 @@ export async function readDurableDataPage(params: {
    */
   exactGraphReadMode?: ExactGraphReadMode;
 }): Promise<SyncRow[]> {
+  const durableCacheKey = durableDataRowListCacheKey(
+    params.rowListCacheScope ?? params.exactGraphPlanCacheScope ?? 'default',
+    params.contextGraphId,
+    params.sinceBatchId,
+    params.assetUals,
+  );
   const cache = params.rowListMemo
     ? {
       memo: params.rowListMemo,
-      key: durableDataRowListCacheKey(
-        params.rowListCacheScope ?? 'default',
-        params.contextGraphId,
-        params.sinceBatchId,
-        params.assetUals,
-      ),
+      key: durableCacheKey,
       refresh: params.refreshRowList,
       refreshGeneration: params.refreshGeneration,
       releaseOnShortPage: params.releaseCacheOnShortPage,
@@ -1650,6 +1657,9 @@ export async function readDurableDataPage(params: {
           params.exactGraphReadMode,
         );
       },
+      params.exactGraphPlanCacheScope
+        ? { key: durableCacheKey, refresh: params.refreshRowList }
+        : undefined,
     );
   }
 
@@ -1808,6 +1818,7 @@ async function readPagedRowsFromExactGraphPlanLoader(
   signal: AbortSignal | undefined,
   planMemo: ExactGraphPagePlanMemo | undefined,
   loadExactGraphPlan: (signal?: AbortSignal) => Promise<ExactGraphPagePlan>,
+  planCache?: { key: string; refresh?: boolean },
 ): Promise<SyncRow[]> {
   const rowSnapshotLimits = cache?.memo.snapshotLoadLimits ?? {
     maxRows: SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS,
@@ -1816,8 +1827,8 @@ async function readPagedRowsFromExactGraphPlanLoader(
   };
   const getPlan = createSessionPlanGetter(
     planMemo,
-    cache?.key,
-    cache?.refresh === true,
+    planCache?.key ?? cache?.key,
+    planCache?.refresh ?? cache?.refresh === true,
     (planSignal) => loadExactGraphPlan(planSignal),
     'Sync session exact-graph plan expired before page completion',
   );

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -30,7 +30,10 @@ import {
   type SyncResponderSnapshotBudget,
 } from './snapshot-budget.js';
 import { estimateStringRowHeapBytes } from '../memory-telemetry.js';
-import { SYNC_BYTE_BUDGET_RESPONSE_BYTES } from '../../dkg-agent-constants.js';
+import {
+  SYNC_BYTE_BUDGET_RESPONSE_BYTES,
+  SYNC_EXACT_PAGE_STORE_RESPONSE_MAX_BYTES,
+} from '../../dkg-agent-constants.js';
 import type { ChangelogSyncResponse, ChangelogDeltaRecord } from '../changelog/wire.js';
 import { durableMetaDelegationSubjectAdmissionExpression } from './durable-meta-admission.js';
 import { exactAssetFilterKey } from '../exact-assets.js';
@@ -2143,7 +2146,13 @@ async function readRowsPageFromExactGraphPlan(
         LIMIT ${expectedRows + (isFinalGraphPage ? 1 : 0)}
       `, {
         ...syncResponderStoreOptions(signal, 'sync.responder.readExactGraphRowsPage'),
-        maxResponseBytes: snapshotResponseByteLimit(snapshotLimits.maxBytesEstimate),
+        // Page-only exact recovery may request thousands of compact rows at
+        // once, but it must not parse an unbounded SPARQL JSON body before the
+        // common 4 MiB N-Quads serializer gets a chance to frame it.
+        maxResponseBytes: Math.min(
+          snapshotResponseByteLimit(snapshotLimits.maxBytesEstimate),
+          SYNC_EXACT_PAGE_STORE_RESPONSE_MAX_BYTES,
+        ),
       });
       if (result.type === 'bindings') {
         for (const row of result.bindings) {

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -902,6 +902,12 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           rowListCacheScope: session && dataRequestPolicy.cacheMode === 'session-snapshot'
             ? peerId
             : undefined,
+          // Exact public VM reads intentionally keep payloads page-only, but
+          // their tiny manifest plan is safe and essential to retain across
+          // the 64-row session pages. Otherwise every page repeats both V2
+          // manifest queries and turns a bounded ten-KA fetch into hundreds of
+          // redundant store scans.
+          exactGraphPlanCacheScope: session ? peerId : undefined,
           refreshRowList: session?.refreshRowList,
           refreshGeneration: session?.refreshGeneration,
           exactGraphPlanMemo: durableDataExactGraphPlanMemo,

--- a/packages/agent/test/exact-asset-responder.test.ts
+++ b/packages/agent/test/exact-asset-responder.test.ts
@@ -94,6 +94,9 @@ describe('exact asset responder', () => {
     expect(manifestQueries).not.toHaveLength(0);
     for (const query of manifestQueries) {
       expect(query).toContain(`VALUES ?ual { <${requested.ual}> }`);
+      expect(query).toMatch(new RegExp(
+        `GRAPH <${contextGraphMetaGraphUri(CG_ID)}> \\{\\s*VALUES \\?ual`,
+      ));
       expect(query).not.toContain(`<${alreadyPresent.ual}>`);
     }
   });

--- a/packages/agent/test/exact-asset-wire-parse.test.ts
+++ b/packages/agent/test/exact-asset-wire-parse.test.ts
@@ -245,10 +245,12 @@ describe('exact-asset wire parsing (parseSyncRequest)', () => {
     const originalQuery = store.query.bind(store);
     const payloadReadLimits: number[] = [];
     let maxPayloadBindings = 0;
+    let manifestMarkerQueries = 0;
     store.query = (async (
       sparql: string,
       options?: Parameters<OxigraphStore['query']>[1],
     ) => {
+      if (sparql.includes('SELECT ?ual ?scopeVersion WHERE')) manifestMarkerQueries += 1;
       const result = await originalQuery(sparql, options);
       const isPagedPayloadRead = sparql.includes('ORDER BY ?s ?p ?o') &&
         payloadGraphs.some((graph) => sparql.includes(`<${graph}>`));
@@ -321,6 +323,10 @@ describe('exact-asset wire parsing (parseSyncRequest)', () => {
     expect(payloadReadLimits.length).toBeGreaterThan(0);
     expect(Math.max(...payloadReadLimits)).toBeLessThanOrEqual(SYNC_REQUEST_SAFE_PAGE_SIZE);
     expect(maxPayloadBindings).toBeLessThanOrEqual(SYNC_REQUEST_SAFE_PAGE_SIZE);
+    // Page-only is a payload-retention policy, not a reason to rebuild the
+    // same bounded graph/count plan on every 64-row request. One authenticated
+    // sync session reads its exact manifest once and reuses the scalar plan.
+    expect(manifestMarkerQueries).toBe(1);
 
     await store.close();
   }, 60_000);

--- a/packages/agent/test/exact-asset-wire-parse.test.ts
+++ b/packages/agent/test/exact-asset-wire-parse.test.ts
@@ -13,6 +13,7 @@ import { DKGAgent } from '../src/index.js';
 import {
   SYNC_BYTE_BUDGET_PAGE_MODE,
   SYNC_BYTE_BUDGET_RESPONSE_BYTES,
+  SYNC_EXACT_PAGE_READ_MAX_ROWS,
   SYNC_PAGE_SIZE,
   SYNC_REQUEST_PAGE_SIZE,
   SYNC_REQUEST_SAFE_PAGE_SIZE,
@@ -297,7 +298,7 @@ describe('exact-asset wire parsing (parseSyncRequest)', () => {
       const lines = linesFromNquads(response);
       expect(new TextEncoder().encode(response).byteLength)
         .toBeLessThanOrEqual(SYNC_BYTE_BUDGET_RESPONSE_BYTES);
-      expect(lines.length).toBeLessThanOrEqual(SYNC_REQUEST_SAFE_PAGE_SIZE);
+      expect(lines.length).toBeLessThanOrEqual(SYNC_EXACT_PAGE_READ_MAX_ROWS);
       if (lines.length === 0) break;
       received.push(...lines);
       offset += lines.length;
@@ -313,18 +314,15 @@ describe('exact-asset wire parsing (parseSyncRequest)', () => {
       page.length === MAX_EXACT_SYNC_ASSETS
       && page.every((ual, index) => ual === canonicalAssetUals[index]))).toBe(true);
     const totalRows = MAX_EXACT_SYNC_ASSETS * rowsPerKa;
-    expect(requestedOffsets).toEqual([
-      ...Array.from(
-        { length: Math.ceil(totalRows / SYNC_REQUEST_SAFE_PAGE_SIZE) },
-        (_, index) => index * SYNC_REQUEST_SAFE_PAGE_SIZE,
-      ),
-      totalRows,
-    ]);
+    expect(requestedOffsets[0]).toBe(0);
+    expect(requestedOffsets.at(-1)).toBe(totalRows);
+    expect(requestedOffsets.every((value, index) =>
+      index === 0 || value > requestedOffsets[index - 1]!)).toBe(true);
     expect(payloadReadLimits.length).toBeGreaterThan(0);
-    expect(Math.max(...payloadReadLimits)).toBeLessThanOrEqual(SYNC_REQUEST_SAFE_PAGE_SIZE);
-    expect(maxPayloadBindings).toBeLessThanOrEqual(SYNC_REQUEST_SAFE_PAGE_SIZE);
+    expect(Math.max(...payloadReadLimits)).toBeLessThanOrEqual(SYNC_EXACT_PAGE_READ_MAX_ROWS);
+    expect(maxPayloadBindings).toBeLessThanOrEqual(SYNC_EXACT_PAGE_READ_MAX_ROWS);
     // Page-only is a payload-retention policy, not a reason to rebuild the
-    // same bounded graph/count plan on every 64-row request. One authenticated
+    // same bounded graph/count plan on every page request. One authenticated
     // sync session reads its exact manifest once and reuses the scalar plan.
     expect(manifestMarkerQueries).toBe(1);
 
@@ -392,7 +390,7 @@ describe('exact-asset wire parsing (parseSyncRequest)', () => {
     await store.close();
   });
 
-  it('keeps fake signature fields on the 64-row page-only exact-fetch policy', async () => {
+  it('keeps fake signature fields on the bounded page-only exact-fetch policy', async () => {
     const contextGraphId = 'fake-signature-public-exact';
     const store = new OxigraphStore();
     const metaGraph = contextGraphMetaGraphUri(contextGraphId);
@@ -461,12 +459,12 @@ describe('exact-asset wire parsing (parseSyncRequest)', () => {
       requesterSignatureVS: 'attacker-controlled-vs',
     }));
 
-    expect(linesFromNquads(response)).toHaveLength(SYNC_REQUEST_SAFE_PAGE_SIZE);
+    expect(linesFromNquads(response)).toHaveLength(200);
     expect(new TextEncoder().encode(response).byteLength)
       .toBeLessThanOrEqual(SYNC_BYTE_BUDGET_RESPONSE_BYTES);
     expect(payloadReadLimits.length).toBeGreaterThan(0);
-    expect(Math.max(...payloadReadLimits)).toBeLessThanOrEqual(SYNC_REQUEST_SAFE_PAGE_SIZE);
-    expect(maxPayloadBindings).toBeLessThanOrEqual(SYNC_REQUEST_SAFE_PAGE_SIZE);
+    expect(Math.max(...payloadReadLimits)).toBeLessThanOrEqual(SYNC_EXACT_PAGE_READ_MAX_ROWS);
+    expect(maxPayloadBindings).toBeLessThanOrEqual(SYNC_EXACT_PAGE_READ_MAX_ROWS);
     expect(payloadSnapshotQueries).toBe(0);
 
     await store.close();

--- a/packages/agent/test/sync-byte-budget-pages.test.ts
+++ b/packages/agent/test/sync-byte-budget-pages.test.ts
@@ -9,6 +9,7 @@ import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import {
   SYNC_BYTE_BUDGET_PAGE_MODE,
   SYNC_BYTE_BUDGET_RESPONSE_BYTES,
+  SYNC_EXACT_PAGE_READ_MAX_ROWS,
   SYNC_PAGE_GROWTH_SUCCESS_THRESHOLD,
   SYNC_PAGE_SIZE,
   SYNC_REQUEST_INITIAL_PAGE_SIZE,
@@ -411,6 +412,36 @@ describe('byte-budget sync pagination', () => {
     failFirstRound = false;
     await expect(run()).resolves.toMatchObject({ completed: true, nextOffset: 0 });
     expect(requestedSizes.at(-1)).toBe(SYNC_REQUEST_SAFE_PAGE_SIZE);
+  });
+
+  it('does not collapse page capacity for a failure before response opening', async () => {
+    const requestedSizes: number[] = [];
+    const pageSizeProfileCache = new SyncPageSizeProfileCache();
+    const scope = pageSizeScope(REMOTE_PEER_ID);
+    let sends = 0;
+    await expect(fetchSyncPages(pageFetchParams({
+      syncPageRetryAttempts: 2,
+      pageSizeProfileCache,
+      buildSyncRequest: async (_cg, _offset, limit) => {
+        requestedSizes.push(limit);
+        return new TextEncoder().encode('request');
+      },
+      parseAndFilter: async () => ({ quads: [], totalQuads: 0 }),
+      send: async () => {
+        sends += 1;
+        if (sends === 1) throw new Error('Remote closed connection during opening');
+        return new Uint8Array();
+      },
+    }))).resolves.toMatchObject({ completed: true, nextOffset: 0 });
+
+    expect(requestedSizes).toEqual([
+      SYNC_REQUEST_INITIAL_PAGE_SIZE,
+      SYNC_REQUEST_INITIAL_PAGE_SIZE,
+    ]);
+    // An empty EOF page is not throughput evidence, so the shared profile is
+    // deliberately left untouched; the important invariant is that the retry
+    // itself kept the 512-row request.
+    expect(pageSizeProfileCache.preferred(scope)).toBeUndefined();
   });
 
   it('retains a terminal transport fallback when no retry callback runs', async () => {
@@ -842,7 +873,7 @@ describe('byte-budget sync pagination', () => {
       hasExactAssetFilter: true,
     })).toEqual({
       usesByteBudgetPage: true,
-      limit: SYNC_REQUEST_SAFE_PAGE_SIZE,
+      limit: SYNC_EXACT_PAGE_READ_MAX_ROWS,
       cacheMode: 'page-only',
       exactGraphReadMode: 'page-only',
     });

--- a/packages/agent/test/sync-byte-budget-pages.test.ts
+++ b/packages/agent/test/sync-byte-budget-pages.test.ts
@@ -414,6 +414,30 @@ describe('byte-budget sync pagination', () => {
     expect(requestedSizes.at(-1)).toBe(SYNC_REQUEST_SAFE_PAGE_SIZE);
   });
 
+  it('lets a verified exact-batch hint escape a stale low page profile', async () => {
+    const requestedSizes: number[] = [];
+    const pageSizeProfileCache = new SyncPageSizeProfileCache();
+    const scope = pageSizeScope(REMOTE_PEER_ID, 'data', false);
+    pageSizeProfileCache.remember(scope, SYNC_REQUEST_SAFE_PAGE_SIZE);
+
+    await expect(fetchSyncPages(pageFetchParams({
+      includeSharedMemory: false,
+      phase: 'data',
+      graphUri: `did:dkg:context-graph:${CG_ID}`,
+      assetUals: ['did:dkg:base:84532/0x1234/1'],
+      initialPageSizeHint: 3_508,
+      pageSizeProfileCache,
+      buildSyncRequest: async (_cg, _offset, limit) => {
+        requestedSizes.push(limit);
+        return new TextEncoder().encode('request');
+      },
+      parseAndFilter: async () => ({ quads: [], totalQuads: 0 }),
+      send: async () => new Uint8Array(),
+    }))).resolves.toMatchObject({ completed: true, nextOffset: 0 });
+
+    expect(requestedSizes).toEqual([3_508]);
+  });
+
   it('does not collapse page capacity for a failure before response opening', async () => {
     const requestedSizes: number[] = [];
     const pageSizeProfileCache = new SyncPageSizeProfileCache();

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -260,14 +260,50 @@ describe('exact VM recovery lifecycle', () => {
       expect(result).toMatchObject({
         outcome: 'no-progress',
         slices: 0,
-        peerId: PEER_A,
         safeOffset: 0,
         result: { complete: false },
+        peerResults: [],
       });
+      expect(result.peerId).toBeUndefined();
       expect(reconcile).not.toHaveBeenCalled();
     } finally {
       // The minimal dispatcher above is intentionally not a production queue;
       // clear it before stop() attempts the normal dispatcher drain.
+      (agent as any).vmReconcileDispatcher = null;
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('does not count a skipped selected-public VM self-reentry as peer success', async () => {
+    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    const contextGraphId = 'selected-public-active-catchup';
+    const remotePeer = { toString: () => PEER_A };
+    try {
+      (agent as any).config.syncContextGraphs = [contextGraphId];
+      (agent as any).config.rfc64PublicCatalogBootstrap = {
+        acceptedPublicPolicies: [{
+          policyEnvelope: {
+            payload: { accessPolicy: 0, contextGraphId },
+          },
+          targets: [],
+        }],
+      };
+      (agent as any).vmReconcileDispatcher = {
+        isInFlight: (key: string) => key === contextGraphId,
+      };
+      (agent as any).waitForSyncProtocol = async () => true;
+
+      const result = await (agent as any).runCatchupOverPeers(
+        contextGraphId,
+        false,
+        [remotePeer],
+      );
+
+      expect(result.peersTried).toBe(0);
+      expect(result.peersResponded).toBe(0);
+      expect(result.peersSucceeded).toBe(0);
+      expect(result.dataSynced).toBe(0);
+    } finally {
       (agent as any).vmReconcileDispatcher = null;
       await agent.stop().catch(() => {});
     }

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -228,6 +228,80 @@ describe('exact VM recovery lifecycle', () => {
     }
   });
 
+  it('does not re-enter an active selected-public VM reconcile from catch-up', async () => {
+    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    const contextGraphId = 'selected-public-active-reconcile';
+    const reconcile = vi.fn();
+    try {
+      (agent as any).config.syncContextGraphs = [contextGraphId];
+      (agent as any).config.rfc64PublicCatalogBootstrap = {
+        acceptedPublicPolicies: [{
+          policyEnvelope: {
+            payload: { accessPolicy: 0, contextGraphId },
+          },
+          targets: [],
+        }],
+      };
+      (agent as any).vmReconcileDispatcher = {
+        isInFlight: (key: string) => key === contextGraphId,
+      };
+      (agent as any).runVmReconcileForCg = reconcile;
+
+      const result = await agent.syncDurableRecoveryContextGraph(contextGraphId, {
+        candidatePeerIds: [PEER_A],
+        candidatesAreSyncCapable: true,
+      });
+
+      expect(result).toMatchObject({
+        outcome: 'no-progress',
+        slices: 0,
+        peerId: PEER_A,
+        safeOffset: 0,
+        result: { complete: false },
+      });
+      expect(reconcile).not.toHaveBeenCalled();
+    } finally {
+      // The minimal dispatcher above is intentionally not a production queue;
+      // clear it before stop() attempts the normal dispatcher drain.
+      (agent as any).vmReconcileDispatcher = null;
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('reports a selected-public VM reconcile exception as a failed peer attempt', async () => {
+    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    const contextGraphId = 'selected-public-reconcile-failure';
+    try {
+      (agent as any).config.syncContextGraphs = [contextGraphId];
+      (agent as any).config.rfc64PublicCatalogBootstrap = {
+        acceptedPublicPolicies: [{
+          policyEnvelope: {
+            payload: { accessPolicy: 0, contextGraphId },
+          },
+          targets: [],
+        }],
+      };
+      (agent as any).runVmReconcileForCg = vi.fn(async () => {
+        throw new Error('chain inventory unavailable');
+      });
+
+      const result = await agent.syncDurableRecoveryContextGraph(contextGraphId, {
+        candidatePeerIds: [PEER_A],
+        candidatesAreSyncCapable: true,
+      });
+
+      expect(result).toMatchObject({
+        outcome: 'no-progress',
+        slices: 1,
+        peerId: PEER_A,
+        result: { complete: false, failedPeers: 1 },
+        peerResults: [{ peerId: PEER_A, result: { failedPeers: 1 } }],
+      });
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
   it('reopens reconcile and membership persistence admission on same-object restart', async () => {
     const membershipUpsert = vi.fn(async () => undefined);
     const agent = await createAgentWithSend(

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -155,6 +155,79 @@ async function createAgentWithSend(
 }
 
 describe('exact VM recovery lifecycle', () => {
+  it('routes selected public VM catch-up through chain inventory without a broad durable pull', async () => {
+    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    const contextGraphId = 'selected-public-chain-inventory';
+    const broadDurableSync = vi.fn(async () => cleanDurableSyncResult());
+    const reconcile = vi.fn()
+      .mockResolvedValueOnce({
+        contextGraphId,
+        onChainId: '77',
+        source: 'manual',
+        status: 'progress',
+        attempted: true,
+        headOrdinal: 500,
+        watermarkBefore: 100,
+        watermarkAfter: 110,
+        reconciledOrdinals: 8,
+        unresolvedOrdinals: 2,
+      })
+      .mockResolvedValueOnce({
+        contextGraphId,
+        onChainId: '77',
+        source: 'manual',
+        status: 'current',
+        attempted: true,
+        headOrdinal: 500,
+        watermarkBefore: 490,
+        watermarkAfter: 500,
+        reconciledOrdinals: 10,
+        unresolvedOrdinals: 0,
+      });
+    try {
+      (agent as any).config.syncContextGraphs = [contextGraphId];
+      (agent as any).config.rfc64PublicCatalogBootstrap = {
+        acceptedPublicPolicies: [{
+          policyEnvelope: {
+            payload: { accessPolicy: 0, contextGraphId },
+          },
+          targets: [],
+        }],
+      };
+      (agent as any).runVmReconcileForCg = reconcile;
+      (agent as any).syncFromPeerDetailed = broadDurableSync;
+
+      const progress = await agent.syncDurableRecoveryContextGraph(contextGraphId, {
+        candidatePeerIds: [PEER_A],
+        candidatesAreSyncCapable: true,
+      });
+      expect(progress).toMatchObject({
+        outcome: 'partial-progress',
+        slices: 1,
+        peerId: PEER_A,
+        safeOffset: 110,
+        result: { complete: false, checkpointAdvances: 1 },
+      });
+
+      const current = await agent.syncDurableRecoveryContextGraph(contextGraphId, {
+        candidatePeerIds: [PEER_A],
+        candidatesAreSyncCapable: true,
+      });
+      expect(current).toMatchObject({
+        outcome: 'terminal',
+        slices: 1,
+        peerId: PEER_A,
+        safeOffset: 500,
+        result: { complete: true, completedPhases: 1, checkpointAdvances: 1 },
+      });
+      expect(reconcile).toHaveBeenCalledTimes(2);
+      expect(reconcile).toHaveBeenNthCalledWith(1, contextGraphId, 'manual');
+      expect(broadDurableSync).not.toHaveBeenCalled();
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
   it('reopens reconcile and membership persistence admission on same-object restart', async () => {
     const membershipUpsert = vi.fn(async () => undefined);
     const agent = await createAgentWithSend(

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -218,7 +218,12 @@ describe('exact VM recovery lifecycle', () => {
         slices: 1,
         peerId: PEER_A,
         safeOffset: 500,
-        result: { complete: true, completedPhases: 1, checkpointAdvances: 1 },
+        result: {
+          complete: true,
+          completedPhases: 1,
+          checkpointAdvances: 1,
+          selectedVmTerminalCompletions: 1,
+        },
       });
       expect(reconcile).toHaveBeenCalledTimes(2);
       expect(reconcile).toHaveBeenNthCalledWith(1, contextGraphId, 'manual');
@@ -1348,6 +1353,46 @@ describe('DKGAgent sync fetch coalescing', () => {
       expect(result.peersResponded).toBe(1);
       expect(result.dataSynced).toBe(40_000);
       expect(agent.getSubscribedContextGraphs().get('coalesced-cg')?.synced).not.toBe(true);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('promotes selected-public VM readiness from a clean chain-terminal result', async () => {
+    const agent = await createAgentWithSend(async () => new Uint8Array(0));
+    const contextGraphId = 'selected-public-terminal-readiness';
+    const remotePeer = { toString: () => PEER_A };
+
+    try {
+      await agent.start();
+      agent.subscribeToContextGraph(contextGraphId);
+      (agent as any).config.syncContextGraphs = [contextGraphId];
+      (agent as any).waitForSyncProtocol = async () => true;
+      (agent as any).refreshMetaSyncedFlags = async () => undefined;
+      (agent as any).syncDurableRecoveryContextGraph = async () => {
+        const result = {
+          ...cleanDurableSyncResult(),
+          selectedVmTerminalCompletions: 1,
+        };
+        return {
+          outcome: 'terminal',
+          result,
+          peerResults: [{ peerId: PEER_A, result }],
+          slices: 1,
+          peerId: PEER_A,
+          safeOffset: 500,
+        };
+      };
+
+      const result = await (agent as any).runCatchupOverPeers(
+        contextGraphId,
+        false,
+        [remotePeer],
+      );
+
+      expect(result.peersSucceeded).toBe(1);
+      expect(result.diagnostics.durable.selectedVmTerminalCompletions).toBe(1);
+      expect(agent.getSubscribedContextGraphs().get(contextGraphId)?.synced).toBe(true);
     } finally {
       await agent.stop().catch(() => {});
     }

--- a/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
+++ b/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
@@ -7,6 +7,7 @@ import {
   knowledgeAssetLayerGraphUri,
 } from '@origintrail-official/dkg-core';
 import {
+  createResponderExactGraphPagePlanMemo,
   createResponderGraphListMemo,
   createResponderSubGraphRegistrationMemo,
 } from '../src/sync/responder/graph-plan.js';
@@ -1545,5 +1546,46 @@ describe('sync responder pagination interleaving', () => {
       bindings: [{ sg: `${cgPrefix}/new`, name: '"new"' }],
     });
     await expect(newSubgraphSession).resolves.toEqual(['new']);
+  });
+
+  it('does not give a newer exact-plan session the superseded pending plan', async () => {
+    const oldPlan = deferred<any>();
+    const newPlan = deferred<any>();
+    const memo = createResponderExactGraphPagePlanMemo();
+    let loads = 0;
+    const load = () => {
+      loads++;
+      return loads === 1 ? oldPlan.promise : newPlan.promise;
+    };
+
+    const oldSession = memo.get('peer:cg:asset', load, {
+      refresh: true,
+      refreshGeneration: 'old-session',
+    });
+    const newSession = memo.get('peer:cg:asset', load, {
+      refresh: true,
+      refreshGeneration: 'new-session',
+    });
+    await Promise.resolve();
+    expect(loads).toBe(1);
+
+    oldPlan.resolve({
+      entries: [{ graph: 'urn:graph:old', rowCount: 1 }],
+      totalRows: 1,
+      pagedGraphs: new Set(),
+    });
+    await expect(oldSession).resolves.toMatchObject({
+      entries: [{ graph: 'urn:graph:old' }],
+    });
+    await vi.waitFor(() => expect(loads).toBe(2));
+
+    newPlan.resolve({
+      entries: [{ graph: 'urn:graph:new', rowCount: 2 }],
+      totalRows: 2,
+      pagedGraphs: new Set(),
+    });
+    await expect(newSession).resolves.toMatchObject({
+      entries: [{ graph: 'urn:graph:new' }],
+    });
   });
 });

--- a/packages/agent/test/vm-reconcile-self-prime.test.ts
+++ b/packages/agent/test/vm-reconcile-self-prime.test.ts
@@ -348,6 +348,60 @@ describe('GH #1098 — VM reconcile sweep self-primes onChainId for a pre-subscr
     )).toBe(false);
   });
 
+  it('persists a VM watermark across non-binding subscription readiness updates', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({
+      name: 'VmReconcileWatermarkSnapshotRefresh',
+      chainAdapter: chain,
+      nodeRole: 'edge',
+    });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const contextGraphId = 'vm-reconcile-watermark-refresh';
+    const initial = {
+      subscribed: true,
+      synced: false,
+      metaSynced: false,
+      sharedMemorySynced: false,
+      onChainId: '298',
+      lastReconciledOrdinal: 0,
+      syncMode: 'always-on' as const,
+    };
+    internals.subscribedContextGraphs.set(contextGraphId, initial);
+    const target = await (internals as any).resolveVmReconcileTarget(contextGraphId);
+
+    (internals as any).setContextGraphSubscription(
+      contextGraphId,
+      {
+        ...initial,
+        synced: true,
+        metaSynced: true,
+        sharedMemorySynced: true,
+      },
+      { persist: false },
+    );
+    const persisted = vi.fn(async (
+      _id: string,
+      candidate: { lastReconciledOrdinal?: number },
+      _signal: AbortSignal | undefined,
+      isCurrent: () => boolean,
+    ) => {
+      expect(candidate.lastReconciledOrdinal).toBe(17);
+      expect(isCurrent()).toBe(true);
+    });
+    (internals as any).persistContextGraphSubscriptionStrict = persisted;
+
+    await (internals as any).persistVmReconcileWatermark(contextGraphId, 17, target);
+
+    expect(persisted).toHaveBeenCalledOnce();
+    expect(internals.subscribedContextGraphs.get(contextGraphId)).toMatchObject({
+      synced: true,
+      metaSynced: true,
+      sharedMemorySynced: true,
+      lastReconciledOrdinal: 17,
+    });
+  });
+
   it('preserves selected-only chain binding safety failures without creating cursor state', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'Rfc64SelectedVmAmbiguousBinding', chainAdapter: chain });

--- a/packages/agent/test/vm-reconcile-self-prime.test.ts
+++ b/packages/agent/test/vm-reconcile-self-prime.test.ts
@@ -291,6 +291,63 @@ describe('GH #1098 — VM reconcile sweep self-primes onChainId for a pre-subscr
     expect(deps.recentOrdinalsPerPass).toBe(0);
   });
 
+  it('keeps an active VM target current across non-binding subscription readiness updates', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({
+      name: 'VmReconcileSubscriptionSnapshotRefresh',
+      chainAdapter: chain,
+      nodeRole: 'edge',
+    });
+    stubNode(agent);
+    const internals = agent as unknown as AgentInternals;
+    const contextGraphId = 'vm-reconcile-readiness-refresh';
+    const initial = {
+      subscribed: true,
+      synced: false,
+      metaSynced: false,
+      sharedMemorySynced: false,
+      onChainId: '298',
+      syncMode: 'always-on' as const,
+    };
+    internals.subscribedContextGraphs.set(contextGraphId, initial);
+
+    const target = await (internals as any).resolveVmReconcileTarget(contextGraphId);
+    const lifecycleGeneration = (internals as any).vmReconcileLifecycleGeneration;
+    expect((internals as any).isVmReconcileTargetCurrent(
+      contextGraphId,
+      target,
+      lifecycleGeneration,
+    )).toBe(true);
+
+    // SWM/catch-up readiness bookkeeping replaces the immutable subscription
+    // record but does not alter membership, the on-chain binding, or the VM
+    // cursor.  That must not abort an otherwise valid VM recovery slice.
+    (internals as any).setContextGraphSubscription(
+      contextGraphId,
+      {
+        ...initial,
+        synced: true,
+        metaSynced: true,
+        sharedMemorySynced: true,
+      },
+      { persist: false },
+    );
+    expect(internals.subscribedContextGraphs.get(contextGraphId)).not.toBe(initial);
+    expect((internals as any).isVmReconcileTargetCurrent(
+      contextGraphId,
+      target,
+      lifecycleGeneration,
+    )).toBe(true);
+
+    // A real ownership transition still clears the cursor and fails closed.
+    (internals as any).unsubscribeFromContextGraph(contextGraphId, { persist: false });
+    expect((internals as any).isVmReconcileTargetCurrent(
+      contextGraphId,
+      target,
+      lifecycleGeneration,
+    )).toBe(false);
+  });
+
   it('preserves selected-only chain binding safety failures without creating cursor state', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'Rfc64SelectedVmAmbiguousBinding', chainAdapter: chain });

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -221,6 +221,18 @@ export class ProtocolRouter {
    * anyway.
    */
   private readonly peerWireVariant = new Map<string, Map<string, 'pooled' | 'one-shot'>>();
+  /**
+   * Relay circuits are reliable for bounded one-shot requests, but opening two
+   * authenticated sync streams to the same relay-only peer concurrently makes
+   * libp2p race the circuit's stream negotiation. The losing request commonly
+   * fails with `Remote closed connection during opening`, then rebuilds and
+   * retries the whole authenticated page.
+   *
+   * Keep one FIFO tail per peer for SINGLE-USE payloads only. Direct peers and
+   * reusable payloads retain their existing parallelism, and different relay
+   * peers never block one another.
+   */
+  private readonly relaySingleUseTails = new Map<string, Promise<void>>();
 
   constructor(node: DKGNode, options?: ProtocolRouterOptions) {
     this.node = node;
@@ -577,7 +589,12 @@ export class ProtocolRouter {
     try {
       const res = await withSpan(
         'protocol_router.send',
-        () => this.sendInner(peerIdStr, protocolId, data, timeoutMsOrOpts),
+        () => this.sendWithRelaySingleUseAdmission(
+          peerIdStr,
+          protocolId,
+          data,
+          timeoutMsOrOpts,
+        ),
         { attributes: { 'dkg.protocol_id': protocolId, 'dkg.peer': peerIdStr.slice(0, 8) } },
       );
       m.protocolSendTotal.add(1, { protocol_id: protocolId, outcome: 'ok' });
@@ -587,6 +604,50 @@ export class ProtocolRouter {
       throw err;
     } finally {
       m.protocolSendDuration.record(Date.now() - startedAt, { protocol_id: protocolId });
+    }
+  }
+
+  private async sendWithRelaySingleUseAdmission(
+    peerIdStr: string,
+    protocolId: string,
+    data: Uint8Array,
+    timeoutMsOrOpts: number | SendOptions,
+  ): Promise<Uint8Array> {
+    const opts: SendOptions = typeof timeoutMsOrOpts === 'number'
+      ? { timeoutMs: timeoutMsOrOpts }
+      : timeoutMsOrOpts;
+    if (
+      opts.payloadReuse !== 'single-use'
+      || !this.peerHasOnlyRelayedConnections(peerIdStr)
+    ) {
+      return this.sendInner(peerIdStr, protocolId, data, timeoutMsOrOpts);
+    }
+
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_SEND_TIMEOUT_MS;
+    const startedAt = Date.now();
+    const deadline = AbortSignal.timeout(timeoutMs);
+    const callerBudget = composeAbortSignalsScoped(deadline, opts.signal);
+    const queueBudget = composeAbortSignalsScoped(callerBudget.signal, this.node.stopSignal);
+    let release: (() => void) | undefined;
+    try {
+      release = await this.acquireRelaySingleUseTurn(
+        peerIdStr,
+        queueBudget.signal ?? deadline,
+      );
+      const remainingMs = Math.max(0, timeoutMs - (Date.now() - startedAt));
+      if (remainingMs === 0 || deadline.aborted) {
+        throw new Error(
+          `send timeout: relay single-use queue exhausted the ${timeoutMs}ms budget`,
+        );
+      }
+      return await this.sendInner(peerIdStr, protocolId, data, {
+        ...opts,
+        timeoutMs: remainingMs,
+      });
+    } finally {
+      release?.();
+      queueBudget.dispose();
+      callerBudget.dispose();
     }
   }
 
@@ -1056,6 +1117,40 @@ export class ProtocolRouter {
       }
     }
     throw lastErr;
+  }
+
+  /**
+   * Acquire one abortable FIFO turn for a single-use send to a relay-only peer.
+   * The caller's already-running overall deadline includes queue wait, so a
+   * stalled predecessor cannot silently extend the public send timeout.
+   */
+  private async acquireRelaySingleUseTurn(
+    peerIdStr: string,
+    signal: AbortSignal,
+  ): Promise<() => void> {
+    const predecessor = (this.relaySingleUseTails.get(peerIdStr) ?? Promise.resolve())
+      .catch(() => undefined);
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    const tail = predecessor.then(() => gate);
+    this.relaySingleUseTails.set(peerIdStr, tail);
+
+    const release = (): void => {
+      releaseGate();
+      if (this.relaySingleUseTails.get(peerIdStr) === tail) {
+        this.relaySingleUseTails.delete(peerIdStr);
+      }
+    };
+
+    try {
+      await waitForPromiseOrAbort(predecessor, signal);
+      return release;
+    } catch (error) {
+      release();
+      throw error;
+    }
   }
 
   /**
@@ -1645,6 +1740,31 @@ function composeAbortSignalsScoped(
     secondary.addEventListener('abort', forwardSecondary, { once: true });
   }
   return { signal: combined.signal, dispose: cleanup };
+}
+
+function waitForPromiseOrAbort(
+  promise: Promise<unknown>,
+  signal: AbortSignal,
+): Promise<void> {
+  if (signal.aborted) return Promise.reject(asAbortError(signal.reason));
+  return new Promise<void>((resolve, reject) => {
+    const cleanup = (): void => signal.removeEventListener('abort', onAbort);
+    const onAbort = (): void => {
+      cleanup();
+      reject(asAbortError(signal.reason));
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      () => {
+        cleanup();
+        resolve();
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
 }
 
 function abortStream(stream: AbortableByteStream, reason: unknown): void {

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -1137,11 +1137,19 @@ export class ProtocolRouter {
     const tail = predecessor.then(() => gate);
     this.relaySingleUseTails.set(peerIdStr, tail);
 
-    const release = (): void => {
-      releaseGate();
+    // Keep the composed tail installed until every predecessor ahead of this
+    // turn has settled. A caller may abandon its queued turn before the
+    // predecessor finishes; deleting the map entry at that point would let a
+    // later send bypass the still-active predecessor and reopen the relay
+    // stream collision this admission queue is meant to prevent.
+    void tail.then(() => {
       if (this.relaySingleUseTails.get(peerIdStr) === tail) {
         this.relaySingleUseTails.delete(peerIdStr);
       }
+    });
+
+    const release = (): void => {
+      releaseGate();
     };
 
     try {

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -989,6 +989,181 @@ describe('ProtocolRouter', () => {
       expect(retired).toEqual([FAKE_PEER_ID]);
     });
 
+    it('serializes concurrent single-use sends over one relay circuit', async () => {
+      let firstRelease!: () => void;
+      let secondRelease!: () => void;
+      const firstGate = new Promise<void>((resolve) => { firstRelease = resolve; });
+      const secondGate = new Promise<void>((resolve) => { secondRelease = resolve; });
+      let newStreamCalls = 0;
+      const relayedConn = makeConn({
+        remoteAddr: `/ip4/9.9.9.9/tcp/4001/p2p/QmRelay/p2p-circuit/p2p/${FAKE_PEER_ID}`,
+        limits: { bytes: 1024 * 1024 },
+        newStream: async () => {
+          newStreamCalls += 1;
+          const call = newStreamCalls;
+          const gate = call === 1 ? firstGate : secondGate;
+          return {
+            writeStatus: 'open' as const,
+            send: () => undefined,
+            close: async () => undefined,
+            abort: () => undefined,
+            async *[Symbol.asyncIterator]() {
+              await gate;
+              yield new Uint8Array([call]);
+            },
+          } as any;
+        },
+      });
+      const router = makeRouterWithPool({
+        connections: () => [relayedConn],
+        poolSend: async () => {
+          throw new Error('pool must not be used for a relay-only peer');
+        },
+      });
+
+      const first = router.send(
+        FAKE_PEER_ID,
+        PROTOCOL_ID,
+        new Uint8Array([1]),
+        { timeoutMs: 5_000, payloadReuse: 'single-use' },
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(newStreamCalls).toBe(1);
+
+      const second = router.send(
+        FAKE_PEER_ID,
+        PROTOCOL_ID,
+        new Uint8Array([2]),
+        { timeoutMs: 5_000, payloadReuse: 'single-use' },
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(newStreamCalls).toBe(1);
+
+      firstRelease();
+      await expect(first).resolves.toEqual(new Uint8Array([1]));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(newStreamCalls).toBe(2);
+      secondRelease();
+      await expect(second).resolves.toEqual(new Uint8Array([2]));
+    });
+
+    it('removes an aborted queued relay send without poisoning the peer FIFO', async () => {
+      let firstRelease!: () => void;
+      const firstGate = new Promise<void>((resolve) => { firstRelease = resolve; });
+      let newStreamCalls = 0;
+      const relayedConn = makeConn({
+        remoteAddr: `/ip4/9.9.9.9/tcp/4001/p2p/QmRelay/p2p-circuit/p2p/${FAKE_PEER_ID}`,
+        limits: { bytes: 1024 * 1024 },
+        newStream: async () => {
+          newStreamCalls += 1;
+          const call = newStreamCalls;
+          return {
+            writeStatus: 'open' as const,
+            send: () => undefined,
+            close: async () => undefined,
+            abort: () => undefined,
+            async *[Symbol.asyncIterator]() {
+              if (call === 1) await firstGate;
+              yield new Uint8Array([call]);
+            },
+          } as any;
+        },
+      });
+      const router = makeRouterWithPool({
+        connections: () => [relayedConn],
+        poolSend: async () => {
+          throw new Error('pool must not be used for a relay-only peer');
+        },
+      });
+
+      const first = router.send(
+        FAKE_PEER_ID,
+        PROTOCOL_ID,
+        new Uint8Array([1]),
+        { timeoutMs: 5_000, payloadReuse: 'single-use' },
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const abort = new AbortController();
+      const abandoned = router.send(
+        FAKE_PEER_ID,
+        PROTOCOL_ID,
+        new Uint8Array([2]),
+        { timeoutMs: 5_000, payloadReuse: 'single-use', signal: abort.signal },
+      );
+      abort.abort(new Error('caller left the queue'));
+      await expect(abandoned).rejects.toMatchObject({ name: 'AbortError' });
+      expect(newStreamCalls).toBe(1);
+
+      const third = router.send(
+        FAKE_PEER_ID,
+        PROTOCOL_ID,
+        new Uint8Array([3]),
+        { timeoutMs: 5_000, payloadReuse: 'single-use' },
+      );
+      firstRelease();
+      await expect(first).resolves.toEqual(new Uint8Array([1]));
+      await expect(third).resolves.toEqual(new Uint8Array([2]));
+      expect(newStreamCalls).toBe(2);
+    });
+
+    it('keeps single-use relay sends parallel across different peers', async () => {
+      const otherPeerId = '12D3KooWPFB8ffBchKzMKNC1ntcfYhru7uY6XJSVsw5MuVZhbqfz';
+      let firstRelease!: () => void;
+      const firstGate = new Promise<void>((resolve) => { firstRelease = resolve; });
+      let firstPeerStreams = 0;
+      let otherPeerStreams = 0;
+      const firstConn = makeConn({
+        remoteAddr: `/ip4/9.9.9.9/tcp/4001/p2p/QmRelay/p2p-circuit/p2p/${FAKE_PEER_ID}`,
+        limits: { bytes: 1024 * 1024 },
+        newStream: async () => {
+          firstPeerStreams += 1;
+          return {
+            ...makeStubStream(new Uint8Array([1])),
+            async *[Symbol.asyncIterator]() {
+              await firstGate;
+              yield new Uint8Array([1]);
+            },
+          } as any;
+        },
+      });
+      const otherConn = makeConn({
+        remotePeerStr: otherPeerId,
+        remoteAddr: `/ip4/8.8.8.8/tcp/4001/p2p/QmRelay/p2p-circuit/p2p/${otherPeerId}`,
+        limits: { bytes: 1024 * 1024 },
+        newStream: async () => {
+          otherPeerStreams += 1;
+          return makeStubStream(new Uint8Array([2])) as any;
+        },
+      });
+      const router = makeRouterWithPool({
+        connections: () => [firstConn, otherConn],
+        poolSend: async () => {
+          throw new Error('pool must not be used for a relay-only peer');
+        },
+      });
+
+      const first = router.send(
+        FAKE_PEER_ID,
+        PROTOCOL_ID,
+        new Uint8Array([1]),
+        { timeoutMs: 5_000, payloadReuse: 'single-use' },
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      const other = router.send(
+        otherPeerId,
+        PROTOCOL_ID,
+        new Uint8Array([2]),
+        { timeoutMs: 5_000, payloadReuse: 'single-use' },
+      );
+
+      await expect(other).resolves.toEqual(new Uint8Array([2]));
+      expect(firstPeerStreams).toBe(1);
+      expect(otherPeerStreams).toBe(1);
+      firstRelease();
+      await expect(first).resolves.toEqual(new Uint8Array([1]));
+    });
+
     it('keeps the pooled path when a direct connection is present alongside a relayed one', async () => {
       let poolSends = 0;
       let newStreamCalls = 0;

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -1101,6 +1101,70 @@ describe('ProtocolRouter', () => {
         new Uint8Array([3]),
         { timeoutMs: 5_000, payloadReuse: 'single-use' },
       );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(newStreamCalls).toBe(1);
+
+      firstRelease();
+      await expect(first).resolves.toEqual(new Uint8Array([1]));
+      await expect(third).resolves.toEqual(new Uint8Array([2]));
+      expect(newStreamCalls).toBe(2);
+    });
+
+    it('charges queued relay wait to the send timeout without poisoning the FIFO', async () => {
+      let firstRelease!: () => void;
+      const firstGate = new Promise<void>((resolve) => { firstRelease = resolve; });
+      let newStreamCalls = 0;
+      const relayedConn = makeConn({
+        remoteAddr: `/ip4/9.9.9.9/tcp/4001/p2p/QmRelay/p2p-circuit/p2p/${FAKE_PEER_ID}`,
+        limits: { bytes: 1024 * 1024 },
+        newStream: async () => {
+          newStreamCalls += 1;
+          const call = newStreamCalls;
+          return {
+            writeStatus: 'open' as const,
+            send: () => undefined,
+            close: async () => undefined,
+            abort: () => undefined,
+            async *[Symbol.asyncIterator]() {
+              if (call === 1) await firstGate;
+              yield new Uint8Array([call]);
+            },
+          } as any;
+        },
+      });
+      const router = makeRouterWithPool({
+        connections: () => [relayedConn],
+        poolSend: async () => {
+          throw new Error('pool must not be used for a relay-only peer');
+        },
+      });
+
+      const first = router.send(
+        FAKE_PEER_ID,
+        PROTOCOL_ID,
+        new Uint8Array([1]),
+        { timeoutMs: 5_000, payloadReuse: 'single-use' },
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const timedOut = router.send(
+        FAKE_PEER_ID,
+        PROTOCOL_ID,
+        new Uint8Array([2]),
+        { timeoutMs: 10, payloadReuse: 'single-use' },
+      );
+      await expect(timedOut).rejects.toMatchObject({ name: 'AbortError' });
+      expect(newStreamCalls).toBe(1);
+
+      const third = router.send(
+        FAKE_PEER_ID,
+        PROTOCOL_ID,
+        new Uint8Array([3]),
+        { timeoutMs: 5_000, payloadReuse: 'single-use' },
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(newStreamCalls).toBe(1);
+
       firstRelease();
       await expect(first).resolves.toEqual(new Uint8Array([1]));
       await expect(third).resolves.toEqual(new Uint8Array([2]));


### PR DESCRIPTION
## User impact

An edge node selecting a public context graph now uses the chain as the authoritative VM inventory and actively reconciles missing finalized assets. Providers retain only the bounded exact graph plan across wire pages, avoiding repeated full manifest scans while keeping payload rows page-only.

RFC-64 catalogs remain SWM-only. This PR does not create a second VM catalog and does not sync every public context graph.

## Before

```mermaid
sequenceDiagram
    participant E as Selected edge node
    participant C as Chain
    participant P as Provider
    E->>P: Recover selected SWM from RFC-64 catalog
    E->>C: Observe finalized VM inventory gradually
    loop Every 64-row exact page
        E->>P: Request next exact VM page
        P->>P: Rebuild exact manifest plan
        P-->>E: One page
    end
    Note over E,P: VM completion can lag or time out
```

## After

```mermaid
sequenceDiagram
    participant E as Selected edge node
    participant C as Chain
    participant P as Provider
    E->>P: Recover selected SWM from RFC-64 catalog
    E->>C: Read bounded finalized VM inventory slice
    E->>P: Request missing exact VM assets
    P->>P: Build and retain bounded graph plan
    loop Conservative 64-row payload pages
        P-->>E: Next verified page
    end
    E->>E: Verify and materialize exact finalized graphs
```

## Safety

- Selection remains explicit and CG-scoped; there is no sync-all edge behavior.
- The blockchain remains the VM inventory and integrity authority.
- The retained plan contains graph IRIs and committed counts only, never payload rows.
- Existing authentication, paging, digest checks, and false-signature protections remain in force.
- Reconciliation is one bounded pass per selected-CG scheduling event and coalesces duplicate work.

## Validation

- Focused exact-fetch and coalescing suites: 47/47 pass.
- Broader requester, responder, and lifecycle slice: 95/95 pass.
- Agent build, type tests, package-root test, CLI build, and diff check pass.
- Testnet local receiver, cold from the corpus perspective and without manual catch-up: SWM 500/500 and VM 500/500 on exact commit 74414be9.
- The final remote-receiver run is still required before release certification.