### PR TITLE
fix(sync): distinguish catch-up jobs from graph continuation

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -360,6 +360,10 @@ import {
   type SelectedSwmContinuationUnit,
 } from './sync/selected-swm-continuation.js';
 import {
+  projectRfc64SelectedSwmGraphSyncStatus,
+  type Rfc64SelectedSwmGraphSyncStatus,
+} from './sync/selected-swm-graph-sync-status.js';
+import {
   applySelectedSwmFreshnessResolution,
   mergeSharedMemoryFreshnessDiagnostics,
 } from './sync/shared-memory-freshness.js';
@@ -4232,13 +4236,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   getRfc64SelectedSwmGraphSyncStatus(
     this: DKGAgent,
     contextGraphId: string,
-  ): {
-    mechanism: 'rfc64-selected-on-connect';
-    state: 'inactive' | 'waiting' | 'continuing' | 'converged';
-    configuredProviderCount: number;
-    retryRequiredProviderCount: number;
-    terminalProviderCount: number;
-  } {
+  ): Rfc64SelectedSwmGraphSyncStatus {
     const selected = (this.config.syncContextGraphs ?? []).includes(contextGraphId);
     const providerPeerIds = [
       ...new Set(this.resolveRfc64CompleteSwmProviderPeerIdsV1(contextGraphId)),
@@ -4249,19 +4247,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     );
     const sharedMemorySynced =
       this.subscribedContextGraphs.get(contextGraphId)?.sharedMemorySynced === true;
-    const state = !selected || providerPeerIds.length === 0
-      ? 'inactive'
-      : sharedMemorySynced || summary.terminalProviders > 0
-        ? 'converged'
-        : summary.retryRequiredProviders > 0
-          ? 'continuing'
-          : 'waiting';
-    return Object.freeze({
-      mechanism: 'rfc64-selected-on-connect',
-      state,
+    return projectRfc64SelectedSwmGraphSyncStatus({
+      selected,
       configuredProviderCount: providerPeerIds.length,
       retryRequiredProviderCount: summary.retryRequiredProviders,
       terminalProviderCount: summary.terminalProviders,
+      sharedMemorySynced,
     });
   }
 

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -4223,6 +4223,48 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     ).filter((contextGraphId) => selected.has(contextGraphId));
   }
 
+  /**
+   * Project the selected RFC-64 retry owner into a graph-scoped, identity-safe
+   * operator status. `continuing` means automatic continuation is still
+   * required; it deliberately does not claim a transfer is in flight at this
+   * exact instant.
+   */
+  getRfc64SelectedSwmGraphSyncStatus(
+    this: DKGAgent,
+    contextGraphId: string,
+  ): {
+    mechanism: 'rfc64-selected-on-connect';
+    state: 'inactive' | 'waiting' | 'continuing' | 'converged';
+    configuredProviderCount: number;
+    retryRequiredProviderCount: number;
+    terminalProviderCount: number;
+  } {
+    const selected = (this.config.syncContextGraphs ?? []).includes(contextGraphId);
+    const providerPeerIds = [
+      ...new Set(this.resolveRfc64CompleteSwmProviderPeerIdsV1(contextGraphId)),
+    ];
+    const summary = this.selectedSwmBootstrapAdmission.summarizeContextGraph(
+      contextGraphId,
+      providerPeerIds,
+    );
+    const sharedMemorySynced =
+      this.subscribedContextGraphs.get(contextGraphId)?.sharedMemorySynced === true;
+    const state = !selected || providerPeerIds.length === 0
+      ? 'inactive'
+      : sharedMemorySynced || summary.terminalProviders > 0
+        ? 'converged'
+        : summary.retryRequiredProviders > 0
+          ? 'continuing'
+          : 'waiting';
+    return Object.freeze({
+      mechanism: 'rfc64-selected-on-connect',
+      state,
+      configuredProviderCount: providerPeerIds.length,
+      retryRequiredProviderCount: summary.retryRequiredProviders,
+      terminalProviderCount: summary.terminalProviders,
+    });
+  }
+
   queueSyncFromPeerOnConnect(
     this: DKGAgent,
     remotePeer: string,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -83,8 +83,6 @@ export {
   type SharedMemoryFreshnessSummary,
 } from './sync/shared-memory-freshness.js';
 export {
-  projectRfc64SelectedSwmGraphSyncStatus,
-  type ProjectRfc64SelectedSwmGraphSyncStatusInput,
   type Rfc64SelectedSwmGraphSyncStatus,
 } from './sync/selected-swm-graph-sync-status.js';
 export {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -83,6 +83,11 @@ export {
   type SharedMemoryFreshnessSummary,
 } from './sync/shared-memory-freshness.js';
 export {
+  projectRfc64SelectedSwmGraphSyncStatus,
+  type ProjectRfc64SelectedSwmGraphSyncStatusInput,
+  type Rfc64SelectedSwmGraphSyncStatus,
+} from './sync/selected-swm-graph-sync-status.js';
+export {
   ContextGraphOnChainIdUnresolvedError,
   VmReconcileQueueClosedError,
   VmReconcileQueueFullError,

--- a/packages/agent/src/sync/selected-swm-bootstrap-admission.ts
+++ b/packages/agent/src/sync/selected-swm-bootstrap-admission.ts
@@ -125,20 +125,18 @@ export class SelectedSwmBootstrapAdmission {
 
   /**
    * Summarize one selected graph without exposing which providers own the
-   * admission records. When `providerPeerIds` is supplied, stale records for
-   * providers that are no longer designated for the graph are ignored.
+   * admission records. The explicit provider scope excludes stale records for
+   * peers that are no longer designated for the graph.
    */
   summarizeContextGraph(
     contextGraphId: string,
-    providerPeerIds?: readonly string[],
+    providerPeerIds: readonly string[],
   ): SelectedSwmBootstrapContextGraphSummary {
-    const providerFilter = providerPeerIds === undefined
-      ? undefined
-      : new Set(providerPeerIds);
+    const providerFilter = new Set(providerPeerIds);
     let retryRequiredProviders = 0;
     let terminalProviders = 0;
     for (const [remotePeer, state] of this.#byPeer) {
-      if (providerFilter !== undefined && !providerFilter.has(remotePeer)) continue;
+      if (!providerFilter.has(remotePeer)) continue;
       if (!state.contextGraphIds.includes(contextGraphId)) continue;
       if (state.phase === 'retry-required') retryRequiredProviders += 1;
       else terminalProviders += 1;

--- a/packages/agent/src/sync/selected-swm-bootstrap-admission.ts
+++ b/packages/agent/src/sync/selected-swm-bootstrap-admission.ts
@@ -13,6 +13,12 @@ export interface SelectedSwmBootstrapTransferOwner {
   readonly generation: number;
 }
 
+/** Identity-free aggregate used by operator status surfaces. */
+export interface SelectedSwmBootstrapContextGraphSummary {
+  readonly retryRequiredProviders: number;
+  readonly terminalProviders: number;
+}
+
 interface SelectedSwmBootstrapAdmissionState extends SelectedSwmBootstrapAdmissionSnapshot {
   readonly generation: number;
 }
@@ -115,6 +121,29 @@ export class SelectedSwmBootstrapAdmission {
       contextGraphIds: state.contextGraphIds,
       phase: state.phase,
     });
+  }
+
+  /**
+   * Summarize one selected graph without exposing which providers own the
+   * admission records. When `providerPeerIds` is supplied, stale records for
+   * providers that are no longer designated for the graph are ignored.
+   */
+  summarizeContextGraph(
+    contextGraphId: string,
+    providerPeerIds?: readonly string[],
+  ): SelectedSwmBootstrapContextGraphSummary {
+    const providerFilter = providerPeerIds === undefined
+      ? undefined
+      : new Set(providerPeerIds);
+    let retryRequiredProviders = 0;
+    let terminalProviders = 0;
+    for (const [remotePeer, state] of this.#byPeer) {
+      if (providerFilter !== undefined && !providerFilter.has(remotePeer)) continue;
+      if (!state.contextGraphIds.includes(contextGraphId)) continue;
+      if (state.phase === 'retry-required') retryRequiredProviders += 1;
+      else terminalProviders += 1;
+    }
+    return Object.freeze({ retryRequiredProviders, terminalProviders });
   }
 
   clear(remotePeer: string): void {

--- a/packages/agent/src/sync/selected-swm-graph-sync-status.ts
+++ b/packages/agent/src/sync/selected-swm-graph-sync-status.ts
@@ -1,0 +1,35 @@
+export interface Rfc64SelectedSwmGraphSyncStatus {
+  readonly mechanism: 'rfc64-selected-on-connect';
+  readonly state: 'inactive' | 'waiting' | 'continuing' | 'converged';
+  readonly configuredProviderCount: number;
+  readonly retryRequiredProviderCount: number;
+  readonly terminalProviderCount: number;
+}
+
+export interface ProjectRfc64SelectedSwmGraphSyncStatusInput {
+  readonly selected: boolean;
+  readonly configuredProviderCount: number;
+  readonly retryRequiredProviderCount: number;
+  readonly terminalProviderCount: number;
+  readonly sharedMemorySynced: boolean;
+}
+
+/** Project retry ownership without exposing provider identities. */
+export function projectRfc64SelectedSwmGraphSyncStatus(
+  input: ProjectRfc64SelectedSwmGraphSyncStatusInput,
+): Rfc64SelectedSwmGraphSyncStatus {
+  const state = !input.selected || input.configuredProviderCount === 0
+    ? 'inactive'
+    : input.sharedMemorySynced || input.terminalProviderCount > 0
+      ? 'converged'
+      : input.retryRequiredProviderCount > 0
+        ? 'continuing'
+        : 'waiting';
+  return Object.freeze({
+    mechanism: 'rfc64-selected-on-connect',
+    state,
+    configuredProviderCount: input.configuredProviderCount,
+    retryRequiredProviderCount: input.retryRequiredProviderCount,
+    terminalProviderCount: input.terminalProviderCount,
+  });
+}

--- a/packages/agent/test/selected-swm-bootstrap-admission.test.ts
+++ b/packages/agent/test/selected-swm-bootstrap-admission.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { LifecycleSyncMethods } from '../src/dkg-agent-lifecycle.js';
 import { SelectedSwmBootstrapAdmission } from '../src/sync/selected-swm-bootstrap-admission.js';
 
 const PEER = '12D3KooWScopeAwareSelectedSwmProvider';
@@ -70,5 +71,74 @@ describe('SelectedSwmBootstrapAdmission', () => {
       contextGraphIds: [],
       phase: 'terminal',
     });
+  });
+
+  it('summarizes one graph without returning provider identities', () => {
+    const admission = new SelectedSwmBootstrapAdmission();
+    const otherPeer = `${PEER}-other`;
+    const stalePeer = `${PEER}-stale`;
+
+    admission.request(PEER, ['cg-a', 'cg-b']);
+    completeScope(admission, ['cg-a', 'cg-b']);
+    admission.request(otherPeer, ['cg-a']);
+    admission.request(stalePeer, ['cg-a']);
+
+    expect(admission.summarizeContextGraph('cg-a', [PEER, otherPeer])).toEqual({
+      retryRequiredProviders: 1,
+      terminalProviders: 1,
+    });
+    expect(admission.summarizeContextGraph('cg-b', [PEER, otherPeer])).toEqual({
+      retryRequiredProviders: 0,
+      terminalProviders: 1,
+    });
+  });
+});
+
+describe('selected RFC-64 graph sync status', () => {
+  const CG = 'cg-selected';
+  const PROVIDER = '12D3KooWSelectedProvider';
+
+  function status(options: {
+    selected?: boolean;
+    providers?: readonly string[];
+    phase?: 'waiting' | 'retry-required' | 'terminal';
+    sharedMemorySynced?: boolean;
+  } = {}) {
+    const admission = new SelectedSwmBootstrapAdmission();
+    if (options.phase === 'retry-required') admission.request(PROVIDER, [CG]);
+    if (options.phase === 'terminal') {
+      const owner = admission.beginTransfer(PROVIDER, [CG]);
+      admission.markTransferTerminal(owner);
+    }
+    const agent = {
+      config: { syncContextGraphs: options.selected === false ? [] : [CG] },
+      resolveRfc64CompleteSwmProviderPeerIdsV1: () => options.providers ?? [PROVIDER],
+      selectedSwmBootstrapAdmission: admission,
+      subscribedContextGraphs: new Map(options.sharedMemorySynced
+        ? [[CG, { sharedMemorySynced: true }]]
+        : []),
+    };
+    return (LifecycleSyncMethods.prototype.getRfc64SelectedSwmGraphSyncStatus as any)
+      .call(agent, CG);
+  }
+
+  it('distinguishes inactive, waiting, continuing, and converged states', () => {
+    expect(status({ selected: false }).state).toBe('inactive');
+    expect(status({ providers: [] }).state).toBe('inactive');
+    expect(status({ phase: 'waiting' })).toMatchObject({
+      state: 'waiting',
+      configuredProviderCount: 1,
+      retryRequiredProviderCount: 0,
+      terminalProviderCount: 0,
+    });
+    expect(status({ phase: 'retry-required' })).toMatchObject({
+      state: 'continuing',
+      retryRequiredProviderCount: 1,
+    });
+    expect(status({ phase: 'terminal' })).toMatchObject({
+      state: 'converged',
+      terminalProviderCount: 1,
+    });
+    expect(status({ sharedMemorySynced: true }).state).toBe('converged');
   });
 });

--- a/packages/agent/test/selected-swm-bootstrap-admission.test.ts
+++ b/packages/agent/test/selected-swm-bootstrap-admission.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest';
-import { LifecycleSyncMethods } from '../src/dkg-agent-lifecycle.js';
 import { SelectedSwmBootstrapAdmission } from '../src/sync/selected-swm-bootstrap-admission.js';
 
 const PEER = '12D3KooWScopeAwareSelectedSwmProvider';
@@ -91,54 +90,5 @@ describe('SelectedSwmBootstrapAdmission', () => {
       retryRequiredProviders: 0,
       terminalProviders: 1,
     });
-  });
-});
-
-describe('selected RFC-64 graph sync status', () => {
-  const CG = 'cg-selected';
-  const PROVIDER = '12D3KooWSelectedProvider';
-
-  function status(options: {
-    selected?: boolean;
-    providers?: readonly string[];
-    phase?: 'waiting' | 'retry-required' | 'terminal';
-    sharedMemorySynced?: boolean;
-  } = {}) {
-    const admission = new SelectedSwmBootstrapAdmission();
-    if (options.phase === 'retry-required') admission.request(PROVIDER, [CG]);
-    if (options.phase === 'terminal') {
-      const owner = admission.beginTransfer(PROVIDER, [CG]);
-      admission.markTransferTerminal(owner);
-    }
-    const agent = {
-      config: { syncContextGraphs: options.selected === false ? [] : [CG] },
-      resolveRfc64CompleteSwmProviderPeerIdsV1: () => options.providers ?? [PROVIDER],
-      selectedSwmBootstrapAdmission: admission,
-      subscribedContextGraphs: new Map(options.sharedMemorySynced
-        ? [[CG, { sharedMemorySynced: true }]]
-        : []),
-    };
-    return (LifecycleSyncMethods.prototype.getRfc64SelectedSwmGraphSyncStatus as any)
-      .call(agent, CG);
-  }
-
-  it('distinguishes inactive, waiting, continuing, and converged states', () => {
-    expect(status({ selected: false }).state).toBe('inactive');
-    expect(status({ providers: [] }).state).toBe('inactive');
-    expect(status({ phase: 'waiting' })).toMatchObject({
-      state: 'waiting',
-      configuredProviderCount: 1,
-      retryRequiredProviderCount: 0,
-      terminalProviderCount: 0,
-    });
-    expect(status({ phase: 'retry-required' })).toMatchObject({
-      state: 'continuing',
-      retryRequiredProviderCount: 1,
-    });
-    expect(status({ phase: 'terminal' })).toMatchObject({
-      state: 'converged',
-      terminalProviderCount: 1,
-    });
-    expect(status({ sharedMemorySynced: true }).state).toBe('converged');
   });
 });

--- a/packages/agent/test/selected-swm-graph-sync-status.test.ts
+++ b/packages/agent/test/selected-swm-graph-sync-status.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { projectRfc64SelectedSwmGraphSyncStatus } from '../src/sync/selected-swm-graph-sync-status.js';
+
+describe('selected RFC-64 graph sync status', () => {
+  function status(overrides: Partial<Parameters<
+    typeof projectRfc64SelectedSwmGraphSyncStatus
+  >[0]> = {}) {
+    return projectRfc64SelectedSwmGraphSyncStatus({
+      selected: true,
+      configuredProviderCount: 1,
+      retryRequiredProviderCount: 0,
+      terminalProviderCount: 0,
+      sharedMemorySynced: false,
+      ...overrides,
+    });
+  }
+
+  it('distinguishes inactive, waiting, continuing, and converged states', () => {
+    expect(status({ selected: false }).state).toBe('inactive');
+    expect(status({ configuredProviderCount: 0 }).state).toBe('inactive');
+    expect(status()).toMatchObject({
+      state: 'waiting',
+      configuredProviderCount: 1,
+      retryRequiredProviderCount: 0,
+      terminalProviderCount: 0,
+    });
+    expect(status({ retryRequiredProviderCount: 1 })).toMatchObject({
+      state: 'continuing',
+      retryRequiredProviderCount: 1,
+    });
+    expect(status({ terminalProviderCount: 1 })).toMatchObject({
+      state: 'converged',
+      terminalProviderCount: 1,
+    });
+    expect(status({ sharedMemorySynced: true }).state).toBe('converged');
+  });
+
+  it('returns an immutable identity-free projection', () => {
+    const projected = status({ retryRequiredProviderCount: 1 });
+    expect(Object.isFrozen(projected)).toBe(true);
+    expect(projected).not.toHaveProperty('providerPeerIds');
+  });
+});

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -4,6 +4,7 @@ import type {
   ContextGraphReconcileResult,
   ContextGraphSyncMode,
   RandomSamplingDisabledReason,
+  Rfc64SelectedSwmGraphSyncStatus,
 } from '@origintrail-official/dkg-agent';
 import type { JournalReadResult } from '@origintrail-official/dkg-publisher';
 import { readApiPort, readPid, isProcessRunning, configExists, loadConfig } from './config.js';
@@ -14,6 +15,7 @@ import {
 } from './finalized-publish-options.js';
 import type { RegisterPcaAgentResult } from './pca-confirmation-wire.js';
 import { parseRegisterPcaAgentResult } from './pca-confirmation-wire.js';
+import type { CatchupJobState, LegacyCatchupJobState } from './catchup-status.js';
 
 export type { KnowledgeAssetFinalizedPublishOptions } from './finalized-publish-options.js';
 
@@ -1654,20 +1656,15 @@ export class ApiClient {
     });
   }
 
-  async catchupStatus(contextGraphId: string): Promise<{
+  async catchupStatus(contextGraphId: string) {
+    const raw = await this.get<{
     jobId: string;
     contextGraphId: string;
     includeWorkspace: boolean;
-    status: 'queued' | 'running' | 'done' | 'denied' | 'deferred' | 'partial' | 'failed' | 'unreachable';
+    status: LegacyCatchupJobState;
     /** Absent only when a newer client is connected to a pre-field daemon. */
-    jobStatus?: 'queued' | 'running' | 'done' | 'denied' | 'deferred' | 'partial' | 'failed' | 'unreachable';
-    graphSync?: {
-      mechanism: 'rfc64-selected-on-connect';
-      state: 'inactive' | 'waiting' | 'continuing' | 'converged';
-      configuredProviderCount: number;
-      retryRequiredProviderCount: number;
-      terminalProviderCount: number;
-    };
+    jobStatus?: CatchupJobState;
+    graphSync?: Rfc64SelectedSwmGraphSyncStatus;
     queuedAt: number;
     startedAt?: number;
     finishedAt?: number;
@@ -1726,8 +1723,12 @@ export class ApiClient {
       };
     };
     error?: string;
-  }> {
-    return this.get(`/api/sync/catchup-status?contextGraphId=${encodeURIComponent(contextGraphId)}`);
+    }>(`/api/sync/catchup-status?contextGraphId=${encodeURIComponent(contextGraphId)}`);
+    return {
+      ...raw,
+      /** Normalize pre-field daemon responses at the API boundary. */
+      jobStatus: raw.jobStatus ?? raw.status,
+    };
   }
 
   async connect(multiaddr: string): Promise<{ connected: boolean }> {

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -4,7 +4,6 @@ import type {
   ContextGraphReconcileResult,
   ContextGraphSyncMode,
   RandomSamplingDisabledReason,
-  Rfc64SelectedSwmGraphSyncStatus,
 } from '@origintrail-official/dkg-agent';
 import type { JournalReadResult } from '@origintrail-official/dkg-publisher';
 import { readApiPort, readPid, isProcessRunning, configExists, loadConfig } from './config.js';
@@ -15,7 +14,10 @@ import {
 } from './finalized-publish-options.js';
 import type { RegisterPcaAgentResult } from './pca-confirmation-wire.js';
 import { parseRegisterPcaAgentResult } from './pca-confirmation-wire.js';
-import type { CatchupJobState, LegacyCatchupJobState } from './catchup-status.js';
+import type {
+  CatchupStatusResponse,
+  CatchupStatusWireResponse,
+} from './catchup-status.js';
 
 export type { KnowledgeAssetFinalizedPublishOptions } from './finalized-publish-options.js';
 
@@ -1656,79 +1658,18 @@ export class ApiClient {
     });
   }
 
-  async catchupStatus(contextGraphId: string) {
-    const raw = await this.get<{
-    jobId: string;
-    contextGraphId: string;
-    includeWorkspace: boolean;
-    status: LegacyCatchupJobState;
-    /** Absent only when a newer client is connected to a pre-field daemon. */
-    jobStatus?: CatchupJobState;
-    graphSync?: Rfc64SelectedSwmGraphSyncStatus;
-    queuedAt: number;
-    startedAt?: number;
-    finishedAt?: number;
-    result?: {
-      connectedPeers: number;
-      totalPeers?: number;
-      selectedPeers?: number;
-      syncCapablePeers: number;
-      peersTried: number;
-      peersResponded: number;
-      peersSucceeded: number;
-      /** Sync-capable peers skipped because an earlier wave already proved every requested plane. */
-      peersNotAttempted?: number;
-      deferredBackpressure: number;
-      dataSynced: number;
-      sharedMemorySynced: number;
-      denied: boolean;
-      deniedPeers: number;
-      diagnostics?: {
-        noProtocolPeers: number;
-        durable: {
-          fetchedMetaTriples: number;
-          fetchedDataTriples: number;
-          insertedMetaTriples: number;
-          insertedDataTriples: number;
-          bytesReceived: number;
-          resumedPhases: number;
-          timedOutPhases: number;
-          completedPhases: number;
-          checkpointAdvances: number;
-          emptyResponses: number;
-          metaOnlyResponses: number;
-          verifiedPrivateOnlyResponses?: number;
-          dataRejectedMissingMeta: number;
-          rejectedKcs: number;
-          failedPeers: number;
-          failedPhases: number;
-          deferredBackpressure: number;
-        };
-        sharedMemory: {
-          fetchedMetaTriples: number;
-          fetchedDataTriples: number;
-          insertedMetaTriples: number;
-          insertedDataTriples: number;
-          bytesReceived: number;
-          resumedPhases: number;
-          timedOutPhases: number;
-          completedPhases: number;
-          checkpointAdvances: number;
-          emptyResponses: number;
-          droppedDataTriples: number;
-          failedPeers: number;
-          failedPhases: number;
-          deferredBackpressure: number;
-        };
-      };
-    };
-    error?: string;
-    }>(`/api/sync/catchup-status?contextGraphId=${encodeURIComponent(contextGraphId)}`);
-    return {
+  async catchupStatus(contextGraphId: string): Promise<CatchupStatusResponse> {
+    const raw = await this.get<CatchupStatusWireResponse>(
+      `/api/sync/catchup-status?contextGraphId=${encodeURIComponent(contextGraphId)}`,
+    );
+    const normalized: CatchupStatusResponse = {
       ...raw,
+      /** Normalize the pre-alias workspace flag at the API boundary. */
+      includeSharedMemory: raw.includeSharedMemory ?? raw.includeWorkspace,
       /** Normalize pre-field daemon responses at the API boundary. */
       jobStatus: raw.jobStatus ?? raw.status,
     };
+    return normalized;
   }
 
   async connect(multiaddr: string): Promise<{ connected: boolean }> {

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -1658,7 +1658,16 @@ export class ApiClient {
     jobId: string;
     contextGraphId: string;
     includeWorkspace: boolean;
-    status: 'queued' | 'running' | 'done' | 'denied' | 'deferred' | 'failed' | 'unreachable';
+    status: 'queued' | 'running' | 'done' | 'denied' | 'deferred' | 'partial' | 'failed' | 'unreachable';
+    /** Absent only when a newer client is connected to a pre-field daemon. */
+    jobStatus?: 'queued' | 'running' | 'done' | 'denied' | 'deferred' | 'partial' | 'failed' | 'unreachable';
+    graphSync?: {
+      mechanism: 'rfc64-selected-on-connect';
+      state: 'inactive' | 'waiting' | 'continuing' | 'converged';
+      configuredProviderCount: number;
+      retryRequiredProviderCount: number;
+      terminalProviderCount: number;
+    };
     queuedAt: number;
     startedAt?: number;
     finishedAt?: number;

--- a/packages/cli/src/catchup-status.ts
+++ b/packages/cli/src/catchup-status.ts
@@ -10,7 +10,34 @@ export const CATCHUP_JOB_STATES = [
 ] as const;
 
 export type CatchupJobState = typeof CATCHUP_JOB_STATES[number];
-export type LegacyCatchupJobState = Exclude<CatchupJobState, 'partial'>;
+
+/** Closed pre-`jobStatus` vocabulary retained for older API clients. */
+export const LEGACY_CATCHUP_JOB_STATES = [
+  'queued',
+  'running',
+  'done',
+  'failed',
+  'denied',
+  'deferred',
+  'unreachable',
+] as const;
+
+export type LegacyCatchupJobState = typeof LEGACY_CATCHUP_JOB_STATES[number];
+
+/**
+ * Keep the compatibility boundary exhaustive: adding a precise job state must
+ * also make an explicit decision about what older clients receive.
+ */
+const LEGACY_CATCHUP_JOB_STATE_BY_STATE = {
+  queued: 'queued',
+  running: 'running',
+  done: 'done',
+  failed: 'failed',
+  denied: 'denied',
+  deferred: 'deferred',
+  partial: 'unreachable',
+  unreachable: 'unreachable',
+} as const satisfies Record<CatchupJobState, LegacyCatchupJobState>;
 
 /** One terminality contract for daemon telemetry and CLI watch behavior. */
 export const CATCHUP_TERMINAL_STATES: ReadonlySet<CatchupJobState> = new Set([
@@ -28,5 +55,5 @@ export function isTerminalCatchupJobState(state: CatchupJobState): boolean {
 
 /** Preserve the pre-`jobStatus` wire vocabulary for older clients. */
 export function toLegacyCatchupJobState(state: CatchupJobState): LegacyCatchupJobState {
-  return state === 'partial' ? 'unreachable' : state;
+  return LEGACY_CATCHUP_JOB_STATE_BY_STATE[state];
 }

--- a/packages/cli/src/catchup-status.ts
+++ b/packages/cli/src/catchup-status.ts
@@ -1,0 +1,32 @@
+export const CATCHUP_JOB_STATES = [
+  'queued',
+  'running',
+  'done',
+  'failed',
+  'denied',
+  'deferred',
+  'partial',
+  'unreachable',
+] as const;
+
+export type CatchupJobState = typeof CATCHUP_JOB_STATES[number];
+export type LegacyCatchupJobState = Exclude<CatchupJobState, 'partial'>;
+
+/** One terminality contract for daemon telemetry and CLI watch behavior. */
+export const CATCHUP_TERMINAL_STATES: ReadonlySet<CatchupJobState> = new Set([
+  'done',
+  'failed',
+  'denied',
+  'deferred',
+  'partial',
+  'unreachable',
+]);
+
+export function isTerminalCatchupJobState(state: CatchupJobState): boolean {
+  return CATCHUP_TERMINAL_STATES.has(state);
+}
+
+/** Preserve the pre-`jobStatus` wire vocabulary for older clients. */
+export function toLegacyCatchupJobState(state: CatchupJobState): LegacyCatchupJobState {
+  return state === 'partial' ? 'unreachable' : state;
+}

--- a/packages/cli/src/catchup-status.ts
+++ b/packages/cli/src/catchup-status.ts
@@ -1,3 +1,6 @@
+import type { Rfc64SelectedSwmGraphSyncStatus } from '@origintrail-official/dkg-agent';
+import type { CatchupJobResult } from './catchup-runner.js';
+
 export const CATCHUP_JOB_STATES = [
   'queued',
   'running',
@@ -23,6 +26,34 @@ export const LEGACY_CATCHUP_JOB_STATES = [
 ] as const;
 
 export type LegacyCatchupJobState = typeof LEGACY_CATCHUP_JOB_STATES[number];
+
+/** Explicit public response shape for the catch-up status endpoint. */
+export interface CatchupStatusResponse {
+  readonly jobId: string;
+  readonly contextGraphId: string;
+  /** Legacy request field retained on the wire. */
+  readonly includeWorkspace: boolean;
+  readonly includeSharedMemory: boolean;
+  /** Closed legacy status vocabulary for older clients. */
+  readonly status: LegacyCatchupJobState;
+  /** Precise bounded-job outcome for upgraded clients. */
+  readonly jobStatus: CatchupJobState;
+  readonly queuedAt: number;
+  readonly startedAt?: number;
+  readonly finishedAt?: number;
+  readonly result?: CatchupJobResult;
+  readonly error?: string;
+  readonly graphSync?: Rfc64SelectedSwmGraphSyncStatus;
+}
+
+/** Older daemons can omit newer aliases; the client normalizes them at the boundary. */
+export type CatchupStatusWireResponse = Omit<
+  CatchupStatusResponse,
+  'includeSharedMemory' | 'jobStatus'
+> & {
+  readonly includeSharedMemory?: boolean;
+  readonly jobStatus?: CatchupJobState;
+};
 
 /**
  * Keep the compatibility boundary exhaustive: adding a precise job state must

--- a/packages/cli/src/cli-helpers.ts
+++ b/packages/cli/src/cli-helpers.ts
@@ -29,6 +29,7 @@ import {
 } from './config.js';
 import { resolveDaemonEntryPoint } from './daemon-entrypoint.js';
 import { ApiClient } from './api-client.js';
+import { isTerminalCatchupJobState } from './catchup-status.js';
 import { parsePositiveIntegerOption, parsePositiveMsOption } from './cli-option-parsers.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from './store-wizard.js';
 import { runConfiguredSourceWorker } from './source-worker-runner.js';
@@ -201,7 +202,7 @@ type CatchupStatusCommandOptions = { watch?: boolean; interval?: string | number
 function printCatchupStatus(status: Awaited<ReturnType<ApiClient['catchupStatus']>>) {
   console.log(`Context Graph: ${status.contextGraphId}`);
   console.log(`Job:           ${status.jobId}`);
-  console.log(`Job Status:    ${status.jobStatus ?? status.status}`);
+  console.log(`Job Status:    ${status.jobStatus}`);
   if (status.graphSync) {
     console.log(`Graph Sync:    ${status.graphSync.state} (${status.graphSync.mechanism})`);
   }
@@ -250,14 +251,6 @@ async function runCatchupStatusCommand(contextGraph: string, opts: CatchupStatus
   const client = await ApiClient.connect();
   const watch = !!opts.watch;
   const intervalSeconds = Math.max(1, Number(opts.interval ?? 2));
-  const terminalStates = new Set([
-    'done',
-    'failed',
-    'denied',
-    'deferred',
-    'partial',
-    'unreachable',
-  ]);
 
   do {
     const status = await client.catchupStatus(contextGraph);
@@ -266,7 +259,7 @@ async function runCatchupStatusCommand(contextGraph: string, opts: CatchupStatus
       console.log(`Watching catch-up status every ${intervalSeconds}s\n`);
     }
     printCatchupStatus(status);
-    if (!watch || terminalStates.has(status.status)) {
+    if (!watch || isTerminalCatchupJobState(status.jobStatus)) {
       return;
     }
     await new Promise((resolve) => setTimeout(resolve, intervalSeconds * 1000));

--- a/packages/cli/src/cli-helpers.ts
+++ b/packages/cli/src/cli-helpers.ts
@@ -201,7 +201,10 @@ type CatchupStatusCommandOptions = { watch?: boolean; interval?: string | number
 function printCatchupStatus(status: Awaited<ReturnType<ApiClient['catchupStatus']>>) {
   console.log(`Context Graph: ${status.contextGraphId}`);
   console.log(`Job:           ${status.jobId}`);
-  console.log(`Status:        ${status.status}`);
+  console.log(`Job Status:    ${status.jobStatus ?? status.status}`);
+  if (status.graphSync) {
+    console.log(`Graph Sync:    ${status.graphSync.state} (${status.graphSync.mechanism})`);
+  }
   console.log(`Shared Memory: ${status.includeWorkspace ? 'enabled' : 'disabled'}`);
   console.log(`Queued:        ${new Date(status.queuedAt).toISOString()}`);
   if (status.startedAt) console.log(`Started:       ${new Date(status.startedAt).toISOString()}`);
@@ -247,7 +250,14 @@ async function runCatchupStatusCommand(contextGraph: string, opts: CatchupStatus
   const client = await ApiClient.connect();
   const watch = !!opts.watch;
   const intervalSeconds = Math.max(1, Number(opts.interval ?? 2));
-  const terminalStates = new Set(['done', 'failed', 'denied', 'deferred', 'unreachable']);
+  const terminalStates = new Set([
+    'done',
+    'failed',
+    'denied',
+    'deferred',
+    'partial',
+    'unreachable',
+  ]);
 
   do {
     const status = await client.catchupStatus(contextGraph);

--- a/packages/cli/src/context-graph-readiness.ts
+++ b/packages/cli/src/context-graph-readiness.ts
@@ -474,7 +474,7 @@ function catchupPlaneReadinessThisRun(input: {
 }
 
 export interface ContextGraphCatchupReadinessClassification {
-  jobStatus: 'done' | 'failed' | 'denied' | 'unreachable';
+  jobStatus: 'done' | 'failed' | 'denied' | 'partial' | 'unreachable';
   error?: string;
   statePatch?: ContextGraphSubscriptionStatePatch;
   readinessPatch?: ContextGraphReadinessPatch;
@@ -589,12 +589,11 @@ export function classifyContextGraphCatchupReadiness(input: {
     if (missingRequestedDurable || missingRequestedSharedMemory) {
       jobStatus = 'unreachable';
       if (madeIncompleteProgress) {
-        // The base sentence is byte-identical to what it has always been; the
-        // shortfall is APPENDED. This is the r26 terminal — "some verified data
-        // landed, the plane is still unready" — and it was the one message that
-        // could not say WHAT was missing even though the answer was computable
-        // in memory at the moment the round gave up.
-        error = 'Verified data was inserted, but catch-up did not complete without a timeout or failed phase. The incomplete plane remains unready; retry once the network is healthier.'
+        jobStatus = 'partial';
+        // This terminal describes only the bounded foreground job. Selected
+        // RFC-64 continuation has its own graph-level lifecycle and can keep
+        // advancing after this job exhausts its budget.
+        error = 'Verified data was inserted, but this bounded catch-up job ended before the requested plane was complete. The incomplete plane remains unready; graph-level synchronization may continue independently.'
           + swmShortfallClause(
             result.diagnostics?.sharedMemory?.swmCoverage,
             result.diagnostics?.sharedMemory?.continuationPasses,

--- a/packages/cli/src/daemon/catchup-telemetry.ts
+++ b/packages/cli/src/daemon/catchup-telemetry.ts
@@ -86,6 +86,7 @@ const TERMINAL_STATES: ReadonlySet<CatchupJobState> = new Set<CatchupJobState>([
   'failed',
   'denied',
   'deferred',
+  'partial',
   'unreachable',
 ]);
 

--- a/packages/cli/src/daemon/catchup-telemetry.ts
+++ b/packages/cli/src/daemon/catchup-telemetry.ts
@@ -22,6 +22,7 @@
 
 import { getMetrics } from '@origintrail-official/dkg-core';
 import type { CatchupJob, CatchupJobState } from './types.js';
+import { isTerminalCatchupJobState } from '../catchup-status.js';
 
 /**
  * Grace period the shutdown drain gives in-flight walks to settle normally.
@@ -80,16 +81,6 @@ export interface CatchupJobLedgerEntry {
  */
 const ledger = new Map<string, CatchupJobLedgerEntry>();
 
-/** Terminal states a job can settle in; `queued`/`running` are not terminal. */
-const TERMINAL_STATES: ReadonlySet<CatchupJobState> = new Set<CatchupJobState>([
-  'done',
-  'failed',
-  'denied',
-  'deferred',
-  'partial',
-  'unreachable',
-]);
-
 /**
  * A job that never reached a terminal state is reported as `failed`.
  *
@@ -100,7 +91,7 @@ const TERMINAL_STATES: ReadonlySet<CatchupJobState> = new Set<CatchupJobState>([
  * closed vocabulary instead of leaking `running` into the series.
  */
 function terminalStatusFor(job: CatchupJob): CatchupJobState {
-  return TERMINAL_STATES.has(job.status) ? job.status : 'failed';
+  return isTerminalCatchupJobState(job.status) ? job.status : 'failed';
 }
 
 /** I7 — one point per subscribe-route return. Never throws. */

--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -1033,7 +1033,10 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
       });
     }
 
-    return jsonResponse(res, 200, toCatchupStatusResponse(job));
+    return jsonResponse(res, 200, toCatchupStatusResponse(
+      job,
+      agent.getRfc64SelectedSwmGraphSyncStatus(job.contextGraphId),
+    ));
   }
 
   // POST /api/verify

--- a/packages/cli/src/daemon/types.ts
+++ b/packages/cli/src/daemon/types.ts
@@ -3,29 +3,13 @@
 // Pure type/interface declarations used across the daemon sub-modules.
 
 import type { CatchupJobResult } from '../catchup-runner.js';
+import type { Rfc64SelectedSwmGraphSyncStatus } from '@origintrail-official/dkg-agent';
+import {
+  toLegacyCatchupJobState,
+  type CatchupJobState,
+} from '../catchup-status.js';
 
-export type CatchupJobState =
-  | "queued"
-  | "running"
-  | "done"
-  | "failed"
-  | "denied"
-  /** Local scheduler capacity was unavailable; retry is safe. */
-  | "deferred"
-  /**
-   * The bounded job inserted verified data but ended before every requested
-   * plane was complete. Graph-level synchronization may continue separately.
-   */
-  | "partial"
-  /**
-   * Catchup completed but no peer could deliver the CG content within
-   * the run — every per-peer sync round either failed or returned
-   * nothing while no responder explicitly denied access. Distinct from
-   * `denied` (curator refused) and `failed` (the worker itself threw)
-   * so the UI can render targeted copy + a "send signed join request"
-   * CTA without misclassifying slow public CGs as denied.
-   */
-  | "unreachable";
+export type { CatchupJobState } from '../catchup-status.js';
 
 export interface CatchupJob {
   jobId: string;
@@ -44,13 +28,7 @@ export interface CatchupTracker {
   latestByContextGraph: Map<string, string>;
 }
 
-export interface CatchupGraphSyncStatus {
-  mechanism: 'rfc64-selected-on-connect';
-  state: 'inactive' | 'waiting' | 'continuing' | 'converged';
-  configuredProviderCount: number;
-  retryRequiredProviderCount: number;
-  terminalProviderCount: number;
-}
+export type CatchupGraphSyncStatus = Rfc64SelectedSwmGraphSyncStatus;
 
 export function toCatchupStatusResponse(
   job: CatchupJob,
@@ -58,7 +36,9 @@ export function toCatchupStatusResponse(
 ) {
   return {
     ...job,
-    /** Explicit alias: `status` is retained for wire compatibility. */
+    /** Older clients keep their closed terminal vocabulary. */
+    status: toLegacyCatchupJobState(job.status),
+    /** Precise bounded-job outcome for upgraded clients. */
     jobStatus: job.status,
     contextGraphId: job.contextGraphId,
     includeSharedMemory: job.includeWorkspace,

--- a/packages/cli/src/daemon/types.ts
+++ b/packages/cli/src/daemon/types.ts
@@ -13,6 +13,11 @@ export type CatchupJobState =
   /** Local scheduler capacity was unavailable; retry is safe. */
   | "deferred"
   /**
+   * The bounded job inserted verified data but ended before every requested
+   * plane was complete. Graph-level synchronization may continue separately.
+   */
+  | "partial"
+  /**
    * Catchup completed but no peer could deliver the CG content within
    * the run — every per-peer sync round either failed or returned
    * nothing while no responder explicitly denied access. Distinct from
@@ -39,10 +44,24 @@ export interface CatchupTracker {
   latestByContextGraph: Map<string, string>;
 }
 
-export function toCatchupStatusResponse(job: CatchupJob) {
+export interface CatchupGraphSyncStatus {
+  mechanism: 'rfc64-selected-on-connect';
+  state: 'inactive' | 'waiting' | 'continuing' | 'converged';
+  configuredProviderCount: number;
+  retryRequiredProviderCount: number;
+  terminalProviderCount: number;
+}
+
+export function toCatchupStatusResponse(
+  job: CatchupJob,
+  graphSync?: CatchupGraphSyncStatus,
+) {
   return {
     ...job,
+    /** Explicit alias: `status` is retained for wire compatibility. */
+    jobStatus: job.status,
     contextGraphId: job.contextGraphId,
     includeSharedMemory: job.includeWorkspace,
+    ...(graphSync === undefined ? {} : { graphSync }),
   };
 }

--- a/packages/cli/src/daemon/types.ts
+++ b/packages/cli/src/daemon/types.ts
@@ -7,6 +7,7 @@ import type { Rfc64SelectedSwmGraphSyncStatus } from '@origintrail-official/dkg-
 import {
   toLegacyCatchupJobState,
   type CatchupJobState,
+  type CatchupStatusResponse,
 } from '../catchup-status.js';
 
 export type { CatchupJobState } from '../catchup-status.js';
@@ -33,15 +34,21 @@ export type CatchupGraphSyncStatus = Rfc64SelectedSwmGraphSyncStatus;
 export function toCatchupStatusResponse(
   job: CatchupJob,
   graphSync?: CatchupGraphSyncStatus,
-) {
+): CatchupStatusResponse {
   return {
-    ...job,
+    jobId: job.jobId,
+    contextGraphId: job.contextGraphId,
+    includeWorkspace: job.includeWorkspace,
+    includeSharedMemory: job.includeWorkspace,
     /** Older clients keep their closed terminal vocabulary. */
     status: toLegacyCatchupJobState(job.status),
     /** Precise bounded-job outcome for upgraded clients. */
     jobStatus: job.status,
-    contextGraphId: job.contextGraphId,
-    includeSharedMemory: job.includeWorkspace,
+    queuedAt: job.queuedAt,
+    ...(job.startedAt === undefined ? {} : { startedAt: job.startedAt }),
+    ...(job.finishedAt === undefined ? {} : { finishedAt: job.finishedAt }),
+    ...(job.result === undefined ? {} : { result: job.result }),
+    ...(job.error === undefined ? {} : { error: job.error }),
     ...(graphSync === undefined ? {} : { graphSync }),
   };
 }

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -127,6 +127,7 @@ describe('ApiClient', () => {
 
       expect(result.status).toBe('unreachable');
       expect(result.jobStatus).toBe('unreachable');
+      expect(result.includeSharedMemory).toBe(true);
     });
 
     it('preserves the precise catch-up jobStatus from an upgraded daemon', async () => {

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -114,6 +114,37 @@ describe('ApiClient', () => {
       expect((calls[0].opts.headers as any).Authorization).toBeUndefined();
     });
 
+    it('normalizes catch-up jobStatus from a pre-field daemon response', async () => {
+      globalThis.fetch = mockFetchOk({
+        jobId: 'legacy-job',
+        contextGraphId: 'cg-legacy',
+        includeWorkspace: true,
+        status: 'unreachable',
+        queuedAt: 1,
+      });
+
+      const result = await client.catchupStatus('cg-legacy');
+
+      expect(result.status).toBe('unreachable');
+      expect(result.jobStatus).toBe('unreachable');
+    });
+
+    it('preserves the precise catch-up jobStatus from an upgraded daemon', async () => {
+      globalThis.fetch = mockFetchOk({
+        jobId: 'partial-job',
+        contextGraphId: 'cg-partial',
+        includeWorkspace: true,
+        status: 'unreachable',
+        jobStatus: 'partial',
+        queuedAt: 1,
+      });
+
+      const result = await client.catchupStatus('cg-partial');
+
+      expect(result.status).toBe('unreachable');
+      expect(result.jobStatus).toBe('partial');
+    });
+
     it('connect() gives DKG_AUTH_TOKEN precedence over the selected home token file', async () => {
       process.env.DKG_HOME = tempDir;
       process.env.DKG_API_PORT = String(PORT);

--- a/packages/cli/test/catchup-status-cli.test.ts
+++ b/packages/cli/test/catchup-status-cli.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ApiClient } from '../src/api-client.js';
+import { runCatchupStatusCommand } from '../src/cli-helpers.js';
+
+describe('catch-up status CLI', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('prints graph continuation and exits watch mode for a partial bounded job', async () => {
+    const catchupStatus = vi.fn().mockResolvedValue({
+      jobId: 'partial-job',
+      contextGraphId: 'cg-selected',
+      includeWorkspace: true,
+      status: 'unreachable',
+      jobStatus: 'partial',
+      queuedAt: 1,
+      graphSync: {
+        mechanism: 'rfc64-selected-on-connect',
+        state: 'continuing',
+        configuredProviderCount: 1,
+        retryRequiredProviderCount: 1,
+        terminalProviderCount: 0,
+      },
+    });
+    vi.spyOn(ApiClient, 'connect').mockResolvedValue({ catchupStatus } as unknown as ApiClient);
+    vi.spyOn(console, 'clear').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await runCatchupStatusCommand('cg-selected', { watch: true, interval: 1 });
+
+    expect(catchupStatus).toHaveBeenCalledTimes(1);
+    const output = log.mock.calls.map(([line]) => String(line)).join('\n');
+    expect(output).toContain('Job Status:    partial');
+    expect(output).toContain('Graph Sync:    continuing (rfc64-selected-on-connect)');
+  });
+});

--- a/packages/cli/test/catchup-status-compatibility.test.ts
+++ b/packages/cli/test/catchup-status-compatibility.test.ts
@@ -4,6 +4,10 @@ import {
   LEGACY_CATCHUP_JOB_STATES,
   toLegacyCatchupJobState,
 } from '../src/catchup-status.js';
+import {
+  toCatchupStatusResponse,
+  type CatchupJob,
+} from '../src/daemon/types.js';
 
 describe('catch-up status compatibility', () => {
   it('maps every precise state into the closed legacy wire vocabulary', () => {
@@ -18,5 +22,26 @@ describe('catch-up status compatibility', () => {
       'unreachable',
     ]);
     expect(LEGACY_CATCHUP_JOB_STATES).not.toContain('partial');
+  });
+
+  it('projects internal jobs field-by-field without leaking future daemon state', () => {
+    const job = {
+      jobId: 'partial-job',
+      contextGraphId: 'cg-selected',
+      includeWorkspace: true,
+      status: 'partial',
+      queuedAt: 1,
+      internalRetryLease: 'must-not-cross-wire-boundary',
+    } satisfies CatchupJob & { internalRetryLease: string };
+
+    expect(toCatchupStatusResponse(job)).toEqual({
+      jobId: 'partial-job',
+      contextGraphId: 'cg-selected',
+      includeWorkspace: true,
+      includeSharedMemory: true,
+      status: 'unreachable',
+      jobStatus: 'partial',
+      queuedAt: 1,
+    });
   });
 });

--- a/packages/cli/test/catchup-status-compatibility.test.ts
+++ b/packages/cli/test/catchup-status-compatibility.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CATCHUP_JOB_STATES,
+  LEGACY_CATCHUP_JOB_STATES,
+  toLegacyCatchupJobState,
+} from '../src/catchup-status.js';
+
+describe('catch-up status compatibility', () => {
+  it('maps every precise state into the closed legacy wire vocabulary', () => {
+    expect(CATCHUP_JOB_STATES.map(toLegacyCatchupJobState)).toEqual([
+      'queued',
+      'running',
+      'done',
+      'failed',
+      'denied',
+      'deferred',
+      'unreachable',
+      'unreachable',
+    ]);
+    expect(LEGACY_CATCHUP_JOB_STATES).not.toContain('partial');
+  });
+});

--- a/packages/cli/test/context-graph-catchup-readiness.test.ts
+++ b/packages/cli/test/context-graph-catchup-readiness.test.ts
@@ -206,7 +206,7 @@ describe('context graph catch-up readiness classification', () => {
     });
 
     expect(classification).toMatchObject({
-      jobStatus: 'unreachable',
+      jobStatus: 'partial',
       readinessPatch: {
         durableVerified: false,
         sharedMemoryVerified: false,
@@ -235,7 +235,7 @@ describe('context graph catch-up readiness classification', () => {
     });
 
     expect(classification).toMatchObject({
-      jobStatus: 'unreachable',
+      jobStatus: 'partial',
       statePatch: {
         // The existing compatibility/write-readiness bit may be opened by a
         // persisted usable plane; the terminal job verdict may not.
@@ -763,8 +763,8 @@ describe('T16 — terminal readiness strings are byte-identical', () => {
     r.diagnostics!.durable.insertedDataTriples = 5;
     r.diagnostics!.durable.timedOutPhases = 1;
     const c = classify(r);
-    expect(c.jobStatus).toBe('unreachable');
-    expect(c.error).toBe('Verified data was inserted, but catch-up did not complete without a timeout or failed phase. The incomplete plane remains unready; retry once the network is healthier.');
+    expect(c.jobStatus).toBe('partial');
+    expect(c.error).toBe('Verified data was inserted, but this bounded catch-up job ended before the requested plane was complete. The incomplete plane remains unready; graph-level synchronization may continue independently.');
   });
 
   it('pins the private missing-graph-proof string', () => {
@@ -860,7 +860,7 @@ describe('T16 — terminal readiness strings are byte-identical', () => {
  * the ones that reach it.
  */
 describe('T16b — the shared-memory shortfall clause (#2050)', () => {
-  const INCOMPLETE_PROGRESS = 'Verified data was inserted, but catch-up did not complete without a timeout or failed phase. The incomplete plane remains unready; retry once the network is healthier.';
+  const INCOMPLETE_PROGRESS = 'Verified data was inserted, but this bounded catch-up job ended before the requested plane was complete. The incomplete plane remains unready; graph-level synchronization may continue independently.';
 
   const r26: SwmSnapshotCoverage = {
     contextGraphId: 'medical-research',
@@ -943,7 +943,7 @@ describe('T16b — the shared-memory shortfall clause (#2050)', () => {
       readinessBeforeCatchup: { version: 0, durableVerified: false, sharedMemoryVerified: false, updatedAt: 0 },
     });
 
-    expect(c.jobStatus).toBe('unreachable');
+    expect(c.jobStatus).toBe('partial');
     // Whole-string equality: the prefix pin in T16 cannot see the append.
     expect(c.error).toBe(INCOMPLETE_PROGRESS + swmShortfallClause(r26, 2));
     expect(c.error).toContain('178/250');
@@ -1037,7 +1037,7 @@ describe('T16b — the shared-memory shortfall clause (#2050)', () => {
  */
 describe('T16b — the shortfall clause reaches the terminal message', () => {
   const before = { version: 0, durableVerified: false, sharedMemoryVerified: false, updatedAt: 0 };
-  const PREFIX = 'Verified data was inserted, but catch-up did not complete without a timeout or failed phase. The incomplete plane remains unready; retry once the network is healthier.';
+  const PREFIX = 'Verified data was inserted, but this bounded catch-up job ended before the requested plane was complete. The incomplete plane remains unready; graph-level synchronization may continue independently.';
 
   /** The r26 shape: data inserted, plane unproven, coverage 72 short. */
   function shortfallResult(over: Partial<{

--- a/packages/cli/test/context-graph-subscribe-readiness.test.ts
+++ b/packages/cli/test/context-graph-subscribe-readiness.test.ts
@@ -227,6 +227,13 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
       isPrivateContextGraph: async () => opts.isPrivate ?? false,
       resolveAgentByToken: () => undefined,
       getDefaultAgentAddress: () => opts.callerAddress ?? '0x0000000000000000000000000000000000000001',
+      getRfc64SelectedSwmGraphSyncStatus: () => ({
+        mechanism: 'rfc64-selected-on-connect',
+        state: 'inactive',
+        configuredProviderCount: 0,
+        retryRequiredProviderCount: 0,
+        terminalProviderCount: 0,
+      }),
     };
 
     server = createServer(async (req, res) => {
@@ -590,6 +597,10 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
     expect(result.statusResponse).toMatchObject({
       jobId: result.response.catchup.jobId,
       status: 'done',
+      jobStatus: 'done',
+      graphSync: {
+        state: 'inactive',
+      },
       result: {
         dataSynced: 3,
         sharedMemorySynced: 4,
@@ -814,8 +825,8 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
     });
 
     expect(result.job).toMatchObject({
-      status: 'unreachable',
-      error: expect.stringContaining('did not complete without a timeout'),
+      status: 'partial',
+      error: expect.stringContaining('bounded catch-up job ended'),
     });
     expect(result.state).toMatchObject({
       synced: false,
@@ -850,7 +861,7 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
       },
     });
 
-    expect(result.job.status).toBe('unreachable');
+    expect(result.job.status).toBe('partial');
     expect(result.state).toMatchObject({
       synced: false,
       sharedMemorySynced: false,
@@ -944,7 +955,7 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
 
     expect(result.response.catchup.status).toBe('queued');
     expect(result.runCalls).toBe(1);
-    expect(result.job.status).toBe('unreachable');
+    expect(result.job.status).toBe('partial');
     expect(result.state).toMatchObject({
       synced: true,
       sharedMemorySynced: true,

--- a/packages/cli/test/context-graph-subscribe-readiness.test.ts
+++ b/packages/cli/test/context-graph-subscribe-readiness.test.ts
@@ -828,6 +828,10 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
       status: 'partial',
       error: expect.stringContaining('bounded catch-up job ended'),
     });
+    expect(result.statusResponse).toMatchObject({
+      status: 'unreachable',
+      jobStatus: 'partial',
+    });
     expect(result.state).toMatchObject({
       synced: false,
       sharedMemorySynced: false,

--- a/packages/cli/test/daemon-catchup-telemetry-shutdown.test.ts
+++ b/packages/cli/test/daemon-catchup-telemetry-shutdown.test.ts
@@ -71,6 +71,7 @@ const {
   beginWalkCatchupJob,
   catchupLedgerSize,
   drainCatchupJobs,
+  recordSyntheticCatchupJob,
   releaseCatchupJob,
   resetCatchupJobLedger,
 } = await import('../src/daemon/catchup-telemetry.js');
@@ -248,6 +249,13 @@ async function createHarness(opts: HarnessOptions = {}) {
     resolveAgentByToken: () => undefined,
     getDefaultAgentAddress: () =>
       opts.callerAddress ?? '0x0000000000000000000000000000000000000001',
+    getRfc64SelectedSwmGraphSyncStatus: () => ({
+      mechanism: 'rfc64-selected-on-connect',
+      state: 'inactive',
+      configuredProviderCount: 0,
+      retryRequiredProviderCount: 0,
+      terminalProviderCount: 0,
+    }),
     eventBus: { emit: () => {} },
     refreshMetaSyncedFlags: async () => {},
   };
@@ -357,6 +365,26 @@ afterEach(() => {
   resetCatchupJobLedger();
   daemonState.catchupRunner = previousRunner;
   daemonState.catchupAcceptingJobs = true;
+});
+
+describe('I8 — partial bounded jobs retain their terminal label', () => {
+  it('records `partial` instead of collapsing it to `failed`', () => {
+    recordSyntheticCatchupJob({
+      jobId: 'partial-job',
+      contextGraphId: 'cg-partial',
+      includeWorkspace: true,
+      status: 'partial',
+      queuedAt: 0,
+      startedAt: 0,
+      finishedAt: 1,
+    });
+
+    expect(metrics.jobs()).toHaveLength(1);
+    expect(metrics.jobs()[0].attrs).toMatchObject({
+      status: 'partial',
+      admission: 'synthetic',
+    });
+  });
 });
 
 describe('I7 — one requests_total point per subscribe-route return', () => {


### PR DESCRIPTION
## Impact

A bounded foreground catch-up job can finish `partial`/budget-exhausted while native RFC-64 selected-SWM continuation remains healthy and keeps advancing on provider connections. The current API and CLI collapse those independent states, making an active receiver look terminal.

This change:
- adds the explicit bounded-job outcome `partial` and a stable `jobStatus` field;
- reports identity-safe graph continuation state separately as `inactive`, `waiting`, `continuing`, or `converged`;
- updates CLI readiness output and telemetry without exposing provider identity;
- keeps older daemon/client interoperability fail-safe through optional fields.

This is intentionally stacked on #2292 for review. It will be retargeted to `testnet-canary` after #2292 merges; merge order remains #2275 → #2292 → this PR.

## Validation

- Rebased onto #2292 head including structural manifest comparison review fix.
- Selected-SWM bootstrap admission: 7/7 passed.
- Catch-up readiness, subscribe readiness, telemetry/shutdown: 119/119 passed.
- Pre-rebase validation of the same change: selected-SWM agent suite 95 passed; agent and CLI build closures passed; full CLI suite 3384 passed (13 skipped); telemetry suite 40 passed.