### PR TITLE
fix(sync): harden selected recovery lifecycle

### DIFF
--- a/packages/agent/src/finalization-recovery-worker.ts
+++ b/packages/agent/src/finalization-recovery-worker.ts
@@ -93,7 +93,12 @@ export class FinalizationRecoveryWorker {
       );
     } finally {
       if (this.#running) {
-        this.schedule(selected >= this.#batchSize ? 0 : this.#pollIntervalMs);
+        // A full durable-inbox batch means that more historical work is
+        // probably ready, but it must not turn this maintenance worker into a
+        // zero-delay loop. Each item may perform several chain reads and store
+        // operations. Yielding for the normal poll interval preserves capacity
+        // for foreground publish, selected sync, and exact VM recovery work.
+        this.schedule(this.#pollIntervalMs);
       }
     }
   }

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -1550,8 +1550,10 @@ function partitionVerifiedGraphScopedAssets(
     // and receipt claim consumed by the chain authenticator below. ACLs,
     // status, timestamps, and local ordering are never accepted as trusted
     // controls from a peer.
-    const metadataQuads = (metadataBySubject.get(ual) ?? []).filter(
-      (quad) => GRAPH_SCOPED_SYNC_METADATA_PREDICATES.has(quad.predicate),
+    const metadataQuads = canonicalizeLegacyReceiptConfirmationMetadata(
+      (metadataBySubject.get(ual) ?? []).filter(
+        (quad) => GRAPH_SCOPED_SYNC_METADATA_PREDICATES.has(quad.predicate),
+      ),
     );
     const versions = new Set(
       metadataQuads
@@ -1626,6 +1628,41 @@ function partitionVerifiedGraphScopedAssets(
       ),
     ),
   };
+}
+
+/**
+ * Heal one legacy race shape without trusting the serving peer's choice of
+ * provenance lane. Older stores can contain both confirmation discriminators
+ * after a receiptless chain repair raced a later transaction receipt write.
+ * When that same envelope carries exactly one receipt hash, retain only the
+ * receipt-backed discriminator: the downstream authenticator still resolves
+ * that transaction on-chain and rejects a forged or mismatched receipt.
+ *
+ * Every other ambiguous shape remains fail-closed. In particular, dual kinds
+ * without one receipt, unknown kinds, or multiple receipt hashes are left
+ * untouched so the canonical parser rejects them.
+ */
+function canonicalizeLegacyReceiptConfirmationMetadata(metadataQuads: Quad[]): Quad[] {
+  const confirmationRows = metadataQuads.filter(
+    (quad) => quad.predicate === GRAPH_KNOWLEDGE_ASSET_CONFIRMATION_KIND_PREDICATE,
+  );
+  if (confirmationRows.length !== 2) return metadataQuads;
+
+  const confirmationKinds = new Set(confirmationRows.map((quad) => stripLiteral(quad.object)));
+  const transactionHashes = metadataQuads.filter((quad) => quad.predicate === TRANSACTION_HASH);
+  if (
+    confirmationKinds.size !== 2
+    || !confirmationKinds.has('transaction')
+    || !confirmationKinds.has('finalized-materialization')
+    || transactionHashes.length !== 1
+  ) {
+    return metadataQuads;
+  }
+
+  return metadataQuads.filter((quad) => !(
+    quad.predicate === GRAPH_KNOWLEDGE_ASSET_CONFIRMATION_KIND_PREDICATE
+    && stripLiteral(quad.object) === 'finalized-materialization'
+  ));
 }
 
 function stripLiteral(raw: string): string {

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -1041,6 +1041,7 @@ export async function readDurableMetaPage(params: {
       params.store,
       params.contextGraphId,
       params.signal,
+      params.assetUals,
     );
     const requested = new Set(params.assetUals);
     const confirmedUals = manifest.confirmedEntries
@@ -1146,9 +1147,13 @@ async function readGraphScopedVmManifest(
   store: TripleStore,
   contextGraphId: string,
   signal?: AbortSignal,
+  assetUals?: readonly string[],
 ): Promise<GraphScopedVmManifest> {
   const metaGraph = contextGraphMetaGraphUri(contextGraphId);
   const contextGraph = contextGraphDataGraphUri(contextGraphId);
+  const exactUalClause = assetUals === undefined
+    ? ''
+    : `VALUES ?ual { ${subjectValues(assetUals)} }`;
   const maxRows = SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS;
   const readBoundedBindings = async (
     sparql: string,
@@ -1191,6 +1196,7 @@ async function readGraphScopedVmManifest(
   // legacy compatibility lane.
   const markerBindings = await readBoundedBindings(`
     SELECT ?ual ?scopeVersion WHERE {
+      ${exactUalClause}
       GRAPH <${assertSafeIri(metaGraph)}> {
         ?ual <${DKG_CONTENT_SCOPE_VERSION}> ?scopeVersion .
       }
@@ -1234,6 +1240,7 @@ async function readGraphScopedVmManifest(
       SELECT ?ual ?scopeVersion ?kaUal ?assertionVersion ?assertionGraph
              ?contextGraph ?publicTripleCount ?privateTripleCount ?status ?subGraphName
       WHERE {
+        ${exactUalClause}
         GRAPH <${assertSafeIri(metaGraph)}> {
           ?ual <${DKG_CONTENT_SCOPE_VERSION}> ?scopeVersion ;
                <${DKG_KA_UAL}> ?kaUal ;
@@ -1631,6 +1638,7 @@ export async function readDurableDataPage(params: {
           params.store,
           params.contextGraphId,
           planSignal,
+          params.assetUals,
         );
         const entries = manifest.confirmedEntries.filter((entry) => requested.has(entry.ual));
         return buildExactGraphPagePlan(

--- a/packages/agent/test/durable-sync-graph-scoped-materialization.test.ts
+++ b/packages/agent/test/durable-sync-graph-scoped-materialization.test.ts
@@ -686,12 +686,91 @@ describe('durable graph-scoped KA materialization', () => {
     );
   });
 
-  it.each([
-    ['conflicting', ['"transaction"', '"finalized-materialization"']],
-    ['unsupported', ['"unsupported"']],
-  ])('rejects %s peer confirmation metadata before durable materialization', async (_label, kinds) => {
+  it('normalizes the legacy dual-kind receipt envelope before chain authentication', async () => {
     const v2Data = dataQuad(2);
     const v2Meta = metadata(2);
+    v2Meta.push(
+      {
+        subject: ual,
+        predicate: `${DKG}publicTripleCount`,
+        object: `"1"^^<${XSD_INTEGER}>`,
+        graph: metaGraph,
+      },
+      {
+        subject: ual,
+        predicate: `${DKG}privateTripleCount`,
+        object: `"0"^^<${XSD_INTEGER}>`,
+        graph: metaGraph,
+      },
+      ...['"transaction"', '"finalized-materialization"'].map((object) => ({
+        subject: ual,
+        predicate: `${DKG}confirmationKind`,
+        object,
+        graph: metaGraph,
+      })),
+    );
+    const materialized: VerifiedGraphScopedAsset[] = [];
+
+    const summary = await runDurableSync({
+      ctx,
+      remotePeerId: 'peer-legacy-dual-confirmation-kind',
+      contextGraphIds: [contextGraphId],
+      durableSyncBudget: uniformDurableSyncBudget(() => Date.now() + 10_000),
+      fetchSyncPages: async ({ phase }) => (
+        phase === 'data' ? page(phase, [v2Data]) : page(phase, v2Meta)
+      ),
+      processDurableBatchInWorker: async () => ({
+        verifiedData: [v2Data],
+        verifiedMeta: v2Meta,
+        verifiedGraphScopedDataGraphs: [assertionGraph],
+        totalFetchedDataQuads: 1,
+        totalFetchedMetaQuads: v2Meta.length,
+        rejectedKcs: 0,
+        emptyResponses: 0,
+        metaOnlyResponses: 0,
+        verifiedPrivateOnlyResponses: 0,
+        dataRejectedMissingMeta: 0,
+      }),
+      storeInsert: async () => {},
+      storeGraphScopedAsset: async ({ asset }) => {
+        materialized.push(asset);
+        return 'applied';
+      },
+      deleteCheckpoint: () => {},
+      setCheckpoint: () => {},
+      logInfo: () => {},
+      logWarn: () => {},
+      logDebug: () => {},
+    });
+
+    expect(summary.failedPhases).toBe(0);
+    expect(materialized).toHaveLength(1);
+    expect(readGraphKnowledgeAssetConfirmationKindV1(materialized[0]!.metadataQuads))
+      .toBe('transaction');
+    expect(materialized[0]!.metadataQuads.filter(
+      (quad) => quad.predicate === `${DKG}confirmationKind`,
+    )).toHaveLength(1);
+  });
+
+  it.each([
+    ['dual-kind without a receipt', ['"transaction"', '"finalized-materialization"']],
+    ['dual-kind with multiple receipts', ['"transaction"', '"finalized-materialization"']],
+    ['unsupported', ['"unsupported"']],
+  ])('rejects %s peer confirmation metadata before durable materialization', async (label, kinds) => {
+    const v2Data = dataQuad(2);
+    const v2Meta = metadata(2);
+    if (label === 'dual-kind without a receipt') {
+      const receiptIndex = v2Meta.findIndex((quad) => quad.predicate === `${DKG}transactionHash`);
+      v2Meta.splice(receiptIndex, 1);
+    }
+    if (label === 'dual-kind with multiple receipts') {
+      v2Meta.push({
+        subject: ual,
+        predicate: `${DKG}transactionHash`,
+        object: `"${transactionHash(3)}"`,
+        graph: metaGraph,
+      });
+    }
     v2Meta.push(
       {
         subject: ual,

--- a/packages/agent/test/exact-asset-responder.test.ts
+++ b/packages/agent/test/exact-asset-responder.test.ts
@@ -50,6 +50,20 @@ describe('exact asset responder', () => {
     const requested = asset(1);
     const alreadyPresent = asset(2);
     await store.insert([...requested.quads, ...alreadyPresent.quads]);
+    const originalQuery = store.query.bind(store);
+    const manifestQueries: string[] = [];
+    store.query = (async (
+      sparql: string,
+      options?: Parameters<OxigraphStore['query']>[1],
+    ) => {
+      if (
+        sparql.includes('<http://dkg.io/ontology/contentScopeVersion>') &&
+        sparql.includes(`GRAPH <${contextGraphMetaGraphUri(CG_ID)}>`)
+      ) {
+        manifestQueries.push(sparql);
+      }
+      return originalQuery(sparql, options);
+    }) as typeof store.query;
 
     const meta = await readDurableMetaPage({
       store,
@@ -77,5 +91,10 @@ describe('exact asset responder', () => {
       p: 'http://schema.org/name',
       o: '"asset-1"',
     }]);
+    expect(manifestQueries).not.toHaveLength(0);
+    for (const query of manifestQueries) {
+      expect(query).toContain(`VALUES ?ual { <${requested.ual}> }`);
+      expect(query).not.toContain(`<${alreadyPresent.ual}>`);
+    }
   });
 });

--- a/packages/agent/test/finalization-recovery-worker.test.ts
+++ b/packages/agent/test/finalization-recovery-worker.test.ts
@@ -5,18 +5,26 @@ import {
 } from '../src/finalization-recovery-worker.js';
 
 describe('FinalizationRecoveryWorker', () => {
-  it('continues full batches immediately and uses the configured SQLite batch size', async () => {
+  it('yields between full batches and uses the configured SQLite batch size', async () => {
+    vi.useFakeTimers();
     const processDueBatch = vi.fn()
       .mockResolvedValueOnce(FINALIZATION_RECOVERY_WORKER_BATCH_SIZE)
       .mockResolvedValueOnce(0);
     const worker = new FinalizationRecoveryWorker(
       processDueBatch,
       { info: () => {}, warn: () => {} },
-      { pollIntervalMs: 60_000 },
+      { pollIntervalMs: 25 },
     );
     try {
       worker.start();
-      await vi.waitFor(() => expect(processDueBatch).toHaveBeenCalledTimes(2));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(processDueBatch).toHaveBeenCalledOnce();
+
+      await vi.advanceTimersByTimeAsync(24);
+      expect(processDueBatch).toHaveBeenCalledOnce();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(processDueBatch).toHaveBeenCalledTimes(2);
       expect(processDueBatch).toHaveBeenNthCalledWith(
         1,
         FINALIZATION_RECOVERY_WORKER_BATCH_SIZE,
@@ -27,6 +35,7 @@ describe('FinalizationRecoveryWorker', () => {
       );
     } finally {
       await worker.stop();
+      vi.useRealTimers();
     }
   });
 


### PR DESCRIPTION
## User impact

Long recovery work yields between bounded batches, exact VM reads cannot drift into unrelated assets, and legacy dual-confirmation records can be recovered instead of remaining permanently incomplete.

## Before

```mermaid
sequenceDiagram
    participant W as Recovery worker
    participant S as Store
    participant R as Receiver
    W->>S: Process consecutive recovery batches
    Note over W,S: Other admitted work can wait
    R->>S: Read exact VM manifest
    S-->>R: Broad or ambiguous result
    R->>R: Legacy dual record remains incomplete
```

## After

```mermaid
sequenceDiagram
    participant W as Recovery worker
    participant S as Store
    participant R as Receiver
    W->>S: Process one bounded batch
    W-->>W: Yield to admitted work
    R->>S: Read manifest scoped to exact VM assets
    S-->>R: Exact bounded result
    R->>R: Materialize compatible dual confirmation
```

## Safety

- Exact manifest scope is narrowed, never widened.
- Yielding changes scheduling, not recovery ordering or integrity checks.
- Legacy repair still requires compatible confirmation evidence.

## Validation

Focused finalization-worker, exact-asset responder, and graph-scoped durable materialization tests cover the changed behavior.