### PR TITLE
fix(sync): resume selected SWM snapshot walks

### DIFF
--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -282,8 +282,8 @@ export interface SharedMemoryMetadataFetchOutcome {
  * it, so a skipped ref can never outlive the evidence that justified the skip.
  */
 export interface SharedMemorySnapshotWalkContinuation {
-  /** Exact ordered manifest that owns every resolved ref below. */
-  readonly orderedManifest: readonly PublicSnapshotMetadata[];
+  /** Take an immutable copy of the exact ordered manifest owning the resolved refs below. */
+  orderedManifestSnapshot(): readonly PublicSnapshotMetadata[];
   /** Query live owner state without exposing its mutable backing collection. */
   isResolved(ref: string): boolean;
   resolvedCount(): number;
@@ -1558,7 +1558,7 @@ export async function syncPublicSnapshotsForMeta(params: {
     ? []
     : collectPublicSnapshotMetadata(params.metaQuads);
   const snapshots = params.snapshotWalk
-    ? [...params.snapshotWalk.orderedManifest]
+    ? params.snapshotWalk.orderedManifestSnapshot()
     : params.recoveryOrder === 'recent-balanced'
       ? orderPublicSnapshotsForBalancedRecency(manifestSnapshots)
       : manifestSnapshots;

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -274,13 +274,34 @@ export interface SharedMemoryMetadataFetchOutcome {
  * Selected-provider snapshot progress bound to one exact, ordered manifest.
  *
  * The owner keeps only refs whose content was already materialized locally.
- * A changed manifest replaces the owner, and a process restart drops it, so a
- * skipped ref can never outlive the evidence that justified the skip.
+ * A changed manifest replaces the continuation, and a process restart drops
+ * it, so a skipped ref can never outlive the evidence that justified the skip.
  */
 export interface SharedMemorySnapshotWalkContinuation {
+  /** Exact ordered manifest that owns every resolved ref below. */
+  readonly orderedManifest: readonly PublicSnapshotMetadata[];
   readonly resolvedRefs: ReadonlySet<string>;
   markResolved(ref: string): void;
 }
+
+type PublicSnapshotWalkSource =
+  | {
+    /** Ordinary lanes derive their walk from the verified metadata page. */
+    readonly metaQuads: readonly Quad[];
+    readonly recoveryOrder?: 'manifest' | 'recent-balanced';
+    readonly snapshotWalk?: never;
+  }
+  | {
+    /**
+     * Selected lanes pass one manifest-bound continuation value. Keeping the
+     * order and its resolved-ref evidence in the same object makes it
+     * impossible to combine metadata from one manifest with skip evidence
+     * from another.
+     */
+    readonly snapshotWalk: SharedMemorySnapshotWalkContinuation;
+    readonly metaQuads?: never;
+    readonly recoveryOrder?: never;
+  };
 
 /**
  * Strategy boundary for metadata retrieval.
@@ -1163,10 +1184,12 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         remotePeerId,
         contextGraphId: pid,
         deadline,
-        metaQuads: processed.verifiedMeta,
-        recoveryOrder: snapshotRecoveryOrder,
-        orderedSnapshots: orderedManifestSnapshots,
-        resolvedSnapshotRefs: snapshotWalk?.resolvedRefs,
+        ...(snapshotWalk
+          ? { snapshotWalk }
+          : {
+            metaQuads: processed.verifiedMeta,
+            recoveryOrder: snapshotRecoveryOrder,
+          }),
         publicSnapshotStore,
         fetchSyncPages,
         deleteCheckpoint,
@@ -1468,12 +1491,6 @@ export async function syncPublicSnapshotsForMeta(params: {
   remotePeerId: string;
   contextGraphId: string;
   deadline: number;
-  metaQuads: readonly Quad[];
-  recoveryOrder?: 'manifest' | 'recent-balanced';
-  /** Precomputed by the selected lane so its continuation binds this exact order. */
-  orderedSnapshots?: readonly PublicSnapshotMetadata[];
-  /** Refs already materialized under the exact ordered manifest above. */
-  resolvedSnapshotRefs?: ReadonlySet<string>;
   publicSnapshotStore?: WorkspacePublicSnapshotStore;
   fetchSyncPages: SharedMemorySyncContext['fetchSyncPages'];
   deleteCheckpoint: (key: string) => void;
@@ -1487,7 +1504,7 @@ export async function syncPublicSnapshotsForMeta(params: {
     snapshot: PublicSnapshotMetadata,
     source: 'cache' | 'network',
   ) => Promise<void>;
-}): Promise<{
+} & PublicSnapshotWalkSource): Promise<{
   bytesReceived: number;
   resumedPhases: number;
   timedOutPhases: number;
@@ -1513,9 +1530,11 @@ export async function syncPublicSnapshotsForMeta(params: {
    */
   yieldedAtDeadline: boolean;
 }> {
-  const manifestSnapshots = collectPublicSnapshotMetadata(params.metaQuads);
-  const snapshots = params.orderedSnapshots
-    ? [...params.orderedSnapshots]
+  const manifestSnapshots = params.snapshotWalk
+    ? []
+    : collectPublicSnapshotMetadata(params.metaQuads);
+  const snapshots = params.snapshotWalk
+    ? [...params.snapshotWalk.orderedManifest]
     : params.recoveryOrder === 'recent-balanced'
       ? orderPublicSnapshotsForBalancedRecency(manifestSnapshots)
       : manifestSnapshots;
@@ -1587,7 +1606,7 @@ export async function syncPublicSnapshotsForMeta(params: {
     // that O(prefix) replay eventually consumed the whole slice and fixed the
     // continuation at N/N+K forever. The owner is in-memory and resets on any
     // manifest change, expiry, release or process restart.
-    if (params.resolvedSnapshotRefs?.has(snapshot.ref)) {
+    if (params.snapshotWalk?.resolvedRefs.has(snapshot.ref)) {
       readySnapshots += 1;
       continue;
     }

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -271,6 +271,18 @@ export interface SharedMemoryMetadataFetchOutcome {
 }
 
 /**
+ * Selected-provider snapshot progress bound to one exact, ordered manifest.
+ *
+ * The owner keeps only refs whose content was already materialized locally.
+ * A changed manifest replaces the owner, and a process restart drops it, so a
+ * skipped ref can never outlive the evidence that justified the skip.
+ */
+export interface SharedMemorySnapshotWalkContinuation {
+  readonly resolvedRefs: ReadonlySet<string>;
+  markResolved(ref: string): void;
+}
+
+/**
  * Strategy boundary for metadata retrieval.
  *
  * The default requester performs one ordinary page fetch. Selected RFC-64 SWM
@@ -280,6 +292,10 @@ export interface SharedMemoryMetadataFetchOutcome {
 export interface SharedMemoryMetadataFetcher {
   fetch(request: SharedMemoryMetadataFetchRequest): Promise<SharedMemoryMetadataFetchOutcome>;
   release(contextGraphId: string): void;
+  snapshotWalk?(
+    contextGraphId: string,
+    orderedManifest: readonly PublicSnapshotMetadata[],
+  ): SharedMemorySnapshotWalkContinuation;
 }
 
 /**
@@ -772,9 +788,15 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       let materializedGraphs = 0;
       let materializationFailures = 0;
       let materializedQuads = 0;
+      const manifestSnapshots = collectPublicSnapshotMetadata(processed.verifiedMeta);
+      const orderedManifestSnapshots = snapshotRecoveryOrder === 'recent-balanced'
+        ? orderPublicSnapshotsForBalancedRecency(manifestSnapshots)
+        : manifestSnapshots;
+      const snapshotWalk = metadataFetcher?.snapshotWalk?.(pid, orderedManifestSnapshots);
       const materializedKeys = new Set<string>();
       /** Snapshot refs whose every descriptor is locally present. */
-      const materializedRefs = new Set<string>();
+      const materializedRefs = new Set<string>(snapshotWalk?.resolvedRefs ?? []);
+      materializedRefsForCg = materializedRefs.size;
       /** Refs that fetched but could not be written; named in the shortfall. */
       const unresolvedRefSample: string[] = [];
 
@@ -1143,6 +1165,8 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         deadline,
         metaQuads: processed.verifiedMeta,
         recoveryOrder: snapshotRecoveryOrder,
+        orderedSnapshots: orderedManifestSnapshots,
+        resolvedSnapshotRefs: snapshotWalk?.resolvedRefs,
         publicSnapshotStore,
         fetchSyncPages,
         deleteCheckpoint,
@@ -1176,7 +1200,10 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         // vacuity decision — and its `manifestComplete` guard — actually lives.
         // The hook still early-returns when the materializer or the store is
         // absent, so this costs nothing when there is genuinely no wiring.
-        onSnapshotReady: (snapshot: PublicSnapshotMetadata) => materializeReadySnapshot(snapshot.ref),
+        onSnapshotReady: async (snapshot: PublicSnapshotMetadata) => {
+          await materializeReadySnapshot(snapshot.ref);
+          if (materializedRefs.has(snapshot.ref)) snapshotWalk?.markResolved(snapshot.ref);
+        },
       });
       if (materializedGraphs > 0) {
         // Reporting only — the counters were already added per KA, inside the
@@ -1443,6 +1470,10 @@ export async function syncPublicSnapshotsForMeta(params: {
   deadline: number;
   metaQuads: readonly Quad[];
   recoveryOrder?: 'manifest' | 'recent-balanced';
+  /** Precomputed by the selected lane so its continuation binds this exact order. */
+  orderedSnapshots?: readonly PublicSnapshotMetadata[];
+  /** Refs already materialized under the exact ordered manifest above. */
+  resolvedSnapshotRefs?: ReadonlySet<string>;
   publicSnapshotStore?: WorkspacePublicSnapshotStore;
   fetchSyncPages: SharedMemorySyncContext['fetchSyncPages'];
   deleteCheckpoint: (key: string) => void;
@@ -1483,9 +1514,11 @@ export async function syncPublicSnapshotsForMeta(params: {
   yieldedAtDeadline: boolean;
 }> {
   const manifestSnapshots = collectPublicSnapshotMetadata(params.metaQuads);
-  const snapshots = params.recoveryOrder === 'recent-balanced'
-    ? orderPublicSnapshotsForBalancedRecency(manifestSnapshots)
-    : manifestSnapshots;
+  const snapshots = params.orderedSnapshots
+    ? [...params.orderedSnapshots]
+    : params.recoveryOrder === 'recent-balanced'
+      ? orderPublicSnapshotsForBalancedRecency(manifestSnapshots)
+      : manifestSnapshots;
   if (snapshots.length === 0) {
     return {
       bytesReceived: 0,
@@ -1548,6 +1581,16 @@ export async function syncPublicSnapshotsForMeta(params: {
   };
 
   for (const [index, snapshot] of snapshots.entries()) {
+    // A selected transfer owner may carry exact, manifest-bound evidence from
+    // an earlier bounded slice. Skipping these refs is intentionally cheaper
+    // than re-reading and re-hashing every snapshot blob and assertion graph:
+    // that O(prefix) replay eventually consumed the whole slice and fixed the
+    // continuation at N/N+K forever. The owner is in-memory and resets on any
+    // manifest change, expiry, release or process restart.
+    if (params.resolvedSnapshotRefs?.has(snapshot.ref)) {
+      readySnapshots += 1;
+      continue;
+    }
     // Yield BETWEEN Knowledge Assets, and check the clock BEFORE doing any work
     // for this one. Both halves matter:
     //

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -284,7 +284,11 @@ export interface SharedMemoryMetadataFetchOutcome {
 export interface SharedMemorySnapshotWalkContinuation {
   /** Exact ordered manifest that owns every resolved ref below. */
   readonly orderedManifest: readonly PublicSnapshotMetadata[];
-  readonly resolvedRefs: ReadonlySet<string>;
+  /** Query live owner state without exposing its mutable backing collection. */
+  isResolved(ref: string): boolean;
+  resolvedCount(): number;
+  /** Take an immutable point-in-time view for reporting or batch setup. */
+  resolvedRefsSnapshot(): readonly string[];
   /** Exact verified metadata rows withheld when this ref was resolved. */
   suppressedMetadataRows(ref: string): readonly Quad[];
   markResolved(ref: string, suppressedMetadataRows?: readonly Quad[]): void;
@@ -822,7 +826,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       const snapshotWalk = metadataFetcher?.snapshotWalk?.(pid, orderedManifestSnapshots);
       const materializedKeys = new Set<string>();
       /** Snapshot refs whose every descriptor is locally present. */
-      const materializedRefs = new Set<string>(snapshotWalk?.resolvedRefs ?? []);
+      const materializedRefs = new Set<string>(snapshotWalk?.resolvedRefsSnapshot() ?? []);
       materializedRefsForCg = materializedRefs.size;
       /** Refs that fetched but could not be written; named in the shortfall. */
       const unresolvedRefSample: string[] = [];
@@ -847,7 +851,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       // resolved ref so a later successful suffix cannot resurrect metadata
       // that the prefix deliberately withheld.
       if (snapshotWalk) {
-        for (const resolvedRef of snapshotWalk.resolvedRefs) {
+        for (const resolvedRef of snapshotWalk.resolvedRefsSnapshot()) {
           snapshotCommit.suppressRows(snapshotWalk.suppressedMetadataRows(resolvedRef));
         }
       }
@@ -1626,7 +1630,7 @@ export async function syncPublicSnapshotsForMeta(params: {
     // that O(prefix) replay eventually consumed the whole slice and fixed the
     // continuation at N/N+K forever. The owner is in-memory and resets on any
     // manifest change, expiry, release or process restart.
-    if (params.snapshotWalk?.resolvedRefs.has(snapshot.ref)) {
+    if (params.snapshotWalk?.isResolved(snapshot.ref)) {
       readySnapshots += 1;
       continue;
     }

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -111,6 +111,10 @@ class GraphScopedSnapshotCommitCoordinator {
     }
   }
 
+  suppressedRows(rows: readonly Quad[]): Quad[] {
+    return rows.filter((quad) => this.#suppressedKeys.has(metadataQuadKey(quad)));
+  }
+
   #suppress(descriptor: GraphScopedSwmRecoveryDescriptor): void {
     for (const quad of descriptor.metadataQuads) {
       const key = metadataQuadKey(quad);
@@ -281,7 +285,9 @@ export interface SharedMemorySnapshotWalkContinuation {
   /** Exact ordered manifest that owns every resolved ref below. */
   readonly orderedManifest: readonly PublicSnapshotMetadata[];
   readonly resolvedRefs: ReadonlySet<string>;
-  markResolved(ref: string): void;
+  /** Exact verified metadata rows withheld when this ref was resolved. */
+  suppressedMetadataRows(ref: string): readonly Quad[];
+  markResolved(ref: string, suppressedMetadataRows?: readonly Quad[]): void;
 }
 
 type PublicSnapshotWalkSource =
@@ -835,6 +841,16 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         processed.verifiedMeta,
         reconcileFinalizedTwin,
       );
+      // A selected continuation skips blob and assertion-graph work for its
+      // verified prefix, but the final bulk metadata append is owned by this
+      // round. Reapply the exact suppression decisions captured with each
+      // resolved ref so a later successful suffix cannot resurrect metadata
+      // that the prefix deliberately withheld.
+      if (snapshotWalk) {
+        for (const resolvedRef of snapshotWalk.resolvedRefs) {
+          snapshotCommit.suppressRows(snapshotWalk.suppressedMetadataRows(resolvedRef));
+        }
+      }
       let contextGraphEnsured = false;
       const ensureContextGraphOnce = async (): Promise<void> => {
         if (contextGraphEnsured) return;
@@ -1225,7 +1241,11 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         // absent, so this costs nothing when there is genuinely no wiring.
         onSnapshotReady: async (snapshot: PublicSnapshotMetadata) => {
           await materializeReadySnapshot(snapshot.ref);
-          if (materializedRefs.has(snapshot.ref)) snapshotWalk?.markResolved(snapshot.ref);
+          if (materializedRefs.has(snapshot.ref)) {
+            const suppressedRows = (snapshotDescriptorsByRef.get(snapshot.ref) ?? [])
+              .flatMap((descriptor) => snapshotCommit.suppressedRows(descriptor.metadataQuads));
+            snapshotWalk?.markResolved(snapshot.ref, suppressedRows);
+          }
         },
       });
       if (materializedGraphs > 0) {

--- a/packages/agent/src/sync/selected-swm-meta-fetcher.ts
+++ b/packages/agent/src/sync/selected-swm-meta-fetcher.ts
@@ -22,7 +22,6 @@ import { DURABLE_DATA_SYNC_SESSION_TTL_MS } from './durable-session.js';
 /** Post-metadata continuation bound to one exact ordered manifest. */
 interface SelectedSwmSnapshotWalkState {
   readonly orderedManifest: readonly PublicSnapshotMetadata[];
-  readonly manifestTokens: readonly string[];
   readonly resolvedRefs: Set<string>;
   readonly suppressedMetadataRowsByRef: Map<string, readonly Quad[]>;
   expiresAtMs: number;
@@ -315,8 +314,8 @@ export function createSelectedSwmMetaFetcher(options: {
     const walk = state.snapshotWalk;
     return state.completed
       && walk !== undefined
-      && walk.manifestTokens.length > 0
-      && walk.resolvedRefs.size < walk.manifestTokens.length;
+      && walk.orderedManifest.length > 0
+      && walk.resolvedRefs.size < walk.orderedManifest.length;
   };
 
   const hasRetainedContinuation = (state: SelectedSwmMetaContinuationState): boolean => (
@@ -501,20 +500,18 @@ export function createSelectedSwmMetaFetcher(options: {
           markResolved: () => {},
         };
       }
-      const tokens = orderedManifest.map(snapshotManifestToken);
       const retainedWalk = state.snapshotWalk;
-      const walk = retainedWalk && manifestTokensEqual(retainedWalk.manifestTokens, tokens)
+      const walk = retainedWalk && manifestsEqual(retainedWalk.orderedManifest, orderedManifest)
         ? retainedWalk
         : {
           orderedManifest: [...orderedManifest],
-          manifestTokens: tokens,
           resolvedRefs: new Set<string>(),
           suppressedMetadataRowsByRef: new Map<string, readonly Quad[]>(),
           expiresAtMs: 0,
         };
       state.snapshotWalk = walk;
       const allowedRefs = new Set(walk.orderedManifest.map((snapshot) => snapshot.ref));
-      if (walk.manifestTokens.length > 0 && walk.resolvedRefs.size < walk.manifestTokens.length) {
+      if (walk.orderedManifest.length > 0 && walk.resolvedRefs.size < walk.orderedManifest.length) {
         walk.expiresAtMs = now() + retentionTtlMs;
       }
       return {
@@ -535,7 +532,7 @@ export function createSelectedSwmMetaFetcher(options: {
             suppressedMetadataRows.map((quad) => ({ ...quad })),
           );
           walk.resolvedRefs.add(ref);
-          if (walk.resolvedRefs.size < walk.manifestTokens.length) {
+          if (walk.resolvedRefs.size < walk.orderedManifest.length) {
             walk.expiresAtMs = now() + retentionTtlMs;
           }
         },
@@ -582,14 +579,15 @@ export function createSelectedSwmMetaFetcher(options: {
   return fetcher;
 }
 
-function snapshotManifestToken(snapshot: PublicSnapshotMetadata): string {
-  return `${snapshot.ref}\0${snapshot.digest}\0${snapshot.count}`;
-}
-
-function manifestTokensEqual(
-  left: readonly string[],
-  right: readonly string[],
+function manifestsEqual(
+  left: readonly PublicSnapshotMetadata[],
+  right: readonly PublicSnapshotMetadata[],
 ): boolean {
   return left.length === right.length
-    && left.every((token, index) => token === right[index]);
+    && left.every((snapshot, index) => {
+      const candidate = right[index];
+      return snapshot.ref === candidate.ref
+        && snapshot.digest === candidate.digest
+        && snapshot.count === candidate.count;
+    });
 }

--- a/packages/agent/src/sync/selected-swm-meta-fetcher.ts
+++ b/packages/agent/src/sync/selected-swm-meta-fetcher.ts
@@ -12,6 +12,7 @@ import {
   type SyncPageResult,
 } from './requester/page-fetch.js';
 import type {
+  PublicSnapshotMetadata,
   SharedMemoryMetadataFetchRequest,
   SharedMemoryMetadataFetcher,
 } from './requester/shared-memory-sync.js';
@@ -28,6 +29,10 @@ interface SelectedSwmMetaContinuationState {
   /** Incremented whenever the responder restarts this prefix from offset zero. */
   generation: number;
   completed: boolean;
+  /** Exact ordered manifest whose locally materialized refs may be skipped. */
+  snapshotManifestTokens?: readonly string[];
+  /** Refs proven materialized while the exact manifest above was current. */
+  resolvedSnapshotRefs: Set<string>;
   expiresAtMs: number;
   retentionLease: SelectedSwmMetaRetentionLease;
 }
@@ -285,12 +290,29 @@ export function createSelectedSwmMetaFetcher(options: {
       requesterScope: options.requesterScope,
       generation: 0,
       completed: false,
+      resolvedSnapshotRefs: new Set(),
       expiresAtMs: 0,
       retentionLease: options.retentionBudget.lease(),
     };
     states.set(contextGraphId, state);
     return state;
   };
+
+  const hasRetainedMetadataPrefix = (state: SelectedSwmMetaContinuationState): boolean => (
+    !state.completed
+    && state.nextOffset > 0
+    && state.quads.length > 0
+  );
+
+  const hasIncompleteSnapshotWalk = (state: SelectedSwmMetaContinuationState): boolean => (
+    state.completed
+    && (state.snapshotManifestTokens?.length ?? 0) > 0
+    && state.resolvedSnapshotRefs.size < state.snapshotManifestTokens!.length
+  );
+
+  const hasRetainedContinuation = (state: SelectedSwmMetaContinuationState): boolean => (
+    hasRetainedMetadataPrefix(state) || hasIncompleteSnapshotWalk(state)
+  );
 
   const pruneExpiredStates = (): void => {
     for (const [contextGraphId, state] of states) {
@@ -300,9 +322,7 @@ export function createSelectedSwmMetaFetcher(options: {
       // Completed/empty state keeps its existing outer-invocation lifecycle.
       if (
         !activeContextGraphs.has(contextGraphId)
-        && !state.completed
-        && state.nextOffset > 0
-        && state.quads.length > 0
+        && hasRetainedContinuation(state)
         && state.expiresAtMs <= now()
       ) {
         release(contextGraphId, state);
@@ -315,9 +335,7 @@ export function createSelectedSwmMetaFetcher(options: {
     const expiringInactiveStates = [...states.entries()]
       .filter(([contextGraphId, state]) => (
         !activeContextGraphs.has(contextGraphId)
-        && !state.completed
-        && state.nextOffset > 0
-        && state.quads.length > 0
+        && hasRetainedContinuation(state)
       ));
     return {
       retained: states.size > 0,
@@ -451,6 +469,35 @@ export function createSelectedSwmMetaFetcher(options: {
       }
     },
     release,
+    snapshotWalk(contextGraphId, orderedManifest) {
+      const state = states.get(contextGraphId);
+      if (!state?.completed) {
+        return { resolvedRefs: new Set<string>(), markResolved: () => {} };
+      }
+      const tokens = orderedManifest.map(snapshotManifestToken);
+      const sameManifest = manifestTokensEqual(state.snapshotManifestTokens, tokens);
+      if (!sameManifest) {
+        state.snapshotManifestTokens = tokens;
+        state.resolvedSnapshotRefs.clear();
+      }
+      const allowedRefs = new Set(orderedManifest.map((snapshot) => snapshot.ref));
+      for (const ref of state.resolvedSnapshotRefs) {
+        if (!allowedRefs.has(ref)) state.resolvedSnapshotRefs.delete(ref);
+      }
+      if (tokens.length > 0 && state.resolvedSnapshotRefs.size < tokens.length) {
+        state.expiresAtMs = now() + retentionTtlMs;
+      }
+      return {
+        resolvedRefs: state.resolvedSnapshotRefs,
+        markResolved(ref: string) {
+          if (states.get(contextGraphId) !== state || !allowedRefs.has(ref)) return;
+          state.resolvedSnapshotRefs.add(ref);
+          if (state.resolvedSnapshotRefs.size < tokens.length) {
+            state.expiresAtMs = now() + retentionTtlMs;
+          }
+        },
+      };
+    },
   };
 
   const fetcher: SelectedSwmMetaFetcher = {
@@ -472,14 +519,12 @@ export function createSelectedSwmMetaFetcher(options: {
     settleOuterInvocation() {
       pruneExpiredStates();
       for (const [contextGraphId, state] of states) {
-        // Completed manifests may be reused by continuation passes in the same
-        // outer invocation, but never become a cross-invocation cache. Empty
-        // state has no validated prefix to justify a non-zero cursor lifetime.
-        if (
-          state.completed
-          || state.nextOffset <= 0
-          || state.quads.length === 0
-        ) {
+        // A completed manifest remains useful only while its exact snapshot
+        // walk is incomplete. That lets later bounded reconciler invocations
+        // skip refs already materialized instead of spending every slice
+        // re-reading the same prefix. Full walks, zero-ref manifests and empty
+        // metadata state have no resumable work and are released immediately.
+        if (!hasRetainedContinuation(state)) {
           release(contextGraphId, state);
           completedContextGraphs.delete(contextGraphId);
         }
@@ -492,4 +537,17 @@ export function createSelectedSwmMetaFetcher(options: {
     },
   });
   return fetcher;
+}
+
+function snapshotManifestToken(snapshot: PublicSnapshotMetadata): string {
+  return `${snapshot.ref}\0${snapshot.digest}\0${snapshot.count}`;
+}
+
+function manifestTokensEqual(
+  left: readonly string[] | undefined,
+  right: readonly string[],
+): boolean {
+  return left !== undefined
+    && left.length === right.length
+    && left.every((token, index) => token === right[index]);
 }

--- a/packages/agent/src/sync/selected-swm-meta-fetcher.ts
+++ b/packages/agent/src/sync/selected-swm-meta-fetcher.ts
@@ -513,7 +513,15 @@ export function createSelectedSwmMetaFetcher(options: {
         };
       state.snapshotWalk = walk;
       const allowedRefs = new Set(walk.orderedManifest.map((snapshot) => snapshot.ref));
-      if (walk.orderedManifest.length > 0 && walk.resolvedRefs.size < walk.orderedManifest.length) {
+      // Opening an unchanged walk is not progress. Sliding this deadline on
+      // every retry could retain stale completed metadata forever and prevent
+      // a corrected remote manifest from ever being observed. Creation starts
+      // the window; markResolved is the only operation allowed to extend it.
+      if (
+        walk.expiresAtMs === 0
+        && walk.orderedManifest.length > 0
+        && walk.resolvedRefs.size < walk.orderedManifest.length
+      ) {
         walk.expiresAtMs = now() + retentionTtlMs;
       }
       return {

--- a/packages/agent/src/sync/selected-swm-meta-fetcher.ts
+++ b/packages/agent/src/sync/selected-swm-meta-fetcher.ts
@@ -19,7 +19,15 @@ import type {
 import type { SelectedSwmMetaRetentionLease } from './selected-swm-meta-budget.js';
 import { DURABLE_DATA_SYNC_SESSION_TTL_MS } from './durable-session.js';
 
-/** Exact prefix retained only by one selected-provider transfer owner. */
+/** Post-metadata continuation bound to one exact ordered manifest. */
+interface SelectedSwmSnapshotWalkState {
+  readonly orderedManifest: readonly PublicSnapshotMetadata[];
+  readonly manifestTokens: readonly string[];
+  readonly resolvedRefs: Set<string>;
+  expiresAtMs: number;
+}
+
+/** Exact metadata prefix retained only by one selected-provider transfer owner. */
 interface SelectedSwmMetaContinuationState {
   quads: Quad[];
   bytesEstimate: number;
@@ -29,11 +37,10 @@ interface SelectedSwmMetaContinuationState {
   /** Incremented whenever the responder restarts this prefix from offset zero. */
   generation: number;
   completed: boolean;
-  /** Exact ordered manifest whose locally materialized refs may be skipped. */
-  snapshotManifestTokens?: readonly string[];
-  /** Refs proven materialized while the exact manifest above was current. */
-  resolvedSnapshotRefs: Set<string>;
-  expiresAtMs: number;
+  /** Prefix expiry; terminal metadata has no prefix retention clock. */
+  metadataExpiresAtMs: number;
+  /** Independent continuation created only after metadata is complete. */
+  snapshotWalk?: SelectedSwmSnapshotWalkState;
   retentionLease: SelectedSwmMetaRetentionLease;
 }
 
@@ -290,8 +297,7 @@ export function createSelectedSwmMetaFetcher(options: {
       requesterScope: options.requesterScope,
       generation: 0,
       completed: false,
-      resolvedSnapshotRefs: new Set(),
-      expiresAtMs: 0,
+      metadataExpiresAtMs: 0,
       retentionLease: options.retentionBudget.lease(),
     };
     states.set(contextGraphId, state);
@@ -304,15 +310,25 @@ export function createSelectedSwmMetaFetcher(options: {
     && state.quads.length > 0
   );
 
-  const hasIncompleteSnapshotWalk = (state: SelectedSwmMetaContinuationState): boolean => (
-    state.completed
-    && (state.snapshotManifestTokens?.length ?? 0) > 0
-    && state.resolvedSnapshotRefs.size < state.snapshotManifestTokens!.length
-  );
+  const hasIncompleteSnapshotWalk = (state: SelectedSwmMetaContinuationState): boolean => {
+    const walk = state.snapshotWalk;
+    return state.completed
+      && walk !== undefined
+      && walk.manifestTokens.length > 0
+      && walk.resolvedRefs.size < walk.manifestTokens.length;
+  };
 
   const hasRetainedContinuation = (state: SelectedSwmMetaContinuationState): boolean => (
     hasRetainedMetadataPrefix(state) || hasIncompleteSnapshotWalk(state)
   );
+
+  const retainedContinuationExpiry = (
+    state: SelectedSwmMetaContinuationState,
+  ): number | undefined => {
+    if (hasRetainedMetadataPrefix(state)) return state.metadataExpiresAtMs;
+    if (hasIncompleteSnapshotWalk(state)) return state.snapshotWalk?.expiresAtMs;
+    return undefined;
+  };
 
   const pruneExpiredStates = (): void => {
     for (const [contextGraphId, state] of states) {
@@ -320,10 +336,11 @@ export function createSelectedSwmMetaFetcher(options: {
       // coordinator's timer is intentionally peer-wide, so enforce each CG's
       // independent TTL at every serialized fetch boundary and timer tick.
       // Completed/empty state keeps its existing outer-invocation lifecycle.
+      const expiryAtMs = retainedContinuationExpiry(state);
       if (
         !activeContextGraphs.has(contextGraphId)
-        && hasRetainedContinuation(state)
-        && state.expiresAtMs <= now()
+        && expiryAtMs !== undefined
+        && expiryAtMs <= now()
       ) {
         release(contextGraphId, state);
         completedContextGraphs.delete(contextGraphId);
@@ -340,7 +357,10 @@ export function createSelectedSwmMetaFetcher(options: {
     return {
       retained: states.size > 0,
       nextExpiryAtMs: expiringInactiveStates.length > 0
-        ? Math.min(...expiringInactiveStates.map(([, state]) => state.expiresAtMs))
+        ? Math.min(...expiringInactiveStates.flatMap(([, state]) => {
+          const expiryAtMs = retainedContinuationExpiry(state);
+          return expiryAtMs === undefined ? [] : [expiryAtMs];
+        }))
         : undefined,
     };
   };
@@ -408,7 +428,7 @@ export function createSelectedSwmMetaFetcher(options: {
       ) {
         // Each Context Graph owns an independent sliding expiry. Progress on a
         // sibling CG cannot keep an abandoned prefix resident.
-        state.expiresAtMs = now() + retentionTtlMs;
+        state.metadataExpiresAtMs = now() + retentionTtlMs;
       }
       if (state.completed) completedContextGraphs.add(request.contextGraphId);
       return { ...fetched, quads: state.quads };
@@ -428,7 +448,8 @@ export function createSelectedSwmMetaFetcher(options: {
         state.bytesEstimate = 0;
         state.nextOffset = 0;
         state.completed = false;
-        state.expiresAtMs = 0;
+        state.metadataExpiresAtMs = 0;
+        state.snapshotWalk = undefined;
         state.generation += 1;
         completedContextGraphs.delete(request.contextGraphId);
         return fetchRetained(request, state, false);
@@ -472,28 +493,39 @@ export function createSelectedSwmMetaFetcher(options: {
     snapshotWalk(contextGraphId, orderedManifest) {
       const state = states.get(contextGraphId);
       if (!state?.completed) {
-        return { resolvedRefs: new Set<string>(), markResolved: () => {} };
+        return {
+          orderedManifest,
+          resolvedRefs: new Set<string>(),
+          markResolved: () => {},
+        };
       }
       const tokens = orderedManifest.map(snapshotManifestToken);
-      const sameManifest = manifestTokensEqual(state.snapshotManifestTokens, tokens);
-      if (!sameManifest) {
-        state.snapshotManifestTokens = tokens;
-        state.resolvedSnapshotRefs.clear();
-      }
-      const allowedRefs = new Set(orderedManifest.map((snapshot) => snapshot.ref));
-      for (const ref of state.resolvedSnapshotRefs) {
-        if (!allowedRefs.has(ref)) state.resolvedSnapshotRefs.delete(ref);
-      }
-      if (tokens.length > 0 && state.resolvedSnapshotRefs.size < tokens.length) {
-        state.expiresAtMs = now() + retentionTtlMs;
+      const retainedWalk = state.snapshotWalk;
+      const walk = retainedWalk && manifestTokensEqual(retainedWalk.manifestTokens, tokens)
+        ? retainedWalk
+        : {
+          orderedManifest: [...orderedManifest],
+          manifestTokens: tokens,
+          resolvedRefs: new Set<string>(),
+          expiresAtMs: 0,
+        };
+      state.snapshotWalk = walk;
+      const allowedRefs = new Set(walk.orderedManifest.map((snapshot) => snapshot.ref));
+      if (walk.manifestTokens.length > 0 && walk.resolvedRefs.size < walk.manifestTokens.length) {
+        walk.expiresAtMs = now() + retentionTtlMs;
       }
       return {
-        resolvedRefs: state.resolvedSnapshotRefs,
+        orderedManifest: walk.orderedManifest,
+        resolvedRefs: walk.resolvedRefs,
         markResolved(ref: string) {
-          if (states.get(contextGraphId) !== state || !allowedRefs.has(ref)) return;
-          state.resolvedSnapshotRefs.add(ref);
-          if (state.resolvedSnapshotRefs.size < tokens.length) {
-            state.expiresAtMs = now() + retentionTtlMs;
+          if (
+            states.get(contextGraphId) !== state
+            || state.snapshotWalk !== walk
+            || !allowedRefs.has(ref)
+          ) return;
+          walk.resolvedRefs.add(ref);
+          if (walk.resolvedRefs.size < walk.manifestTokens.length) {
+            walk.expiresAtMs = now() + retentionTtlMs;
           }
         },
       };
@@ -544,10 +576,9 @@ function snapshotManifestToken(snapshot: PublicSnapshotMetadata): string {
 }
 
 function manifestTokensEqual(
-  left: readonly string[] | undefined,
+  left: readonly string[],
   right: readonly string[],
 ): boolean {
-  return left !== undefined
-    && left.length === right.length
+  return left.length === right.length
     && left.every((token, index) => token === right[index]);
 }

--- a/packages/agent/src/sync/selected-swm-meta-fetcher.ts
+++ b/packages/agent/src/sync/selected-swm-meta-fetcher.ts
@@ -495,7 +495,9 @@ export function createSelectedSwmMetaFetcher(options: {
       if (!state?.completed) {
         return {
           orderedManifest,
-          resolvedRefs: new Set<string>(),
+          isResolved: () => false,
+          resolvedCount: () => 0,
+          resolvedRefsSnapshot: () => [],
           suppressedMetadataRows: () => [],
           markResolved: () => {},
         };
@@ -516,7 +518,15 @@ export function createSelectedSwmMetaFetcher(options: {
       }
       return {
         orderedManifest: walk.orderedManifest,
-        resolvedRefs: walk.resolvedRefs,
+        isResolved(ref: string) {
+          return walk.resolvedRefs.has(ref);
+        },
+        resolvedCount() {
+          return walk.resolvedRefs.size;
+        },
+        resolvedRefsSnapshot() {
+          return Object.freeze([...walk.resolvedRefs]);
+        },
         suppressedMetadataRows(ref: string) {
           return walk.suppressedMetadataRowsByRef.get(ref) ?? [];
         },

--- a/packages/agent/src/sync/selected-swm-meta-fetcher.ts
+++ b/packages/agent/src/sync/selected-swm-meta-fetcher.ts
@@ -24,6 +24,7 @@ interface SelectedSwmSnapshotWalkState {
   readonly orderedManifest: readonly PublicSnapshotMetadata[];
   readonly manifestTokens: readonly string[];
   readonly resolvedRefs: Set<string>;
+  readonly suppressedMetadataRowsByRef: Map<string, readonly Quad[]>;
   expiresAtMs: number;
 }
 
@@ -496,6 +497,7 @@ export function createSelectedSwmMetaFetcher(options: {
         return {
           orderedManifest,
           resolvedRefs: new Set<string>(),
+          suppressedMetadataRows: () => [],
           markResolved: () => {},
         };
       }
@@ -507,6 +509,7 @@ export function createSelectedSwmMetaFetcher(options: {
           orderedManifest: [...orderedManifest],
           manifestTokens: tokens,
           resolvedRefs: new Set<string>(),
+          suppressedMetadataRowsByRef: new Map<string, readonly Quad[]>(),
           expiresAtMs: 0,
         };
       state.snapshotWalk = walk;
@@ -517,12 +520,20 @@ export function createSelectedSwmMetaFetcher(options: {
       return {
         orderedManifest: walk.orderedManifest,
         resolvedRefs: walk.resolvedRefs,
-        markResolved(ref: string) {
+        suppressedMetadataRows(ref: string) {
+          return walk.suppressedMetadataRowsByRef.get(ref) ?? [];
+        },
+        markResolved(ref: string, suppressedMetadataRows: readonly Quad[] = []) {
           if (
             states.get(contextGraphId) !== state
             || state.snapshotWalk !== walk
             || !allowedRefs.has(ref)
+            || walk.resolvedRefs.has(ref)
           ) return;
+          walk.suppressedMetadataRowsByRef.set(
+            ref,
+            suppressedMetadataRows.map((quad) => ({ ...quad })),
+          );
           walk.resolvedRefs.add(ref);
           if (walk.resolvedRefs.size < walk.manifestTokens.length) {
             walk.expiresAtMs = now() + retentionTtlMs;

--- a/packages/agent/src/sync/selected-swm-meta-fetcher.ts
+++ b/packages/agent/src/sync/selected-swm-meta-fetcher.ts
@@ -494,7 +494,7 @@ export function createSelectedSwmMetaFetcher(options: {
       const state = states.get(contextGraphId);
       if (!state?.completed) {
         return {
-          orderedManifest,
+          orderedManifestSnapshot: () => immutableManifestSnapshot(orderedManifest),
           isResolved: () => false,
           resolvedCount: () => 0,
           resolvedRefsSnapshot: () => [],
@@ -506,7 +506,7 @@ export function createSelectedSwmMetaFetcher(options: {
       const walk = retainedWalk && manifestsEqual(retainedWalk.orderedManifest, orderedManifest)
         ? retainedWalk
         : {
-          orderedManifest: [...orderedManifest],
+          orderedManifest: immutableManifestSnapshot(orderedManifest),
           resolvedRefs: new Set<string>(),
           suppressedMetadataRowsByRef: new Map<string, readonly Quad[]>(),
           expiresAtMs: 0,
@@ -517,7 +517,9 @@ export function createSelectedSwmMetaFetcher(options: {
         walk.expiresAtMs = now() + retentionTtlMs;
       }
       return {
-        orderedManifest: walk.orderedManifest,
+        orderedManifestSnapshot() {
+          return immutableManifestSnapshot(walk.orderedManifest);
+        },
         isResolved(ref: string) {
           return walk.resolvedRefs.has(ref);
         },
@@ -528,7 +530,7 @@ export function createSelectedSwmMetaFetcher(options: {
           return Object.freeze([...walk.resolvedRefs]);
         },
         suppressedMetadataRows(ref: string) {
-          return walk.suppressedMetadataRowsByRef.get(ref) ?? [];
+          return immutableQuadSnapshot(walk.suppressedMetadataRowsByRef.get(ref) ?? []);
         },
         markResolved(ref: string, suppressedMetadataRows: readonly Quad[] = []) {
           if (
@@ -539,7 +541,7 @@ export function createSelectedSwmMetaFetcher(options: {
           ) return;
           walk.suppressedMetadataRowsByRef.set(
             ref,
-            suppressedMetadataRows.map((quad) => ({ ...quad })),
+            immutableQuadSnapshot(suppressedMetadataRows),
           );
           walk.resolvedRefs.add(ref);
           if (walk.resolvedRefs.size < walk.orderedManifest.length) {
@@ -600,4 +602,14 @@ function manifestsEqual(
         && snapshot.digest === candidate.digest
         && snapshot.count === candidate.count;
     });
+}
+
+function immutableManifestSnapshot(
+  manifest: readonly PublicSnapshotMetadata[],
+): readonly PublicSnapshotMetadata[] {
+  return Object.freeze(manifest.map((snapshot) => Object.freeze({ ...snapshot })));
+}
+
+function immutableQuadSnapshot(quads: readonly Quad[]): readonly Quad[] {
+  return Object.freeze(quads.map((quad) => Object.freeze({ ...quad })));
 }

--- a/packages/agent/test/selected-swm-lifecycle-core.test.ts
+++ b/packages/agent/test/selected-swm-lifecycle-core.test.ts
@@ -673,6 +673,66 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
     }
   });
 
+  it('resumes an exact snapshot walk across bounded outer reconciler invocations', async () => {
+    const publicCg = 'selected-cross-outer-snapshots';
+    const manifest = snapshotManifest(publicCg, 10);
+    let wallNow = 1_000;
+    const readsByAdmission = new Map<number, number>();
+    const harness = createSelectedSwmLifecycleHarness({
+      contextGraphs: { public: publicCg },
+      manifest,
+      clock: { now: () => wallNow, deadline: () => wallNow + 1 },
+      onSnapshotRead: ({ publicAdmission }) => {
+        const reads = (readsByAdmission.get(publicAdmission) ?? 0) + 1;
+        readsByAdmission.set(publicAdmission, reads);
+        if (reads === 2) wallNow += 120_000;
+      },
+    });
+    const plan = {
+      publicContextGraphIds: [publicCg],
+      privateRecoverFromCurator: [],
+      eligibleContextGraphIds: [publicCg],
+    };
+
+    try {
+      const first = await callSelectedSharedMemoryFromPeerDetailed(
+        harness.agent,
+        [publicCg],
+        { selectedSwmPriority: true, priority: 2_000, sharedMemorySyncPlan: plan },
+      );
+      expect(first.selectedScopeComplete).toBe(false);
+      expect(first.shared.swmCoverage).toMatchObject({
+        contextGraphId: publicCg,
+        snapshotsResolved: 8,
+        snapshotsTotal: 10,
+        missingCount: 2,
+      });
+      expect(first.shared.continuationPasses).toBe(3);
+      expect(harness.probes.metaFetches()).toBe(1);
+      expect(harness.probes.snapshotReads()).toBe(8);
+
+      const second = await callSelectedSharedMemoryFromPeerDetailed(
+        harness.agent,
+        [publicCg],
+        { selectedSwmPriority: true, priority: 2_000, sharedMemorySyncPlan: plan },
+      );
+      expect(second.selectedScopeComplete).toBe(true);
+      expect(second.shared.swmCoverage).toMatchObject({
+        contextGraphId: publicCg,
+        snapshotsResolved: 10,
+        snapshotsTotal: 10,
+        missingCount: 0,
+      });
+      // The completed manifest and eight proven refs survived the outer
+      // boundary. No metadata refetch and no re-read of the old prefix.
+      expect(harness.probes.metaFetches()).toBe(1);
+      expect(harness.probes.snapshotReads()).toBe(10);
+      expect(harness.probes.publicAdmissions()).toBe(5);
+    } finally {
+      await harness.close();
+    }
+  });
+
   it('expires a cross-invocation prefix and starts a fresh responder scope', async () => {
     const publicCg = 'selected-cross-outer-expiry';
     const manifest = snapshotManifest(publicCg, 2);

--- a/packages/agent/test/selected-swm-lifecycle-queue.test.ts
+++ b/packages/agent/test/selected-swm-lifecycle-queue.test.ts
@@ -129,11 +129,13 @@ describe('selected RFC-64 SWM lifecycle queue and budgets', () => {
     let firstBlocked = false;
     const harness = createSelectedSwmLifecycleHarness({
       // The first selected call is a clean empty 0/0 graph. The queued second
-      // call owns this two-ref manifest and yields after materializing one ref,
-      // so it remains genuinely incomplete after zero-ref completion became
-      // explicit terminal evidence.
+      // call owns a five-ref manifest and its four bounded admissions each
+      // materialize one ref, so it remains genuinely incomplete after
+      // zero-ref completion became explicit terminal evidence. Five is
+      // intentional: selected snapshot continuation now skips the resolved
+      // prefix, so a two-ref fixture correctly completes on its second pass.
       contextGraphs: { public: incompleteCg },
-      manifest: snapshotManifest(incompleteCg, 2),
+      manifest: snapshotManifest(incompleteCg, 5),
       clock: { now: () => wallNow, deadline: () => wallNow + 1 },
       reportEmptyResponse: true,
       beforeAdmissionRun: async ({ contextGraphId }) => {
@@ -178,8 +180,8 @@ describe('selected RFC-64 SWM lifecycle queue and budgets', () => {
       });
       expect(incompleteSummary.swmCoverage).toMatchObject({
         contextGraphId: incompleteCg,
-        snapshotsResolved: 1,
-        snapshotsTotal: 2,
+        snapshotsResolved: 4,
+        snapshotsTotal: 5,
       });
       expect(harness.agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(true);
     } finally {

--- a/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
+++ b/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
@@ -4,7 +4,6 @@ import {
   createSelectedSwmMetaFetcher,
   SelectedSwmMetaTransferOwner,
 } from '../src/sync/selected-swm-meta-fetcher.js';
-import { syncPublicSnapshotsForMeta } from '../src/sync/requester/shared-memory-sync.js';
 import { SelectedSwmMetaTransferCoordinator } from '../src/sync/selected-swm-meta-transfer-coordinator.js';
 import { createSelectedSwmMetaRetentionBudget } from '../src/sync/selected-swm-meta-budget.js';
 
@@ -196,55 +195,23 @@ describe('selected SWM metadata transfer ownership', () => {
       changedDigest[1]!,
     ];
     const reordered = [changedCount[1]!, changedCount[0]!];
-    const requestedRefs: string[] = [];
-
     try {
       await coordinator.run(peerId, createFetcher, async (fetcher) => {
         await fetcher.strategy.fetch(request);
         const walk = fetcher.strategy.snapshotWalk!(contextGraphId, original);
         walk.markResolved('ref-a');
         expect(walk.resolvedRefsSnapshot()).toEqual(['ref-a']);
+        const exposed = walk.orderedManifestSnapshot();
+        expect(() => {
+          (exposed as unknown as Array<{ ref: string }>)[0]!.ref = 'mutated-ref';
+        }).toThrow();
+        expect(walk.orderedManifestSnapshot()).toEqual(original);
       });
 
       await coordinator.run(peerId, createFetcher, async (fetcher) => {
         await fetcher.strategy.fetch(request);
         const walk = fetcher.strategy.snapshotWalk!(contextGraphId, changedDigest);
         expect(walk.resolvedRefsSnapshot()).toEqual([]);
-        await syncPublicSnapshotsForMeta({
-          ctx: testContext,
-          remotePeerId: peerId,
-          contextGraphId,
-          deadline: Date.now() + 1_000,
-          snapshotWalk: walk,
-          publicSnapshotStore: {
-            getSnapshot: async () => null,
-            putSnapshot: async ({ digest }) => ({ ref: digest, byteLength: 0 }),
-          },
-          fetchSyncPages: async (
-            _ctx,
-            _remotePeerId,
-            _contextGraphId,
-            _includeSharedMemory,
-            _phase,
-            _graphUri,
-            _deadline,
-            options,
-          ) => {
-            requestedRefs.push(options?.snapshotRef ?? '');
-            return {
-              quads: [],
-              bytesReceived: 0,
-              resumedFromOffset: 0,
-              nextOffset: 0,
-              checkpointKey: 'changed-manifest-snapshot',
-              completed: false,
-              timedOut: true,
-            };
-          },
-          deleteCheckpoint: () => {},
-          setCheckpoint: () => {},
-        });
-        expect(requestedRefs).toEqual(['ref-a']);
         walk.markResolved('ref-a');
       });
 

--- a/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
+++ b/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
@@ -154,7 +154,7 @@ describe('selected SWM metadata transfer ownership', () => {
     }
   });
 
-  it('invalidates resolved refs when the exact manifest changes digest or order', async () => {
+  it('invalidates resolved refs when the exact manifest changes digest, count, or order', async () => {
     const peerId = 'peer-manifest-invalidation';
     const contextGraphId = 'cg-manifest-invalidation';
     const coordinator = new SelectedSwmMetaTransferCoordinator();
@@ -189,7 +189,11 @@ describe('selected SWM metadata transfer ownership', () => {
       { ref: 'ref-a', digest: 'digest-a-v2', count: 1 },
       { ref: 'ref-b', digest: 'digest-b', count: 1 },
     ];
-    const reordered = [changedDigest[1]!, changedDigest[0]!];
+    const changedCount = [
+      { ...changedDigest[0]!, count: 2 },
+      changedDigest[1]!,
+    ];
+    const reordered = [changedCount[1]!, changedCount[0]!];
     const requestedRefs: string[] = [];
 
     try {
@@ -239,6 +243,13 @@ describe('selected SWM metadata transfer ownership', () => {
           setCheckpoint: () => {},
         });
         expect(requestedRefs).toEqual(['ref-a']);
+        walk.markResolved('ref-a');
+      });
+
+      await coordinator.run(peerId, createFetcher, async (fetcher) => {
+        await fetcher.strategy.fetch(request);
+        const walk = fetcher.strategy.snapshotWalk!(contextGraphId, changedCount);
+        expect([...walk.resolvedRefs]).toEqual([]);
         walk.markResolved('ref-a');
       });
 

--- a/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
+++ b/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
@@ -41,6 +41,71 @@ describe('selected SWM metadata transfer ownership', () => {
     await coordinator.close();
   });
 
+  it('retains a completed manifest only while its exact snapshot walk is incomplete', async () => {
+    const peerId = 'peer-snapshot-resume';
+    const contextGraphId = 'cg-snapshot-resume';
+    const coordinator = new SelectedSwmMetaTransferCoordinator();
+    const fetchPage = vi.fn(async () => ({
+      quads: [{ subject: 'urn:manifest', predicate: 'urn:p', object: '"o"', graph: 'urn:meta' }],
+      bytesReceived: 1,
+      resumedFromOffset: 0,
+      nextOffset: 1,
+      checkpointKey: 'snapshot-resume-checkpoint',
+      completed: true,
+      timedOut: false,
+    }));
+    const createFetcher = vi.fn(() => createSelectedSwmMetaFetcher({
+      remotePeerId: peerId,
+      requesterScope: 'selected-swm-meta:retained:snapshot-resume',
+      retentionBudget: retentionBudget(),
+      deleteCheckpoint: () => {},
+      fetchPage,
+    }));
+    const request = {
+      ctx: testContext,
+      remotePeerId: peerId,
+      contextGraphId,
+      graphUri: 'urn:meta',
+      deadline: Date.now() + 1_000,
+    };
+    const manifest = [
+      { ref: 'ref-a', digest: 'digest-a', count: 1 },
+      { ref: 'ref-b', digest: 'digest-b', count: 1 },
+      { ref: 'ref-c', digest: 'digest-c', count: 1 },
+    ];
+
+    try {
+      await coordinator.run(peerId, createFetcher, async (fetcher) => {
+        await fetcher.strategy.fetch(request);
+        const walk = fetcher.strategy.snapshotWalk!(contextGraphId, manifest);
+        walk.markResolved('ref-a');
+        expect([...walk.resolvedRefs]).toEqual(['ref-a']);
+      });
+
+      await coordinator.run(peerId, createFetcher, async (fetcher) => {
+        const cached = await fetcher.strategy.fetch(request);
+        expect(cached.result.bytesReceived).toBe(0);
+        const walk = fetcher.strategy.snapshotWalk!(contextGraphId, manifest);
+        expect([...walk.resolvedRefs]).toEqual(['ref-a']);
+        walk.markResolved('ref-b');
+        walk.markResolved('ref-c');
+      });
+
+      expect(fetchPage).toHaveBeenCalledOnce();
+      expect(createFetcher).toHaveBeenCalledOnce();
+
+      // A fully resolved walk is terminal owner state. The next outer
+      // invocation must start from a new fetcher rather than retaining trust.
+      await coordinator.run(peerId, createFetcher, async (fetcher) => {
+        await fetcher.strategy.fetch(request);
+      });
+      expect(fetchPage).toHaveBeenCalledTimes(2);
+      expect(createFetcher).toHaveBeenCalledTimes(2);
+    } finally {
+      await coordinator.close();
+    }
+  });
+
   it('notifies its registry after timer-driven final-prefix expiry', async () => {
     const baseNow = Date.now();
     let elapsedMs = 0;

--- a/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
+++ b/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
@@ -83,14 +83,16 @@ describe('selected SWM metadata transfer ownership', () => {
         await fetcher.strategy.fetch(request);
         const walk = fetcher.strategy.snapshotWalk!(contextGraphId, manifest);
         walk.markResolved('ref-a', [suppressedRow]);
-        expect([...walk.resolvedRefs]).toEqual(['ref-a']);
+        expect(walk.resolvedRefsSnapshot()).toEqual(['ref-a']);
+        expect(walk.isResolved('ref-a')).toBe(true);
+        expect(walk.resolvedCount()).toBe(1);
       });
 
       await coordinator.run(peerId, createFetcher, async (fetcher) => {
         const cached = await fetcher.strategy.fetch(request);
         expect(cached.result.bytesReceived).toBe(0);
         const walk = fetcher.strategy.snapshotWalk!(contextGraphId, manifest);
-        expect([...walk.resolvedRefs]).toEqual(['ref-a']);
+        expect(walk.resolvedRefsSnapshot()).toEqual(['ref-a']);
         expect(walk.suppressedMetadataRows('ref-a')).toEqual([suppressedRow]);
         walk.markResolved('ref-a');
         expect(walk.suppressedMetadataRows('ref-a')).toEqual([suppressedRow]);
@@ -201,13 +203,13 @@ describe('selected SWM metadata transfer ownership', () => {
         await fetcher.strategy.fetch(request);
         const walk = fetcher.strategy.snapshotWalk!(contextGraphId, original);
         walk.markResolved('ref-a');
-        expect([...walk.resolvedRefs]).toEqual(['ref-a']);
+        expect(walk.resolvedRefsSnapshot()).toEqual(['ref-a']);
       });
 
       await coordinator.run(peerId, createFetcher, async (fetcher) => {
         await fetcher.strategy.fetch(request);
         const walk = fetcher.strategy.snapshotWalk!(contextGraphId, changedDigest);
-        expect([...walk.resolvedRefs]).toEqual([]);
+        expect(walk.resolvedRefsSnapshot()).toEqual([]);
         await syncPublicSnapshotsForMeta({
           ctx: testContext,
           remotePeerId: peerId,
@@ -249,14 +251,14 @@ describe('selected SWM metadata transfer ownership', () => {
       await coordinator.run(peerId, createFetcher, async (fetcher) => {
         await fetcher.strategy.fetch(request);
         const walk = fetcher.strategy.snapshotWalk!(contextGraphId, changedCount);
-        expect([...walk.resolvedRefs]).toEqual([]);
+        expect(walk.resolvedRefsSnapshot()).toEqual([]);
         walk.markResolved('ref-a');
       });
 
       await coordinator.run(peerId, createFetcher, async (fetcher) => {
         await fetcher.strategy.fetch(request);
         const walk = fetcher.strategy.snapshotWalk!(contextGraphId, reordered);
-        expect([...walk.resolvedRefs]).toEqual([]);
+        expect(walk.resolvedRefsSnapshot()).toEqual([]);
         walk.markResolved('ref-a');
         walk.markResolved('ref-b');
       });

--- a/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
+++ b/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
@@ -74,12 +74,15 @@ describe('selected SWM metadata transfer ownership', () => {
       { ref: 'ref-b', digest: 'digest-b', count: 1 },
       { ref: 'ref-c', digest: 'digest-c', count: 1 },
     ];
+    const suppressedRow = {
+      subject: 'urn:suppressed', predicate: 'urn:p', object: '"o"', graph: 'urn:meta',
+    };
 
     try {
       await coordinator.run(peerId, createFetcher, async (fetcher) => {
         await fetcher.strategy.fetch(request);
         const walk = fetcher.strategy.snapshotWalk!(contextGraphId, manifest);
-        walk.markResolved('ref-a');
+        walk.markResolved('ref-a', [suppressedRow]);
         expect([...walk.resolvedRefs]).toEqual(['ref-a']);
       });
 
@@ -88,6 +91,9 @@ describe('selected SWM metadata transfer ownership', () => {
         expect(cached.result.bytesReceived).toBe(0);
         const walk = fetcher.strategy.snapshotWalk!(contextGraphId, manifest);
         expect([...walk.resolvedRefs]).toEqual(['ref-a']);
+        expect(walk.suppressedMetadataRows('ref-a')).toEqual([suppressedRow]);
+        walk.markResolved('ref-a');
+        expect(walk.suppressedMetadataRows('ref-a')).toEqual([suppressedRow]);
         walk.markResolved('ref-b');
         walk.markResolved('ref-c');
       });

--- a/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
+++ b/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
@@ -114,6 +114,90 @@ describe('selected SWM metadata transfer ownership', () => {
     }
   });
 
+  it('does not extend completed-manifest retention on no-progress retries', async () => {
+    const peerId = 'peer-snapshot-no-progress-expiry';
+    const contextGraphId = 'cg-snapshot-no-progress-expiry';
+    const baseNow = Date.now();
+    let elapsedMs = 0;
+    const clock = () => baseNow + elapsedMs;
+    const coordinator = new SelectedSwmMetaTransferCoordinator({ now: clock });
+    const firstManifest = [
+      { ref: 'ref-a', digest: 'digest-a', count: 1 },
+      { ref: 'ref-stale', digest: 'digest-stale', count: 1 },
+    ];
+    const correctedManifest = [
+      firstManifest[0]!,
+      { ref: 'ref-fixed', digest: 'digest-fixed', count: 1 },
+    ];
+    let fetchGeneration = 0;
+    const fetchPage = vi.fn(async () => {
+      fetchGeneration += 1;
+      return {
+        quads: [{
+          subject: `urn:manifest:${fetchGeneration}`,
+          predicate: 'urn:p',
+          object: '"o"',
+          graph: 'urn:meta',
+        }],
+        bytesReceived: 1,
+        resumedFromOffset: 0,
+        nextOffset: 1,
+        checkpointKey: `no-progress-expiry-${fetchGeneration}`,
+        completed: true,
+        timedOut: false,
+      };
+    });
+    const createFetcher = vi.fn(() => createSelectedSwmMetaFetcher({
+      remotePeerId: peerId,
+      requesterScope: 'selected-swm-meta:retained:no-progress-expiry',
+      retentionBudget: retentionBudget(),
+      deleteCheckpoint: () => {},
+      fetchPage,
+      now: clock,
+      retentionTtlMs: 10_000,
+    }));
+    const request = {
+      ctx: testContext,
+      remotePeerId: peerId,
+      contextGraphId,
+      graphUri: 'urn:meta',
+      deadline: clock() + 60_000,
+    };
+
+    try {
+      await coordinator.run(peerId, createFetcher, async (fetcher) => {
+        await fetcher.strategy.fetch(request);
+        const walk = fetcher.strategy.snapshotWalk!(contextGraphId, firstManifest);
+        walk.markResolved('ref-a');
+      });
+
+      for (const retryAtMs of [4_000, 9_000]) {
+        elapsedMs = retryAtMs;
+        await coordinator.run(peerId, createFetcher, async (fetcher) => {
+          const cached = await fetcher.strategy.fetch({ ...request, deadline: clock() + 60_000 });
+          expect(cached.result.bytesReceived).toBe(0);
+          const walk = fetcher.strategy.snapshotWalk!(contextGraphId, firstManifest);
+          expect(walk.resolvedRefsSnapshot()).toEqual(['ref-a']);
+          // Deliberately make no progress.
+        });
+      }
+
+      elapsedMs = 10_001;
+      await coordinator.run(peerId, createFetcher, async (fetcher) => {
+        const refreshed = await fetcher.strategy.fetch({ ...request, deadline: clock() + 60_000 });
+        expect(refreshed.result.bytesReceived).toBe(1);
+        const walk = fetcher.strategy.snapshotWalk!(contextGraphId, correctedManifest);
+        expect(walk.resolvedRefsSnapshot()).toEqual([]);
+        expect(walk.orderedManifestSnapshot()).toEqual(correctedManifest);
+      });
+
+      expect(fetchPage).toHaveBeenCalledTimes(2);
+      expect(createFetcher).toHaveBeenCalledTimes(2);
+    } finally {
+      await coordinator.close();
+    }
+  });
+
   it('releases completed metadata when no snapshot walk remains active', async () => {
     const peerId = 'peer-complete-without-walk';
     const contextGraphId = 'cg-complete-without-walk';

--- a/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
+++ b/packages/agent/test/selected-swm-meta-transfer-coordinator.test.ts
@@ -4,6 +4,7 @@ import {
   createSelectedSwmMetaFetcher,
   SelectedSwmMetaTransferOwner,
 } from '../src/sync/selected-swm-meta-fetcher.js';
+import { syncPublicSnapshotsForMeta } from '../src/sync/requester/shared-memory-sync.js';
 import { SelectedSwmMetaTransferCoordinator } from '../src/sync/selected-swm-meta-transfer-coordinator.js';
 import { createSelectedSwmMetaRetentionBudget } from '../src/sync/selected-swm-meta-budget.js';
 
@@ -101,6 +102,150 @@ describe('selected SWM metadata transfer ownership', () => {
       });
       expect(fetchPage).toHaveBeenCalledTimes(2);
       expect(createFetcher).toHaveBeenCalledTimes(2);
+    } finally {
+      await coordinator.close();
+    }
+  });
+
+  it('releases completed metadata when no snapshot walk remains active', async () => {
+    const peerId = 'peer-complete-without-walk';
+    const contextGraphId = 'cg-complete-without-walk';
+    const coordinator = new SelectedSwmMetaTransferCoordinator();
+    const fetchPage = vi.fn(async () => ({
+      quads: [{ subject: 'urn:terminal-meta', predicate: 'urn:p', object: '"o"', graph: 'urn:meta' }],
+      bytesReceived: 1,
+      resumedFromOffset: 0,
+      nextOffset: 1,
+      checkpointKey: 'terminal-meta-checkpoint',
+      completed: true,
+      timedOut: false,
+    }));
+    const createFetcher = vi.fn(() => createSelectedSwmMetaFetcher({
+      remotePeerId: peerId,
+      requesterScope: 'selected-swm-meta:retained:terminal-without-walk',
+      retentionBudget: retentionBudget(),
+      deleteCheckpoint: () => {},
+      fetchPage,
+    }));
+    const request = {
+      ctx: testContext,
+      remotePeerId: peerId,
+      contextGraphId,
+      graphUri: 'urn:meta',
+      deadline: Date.now() + 1_000,
+    };
+
+    try {
+      await coordinator.run(peerId, createFetcher, (fetcher) => fetcher.strategy.fetch(request));
+      await coordinator.run(peerId, createFetcher, (fetcher) => fetcher.strategy.fetch(request));
+
+      // Terminal metadata without a post-metadata walk carries no resumable
+      // work into the next outer invocation.
+      expect(fetchPage).toHaveBeenCalledTimes(2);
+      expect(createFetcher).toHaveBeenCalledTimes(2);
+    } finally {
+      await coordinator.close();
+    }
+  });
+
+  it('invalidates resolved refs when the exact manifest changes digest or order', async () => {
+    const peerId = 'peer-manifest-invalidation';
+    const contextGraphId = 'cg-manifest-invalidation';
+    const coordinator = new SelectedSwmMetaTransferCoordinator();
+    const fetchPage = vi.fn(async () => ({
+      quads: [{ subject: 'urn:manifest', predicate: 'urn:p', object: '"o"', graph: 'urn:meta' }],
+      bytesReceived: 1,
+      resumedFromOffset: 0,
+      nextOffset: 1,
+      checkpointKey: 'manifest-invalidation-checkpoint',
+      completed: true,
+      timedOut: false,
+    }));
+    const createFetcher = vi.fn(() => createSelectedSwmMetaFetcher({
+      remotePeerId: peerId,
+      requesterScope: 'selected-swm-meta:retained:manifest-invalidation',
+      retentionBudget: retentionBudget(),
+      deleteCheckpoint: () => {},
+      fetchPage,
+    }));
+    const request = {
+      ctx: testContext,
+      remotePeerId: peerId,
+      contextGraphId,
+      graphUri: 'urn:meta',
+      deadline: Date.now() + 1_000,
+    };
+    const original = [
+      { ref: 'ref-a', digest: 'digest-a', count: 1 },
+      { ref: 'ref-b', digest: 'digest-b', count: 1 },
+    ];
+    const changedDigest = [
+      { ref: 'ref-a', digest: 'digest-a-v2', count: 1 },
+      { ref: 'ref-b', digest: 'digest-b', count: 1 },
+    ];
+    const reordered = [changedDigest[1]!, changedDigest[0]!];
+    const requestedRefs: string[] = [];
+
+    try {
+      await coordinator.run(peerId, createFetcher, async (fetcher) => {
+        await fetcher.strategy.fetch(request);
+        const walk = fetcher.strategy.snapshotWalk!(contextGraphId, original);
+        walk.markResolved('ref-a');
+        expect([...walk.resolvedRefs]).toEqual(['ref-a']);
+      });
+
+      await coordinator.run(peerId, createFetcher, async (fetcher) => {
+        await fetcher.strategy.fetch(request);
+        const walk = fetcher.strategy.snapshotWalk!(contextGraphId, changedDigest);
+        expect([...walk.resolvedRefs]).toEqual([]);
+        await syncPublicSnapshotsForMeta({
+          ctx: testContext,
+          remotePeerId: peerId,
+          contextGraphId,
+          deadline: Date.now() + 1_000,
+          snapshotWalk: walk,
+          publicSnapshotStore: {
+            getSnapshot: async () => null,
+            putSnapshot: async ({ digest }) => ({ ref: digest, byteLength: 0 }),
+          },
+          fetchSyncPages: async (
+            _ctx,
+            _remotePeerId,
+            _contextGraphId,
+            _includeSharedMemory,
+            _phase,
+            _graphUri,
+            _deadline,
+            options,
+          ) => {
+            requestedRefs.push(options?.snapshotRef ?? '');
+            return {
+              quads: [],
+              bytesReceived: 0,
+              resumedFromOffset: 0,
+              nextOffset: 0,
+              checkpointKey: 'changed-manifest-snapshot',
+              completed: false,
+              timedOut: true,
+            };
+          },
+          deleteCheckpoint: () => {},
+          setCheckpoint: () => {},
+        });
+        expect(requestedRefs).toEqual(['ref-a']);
+        walk.markResolved('ref-a');
+      });
+
+      await coordinator.run(peerId, createFetcher, async (fetcher) => {
+        await fetcher.strategy.fetch(request);
+        const walk = fetcher.strategy.snapshotWalk!(contextGraphId, reordered);
+        expect([...walk.resolvedRefs]).toEqual([]);
+        walk.markResolved('ref-a');
+        walk.markResolved('ref-b');
+      });
+
+      expect(fetchPage).toHaveBeenCalledOnce();
+      expect(createFetcher).toHaveBeenCalledOnce();
     } finally {
       await coordinator.close();
     }

--- a/packages/agent/test/swm-public-snapshot-materialization.test.ts
+++ b/packages/agent/test/swm-public-snapshot-materialization.test.ts
@@ -53,6 +53,7 @@ import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
 import {
   runSharedMemorySync,
   type SharedMemoryMetadataFetcher,
+  type SharedMemorySnapshotWalkContinuation,
 } from '../src/sync/requester/shared-memory-sync.js';
 import type { SharedMemorySnapshotMaterializer, StoredWorkspaceHeadState } from '../src/sync/requester/swm-snapshot-materializer.js';
 
@@ -326,34 +327,57 @@ describe('public SWM snapshot materialization', () => {
     expect(h.events.slice(reconciliation + 1)).not.toContain('meta-inserted');
   });
 
-  it('reapplies resolved-prefix suppression before a resumed round bulk-inserts metadata', async () => {
+  it('captures first-round suppression and reapplies it before a resumed bulk metadata insert', async () => {
     const fx = fixture();
-    const walk = {
-      orderedManifest: [{ ref: fx.digest, digest: fx.digest, count: fx.payload.length }],
-      isResolved: (ref) => ref === fx.digest,
-      resolvedCount: () => 1,
-      resolvedRefsSnapshot: () => [fx.digest],
-      suppressedMetadataRows: (ref: string) => ref === fx.digest ? fx.meta : [],
-      markResolved: () => {},
-    };
-    const h = harness({
-      metadataFetcher: {
-        fetch: async () => ({ result: page(fx.meta), continuationYielded: false }),
-        release: () => {},
-        snapshotWalk: () => walk,
+    const manifest = [{ ref: fx.digest, digest: fx.digest, count: fx.payload.length }];
+    const resolved = new Set<string>();
+    const suppressedByRef = new Map<string, readonly Quad[]>();
+    const walk: SharedMemorySnapshotWalkContinuation = {
+      orderedManifestSnapshot: () => manifest.map((snapshot) => ({ ...snapshot })),
+      isResolved: (ref) => resolved.has(ref),
+      resolvedCount: () => resolved.size,
+      resolvedRefsSnapshot: () => [...resolved],
+      suppressedMetadataRows: (ref) => suppressedByRef.get(ref) ?? [],
+      markResolved: (ref, suppressedRows = []) => {
+        suppressedByRef.set(ref, suppressedRows.map((quad) => ({ ...quad })));
+        resolved.add(ref);
       },
+    };
+    const metadataFetcher: SharedMemoryMetadataFetcher = {
+      fetch: async () => ({ result: page(fx.meta), continuationYielded: false }),
+      release: () => {},
+      snapshotWalk: () => walk,
+    };
+    const first = harness({
+      reconcileDisposition: 'suppress-metadata',
+      metadataFetcher,
     });
 
-    const summary = await h.run();
+    const firstSummary = await first.run();
 
-    expect(summary.failedPhases).toBe(0);
-    expect(h.replaced).toHaveLength(0);
-    expect(h.events).not.toContain('finalized-twin-reconciled');
-    const suppressedSubjects = new Set([
+    expect(firstSummary.failedPhases).toBe(0);
+    expect(first.replaced).toHaveLength(1);
+    expect(resolved).toEqual(new Set([fx.digest]));
+    const retiredSubjects = new Set([
       `${UAL}#dkg-swm-head`,
       `urn:dkg:share:${CG}:snapshot-materialization-op`,
     ]);
-    expect(h.inserted.flat().filter((quad) => suppressedSubjects.has(quad.subject)))
+    const capturedRows = suppressedByRef.get(fx.digest) ?? [];
+    expect(capturedRows.filter((quad) => retiredSubjects.has(quad.subject)).length)
+      .toBeGreaterThan(0);
+
+    const resumed = harness({
+      metadataFetcher: {
+        ...metadataFetcher,
+      },
+    });
+
+    const resumedSummary = await resumed.run();
+
+    expect(resumedSummary.failedPhases).toBe(0);
+    expect(resumed.replaced).toHaveLength(0);
+    expect(resumed.events).not.toContain('finalized-twin-reconciled');
+    expect(resumed.inserted.flat().filter((quad) => retiredSubjects.has(quad.subject)))
       .toHaveLength(0);
   });
 

--- a/packages/agent/test/swm-public-snapshot-materialization.test.ts
+++ b/packages/agent/test/swm-public-snapshot-materialization.test.ts
@@ -50,7 +50,10 @@ import {
 } from '@origintrail-official/dkg-publisher';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
-import { runSharedMemorySync } from '../src/sync/requester/shared-memory-sync.js';
+import {
+  runSharedMemorySync,
+  type SharedMemoryMetadataFetcher,
+} from '../src/sync/requester/shared-memory-sync.js';
 import type { SharedMemorySnapshotMaterializer, StoredWorkspaceHeadState } from '../src/sync/requester/swm-snapshot-materializer.js';
 
 const CG = 'ws00-snapshot-materialization';
@@ -129,6 +132,7 @@ interface HarnessOverrides {
   reconcileDisposition?: 'preserve' | 'suppress-metadata';
   publisherPeerId?: string;
   additionalVerifiedMeta?: Quad[];
+  metadataFetcher?: SharedMemoryMetadataFetcher;
 }
 
 function harness(overrides: HarnessOverrides = {}) {
@@ -174,6 +178,7 @@ function harness(overrides: HarnessOverrides = {}) {
         emptyResponses: 0,
         entityCreators: [],
       }),
+      ...(overrides.metadataFetcher ? { metadataFetcher: overrides.metadataFetcher } : {}),
       ...(overrides.subGraphName
         ? {
             getRegisteredSubGraphNames: async () => [overrides.subGraphName!],
@@ -319,6 +324,35 @@ describe('public SWM snapshot materialization', () => {
     const reconciliation = h.events.indexOf('finalized-twin-reconciled');
     expect(reconciliation).toBeGreaterThan(h.events.indexOf('lock-released'));
     expect(h.events.slice(reconciliation + 1)).not.toContain('meta-inserted');
+  });
+
+  it('reapplies resolved-prefix suppression before a resumed round bulk-inserts metadata', async () => {
+    const fx = fixture();
+    const walk = {
+      orderedManifest: [{ ref: fx.digest, digest: fx.digest, count: fx.payload.length }],
+      resolvedRefs: new Set([fx.digest]),
+      suppressedMetadataRows: (ref: string) => ref === fx.digest ? fx.meta : [],
+      markResolved: () => {},
+    };
+    const h = harness({
+      metadataFetcher: {
+        fetch: async () => ({ result: page(fx.meta), continuationYielded: false }),
+        release: () => {},
+        snapshotWalk: () => walk,
+      },
+    });
+
+    const summary = await h.run();
+
+    expect(summary.failedPhases).toBe(0);
+    expect(h.replaced).toHaveLength(0);
+    expect(h.events).not.toContain('finalized-twin-reconciled');
+    const suppressedSubjects = new Set([
+      `${UAL}#dkg-swm-head`,
+      `urn:dkg:share:${CG}:snapshot-materialization-op`,
+    ]);
+    expect(h.inserted.flat().filter((quad) => suppressedSubjects.has(quad.subject)))
+      .toHaveLength(0);
   });
 
   it('does not alias delimiter-like RDF terms in the suppression ledger', async () => {

--- a/packages/agent/test/swm-public-snapshot-materialization.test.ts
+++ b/packages/agent/test/swm-public-snapshot-materialization.test.ts
@@ -330,7 +330,9 @@ describe('public SWM snapshot materialization', () => {
     const fx = fixture();
     const walk = {
       orderedManifest: [{ ref: fx.digest, digest: fx.digest, count: fx.payload.length }],
-      resolvedRefs: new Set([fx.digest]),
+      isResolved: (ref) => ref === fx.digest,
+      resolvedCount: () => 1,
+      resolvedRefsSnapshot: () => [fx.digest],
       suppressedMetadataRows: (ref: string) => ref === fx.digest ? fx.meta : [],
       markResolved: () => {},
     };

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -20,6 +20,7 @@ import {
   collectPublicSnapshotMetadata,
   runSharedMemorySync,
   selectSwmSnapshotCoverage,
+  syncPublicSnapshotsForMeta,
 } from '../src/sync/requester/shared-memory-sync.js';
 import type { SwmSnapshotCoverage } from '../src/dkg-agent-types.js';
 import {
@@ -108,6 +109,66 @@ function sharedMemoryProcessResult() {
     entityCreators: [],
   };
 }
+
+describe('selected snapshot walk continuation', () => {
+  it('skips an exact resolved prefix and spends the next slice on unresolved snapshots', async () => {
+    const first = [quad('resolved-prefix')].map((row) => ({ ...row, graph: '' }));
+    const second = [quad('next-unresolved')].map((row) => ({ ...row, graph: '' }));
+    const firstDigest = workspacePublicQuadsDigest(first);
+    const secondDigest = workspacePublicQuadsDigest(second);
+    const snapshots = [
+      { ref: firstDigest, digest: firstDigest, count: first.length },
+      { ref: secondDigest, digest: secondDigest, count: second.length },
+    ];
+    const cacheReads: string[] = [];
+    const fetchedRefs: string[] = [];
+    const readyRefs: string[] = [];
+
+    const result = await syncPublicSnapshotsForMeta({
+      ctx,
+      remotePeerId: 'peer-resume-prefix',
+      contextGraphId: 'cg-resume-prefix',
+      deadline: Date.now() + 60_000,
+      metaQuads: [],
+      orderedSnapshots: snapshots,
+      resolvedSnapshotRefs: new Set([firstDigest]),
+      publicSnapshotStore: {
+        getSnapshot: async (ref) => {
+          cacheReads.push(ref);
+          return null;
+        },
+        putSnapshot: async ({ digest }) => ({ ref: digest, byteLength: 1 }),
+      },
+      fetchSyncPages: async (
+        _ctx,
+        _peer,
+        contextGraphId,
+        _includeSharedMemory,
+        phase,
+        _graph,
+        _deadline,
+        options,
+      ) => {
+        expect(phase).toBe('snapshot');
+        fetchedRefs.push(options!.snapshotRef!);
+        return pageResult(contextGraphId, phase, { quads: second });
+      },
+      deleteCheckpoint: () => {},
+      setCheckpoint: () => {},
+      onSnapshotReady: async (snapshot) => { readyRefs.push(snapshot.ref); },
+    });
+
+    expect(cacheReads).toEqual([secondDigest]);
+    expect(fetchedRefs).toEqual([secondDigest]);
+    expect(readyRefs).toEqual([secondDigest]);
+    expect(result).toMatchObject({
+      readySnapshots: 2,
+      totalSnapshots: 2,
+      completed: true,
+      missingCount: 0,
+    });
+  });
+});
 
 describe('sync requester progress accounting', () => {
   it('does not count a denied durable graph but counts the subsequent clean-empty graph', async () => {

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -132,6 +132,7 @@ describe('selected snapshot walk continuation', () => {
       snapshotWalk: {
         orderedManifest: snapshots,
         resolvedRefs: new Set([firstDigest]),
+        suppressedMetadataRows: () => [],
         markResolved: () => {},
       },
       publicSnapshotStore: {

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -130,7 +130,7 @@ describe('selected snapshot walk continuation', () => {
       contextGraphId: 'cg-resume-prefix',
       deadline: Date.now() + 60_000,
       snapshotWalk: {
-        orderedManifest: snapshots,
+        orderedManifestSnapshot: () => snapshots.map((snapshot) => ({ ...snapshot })),
         isResolved: (ref) => ref === firstDigest,
         resolvedCount: () => 1,
         resolvedRefsSnapshot: () => [firstDigest],
@@ -166,6 +166,63 @@ describe('selected snapshot walk continuation', () => {
     expect(cacheReads).toEqual([secondDigest]);
     expect(fetchedRefs).toEqual([secondDigest]);
     expect(readyRefs).toEqual([secondDigest]);
+    expect(result).toMatchObject({
+      readySnapshots: 2,
+      totalSnapshots: 2,
+      completed: true,
+      missingCount: 0,
+    });
+  });
+
+  it('starts at the first snapshot when a changed manifest has no retained resolution', async () => {
+    const first = [quad('changed-manifest-first')].map((row) => ({ ...row, graph: '' }));
+    const second = [quad('changed-manifest-second')].map((row) => ({ ...row, graph: '' }));
+    const firstDigest = workspacePublicQuadsDigest(first);
+    const secondDigest = workspacePublicQuadsDigest(second);
+    const snapshots = [
+      { ref: firstDigest, digest: firstDigest, count: first.length },
+      { ref: secondDigest, digest: secondDigest, count: second.length },
+    ];
+    const fetchedRefs: string[] = [];
+
+    const result = await syncPublicSnapshotsForMeta({
+      ctx,
+      remotePeerId: 'peer-changed-manifest',
+      contextGraphId: 'cg-changed-manifest',
+      deadline: Date.now() + 60_000,
+      snapshotWalk: {
+        orderedManifestSnapshot: () => snapshots.map((snapshot) => ({ ...snapshot })),
+        isResolved: () => false,
+        resolvedCount: () => 0,
+        resolvedRefsSnapshot: () => [],
+        suppressedMetadataRows: () => [],
+        markResolved: () => {},
+      },
+      publicSnapshotStore: {
+        getSnapshot: async () => null,
+        putSnapshot: async ({ digest }) => ({ ref: digest, byteLength: 1 }),
+      },
+      fetchSyncPages: async (
+        _ctx,
+        _peer,
+        contextGraphId,
+        _includeSharedMemory,
+        phase,
+        _graph,
+        _deadline,
+        options,
+      ) => {
+        const ref = options!.snapshotRef!;
+        fetchedRefs.push(ref);
+        return pageResult(contextGraphId, phase, {
+          quads: ref === firstDigest ? first : second,
+        });
+      },
+      deleteCheckpoint: () => {},
+      setCheckpoint: () => {},
+    });
+
+    expect(fetchedRefs).toEqual([firstDigest, secondDigest]);
     expect(result).toMatchObject({
       readySnapshots: 2,
       totalSnapshots: 2,

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -131,7 +131,9 @@ describe('selected snapshot walk continuation', () => {
       deadline: Date.now() + 60_000,
       snapshotWalk: {
         orderedManifest: snapshots,
-        resolvedRefs: new Set([firstDigest]),
+        isResolved: (ref) => ref === firstDigest,
+        resolvedCount: () => 1,
+        resolvedRefsSnapshot: () => [firstDigest],
         suppressedMetadataRows: () => [],
         markResolved: () => {},
       },

--- a/packages/agent/test/sync-requester-progress.test.ts
+++ b/packages/agent/test/sync-requester-progress.test.ts
@@ -129,9 +129,11 @@ describe('selected snapshot walk continuation', () => {
       remotePeerId: 'peer-resume-prefix',
       contextGraphId: 'cg-resume-prefix',
       deadline: Date.now() + 60_000,
-      metaQuads: [],
-      orderedSnapshots: snapshots,
-      resolvedSnapshotRefs: new Set([firstDigest]),
+      snapshotWalk: {
+        orderedManifest: snapshots,
+        resolvedRefs: new Set([firstDigest]),
+        markResolved: () => {},
+      },
       publicSnapshotStore: {
         getSnapshot: async (ref) => {
           cacheReads.push(ref);


### PR DESCRIPTION
## User impact

A selected public Context Graph with thousands of SWM assets can now finish native RFC-64 catch-up across bounded scheduler jobs. Receivers no longer spend every job re-reading and re-validating the same manifest prefix while the unresolved suffix never receives service.

This changes no trust boundary: progress is in-memory, bound to the exact ordered manifest, and retained only while that manifest walk is incomplete. A changed manifest, owner expiry, release, or process restart discards it and revalidates from source.

## Before

```mermaid
sequenceDiagram
    participant Job1 as Bounded sync job 1
    participant Job2 as Bounded sync job 2
    participant Manifest as Exact SWM manifest
    participant Store as Receiver store

    Job1->>Manifest: Read assets 1 through N
    Job1->>Store: Verify and materialize prefix
    Job1-->>Job2: Release completed metadata state
    Job2->>Manifest: Start again at asset 1
    Job2->>Store: Re-read and re-hash the same prefix
    Job2-->>Job2: Budget expires before unresolved suffix
```

## After

```mermaid
sequenceDiagram
    participant Job1 as Bounded sync job 1
    participant Owner as Manifest-bound continuation owner
    participant Job2 as Bounded sync job 2
    participant Store as Receiver store

    Job1->>Owner: Bind exact ordered manifest
    Job1->>Store: Verify and materialize prefix
    Job1->>Owner: Mark only successfully materialized refs resolved
    Owner-->>Job2: Retain completed metadata and resolved refs
    Job2->>Owner: Confirm the same exact manifest
    Job2->>Store: Skip verified prefix and process unresolved suffix
    Job2->>Owner: Release state only at terminal coverage
```

## Safety properties

- A ref is marked resolved only after local materialization succeeds.
- The continuation is bound to the exact ordered ref, digest, and count tuple set.
- Manifest drift clears the retained prefix.
- State expires with the selected metadata owner and is never durable trust.
- Process restart safely loses the optimization and forces revalidation.
- Empty, zero-ref, fully resolved, and released owners do not retain stale state.

## Validation

- Agent build, type tests, and package-root boundary: pass.
- Focused selected-SWM and current-canary regression lane: 195/195 pass.
- Full agent unit lane: 201 files, 2,926 passed, 5 skipped, 0 failed.
- Testnet hotfix exact head `a2ce493d`:
  - RFC-64 gate recorded enabled + selected + catalog-backed for the exact CG.
  - A real 1,698-snapshot selected SWM walk reached 1,698/1,698, zero missing, zero materialization failures, stop reason `plane-proven`.
  - Local receiver scored 500/500 SWM and 500/500 VM with zero missing or mismatches on run `open-20260817-97100`.
  - Distributed external receiver validation remains in progress; this PR is not authorized for merge by the runtime hotfix.

## Scope

This is the DKG production fix only. Harness compatibility for the current `rfc64PublicCatalog` status shape is tracked independently in OriginTrail/dkg-blackbox-harness#17.