### PR TITLE
feat: add pressure-based SWM snapshot GC

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -38,6 +38,7 @@
 * [Publishing Conviction](use-dkg/publishing-conviction.md)
 * [Relays & Peers](use-dkg/relays-and-peers.md)
 * [Storage SPARQL HTTP](use-dkg/storage-sparql-http.md)
+* [SWM Public Snapshot Garbage Collection](use-dkg/swm-public-snapshot-gc.md)
 * [Host-Mode Manual Subscribe](use-dkg/host-mode-manual-subscribe.md)
 * [Updates & Rollback](use-dkg/updates-and-rollback.md)
 * [Migrate to npm](use-dkg/migrate-to-npm.md)

--- a/docs/active-now/swm-public-snapshot-gc-v2-spec.md
+++ b/docs/active-now/swm-public-snapshot-gc-v2-spec.md
@@ -1,0 +1,318 @@
+# SWM public snapshot GC v2: proof-driven retention
+
+Status: proposed follow-up to GC v1
+Tracking: GitHub issue #2269
+
+## Summary
+
+GC v2 must keep the free-space watermarks and admission control introduced by
+v1, while replacing age-only eligibility with explicit proof that deleting a
+local blob cannot remove the network's only durable copy. It must distinguish
+locally originated durable state from verified peer cache, protect active
+operations across asynchronous reads and writes, and rehydrate evicted cache on
+demand.
+
+Free space determines **when and how much** to collect. Provenance, lifecycle
+state, leases, and replication evidence determine **what may be deleted**.
+
+## Facts validated while implementing v1
+
+These findings come from the `testnet-canary` implementation at commit
+`644b697` and constrain the v2 design:
+
+1. The file store is content addressed. A digest maps to
+   `<root>/<aa>/<bb>/<digest>.nq`; legacy `.json` files remain readable. Atomic
+   writes create a sibling `.tmp` file before rename.
+2. Local publication and verified network synchronization both call the same
+   `putSnapshot({ digest, quads })` API. The store therefore cannot currently
+   tell an origin copy from a refetchable peer copy.
+3. New metadata normally does not contain `dkg:publicSnapshotRef`. A snapshot is
+   file-store-backed when `dkg:publicQuadsDigest` exists and
+   `dkg:publicSnapshotGraph` does not; the digest is the implicit reference.
+   Legacy explicit references still take precedence.
+4. An RDF reference is not itself a retention proof. The snapshot sync walk
+   treats a missing/invalid local blob as a cache miss, fetches pages from the
+   peer, verifies digest and count, and stores the verified result. However,
+   direct workspace resolution and graph-scoped recovery paths can currently
+   return/throw "snapshot missing" without initiating that fetch.
+5. Page indexes live in SQLite's `snapshot_page_indexes` table. Its adapter only
+   exposes `get` and `upsert`; deleting a blob currently leaves a small derived
+   row behind.
+6. Paged reads hold an open file descriptor, but the store previously had no
+   logical lease visible to maintenance work. V1 adds process-local active-file
+   protection, which does not protect a second process sharing the directory.
+7. Directory scanning is acceptable as an emergency mechanism but does not
+   scale as the durable source of last-access, provenance, pin, or proof data.
+   The incident directories contained tens of thousands of blobs.
+8. Repeated writes of an existing content-addressed digest previously created a
+   second full temporary payload. V1 short-circuits an existing immutable file;
+   v2 must preserve that invariant and verify it during inventory repair.
+
+## Goals
+
+- Never evict an unreplicated locally originated snapshot.
+- Prefer eviction of verified peer cache and definite orphans.
+- Maintain configurable trigger, target, and hard-reserve watermarks.
+- Support safe collection during concurrent reads, writes, sync, publication,
+  finalization, and process restart.
+- Rehydrate evicted referenced cache before a caller needs the quads.
+- Bound the blob catalog and page-index metadata as well as file bytes.
+- Provide explainable dry-run plans, metrics, and audit logs.
+- Upgrade an existing v1 directory without requiring downtime.
+
+## Non-goals
+
+- GC does not delete RDF operation metadata, workspace heads, finalized KA
+  graphs, or graph-backed `dkg:publicSnapshotGraph` content.
+- GC does not weaken digest/count verification or ACK/finality rules.
+- GC does not use free space alone as evidence that a file is disposable.
+
+## Persistent blob catalog
+
+Add a transactional `snapshot_blobs` catalog, preferably beside the existing
+SQLite page-index table. One row represents one canonical digest:
+
+| Field | Purpose |
+| --- | --- |
+| `snapshot_digest` | Canonical `sha256:<hex>` primary key |
+| `format_version` | On-disk serialization version |
+| `byte_length` | Reclaim planning without filesystem-wide `stat` |
+| `created_at_ms` | First successful local materialization |
+| `last_access_at_ms` | Coalesced LRU signal; updates must be rate limited |
+| `source` | `local_publish`, `network_sync`, or `legacy_unknown` |
+| `lifecycle` | `writing`, `ready`, `tombstoned`, or `missing` |
+| `verified_at_ms` | Last successful digest/count verification |
+| `context_graph_id` | Recovery and audit scope when known |
+| `share_operation_id` | Originating operation when known |
+| `source_peer_id` | Last verified network source when known |
+| `finalized_at_ms` | Local operation reached terminal finality |
+| `replica_proof_count` | Distinct valid storage proofs currently recorded |
+| `replica_proof_expires_at_ms` | Earliest expiry of proofs used for eviction |
+| `pin_reason` | Nullable operator/system pin |
+| `generation` | Monotonic value for lease/tombstone race detection |
+
+The catalog update and file transition must be crash consistent. A successful
+`putSnapshot` changes `writing` to `ready` only after rename and verification.
+Startup reconciliation repairs `writing`, `tombstoned`, missing, and unknown
+filesystem/catalog combinations.
+
+Change `putSnapshot` to accept optional provenance:
+
+```ts
+type SnapshotProvenance =
+  | {
+      source: 'local_publish';
+      contextGraphId: string;
+      shareOperationId: string;
+    }
+  | {
+      source: 'network_sync';
+      contextGraphId: string;
+      sourcePeerId: string;
+    };
+```
+
+Every production call site must supply provenance. The field can remain
+optional temporarily for third-party stores, but omitted provenance is
+`legacy_unknown` and fail-closed for deletion.
+
+## Deletion proofs
+
+A blob is eligible only when it has no active lease or pin and at least one of
+these proofs is true:
+
+1. **Definite orphan:** no explicit `publicSnapshotRef`, no implicit
+   `publicQuadsDigest` reference without a `publicSnapshotGraph`, no pending
+   job/finalization reference, and it is older than the orphan grace period.
+2. **Verified peer cache:** `source=network_sync`, digest/count verification
+   succeeded, the cache grace period elapsed, and a current durable source or
+   deterministic reconstruction path is proven available.
+3. **Replicated local origin:** local publication is terminal/finalized and the
+   configured minimum number of distinct valid retention-proof holders confirms
+   recoverability. Proofs must belong to the relevant network/chain epoch, must
+   not count duplicate operational identities, and must remain valid beyond the
+   configured recovery window.
+
+`legacy_unknown`, locally pending, failed publication, insufficiently
+replicated, corrupt, or proof-expired rows are not eligible. Operators may
+explicitly pin any digest.
+
+The exact replica threshold is network policy, not a hard-coded store constant.
+The catalog records evidence; a proof provider in the publisher/agent layer
+evaluates current policy.
+
+A historical storage ACK is not automatically a permanent retention proof: a
+receiver may later evict its own cache. It qualifies only if the protocol binds
+that ACK to a still-valid retention commitment, a current inventory challenge,
+or a deterministic durable source from which the exact digest can be rebuilt.
+Without one of those witnesses, the local-origin blob remains pinned.
+
+## Complete mark sources
+
+The mark phase must combine:
+
+- Legacy explicit `dkg:publicSnapshotRef` rows.
+- Implicit refs: `dkg:publicQuadsDigest` rows with no
+  `dkg:publicSnapshotGraph`.
+- Current workspace heads and graph-scoped heads.
+- Queued/running publish, promotion, retry, recovery, and finalization jobs.
+- In-progress snapshot sync and materialization.
+- Active in-process leases and cross-process lease/lock records.
+- Operator/system pins.
+- Local-origin rows lacking sufficient terminal replication proof.
+
+References identify consumers and recovery descriptors. They do not override a
+valid peer-cache or replicated-origin eviction proof; otherwise referenced cache
+could never be bounded.
+
+## Leases and concurrency
+
+Reads, paged reads, writes, verification, and network serving acquire a digest
+lease before accessing the blob. GC atomically transitions an eligible catalog
+row from `ready` to `tombstoned` only when no unexpired lease exists and the row
+generation still matches its plan.
+
+For the normal single-daemon deployment, in-memory reference counts are the
+fast path. A small SQLite lease/owner record or an exclusive node-directory
+lock must prevent a maintenance CLI or second process from sweeping files used
+by the daemon. Expired leases require an owner/process-generation check before
+reclamation.
+
+Deletion is idempotent:
+
+1. Transactionally mark the row `tombstoned` with a new generation.
+2. Unlink the immutable blob.
+3. Delete its `snapshot_page_indexes` row.
+4. Commit the catalog row as `missing` or remove it after the audit-retention
+   window.
+
+Startup completes interrupted tombstones. A concurrent put either cancels the
+tombstone with a newer generation or writes and publishes a new `ready`
+generation after deletion; it must never be mistaken for the old plan.
+
+## Cache-miss rehydration
+
+The file store cannot fetch peers by itself. Add an agent-layer snapshot
+resolver that composes local storage with the existing snapshot page transport:
+
+1. Local `getSnapshot` reports a typed miss.
+2. The resolver single-flights concurrent misses for the same digest.
+3. It selects an authoritative recovery descriptor and eligible peer.
+4. It fetches the complete snapshot, never persisting an unverified prefix.
+5. It verifies digest and triple count.
+6. It writes the blob with `source=network_sync` provenance and resumes callers.
+
+Wire this resolver into direct workspace resolution, graph-scoped recovery,
+sync, ACK preparation, and snapshot-serving paths. An ACK must not be emitted
+until rehydration and integrity verification succeed. If no peer can serve the
+blob, return a typed retryable-unavailable result rather than corrupting
+metadata or pretending the snapshot is complete.
+
+## Collection algorithm
+
+The periodic and pre-write entry points share one single-flight planner:
+
+```text
+clean abandoned temp/writing records
+read filesystem available bytes
+if above trigger and no pending write threatens reserve: stop
+
+desired = max(targetFreeBytes, hardReserveBytes + pendingWriteBytes)
+mark leases, pins, pending local work, and unproven local origins
+load proven candidates from the catalog
+order: definite orphan, verified peer cache LRU, replicated local origin LRU
+tombstone and delete until desired is reached or candidates are exhausted
+
+if pending write still violates hard reserve:
+  reject it with SNAPSHOT_STORAGE_CAPACITY
+```
+
+Do not hold a database transaction during filesystem or network I/O. Plan in a
+short read transaction and use generation-checked state transitions per blob.
+Cap deletions or wall-clock time per periodic pass so GC cannot starve ACK and
+sync work; pre-write emergency collection may continue until the write is safe
+or proven impossible.
+
+## Configuration
+
+V2 retains the v1 fields and adds policy controls:
+
+```json
+{
+  "gc": {
+    "enabled": true,
+    "mode": "proof-driven",
+    "intervalMs": 300000,
+    "triggerFreeBytes": 16106127360,
+    "targetFreeBytes": 26843545600,
+    "hardReserveBytes": 5368709120,
+    "orphanGraceMs": 86400000,
+    "peerCacheGraceMs": 86400000,
+    "localOriginGraceMs": 604800000,
+    "minimumReplicaProofs": 3,
+    "leaseTimeoutMs": 900000,
+    "maxPassMs": 30000,
+    "unknownLegacyPolicy": "pin"
+  }
+}
+```
+
+Defaults must be derived from network policy and filesystem size or remain
+explicitly opt-in. `hardReserveBytes` is the final admission boundary, not the
+normal collection trigger.
+
+## Observability and tooling
+
+Expose at least:
+
+- Available bytes, store bytes, catalog rows by source/lifecycle.
+- GC runs by reason and outcome.
+- Planned/deleted/skipped/failed files and bytes by proof class.
+- Active leases and pins.
+- Capacity rejections.
+- Cache misses, refetch attempts, refetch latency, and failures.
+- Inventory/catalog drift and stale page-index rows.
+
+Add commands equivalent to:
+
+```text
+dkg snapshots inventory
+dkg snapshots gc --dry-run
+dkg snapshots gc
+dkg snapshots pin <digest>
+dkg snapshots unpin <digest>
+```
+
+Dry-run output must state the proof class and skip reason per sampled digest and
+aggregate the complete byte/count plan.
+
+## Migration and rollout
+
+1. Ship catalog creation and provenance recording with collection in report-only
+   mode.
+2. Inventory existing files. Classify from durable metadata and job/ACK state;
+   leave ambiguous rows `legacy_unknown` and pinned.
+3. Compare filesystem, implicit/explicit references, page indexes, and catalog
+   in canary telemetry.
+4. Enable deletion for definite orphans and verified peer cache on one testnet
+   canary.
+5. Exercise cache-miss rehydration and restart-during-tombstone tests.
+6. Enable replicated local-origin eviction only after ACK proof evaluation has
+   passed shadow-mode audits.
+7. Roll out by chain, retaining v1 hard-reserve admission as the fail-safe.
+
+## Acceptance criteria
+
+- A sole-copy local snapshot is never selected or deleted.
+- A finalized local snapshot with sufficient current proofs is reclaimable.
+- A verified peer-cache miss rehydrates and produces byte-equivalent quads.
+- Implicit digest references and legacy explicit references are both found.
+- Active read/write/sync/serve leases defeat a concurrent GC plan.
+- Restart at every tombstone transition converges without a corrupt ready row.
+- Deletion also removes the derived page-index row.
+- A malformed/corrupt blob is never treated as verified cache.
+- Failed unlink, SQLite busy, statfs failure, unavailable peers, and `ENOSPC`
+  produce bounded retries and explicit health/metrics.
+- Under sustained load the configured hard reserve is maintained, or new
+  snapshot writes are rejected before the triple store loses its own capacity.
+- V1 directories migrate without deleting `legacy_unknown` blobs by default.

--- a/docs/use-dkg/swm-public-snapshot-gc.md
+++ b/docs/use-dkg/swm-public-snapshot-gc.md
@@ -1,0 +1,58 @@
+# SWM public snapshot garbage collection
+
+The file-backed shared-memory (SWM) public snapshot store supports an opt-in,
+pressure-based garbage collector. GC v1 is an incident guardrail: it bounds disk
+growth using file age and free-space watermarks. It does not inspect RDF
+references or replication proofs.
+
+## Recommended 75 GiB node configuration
+
+```json
+{
+  "sharedMemoryPublicSnapshotStorage": {
+    "enabled": true,
+    "directory": "/var/lib/dkg/swm-public-snapshots",
+    "gc": {
+      "enabled": true,
+      "intervalMs": 300000,
+      "triggerFreeBytes": 16106127360,
+      "targetFreeBytes": 26843545600,
+      "hardReserveBytes": 5368709120,
+      "minAgeMs": 604800000,
+      "staleTempAgeMs": 3600000
+    }
+  }
+}
+```
+
+GC is disabled unless `gc.enabled` is `true`. When enabled, the store:
+
+1. Checks the snapshot filesystem every `intervalMs` and before a write that
+   could cross a watermark.
+2. Removes abandoned atomic-write `.tmp` files older than `staleTempAgeMs`.
+3. Starts snapshot eviction below `triggerFreeBytes` and deletes eligible
+   `.nq` or legacy `.json` files oldest first.
+4. Stops when `targetFreeBytes` is available or no eligible files remain.
+5. Never age-evicts a file newer than `minAgeMs`, or a file in use by this
+   process.
+6. Rejects a new snapshot with error code `SNAPSHOT_STORAGE_CAPACITY` when the
+   write would consume `hardReserveBytes` and GC cannot recover enough space.
+
+The hard reserve protects the triple store and other node state from an
+`ENOSPC` cascade. It should be lower than the trigger; the target should be at
+least as high as the trigger. Defaults are 5 GiB, 15 GiB, and 25 GiB
+respectively, but operators must size them for the filesystem hosting the
+configured snapshot directory.
+
+## V1 safety boundary
+
+V1 treats sufficiently old snapshots as recoverable cache. Metadata may still
+refer to an evicted digest. Normal SWM synchronization detects a missing or
+invalid local blob, fetches it from a peer, verifies its digest and count, and
+writes it back. Some direct local resolution paths do not yet refetch on demand,
+so nodes that may hold the only copy of locally produced data should use a
+longer minimum age or leave v1 disabled until replication is established.
+
+GC v2 will replace age as the deletion proof with recorded provenance,
+replication/finality evidence, leases, and cache-miss rehydration. See
+[`../active-now/swm-public-snapshot-gc-v2-spec.md`](../active-now/swm-public-snapshot-gc-v2-spec.md).

--- a/packages/agent/src/dkg-agent-helpers.ts
+++ b/packages/agent/src/dkg-agent-helpers.ts
@@ -296,7 +296,11 @@ export function createPublicSnapshotStore(
   config: SharedMemoryPublicSnapshotStorageConfig | undefined,
 ): WorkspacePublicSnapshotStore | undefined {
   if (!dataDir || config?.enabled === false) return undefined;
-  return new FileWorkspacePublicSnapshotStore(config?.directory ?? join(dataDir, 'swm-public-snapshots'));
+  return new FileWorkspacePublicSnapshotStore(
+    config?.directory ?? join(dataDir, 'swm-public-snapshots'),
+    undefined,
+    { gc: config?.gc },
+  );
 }
 
 export function applyDefaultLargeLiteralStorage(

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -363,6 +363,15 @@ export interface LargeLiteralStorageConfig {
 export interface SharedMemoryPublicSnapshotStorageConfig {
   enabled?: boolean;
   directory?: string;
+  gc?: {
+    enabled?: boolean;
+    intervalMs?: number;
+    triggerFreeBytes?: number;
+    targetFreeBytes?: number;
+    hardReserveBytes?: number;
+    minAgeMs?: number;
+    staleTempAgeMs?: number;
+  };
 }
 
 /** Optional LLM config for the Node UI chatbot (OpenAI-compatible API). */

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1647,6 +1647,7 @@ export async function runDaemonInner(
     dkgDir(),
     { sharedMemoryPublicSnapshotStorage: runtimeSnapshotStorage },
     snapshotPageIndexStore,
+    log,
   );
   const chainCursorScope = chainBase?.type === 'mock'
     ? (chainBase.chainId ?? 'mock:31337')

--- a/packages/cli/src/daemon/oxigraph-managed.ts
+++ b/packages/cli/src/daemon/oxigraph-managed.ts
@@ -100,7 +100,24 @@ interface ConfigLike {
   sharedMemoryPublicSnapshotStorage?: {
     enabled?: boolean;
     directory?: string;
+    gc?: SnapshotGarbageCollectionConfigLike;
   };
+}
+
+interface SnapshotGarbageCollectionConfigLike {
+  enabled?: boolean;
+  intervalMs?: number;
+  triggerFreeBytes?: number;
+  targetFreeBytes?: number;
+  hardReserveBytes?: number;
+  minAgeMs?: number;
+  staleTempAgeMs?: number;
+}
+
+interface ManagedSnapshotStorageConfig {
+  enabled: boolean;
+  directory: string;
+  gc?: SnapshotGarbageCollectionConfigLike;
 }
 
 export interface ManagedOxigraphPlan {
@@ -143,7 +160,7 @@ export interface ManagedOxigraphPlan {
    * explicit `directory` would fail validateStoreConfig(). Defaulted to
    * the same `swm-public-snapshots` dir createPublicSnapshotStore() uses.
    */
-  sharedMemoryPublicSnapshotStorage?: { enabled: boolean; directory: string };
+  sharedMemoryPublicSnapshotStorage?: ManagedSnapshotStorageConfig;
 }
 
 /**
@@ -195,6 +212,9 @@ export function planManagedOxigraph(
           directory:
             config.sharedMemoryPublicSnapshotStorage.directory ??
             join(dataDir, 'swm-public-snapshots'),
+          ...(config.sharedMemoryPublicSnapshotStorage.gc === undefined
+            ? {}
+            : { gc: config.sharedMemoryPublicSnapshotStorage.gc }),
         }
       : undefined;
 
@@ -238,7 +258,7 @@ export interface ManagedOxigraphResult {
   };
   largeLiteralStorage: { enabled: boolean; thresholdBytes?: number; directory: string };
   /** Set only when the operator enabled the feature (else leave config as-is). */
-  sharedMemoryPublicSnapshotStorage?: { enabled: boolean; directory: string };
+  sharedMemoryPublicSnapshotStorage?: ManagedSnapshotStorageConfig;
 }
 
 export interface StartManagedOxigraphOptions {

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -958,6 +958,7 @@ export function createPublicSnapshotStore(
   dataDir: string,
   config?: Pick<DkgConfig, 'sharedMemoryPublicSnapshotStorage'>,
   pageIndexStore?: SnapshotPageIndexStore,
+  log?: (message: string) => void,
 ): WorkspacePublicSnapshotStore | undefined {
   const snapshotConfig = config?.sharedMemoryPublicSnapshotStorage;
   if (snapshotConfig?.enabled === false) {
@@ -966,6 +967,7 @@ export function createPublicSnapshotStore(
   return new FileWorkspacePublicSnapshotStore(
     snapshotConfig?.directory ?? join(dataDir, 'swm-public-snapshots'),
     pageIndexStore,
+    { gc: snapshotConfig?.gc, log },
   );
 }
 

--- a/packages/cli/test/oxigraph-managed.test.ts
+++ b/packages/cli/test/oxigraph-managed.test.ts
@@ -336,6 +336,30 @@ describe('planManagedOxigraph', () => {
     });
   });
 
+  it('preserves snapshot GC watermarks through the managed store rewrite', () => {
+    const gc = {
+      enabled: true,
+      intervalMs: 300_000,
+      triggerFreeBytes: 15 * 1024 ** 3,
+      targetFreeBytes: 25 * 1024 ** 3,
+      hardReserveBytes: 5 * 1024 ** 3,
+      minAgeMs: 7 * 24 * 60 * 60 * 1_000,
+    };
+    const plan = planManagedOxigraph(
+      {
+        store: { backend: MANAGED_OXIGRAPH_BACKEND },
+        sharedMemoryPublicSnapshotStorage: { enabled: true, gc },
+      },
+      '/data',
+    );
+
+    expect(plan!.sharedMemoryPublicSnapshotStorage).toEqual({
+      enabled: true,
+      directory: join('/data', 'swm-public-snapshots'),
+      gc,
+    });
+  });
+
   it('preserves graphSetIndex options through the managed store rewrite plan', () => {
     const plan = planManagedOxigraph(
       {

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -343,10 +343,14 @@ export {
 export { SharedMemoryHandler, WorkspaceHandler } from './workspace-handler.js';
 export {
   FileWorkspacePublicSnapshotStore,
+  SnapshotStorageCapacityError,
   parseWorkspacePublicSnapshotNQuads,
   serializeWorkspacePublicSnapshotQuads,
   workspacePublicQuadsDigest,
+  type FileWorkspacePublicSnapshotStoreOptions,
+  type SharedMemoryPublicSnapshotGarbageCollectionConfig,
   type SharedMemoryPublicSnapshotStorageConfig,
+  type SnapshotGarbageCollectionResult,
   type SnapshotPageIndexRecord,
   type SnapshotPageIndexStore,
   type WorkspacePublicSnapshotStore,

--- a/packages/publisher/src/workspace-snapshot-store.ts
+++ b/packages/publisher/src/workspace-snapshot-store.ts
@@ -1,5 +1,16 @@
-import { mkdir, open, readFile, rename, stat, writeFile } from 'node:fs/promises';
+import {
+  mkdir,
+  open,
+  readFile,
+  readdir,
+  rename,
+  stat,
+  statfs,
+  unlink,
+  writeFile,
+} from 'node:fs/promises';
 import { createHash } from 'node:crypto';
+import type { Dirent } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { createInterface } from 'node:readline';
 import type { Quad } from '@origintrail-official/dkg-storage';
@@ -7,6 +18,45 @@ import type { Quad } from '@origintrail-official/dkg-storage';
 export interface SharedMemoryPublicSnapshotStorageConfig {
   enabled?: boolean;
   directory?: string;
+  gc?: SharedMemoryPublicSnapshotGarbageCollectionConfig;
+}
+
+export interface SharedMemoryPublicSnapshotGarbageCollectionConfig {
+  /** Disabled by default so operators opt in to the v1 age-based policy. */
+  enabled?: boolean;
+  /** How often the background pressure check runs. Default: 5 minutes. */
+  intervalMs?: number;
+  /** Start snapshot eviction below this amount of available space. Default: 15 GiB. */
+  triggerFreeBytes?: number;
+  /** Continue snapshot eviction until this amount is available. Default: 25 GiB. */
+  targetFreeBytes?: number;
+  /** Preserve this capacity for the triple store and other node state. Default: 5 GiB. */
+  hardReserveBytes?: number;
+  /** Never age-evict snapshots newer than this. Default: 7 days. */
+  minAgeMs?: number;
+  /** Remove abandoned atomic-write files after this age. Default: 1 hour. */
+  staleTempAgeMs?: number;
+}
+
+export interface SnapshotGarbageCollectionResult {
+  readonly triggered: boolean;
+  readonly availableBytesBefore: number;
+  readonly availableBytesAfter: number;
+  readonly deletedSnapshots: number;
+  readonly deletedSnapshotBytes: number;
+  readonly deletedTempFiles: number;
+  readonly deletedTempBytes: number;
+  readonly skippedActiveFiles: number;
+  readonly failedDeletions: number;
+}
+
+export interface FileWorkspacePublicSnapshotStoreOptions {
+  readonly gc?: SharedMemoryPublicSnapshotGarbageCollectionConfig;
+  readonly log?: (message: string) => void;
+  /** Test seam; production callers use statfs(2). */
+  readonly getAvailableBytes?: (directory: string) => Promise<number>;
+  /** Test seam; production callers use Date.now(). */
+  readonly now?: () => number;
 }
 
 export interface WorkspacePublicSnapshotStore {
@@ -47,6 +97,53 @@ export interface SnapshotPageIndexStore {
 const SNAPSHOT_PAGE_INDEX_VERSION = 1;
 const SNAPSHOT_PAGE_INDEX_STRIDE = 128;
 const SNAPSHOT_PAGE_INDEX_CACHE_MAX = 64;
+const GIB = 1024 ** 3;
+const DEFAULT_SNAPSHOT_GC_INTERVAL_MS = 5 * 60 * 1_000;
+const DEFAULT_SNAPSHOT_GC_TRIGGER_FREE_BYTES = 15 * GIB;
+const DEFAULT_SNAPSHOT_GC_TARGET_FREE_BYTES = 25 * GIB;
+const DEFAULT_SNAPSHOT_GC_HARD_RESERVE_BYTES = 5 * GIB;
+const DEFAULT_SNAPSHOT_GC_MIN_AGE_MS = 7 * 24 * 60 * 60 * 1_000;
+const DEFAULT_SNAPSHOT_GC_STALE_TEMP_AGE_MS = 60 * 60 * 1_000;
+const SNAPSHOT_FILE_PATTERN = /^([a-f0-9]{64})\.(?:nq|json)$/i;
+const SNAPSHOT_TEMP_FILE_PATTERN = /^([a-f0-9]{64})\.(?:nq|json)\.\d+\.\d+\.tmp$/i;
+const SNAPSHOT_FILE_STAT_CONCURRENCY = 64;
+
+interface ResolvedSnapshotGarbageCollectionConfig {
+  enabled: boolean;
+  intervalMs: number;
+  triggerFreeBytes: number;
+  targetFreeBytes: number;
+  hardReserveBytes: number;
+  minAgeMs: number;
+  staleTempAgeMs: number;
+}
+
+interface SnapshotStoreFile {
+  path: string;
+  name: string;
+  hash: string;
+}
+
+interface SnapshotStoreFileMetadata extends SnapshotStoreFile {
+  size: number;
+  mtimeMs: number;
+}
+
+export class SnapshotStorageCapacityError extends Error {
+  readonly code = 'SNAPSHOT_STORAGE_CAPACITY';
+
+  constructor(
+    readonly availableBytes: number,
+    readonly requiredBytes: number,
+    readonly hardReserveBytes: number,
+  ) {
+    super(
+      `Insufficient shared-memory snapshot storage capacity: ${availableBytes} bytes available, `
+      + `${requiredBytes} bytes required, ${hardReserveBytes} byte hard reserve`,
+    );
+    this.name = 'SnapshotStorageCapacityError';
+  }
+}
 
 interface SnapshotPageIndexCore {
   version: typeof SNAPSHOT_PAGE_INDEX_VERSION;
@@ -65,27 +162,92 @@ interface SnapshotFileFingerprint {
 
 export class FileWorkspacePublicSnapshotStore implements WorkspacePublicSnapshotStore {
   private readonly pageIndexCache = new Map<string, Promise<SnapshotPageIndexCore>>();
+  private readonly pendingWrites = new Map<
+    string,
+    Promise<{ readonly ref: string; readonly byteLength: number }>
+  >();
+  private readonly activeSnapshots = new Map<string, number>();
+  private readonly gcConfig: ResolvedSnapshotGarbageCollectionConfig;
+  private readonly log?: (message: string) => void;
+  private readonly getAvailableBytes: (directory: string) => Promise<number>;
+  private readonly now: () => number;
+  private readonly gcTimer?: NodeJS.Timeout;
+  private garbageCollectionRun?: Promise<SnapshotGarbageCollectionResult>;
+  private garbageCollectionRequiredWriteBytes = 0;
 
   constructor(
     private readonly directory: string,
     private readonly pageIndexStore?: SnapshotPageIndexStore,
-  ) {}
+    options: FileWorkspacePublicSnapshotStoreOptions = {},
+  ) {
+    this.gcConfig = resolveSnapshotGarbageCollectionConfig(options.gc);
+    this.log = options.log;
+    this.getAvailableBytes = options.getAvailableBytes ?? filesystemAvailableBytes;
+    this.now = options.now ?? Date.now;
+    if (this.gcConfig.enabled) {
+      this.gcTimer = setInterval(() => {
+        void this.collectGarbage().then((result) => {
+          if (
+            result.triggered
+            || result.deletedSnapshots > 0
+            || result.deletedTempFiles > 0
+            || result.failedDeletions > 0
+          ) {
+            this.logGarbageCollection(result);
+          }
+        }).catch((error) => {
+          this.log?.(`[SWM-SNAPSHOT-GC] periodic collection failed: ${errorMessage(error)}`);
+        });
+      }, this.gcConfig.intervalMs);
+      this.gcTimer.unref();
+    }
+  }
 
   async putSnapshot(input: {
     readonly digest: string;
     readonly quads: readonly Quad[];
   }): Promise<{ readonly ref: string; readonly byteLength: number }> {
     const hash = snapshotHash(input.digest);
+    const pending = this.pendingWrites.get(hash);
+    if (pending) return pending;
+
+    const operation = this.withActiveSnapshot(hash, () => this.putSnapshotOnce(input, hash));
+    this.pendingWrites.set(hash, operation);
+    try {
+      return await operation;
+    } finally {
+      if (this.pendingWrites.get(hash) === operation) this.pendingWrites.delete(hash);
+    }
+  }
+
+  private async putSnapshotOnce(
+    input: { readonly digest: string; readonly quads: readonly Quad[] },
+    hash: string,
+  ): Promise<{ readonly ref: string; readonly byteLength: number }> {
     const filePath = snapshotPath(this.directory, hash, 'nq');
+    const existingByteLength = await existingFileSize(filePath);
+    if (existingByteLength !== null) {
+      return { ref: input.digest, byteLength: existingByteLength };
+    }
+
     const { payload, offsets, fileBytes } = serializeWorkspacePublicSnapshotWithIndex(input.quads);
 
     await mkdir(dirname(filePath), { recursive: true });
+    await this.ensureWriteCapacity(fileBytes);
     const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
-    await writeFile(tempPath, payload, 'utf8');
-    await rename(tempPath, filePath).catch(async (err: NodeJS.ErrnoException) => {
-      if (err.code === 'EEXIST') return;
-      throw err;
-    });
+    try {
+      await writeFile(tempPath, payload, 'utf8');
+      await rename(tempPath, filePath).catch(async (err: NodeJS.ErrnoException) => {
+        if (err.code === 'EEXIST') return;
+        throw err;
+      });
+    } finally {
+      await unlink(tempPath).catch((error: NodeJS.ErrnoException) => {
+        if (error.code !== 'ENOENT') {
+          this.log?.(`[SWM-SNAPSHOT-GC] failed to remove write temp file ${tempPath}: ${error.message}`);
+        }
+      });
+    }
 
     const fingerprint = await stat(filePath);
     const index: SnapshotPageIndexCore = {
@@ -107,16 +269,18 @@ export class FileWorkspacePublicSnapshotStore implements WorkspacePublicSnapshot
 
   async getSnapshot(ref: string): Promise<Quad[] | null> {
     const hash = snapshotHash(ref);
-    const nquadsPath = snapshotPath(this.directory, hash, 'nq');
-    let raw: string;
-    try {
-      raw = await readFile(nquadsPath, 'utf8');
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
-      return this.getLegacyJsonSnapshot(ref, hash);
-    }
+    return this.withActiveSnapshot(hash, async () => {
+      const nquadsPath = snapshotPath(this.directory, hash, 'nq');
+      let raw: string;
+      try {
+        raw = await readFile(nquadsPath, 'utf8');
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+        return this.getLegacyJsonSnapshot(ref, hash);
+      }
 
-    return parseWorkspacePublicSnapshotNQuads(raw, ref);
+      return parseWorkspacePublicSnapshotNQuads(raw, ref);
+    });
   }
 
   async getSnapshotPage(
@@ -129,56 +293,235 @@ export class FileWorkspacePublicSnapshotStore implements WorkspacePublicSnapshot
     const safeLimit = Math.max(0, Math.floor(limit));
     if (safeLimit === 0) return [];
     const hash = snapshotHash(ref);
-    const nquadsPath = snapshotPath(this.directory, hash, 'nq');
-    let file: Awaited<ReturnType<typeof open>>;
-    try {
-      file = await open(nquadsPath, 'r');
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
-      const legacy = await this.getLegacyJsonSnapshot(ref, hash);
-      return legacy?.slice(safeOffset, safeOffset + safeLimit) ?? null;
-    }
-
-    let startRow = 0;
-    let startByte = 0;
-    try {
-      const index = await this.getPageIndex(ref, nquadsPath);
-      const checkpoint = Math.min(
-        Math.floor(safeOffset / index.stride),
-        Math.max(0, index.offsets.length - 1),
-      );
-      startRow = checkpoint * index.stride;
-      startByte = index.offsets[checkpoint] ?? 0;
-    } catch {
-      // Page indexes are derived data. The already-open snapshot remains the
-      // source of truth, so index failures fall back to scanning from row zero.
-    }
-
-    const input = file.createReadStream({
-      encoding: 'utf8',
-      autoClose: false,
-      start: startByte,
-      signal: options?.signal,
-    });
-    const lines = createInterface({ input, crlfDelay: Infinity });
-    const page: Quad[] = [];
-    let row = startRow;
-    try {
-      for await (const rawLine of lines) {
-        const line = rawLine.trim();
-        if (!line) continue;
-        if (row >= safeOffset) {
-          page.push(parseNQuadLine(line, ref, row));
-          if (page.length >= safeLimit) break;
-        }
-        row += 1;
+    return this.withActiveSnapshot(hash, async () => {
+      const nquadsPath = snapshotPath(this.directory, hash, 'nq');
+      let file: Awaited<ReturnType<typeof open>>;
+      try {
+        file = await open(nquadsPath, 'r');
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+        const legacy = await this.getLegacyJsonSnapshot(ref, hash);
+        return legacy?.slice(safeOffset, safeOffset + safeLimit) ?? null;
       }
-      return page;
-    } finally {
-      lines.close();
-      input.destroy();
-      await file.close().catch(() => {});
+
+      let startRow = 0;
+      let startByte = 0;
+      try {
+        const index = await this.getPageIndex(ref, nquadsPath);
+        const checkpoint = Math.min(
+          Math.floor(safeOffset / index.stride),
+          Math.max(0, index.offsets.length - 1),
+        );
+        startRow = checkpoint * index.stride;
+        startByte = index.offsets[checkpoint] ?? 0;
+      } catch {
+        // Page indexes are derived data. The already-open snapshot remains the
+        // source of truth, so index failures fall back to scanning from row zero.
+      }
+
+      const input = file.createReadStream({
+        encoding: 'utf8',
+        autoClose: false,
+        start: startByte,
+        signal: options?.signal,
+      });
+      const lines = createInterface({ input, crlfDelay: Infinity });
+      const page: Quad[] = [];
+      let row = startRow;
+      try {
+        for await (const rawLine of lines) {
+          const line = rawLine.trim();
+          if (!line) continue;
+          if (row >= safeOffset) {
+            page.push(parseNQuadLine(line, ref, row));
+            if (page.length >= safeLimit) break;
+          }
+          row += 1;
+        }
+        return page;
+      } finally {
+        lines.close();
+        input.destroy();
+        await file.close().catch(() => {});
+      }
+    });
+  }
+
+  stopGarbageCollection(): void {
+    if (this.gcTimer) clearInterval(this.gcTimer);
+  }
+
+  async collectGarbage(
+    options: { readonly requiredWriteBytes?: number } = {},
+  ): Promise<SnapshotGarbageCollectionResult> {
+    if (!this.gcConfig.enabled) return emptyGarbageCollectionResult();
+    const requiredWriteBytes = Math.max(0, options.requiredWriteBytes ?? 0);
+    if (this.garbageCollectionRun) {
+      const runningRequiredWriteBytes = this.garbageCollectionRequiredWriteBytes;
+      const result = await this.garbageCollectionRun;
+      return requiredWriteBytes > runningRequiredWriteBytes
+        ? this.collectGarbage({ requiredWriteBytes })
+        : result;
     }
+
+    const run = this.collectGarbageOnce(requiredWriteBytes);
+    this.garbageCollectionRequiredWriteBytes = requiredWriteBytes;
+    this.garbageCollectionRun = run;
+    try {
+      return await run;
+    } finally {
+      if (this.garbageCollectionRun === run) {
+        this.garbageCollectionRun = undefined;
+        this.garbageCollectionRequiredWriteBytes = 0;
+      }
+    }
+  }
+
+  private async collectGarbageOnce(
+    requiredWriteBytes: number,
+  ): Promise<SnapshotGarbageCollectionResult> {
+    await mkdir(this.directory, { recursive: true });
+    const availableBytesBefore = await this.getAvailableBytes(this.directory);
+    let availableBytesAfter = availableBytesBefore;
+    let deletedSnapshots = 0;
+    let deletedSnapshotBytes = 0;
+    let deletedTempFiles = 0;
+    let deletedTempBytes = 0;
+    let skippedActiveFiles = 0;
+    let failedDeletions = 0;
+    const now = this.now();
+    const files = await listSnapshotStoreFiles(this.directory);
+    const tempFiles = files.filter((file) => SNAPSHOT_TEMP_FILE_PATTERN.test(file.name));
+    const staleTempFiles = await statSnapshotStoreFiles(
+      tempFiles,
+      now - this.gcConfig.staleTempAgeMs,
+    );
+
+    for (const file of staleTempFiles) {
+      if (this.isSnapshotActive(file.hash)) {
+        skippedActiveFiles += 1;
+        continue;
+      }
+      try {
+        await unlink(file.path);
+        deletedTempFiles += 1;
+        deletedTempBytes += file.size;
+        availableBytesAfter += file.size;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') failedDeletions += 1;
+      }
+    }
+
+    const triggered = availableBytesBefore < this.gcConfig.triggerFreeBytes
+      || availableBytesBefore - requiredWriteBytes < this.gcConfig.hardReserveBytes;
+    if (triggered) {
+      const targetAvailableBytes = Math.max(
+        this.gcConfig.targetFreeBytes,
+        this.gcConfig.hardReserveBytes + requiredWriteBytes,
+      );
+      const snapshotFiles = files.filter((file) => SNAPSHOT_FILE_PATTERN.test(file.name));
+      const candidates = await statSnapshotStoreFiles(
+        snapshotFiles,
+        now - this.gcConfig.minAgeMs,
+      );
+      candidates.sort(
+        (left, right) => left.mtimeMs - right.mtimeMs || left.path.localeCompare(right.path),
+      );
+
+      for (const file of candidates) {
+        if (availableBytesAfter >= targetAvailableBytes) break;
+        if (this.isSnapshotActive(file.hash)) {
+          skippedActiveFiles += 1;
+          continue;
+        }
+        try {
+          await unlink(file.path);
+          deletedSnapshots += 1;
+          deletedSnapshotBytes += file.size;
+          availableBytesAfter += file.size;
+          this.forgetPageIndex(file.hash);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') failedDeletions += 1;
+        }
+      }
+    }
+
+    return {
+      triggered,
+      availableBytesBefore,
+      availableBytesAfter,
+      deletedSnapshots,
+      deletedSnapshotBytes,
+      deletedTempFiles,
+      deletedTempBytes,
+      skippedActiveFiles,
+      failedDeletions,
+    };
+  }
+
+  private async ensureWriteCapacity(requiredWriteBytes: number): Promise<void> {
+    if (!this.gcConfig.enabled) return;
+    const availableBytes = await this.getAvailableBytes(this.directory);
+    const needsCollection = availableBytes < this.gcConfig.triggerFreeBytes
+      || availableBytes - requiredWriteBytes < this.gcConfig.hardReserveBytes;
+    const result = needsCollection
+      ? await this.collectGarbage({ requiredWriteBytes })
+      : undefined;
+    // Admission is based on a fresh filesystem reading, not projected file
+    // sizes: an unlinked file held open by another process may not have
+    // released its blocks yet.
+    const availableAfterCollection = result
+      ? await this.getAvailableBytes(this.directory)
+      : availableBytes;
+    if (availableAfterCollection - requiredWriteBytes < this.gcConfig.hardReserveBytes) {
+      throw new SnapshotStorageCapacityError(
+        availableAfterCollection,
+        requiredWriteBytes,
+        this.gcConfig.hardReserveBytes,
+      );
+    }
+    if (
+      result
+      && (
+        result.triggered
+        || result.deletedSnapshots > 0
+        || result.deletedTempFiles > 0
+        || result.failedDeletions > 0
+      )
+    ) {
+      this.logGarbageCollection(result);
+    }
+  }
+
+  private async withActiveSnapshot<T>(hash: string, operation: () => Promise<T>): Promise<T> {
+    this.activeSnapshots.set(hash, (this.activeSnapshots.get(hash) ?? 0) + 1);
+    try {
+      return await operation();
+    } finally {
+      const remaining = (this.activeSnapshots.get(hash) ?? 1) - 1;
+      if (remaining > 0) this.activeSnapshots.set(hash, remaining);
+      else this.activeSnapshots.delete(hash);
+    }
+  }
+
+  private isSnapshotActive(hash: string): boolean {
+    return (this.activeSnapshots.get(hash) ?? 0) > 0;
+  }
+
+  private forgetPageIndex(hash: string): void {
+    for (const ref of this.pageIndexCache.keys()) {
+      if (snapshotHash(ref) === hash) this.pageIndexCache.delete(ref);
+    }
+  }
+
+  private logGarbageCollection(result: SnapshotGarbageCollectionResult): void {
+    this.log?.(
+      `[SWM-SNAPSHOT-GC] triggered=${result.triggered} snapshots=${result.deletedSnapshots} `
+      + `snapshotBytes=${result.deletedSnapshotBytes} tempFiles=${result.deletedTempFiles} `
+      + `tempBytes=${result.deletedTempBytes} availableBefore=${result.availableBytesBefore} `
+      + `availableAfter=${result.availableBytesAfter} activeSkipped=${result.skippedActiveFiles} `
+      + `failed=${result.failedDeletions}`,
+    );
   }
 
   private getPageIndex(ref: string, nquadsPath: string): Promise<SnapshotPageIndexCore> {
@@ -291,6 +634,157 @@ function canonicalSnapshotDigest(ref: string): string {
 
 function snapshotPath(directory: string, hash: string, extension: 'json' | 'nq'): string {
   return join(directory, hash.slice(0, 2), hash.slice(2, 4), `${hash}.${extension}`);
+}
+
+function resolveSnapshotGarbageCollectionConfig(
+  config: SharedMemoryPublicSnapshotGarbageCollectionConfig | undefined,
+): ResolvedSnapshotGarbageCollectionConfig {
+  const enabled = config?.enabled ?? false;
+  if (typeof enabled !== 'boolean') {
+    throw new Error('sharedMemoryPublicSnapshotStorage.gc.enabled must be a boolean');
+  }
+  const resolved = {
+    enabled,
+    intervalMs: snapshotGcInteger(
+      config?.intervalMs,
+      DEFAULT_SNAPSHOT_GC_INTERVAL_MS,
+      'intervalMs',
+      1,
+    ),
+    triggerFreeBytes: snapshotGcInteger(
+      config?.triggerFreeBytes,
+      DEFAULT_SNAPSHOT_GC_TRIGGER_FREE_BYTES,
+      'triggerFreeBytes',
+      0,
+    ),
+    targetFreeBytes: snapshotGcInteger(
+      config?.targetFreeBytes,
+      DEFAULT_SNAPSHOT_GC_TARGET_FREE_BYTES,
+      'targetFreeBytes',
+      0,
+    ),
+    hardReserveBytes: snapshotGcInteger(
+      config?.hardReserveBytes,
+      DEFAULT_SNAPSHOT_GC_HARD_RESERVE_BYTES,
+      'hardReserveBytes',
+      0,
+    ),
+    minAgeMs: snapshotGcInteger(
+      config?.minAgeMs,
+      DEFAULT_SNAPSHOT_GC_MIN_AGE_MS,
+      'minAgeMs',
+      0,
+    ),
+    staleTempAgeMs: snapshotGcInteger(
+      config?.staleTempAgeMs,
+      DEFAULT_SNAPSHOT_GC_STALE_TEMP_AGE_MS,
+      'staleTempAgeMs',
+      0,
+    ),
+  };
+  if (resolved.targetFreeBytes < resolved.triggerFreeBytes) {
+    throw new Error(
+      'sharedMemoryPublicSnapshotStorage.gc.targetFreeBytes must be greater than or equal to triggerFreeBytes',
+    );
+  }
+  if (resolved.hardReserveBytes >= resolved.triggerFreeBytes) {
+    throw new Error(
+      'sharedMemoryPublicSnapshotStorage.gc.hardReserveBytes must be less than triggerFreeBytes',
+    );
+  }
+  return resolved;
+}
+
+function snapshotGcInteger(
+  value: number | undefined,
+  defaultValue: number,
+  field: string,
+  minimum: number,
+): number {
+  const resolved = value ?? defaultValue;
+  if (!Number.isSafeInteger(resolved) || resolved < minimum) {
+    throw new Error(
+      `sharedMemoryPublicSnapshotStorage.gc.${field} must be a safe integer greater than or equal to ${minimum}`,
+    );
+  }
+  return resolved;
+}
+
+async function filesystemAvailableBytes(directory: string): Promise<number> {
+  const filesystem = await statfs(directory);
+  return filesystem.bavail * filesystem.bsize;
+}
+
+async function existingFileSize(filePath: string): Promise<number | null> {
+  try {
+    return (await stat(filePath)).size;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+async function listSnapshotStoreFiles(directory: string): Promise<SnapshotStoreFile[]> {
+  let entries: Dirent<string>[];
+  try {
+    entries = await readdir(directory, { recursive: true, withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
+  }
+  const files: SnapshotStoreFile[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const match = entry.name.match(SNAPSHOT_FILE_PATTERN)
+      ?? entry.name.match(SNAPSHOT_TEMP_FILE_PATTERN);
+    if (!match?.[1]) continue;
+    files.push({
+      path: join(entry.parentPath, entry.name),
+      name: entry.name,
+      hash: match[1].toLowerCase(),
+    });
+  }
+  return files;
+}
+
+async function statSnapshotStoreFiles(
+  files: readonly SnapshotStoreFile[],
+  latestMtimeMs: number,
+): Promise<SnapshotStoreFileMetadata[]> {
+  const result: SnapshotStoreFileMetadata[] = [];
+  for (let offset = 0; offset < files.length; offset += SNAPSHOT_FILE_STAT_CONCURRENCY) {
+    const batch = files.slice(offset, offset + SNAPSHOT_FILE_STAT_CONCURRENCY);
+    const metadata = await Promise.all(batch.map(async (file) => {
+      try {
+        const fileStat = await stat(file.path);
+        if (!fileStat.isFile() || fileStat.mtimeMs > latestMtimeMs) return null;
+        return { ...file, size: fileStat.size, mtimeMs: fileStat.mtimeMs };
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+        throw error;
+      }
+    }));
+    result.push(...metadata.filter((value): value is SnapshotStoreFileMetadata => value !== null));
+  }
+  return result;
+}
+
+function emptyGarbageCollectionResult(): SnapshotGarbageCollectionResult {
+  return {
+    triggered: false,
+    availableBytesBefore: 0,
+    availableBytesAfter: 0,
+    deletedSnapshots: 0,
+    deletedSnapshotBytes: 0,
+    deletedTempFiles: 0,
+    deletedTempBytes: 0,
+    skippedActiveFiles: 0,
+    failedDeletions: 0,
+  };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function serializeWorkspacePublicSnapshotWithIndex(quads: readonly Quad[]): {

--- a/packages/publisher/test/workspace-snapshot-store.test.ts
+++ b/packages/publisher/test/workspace-snapshot-store.test.ts
@@ -1,11 +1,22 @@
 import { createHash } from 'node:crypto';
-import { mkdtemp, readdir, rename, rm, stat, utimes } from 'node:fs/promises';
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  rename,
+  rm,
+  stat,
+  statfs,
+  utimes,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import { describe, expect, it, vi } from 'vitest';
 import {
   FileWorkspacePublicSnapshotStore,
+  SnapshotStorageCapacityError,
   type SnapshotPageIndexRecord,
   type SnapshotPageIndexStore,
   workspacePublicQuadsDigest,
@@ -498,5 +509,324 @@ describe('FileWorkspacePublicSnapshotStore paging', () => {
     } finally {
       await rm(directory, { recursive: true, force: true });
     }
+  });
+});
+
+describe('FileWorkspacePublicSnapshotStore GC v1', () => {
+  it('does not rewrite an immutable snapshot that is already present', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-snapshot-gc-'));
+    const pageIndexes = new MemoryPageIndexStore();
+    const store = new FileWorkspacePublicSnapshotStore(directory, pageIndexes);
+    const quads = makeQuads(3, 'deduplicated');
+
+    try {
+      const first = await store.putSnapshot({ digest: DIGEST, quads });
+      const oldTime = new Date(Date.now() - 10_000);
+      await utimes(snapshotPath(directory), oldTime, oldTime);
+
+      const second = await store.putSnapshot({ digest: DIGEST, quads });
+
+      expect(second).toEqual(first);
+      expect((await stat(snapshotPath(directory))).mtimeMs).toBeCloseTo(oldTime.getTime(), -2);
+      expect(pageIndexes.writes).toBe(1);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('deletes oldest eligible snapshots under pressure until the target is reached', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-snapshot-gc-'));
+    const writer = new FileWorkspacePublicSnapshotStore(directory);
+    const oldestDigest = digestFor(101);
+    const olderDigest = digestFor(102);
+    const youngDigest = digestFor(103);
+    const quads = makeQuads(4, 'pressure');
+    const now = Date.now();
+    let store: FileWorkspacePublicSnapshotStore | undefined;
+
+    try {
+      await writer.putSnapshot({ digest: oldestDigest, quads });
+      await writer.putSnapshot({ digest: olderDigest, quads });
+      await writer.putSnapshot({ digest: youngDigest, quads });
+      await utimes(snapshotPath(directory, oldestDigest), new Date(now - 30_000), new Date(now - 30_000));
+      await utimes(snapshotPath(directory, olderDigest), new Date(now - 20_000), new Date(now - 20_000));
+      const oldestSize = (await stat(snapshotPath(directory, oldestDigest))).size;
+
+      store = new FileWorkspacePublicSnapshotStore(directory, undefined, {
+        gc: {
+          enabled: true,
+          intervalMs: 60_000,
+          triggerFreeBytes: 1,
+          targetFreeBytes: oldestSize,
+          hardReserveBytes: 0,
+          minAgeMs: 10_000,
+          staleTempAgeMs: 1_000,
+        },
+        getAvailableBytes: async () => 0,
+        now: () => now,
+      });
+      const result = await store.collectGarbage();
+
+      expect(result).toMatchObject({
+        triggered: true,
+        deletedSnapshots: 1,
+        deletedSnapshotBytes: oldestSize,
+        availableBytesAfter: oldestSize,
+      });
+      await expect(stat(snapshotPath(directory, oldestDigest))).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(stat(snapshotPath(directory, olderDigest))).resolves.toBeTruthy();
+      await expect(stat(snapshotPath(directory, youngDigest))).resolves.toBeTruthy();
+    } finally {
+      store?.stopGarbageCollection();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('removes stale temp files even when free space is above the pressure trigger', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-snapshot-gc-'));
+    const hash = DIGEST.slice('sha256:'.length);
+    const tempDirectory = snapshotDirectory(directory);
+    const tempPath = join(tempDirectory, `${hash}.nq.123.456.tmp`);
+    const now = Date.now();
+    let store: FileWorkspacePublicSnapshotStore | undefined;
+
+    try {
+      await mkdir(tempDirectory, { recursive: true });
+      await writeFile(tempPath, 'abandoned temp file');
+      await utimes(tempPath, new Date(now - 10_000), new Date(now - 10_000));
+      store = new FileWorkspacePublicSnapshotStore(directory, undefined, {
+        gc: {
+          enabled: true,
+          intervalMs: 60_000,
+          triggerFreeBytes: 20,
+          targetFreeBytes: 30,
+          hardReserveBytes: 10,
+          minAgeMs: 10_000,
+          staleTempAgeMs: 5_000,
+        },
+        getAvailableBytes: async () => 100,
+        now: () => now,
+      });
+
+      const result = await store.collectGarbage();
+
+      expect(result).toMatchObject({
+        triggered: false,
+        deletedTempFiles: 1,
+        deletedSnapshots: 0,
+      });
+      await expect(stat(tempPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      store?.stopGarbageCollection();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('runs the pressure collector periodically', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-snapshot-gc-'));
+    const quads = makeQuads(2, 'periodic');
+    const now = Date.now();
+    let resolveCollected!: () => void;
+    const collected = new Promise<void>((resolve) => { resolveCollected = resolve; });
+    let store: FileWorkspacePublicSnapshotStore | undefined;
+
+    try {
+      await new FileWorkspacePublicSnapshotStore(directory)
+        .putSnapshot({ digest: DIGEST, quads });
+      await utimes(snapshotPath(directory), new Date(now - 20_000), new Date(now - 20_000));
+      const snapshotSize = (await stat(snapshotPath(directory))).size;
+      store = new FileWorkspacePublicSnapshotStore(directory, undefined, {
+        gc: {
+          enabled: true,
+          intervalMs: 10,
+          triggerFreeBytes: 1,
+          targetFreeBytes: snapshotSize,
+          hardReserveBytes: 0,
+          minAgeMs: 10_000,
+          staleTempAgeMs: 1_000,
+        },
+        getAvailableBytes: async () => 0,
+        now: () => now,
+        log: (message) => {
+          if (message.includes('snapshots=1')) resolveCollected();
+        },
+      });
+
+      await Promise.race([
+        collected,
+        new Promise<never>((_, reject) => {
+          setTimeout(() => reject(new Error('periodic snapshot GC did not run')), 1_000).unref();
+        }),
+      ]);
+
+      await expect(stat(snapshotPath(directory))).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      store?.stopGarbageCollection();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('protects snapshots participating in an active paged read', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-snapshot-gc-'));
+    const quads = makeQuads(3, 'active');
+    const now = Date.now();
+    let indexReadStarted = false;
+    let releaseIndexRead!: () => void;
+    const indexReadBlocked = new Promise<void>((resolve) => { releaseIndexRead = resolve; });
+    let store: FileWorkspacePublicSnapshotStore | undefined;
+    const blockingPageIndexes: SnapshotPageIndexStore = {
+      get: async () => {
+        indexReadStarted = true;
+        await indexReadBlocked;
+        return null;
+      },
+      upsert: async () => {},
+    };
+
+    try {
+      await new FileWorkspacePublicSnapshotStore(directory)
+        .putSnapshot({ digest: DIGEST, quads });
+      await utimes(snapshotPath(directory), new Date(now - 20_000), new Date(now - 20_000));
+      store = new FileWorkspacePublicSnapshotStore(directory, blockingPageIndexes, {
+        gc: {
+          enabled: true,
+          intervalMs: 60_000,
+          triggerFreeBytes: 1,
+          targetFreeBytes: 1,
+          hardReserveBytes: 0,
+          minAgeMs: 10_000,
+          staleTempAgeMs: 1_000,
+        },
+        getAvailableBytes: async () => 0,
+        now: () => now,
+      });
+      const pageRead = store.getSnapshotPage(DIGEST, 1, 1);
+      await vi.waitFor(() => expect(indexReadStarted).toBe(true));
+
+      const result = await store.collectGarbage();
+      releaseIndexRead();
+
+      expect(result).toMatchObject({ deletedSnapshots: 0, skippedActiveFiles: 1 });
+      await expect(pageRead).resolves.toEqual(quads.slice(1, 2));
+      await expect(stat(snapshotPath(directory))).resolves.toBeTruthy();
+    } finally {
+      releaseIndexRead?.();
+      store?.stopGarbageCollection();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a new snapshot before violating the hard reserve', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-snapshot-gc-'));
+    const now = Date.now();
+    const store = new FileWorkspacePublicSnapshotStore(directory, undefined, {
+      gc: {
+        enabled: true,
+        intervalMs: 60_000,
+        triggerFreeBytes: 20,
+        targetFreeBytes: 30,
+        hardReserveBytes: 10,
+        minAgeMs: 10_000,
+        staleTempAgeMs: 1_000,
+      },
+      getAvailableBytes: async () => 15,
+      now: () => now,
+    });
+
+    try {
+      const write = store.putSnapshot({ digest: DIGEST, quads: makeQuads(3, 'capacity') });
+      await expect(write).rejects.toBeInstanceOf(SnapshotStorageCapacityError);
+      await expect(write).rejects.toMatchObject({
+        code: 'SNAPSHOT_STORAGE_CAPACITY',
+        availableBytes: 15,
+        hardReserveBytes: 10,
+      });
+      await expect(stat(snapshotPath(directory))).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      store.stopGarbageCollection();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('uses real filesystem availability for collection and capacity admission', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-snapshot-gc-statfs-'));
+    const oldDigest = digestFor(201);
+    const rejectedDigest = digestFor(202);
+    const now = Date.now();
+    let gcStore: FileWorkspacePublicSnapshotStore | undefined;
+    let capacityStore: FileWorkspacePublicSnapshotStore | undefined;
+
+    try {
+      await new FileWorkspacePublicSnapshotStore(directory).putSnapshot({
+        digest: oldDigest,
+        quads: makeQuads(4, 'real-statfs-old'),
+      });
+      await utimes(
+        snapshotPath(directory, oldDigest),
+        new Date(now - 20_000),
+        new Date(now - 20_000),
+      );
+      gcStore = new FileWorkspacePublicSnapshotStore(directory, undefined, {
+        gc: {
+          enabled: true,
+          intervalMs: 60_000,
+          triggerFreeBytes: Number.MAX_SAFE_INTEGER - 1,
+          targetFreeBytes: Number.MAX_SAFE_INTEGER,
+          hardReserveBytes: 0,
+          minAgeMs: 10_000,
+          staleTempAgeMs: 1_000,
+        },
+        now: () => now,
+      });
+
+      const result = await gcStore.collectGarbage();
+
+      expect(result.triggered).toBe(true);
+      expect(result.deletedSnapshots).toBe(1);
+      expect(result.availableBytesBefore).toBeGreaterThan(0);
+      await expect(stat(snapshotPath(directory, oldDigest)))
+        .rejects.toMatchObject({ code: 'ENOENT' });
+
+      const filesystem = await statfs(directory);
+      const availableBytes = filesystem.bavail * filesystem.bsize;
+      const hardReserveBytes = availableBytes + 1024 ** 3;
+      capacityStore = new FileWorkspacePublicSnapshotStore(directory, undefined, {
+        gc: {
+          enabled: true,
+          intervalMs: 60_000,
+          triggerFreeBytes: hardReserveBytes + 1,
+          targetFreeBytes: hardReserveBytes + 1,
+          hardReserveBytes,
+          minAgeMs: Number.MAX_SAFE_INTEGER,
+          staleTempAgeMs: 1_000,
+        },
+        now: () => now,
+      });
+
+      await expect(capacityStore.putSnapshot({
+        digest: rejectedDigest,
+        quads: makeQuads(4, 'real-statfs-capacity'),
+      })).rejects.toMatchObject({
+        code: 'SNAPSHOT_STORAGE_CAPACITY',
+        hardReserveBytes,
+      });
+      await expect(stat(snapshotPath(directory, rejectedDigest)))
+        .rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      gcStore?.stopGarbageCollection();
+      capacityStore?.stopGarbageCollection();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects inconsistent watermarks at construction time', () => {
+    expect(() => new FileWorkspacePublicSnapshotStore('/tmp/dkg-invalid-gc', undefined, {
+      gc: {
+        enabled: true,
+        triggerFreeBytes: 20,
+        targetFreeBytes: 10,
+        hardReserveBytes: 5,
+      },
+    })).toThrow('targetFreeBytes must be greater than or equal to triggerFreeBytes');
   });
 });


### PR DESCRIPTION
## Summary

- add opt-in pressure-based GC for SWM public snapshots
- keep GC disabled by default for controlled rollout
- add hard-reserve write admission, stale temp cleanup, active-file protection, and operational logs
- document the later proof-driven GC v2 design

## Validation

- publisher unit suite: 50 files / 583 tests passed
- focused real-statfs snapshot-store test: 32 / 32 passed
- CLI selected integration suites: 45 / 45 passed
- agent SWM snapshot suites: 3 / 3 passed
- publisher, agent, and CLI builds passed
- synthetic 56,000-snapshot sweep: 56,000 deleted, 0 failures, 0 remaining, 8.263s GC time

## Rollout

The feature defaults off. After merge, enable only on selected testnet beacons with node-specific thresholds and restart the node.