### PR TITLE
fix(sync): rotate VM recovery across connected providers

### DIFF
--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -4569,15 +4569,18 @@ export class SwmHostModeMethods extends DKGAgentBase {
     )
       .map((peer) => peer.toString());
     // Structural curators are authoritative and may contain the only holder.
-    // Ordinary connected peers are opportunistic fallback only: cap that tier
-    // separately so connection churn cannot stretch a negative cycle to 256
-    // elevated prefix downloads.
+    // Ordinary connected peers are opportunistic fallback, but they must all
+    // remain visible inside the bounded proof roster. Capping this tier at the
+    // per-pass transport limit made the same three high-ranked peers the entire
+    // roster forever, so a fourth connected replica could never be reached.
+    // `VmRecoveryProviderPolicy` still caps each physical pass below; retaining
+    // the larger bounded roster only lets subsequent passes continue rotation.
     const boundedCurators = [...new Set(curatorOrder)]
       .slice(0, DKGAgentBase.VM_RECONCILE_EXACT_ROSTER_MAX);
     const curatorSet = new Set(boundedCurators);
-    const ordinaryBudget = Math.min(
-      DKGAgentBase.VM_RECONCILE_EXACT_PEER_MAX,
-      Math.max(0, DKGAgentBase.VM_RECONCILE_EXACT_ROSTER_MAX - boundedCurators.length),
+    const ordinaryBudget = Math.max(
+      0,
+      DKGAgentBase.VM_RECONCILE_EXACT_ROSTER_MAX - boundedCurators.length,
     );
     const boundedOrdinary = ordinaryOrder
       .filter((peerId) => !curatorSet.has(peerId))

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -3387,6 +3387,65 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect(curatorResolutions).toBe(4);
   });
 
+  it('continues exact recovery past the per-pass peer cap to a later connected holder', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmLaterConnectedHolder', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const peers = [
+      '12D3KooWLaterConnectedA',
+      '12D3KooWLaterConnectedB',
+      '12D3KooWLaterConnectedC',
+      '12D3KooWLaterConnectedHolder',
+    ];
+    const holderPeerId = peers[3]!;
+    const localCgId = '0x0000000000000000000000000000000000000001/later-holder';
+    const connected = peers.map((peerId) => ({ toString: () => peerId }));
+    (internals as any).node = {
+      peerId: '12D3KooWLaterConnectedLocal',
+      libp2p: { getConnections: () => connected.map((remotePeer) => ({ remotePeer })) },
+    };
+    (internals as any).resolveCuratorPeerIdsForCg = async () => ({
+      peerIds: [], curatorIsLocal: true, legacyTripleResolved: false, lookupFailed: false,
+    });
+    (internals as any).ensurePeerConnected = async () => undefined;
+    (internals as any).selectCatchupPeers = (ordered: Array<{ toString(): string }>) => ordered;
+    (internals as any).waitForSyncProtocol = async () => true;
+    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+    const attempts: string[] = [];
+    let lastPeerId: string | undefined;
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (peerId: string) => {
+      attempts.push(peerId);
+      lastPeerId = peerId;
+      const found = peerId === holderPeerId;
+      return {
+        result: {
+          fetchedDataTriples: found ? 1 : 0,
+          fetchedMetaTriples: found ? 8 : 0,
+          insertedTriples: found ? 9 : 0,
+          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: found ? 'found' : 'clean-absent',
+      };
+    };
+    const target = vmRecoveryTarget(localCgId, 0, 'later-holder');
+    (internals as any).reconcileChainOrdinal = async () => (
+      lastPeerId === holderPeerId
+        ? { status: 'reconciled', blockNumber: 100 }
+        : { status: 'pending', recovery: target }
+    );
+
+    let result;
+    for (let pass = 0; pass < peers.length; pass += 1) {
+      result = await internals.recoverVmReconcileBatch(
+        localCgId, 1n, [target], 100, () => true,
+      );
+      (internals as any).vmReconcileFetchCooldowns.delete(localCgId);
+    }
+
+    expect(attempts).toEqual(peers);
+    expect(result?.outcomes.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
+  });
+
   it('ranks a resolved structural curator ahead of an ordinary capped roster', async () => {
     const chain = new MockChainAdapter();
     agent = await DKGAgent.create({ name: 'ExactVmResolvedCuratorRoster', chainAdapter: chain });


### PR DESCRIPTION
## Impact

A VM receiver currently bounds the *candidate roster* to the same three high-ranked connected peers. If those peers do not hold a missing KA, a fourth connected replica is never attempted—even across later reconciliation passes.

This change keeps all connected candidates inside the existing bounded roster while preserving the current maximum of three physical providers considered per pass. Retry state advances through the roster across passes, so a later replica can repair the VM gap without increasing one pass's network or store pressure.

### Before

```mermaid
sequenceDiagram
    participant R as Receiver
    participant P1 as Provider 1
    participant P2 as Provider 2
    participant P3 as Provider 3
    participant P4 as Provider 4 with asset
    loop Every reconcile pass
        R->>P1: Exact VM probe
        P1-->>R: Clean absence
        R->>P2: Exact VM probe
        P2-->>R: Clean absence
        R->>P3: Exact VM probe
        P3-->>R: Clean absence
        Note over R,P4: Provider 4 was removed from the roster
    end
```

### After

```mermaid
sequenceDiagram
    participant R as Receiver
    participant P1 as Provider 1
    participant P2 as Provider 2
    participant P3 as Provider 3
    participant P4 as Provider 4 with asset
    R->>P1: Exact VM probe
    P1-->>R: Clean absence
    R->>P2: Exact VM probe
    P2-->>R: Clean absence
    R->>P3: Exact VM probe
    P3-->>R: Clean absence
    Note over R: Per-pass provider budget remains bounded
    R->>P4: Next-pass exact VM probe
    P4-->>R: Exact asset
    R->>R: Verify against chain and install
```

## Validation

- `core-fills-gap.test.ts`: 124/124 passed
- New regression proves a fourth connected holder is reached only after the first three return clean absence
- Agent build, type tests, package-root check: passed on the combined runtime candidate
- Full Testnet Blackbox validation is in progress; no dashboard/observer is running
