### PR TITLE
feat: enable snapshot GC by default

### DIFF
--- a/docs/use-dkg/swm-public-snapshot-gc.md
+++ b/docs/use-dkg/swm-public-snapshot-gc.md
@@ -1,9 +1,10 @@
 # SWM public snapshot garbage collection
 
-The file-backed shared-memory (SWM) public snapshot store supports an opt-in,
-pressure-based garbage collector. GC v1 is an incident guardrail: it bounds disk
-growth using file age and free-space watermarks. It does not inspect RDF
-references or replication proofs.
+The file-backed shared-memory (SWM) public snapshot store enables a
+pressure-based garbage collector by default. GC v1 is an incident guardrail: it
+bounds disk growth using file age and free-space watermarks. It does not inspect
+RDF references or replication proofs. Set `gc.enabled` to `false` for an
+explicit per-node opt-out.
 
 ## Recommended 75 GiB node configuration
 
@@ -25,7 +26,7 @@ references or replication proofs.
 }
 ```
 
-GC is disabled unless `gc.enabled` is `true`. When enabled, the store:
+GC is enabled unless `gc.enabled` is `false`. When enabled, the store:
 
 1. Checks the snapshot filesystem every `intervalMs` and before a write that
    could cross a watermark.
@@ -40,9 +41,11 @@ GC is disabled unless `gc.enabled` is `true`. When enabled, the store:
 
 The hard reserve protects the triple store and other node state from an
 `ENOSPC` cascade. It should be lower than the trigger; the target should be at
-least as high as the trigger. Defaults are 5 GiB, 15 GiB, and 25 GiB
-respectively, but operators must size them for the filesystem hosting the
-configured snapshot directory.
+least as high as the trigger. On filesystems of 75 GiB or more, the automatic
+defaults are a 5 GiB reserve, 15 GiB trigger, and 25 GiB target. On smaller
+filesystems, all three automatic watermarks scale together to 1/15, 1/5, and
+1/3 of total filesystem capacity. Supplying any watermark opts into fixed byte
+values, with omitted watermarks retaining their unscaled defaults.
 
 ## V1 safety boundary
 

--- a/packages/publisher/src/workspace-snapshot-store.ts
+++ b/packages/publisher/src/workspace-snapshot-store.ts
@@ -22,7 +22,7 @@ export interface SharedMemoryPublicSnapshotStorageConfig {
 }
 
 export interface SharedMemoryPublicSnapshotGarbageCollectionConfig {
-  /** Disabled by default so operators opt in to the v1 age-based policy. */
+  /** Enabled by default. Set false to opt out of the v1 age-based policy. */
   enabled?: boolean;
   /** How often the background pressure check runs. Default: 5 minutes. */
   intervalMs?: number;
@@ -53,8 +53,13 @@ export interface SnapshotGarbageCollectionResult {
 export interface FileWorkspacePublicSnapshotStoreOptions {
   readonly gc?: SharedMemoryPublicSnapshotGarbageCollectionConfig;
   readonly log?: (message: string) => void;
-  /** Test seam; production callers use statfs(2). */
+  /** Test seam; production callers use statfs(2). Prefer getFilesystemSpace. */
   readonly getAvailableBytes?: (directory: string) => Promise<number>;
+  /** Test seam for capacity-aware default watermarks; production callers use statfs(2). */
+  readonly getFilesystemSpace?: (directory: string) => Promise<{
+    readonly availableBytes: number;
+    readonly totalBytes: number;
+  }>;
   /** Test seam; production callers use Date.now(). */
   readonly now?: () => number;
 }
@@ -104,12 +109,14 @@ const DEFAULT_SNAPSHOT_GC_TARGET_FREE_BYTES = 25 * GIB;
 const DEFAULT_SNAPSHOT_GC_HARD_RESERVE_BYTES = 5 * GIB;
 const DEFAULT_SNAPSHOT_GC_MIN_AGE_MS = 7 * 24 * 60 * 60 * 1_000;
 const DEFAULT_SNAPSHOT_GC_STALE_TEMP_AGE_MS = 60 * 60 * 1_000;
+const DEFAULT_SNAPSHOT_GC_REFERENCE_FILESYSTEM_BYTES = 75 * GIB;
 const SNAPSHOT_FILE_PATTERN = /^([a-f0-9]{64})\.(?:nq|json)$/i;
 const SNAPSHOT_TEMP_FILE_PATTERN = /^([a-f0-9]{64})\.(?:nq|json)\.\d+\.\d+\.tmp$/i;
 const SNAPSHOT_FILE_STAT_CONCURRENCY = 64;
 
 interface ResolvedSnapshotGarbageCollectionConfig {
   enabled: boolean;
+  scaleDefaultWatermarksToFilesystem: boolean;
   intervalMs: number;
   triggerFreeBytes: number;
   targetFreeBytes: number;
@@ -169,7 +176,10 @@ export class FileWorkspacePublicSnapshotStore implements WorkspacePublicSnapshot
   private readonly activeSnapshots = new Map<string, number>();
   private readonly gcConfig: ResolvedSnapshotGarbageCollectionConfig;
   private readonly log?: (message: string) => void;
-  private readonly getAvailableBytes: (directory: string) => Promise<number>;
+  private readonly getFilesystemSpace: (directory: string) => Promise<{
+    readonly availableBytes: number;
+    readonly totalBytes: number;
+  }>;
   private readonly now: () => number;
   private readonly gcTimer?: NodeJS.Timeout;
   private garbageCollectionRun?: Promise<SnapshotGarbageCollectionResult>;
@@ -182,7 +192,14 @@ export class FileWorkspacePublicSnapshotStore implements WorkspacePublicSnapshot
   ) {
     this.gcConfig = resolveSnapshotGarbageCollectionConfig(options.gc);
     this.log = options.log;
-    this.getAvailableBytes = options.getAvailableBytes ?? filesystemAvailableBytes;
+    const getAvailableBytes = options.getAvailableBytes;
+    this.getFilesystemSpace = options.getFilesystemSpace
+      ?? (getAvailableBytes
+        ? async (path) => ({
+          availableBytes: await getAvailableBytes(path),
+          totalBytes: DEFAULT_SNAPSHOT_GC_REFERENCE_FILESYSTEM_BYTES,
+        })
+        : filesystemSpace);
     this.now = options.now ?? Date.now;
     if (this.gcConfig.enabled) {
       this.gcTimer = setInterval(() => {
@@ -381,7 +398,12 @@ export class FileWorkspacePublicSnapshotStore implements WorkspacePublicSnapshot
     requiredWriteBytes: number,
   ): Promise<SnapshotGarbageCollectionResult> {
     await mkdir(this.directory, { recursive: true });
-    const availableBytesBefore = await this.getAvailableBytes(this.directory);
+    const filesystem = await this.getFilesystemSpace(this.directory);
+    const availableBytesBefore = filesystem.availableBytes;
+    const watermarks = snapshotGarbageCollectionWatermarks(
+      this.gcConfig,
+      filesystem.totalBytes,
+    );
     let availableBytesAfter = availableBytesBefore;
     let deletedSnapshots = 0;
     let deletedSnapshotBytes = 0;
@@ -412,12 +434,12 @@ export class FileWorkspacePublicSnapshotStore implements WorkspacePublicSnapshot
       }
     }
 
-    const triggered = availableBytesBefore < this.gcConfig.triggerFreeBytes
-      || availableBytesBefore - requiredWriteBytes < this.gcConfig.hardReserveBytes;
+    const triggered = availableBytesBefore < watermarks.triggerFreeBytes
+      || availableBytesBefore - requiredWriteBytes < watermarks.hardReserveBytes;
     if (triggered) {
       const targetAvailableBytes = Math.max(
-        this.gcConfig.targetFreeBytes,
-        this.gcConfig.hardReserveBytes + requiredWriteBytes,
+        watermarks.targetFreeBytes,
+        watermarks.hardReserveBytes + requiredWriteBytes,
       );
       const snapshotFiles = files.filter((file) => SNAPSHOT_FILE_PATTERN.test(file.name));
       const candidates = await statSnapshotStoreFiles(
@@ -461,9 +483,14 @@ export class FileWorkspacePublicSnapshotStore implements WorkspacePublicSnapshot
 
   private async ensureWriteCapacity(requiredWriteBytes: number): Promise<void> {
     if (!this.gcConfig.enabled) return;
-    const availableBytes = await this.getAvailableBytes(this.directory);
-    const needsCollection = availableBytes < this.gcConfig.triggerFreeBytes
-      || availableBytes - requiredWriteBytes < this.gcConfig.hardReserveBytes;
+    const filesystem = await this.getFilesystemSpace(this.directory);
+    const availableBytes = filesystem.availableBytes;
+    const watermarks = snapshotGarbageCollectionWatermarks(
+      this.gcConfig,
+      filesystem.totalBytes,
+    );
+    const needsCollection = availableBytes < watermarks.triggerFreeBytes
+      || availableBytes - requiredWriteBytes < watermarks.hardReserveBytes;
     const result = needsCollection
       ? await this.collectGarbage({ requiredWriteBytes })
       : undefined;
@@ -471,13 +498,13 @@ export class FileWorkspacePublicSnapshotStore implements WorkspacePublicSnapshot
     // sizes: an unlinked file held open by another process may not have
     // released its blocks yet.
     const availableAfterCollection = result
-      ? await this.getAvailableBytes(this.directory)
+      ? (await this.getFilesystemSpace(this.directory)).availableBytes
       : availableBytes;
-    if (availableAfterCollection - requiredWriteBytes < this.gcConfig.hardReserveBytes) {
+    if (availableAfterCollection - requiredWriteBytes < watermarks.hardReserveBytes) {
       throw new SnapshotStorageCapacityError(
         availableAfterCollection,
         requiredWriteBytes,
-        this.gcConfig.hardReserveBytes,
+        watermarks.hardReserveBytes,
       );
     }
     if (
@@ -639,12 +666,15 @@ function snapshotPath(directory: string, hash: string, extension: 'json' | 'nq')
 function resolveSnapshotGarbageCollectionConfig(
   config: SharedMemoryPublicSnapshotGarbageCollectionConfig | undefined,
 ): ResolvedSnapshotGarbageCollectionConfig {
-  const enabled = config?.enabled ?? false;
+  const enabled = config?.enabled ?? true;
   if (typeof enabled !== 'boolean') {
     throw new Error('sharedMemoryPublicSnapshotStorage.gc.enabled must be a boolean');
   }
   const resolved = {
     enabled,
+    scaleDefaultWatermarksToFilesystem: config?.triggerFreeBytes === undefined
+      && config?.targetFreeBytes === undefined
+      && config?.hardReserveBytes === undefined,
     intervalMs: snapshotGcInteger(
       config?.intervalMs,
       DEFAULT_SNAPSHOT_GC_INTERVAL_MS,
@@ -695,6 +725,31 @@ function resolveSnapshotGarbageCollectionConfig(
   return resolved;
 }
 
+function snapshotGarbageCollectionWatermarks(
+  config: ResolvedSnapshotGarbageCollectionConfig,
+  totalBytes: number,
+): Pick<
+  ResolvedSnapshotGarbageCollectionConfig,
+  'triggerFreeBytes' | 'targetFreeBytes' | 'hardReserveBytes'
+> {
+  if (!config.scaleDefaultWatermarksToFilesystem) return config;
+  const safeTotalBytes = Math.max(1, Math.floor(totalBytes));
+  const triggerFreeBytes = Math.max(
+    1,
+    Math.min(config.triggerFreeBytes, Math.floor(safeTotalBytes / 5)),
+  );
+  const targetFreeBytes = Math.max(
+    triggerFreeBytes,
+    Math.min(config.targetFreeBytes, Math.floor(safeTotalBytes / 3)),
+  );
+  const hardReserveBytes = Math.min(
+    triggerFreeBytes - 1,
+    config.hardReserveBytes,
+    Math.floor(safeTotalBytes / 15),
+  );
+  return { triggerFreeBytes, targetFreeBytes, hardReserveBytes };
+}
+
 function snapshotGcInteger(
   value: number | undefined,
   defaultValue: number,
@@ -710,9 +765,15 @@ function snapshotGcInteger(
   return resolved;
 }
 
-async function filesystemAvailableBytes(directory: string): Promise<number> {
+async function filesystemSpace(directory: string): Promise<{
+  readonly availableBytes: number;
+  readonly totalBytes: number;
+}> {
   const filesystem = await statfs(directory);
-  return filesystem.bavail * filesystem.bsize;
+  return {
+    availableBytes: filesystem.bavail * filesystem.bsize,
+    totalBytes: filesystem.blocks * filesystem.bsize,
+  };
 }
 
 async function existingFileSize(filePath: string): Promise<number | null> {

--- a/packages/publisher/test/workspace-snapshot-store.test.ts
+++ b/packages/publisher/test/workspace-snapshot-store.test.ts
@@ -7,6 +7,7 @@ import {
   rm,
   stat,
   statfs,
+  truncate,
   utimes,
   writeFile,
 } from 'node:fs/promises';
@@ -530,6 +531,75 @@ describe('FileWorkspacePublicSnapshotStore GC v1', () => {
       expect((await stat(snapshotPath(directory))).mtimeMs).toBeCloseTo(oldTime.getTime(), -2);
       expect(pageIndexes.writes).toBe(1);
     } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('enables GC by default and scales automatic watermarks on smaller filesystems', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-snapshot-gc-default-'));
+    const oldestDigest = digestFor(91);
+    const olderDigest = digestFor(92);
+    const now = Date.now();
+    const gib = 1024 ** 3;
+    let store: FileWorkspacePublicSnapshotStore | undefined;
+
+    try {
+      const writer = new FileWorkspacePublicSnapshotStore(directory, undefined, {
+        gc: { enabled: false },
+      });
+      await writer.putSnapshot({ digest: oldestDigest, quads: makeQuads(1, 'default-oldest') });
+      await writer.putSnapshot({ digest: olderDigest, quads: makeQuads(1, 'default-older') });
+      await truncate(snapshotPath(directory, oldestDigest), 3 * gib);
+      await truncate(snapshotPath(directory, olderDigest), gib);
+      await utimes(
+        snapshotPath(directory, oldestDigest),
+        new Date(now - 9 * 24 * 60 * 60 * 1_000),
+        new Date(now - 9 * 24 * 60 * 60 * 1_000),
+      );
+      await utimes(
+        snapshotPath(directory, olderDigest),
+        new Date(now - 8 * 24 * 60 * 60 * 1_000),
+        new Date(now - 8 * 24 * 60 * 60 * 1_000),
+      );
+
+      store = new FileWorkspacePublicSnapshotStore(directory, undefined, {
+        getFilesystemSpace: async () => ({
+          availableBytes: Math.floor(3.9 * gib),
+          totalBytes: 20 * gib,
+        }),
+        now: () => now,
+      });
+      const result = await store.collectGarbage();
+
+      expect(result).toMatchObject({
+        triggered: true,
+        deletedSnapshots: 1,
+        deletedSnapshotBytes: 3 * gib,
+      });
+      await expect(stat(snapshotPath(directory, oldestDigest)))
+        .rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(stat(snapshotPath(directory, olderDigest))).resolves.toBeTruthy();
+    } finally {
+      store?.stopGarbageCollection();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('retains an explicit GC opt-out', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-snapshot-gc-disabled-'));
+    const store = new FileWorkspacePublicSnapshotStore(directory, undefined, {
+      gc: { enabled: false },
+      getFilesystemSpace: async () => ({ availableBytes: 0, totalBytes: 20 * 1024 ** 3 }),
+    });
+
+    try {
+      await store.putSnapshot({ digest: DIGEST, quads: makeQuads(1, 'disabled') });
+      const result = await store.collectGarbage();
+
+      expect(result).toMatchObject({ triggered: false, deletedSnapshots: 0 });
+      await expect(stat(snapshotPath(directory))).resolves.toBeTruthy();
+    } finally {
+      store.stopGarbageCollection();
       await rm(directory, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary

- enable pressure-based SWM public snapshot GC by default for every Core node using the file-backed store
- retain `gc.enabled: false` as an explicit per-node kill switch
- scale omitted 15/25/5 GiB watermarks proportionally on filesystems below 75 GiB, avoiding impossible targets on smaller nodes
- document the default-on and capacity-aware behavior

## Live beacon validation

Validated on `dkg-v10-beacon-03` using integration commit `88df5cd1a6a6e2565bd957751bb163507f8e8eac` while retaining its active graph-index recovery stack.

The test config intentionally omitted `gc.enabled`. With free space just below a temporary trigger, the live node emitted:

```
[SWM-SNAPSHOT-GC] triggered=true snapshots=560 snapshotBytes=334365248 tempFiles=0 tempBytes=0 availableBefore=27004657664 availableAfter=27339022912 activeSkipped=0 failed=0
```

After the proof, the entire `gc` block was removed and the node restarted. It remains healthy on the default configuration: Core role, 16 connected peers, admission 0/64, zero admission rejections, and no post-restart errors.

## Validation

- focused snapshot-store tests: 34/34
- full publisher suite: 127 files, 1,848 passed, 6 skipped
- agent SWM snapshot sync: 2/2
- selected CLI wiring: 27/27
- publisher, agent, and CLI builds
