### PR TITLE
fix(store): bound managed Oxigraph queries and expose retryable timeouts

### DIFF
--- a/docs/use-dkg/storage-sparql-http.md
+++ b/docs/use-dkg/storage-sparql-http.md
@@ -73,7 +73,7 @@ Managed Oxigraph accepts optional launch settings under `store.options`:
       "cacheDir": "/var/lib/dkg/oxigraph-bin",
       "readyTimeoutMs": 180000,
       "clientTimeoutMs": 180000,
-      "queryTimeoutS": 35,
+      "queryTimeoutS": 175,
       "memoryHighMiB": 2048,
       "memoryMaxMiB": 3072
     }
@@ -83,9 +83,11 @@ Managed Oxigraph accepts optional launch settings under `store.options`:
 
 `readyTimeoutMs` is the maximum startup readiness wait in milliseconds. It must be a positive integer; invalid values are ignored and the default 30-second timeout is used. Increase it when a large or recovering RocksDB database needs longer to open.
 
-`clientTimeoutMs` is the SPARQL HTTP client deadline in milliseconds. It can be raised independently when a valid store mutation needs longer than the default 30 seconds, without enabling a native Oxigraph query timeout. When set, it takes precedence over the client deadline derived from `queryTimeoutS`.
+`clientTimeoutMs` is the SPARQL HTTP client deadline in milliseconds. Managed Oxigraph defaults to 30 seconds. When you configure a longer client deadline, the daemon automatically derives a native query deadline five seconds earlier (for example, `180000` derives `175` seconds) so disconnecting the HTTP client cannot leave an unbounded query running inside Oxigraph.
 
-`queryTimeoutS` is the native Oxigraph query timeout in seconds and is passed to `oxigraph serve --timeout-s`. When `clientTimeoutMs` is omitted, the rewritten HTTP store timeout includes an additional five-second grace period so Oxigraph can return its timeout response before the client aborts the request.
+`queryTimeoutS` is the native Oxigraph query timeout in seconds and is passed to `oxigraph serve --timeout-s`. The default is 25 seconds. An explicit value overrides the derived native deadline; when necessary, the daemon extends `clientTimeoutMs` so the native timeout still fires at least five seconds before the HTTP deadline. The native deadline applies to query evaluation, while the client deadline also bounds updates and response decoding. Upgraded nodes must restart once so the managed Oxigraph child is relaunched with `--timeout-s`.
+
+Blazegraph uses the same bounded/retryable DKG contract with backend-specific cancellation semantics. Its 30-second client deadline sends a wider 120-second `X-BIGDATA-MAX-QUERY-MILLIS` server bound: the wider server limit caps abandoned work without allowing Blazegraph's mid-stream timeout behavior to be mistaken for a complete CONSTRUCT result. Store admission pressure returns `503 STORE_SCHEDULER_BUSY` with `outcome: "not_started"`; an adapter deadline returns `503 STORE_OPERATION_TIMEOUT`, `retryable: true`, and `outcome: "indeterminate"`. For an indeterminate write, retry the same Knowledge Asset name/idempotency key rather than creating a new asset.
 
 On Linux hosts using systemd, `memoryMaxMiB` runs managed Oxigraph in a dedicated transient user scope with a finite hard limit and disables swap for that scope, so database pressure cannot spill into host swap and stall the node. Optional `memoryHighMiB` sets its soft reclaim threshold and must not exceed `memoryMaxMiB`. This keeps Oxigraph outside the DKG daemon service's cgroup, so a finite `MemoryMax` on the daemon cannot kill the store or throttle the Node.js control plane as one combined process group. Enable lingering once for the node service account (`sudo loginctl enable-linger <dkg-user>`) so its user manager and bus exist before the system service starts at boot; verify with `systemctl --user is-system-running` as that account. The daemon supplies the required user-bus environment automatically. Startup fails rather than silently dropping configured limits when the scope cannot be created.
 

--- a/docs/use-dkg/storage-sparql-http.md
+++ b/docs/use-dkg/storage-sparql-http.md
@@ -83,7 +83,7 @@ Managed Oxigraph accepts optional launch settings under `store.options`:
 
 `readyTimeoutMs` is the maximum startup readiness wait in milliseconds. It must be a positive integer; invalid values are ignored and the default 30-second timeout is used. Increase it when a large or recovering RocksDB database needs longer to open.
 
-`clientTimeoutMs` is the SPARQL HTTP client deadline in milliseconds. Managed Oxigraph defaults to 30 seconds. When you configure a longer client deadline, the daemon automatically derives a native query deadline five seconds earlier (for example, `180000` derives `175` seconds) so disconnecting the HTTP client cannot leave an unbounded query running inside Oxigraph.
+`clientTimeoutMs` is the SPARQL HTTP client deadline in milliseconds. Managed Oxigraph defaults to 30 seconds. When you configure a longer client deadline, the daemon automatically derives a native query deadline five seconds earlier (for example, `180000` derives `175` seconds). If an Oxigraph evaluator path does not honor native cancellation before the client deadline, the daemon terminates and supervises a fresh managed Oxigraph process so the store cannot remain stalled indefinitely.
 
 `queryTimeoutS` is the native Oxigraph query timeout in seconds and is passed to `oxigraph serve --timeout-s`. The default is 25 seconds. An explicit value overrides the derived native deadline; when necessary, the daemon extends `clientTimeoutMs` so the native timeout still fires at least five seconds before the HTTP deadline. The native deadline applies to query evaluation, while the client deadline also bounds updates and response decoding. Upgraded nodes must restart once so the managed Oxigraph child is relaunched with `--timeout-s`.
 

--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -19,6 +19,10 @@ import {
 } from '@origintrail-official/dkg-core';
 import { enrichEvmError, isChainRpcTransportError } from '@origintrail-official/dkg-chain';
 import type { DKGAgent, ContextGraphWritePreflightProbe } from '@origintrail-official/dkg-agent';
+import {
+  StoreSchedulerBusyError,
+  isStoreOperationTimeoutError,
+} from '@origintrail-official/dkg-storage';
 import type { DkgConfig } from '../config.js';
 import { enforceSignedRequestPostBody } from '../auth.js';
 
@@ -50,6 +54,58 @@ export function payloadTooLargeResponseBody(err: unknown): Record<string, unknow
   const hint = shaped.hint;
   if (typeof hint === 'string' && hint.length > 0) body.hint = hint;
   return body;
+}
+
+/**
+ * Map transient triple-store pressure to one retryable HTTP contract across
+ * query and lifecycle routes. Scheduler shedding is known not to have started;
+ * a dispatched write timeout is indeterminate and clients must retry the same
+ * idempotency key / Knowledge Asset name rather than minting a new asset.
+ */
+export function respondIfStoreUnavailable(res: ServerResponse, err: unknown): boolean {
+  if (err instanceof StoreSchedulerBusyError) {
+    jsonResponse(
+      res,
+      503,
+      {
+        error: err.message,
+        code: err.code,
+        reason: err.reason,
+        priority: err.priority,
+        retryable: true,
+        outcome: 'not_started',
+      },
+      undefined,
+      { 'Retry-After': '1' },
+    );
+    return true;
+  }
+
+  if (!isStoreOperationTimeoutError(err)) return false;
+  const shaped = err as {
+    message?: unknown;
+    backend?: unknown;
+    operation?: unknown;
+    timeoutMs?: unknown;
+  };
+  jsonResponse(
+    res,
+    503,
+    {
+      error: typeof shaped.message === 'string'
+        ? shaped.message
+        : 'Triple-store operation exceeded its deadline',
+      code: 'STORE_OPERATION_TIMEOUT',
+      retryable: true,
+      outcome: 'indeterminate',
+      ...(typeof shaped.backend === 'string' ? { backend: shaped.backend } : {}),
+      ...(typeof shaped.operation === 'string' ? { operation: shaped.operation } : {}),
+      ...(typeof shaped.timeoutMs === 'number' ? { timeoutMs: shaped.timeoutMs } : {}),
+    },
+    undefined,
+    { 'Retry-After': '1' },
+  );
+  return true;
 }
 
 /**
@@ -97,6 +153,9 @@ export function respondWithDaemonError(res: ServerResponse, err: any): void {
     // Funded-wallet selection found no operational wallet with gas + TRAC — a
     // user-actionable funding condition (4xx), not a server bug.
     jsonResponse(res, 400, noFundedPublisherWalletBody(typeof err?.message === 'string' ? err.message : String(err)));
+  } else if (respondIfStoreUnavailable(res, err)) {
+    // Store admission pressure and adapter deadlines are transient. The typed
+    // response preserves whether work never started or may have completed.
   } else if (respondIfChainRpcTransportError(res, err)) {
     // Transient transport exhaustion (RPC_ENDPOINTS_EXHAUSTED /
     // RPC_RECEIPT_LOOKUP_FAILED → 503, TIMEOUT → 504) is retryable — a route

--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -63,7 +63,12 @@ export function payloadTooLargeResponseBody(err: unknown): Record<string, unknow
  * a dispatched write timeout is indeterminate and clients must retry the same
  * idempotency key / Knowledge Asset name rather than minting a new asset.
  */
-export function respondIfStoreUnavailable(res: ServerResponse, err: unknown): boolean {
+export type StoreUnavailableOutcome = 'not_started' | 'indeterminate';
+
+export function respondIfStoreUnavailable(
+  res: ServerResponse,
+  err: unknown,
+): StoreUnavailableOutcome | null {
   if (err instanceof StoreSchedulerBusyError) {
     jsonResponse(
       res,
@@ -79,10 +84,11 @@ export function respondIfStoreUnavailable(res: ServerResponse, err: unknown): bo
       undefined,
       { 'Retry-After': '1' },
     );
-    return true;
+    return 'not_started';
   }
 
-  if (!isStoreOperationTimeoutError(err)) return false;
+  if (!isStoreOperationTimeoutError(err)) return null;
+  const outcome = err.outcome ?? 'indeterminate';
   jsonResponse(
     res,
     503,
@@ -92,7 +98,7 @@ export function respondIfStoreUnavailable(res: ServerResponse, err: unknown): bo
         : 'Triple-store operation exceeded its deadline',
       code: STORE_OPERATION_TIMEOUT_CODE,
       retryable: true,
-      outcome: err.outcome ?? 'indeterminate',
+      outcome,
       ...(typeof err.backend === 'string' ? { backend: err.backend } : {}),
       ...(typeof err.operation === 'string' ? { operation: err.operation } : {}),
       ...(typeof err.timeoutMs === 'number' ? { timeoutMs: err.timeoutMs } : {}),
@@ -100,7 +106,7 @@ export function respondIfStoreUnavailable(res: ServerResponse, err: unknown): bo
     undefined,
     { 'Retry-After': '1' },
   );
-  return true;
+  return outcome;
 }
 
 /**

--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -20,6 +20,7 @@ import {
 import { enrichEvmError, isChainRpcTransportError } from '@origintrail-official/dkg-chain';
 import type { DKGAgent, ContextGraphWritePreflightProbe } from '@origintrail-official/dkg-agent';
 import {
+  STORE_OPERATION_TIMEOUT_CODE,
   StoreSchedulerBusyError,
   isStoreOperationTimeoutError,
 } from '@origintrail-official/dkg-storage';
@@ -82,25 +83,19 @@ export function respondIfStoreUnavailable(res: ServerResponse, err: unknown): bo
   }
 
   if (!isStoreOperationTimeoutError(err)) return false;
-  const shaped = err as {
-    message?: unknown;
-    backend?: unknown;
-    operation?: unknown;
-    timeoutMs?: unknown;
-  };
   jsonResponse(
     res,
     503,
     {
-      error: typeof shaped.message === 'string'
-        ? shaped.message
+      error: typeof err.message === 'string'
+        ? err.message
         : 'Triple-store operation exceeded its deadline',
-      code: 'STORE_OPERATION_TIMEOUT',
+      code: STORE_OPERATION_TIMEOUT_CODE,
       retryable: true,
-      outcome: 'indeterminate',
-      ...(typeof shaped.backend === 'string' ? { backend: shaped.backend } : {}),
-      ...(typeof shaped.operation === 'string' ? { operation: shaped.operation } : {}),
-      ...(typeof shaped.timeoutMs === 'number' ? { timeoutMs: shaped.timeoutMs } : {}),
+      outcome: err.outcome ?? 'indeterminate',
+      ...(typeof err.backend === 'string' ? { backend: err.backend } : {}),
+      ...(typeof err.operation === 'string' ? { operation: err.operation } : {}),
+      ...(typeof err.timeoutMs === 'number' ? { timeoutMs: err.timeoutMs } : {}),
     },
     undefined,
     { 'Retry-After': '1' },

--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -65,15 +65,23 @@ export function payloadTooLargeResponseBody(err: unknown): Record<string, unknow
  */
 export type StoreUnavailableOutcome = 'not_started' | 'indeterminate';
 
-export function respondIfStoreUnavailable(
-  res: ServerResponse,
+export interface StoreUnavailableClassification {
+  outcome: StoreUnavailableOutcome;
+  body: Record<string, unknown>;
+}
+
+/**
+ * Pure store-failure classification. Routes with partial-success context can
+ * extend `body` before rendering it instead of losing that context through the
+ * ordinary all-or-nothing responder below.
+ */
+export function classifyStoreUnavailable(
   err: unknown,
-): StoreUnavailableOutcome | null {
+): StoreUnavailableClassification | null {
   if (err instanceof StoreSchedulerBusyError) {
-    jsonResponse(
-      res,
-      503,
-      {
+    return {
+      outcome: 'not_started',
+      body: {
         error: err.message,
         code: err.code,
         reason: err.reason,
@@ -81,18 +89,14 @@ export function respondIfStoreUnavailable(
         retryable: true,
         outcome: 'not_started',
       },
-      undefined,
-      { 'Retry-After': '1' },
-    );
-    return 'not_started';
+    };
   }
 
   if (!isStoreOperationTimeoutError(err)) return null;
   const outcome = err.outcome ?? 'indeterminate';
-  jsonResponse(
-    res,
-    503,
-    {
+  return {
+    outcome,
+    body: {
       error: typeof err.message === 'string'
         ? err.message
         : 'Triple-store operation exceeded its deadline',
@@ -103,10 +107,23 @@ export function respondIfStoreUnavailable(
       ...(typeof err.operation === 'string' ? { operation: err.operation } : {}),
       ...(typeof err.timeoutMs === 'number' ? { timeoutMs: err.timeoutMs } : {}),
     },
+  };
+}
+
+export function respondIfStoreUnavailable(
+  res: ServerResponse,
+  err: unknown,
+): StoreUnavailableOutcome | null {
+  const classified = classifyStoreUnavailable(err);
+  if (!classified) return null;
+  jsonResponse(
+    res,
+    503,
+    classified.body,
     undefined,
     { 'Retry-After': '1' },
   );
-  return outcome;
+  return classified.outcome;
 }
 
 /**

--- a/packages/cli/src/daemon/oxigraph-managed.ts
+++ b/packages/cli/src/daemon/oxigraph-managed.ts
@@ -341,6 +341,7 @@ export async function startManagedOxigraph(
       ...plan.storeConfigTemplate.options,
       queryEndpoint: handle.queryEndpoint,
       updateEndpoint: handle.updateEndpoint,
+      getRecoveryState: () => handle.getRecoveryState(),
       onClientTimeout: (operation: string) => {
         if (operation !== 'query' && operation !== 'construct') return;
         handle.requestRestart(`${operation} exceeded the managed SPARQL client deadline`);

--- a/packages/cli/src/daemon/oxigraph-managed.ts
+++ b/packages/cli/src/daemon/oxigraph-managed.ts
@@ -40,6 +40,9 @@ export const MANAGED_OXIGRAPH_BACKEND = 'oxigraph-server';
 /** Default loopback bind port. Override via `store.options.port`. */
 export const DEFAULT_OXIGRAPH_PORT = 7878;
 
+/** Mirrors SparqlHttpStore's default while making the managed launch invariant explicit. */
+export const DEFAULT_MANAGED_OXIGRAPH_CLIENT_TIMEOUT_MS = 30_000;
+
 const MANAGED_OXIGRAPH_CLIENT_TIMEOUT_GRACE_MS = 5_000;
 // Node timers (and AbortSignal.timeout) coerce any delay above 2^31-1 ms to 1ms
 // with a TimeoutOverflowWarning — aborting the request almost immediately, the
@@ -75,10 +78,29 @@ function resolveManagedQueryClientTimeoutMs(
   clientTimeoutMs: number | undefined,
   queryTimeoutS: number | undefined,
 ): number | undefined {
-  if (clientTimeoutMs !== undefined) return clampNodeTimerMs(clientTimeoutMs);
+  if (clientTimeoutMs !== undefined) {
+    const configured = clampNodeTimerMs(clientTimeoutMs);
+    return queryTimeoutS === undefined
+      ? configured
+      : Math.max(
+          configured,
+          clampNodeTimerMs(queryTimeoutS * 1_000 + MANAGED_OXIGRAPH_CLIENT_TIMEOUT_GRACE_MS),
+        );
+  }
   return queryTimeoutS === undefined
     ? undefined
     : clampNodeTimerMs(queryTimeoutS * 1_000 + MANAGED_OXIGRAPH_CLIENT_TIMEOUT_GRACE_MS);
+}
+
+function deriveManagedQueryTimeoutS(clientTimeoutMs: number | undefined): number | undefined {
+  if (clientTimeoutMs === undefined) return undefined;
+  const clampedClientTimeoutMs = clampNodeTimerMs(clientTimeoutMs);
+  return Math.max(
+    1,
+    Math.floor(
+      (clampedClientTimeoutMs - MANAGED_OXIGRAPH_CLIENT_TIMEOUT_GRACE_MS) / 1_000,
+    ),
+  );
 }
 
 interface StoreConfigLike {
@@ -148,7 +170,7 @@ export interface ManagedOxigraphPlan {
   readyTimeoutMs?: number;
   /** Native Oxigraph query timeout, passed as `oxigraph serve --timeout-s`. */
   queryTimeoutS?: number;
-  /** SPARQL HTTP client deadline, independent from Oxigraph's native timeout. */
+  /** SPARQL HTTP client deadline; kept after Oxigraph's native timeout when both exist. */
   clientTimeoutMs?: number;
   /** Finite limits applied to an isolated systemd user scope. */
   memoryLimits?: OxigraphMemoryLimits;
@@ -176,9 +198,16 @@ export function planManagedOxigraph(
   const options = config.store.options ?? {};
   const port = resolveManagedOxigraphPort(options);
   const readyTimeoutMs = resolvePositiveIntegerOption(options, 'readyTimeoutMs');
-  const queryTimeoutS = resolvePositiveIntegerOption(options, 'queryTimeoutS');
+  const configuredClientTimeoutMs = resolvePositiveIntegerOption(options, 'clientTimeoutMs')
+    ?? DEFAULT_MANAGED_OXIGRAPH_CLIENT_TIMEOUT_MS;
+  // A client-only deadline closes the HTTP socket but cannot cancel an
+  // evaluation already running inside the Oxigraph server. Derive a native
+  // deadline with five seconds of client grace so timed-out queries are
+  // interrupted server-side instead of accumulating as zombies.
+  const queryTimeoutS = resolvePositiveIntegerOption(options, 'queryTimeoutS')
+    ?? deriveManagedQueryTimeoutS(configuredClientTimeoutMs);
   const clientTimeoutMs = resolveManagedQueryClientTimeoutMs(
-    resolvePositiveIntegerOption(options, 'clientTimeoutMs'),
+    configuredClientTimeoutMs,
     queryTimeoutS,
   );
   const memoryLimits = normalizeOxigraphMemoryLimits({

--- a/packages/cli/src/daemon/oxigraph-managed.ts
+++ b/packages/cli/src/daemon/oxigraph-managed.ts
@@ -23,6 +23,7 @@
  * matching the Blazegraph-Docker provisioner's contract.
  */
 import { join } from 'node:path';
+import { DEFAULT_SPARQL_HTTP_TIMEOUT_MS } from '@origintrail-official/dkg-storage';
 import { ensureOxigraphBinary } from './oxigraph-binary.js';
 import {
   startOxigraphServer,
@@ -40,15 +41,15 @@ export const MANAGED_OXIGRAPH_BACKEND = 'oxigraph-server';
 /** Default loopback bind port. Override via `store.options.port`. */
 export const DEFAULT_OXIGRAPH_PORT = 7878;
 
-/** Mirrors SparqlHttpStore's default while making the managed launch invariant explicit. */
-export const DEFAULT_MANAGED_OXIGRAPH_CLIENT_TIMEOUT_MS = 30_000;
-
 const MANAGED_OXIGRAPH_CLIENT_TIMEOUT_GRACE_MS = 5_000;
 // Node timers (and AbortSignal.timeout) coerce any delay above 2^31-1 ms to 1ms
 // with a TimeoutOverflowWarning — aborting the request almost immediately, the
 // opposite of a long timeout. Cap the derived client timeout so an absurd
 // operator-configured queryTimeoutS degrades to "very long", never "instant".
 const MAX_NODE_TIMER_MS = 2_147_483_647;
+const MAX_MANAGED_OXIGRAPH_QUERY_TIMEOUT_S = Math.floor(
+  (MAX_NODE_TIMER_MS - MANAGED_OXIGRAPH_CLIENT_TIMEOUT_GRACE_MS) / 1_000,
+);
 
 /** Same port validation as {@link planManagedOxigraph} — shared with status. */
 export function resolveManagedOxigraphPort(
@@ -74,33 +75,40 @@ function clampNodeTimerMs(value: number): number {
   return Math.min(value, MAX_NODE_TIMER_MS);
 }
 
-function resolveManagedQueryClientTimeoutMs(
-  clientTimeoutMs: number | undefined,
-  queryTimeoutS: number | undefined,
-): number | undefined {
-  if (clientTimeoutMs !== undefined) {
-    const configured = clampNodeTimerMs(clientTimeoutMs);
-    return queryTimeoutS === undefined
-      ? configured
-      : Math.max(
-          configured,
-          clampNodeTimerMs(queryTimeoutS * 1_000 + MANAGED_OXIGRAPH_CLIENT_TIMEOUT_GRACE_MS),
-        );
-  }
-  return queryTimeoutS === undefined
-    ? undefined
-    : clampNodeTimerMs(queryTimeoutS * 1_000 + MANAGED_OXIGRAPH_CLIENT_TIMEOUT_GRACE_MS);
+interface ManagedOxigraphDeadlines {
+  queryTimeoutS: number;
+  clientTimeoutMs: number;
 }
 
-function deriveManagedQueryTimeoutS(clientTimeoutMs: number | undefined): number | undefined {
-  if (clientTimeoutMs === undefined) return undefined;
-  const clampedClientTimeoutMs = clampNodeTimerMs(clientTimeoutMs);
-  return Math.max(
+/** Resolve the required native/client pair and enforce native < client. */
+function resolveManagedOxigraphDeadlines(
+  options: Record<string, unknown> | undefined,
+): ManagedOxigraphDeadlines {
+  const configuredClientTimeoutMs = clampNodeTimerMs(
+    resolvePositiveIntegerOption(options, 'clientTimeoutMs')
+      ?? DEFAULT_SPARQL_HTTP_TIMEOUT_MS,
+  );
+  const derivedQueryTimeoutS = Math.max(
     1,
     Math.floor(
-      (clampedClientTimeoutMs - MANAGED_OXIGRAPH_CLIENT_TIMEOUT_GRACE_MS) / 1_000,
+      (configuredClientTimeoutMs - MANAGED_OXIGRAPH_CLIENT_TIMEOUT_GRACE_MS) / 1_000,
     ),
   );
+  const configuredQueryTimeoutS = resolvePositiveIntegerOption(options, 'queryTimeoutS');
+  const queryTimeoutS = Math.min(
+    configuredQueryTimeoutS ?? derivedQueryTimeoutS,
+    MAX_MANAGED_OXIGRAPH_QUERY_TIMEOUT_S,
+  );
+  const minimumClientTimeoutMs = clampNodeTimerMs(
+    queryTimeoutS * 1_000 + MANAGED_OXIGRAPH_CLIENT_TIMEOUT_GRACE_MS,
+  );
+  return {
+    queryTimeoutS,
+    clientTimeoutMs: configuredQueryTimeoutS !== undefined
+      && configuredQueryTimeoutS > MAX_MANAGED_OXIGRAPH_QUERY_TIMEOUT_S
+      ? MAX_NODE_TIMER_MS
+      : Math.max(configuredClientTimeoutMs, minimumClientTimeoutMs),
+  };
 }
 
 interface StoreConfigLike {
@@ -169,9 +177,9 @@ export interface ManagedOxigraphPlan {
   /** Startup readiness deadline passed to the managed server supervisor. */
   readyTimeoutMs?: number;
   /** Native Oxigraph query timeout, passed as `oxigraph serve --timeout-s`. */
-  queryTimeoutS?: number;
+  queryTimeoutS: number;
   /** SPARQL HTTP client deadline; kept after Oxigraph's native timeout when both exist. */
-  clientTimeoutMs?: number;
+  clientTimeoutMs: number;
   /** Finite limits applied to an isolated systemd user scope. */
   memoryLimits?: OxigraphMemoryLimits;
   /**
@@ -198,18 +206,11 @@ export function planManagedOxigraph(
   const options = config.store.options ?? {};
   const port = resolveManagedOxigraphPort(options);
   const readyTimeoutMs = resolvePositiveIntegerOption(options, 'readyTimeoutMs');
-  const configuredClientTimeoutMs = resolvePositiveIntegerOption(options, 'clientTimeoutMs')
-    ?? DEFAULT_MANAGED_OXIGRAPH_CLIENT_TIMEOUT_MS;
   // A client-only deadline closes the HTTP socket but cannot cancel an
   // evaluation already running inside the Oxigraph server. Derive a native
   // deadline with five seconds of client grace so timed-out queries are
   // interrupted server-side instead of accumulating as zombies.
-  const queryTimeoutS = resolvePositiveIntegerOption(options, 'queryTimeoutS')
-    ?? deriveManagedQueryTimeoutS(configuredClientTimeoutMs);
-  const clientTimeoutMs = resolveManagedQueryClientTimeoutMs(
-    configuredClientTimeoutMs,
-    queryTimeoutS,
-  );
+  const { queryTimeoutS, clientTimeoutMs } = resolveManagedOxigraphDeadlines(options);
   const memoryLimits = normalizeOxigraphMemoryLimits({
     highMiB: options.memoryHighMiB,
     maxMiB: options.memoryMaxMiB,
@@ -254,9 +255,7 @@ export function planManagedOxigraph(
     // we own end-to-end; queryEndpoint/updateEndpoint added at launch.
     options: {
       managedByDkg: true,
-      ...(clientTimeoutMs === undefined
-        ? {}
-        : { timeout: clientTimeoutMs }),
+      timeout: clientTimeoutMs,
     },
   };
   if (graphSetIndex !== undefined) {

--- a/packages/cli/src/daemon/oxigraph-managed.ts
+++ b/packages/cli/src/daemon/oxigraph-managed.ts
@@ -255,6 +255,7 @@ export function planManagedOxigraph(
     // we own end-to-end; queryEndpoint/updateEndpoint added at launch.
     options: {
       managedByDkg: true,
+      managedOxigraph: true,
       timeout: clientTimeoutMs,
     },
   };
@@ -340,6 +341,10 @@ export async function startManagedOxigraph(
       ...plan.storeConfigTemplate.options,
       queryEndpoint: handle.queryEndpoint,
       updateEndpoint: handle.updateEndpoint,
+      onClientTimeout: (operation: string) => {
+        if (operation !== 'query' && operation !== 'construct') return;
+        handle.requestRestart(`${operation} exceeded the managed SPARQL client deadline`);
+      },
     },
   };
   if (plan.storeConfigTemplate.graphSetIndex !== undefined) {

--- a/packages/cli/src/daemon/oxigraph-server.ts
+++ b/packages/cli/src/daemon/oxigraph-server.ts
@@ -102,6 +102,12 @@ export interface OxigraphServerHandle {
   readonly port: number;
   readonly queryEndpoint: string;
   readonly updateEndpoint: string;
+  /**
+   * Terminate an unhealthy managed server and let the existing supervisor
+   * respawn it. Returns false when shutdown/recovery is already in progress;
+   * accepted requests re-verify listener ownership before sending a signal.
+   */
+  requestRestart(reason: string): boolean;
   /** Stop the server and prevent further restarts. Idempotent. */
   stop(): Promise<void>;
   /**
@@ -171,7 +177,9 @@ export async function startOxigraphServer(
   let stopping = false;
   let ready = false;
   let child: ChildProcess | null = null;
+  let listenerPid: number | null = null;
   let restarts = 0;
+  let requestedRestartReason: string | null = null;
   // Tail of the child's stderr, surfaced in the startup error so a bind
   // failure (`Address already in use`) is visible to the operator.
   let lastStderr = '';
@@ -229,7 +237,10 @@ export async function startOxigraphServer(
       // off to revive(), which respawns and re-proves ownership before
       // restoring `ready`.
       ready = false;
+      listenerPid = null;
       markStoreDown();
+      const recoveryReason = requestedRestartReason;
+      requestedRestartReason = null;
       // Best-effort OOM classification: `oom_kill` is cgroup-scoped, not
       // per-PID, so use an increment only as supporting evidence for a
       // SIGKILL-compatible child death. This catches MemoryMax/host OOM kills
@@ -245,9 +256,9 @@ export async function startOxigraphServer(
       })) {
         oomNote = ', OOM-killed by cgroup memory cap (or host OOM)';
       }
-      scheduleRevive(
-        `server exited unexpectedly (code=${code ?? 'null'}, signal=${signal ?? 'null'}${oomNote})`,
-      );
+      scheduleRevive(recoveryReason === null
+        ? `server exited unexpectedly (code=${code ?? 'null'}, signal=${signal ?? 'null'}${oomNote})`
+        : `server terminated for recovery (${recoveryReason}; signal=${signal ?? 'null'}${oomNote})`);
     });
     return c;
   };
@@ -313,6 +324,7 @@ export async function startOxigraphServer(
   const revive = async (): Promise<void> => {
     if (stopping) return;
     child = spawnChild();
+    listenerPid = null;
     const reviveDeadline = Date.now() + readyTimeoutMs;
     while (Date.now() < reviveDeadline) {
       if (stopping) return;
@@ -320,9 +332,12 @@ export async function startOxigraphServer(
       // because `ready` is false). Retry with backoff; never adopt whatever
       // may now be answering on the port.
       if (!childAlive()) break;
-      const listenerPid = await probeReady();
-      if (listenerPid !== null && childAlive()) {
-        captureOomSnapshotForListener(child!, listenerPid);
+      const verifiedListenerPid = await probeReady();
+      if (verifiedListenerPid !== null && childAlive()) {
+        captureOomSnapshotForListener(child!, verifiedListenerPid);
+        // Keep the actual listener PID, not the optional systemd-run wrapper,
+        // so timeout recovery terminates Oxigraph itself inside its scope.
+        listenerPid = verifiedListenerPid;
         ready = true;
         restarts = 0;
         log(`[oxigraph] server restarted and healthy on ${bind}.`);
@@ -356,6 +371,56 @@ export async function startOxigraphServer(
     } catch {
       /* best-effort */
     }
+  };
+
+  const terminateVerifiedListener = async (
+    expectedChild: ChildProcess,
+    expectedListenerPid: number,
+  ): Promise<void> => {
+    let verifiedListenerPid: number | null = null;
+    try {
+      verifiedListenerPid = await launchStrategy.resolveListenerPid(
+        expectedChild,
+        port,
+        host,
+        io.findListenOwnerPid,
+      );
+    } catch {
+      /* handled by the fail-closed branch below */
+    }
+    if (
+      stopping
+      || child !== expectedChild
+      || !childAlive()
+      || requestedRestartReason === null
+    ) return;
+    if (verifiedListenerPid !== expectedListenerPid) {
+      log('[oxigraph] recovery restart cancelled: verified listener ownership changed');
+      requestedRestartReason = null;
+      return;
+    }
+    try {
+      process.kill(expectedListenerPid, 'SIGKILL');
+    } catch {
+      log('[oxigraph] recovery restart could not signal the verified listener');
+      requestedRestartReason = null;
+    }
+  };
+
+  const requestRestart = (reason: string): boolean => {
+    if (
+      stopping
+      || !ready
+      || !childAlive()
+      || listenerPid === null
+      || requestedRestartReason !== null
+    ) return false;
+    const normalizedReason = reason.trim().slice(0, 500) || 'unspecified health failure';
+    requestedRestartReason = normalizedReason;
+    markStoreDown();
+    log(`[oxigraph] ${normalizedReason}; terminating server for supervised recovery`);
+    void terminateVerifiedListener(child!, listenerPid);
+    return true;
   };
 
   const stop = async (): Promise<void> => {
@@ -407,16 +472,19 @@ export async function startOxigraphServer(
       childDied = true;
       break;
     }
-    const listenerPid = await probeReady();
-    if (listenerPid !== null) {
+    const verifiedListenerPid = await probeReady();
+    if (verifiedListenerPid !== null) {
       // Only trust a 200 if the child WE spawned is the one still alive
       // and bound — guards the race where a foreign server answers while
       // our child has just died on EADDRINUSE.
       if (childAlive()) {
-        captureOomSnapshotForListener(child!, listenerPid);
+        captureOomSnapshotForListener(child!, verifiedListenerPid);
+        // Persist the verified listener owner for targeted timeout recovery.
+        // This differs from `child.pid` when Oxigraph runs in a systemd scope.
+        listenerPid = verifiedListenerPid;
         ready = true;
         log(`Oxigraph server ready on ${bind} after ${attempt} probe(s).`);
-        return { host, port, queryEndpoint, updateEndpoint, stop, killSync };
+        return { host, port, queryEndpoint, updateEndpoint, requestRestart, stop, killSync };
       }
       childDied = true;
       break;

--- a/packages/cli/src/daemon/oxigraph-server.ts
+++ b/packages/cli/src/daemon/oxigraph-server.ts
@@ -52,6 +52,8 @@ import {
 export interface OxigraphServerIo {
   spawn: typeof spawn;
   fetch: typeof globalThis.fetch;
+  /** Signal a listener PID after ownership has been re-verified. Injectable for safety tests. */
+  killProcess: typeof process.kill;
   /**
    * Resolve the child/descendant PID that owns the listen socket (not merely
    * that something on the port returns HTTP 200).
@@ -108,6 +110,8 @@ export interface OxigraphServerHandle {
    * accepted requests re-verify listener ownership before sending a signal.
    */
   requestRestart(reason: string): boolean;
+  /** Runtime-only recovery state consumed by the managed SPARQL adapter. */
+  getRecoveryState(): OxigraphRecoveryState;
   /** Stop the server and prevent further restarts. Idempotent. */
   stop(): Promise<void>;
   /**
@@ -116,6 +120,11 @@ export interface OxigraphServerHandle {
    * fatal `process.exit()` after the server started. Idempotent.
    */
   killSync(): void;
+}
+
+export interface OxigraphRecoveryState {
+  recovering: boolean;
+  generation: number;
 }
 
 const DEFAULT_HOST = '127.0.0.1';
@@ -153,6 +162,7 @@ export async function startOxigraphServer(
   const io: OxigraphServerIo = {
     spawn: ioOverrides.spawn ?? spawn,
     fetch: ioOverrides.fetch ?? globalThis.fetch,
+    killProcess: ioOverrides.killProcess ?? process.kill,
     findListenOwnerPid: ioOverrides.findListenOwnerPid ?? findListenOwnerPid,
     readCgroupOomSnapshot: ioOverrides.readCgroupOomSnapshot ?? readCgroupOomSnapshot,
     readCgroupOomKill: ioOverrides.readCgroupOomKill ?? readCgroupOomKill,
@@ -174,12 +184,22 @@ export async function startOxigraphServer(
   const restartMax = opts.restartBackoffMaxMs ?? DEFAULT_RESTART_MAX_MS;
   const queryTimeoutS = normalizePositiveInteger(opts.queryTimeoutS);
 
-  let stopping = false;
-  let ready = false;
+  interface RestartRequest {
+    child: ChildProcess;
+    listenerPid: number;
+    reason: string;
+  }
+  type LifecycleState =
+    | { phase: 'starting' }
+    | { phase: 'ready'; listenerPid: number }
+    | { phase: 'restart-requested'; request: RestartRequest }
+    | { phase: 'recovering'; reason: string }
+    | { phase: 'stopping' };
+
+  let lifecycle: LifecycleState = { phase: 'starting' };
+  let recoveryGeneration = 0;
   let child: ChildProcess | null = null;
-  let listenerPid: number | null = null;
   let restarts = 0;
-  let requestedRestartReason: string | null = null;
   // Tail of the child's stderr, surfaced in the startup error so a bind
   // failure (`Address already in use`) is visible to the operator.
   let lastStderr = '';
@@ -189,6 +209,7 @@ export async function startOxigraphServer(
   // ready/revive loops treat a spawn error as a dead child.
   const erroredChildren = new WeakSet<ChildProcess>();
   const oomSnapshots = new WeakMap<ChildProcess, CgroupOomSnapshot>();
+  const isStopping = (): boolean => lifecycle.phase === 'stopping';
 
   const spawnChild = (): ChildProcess => {
     const args = ['serve', '--location', opts.location, '--bind', bind];
@@ -221,8 +242,12 @@ export async function startOxigraphServer(
       }
     });
     c.once('exit', (code, signal) => {
-      if (stopping) return;
-      // Two cases land here with `ready === false` and must NOT (re)start:
+      if (lifecycle.phase === 'stopping') return;
+      const requestedRecovery = lifecycle.phase === 'restart-requested'
+        && lifecycle.request.child === c
+        ? lifecycle.request
+        : null;
+      // Two cases land here outside ready/requested-recovery and must NOT (re)start:
       //   1. Startup-phase exit — usually a bind failure (the port is taken
       //      by another local SPARQL server). The ready loop observes the
       //      dead child and fails fast with the captured stderr.
@@ -231,16 +256,13 @@ export async function startOxigraphServer(
       //      window, so we must not double-schedule here.
       // Restarting on either would risk looping against a port we can't own,
       // and a foreign server answering there could be mistaken for ours.
-      if (!ready) return;
-      // We just lost a confirmed-healthy child. Drop `ready` immediately so
+      if (lifecycle.phase !== 'ready' && requestedRecovery === null) return;
+      // We just lost a confirmed-healthy child. Enter recovery immediately so
       // nothing treats the (now foreign-or-dead) endpoint as ours, then hand
       // off to revive(), which respawns and re-proves ownership before
       // restoring `ready`.
-      ready = false;
-      listenerPid = null;
       markStoreDown();
-      const recoveryReason = requestedRestartReason;
-      requestedRestartReason = null;
+      if (requestedRecovery === null) recoveryGeneration += 1;
       // Best-effort OOM classification: `oom_kill` is cgroup-scoped, not
       // per-PID, so use an increment only as supporting evidence for a
       // SIGKILL-compatible child death. This catches MemoryMax/host OOM kills
@@ -256,9 +278,11 @@ export async function startOxigraphServer(
       })) {
         oomNote = ', OOM-killed by cgroup memory cap (or host OOM)';
       }
-      scheduleRevive(recoveryReason === null
+      const recoveryReason = requestedRecovery === null
         ? `server exited unexpectedly (code=${code ?? 'null'}, signal=${signal ?? 'null'}${oomNote})`
-        : `server terminated for recovery (${recoveryReason}; signal=${signal ?? 'null'}${oomNote})`);
+        : `server terminated for recovery (${requestedRecovery.reason}; signal=${signal ?? 'null'}${oomNote})`;
+      lifecycle = { phase: 'recovering', reason: recoveryReason };
+      scheduleRevive(recoveryReason);
     });
     return c;
   };
@@ -306,6 +330,7 @@ export async function startOxigraphServer(
   // re-establish ownership, so a crash-looping binary (or a permanently-taken
   // port) never pegs the CPU.
   const scheduleRevive = (reason: string): void => {
+    if (lifecycle.phase !== 'stopping') lifecycle = { phase: 'recovering', reason };
     restarts += 1;
     const delay = Math.min(restartMax, restartBase * 2 ** (restarts - 1));
     log(`[oxigraph] ${reason}; restart #${restarts} in ${delay}ms`);
@@ -322,12 +347,11 @@ export async function startOxigraphServer(
   // queries surface honest errors rather than silently hitting a foreign
   // SPARQL server.
   const revive = async (): Promise<void> => {
-    if (stopping) return;
+    if (isStopping()) return;
     child = spawnChild();
-    listenerPid = null;
     const reviveDeadline = Date.now() + readyTimeoutMs;
     while (Date.now() < reviveDeadline) {
-      if (stopping) return;
+      if (isStopping()) return;
       // Respawned child died (its own exit handler stays out of the way
       // because `ready` is false). Retry with backoff; never adopt whatever
       // may now be answering on the port.
@@ -337,15 +361,14 @@ export async function startOxigraphServer(
         captureOomSnapshotForListener(child!, verifiedListenerPid);
         // Keep the actual listener PID, not the optional systemd-run wrapper,
         // so timeout recovery terminates Oxigraph itself inside its scope.
-        listenerPid = verifiedListenerPid;
-        ready = true;
+        lifecycle = { phase: 'ready', listenerPid: verifiedListenerPid };
         restarts = 0;
         log(`[oxigraph] server restarted and healthy on ${bind}.`);
         return;
       }
       await sleep(readyIntervalMs);
     }
-    if (stopping) return;
+    if (isStopping()) return;
     // Timed out with the child still running but unresponsive. Kill it
     // before respawning — otherwise each retry stacks another live
     // `oxigraph serve`, and they fight over the port (self-inflicted
@@ -364,7 +387,7 @@ export async function startOxigraphServer(
   // await): signals the child so a fatal `process.exit()` elsewhere in
   // boot doesn't orphan the server. Safe to call alongside `stop()`.
   const killSync = (): void => {
-    stopping = true;
+    lifecycle = { phase: 'stopping' };
     markStoreDown();
     try {
       if (childAlive()) child!.kill('SIGTERM');
@@ -373,14 +396,11 @@ export async function startOxigraphServer(
     }
   };
 
-  const terminateVerifiedListener = async (
-    expectedChild: ChildProcess,
-    expectedListenerPid: number,
-  ): Promise<void> => {
+  const terminateVerifiedListener = async (request: RestartRequest): Promise<void> => {
     let verifiedListenerPid: number | null = null;
     try {
       verifiedListenerPid = await launchStrategy.resolveListenerPid(
-        expectedChild,
+        request.child,
         port,
         host,
         io.findListenOwnerPid,
@@ -389,43 +409,51 @@ export async function startOxigraphServer(
       /* handled by the fail-closed branch below */
     }
     if (
-      stopping
-      || child !== expectedChild
+      lifecycle.phase !== 'restart-requested'
+      || lifecycle.request !== request
+      || child !== request.child
       || !childAlive()
-      || requestedRestartReason === null
     ) return;
-    if (verifiedListenerPid !== expectedListenerPid) {
+    if (verifiedListenerPid !== request.listenerPid) {
       log('[oxigraph] recovery restart cancelled: verified listener ownership changed');
-      requestedRestartReason = null;
+      lifecycle = { phase: 'ready', listenerPid: request.listenerPid };
       return;
     }
     try {
-      process.kill(expectedListenerPid, 'SIGKILL');
+      io.killProcess(request.listenerPid, 'SIGKILL');
     } catch {
       log('[oxigraph] recovery restart could not signal the verified listener');
-      requestedRestartReason = null;
+      lifecycle = { phase: 'ready', listenerPid: request.listenerPid };
     }
   };
 
   const requestRestart = (reason: string): boolean => {
     if (
-      stopping
-      || !ready
+      lifecycle.phase !== 'ready'
       || !childAlive()
-      || listenerPid === null
-      || requestedRestartReason !== null
     ) return false;
     const normalizedReason = reason.trim().slice(0, 500) || 'unspecified health failure';
-    requestedRestartReason = normalizedReason;
+    const request: RestartRequest = {
+      child: child!,
+      listenerPid: lifecycle.listenerPid,
+      reason: normalizedReason,
+    };
+    recoveryGeneration += 1;
+    lifecycle = { phase: 'restart-requested', request };
     markStoreDown();
     log(`[oxigraph] ${normalizedReason}; terminating server for supervised recovery`);
-    void terminateVerifiedListener(child!, listenerPid);
+    void terminateVerifiedListener(request);
     return true;
   };
 
+  const getRecoveryState = (): OxigraphRecoveryState => ({
+    recovering: lifecycle.phase !== 'ready',
+    generation: recoveryGeneration,
+  });
+
   const stop = async (): Promise<void> => {
-    if (stopping) return;
-    stopping = true;
+    if (lifecycle.phase === 'stopping') return;
+    lifecycle = { phase: 'stopping' };
     markStoreDown();
     const c = child;
     child = null;
@@ -481,10 +509,18 @@ export async function startOxigraphServer(
         captureOomSnapshotForListener(child!, verifiedListenerPid);
         // Persist the verified listener owner for targeted timeout recovery.
         // This differs from `child.pid` when Oxigraph runs in a systemd scope.
-        listenerPid = verifiedListenerPid;
-        ready = true;
+        lifecycle = { phase: 'ready', listenerPid: verifiedListenerPid };
         log(`Oxigraph server ready on ${bind} after ${attempt} probe(s).`);
-        return { host, port, queryEndpoint, updateEndpoint, requestRestart, stop, killSync };
+        return {
+          host,
+          port,
+          queryEndpoint,
+          updateEndpoint,
+          requestRestart,
+          getRecoveryState,
+          stop,
+          killSync,
+        };
       }
       childDied = true;
       break;

--- a/packages/cli/src/daemon/oxigraph-server.ts
+++ b/packages/cli/src/daemon/oxigraph-server.ts
@@ -188,6 +188,7 @@ export async function startOxigraphServer(
     child: ChildProcess;
     listenerPid: number;
     reason: string;
+    signalAccepted: boolean;
   }
   type LifecycleState =
     | { phase: 'starting' }
@@ -262,7 +263,9 @@ export async function startOxigraphServer(
       // off to revive(), which respawns and re-proves ownership before
       // restoring `ready`.
       markStoreDown();
-      if (requestedRecovery === null) recoveryGeneration += 1;
+      if (requestedRecovery === null || !requestedRecovery.signalAccepted) {
+        recoveryGeneration += 1;
+      }
       // Best-effort OOM classification: `oom_kill` is cgroup-scoped, not
       // per-PID, so use an increment only as supporting evidence for a
       // SIGKILL-compatible child death. This catches MemoryMax/host OOM kills
@@ -420,7 +423,10 @@ export async function startOxigraphServer(
       return;
     }
     try {
-      io.killProcess(request.listenerPid, 'SIGKILL');
+      const signalled = io.killProcess(request.listenerPid, 'SIGKILL');
+      if (!signalled) throw new Error('process signal was not accepted');
+      request.signalAccepted = true;
+      recoveryGeneration += 1;
     } catch {
       log('[oxigraph] recovery restart could not signal the verified listener');
       lifecycle = { phase: 'ready', listenerPid: request.listenerPid };
@@ -437,8 +443,8 @@ export async function startOxigraphServer(
       child: child!,
       listenerPid: lifecycle.listenerPid,
       reason: normalizedReason,
+      signalAccepted: false,
     };
-    recoveryGeneration += 1;
     lifecycle = { phase: 'restart-requested', request };
     markStoreDown();
     log(`[oxigraph] ${normalizedReason}; terminating server for supervised recovery`);
@@ -447,7 +453,9 @@ export async function startOxigraphServer(
   };
 
   const getRecoveryState = (): OxigraphRecoveryState => ({
-    recovering: lifecycle.phase !== 'ready',
+    recovering: lifecycle.phase === 'recovering'
+      || lifecycle.phase === 'stopping'
+      || (lifecycle.phase === 'restart-requested' && lifecycle.request.signalAccepted),
     generation: recoveryGeneration,
   });
 

--- a/packages/cli/src/daemon/oxigraph-server.ts
+++ b/packages/cli/src/daemon/oxigraph-server.ts
@@ -184,22 +184,15 @@ export async function startOxigraphServer(
   const restartMax = opts.restartBackoffMaxMs ?? DEFAULT_RESTART_MAX_MS;
   const queryTimeoutS = normalizePositiveInteger(opts.queryTimeoutS);
 
-  interface RestartRequest {
-    child: ChildProcess;
-    listenerPid: number;
-    reason: string;
-    signalAccepted: boolean;
-  }
   type LifecycleState =
-    | { phase: 'starting' }
-    | { phase: 'ready'; listenerPid: number }
-    | { phase: 'restart-requested'; request: RestartRequest }
-    | { phase: 'recovering'; reason: string }
-    | { phase: 'stopping' };
+    | { phase: 'starting'; child: ChildProcess | null; generation: number }
+    | { phase: 'ready'; child: ChildProcess; listenerPid: number; generation: number }
+    | { phase: 'restart-verifying'; child: ChildProcess; listenerPid: number; reason: string; generation: number }
+    | { phase: 'restart-signalled'; child: ChildProcess; listenerPid: number; reason: string; generation: number }
+    | { phase: 'recovering'; child: ChildProcess | null; reason: string; generation: number }
+    | { phase: 'stopping'; child: ChildProcess | null; generation: number };
 
-  let lifecycle: LifecycleState = { phase: 'starting' };
-  let recoveryGeneration = 0;
-  let child: ChildProcess | null = null;
+  let lifecycle: LifecycleState = { phase: 'starting', child: null, generation: 0 };
   let restarts = 0;
   // Tail of the child's stderr, surfaced in the startup error so a bind
   // failure (`Address already in use`) is visible to the operator.
@@ -211,6 +204,11 @@ export async function startOxigraphServer(
   const erroredChildren = new WeakSet<ChildProcess>();
   const oomSnapshots = new WeakMap<ChildProcess, CgroupOomSnapshot>();
   const isStopping = (): boolean => lifecycle.phase === 'stopping';
+  const childAlive = (candidate: ChildProcess | null): candidate is ChildProcess =>
+    candidate != null
+    && !erroredChildren.has(candidate)
+    && candidate.exitCode === null
+    && candidate.signalCode === null;
 
   const spawnChild = (): ChildProcess => {
     const args = ['serve', '--location', opts.location, '--bind', bind];
@@ -244,9 +242,10 @@ export async function startOxigraphServer(
     });
     c.once('exit', (code, signal) => {
       if (lifecycle.phase === 'stopping') return;
-      const requestedRecovery = lifecycle.phase === 'restart-requested'
-        && lifecycle.request.child === c
-        ? lifecycle.request
+      if (lifecycle.child !== c) return;
+      const requestedRecovery = lifecycle.phase === 'restart-verifying'
+        || lifecycle.phase === 'restart-signalled'
+        ? lifecycle
         : null;
       // Two cases land here outside ready/requested-recovery and must NOT (re)start:
       //   1. Startup-phase exit — usually a bind failure (the port is taken
@@ -263,9 +262,8 @@ export async function startOxigraphServer(
       // off to revive(), which respawns and re-proves ownership before
       // restoring `ready`.
       markStoreDown();
-      if (requestedRecovery === null || !requestedRecovery.signalAccepted) {
-        recoveryGeneration += 1;
-      }
+      const generation = lifecycle.generation
+        + (lifecycle.phase === 'restart-signalled' ? 0 : 1);
       // Best-effort OOM classification: `oom_kill` is cgroup-scoped, not
       // per-PID, so use an increment only as supporting evidence for a
       // SIGKILL-compatible child death. This catches MemoryMax/host OOM kills
@@ -284,17 +282,11 @@ export async function startOxigraphServer(
       const recoveryReason = requestedRecovery === null
         ? `server exited unexpectedly (code=${code ?? 'null'}, signal=${signal ?? 'null'}${oomNote})`
         : `server terminated for recovery (${requestedRecovery.reason}; signal=${signal ?? 'null'}${oomNote})`;
-      lifecycle = { phase: 'recovering', reason: recoveryReason };
+      lifecycle = { phase: 'recovering', child: null, reason: recoveryReason, generation };
       scheduleRevive(recoveryReason);
     });
     return c;
   };
-
-  const childAlive = (): boolean =>
-    child != null &&
-    !erroredChildren.has(child) &&
-    child.exitCode === null &&
-    child.signalCode === null;
 
   const captureOomSnapshotForListener = (c: ChildProcess, listenerPid: number): void => {
     if (oomSnapshots.has(c)) return;
@@ -302,9 +294,8 @@ export async function startOxigraphServer(
     if (snapshot) oomSnapshots.set(c, snapshot);
   };
 
-  const probeReady = async (): Promise<number | null> => {
-    const c = child;
-    if (!c || !childAlive()) return null;
+  const probeReady = async (c: ChildProcess): Promise<number | null> => {
+    if (!childAlive(c)) return null;
     try {
       const res = await io.fetch(queryEndpoint, {
         method: 'POST',
@@ -322,7 +313,7 @@ export async function startOxigraphServer(
         host,
         io.findListenOwnerPid,
       );
-      return listenerPid !== null && childAlive() ? listenerPid : null;
+      return listenerPid !== null && childAlive(c) ? listenerPid : null;
     } catch {
       return null;
     }
@@ -333,7 +324,13 @@ export async function startOxigraphServer(
   // re-establish ownership, so a crash-looping binary (or a permanently-taken
   // port) never pegs the CPU.
   const scheduleRevive = (reason: string): void => {
-    if (lifecycle.phase !== 'stopping') lifecycle = { phase: 'recovering', reason };
+    if (lifecycle.phase === 'stopping') return;
+    lifecycle = {
+      phase: 'recovering',
+      child: lifecycle.child,
+      reason,
+      generation: lifecycle.generation,
+    };
     restarts += 1;
     const delay = Math.min(restartMax, restartBase * 2 ** (restarts - 1));
     log(`[oxigraph] ${reason}; restart #${restarts} in ${delay}ms`);
@@ -351,38 +348,55 @@ export async function startOxigraphServer(
   // SPARQL server.
   const revive = async (): Promise<void> => {
     if (isStopping()) return;
-    child = spawnChild();
+    const generation = lifecycle.generation;
+    const reason = lifecycle.phase === 'recovering'
+      ? lifecycle.reason
+      : 'supervised recovery';
+    const candidate = spawnChild();
+    lifecycle = { phase: 'recovering', child: candidate, reason, generation };
     const reviveDeadline = Date.now() + readyTimeoutMs;
     while (Date.now() < reviveDeadline) {
-      if (isStopping()) return;
+      if (
+        lifecycle.phase !== 'recovering'
+        || lifecycle.child !== candidate
+      ) return;
       // Respawned child died (its own exit handler stays out of the way
       // because `ready` is false). Retry with backoff; never adopt whatever
       // may now be answering on the port.
-      if (!childAlive()) break;
-      const verifiedListenerPid = await probeReady();
-      if (verifiedListenerPid !== null && childAlive()) {
-        captureOomSnapshotForListener(child!, verifiedListenerPid);
+      if (!childAlive(candidate)) break;
+      const verifiedListenerPid = await probeReady(candidate);
+      if (verifiedListenerPid !== null && childAlive(candidate)) {
+        captureOomSnapshotForListener(candidate, verifiedListenerPid);
         // Keep the actual listener PID, not the optional systemd-run wrapper,
         // so timeout recovery terminates Oxigraph itself inside its scope.
-        lifecycle = { phase: 'ready', listenerPid: verifiedListenerPid };
+        lifecycle = {
+          phase: 'ready',
+          child: candidate,
+          listenerPid: verifiedListenerPid,
+          generation,
+        };
         restarts = 0;
         log(`[oxigraph] server restarted and healthy on ${bind}.`);
         return;
       }
       await sleep(readyIntervalMs);
     }
-    if (isStopping()) return;
+    if (
+      lifecycle.phase !== 'recovering'
+      || lifecycle.child !== candidate
+    ) return;
     // Timed out with the child still running but unresponsive. Kill it
     // before respawning — otherwise each retry stacks another live
     // `oxigraph serve`, and they fight over the port (self-inflicted
     // EADDRINUSE). Its exit handler won't restart (ready is false).
-    if (childAlive()) {
+    if (childAlive(candidate)) {
       try {
-        child!.kill('SIGKILL');
+        candidate.kill('SIGKILL');
       } catch {
         /* best-effort */
       }
     }
+    lifecycle = { phase: 'recovering', child: null, reason, generation };
     scheduleRevive(`respawned server did not become ready on ${bind}`);
   };
 
@@ -390,16 +404,23 @@ export async function startOxigraphServer(
   // await): signals the child so a fatal `process.exit()` elsewhere in
   // boot doesn't orphan the server. Safe to call alongside `stop()`.
   const killSync = (): void => {
-    lifecycle = { phase: 'stopping' };
+    const candidate = lifecycle.child;
+    lifecycle = {
+      phase: 'stopping',
+      child: candidate,
+      generation: lifecycle.generation,
+    };
     markStoreDown();
     try {
-      if (childAlive()) child!.kill('SIGTERM');
+      if (childAlive(candidate)) candidate.kill('SIGTERM');
     } catch {
       /* best-effort */
     }
   };
 
-  const terminateVerifiedListener = async (request: RestartRequest): Promise<void> => {
+  const terminateVerifiedListener = async (
+    request: Extract<LifecycleState, { phase: 'restart-verifying' }>,
+  ): Promise<void> => {
     let verifiedListenerPid: number | null = null;
     try {
       verifiedListenerPid = await launchStrategy.resolveListenerPid(
@@ -412,40 +433,54 @@ export async function startOxigraphServer(
       /* handled by the fail-closed branch below */
     }
     if (
-      lifecycle.phase !== 'restart-requested'
-      || lifecycle.request !== request
-      || child !== request.child
-      || !childAlive()
+      lifecycle !== request
+      || !childAlive(request.child)
     ) return;
     if (verifiedListenerPid !== request.listenerPid) {
       log('[oxigraph] recovery restart cancelled: verified listener ownership changed');
-      lifecycle = { phase: 'ready', listenerPid: request.listenerPid };
+      lifecycle = {
+        phase: 'ready',
+        child: request.child,
+        listenerPid: request.listenerPid,
+        generation: request.generation,
+      };
       return;
     }
     try {
       const signalled = io.killProcess(request.listenerPid, 'SIGKILL');
       if (!signalled) throw new Error('process signal was not accepted');
-      request.signalAccepted = true;
-      recoveryGeneration += 1;
+      lifecycle = {
+        phase: 'restart-signalled',
+        child: request.child,
+        listenerPid: request.listenerPid,
+        reason: request.reason,
+        generation: request.generation + 1,
+      };
     } catch {
       log('[oxigraph] recovery restart could not signal the verified listener');
-      lifecycle = { phase: 'ready', listenerPid: request.listenerPid };
+      lifecycle = {
+        phase: 'ready',
+        child: request.child,
+        listenerPid: request.listenerPid,
+        generation: request.generation,
+      };
     }
   };
 
   const requestRestart = (reason: string): boolean => {
     if (
       lifecycle.phase !== 'ready'
-      || !childAlive()
+      || !childAlive(lifecycle.child)
     ) return false;
     const normalizedReason = reason.trim().slice(0, 500) || 'unspecified health failure';
-    const request: RestartRequest = {
-      child: child!,
+    const request: Extract<LifecycleState, { phase: 'restart-verifying' }> = {
+      phase: 'restart-verifying',
+      child: lifecycle.child,
       listenerPid: lifecycle.listenerPid,
       reason: normalizedReason,
-      signalAccepted: false,
+      generation: lifecycle.generation,
     };
-    lifecycle = { phase: 'restart-requested', request };
+    lifecycle = request;
     markStoreDown();
     log(`[oxigraph] ${normalizedReason}; terminating server for supervised recovery`);
     void terminateVerifiedListener(request);
@@ -455,16 +490,20 @@ export async function startOxigraphServer(
   const getRecoveryState = (): OxigraphRecoveryState => ({
     recovering: lifecycle.phase === 'recovering'
       || lifecycle.phase === 'stopping'
-      || (lifecycle.phase === 'restart-requested' && lifecycle.request.signalAccepted),
-    generation: recoveryGeneration,
+      || lifecycle.phase === 'restart-signalled',
+    generation: lifecycle.generation,
   });
 
   const stop = async (): Promise<void> => {
     if (lifecycle.phase === 'stopping') return;
-    lifecycle = { phase: 'stopping' };
+    const candidate = lifecycle.child;
+    lifecycle = {
+      phase: 'stopping',
+      child: candidate,
+      generation: lifecycle.generation,
+    };
     markStoreDown();
-    const c = child;
-    child = null;
+    const c = candidate;
     if (!c || c.exitCode !== null || c.signalCode !== null) return;
     await new Promise<void>((resolve) => {
       let settled = false;
@@ -494,7 +533,12 @@ export async function startOxigraphServer(
   );
   const launchSummary = launchStrategy.logSummary();
   if (launchSummary) log(launchSummary);
-  child = spawnChild();
+  const initialChild = spawnChild();
+  lifecycle = {
+    phase: 'starting',
+    child: initialChild,
+    generation: lifecycle.generation,
+  };
 
   const deadline = Date.now() + readyTimeoutMs;
   let attempt = 0;
@@ -504,20 +548,25 @@ export async function startOxigraphServer(
     // Our spawned child exited during startup — almost always a bind
     // failure. Stop probing and fail fast; do NOT adopt whatever may be
     // answering on the port (it could be a foreign SPARQL server).
-    if (!childAlive()) {
+    if (!childAlive(initialChild)) {
       childDied = true;
       break;
     }
-    const verifiedListenerPid = await probeReady();
+    const verifiedListenerPid = await probeReady(initialChild);
     if (verifiedListenerPid !== null) {
       // Only trust a 200 if the child WE spawned is the one still alive
       // and bound — guards the race where a foreign server answers while
       // our child has just died on EADDRINUSE.
-      if (childAlive()) {
-        captureOomSnapshotForListener(child!, verifiedListenerPid);
+      if (childAlive(initialChild)) {
+        captureOomSnapshotForListener(initialChild, verifiedListenerPid);
         // Persist the verified listener owner for targeted timeout recovery.
         // This differs from `child.pid` when Oxigraph runs in a systemd scope.
-        lifecycle = { phase: 'ready', listenerPid: verifiedListenerPid };
+        lifecycle = {
+          phase: 'ready',
+          child: initialChild,
+          listenerPid: verifiedListenerPid,
+          generation: lifecycle.generation,
+        };
         log(`Oxigraph server ready on ${bind} after ${attempt} probe(s).`);
         return {
           host,

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -446,7 +446,7 @@ function respondReconcileError(res: ServerResponse, err: unknown): void {
 /**
  * Refuse to mint a new catch-up job because the daemon is shutting down.
  *
- * Shaped after `respondIfApiQueryStoreBusy` — retryable 503 plus `Retry-After`
+ * Shaped after `respondIfStoreUnavailable` — retryable 503 plus `Retry-After`
  * — because that is what this is: the request is fine, the node just cannot
  * take on new work it will never drain. Returned from BOTH mint sites, which
  * is why I7's `result` vocabulary needed a seventh value; a 503 that clamped

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -40,6 +40,7 @@ import {
   validateQuadObjectTerms,
   respondIfReconcileUnavailable,
   respondIfStoreUnavailable,
+  classifyStoreUnavailable,
   respondIfChainRpcTransportError,
   sanitizeRpcMessage,
   validateWritableQuadLiteralSizes,
@@ -1065,6 +1066,28 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       }
 
       const errors: Array<{ phase: string; error: string }> = [];
+      const respondWithPartialStoreFailure = (
+        error: unknown,
+        phase: 'swm-share' | 'vm-publish',
+      ): boolean => {
+        const classified = classifyStoreUnavailable(error);
+        if (!classified) return false;
+        jsonResponse(
+          res,
+          503,
+          {
+            created: true,
+            ...result,
+            phase,
+            ...classified.body,
+            retryAction: 'retry_same_knowledge_asset',
+            retryKnowledgeAssetName: name,
+          },
+          undefined,
+          { 'Retry-After': '1' },
+        );
+        return true;
+      };
       if (alsoShareSwm === true) {
         try {
           // Carry the same resolved author into the share. The asset is already
@@ -1090,6 +1113,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
             recordActivityAndNotify(ctx, { contextGraphId: resolvedContextGraphId, kind: "promoted", actorAgentAddress: resolvedAuthorAgentAddress ?? requestAgentAddress, subGraphName, tripleCount: share.promotedCount });
           }
         } catch (e: any) {
+          if (respondWithPartialStoreFailure(e, 'swm-share')) return;
           errors.push({ phase: "swm-share", error: sanitizeRpcMessage(e?.message ?? String(e)) });
         }
       }
@@ -1122,6 +1146,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
           }
           recordPcaDiscount(ctx, resolvedContextGraphId, pub?.onChainResult);
         } catch (e: any) {
+          if (respondWithPartialStoreFailure(e, 'vm-publish')) return;
           errors.push({ phase: "vm-publish", error: sanitizeRpcMessage(e?.message ?? String(e)) });
         }
       }

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -39,6 +39,7 @@ import {
   isWritableQuad,
   validateQuadObjectTerms,
   respondIfReconcileUnavailable,
+  respondIfStoreUnavailable,
   respondIfChainRpcTransportError,
   sanitizeRpcMessage,
   validateWritableQuadLiteralSizes,
@@ -226,6 +227,7 @@ function respondAssertionError(res: RequestContext["res"], e: any): void {
     jsonResponse(res, 413, payloadTooLargeResponseBody(e));
     return;
   }
+  if (respondIfStoreUnavailable(res, e)) return;
   if (e?.name === "AssertionNotPersistedError" || e?.code === "ASSERTION_NOT_PERSISTED") {
     jsonResponse(res, 409, {
       error: e.message,
@@ -1132,6 +1134,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       if (e?.code === "OVERSIZED_RDF_LITERAL") {
         return jsonResponse(res, 400, oversizedRdfLiteralResponseBody(e));
       }
+      if (respondIfStoreUnavailable(res, e)) return;
       // Transient KA-number-floor reconcile failure (rate-limited RPC) -> 503.
       if (respondIfReconcileUnavailable(res, e)) return;
       return jsonResponse(res, 500, { error: e?.message ?? String(e) });
@@ -1719,6 +1722,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         // relabel an author-selection failure whose message happens to contain
         // "is not finalized" as a generic VM_PUBLISH_PRECONDITION.
         if (respondAuthorSelectionError(res, e)) return;
+        if (respondIfStoreUnavailable(res, e)) return;
         if (e?.code === "PUBLISH_NOT_FULL_SHARE" || /is not finalized/.test(msg) || /No quads in shared memory/.test(msg) || /has no private payload/.test(msg)) {
           return jsonResponse(res, 409, { code: e?.code === "PUBLISH_NOT_FULL_SHARE" ? "PUBLISH_NOT_FULL_SHARE" : "VM_PUBLISH_PRECONDITION", error: msg });
         }

--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -228,6 +228,7 @@ import {
   deriveBlockExplorerUrl,
   classifyClientError,
   sanitizeRevertMessage,
+  respondIfStoreUnavailable,
 } from '../http-utils.js';
 import {
   normalizeRepo,
@@ -391,21 +392,7 @@ export function createApiQueryRequestLifecycle(
 /** Map retryable, pre-dispatch read shedding without changing write routes. */
 export function respondIfApiQueryStoreBusy(res: ServerResponse, err: unknown): boolean {
   if (!(err instanceof StoreSchedulerBusyError)) return false;
-
-  jsonResponse(
-    res,
-    503,
-    {
-      error: err.message,
-      code: err.code,
-      reason: err.reason,
-      priority: err.priority,
-      retryable: true,
-    },
-    undefined,
-    { 'Retry-After': '1' },
-  );
-  return true;
+  return respondIfStoreUnavailable(res, err);
 }
 
 function parseVerifyTimeoutMs(

--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -72,7 +72,6 @@ import {
   LlmClient,
   type MetricsSource,
 } from "@origintrail-official/dkg-node-ui";
-import { StoreSchedulerBusyError } from '@origintrail-official/dkg-storage';
 import {
   loadConfig,
   saveConfig,
@@ -389,11 +388,6 @@ export function createApiQueryRequestLifecycle(
   };
 }
 
-/** Map retryable scheduler pressure and store deadlines at local read catches. */
-export function respondIfApiQueryStoreBusy(res: ServerResponse, err: unknown): boolean {
-  return respondIfStoreUnavailable(res, err);
-}
-
 function parseVerifyTimeoutMs(
   raw: unknown,
 ): { value: number | undefined } | { error: string } {
@@ -693,11 +687,12 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
         if (!res.writableEnded) res.end();
         return;
       }
-      if (respondIfApiQueryStoreBusy(res, err)) {
+      const storeUnavailableOutcome = respondIfStoreUnavailable(res, err);
+      if (storeUnavailableOutcome !== null) {
         // Pre-dispatch shedding is a cancellation; a store deadline may have
         // executed and remains an operation failure even though both map to a
         // retryable 503 for the caller.
-        if (err instanceof StoreSchedulerBusyError) tracker.cancel(ctx, err);
+        if (storeUnavailableOutcome === 'not_started') tracker.cancel(ctx, err);
         else tracker.fail(ctx, err);
         return;
       }
@@ -801,7 +796,7 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
       );
       if (typeT) entityRdfType = typeT.o;
     } catch (err: any) {
-      if (respondIfApiQueryStoreBusy(res, err)) return;
+      if (respondIfStoreUnavailable(res, err) !== null) return;
       return jsonResponse(res, 500, {
         error: `Failed to fetch entity triples: ${err.message}`,
       });

--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -389,9 +389,8 @@ export function createApiQueryRequestLifecycle(
   };
 }
 
-/** Map retryable, pre-dispatch read shedding without changing write routes. */
+/** Map retryable scheduler pressure and store deadlines at local read catches. */
 export function respondIfApiQueryStoreBusy(res: ServerResponse, err: unknown): boolean {
-  if (!(err instanceof StoreSchedulerBusyError)) return false;
   return respondIfStoreUnavailable(res, err);
 }
 
@@ -695,10 +694,11 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
         return;
       }
       if (respondIfApiQueryStoreBusy(res, err)) {
-        // Admission shedding means the operation never reached the store. Keep
-        // it visible with the scheduler reason, but do not count it as an
-        // execution failure in dashboard health rates.
-        tracker.cancel(ctx, err);
+        // Pre-dispatch shedding is a cancellation; a store deadline may have
+        // executed and remains an operation failure even though both map to a
+        // retryable 503 for the caller.
+        if (err instanceof StoreSchedulerBusyError) tracker.cancel(ctx, err);
+        else tracker.fail(ctx, err);
         return;
       }
       tracker.fail(ctx, err);

--- a/packages/cli/test/daemon-ka-transport.test.ts
+++ b/packages/cli/test/daemon-ka-transport.test.ts
@@ -7,6 +7,10 @@
 // daemon / storage / native deps.
 import { describe, it, expect } from 'vitest';
 import { ChainRpcTransportError } from '@origintrail-official/dkg-chain';
+import {
+  StoreOperationTimeoutError,
+  StoreSchedulerBusyError,
+} from '@origintrail-official/dkg-storage';
 import { handleKnowledgeAssetsRoutes } from '../src/daemon/routes/knowledge-assets.js';
 import { handleMemoryRoutes } from '../src/daemon/routes/memory.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
@@ -59,6 +63,42 @@ const ACCEPT_PROBE = {
 };
 function publishAgent(extra: Record<string, unknown>) {
   return { probeContextGraphWritePreflight: async () => ACCEPT_PROBE, ...extra };
+}
+
+const STORE_FAILURE_CASES = [
+  {
+    label: 'store timeout',
+    makeError: (operation: string) => new StoreOperationTimeoutError({
+      backend: 'oxigraph-server',
+      operation,
+      timeoutMs: 30_000,
+    }),
+    code: 'STORE_OPERATION_TIMEOUT',
+    outcome: 'indeterminate',
+  },
+  {
+    label: 'scheduler pressure',
+    makeError: (operation: string) => new StoreSchedulerBusyError(
+      'queue_wait_timeout',
+      'normal',
+      operation,
+    ),
+    code: 'STORE_SCHEDULER_BUSY',
+    outcome: 'not_started',
+  },
+] as const;
+
+function expectStoreUnavailableResponse(
+  res: ReturnType<typeof fakeRes>,
+  expected: { code: string; outcome: string },
+): void {
+  expect(res.statusCode).toBe(503);
+  expect(res.headers['Retry-After']).toBe('1');
+  expect(JSON.parse(res.body)).toMatchObject({
+    code: expected.code,
+    retryable: true,
+    outcome: expected.outcome,
+  });
 }
 function exhaustion() {
   const e: any = new Error(
@@ -128,6 +168,62 @@ describe('knowledge-assets publish routes — transport-status mapping (#1329)',
       expect(res.statusCode).toBe(404);
       expect(JSON.parse(res.body).code).toBe('DIRECT_PUBLISH_ROUTE_REMOVED');
       expect(called).toBe(false);
+    });
+  });
+
+  describe.each(STORE_FAILURE_CASES)('$label route mapping', ({ makeError, code, outcome }) => {
+    it('maps the create catch boundary to the shared retryable 503 contract', async () => {
+      const agent = publishAgent({
+        assertion: {
+          history: async () => null,
+          create: async () => { throw makeError('create'); },
+        },
+      });
+      const { res, done } = runKaCtx(
+        'POST',
+        '/api/knowledge-assets',
+        agent,
+        { contextGraphId: 'cg-1', name: 'timeout-create' },
+      );
+
+      await done;
+      expectStoreUnavailableResponse(res, { code, outcome });
+    });
+
+    it('maps the WM mutation catch boundary to the shared retryable 503 contract', async () => {
+      const agent = publishAgent({
+        assertion: {
+          history: async () => ({ state: 'draft-open' }),
+          write: async () => { throw makeError('write'); },
+        },
+      });
+      const { res, done } = runKaCtx(
+        'POST',
+        '/api/knowledge-assets/timeout-write/wm/write',
+        agent,
+        {
+          contextGraphId: 'cg-1',
+          quads: [{ subject: 'http://s', predicate: 'http://p', object: '"o"' }],
+        },
+      );
+
+      await done;
+      expectStoreUnavailableResponse(res, { code, outcome });
+    });
+
+    it('maps the VM publish catch boundary to the shared retryable 503 contract', async () => {
+      const agent = publishAgent({
+        publishFromFinalizedAssertion: async () => { throw makeError('publish'); },
+      });
+      const { res, done } = runKaCtx(
+        'POST',
+        '/api/knowledge-assets/timeout-publish/vm/publish',
+        agent,
+        { contextGraphId: 'cg-1' },
+      );
+
+      await done;
+      expectStoreUnavailableResponse(res, { code, outcome });
     });
   });
 

--- a/packages/cli/test/daemon-ka-transport.test.ts
+++ b/packages/cli/test/daemon-ka-transport.test.ts
@@ -225,6 +225,80 @@ describe('knowledge-assets publish routes — transport-status mapping (#1329)',
       await done;
       expectStoreUnavailableResponse(res, { code, outcome });
     });
+
+    it('preserves partial-create context when the optional SWM tail is unavailable', async () => {
+      const agent = publishAgent({
+        assertion: {
+          history: async () => null,
+          create: async () => {},
+          write: async () => {},
+          finalize: async () => ({
+            merkleRoot: new Uint8Array(32),
+            authorAddress: '0x0000000000000000000000000000000000000001',
+          }),
+          promote: async () => { throw makeError('promote'); },
+        },
+      });
+      const { res, done } = runKaCtx(
+        'POST',
+        '/api/knowledge-assets',
+        agent,
+        {
+          contextGraphId: 'cg-1',
+          name: 'partial-swm',
+          quads: [{ subject: 'http://s', predicate: 'http://p', object: '"o"' }],
+          alsoShareSwm: true,
+        },
+      );
+
+      await done;
+      expectStoreUnavailableResponse(res, { code, outcome });
+      expect(JSON.parse(res.body)).toMatchObject({
+        created: true,
+        name: 'partial-swm',
+        status: 'wm-sealed',
+        phase: 'swm-share',
+        retryAction: 'retry_same_knowledge_asset',
+        retryKnowledgeAssetName: 'partial-swm',
+      });
+    });
+
+    it('preserves partial-create context when the optional VM tail is unavailable', async () => {
+      const agent = publishAgent({
+        assertion: {
+          history: async () => null,
+          create: async () => {},
+          write: async () => {},
+          finalize: async () => ({
+            merkleRoot: new Uint8Array(32),
+            authorAddress: '0x0000000000000000000000000000000000000001',
+          }),
+        },
+        publishFromFinalizedAssertion: async () => { throw makeError('publish'); },
+      });
+      const { res, done } = runKaCtx(
+        'POST',
+        '/api/knowledge-assets',
+        agent,
+        {
+          contextGraphId: 'cg-1',
+          name: 'partial-vm',
+          quads: [{ subject: 'http://s', predicate: 'http://p', object: '"o"' }],
+          alsoPublishVm: true,
+        },
+      );
+
+      await done;
+      expectStoreUnavailableResponse(res, { code, outcome });
+      expect(JSON.parse(res.body)).toMatchObject({
+        created: true,
+        name: 'partial-vm',
+        status: 'wm-sealed',
+        phase: 'vm-publish',
+        retryAction: 'retry_same_knowledge_asset',
+        retryKnowledgeAssetName: 'partial-vm',
+      });
+    });
   });
 
   describe('POST /api/knowledge-assets/batch-rejections/report', () => {

--- a/packages/cli/test/oxigraph-managed.test.ts
+++ b/packages/cli/test/oxigraph-managed.test.ts
@@ -104,7 +104,7 @@ describe('planManagedOxigraph', () => {
     });
     expect(plan!.storeConfigTemplate).toEqual({
       backend: 'sparql-http',
-      options: { managedByDkg: true, timeout: 30_000 },
+      options: { managedByDkg: true, managedOxigraph: true, timeout: 30_000 },
     });
     expect(plan!.queryTimeoutS).toBe(25);
     expect(plan!.clientTimeoutMs).toBe(30_000);
@@ -281,7 +281,11 @@ describe('planManagedOxigraph', () => {
     expect(plan!.readyTimeoutMs).toBeUndefined();
     expect(plan!.queryTimeoutS).toBe(25);
     expect(plan!.clientTimeoutMs).toBe(30_000);
-    expect(plan!.storeConfigTemplate.options).toEqual({ managedByDkg: true, timeout: 30_000 });
+    expect(plan!.storeConfigTemplate.options).toEqual({
+      managedByDkg: true,
+      managedOxigraph: true,
+      timeout: 30_000,
+    });
   });
 
   it('resolveManagedOxigraphPort rejects out-of-range values', () => {
@@ -562,9 +566,11 @@ describe('startManagedOxigraph (real download + real server)', () => {
           backend: 'sparql-http',
           options: {
             managedByDkg: true,
+            managedOxigraph: true,
             timeout: 30_000,
             queryEndpoint: `http://127.0.0.1:${port}/query`,
             updateEndpoint: `http://127.0.0.1:${port}/update`,
+            onClientTimeout: expect.any(Function),
           },
         });
         expect(result!.largeLiteralStorage.directory).toBe(join(dataDir, 'literal-blobs'));

--- a/packages/cli/test/oxigraph-managed.test.ts
+++ b/packages/cli/test/oxigraph-managed.test.ts
@@ -248,7 +248,7 @@ describe('planManagedOxigraph', () => {
       },
       '/data',
     );
-    expect(plan!.queryTimeoutS).toBe(4_294_967);
+    expect(plan!.queryTimeoutS).toBe(2_147_478);
     expect(plan!.clientTimeoutMs).toBe(2_147_483_647);
     expect(plan!.storeConfigTemplate.options.timeout).toBe(2_147_483_647);
   });

--- a/packages/cli/test/oxigraph-managed.test.ts
+++ b/packages/cli/test/oxigraph-managed.test.ts
@@ -104,8 +104,10 @@ describe('planManagedOxigraph', () => {
     });
     expect(plan!.storeConfigTemplate).toEqual({
       backend: 'sparql-http',
-      options: { managedByDkg: true },
+      options: { managedByDkg: true, timeout: 30_000 },
     });
+    expect(plan!.queryTimeoutS).toBe(25);
+    expect(plan!.clientTimeoutMs).toBe(30_000);
   });
 
   it('honours operator overrides for port, location and cacheDir', () => {
@@ -139,7 +141,7 @@ describe('planManagedOxigraph', () => {
     expect(plan!.storeConfigTemplate.options.timeout).toBe(40_000);
   });
 
-  it('honours an independent HTTP client timeout without enabling the native Oxigraph timeout', () => {
+  it('derives a native Oxigraph deadline before a configured HTTP client timeout', () => {
     const plan = planManagedOxigraph(
       {
         store: {
@@ -149,7 +151,7 @@ describe('planManagedOxigraph', () => {
       },
       '/data',
     );
-    expect(plan!.queryTimeoutS).toBeUndefined();
+    expect(plan!.queryTimeoutS).toBe(175);
     expect(plan!.clientTimeoutMs).toBe(180_000);
     expect(plan!.storeConfigTemplate.options.timeout).toBe(180_000);
   });
@@ -167,6 +169,36 @@ describe('planManagedOxigraph', () => {
     expect(plan!.queryTimeoutS).toBe(35);
     expect(plan!.clientTimeoutMs).toBe(120_000);
     expect(plan!.storeConfigTemplate.options.timeout).toBe(120_000);
+  });
+
+  it('extends an unsafe client deadline so the native timeout fires first', () => {
+    const plan = planManagedOxigraph(
+      {
+        store: {
+          backend: MANAGED_OXIGRAPH_BACKEND,
+          options: { queryTimeoutS: 35, clientTimeoutMs: 30_000 },
+        },
+      },
+      '/data',
+    );
+    expect(plan!.queryTimeoutS).toBe(35);
+    expect(plan!.clientTimeoutMs).toBe(40_000);
+    expect(plan!.storeConfigTemplate.options.timeout).toBe(40_000);
+  });
+
+  it('keeps even a very short configured client deadline behind a native timeout', () => {
+    const plan = planManagedOxigraph(
+      {
+        store: {
+          backend: MANAGED_OXIGRAPH_BACKEND,
+          options: { clientTimeoutMs: 2_000 },
+        },
+      },
+      '/data',
+    );
+    expect(plan!.queryTimeoutS).toBe(1);
+    expect(plan!.clientTimeoutMs).toBe(6_000);
+    expect(plan!.storeConfigTemplate.options.timeout).toBe(6_000);
   });
 
   it('plans finite managed Oxigraph memory limits independently of the daemon service', () => {
@@ -231,11 +263,12 @@ describe('planManagedOxigraph', () => {
       },
       '/data',
     );
+    expect(plan!.queryTimeoutS).toBe(2_147_478);
     expect(plan!.clientTimeoutMs).toBe(2_147_483_647);
     expect(plan!.storeConfigTemplate.options.timeout).toBe(2_147_483_647);
   });
 
-  it('ignores invalid managed Oxigraph timeout options', () => {
+  it('falls back to safe managed Oxigraph deadlines for invalid timeout options', () => {
     const plan = planManagedOxigraph(
       {
         store: {
@@ -246,9 +279,9 @@ describe('planManagedOxigraph', () => {
       '/data',
     );
     expect(plan!.readyTimeoutMs).toBeUndefined();
-    expect(plan!.queryTimeoutS).toBeUndefined();
-    expect(plan!.clientTimeoutMs).toBeUndefined();
-    expect(plan!.storeConfigTemplate.options).toEqual({ managedByDkg: true });
+    expect(plan!.queryTimeoutS).toBe(25);
+    expect(plan!.clientTimeoutMs).toBe(30_000);
+    expect(plan!.storeConfigTemplate.options).toEqual({ managedByDkg: true, timeout: 30_000 });
   });
 
   it('resolveManagedOxigraphPort rejects out-of-range values', () => {
@@ -432,7 +465,7 @@ describe('startManagedOxigraph (real download + real server)', () => {
     }
   });
 
-  it('forwards an independent client timeout without passing --timeout-s to Oxigraph', async () => {
+  it('forwards the native deadline derived from a configured client timeout', async () => {
     const dataDir = await mkdtemp(join(tmpdir(), 'oxi-managed-'));
     const port = await freePort();
 
@@ -451,7 +484,9 @@ describe('startManagedOxigraph (real download + real server)', () => {
       expect(result).not.toBeNull();
       expect(result!.storeConfig.options.timeout).toBe(180_000);
       const args = await fetchManagedArgs(port);
-      expect(args).not.toContain('--timeout-s');
+      const timeoutIndex = args.indexOf('--timeout-s');
+      expect(timeoutIndex).toBeGreaterThanOrEqual(0);
+      expect(args[timeoutIndex + 1]).toBe('175');
     } finally {
       await result?.handle.stop();
       await rm(dataDir, { recursive: true, force: true });
@@ -527,6 +562,7 @@ describe('startManagedOxigraph (real download + real server)', () => {
           backend: 'sparql-http',
           options: {
             managedByDkg: true,
+            timeout: 30_000,
             queryEndpoint: `http://127.0.0.1:${port}/query`,
             updateEndpoint: `http://127.0.0.1:${port}/update`,
           },

--- a/packages/cli/test/oxigraph-managed.test.ts
+++ b/packages/cli/test/oxigraph-managed.test.ts
@@ -52,6 +52,11 @@ const srv = http.createServer((req, res) => {
     res.end(JSON.stringify(args));
     return;
   }
+  if (req.url === '/pid') {
+    res.statusCode = 200;
+    res.end(String(process.pid));
+    return;
+  }
   res.statusCode = 200;
   res.setHeader('Content-Type', 'application/sparql-results+json');
   res.end(JSON.stringify({ head: {}, boolean: true }));
@@ -430,6 +435,11 @@ async function fetchManagedArgs(port: number): Promise<string[]> {
   return await res.json() as string[];
 }
 
+async function fetchManagedPid(port: number): Promise<number> {
+  const res = await fetch(`http://127.0.0.1:${port}/pid`);
+  return Number(await res.text());
+}
+
 describe('startManagedOxigraph (real download + real server)', () => {
   it('returns null for non-managed backends', async () => {
     // Contract: a non-managed backend is a no-op — null result, and nothing
@@ -491,6 +501,75 @@ describe('startManagedOxigraph (real download + real server)', () => {
       const timeoutIndex = args.indexOf('--timeout-s');
       expect(timeoutIndex).toBeGreaterThanOrEqual(0);
       expect(args[timeoutIndex + 1]).toBe('175');
+    } finally {
+      await result?.handle.stop();
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it('wires query and construct timeouts to recovery while filtering mutations', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'oxi-managed-'));
+    const port = await freePort();
+    const result = await startManagedOxigraph({
+      config: {
+        store: {
+          backend: MANAGED_OXIGRAPH_BACKEND,
+          options: { port, readyTimeoutMs: 5_000 },
+        },
+      },
+      dataDir,
+      platform: 'freebsd',
+      log: () => {},
+    });
+    try {
+      const onClientTimeout = result!.storeConfig.options.onClientTimeout as (operation: string) => void;
+      const getRecoveryState = result!.storeConfig.options.getRecoveryState as () => {
+        recovering: boolean;
+        generation: number;
+      };
+      const pid1 = await fetchManagedPid(port);
+
+      onClientTimeout('insert');
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      expect(await fetchManagedPid(port)).toBe(pid1);
+      expect(getRecoveryState().generation).toBe(0);
+
+      onClientTimeout('query');
+      expect(getRecoveryState()).toMatchObject({ recovering: true, generation: 1 });
+      let pid2 = 0;
+      for (let i = 0; i < 100; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        try {
+          pid2 = await fetchManagedPid(port);
+          if (pid2 !== pid1) break;
+        } catch {
+          /* server is between processes */
+        }
+      }
+      expect(pid2).toBeGreaterThan(0);
+      expect(pid2).not.toBe(pid1);
+      for (let i = 0; i < 50 && getRecoveryState().recovering; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      expect(getRecoveryState()).toEqual({ recovering: false, generation: 1 });
+
+      onClientTimeout('construct');
+      let pid3 = 0;
+      for (let i = 0; i < 100; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        try {
+          pid3 = await fetchManagedPid(port);
+          if (pid3 !== pid2) break;
+        } catch {
+          /* server is between processes */
+        }
+      }
+      expect(pid3).toBeGreaterThan(0);
+      expect(pid3).not.toBe(pid2);
+      for (let i = 0; i < 50 && getRecoveryState().recovering; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      expect(getRecoveryState()).toEqual({ recovering: false, generation: 2 });
     } finally {
       await result?.handle.stop();
       await rm(dataDir, { recursive: true, force: true });
@@ -570,6 +649,7 @@ describe('startManagedOxigraph (real download + real server)', () => {
             timeout: 30_000,
             queryEndpoint: `http://127.0.0.1:${port}/query`,
             updateEndpoint: `http://127.0.0.1:${port}/update`,
+            getRecoveryState: expect.any(Function),
             onClientTimeout: expect.any(Function),
           },
         });

--- a/packages/cli/test/oxigraph-managed.test.ts
+++ b/packages/cli/test/oxigraph-managed.test.ts
@@ -535,7 +535,9 @@ describe('startManagedOxigraph (real download + real server)', () => {
       expect(getRecoveryState().generation).toBe(0);
 
       onClientTimeout('query');
-      expect(getRecoveryState()).toMatchObject({ recovering: true, generation: 1 });
+      // Ownership verification is asynchronous; an unverified request is not
+      // yet a recovery generation and must not be exposed as one.
+      expect(getRecoveryState()).toEqual({ recovering: false, generation: 0 });
       let pid2 = 0;
       for (let i = 0; i < 100; i++) {
         await new Promise((resolve) => setTimeout(resolve, 50));

--- a/packages/cli/test/oxigraph-server.test.ts
+++ b/packages/cli/test/oxigraph-server.test.ts
@@ -18,7 +18,7 @@
  * production code path; only the supervised binary's identity differs, and
  * the binary's own behaviour is real, not emitted by the test.
  */
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { mkdtemp, rm, writeFile, chmod } from 'node:fs/promises';
 import { createServer, type Server } from 'node:net';
 import { spawn } from 'node:child_process';
@@ -348,6 +348,7 @@ describe('startOxigraphServer (real child processes)', () => {
     try {
       const pid1 = await fetchPid(port);
       expect(handle.requestRestart('query exceeded the managed SPARQL client deadline')).toBe(true);
+      expect(handle.getRecoveryState()).toEqual({ recovering: true, generation: 1 });
       expect(handle.requestRestart('duplicate timeout')).toBe(false);
 
       let pid2 = 0;
@@ -362,7 +363,41 @@ describe('startOxigraphServer (real child processes)', () => {
       }
       expect(pid2, 'supervisor never recovered the explicitly restarted child').toBeGreaterThan(0);
       expect(pid2).not.toBe(pid1);
+      for (let i = 0; i < 50 && handle.getRecoveryState().recovering; i++) await sleep(20);
+      expect(handle.getRecoveryState()).toEqual({ recovering: false, generation: 1 });
       expect(logs.some((line) => line.includes('server terminated for recovery'))).toBe(true);
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  it('cancels recovery without signalling when listener ownership changes', async () => {
+    const port = await freePort();
+    const logs: string[] = [];
+    let reportChangedOwner = false;
+    const killProcess = vi.fn(() => true) as unknown as typeof process.kill;
+    const handle = await startOxigraphServer(startOpts(port, {
+      log: (line: string) => logs.push(line),
+      io: {
+        killProcess,
+        findListenOwnerPid: async (child, listenerPort, host, ownership) => {
+          const actual = await findListenOwnerPid(child, listenerPort, host, ownership);
+          return reportChangedOwner && actual !== null ? actual + 100_000 : actual;
+        },
+      },
+    }));
+    try {
+      const pid = await fetchPid(port);
+      reportChangedOwner = true;
+      expect(handle.requestRestart('ownership-negative-path')).toBe(true);
+
+      for (let i = 0; i < 50 && handle.getRecoveryState().recovering; i++) await sleep(20);
+
+      expect(killProcess).not.toHaveBeenCalled();
+      expect(handle.getRecoveryState().recovering).toBe(false);
+      expect(await fetchPid(port)).toBe(pid);
+      expect(await portAnswers(port)).toBe(true);
+      expect(logs.some((line) => line.includes('ownership changed'))).toBe(true);
     } finally {
       await handle.stop();
     }
@@ -425,6 +460,8 @@ describe('startOxigraphServer (real child processes)', () => {
     const handle = await startOxigraphServer(startOpts(port));
     expect(await portAnswers(port)).toBe(true);
     await handle.stop();
+    expect(handle.getRecoveryState().recovering).toBe(true);
+    expect(handle.requestRestart('after-stop')).toBe(false);
     // Wait well past restartBackoffMaxMs: a buggy supervisor would have
     // respawned by now and the probe would answer.
     await sleep(600);

--- a/packages/cli/test/oxigraph-server.test.ts
+++ b/packages/cli/test/oxigraph-server.test.ts
@@ -28,6 +28,7 @@ import { SparqlHttpStore } from '@origintrail-official/dkg-storage';
 import { startOxigraphServer } from '../src/daemon/oxigraph-server.js';
 import { createOxigraphLaunchStrategy } from '../src/daemon/oxigraph-launch-strategy.js';
 import { OXIGRAPH_WATCHDOG_OOM_MARKER } from '../src/daemon/oxigraph-parent-watchdog.js';
+import { OXIGRAPH_VERSION } from '../src/daemon/oxigraph-binary.js';
 import {
   childOwnsListenPort,
   findListenOwnerPid,
@@ -70,6 +71,21 @@ async function portAnswers(port: number): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+async function executableVersion(binaryPath: string): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(binaryPath, ['--version'], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (chunk) => { stdout += String(chunk); });
+    child.stderr?.on('data', (chunk) => { stderr += String(chunk); });
+    child.once('error', reject);
+    child.once('close', (code) => {
+      if (code === 0) resolve(stdout.trim());
+      else reject(new Error(`Oxigraph --version exited ${code}: ${stderr.trim()}`));
+    });
+  });
 }
 
 beforeAll(async () => {
@@ -437,6 +453,46 @@ describe('startOxigraphServer (real child processes)', () => {
     }
   });
 
+  it.each(['throws', 'returns false'] as const)(
+    'rolls back a restart whose SIGKILL %s and accepts a later request',
+    async (failureMode) => {
+      const port = await freePort();
+      const logs: string[] = [];
+      let signalAttempts = 0;
+      const killProcess = vi.fn(() => {
+        signalAttempts += 1;
+        if (failureMode === 'returns false') return false;
+        const error = new Error('operation not permitted') as NodeJS.ErrnoException;
+        error.code = 'EPERM';
+        throw error;
+      }) as unknown as typeof process.kill;
+      const handle = await startOxigraphServer(startOpts(port, {
+        log: (line: string) => logs.push(line),
+        io: { killProcess },
+      }));
+      try {
+        const pid = await fetchPid(port);
+        expect(handle.requestRestart(`signal failure: ${failureMode}`)).toBe(true);
+        for (let i = 0; i < 50 && signalAttempts < 1; i++) await sleep(20);
+
+        expect(signalAttempts).toBe(1);
+        expect(handle.getRecoveryState()).toEqual({ recovering: false, generation: 0 });
+        expect(await fetchPid(port)).toBe(pid);
+        expect(await portAnswers(port)).toBe(true);
+
+        // Rollback must restore ready, not strand the supervisor in a request
+        // phase that rejects every future recovery attempt.
+        expect(handle.requestRestart(`second signal failure: ${failureMode}`)).toBe(true);
+        for (let i = 0; i < 50 && signalAttempts < 2; i++) await sleep(20);
+        expect(signalAttempts).toBe(2);
+        expect(handle.getRecoveryState()).toEqual({ recovering: false, generation: 0 });
+        expect(logs.filter((line) => line.includes('could not signal')).length).toBe(2);
+      } finally {
+        await handle.stop();
+      }
+    },
+  );
+
   it('targets the verified Oxigraph listener when a systemd-style wrapper owns the child', async () => {
     const port = await freePort();
     const wrapperPids: number[] = [];
@@ -515,6 +571,78 @@ describe('startOxigraphServer (real child processes)', () => {
     expect(await portAnswers(port)).toBe(false);
   });
 });
+
+const nativeOxigraphTestBinary = process.env.DKG_OXIGRAPH_TEST_BINARY;
+
+describe.skipIf(!nativeOxigraphTestBinary)(
+  'managed response completeness (pinned real Oxigraph executable)',
+  () => {
+    it('rejects native-deadline SELECT and CONSTRUCT streams instead of returning partial data', async () => {
+      const binaryPath = nativeOxigraphTestBinary!;
+      expect(await executableVersion(binaryPath)).toBe(`oxigraph ${OXIGRAPH_VERSION}`);
+
+      const location = await mkdtemp(join(tmpdir(), 'oxi-native-timeout-'));
+      const port = await freePort();
+      const handle = await startOxigraphServer({
+        binaryPath,
+        location,
+        port,
+        queryTimeoutS: 1,
+        readyTimeoutMs: 10_000,
+        readyIntervalMs: 50,
+        stopGraceMs: 2_000,
+        restartBackoffBaseMs: 100,
+        restartBackoffMaxMs: 200,
+        log: () => {},
+      });
+      const endpoint = `http://127.0.0.1:${port}`;
+      const store = new SparqlHttpStore({
+        queryEndpoint: `${endpoint}/query`,
+        updateEndpoint: `${endpoint}/update`,
+        managedByDkg: true,
+        managedOxigraph: true,
+        timeout: 10_000,
+      });
+
+      try {
+        await store.insert(Array.from({ length: 100 }, (_, index) => ({
+          subject: `urn:s${index}`,
+          predicate: 'urn:p',
+          object: `"${index}"`,
+          graph: '',
+        })));
+        const expensivePattern = `
+          ?a <urn:p> ?x .
+          ?b <urn:p> ?y .
+          ?c <urn:p> ?z .
+          ?d <urn:p> ?w .
+          FILTER(SHA512(CONCAT(STR(?a), STR(?b), STR(?c), STR(?d))) != "")
+        `;
+
+        await expect(store.query(
+          `SELECT (COUNT(*) AS ?count) WHERE { ${expensivePattern} }`,
+        )).rejects.toMatchObject({
+          code: 'STORE_OPERATION_TIMEOUT',
+          backend: 'oxigraph-server',
+          operation: 'query',
+          outcome: 'indeterminate',
+        });
+        await expect(store.query(
+          `CONSTRUCT { ?a <urn:joined> ?b } WHERE { ${expensivePattern} }`,
+        )).rejects.toMatchObject({
+          code: 'STORE_OPERATION_TIMEOUT',
+          backend: 'oxigraph-server',
+          operation: 'construct',
+          outcome: 'indeterminate',
+        });
+      } finally {
+        await store.close();
+        await handle.stop();
+        await rm(location, { recursive: true, force: true });
+      }
+    }, 30_000);
+  },
+);
 
 describe('startOxigraphServer OOM classification in the restart log', () => {
   // The cgroup OOM readers are the one piece that can't be exercised against a

--- a/packages/cli/test/oxigraph-server.test.ts
+++ b/packages/cli/test/oxigraph-server.test.ts
@@ -341,6 +341,85 @@ describe('startOxigraphServer (real child processes)', () => {
     }
   });
 
+  it('restarts the child on an explicit recovery request and coalesces duplicates', async () => {
+    const port = await freePort();
+    const logs: string[] = [];
+    const handle = await startOxigraphServer(startOpts(port, { log: (line: string) => logs.push(line) }));
+    try {
+      const pid1 = await fetchPid(port);
+      expect(handle.requestRestart('query exceeded the managed SPARQL client deadline')).toBe(true);
+      expect(handle.requestRestart('duplicate timeout')).toBe(false);
+
+      let pid2 = 0;
+      for (let i = 0; i < 100; i++) {
+        await sleep(100);
+        try {
+          pid2 = await fetchPid(port);
+          if (pid2 && pid2 !== pid1) break;
+        } catch {
+          /* recovery is still in progress */
+        }
+      }
+      expect(pid2, 'supervisor never recovered the explicitly restarted child').toBeGreaterThan(0);
+      expect(pid2).not.toBe(pid1);
+      expect(logs.some((line) => line.includes('server terminated for recovery'))).toBe(true);
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  it('targets the verified Oxigraph listener when a systemd-style wrapper owns the child', async () => {
+    const port = await freePort();
+    const wrapperProgram = `
+      const { spawn } = require('node:child_process');
+      const [command, ...args] = process.argv.slice(1);
+      const child = spawn(command, args, { stdio: 'inherit' });
+      process.on('SIGTERM', () => child.kill('SIGTERM'));
+      child.once('exit', (code, signal) => process.exit(signal === 'SIGKILL' ? 137 : (code ?? 1)));
+    `;
+    const injectedSpawn = ((_command: string, args: readonly string[], options: Parameters<typeof spawn>[2]) => {
+      const binaryIndex = args.indexOf(standin);
+      return spawn(
+        process.execPath,
+        ['-e', wrapperProgram, standin, ...args.slice(binaryIndex + 1)],
+        options,
+      );
+    }) as typeof spawn;
+    const handle = await startOxigraphServer(startOpts(port, {
+      memoryLimits: { maxMiB: 256 },
+      platform: 'linux',
+      io: {
+        spawn: injectedSpawn,
+        findListenOwnerPid: async () => await fetchPid(port),
+      },
+    }));
+    try {
+      const pid1 = await fetchPid(port);
+      expect(handle.requestRestart('client deadline fallback')).toBe(true);
+
+      let pid2 = 0;
+      for (let i = 0; i < 100; i++) {
+        await sleep(100);
+        try {
+          pid2 = await fetchPid(port);
+          if (pid2 && pid2 !== pid1) break;
+        } catch {
+          /* recovery is still in progress */
+        }
+      }
+      expect(pid2, 'supervisor did not replace the scoped listener').toBeGreaterThan(0);
+      expect(pid2).not.toBe(pid1);
+    } finally {
+      await handle.stop();
+      // Failure-path cleanup if a regression orphaned the listener behind its wrapper.
+      try {
+        process.kill(await fetchPid(port), 'SIGKILL');
+      } catch {
+        /* port is already free */
+      }
+    }
+  });
+
   it('does NOT restart after stop() — the port stays free past the backoff window', async () => {
     const port = await freePort();
     const handle = await startOxigraphServer(startOpts(port));

--- a/packages/cli/test/oxigraph-server.test.ts
+++ b/packages/cli/test/oxigraph-server.test.ts
@@ -24,6 +24,7 @@ import { createServer, type Server } from 'node:net';
 import { spawn } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { SparqlHttpStore } from '@origintrail-official/dkg-storage';
 import { startOxigraphServer } from '../src/daemon/oxigraph-server.js';
 import { createOxigraphLaunchStrategy } from '../src/daemon/oxigraph-launch-strategy.js';
 import { OXIGRAPH_WATCHDOG_OOM_MARKER } from '../src/daemon/oxigraph-parent-watchdog.js';
@@ -336,6 +337,8 @@ describe('startOxigraphServer (real child processes)', () => {
       }
       expect(pid2, 'supervisor never respawned the crashed child').toBeGreaterThan(0);
       expect(pid2).not.toBe(pid1);
+      for (let i = 0; i < 50 && handle.getRecoveryState().recovering; i++) await sleep(20);
+      expect(handle.getRecoveryState()).toEqual({ recovering: false, generation: 1 });
     } finally {
       await handle.stop();
     }
@@ -348,7 +351,7 @@ describe('startOxigraphServer (real child processes)', () => {
     try {
       const pid1 = await fetchPid(port);
       expect(handle.requestRestart('query exceeded the managed SPARQL client deadline')).toBe(true);
-      expect(handle.getRecoveryState()).toEqual({ recovering: true, generation: 1 });
+      expect(handle.getRecoveryState()).toEqual({ recovering: false, generation: 0 });
       expect(handle.requestRestart('duplicate timeout')).toBe(false);
 
       let pid2 = 0;
@@ -376,6 +379,7 @@ describe('startOxigraphServer (real child processes)', () => {
     const logs: string[] = [];
     let reportChangedOwner = false;
     const killProcess = vi.fn(() => true) as unknown as typeof process.kill;
+    const originalFetch = globalThis.fetch;
     const handle = await startOxigraphServer(startOpts(port, {
       log: (line: string) => logs.push(line),
       io: {
@@ -388,23 +392,55 @@ describe('startOxigraphServer (real child processes)', () => {
     }));
     try {
       const pid = await fetchPid(port);
+      let rejectUpdate!: (error: unknown) => void;
+      let markUpdateStarted!: () => void;
+      const updateStarted = new Promise<void>((resolve) => { markUpdateStarted = resolve; });
+      globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+        if (String(init?.body ?? '').startsWith('INSERT')) {
+          markUpdateStarted();
+          return await new Promise<Response>((_resolve, reject) => { rejectUpdate = reject; });
+        }
+        return await originalFetch(input, init);
+      }) as typeof fetch;
+      const store = new SparqlHttpStore({
+        queryEndpoint: `http://127.0.0.1:${port}/query`,
+        updateEndpoint: `http://127.0.0.1:${port}/update`,
+        managedOxigraph: true,
+        timeout: 5_000,
+        getRecoveryState: () => handle.getRecoveryState(),
+      });
+      const updateFailure = store.insert([{
+        subject: 'http://ex.org/s',
+        predicate: 'http://ex.org/p',
+        object: '"value"',
+        graph: 'http://ex.org/g',
+      }]).catch((error) => error);
+      await updateStarted;
       reportChangedOwner = true;
       expect(handle.requestRestart('ownership-negative-path')).toBe(true);
 
-      for (let i = 0; i < 50 && handle.getRecoveryState().recovering; i++) await sleep(20);
+      for (let i = 0; i < 50 && !logs.some((line) => line.includes('ownership changed')); i++) {
+        await sleep(20);
+      }
 
       expect(killProcess).not.toHaveBeenCalled();
-      expect(handle.getRecoveryState().recovering).toBe(false);
+      expect(handle.getRecoveryState()).toEqual({ recovering: false, generation: 0 });
+      const definitiveError = new Error('definitive backend failure after cancelled restart');
+      rejectUpdate(definitiveError);
+      expect(await updateFailure).toBe(definitiveError);
       expect(await fetchPid(port)).toBe(pid);
       expect(await portAnswers(port)).toBe(true);
       expect(logs.some((line) => line.includes('ownership changed'))).toBe(true);
     } finally {
+      globalThis.fetch = originalFetch;
       await handle.stop();
     }
   });
 
   it('targets the verified Oxigraph listener when a systemd-style wrapper owns the child', async () => {
     const port = await freePort();
+    const wrapperPids: number[] = [];
+    const recoverySignals: Array<{ pid: number; signal: NodeJS.Signals | number }> = [];
     const wrapperProgram = `
       const { spawn } = require('node:child_process');
       const [command, ...args] = process.argv.slice(1);
@@ -414,17 +450,24 @@ describe('startOxigraphServer (real child processes)', () => {
     `;
     const injectedSpawn = ((_command: string, args: readonly string[], options: Parameters<typeof spawn>[2]) => {
       const binaryIndex = args.indexOf(standin);
-      return spawn(
+      const wrapper = spawn(
         process.execPath,
         ['-e', wrapperProgram, standin, ...args.slice(binaryIndex + 1)],
         options,
       );
+      if (wrapper.pid !== undefined) wrapperPids.push(wrapper.pid);
+      return wrapper;
     }) as typeof spawn;
+    const killProcess = ((pid: number, signal?: NodeJS.Signals | number) => {
+      recoverySignals.push({ pid, signal: signal ?? 'SIGTERM' });
+      return process.kill(pid, signal);
+    }) as typeof process.kill;
     const handle = await startOxigraphServer(startOpts(port, {
       memoryLimits: { maxMiB: 256 },
       platform: 'linux',
       io: {
         spawn: injectedSpawn,
+        killProcess,
         findListenOwnerPid: async () => await fetchPid(port),
       },
     }));
@@ -444,6 +487,10 @@ describe('startOxigraphServer (real child processes)', () => {
       }
       expect(pid2, 'supervisor did not replace the scoped listener').toBeGreaterThan(0);
       expect(pid2).not.toBe(pid1);
+      expect(wrapperPids[0]).toBeGreaterThan(0);
+      expect(pid1).not.toBe(wrapperPids[0]);
+      expect(recoverySignals).toContainEqual({ pid: pid1, signal: 'SIGKILL' });
+      expect(recoverySignals.some((entry) => entry.pid === wrapperPids[0])).toBe(false);
     } finally {
       await handle.stop();
       // Failure-path cleanup if a regression orphaned the listener behind its wrapper.

--- a/packages/cli/test/query-route-lifecycle.test.ts
+++ b/packages/cli/test/query-route-lifecycle.test.ts
@@ -1,7 +1,10 @@
 import { EventEmitter } from 'node:events';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { StoreSchedulerBusyError } from '@origintrail-official/dkg-storage';
+import {
+  StoreOperationTimeoutError,
+  StoreSchedulerBusyError,
+} from '@origintrail-official/dkg-storage';
 import {
   configureApiQueryPriority,
   createApiQueryRequestLifecycle,
@@ -14,9 +17,14 @@ import type { RequestContext } from '../src/daemon/routes/context.js';
 class RequestStub extends EventEmitter {
   aborted = false;
   method = 'POST';
-  __dkgPrebufferedBody = Buffer.from(JSON.stringify({
+  __dkgPrebufferedBody: Buffer;
+
+  constructor(body: Record<string, unknown> = {
     sparql: 'SELECT ?s WHERE { ?s ?p ?o }',
-  }));
+  }) {
+    super();
+    this.__dkgPrebufferedBody = Buffer.from(JSON.stringify(body));
+  }
 }
 
 class ResponseStub extends EventEmitter {
@@ -146,6 +154,29 @@ describe('/api/query request lifecycle', () => {
     });
   });
 
+  it('maps store deadlines to retryable HTTP 503', () => {
+    const res = new ResponseStub();
+    const error = new StoreOperationTimeoutError({
+      backend: 'oxigraph-server',
+      operation: 'query',
+      timeoutMs: 30_000,
+    });
+
+    expect(respondIfApiQueryStoreBusy(
+      res as unknown as ServerResponse,
+      error,
+    )).toBe(true);
+    expect(res.statusCode).toBe(503);
+    expect(res.headers['Retry-After']).toBe('1');
+    expect(JSON.parse(res.body)).toMatchObject({
+      code: 'STORE_OPERATION_TIMEOUT',
+      retryable: true,
+      outcome: 'indeterminate',
+      backend: 'oxigraph-server',
+      operation: 'query',
+    });
+  });
+
   it('does not reclassify unrelated route errors', () => {
     const res = new ResponseStub();
     expect(respondIfApiQueryStoreBusy(
@@ -194,6 +225,38 @@ describe('/api/query request lifecycle', () => {
     expect(res.statusCode).toBe(200);
     expect(tracker.complete).toHaveBeenCalledTimes(1);
     expect(tracker.fail).not.toHaveBeenCalled();
+  });
+
+  it('maps a GenUI entity-query store timeout through the route as retryable 503', async () => {
+    const req = new RequestStub({
+      contextGraphId: 'cg-1',
+      entityUri: 'urn:entity:1',
+      libraryPrompt: 'Render the entity',
+    });
+    const res = new ResponseStub();
+    const timeout = new StoreOperationTimeoutError({
+      backend: 'oxigraph-server',
+      operation: 'query',
+      timeoutMs: 30_000,
+    });
+    const ctx = queryRouteContext(req, res, {
+      query: vi.fn(async () => { throw timeout; }),
+    }, {});
+    ctx.path = '/api/genui/render';
+    ctx.url = new URL('http://127.0.0.1/api/genui/render');
+    ctx.config = { llm: { apiKey: 'test-key' } } as RequestContext['config'];
+
+    await handleQueryRoutes(ctx);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.headers['Retry-After']).toBe('1');
+    expect(JSON.parse(res.body)).toMatchObject({
+      code: 'STORE_OPERATION_TIMEOUT',
+      retryable: true,
+      outcome: 'indeterminate',
+      backend: 'oxigraph-server',
+      operation: 'query',
+    });
   });
 
   it('aborts the route signal on disconnect and maps canonical shedding to 503', async () => {

--- a/packages/cli/test/query-route-lifecycle.test.ts
+++ b/packages/cli/test/query-route-lifecycle.test.ts
@@ -142,6 +142,7 @@ describe('/api/query request lifecycle', () => {
       reason: 'queue_wait_timeout',
       priority: 'background',
       retryable: true,
+      outcome: 'not_started',
     });
   });
 

--- a/packages/cli/test/query-route-lifecycle.test.ts
+++ b/packages/cli/test/query-route-lifecycle.test.ts
@@ -10,8 +10,8 @@ import {
   createApiQueryRequestLifecycle,
   handleQueryRoutes,
   resolveApiQueryPriority,
-  respondIfApiQueryStoreBusy,
 } from '../src/daemon/routes/query.js';
+import { respondIfStoreUnavailable } from '../src/daemon/http-utils.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
 
 class RequestStub extends EventEmitter {
@@ -139,10 +139,10 @@ describe('/api/query request lifecycle', () => {
       'api.query',
     );
 
-    expect(respondIfApiQueryStoreBusy(
+    expect(respondIfStoreUnavailable(
       res as unknown as ServerResponse,
       error,
-    )).toBe(true);
+    )).toBe('not_started');
     expect(res.statusCode).toBe(503);
     expect(res.headers['Retry-After']).toBe('1');
     expect(JSON.parse(res.body)).toMatchObject({
@@ -162,10 +162,10 @@ describe('/api/query request lifecycle', () => {
       timeoutMs: 30_000,
     });
 
-    expect(respondIfApiQueryStoreBusy(
+    expect(respondIfStoreUnavailable(
       res as unknown as ServerResponse,
       error,
-    )).toBe(true);
+    )).toBe('indeterminate');
     expect(res.statusCode).toBe(503);
     expect(res.headers['Retry-After']).toBe('1');
     expect(JSON.parse(res.body)).toMatchObject({
@@ -179,18 +179,18 @@ describe('/api/query request lifecycle', () => {
 
   it('does not reclassify unrelated route errors', () => {
     const res = new ResponseStub();
-    expect(respondIfApiQueryStoreBusy(
+    expect(respondIfStoreUnavailable(
       res as unknown as ServerResponse,
       new Error('parse failed'),
-    )).toBe(false);
-    expect(respondIfApiQueryStoreBusy(
+    )).toBeNull();
+    expect(respondIfStoreUnavailable(
       res as unknown as ServerResponse,
       {
         code: 'STORE_SCHEDULER_BUSY',
         reason: 'queue_full',
         priority: 'background',
       },
-    )).toBe(false);
+    )).toBeNull();
     expect(res.writableEnded).toBe(false);
   });
 
@@ -225,6 +225,35 @@ describe('/api/query request lifecycle', () => {
     expect(res.statusCode).toBe(200);
     expect(tracker.complete).toHaveBeenCalledTimes(1);
     expect(tracker.fail).not.toHaveBeenCalled();
+  });
+
+  it('tracks not-started store failures as cancellation and indeterminate failures as failure', async () => {
+    for (const outcome of ['not_started', 'indeterminate'] as const) {
+      const req = new RequestStub();
+      const res = new ResponseStub();
+      const tracker = {
+        start: vi.fn(),
+        startPhase: vi.fn(),
+        completePhase: vi.fn(),
+        complete: vi.fn(),
+        fail: vi.fn(),
+        cancel: vi.fn(),
+      };
+      const error = new StoreOperationTimeoutError({
+        backend: 'oxigraph-server',
+        operation: 'query',
+        outcome,
+      });
+
+      await handleQueryRoutes(queryRouteContext(req, res, {
+        query: vi.fn(async () => { throw error; }),
+      }, tracker));
+
+      expect(res.statusCode).toBe(503);
+      expect(JSON.parse(res.body)).toMatchObject({ outcome });
+      expect(tracker.cancel).toHaveBeenCalledTimes(outcome === 'not_started' ? 1 : 0);
+      expect(tracker.fail).toHaveBeenCalledTimes(outcome === 'indeterminate' ? 1 : 0);
+    }
   });
 
   it('maps a GenUI entity-query store timeout through the route as retryable 503', async () => {

--- a/packages/cli/test/store-unavailable-response.test.ts
+++ b/packages/cli/test/store-unavailable-response.test.ts
@@ -79,9 +79,28 @@ describe('respondIfStoreUnavailable', () => {
     });
   });
 
+  it('accepts a code-only timeout crossing a package/prototype boundary', () => {
+    const res = mockResponse();
+
+    expect(respondIfStoreUnavailable(res, {
+      code: 'STORE_OPERATION_TIMEOUT',
+      message: 'wrapped store timeout',
+    })).toBe(true);
+    expect(JSON.parse(res.body ?? '{}')).toEqual({
+      error: 'wrapped store timeout',
+      code: 'STORE_OPERATION_TIMEOUT',
+      retryable: true,
+      outcome: 'indeterminate',
+    });
+  });
+
   it('does not reclassify unrelated failures', () => {
     const res = mockResponse();
     expect(respondIfStoreUnavailable(res, new Error('invalid query'))).toBe(false);
+    expect(respondIfStoreUnavailable(res, {
+      code: 'STORE_OPERATION_TIMEOUT',
+      outcome: 'completed',
+    })).toBe(false);
     expect(res.writableEnded).toBe(false);
   });
 });

--- a/packages/cli/test/store-unavailable-response.test.ts
+++ b/packages/cli/test/store-unavailable-response.test.ts
@@ -1,0 +1,107 @@
+import type { ServerResponse } from 'node:http';
+import { describe, expect, it } from 'vitest';
+import {
+  StoreOperationTimeoutError,
+  StoreSchedulerBusyError,
+} from '@origintrail-official/dkg-storage';
+import {
+  respondIfStoreUnavailable,
+  respondWithDaemonError,
+} from '../src/daemon/http-utils.js';
+
+function mockResponse(): ServerResponse & {
+  headers: Record<string, string>;
+  body?: string;
+} {
+  return {
+    statusCode: 200,
+    headersSent: false,
+    writableEnded: false,
+    headers: {},
+    writeHead(status: number, headers?: Record<string, string>) {
+      this.statusCode = status;
+      if (headers) Object.assign(this.headers, headers);
+      this.headersSent = true;
+      return this;
+    },
+    setHeader(key: string, value: string) {
+      this.headers[key] = value;
+      return this;
+    },
+    end(body?: string) {
+      this.body = body;
+      this.writableEnded = true;
+      return this;
+    },
+  } as unknown as ServerResponse & { headers: Record<string, string>; body?: string };
+}
+
+describe('respondIfStoreUnavailable', () => {
+  it('maps pre-dispatch scheduler shedding to retryable 503 with a known outcome', () => {
+    const res = mockResponse();
+    const error = new StoreSchedulerBusyError(
+      'queue_wait_timeout',
+      'normal',
+      'knowledge-assets.write',
+    );
+
+    expect(respondIfStoreUnavailable(res, error)).toBe(true);
+    expect(res.statusCode).toBe(503);
+    expect(res.headers['Retry-After']).toBe('1');
+    expect(JSON.parse(res.body ?? '{}')).toMatchObject({
+      code: 'STORE_SCHEDULER_BUSY',
+      reason: 'queue_wait_timeout',
+      priority: 'normal',
+      retryable: true,
+      outcome: 'not_started',
+    });
+  });
+
+  it('maps an adapter deadline to retryable 503 with an indeterminate outcome', () => {
+    const res = mockResponse();
+    const error = new StoreOperationTimeoutError({
+      backend: 'oxigraph-server',
+      operation: 'query',
+      timeoutMs: 30_000,
+    });
+
+    expect(respondIfStoreUnavailable(res, error)).toBe(true);
+    expect(res.statusCode).toBe(503);
+    expect(res.headers['Retry-After']).toBe('1');
+    expect(JSON.parse(res.body ?? '{}')).toEqual({
+      error: 'oxigraph-server query exceeded its store deadline after 30000ms',
+      code: 'STORE_OPERATION_TIMEOUT',
+      retryable: true,
+      outcome: 'indeterminate',
+      backend: 'oxigraph-server',
+      operation: 'query',
+      timeoutMs: 30_000,
+    });
+  });
+
+  it('does not reclassify unrelated failures', () => {
+    const res = mockResponse();
+    expect(respondIfStoreUnavailable(res, new Error('invalid query'))).toBe(false);
+    expect(res.writableEnded).toBe(false);
+  });
+});
+
+describe('respondWithDaemonError store fallback', () => {
+  it('preserves the retryable store-timeout contract at the top-level route boundary', () => {
+    const res = mockResponse();
+    respondWithDaemonError(res, new StoreOperationTimeoutError({
+      backend: 'blazegraph',
+      operation: 'insert',
+      timeoutMs: 30_000,
+    }));
+
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(res.body ?? '{}')).toMatchObject({
+      code: 'STORE_OPERATION_TIMEOUT',
+      retryable: true,
+      outcome: 'indeterminate',
+      backend: 'blazegraph',
+      operation: 'insert',
+    });
+  });
+});

--- a/packages/cli/test/store-unavailable-response.test.ts
+++ b/packages/cli/test/store-unavailable-response.test.ts
@@ -45,7 +45,7 @@ describe('respondIfStoreUnavailable', () => {
       'knowledge-assets.write',
     );
 
-    expect(respondIfStoreUnavailable(res, error)).toBe(true);
+    expect(respondIfStoreUnavailable(res, error)).toBe('not_started');
     expect(res.statusCode).toBe(503);
     expect(res.headers['Retry-After']).toBe('1');
     expect(JSON.parse(res.body ?? '{}')).toMatchObject({
@@ -65,7 +65,7 @@ describe('respondIfStoreUnavailable', () => {
       timeoutMs: 30_000,
     });
 
-    expect(respondIfStoreUnavailable(res, error)).toBe(true);
+    expect(respondIfStoreUnavailable(res, error)).toBe('indeterminate');
     expect(res.statusCode).toBe(503);
     expect(res.headers['Retry-After']).toBe('1');
     expect(JSON.parse(res.body ?? '{}')).toEqual({
@@ -85,7 +85,7 @@ describe('respondIfStoreUnavailable', () => {
     expect(respondIfStoreUnavailable(res, {
       code: 'STORE_OPERATION_TIMEOUT',
       message: 'wrapped store timeout',
-    })).toBe(true);
+    })).toBe('indeterminate');
     expect(JSON.parse(res.body ?? '{}')).toEqual({
       error: 'wrapped store timeout',
       code: 'STORE_OPERATION_TIMEOUT',
@@ -96,11 +96,11 @@ describe('respondIfStoreUnavailable', () => {
 
   it('does not reclassify unrelated failures', () => {
     const res = mockResponse();
-    expect(respondIfStoreUnavailable(res, new Error('invalid query'))).toBe(false);
+    expect(respondIfStoreUnavailable(res, new Error('invalid query'))).toBeNull();
     expect(respondIfStoreUnavailable(res, {
       code: 'STORE_OPERATION_TIMEOUT',
       outcome: 'completed',
-    })).toBe(false);
+    })).toBeNull();
     expect(res.writableEnded).toBe(false);
   });
 });

--- a/packages/cli/test/store-unavailable-response.test.ts
+++ b/packages/cli/test/store-unavailable-response.test.ts
@@ -5,6 +5,7 @@ import {
   StoreSchedulerBusyError,
 } from '@origintrail-official/dkg-storage';
 import {
+  classifyStoreUnavailable,
   respondIfStoreUnavailable,
   respondWithDaemonError,
 } from '../src/daemon/http-utils.js';
@@ -37,6 +38,27 @@ function mockResponse(): ServerResponse & {
 }
 
 describe('respondIfStoreUnavailable', () => {
+  it('classifies without rendering so partial-success routes can extend the body', () => {
+    const classified = classifyStoreUnavailable(new StoreOperationTimeoutError({
+      backend: 'oxigraph-server',
+      operation: 'publish',
+      timeoutMs: 30_000,
+    }));
+
+    expect(classified).toEqual({
+      outcome: 'indeterminate',
+      body: {
+        error: 'oxigraph-server publish exceeded its store deadline after 30000ms',
+        code: 'STORE_OPERATION_TIMEOUT',
+        retryable: true,
+        outcome: 'indeterminate',
+        backend: 'oxigraph-server',
+        operation: 'publish',
+        timeoutMs: 30_000,
+      },
+    });
+  });
+
   it('maps pre-dispatch scheduler shedding to retryable 503 with a known outcome', () => {
     const res = mockResponse();
     const error = new StoreSchedulerBusyError(

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
           'test/backpressure-route.test.ts',
       'test/status-route-store-quads.test.ts',
       'test/query-route-lifecycle.test.ts',
+      'test/store-unavailable-response.test.ts',
           'test/status-command-store.test.ts',
           'test/memory-graph-events.test.ts',
           'test/memory-turn-route.test.ts',

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -117,6 +117,7 @@ function createStoreOperationDeadline(
   timeoutMs: number,
   callerSignal?: AbortSignal,
   operation = 'operation',
+  outcome: () => 'not_started' | 'indeterminate' = () => 'indeterminate',
 ): StoreOperationDeadline {
   const controller = new AbortController();
   const deadlineAt = performance.now() + timeoutMs;
@@ -127,6 +128,7 @@ function createStoreOperationDeadline(
     backend: 'blazegraph',
     operation,
     timeoutMs,
+    outcome: outcome(),
   });
   const detachCaller = () => {
     if (!callerAttached) return;
@@ -220,13 +222,14 @@ export class BlazegraphStore implements TripleStore {
     options: QueryOptions | undefined,
     work: (deadline: StoreOperationDeadline) => Promise<T>,
   ): Promise<T> {
+    let admitted = false;
     const deadline = createStoreOperationDeadline(
       this.operationTimeoutMs,
       options?.signal,
       operation,
+      () => admitted ? 'indeterminate' : 'not_started',
     );
     const source = options?.source ?? `blazegraph.${operation}`;
-    let admitted = false;
     const scheduled = externalStorePriorityScheduler.run(
       options?.priority,
       source,
@@ -457,11 +460,11 @@ export class BlazegraphStore implements TripleStore {
   // -------------------------------------------------------------------
 
   async query(sparql: string, options?: TripleStoreQueryOptions): Promise<QueryResult> {
-    return this.runStoreWork('query', options, async (deadline) => {
-      const trimmed = sparql.trim();
-      const upper = trimmed.toUpperCase();
-      const isAsk = upper.startsWith('ASK');
-      const isConstruct = upper.startsWith('CONSTRUCT') || upper.startsWith('DESCRIBE');
+    const trimmed = sparql.trim();
+    const upper = trimmed.toUpperCase();
+    const isAsk = upper.startsWith('ASK');
+    const isConstruct = upper.startsWith('CONSTRUCT') || upper.startsWith('DESCRIBE');
+    return this.runStoreWork(isConstruct ? 'construct' : 'query', options, async (deadline) => {
 
       if (isConstruct) {
         return this.queryConstruct(trimmed, deadline, options);

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -34,6 +34,7 @@ import {
 import { quadToNQuad } from '../bounded-rdf.js';
 import { readResponseTextBounded } from '../http-response-limit.js';
 import { scanNQuadLines, type NQuadLineScan } from '../nquads-text.js';
+import { StoreOperationTimeoutError } from '../store-operation-timeout.js';
 
 export const DEFAULT_BLAZEGRAPH_OPERATION_TIMEOUT_MS = 30_000;
 
@@ -115,16 +116,18 @@ function abortError(signal: AbortSignal): Error {
 function createStoreOperationDeadline(
   timeoutMs: number,
   callerSignal?: AbortSignal,
+  operation = 'operation',
 ): StoreOperationDeadline {
   const controller = new AbortController();
   const deadlineAt = performance.now() + timeoutMs;
   let timer: ReturnType<typeof setTimeout> | undefined;
   let callerAttached = false;
 
-  const timeoutError = () => new DOMException(
-    `Blazegraph operation exceeded its ${timeoutMs}ms deadline`,
-    'TimeoutError',
-  );
+  const timeoutError = () => new StoreOperationTimeoutError({
+    backend: 'blazegraph',
+    operation,
+    timeoutMs,
+  });
   const detachCaller = () => {
     if (!callerAttached) return;
     callerAttached = false;
@@ -217,7 +220,11 @@ export class BlazegraphStore implements TripleStore {
     options: QueryOptions | undefined,
     work: (deadline: StoreOperationDeadline) => Promise<T>,
   ): Promise<T> {
-    const deadline = createStoreOperationDeadline(this.operationTimeoutMs, options?.signal);
+    const deadline = createStoreOperationDeadline(
+      this.operationTimeoutMs,
+      options?.signal,
+      operation,
+    );
     const source = options?.source ?? `blazegraph.${operation}`;
     let admitted = false;
     const scheduled = externalStorePriorityScheduler.run(

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -124,6 +124,10 @@ export interface SparqlHttpStoreOptions {
    * index/revalidation owner.
    */
   managedByDkg?: boolean;
+  /** Runtime-only marker for a daemon-supervised Oxigraph endpoint. */
+  managedOxigraph?: boolean;
+  /** Runtime-only recovery hook invoked when the HTTP client deadline fires. */
+  onClientTimeout?: (operation: string) => void;
   /**
    * Declare that the endpoint executes a whole multi-operation SPARQL Update
    * request as one transaction (SPARQL 1.1 only RECOMMENDS this). Required for
@@ -154,6 +158,8 @@ export class SparqlHttpStore implements TripleStore {
   private readonly timeout: number;
   private readonly headers: Record<string, string>;
   private readonly managedByDkg: boolean;
+  private readonly managedOxigraph: boolean;
+  private readonly onClientTimeout?: (operation: string) => void;
   private readonly atomicUpdates: boolean;
 
   private readonly now: () => number;
@@ -178,7 +184,9 @@ export class SparqlHttpStore implements TripleStore {
     this.updateEndpoint = (options.updateEndpoint ?? options.queryEndpoint).replace(/\/$/, '');
     this.timeout = options.timeout ?? DEFAULT_SPARQL_HTTP_TIMEOUT_MS;
     this.managedByDkg = options.managedByDkg === true;
-    this.atomicUpdates = options.atomicUpdates === true || this.managedByDkg;
+    this.managedOxigraph = options.managedOxigraph === true || this.managedByDkg;
+    this.onClientTimeout = options.onClientTimeout;
+    this.atomicUpdates = options.atomicUpdates === true || this.managedOxigraph;
     this.now = options.now ?? monotonicNow;
     this.slowQueryThresholdMs = normalizeNonNegativeNumber(
       options.slowQueryThresholdMs,
@@ -214,6 +222,14 @@ export class SparqlHttpStore implements TripleStore {
     );
   }
 
+  private notifyClientTimeout(operation: string): void {
+    try {
+      this.onClientTimeout?.(operation);
+    } catch {
+      // Recovery notification must never replace the typed timeout contract.
+    }
+  }
+
   getPressureSnapshot(): StorePressureSnapshot {
     return externalStorePriorityScheduler.snapshot;
   }
@@ -226,6 +242,7 @@ export class SparqlHttpStore implements TripleStore {
   private async postQuery<T>(
     sparql: string,
     accept: string,
+    operation: 'query' | 'construct',
     options: SparqlHttpQueryOptions | undefined,
     consume: (response: Response) => Promise<T>,
   ): Promise<T> {
@@ -257,14 +274,15 @@ export class SparqlHttpStore implements TripleStore {
     } catch (error) {
       if (signal.aborted) {
         getMetrics().storeCancellationCompletedTotal.add(1, {
-          operation: 'query',
-          source: options?.source ?? 'sparql-http.query',
+          operation,
+          source: options?.source ?? `sparql-http.${operation}`,
         });
       }
       if (timeoutSignal.aborted) {
+        this.notifyClientTimeout(operation);
         throw new StoreOperationTimeoutError({
-          backend: this.managedByDkg ? 'oxigraph-server' : 'sparql-http',
-          operation: 'query',
+          backend: this.managedOxigraph ? 'oxigraph-server' : 'sparql-http',
+          operation,
           timeoutMs: this.timeout,
           cause: error,
         });
@@ -311,8 +329,9 @@ export class SparqlHttpStore implements TripleStore {
           });
         }
         if (timeoutSignal.aborted) {
+          this.notifyClientTimeout(operation);
           throw new StoreOperationTimeoutError({
-            backend: this.managedByDkg ? 'oxigraph-server' : 'sparql-http',
+            backend: this.managedOxigraph ? 'oxigraph-server' : 'sparql-http',
             operation,
             timeoutMs: this.timeout,
             cause: error,
@@ -571,12 +590,13 @@ export class SparqlHttpStore implements TripleStore {
         return await this.postQuery(
           trimmed,
           'application/sparql-results+json',
+          'query',
           effectiveOptions,
           async (res) => {
             if (!res.ok) {
               const text = await readSparqlResponseText(res, {
                 maxResponseBytes: effectiveOptions.maxResponseBytes,
-                managedOxigraph: this.managedByDkg,
+                managedOxigraph: this.managedOxigraph,
                 operation: 'query',
                 tolerateReadFailure: true,
               });
@@ -585,7 +605,7 @@ export class SparqlHttpStore implements TripleStore {
 
             const text = await readSparqlResponseText(res, {
               maxResponseBytes: effectiveOptions.maxResponseBytes,
-              managedOxigraph: this.managedByDkg,
+              managedOxigraph: this.managedOxigraph,
               operation: 'query',
             });
             const json = JSON.parse(text) as AdapterSparqlJsonSelectResponse | W3CAskResponse;
@@ -615,12 +635,13 @@ export class SparqlHttpStore implements TripleStore {
     return this.postQuery(
       sparql,
       'application/n-quads, text/n-quads',
+      'construct',
       options,
       async (res) => {
         if (!res.ok) {
           const text = await readSparqlResponseText(res, {
             maxResponseBytes: options?.maxResponseBytes,
-            managedOxigraph: this.managedByDkg,
+            managedOxigraph: this.managedOxigraph,
             operation: 'construct',
             tolerateReadFailure: true,
           });
@@ -628,7 +649,7 @@ export class SparqlHttpStore implements TripleStore {
         }
         const text = await readSparqlResponseText(res, {
           maxResponseBytes: options?.maxResponseBytes,
-          managedOxigraph: this.managedByDkg,
+          managedOxigraph: this.managedOxigraph,
           operation: 'construct',
         });
         const quads = parseNQuadsTextTolerant(text);

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -103,6 +103,11 @@ export interface SparqlHttpSlowQueryEvent {
   queryBytes: number;
 }
 
+export interface SparqlHttpRecoveryState {
+  recovering: boolean;
+  generation: number;
+}
+
 export interface SparqlHttpStoreOptions {
   /** SPARQL query endpoint URL (required). */
   queryEndpoint: string;
@@ -128,6 +133,8 @@ export interface SparqlHttpStoreOptions {
   managedOxigraph?: boolean;
   /** Runtime-only recovery hook invoked when the HTTP client deadline fires. */
   onClientTimeout?: (operation: string) => void;
+  /** Runtime-only managed-server state used to classify restart collateral. */
+  getRecoveryState?: () => SparqlHttpRecoveryState;
   /**
    * Declare that the endpoint executes a whole multi-operation SPARQL Update
    * request as one transaction (SPARQL 1.1 only RECOMMENDS this). Required for
@@ -160,6 +167,7 @@ export class SparqlHttpStore implements TripleStore {
   private readonly managedByDkg: boolean;
   private readonly managedOxigraph: boolean;
   private readonly onClientTimeout?: (operation: string) => void;
+  private readonly getRecoveryState?: () => SparqlHttpRecoveryState;
   private readonly atomicUpdates: boolean;
 
   private readonly now: () => number;
@@ -186,6 +194,7 @@ export class SparqlHttpStore implements TripleStore {
     this.managedByDkg = options.managedByDkg === true;
     this.managedOxigraph = options.managedOxigraph === true || this.managedByDkg;
     this.onClientTimeout = options.onClientTimeout;
+    this.getRecoveryState = options.getRecoveryState;
     this.atomicUpdates = options.atomicUpdates === true || this.managedOxigraph;
     this.now = options.now ?? monotonicNow;
     this.slowQueryThresholdMs = normalizeNonNegativeNumber(
@@ -211,6 +220,10 @@ export class SparqlHttpStore implements TripleStore {
     options: QueryOptions | undefined,
     work: (signal: AbortSignal | undefined) => Promise<T>,
   ): Promise<T> {
+    const recovery = this.readRecoveryState();
+    if (recovery?.recovering) {
+      return Promise.reject(this.recoveryError(operation, 'not_started'));
+    }
     return this.workLifecycle.run(
       options?.signal,
       (signal) => externalStorePriorityScheduler.run(
@@ -219,6 +232,47 @@ export class SparqlHttpStore implements TripleStore {
         () => work(signal),
         signal,
       ),
+    );
+  }
+
+  private readRecoveryState(): SparqlHttpRecoveryState | null {
+    if (!this.managedOxigraph || !this.getRecoveryState) return null;
+    try {
+      const state = this.getRecoveryState();
+      if (
+        typeof state?.recovering === 'boolean'
+        && Number.isSafeInteger(state.generation)
+        && state.generation >= 0
+      ) return state;
+    } catch {
+      // A broken observability hook must not replace the endpoint's real result.
+    }
+    return null;
+  }
+
+  private recoveryError(
+    operation: string,
+    outcome: 'not_started' | 'indeterminate',
+    cause?: unknown,
+  ): StoreOperationTimeoutError {
+    return new StoreOperationTimeoutError({
+      backend: 'oxigraph-server',
+      operation,
+      outcome,
+      message: outcome === 'not_started'
+        ? `Managed Oxigraph is recovering; ${operation} was not started`
+        : `Managed Oxigraph recovery interrupted ${operation}; outcome is indeterminate`,
+      cause,
+    });
+  }
+
+  private recoveryInterrupted(
+    started: SparqlHttpRecoveryState | null,
+  ): boolean {
+    const current = this.readRecoveryState();
+    return current !== null && (
+      current.recovering
+      || (started !== null && current.generation !== started.generation)
     );
   }
 
@@ -246,6 +300,10 @@ export class SparqlHttpStore implements TripleStore {
     options: SparqlHttpQueryOptions | undefined,
     consume: (response: Response) => Promise<T>,
   ): Promise<T> {
+    const recoveryAtStart = this.readRecoveryState();
+    if (recoveryAtStart?.recovering) {
+      throw this.recoveryError(operation, 'not_started');
+    }
     // Direct POST (W3C SPARQL 1.1 Protocol §2.1.3): the query is the raw
     // request body with `application/sparql-query`, not URL-encoded form
     // data. Form-encoded bodies (`query=...`) are parsed by the server's
@@ -287,6 +345,9 @@ export class SparqlHttpStore implements TripleStore {
           cause: error,
         });
       }
+      if (this.recoveryInterrupted(recoveryAtStart)) {
+        throw this.recoveryError(operation, 'indeterminate', error);
+      }
       throw error;
     } finally {
       signalScope.dispose();
@@ -302,6 +363,10 @@ export class SparqlHttpStore implements TripleStore {
     // request body with `application/sparql-update`, not URL-encoded form
     // data. See postQuery for why form encoding breaks large payloads.
     return this.runStoreWork(operation, options, async (lifecycleSignal) => {
+      const recoveryAtStart = this.readRecoveryState();
+      if (recoveryAtStart?.recovering) {
+        throw this.recoveryError(operation, 'not_started');
+      }
       const timeoutSignal = AbortSignal.timeout(this.timeout);
       const signalScope = composeAbortSignals(lifecycleSignal, timeoutSignal);
       const signal = signalScope.signal ?? timeoutSignal;
@@ -336,6 +401,9 @@ export class SparqlHttpStore implements TripleStore {
             timeoutMs: this.timeout,
             cause: error,
           });
+        }
+        if (this.recoveryInterrupted(recoveryAtStart)) {
+          throw this.recoveryError(operation, 'indeterminate', error);
         }
         throw error;
       } finally {

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -48,7 +48,6 @@ import {
   isAtomicGraphReplaceStagingGraph,
 } from '../atomic-graph-replace.js';
 import { UnsupportedTripleStoreCapabilityError } from '../unsupported-capability-error.js';
-import { readResponseTextBounded } from '../http-response-limit.js';
 import {
   assertQuadLiteralsMutf8Safe,
   classifySparqlOperation,
@@ -57,12 +56,10 @@ import {
 } from '@origintrail-official/dkg-core';
 import { createHash } from 'node:crypto';
 import { performance } from 'node:perf_hooks';
-import {
-  AbortableStoreWorkLifecycle,
-  composeAbortSignals,
-} from '../abortable-store-work-lifecycle.js';
+import { AbortableStoreWorkLifecycle, composeAbortSignals } from '../abortable-store-work-lifecycle.js';
 import { parseNQuadsTextTolerant } from '../nquads-text.js';
 import { StoreOperationTimeoutError } from '../store-operation-timeout.js';
+import { readSparqlResponseText } from './sparql-response-policy.js';
 
 function throwIfAborted(signal: AbortSignal | undefined): void {
   if (!signal?.aborted) return;
@@ -88,11 +85,7 @@ function raceAgainstAbort<T>(work: Promise<T>, signal: AbortSignal | undefined):
 const DEFAULT_SLOW_QUERY_THRESHOLD_MS = 10_000;
 const DEFAULT_SLOW_QUERY_SAMPLE_RATE = 1;
 const MANAGED_LIST_GRAPHS_CACHE_MS = 30_000;
-// Oxigraph 0.5.x appends this exact evaluator error to an already-started
-// SELECT/CONSTRUCT response when `serve --timeout-s` cancels the query. Detect
-// the suffix before JSON/N-Quads parsing so a partial response can never be
-// mistaken for a complete result.
-const MANAGED_OXIGRAPH_CANCELLATION_SUFFIX = 'The SPARQL operation has been cancelled';
+export const DEFAULT_SPARQL_HTTP_TIMEOUT_MS = 30_000;
 const monotonicNow = (): number => performance.now();
 
 export interface SparqlHttpQueryOptions extends QueryOptions {
@@ -183,7 +176,7 @@ export class SparqlHttpStore implements TripleStore {
     }
     this.queryEndpoint = options.queryEndpoint.replace(/\/$/, '');
     this.updateEndpoint = (options.updateEndpoint ?? options.queryEndpoint).replace(/\/$/, '');
-    this.timeout = options.timeout ?? 30_000;
+    this.timeout = options.timeout ?? DEFAULT_SPARQL_HTTP_TIMEOUT_MS;
     this.managedByDkg = options.managedByDkg === true;
     this.atomicUpdates = options.atomicUpdates === true || this.managedByDkg;
     this.now = options.now ?? monotonicNow;
@@ -223,19 +216,6 @@ export class SparqlHttpStore implements TripleStore {
 
   getPressureSnapshot(): StorePressureSnapshot {
     return externalStorePriorityScheduler.snapshot;
-  }
-
-  private throwIfManagedOxigraphQueryCancelled(text: string, operation: string): void {
-    if (
-      this.managedByDkg
-      && text.trimEnd().endsWith(MANAGED_OXIGRAPH_CANCELLATION_SUFFIX)
-    ) {
-      throw new StoreOperationTimeoutError({
-        backend: 'oxigraph-server',
-        operation,
-        message: `Managed Oxigraph ${operation} exceeded its server-side query deadline`,
-      });
-    }
   }
 
   /** {@link GraphWriteGenSource} capability (#1609) — see graph-write-gen.ts. */
@@ -594,18 +574,20 @@ export class SparqlHttpStore implements TripleStore {
           effectiveOptions,
           async (res) => {
             if (!res.ok) {
-              const text = await (effectiveOptions.maxResponseBytes === undefined
-                ? res.text()
-                : readResponseTextBounded(res, effectiveOptions.maxResponseBytes)
-              ).catch(() => '');
-              this.throwIfManagedOxigraphQueryCancelled(text, 'query');
+              const text = await readSparqlResponseText(res, {
+                maxResponseBytes: effectiveOptions.maxResponseBytes,
+                managedOxigraph: this.managedByDkg,
+                operation: 'query',
+                tolerateReadFailure: true,
+              });
               throw new Error(`SPARQL HTTP query failed (${res.status}): ${text.slice(0, 300)}`);
             }
 
-            const text = effectiveOptions.maxResponseBytes === undefined
-              ? await res.text()
-              : await readResponseTextBounded(res, effectiveOptions.maxResponseBytes);
-            this.throwIfManagedOxigraphQueryCancelled(text, 'query');
+            const text = await readSparqlResponseText(res, {
+              maxResponseBytes: effectiveOptions.maxResponseBytes,
+              managedOxigraph: this.managedByDkg,
+              operation: 'query',
+            });
             const json = JSON.parse(text) as AdapterSparqlJsonSelectResponse | W3CAskResponse;
 
             if (isAsk || 'boolean' in json) {
@@ -636,17 +618,19 @@ export class SparqlHttpStore implements TripleStore {
       options,
       async (res) => {
         if (!res.ok) {
-          const text = await (options?.maxResponseBytes === undefined
-            ? res.text()
-            : readResponseTextBounded(res, options.maxResponseBytes)
-          ).catch(() => '');
-          this.throwIfManagedOxigraphQueryCancelled(text, 'construct');
+          const text = await readSparqlResponseText(res, {
+            maxResponseBytes: options?.maxResponseBytes,
+            managedOxigraph: this.managedByDkg,
+            operation: 'construct',
+            tolerateReadFailure: true,
+          });
           throw new Error(`SPARQL HTTP construct failed (${res.status}): ${text.slice(0, 300)}`);
         }
-        const text = options?.maxResponseBytes === undefined
-          ? await res.text()
-          : await readResponseTextBounded(res, options.maxResponseBytes);
-        this.throwIfManagedOxigraphQueryCancelled(text, 'construct');
+        const text = await readSparqlResponseText(res, {
+          maxResponseBytes: options?.maxResponseBytes,
+          managedOxigraph: this.managedByDkg,
+          operation: 'construct',
+        });
         const quads = parseNQuadsTextTolerant(text);
         return { type: 'quads', quads };
       },

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -62,6 +62,7 @@ import {
   composeAbortSignals,
 } from '../abortable-store-work-lifecycle.js';
 import { parseNQuadsTextTolerant } from '../nquads-text.js';
+import { StoreOperationTimeoutError } from '../store-operation-timeout.js';
 
 function throwIfAborted(signal: AbortSignal | undefined): void {
   if (!signal?.aborted) return;
@@ -87,6 +88,11 @@ function raceAgainstAbort<T>(work: Promise<T>, signal: AbortSignal | undefined):
 const DEFAULT_SLOW_QUERY_THRESHOLD_MS = 10_000;
 const DEFAULT_SLOW_QUERY_SAMPLE_RATE = 1;
 const MANAGED_LIST_GRAPHS_CACHE_MS = 30_000;
+// Oxigraph 0.5.x appends this exact evaluator error to an already-started
+// SELECT/CONSTRUCT response when `serve --timeout-s` cancels the query. Detect
+// the suffix before JSON/N-Quads parsing so a partial response can never be
+// mistaken for a complete result.
+const MANAGED_OXIGRAPH_CANCELLATION_SUFFIX = 'The SPARQL operation has been cancelled';
 const monotonicNow = (): number => performance.now();
 
 export interface SparqlHttpQueryOptions extends QueryOptions {
@@ -219,6 +225,19 @@ export class SparqlHttpStore implements TripleStore {
     return externalStorePriorityScheduler.snapshot;
   }
 
+  private throwIfManagedOxigraphQueryCancelled(text: string, operation: string): void {
+    if (
+      this.managedByDkg
+      && text.trimEnd().endsWith(MANAGED_OXIGRAPH_CANCELLATION_SUFFIX)
+    ) {
+      throw new StoreOperationTimeoutError({
+        backend: 'oxigraph-server',
+        operation,
+        message: `Managed Oxigraph ${operation} exceeded its server-side query deadline`,
+      });
+    }
+  }
+
   /** {@link GraphWriteGenSource} capability (#1609) — see graph-write-gen.ts. */
   getWriteGen(graphPrefix: string): number {
     return this.writeGen.getWriteGen(graphPrefix);
@@ -262,6 +281,14 @@ export class SparqlHttpStore implements TripleStore {
           source: options?.source ?? 'sparql-http.query',
         });
       }
+      if (timeoutSignal.aborted) {
+        throw new StoreOperationTimeoutError({
+          backend: this.managedByDkg ? 'oxigraph-server' : 'sparql-http',
+          operation: 'query',
+          timeoutMs: this.timeout,
+          cause: error,
+        });
+      }
       throw error;
     } finally {
       signalScope.dispose();
@@ -301,6 +328,14 @@ export class SparqlHttpStore implements TripleStore {
           getMetrics().storeCancellationCompletedTotal.add(1, {
             operation,
             source: options?.source ?? `sparql-http.${operation}`,
+          });
+        }
+        if (timeoutSignal.aborted) {
+          throw new StoreOperationTimeoutError({
+            backend: this.managedByDkg ? 'oxigraph-server' : 'sparql-http',
+            operation,
+            timeoutMs: this.timeout,
+            cause: error,
           });
         }
         throw error;
@@ -563,14 +598,15 @@ export class SparqlHttpStore implements TripleStore {
                 ? res.text()
                 : readResponseTextBounded(res, effectiveOptions.maxResponseBytes)
               ).catch(() => '');
+              this.throwIfManagedOxigraphQueryCancelled(text, 'query');
               throw new Error(`SPARQL HTTP query failed (${res.status}): ${text.slice(0, 300)}`);
             }
 
-            const json = effectiveOptions.maxResponseBytes === undefined
-              ? await res.json() as AdapterSparqlJsonSelectResponse | W3CAskResponse
-              : JSON.parse(
-                  await readResponseTextBounded(res, effectiveOptions.maxResponseBytes),
-                ) as AdapterSparqlJsonSelectResponse | W3CAskResponse;
+            const text = effectiveOptions.maxResponseBytes === undefined
+              ? await res.text()
+              : await readResponseTextBounded(res, effectiveOptions.maxResponseBytes);
+            this.throwIfManagedOxigraphQueryCancelled(text, 'query');
+            const json = JSON.parse(text) as AdapterSparqlJsonSelectResponse | W3CAskResponse;
 
             if (isAsk || 'boolean' in json) {
               return {
@@ -604,11 +640,13 @@ export class SparqlHttpStore implements TripleStore {
             ? res.text()
             : readResponseTextBounded(res, options.maxResponseBytes)
           ).catch(() => '');
+          this.throwIfManagedOxigraphQueryCancelled(text, 'construct');
           throw new Error(`SPARQL HTTP construct failed (${res.status}): ${text.slice(0, 300)}`);
         }
         const text = options?.maxResponseBytes === undefined
           ? await res.text()
           : await readResponseTextBounded(res, options.maxResponseBytes);
+        this.throwIfManagedOxigraphQueryCancelled(text, 'construct');
         const quads = parseNQuadsTextTolerant(text);
         return { type: 'quads', quads };
       },

--- a/packages/storage/src/adapters/sparql-response-policy.ts
+++ b/packages/storage/src/adapters/sparql-response-policy.ts
@@ -1,0 +1,42 @@
+import { readResponseTextBounded } from '../http-response-limit.js';
+import { StoreOperationTimeoutError } from '../store-operation-timeout.js';
+
+// Oxigraph 0.5.x appends this evaluator error to an already-started
+// SELECT/CONSTRUCT response when `serve --timeout-s` cancels the query.
+const MANAGED_OXIGRAPH_CANCELLATION_SUFFIX = 'The SPARQL operation has been cancelled';
+
+export interface SparqlResponseTextOptions {
+  maxResponseBytes?: number;
+  managedOxigraph?: boolean;
+  operation: string;
+  tolerateReadFailure?: boolean;
+}
+
+/**
+ * Read a SPARQL response body under the configured size bound and apply the
+ * endpoint-specific completeness policy before a generic adapter parses it.
+ *
+ * Managed Oxigraph may commit HTTP 200 and stream a partial result before its
+ * native evaluator deadline fires. Reject its cancellation suffix here so no
+ * SELECT/CONSTRUCT decoder can mistake that prefix for a complete response.
+ */
+export async function readSparqlResponseText(
+  response: Response,
+  options: SparqlResponseTextOptions,
+): Promise<string> {
+  const read = options.maxResponseBytes === undefined
+    ? response.text()
+    : readResponseTextBounded(response, options.maxResponseBytes);
+  const text = options.tolerateReadFailure ? await read.catch(() => '') : await read;
+  if (
+    options.managedOxigraph === true
+    && text.trimEnd().endsWith(MANAGED_OXIGRAPH_CANCELLATION_SUFFIX)
+  ) {
+    throw new StoreOperationTimeoutError({
+      backend: 'oxigraph-server',
+      operation: options.operation,
+      message: `Managed Oxigraph ${options.operation} exceeded its server-side query deadline`,
+    });
+  }
+  return text;
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -53,6 +53,12 @@ export {
   type StoreSchedulerBusyReason,
 } from './store-priority-scheduler.js';
 export {
+  STORE_OPERATION_TIMEOUT_CODE,
+  StoreOperationTimeoutError,
+  isStoreOperationTimeoutError,
+  type StoreOperationTimeoutErrorOptions,
+} from './store-operation-timeout.js';
+export {
   EXTERNAL_LITERAL_REF_DATATYPE,
   SHARED_MEMORY_GRAPH_SUFFIX,
   DEFAULT_LARGE_LITERAL_THRESHOLD_BYTES,

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -57,6 +57,8 @@ export {
   StoreOperationTimeoutError,
   isStoreOperationTimeoutError,
   type StoreOperationTimeoutErrorOptions,
+  type StoreOperationTimeoutErrorLike,
+  type StoreOperationOutcome,
 } from './store-operation-timeout.js';
 export {
   EXTERNAL_LITERAL_REF_DATATYPE,
@@ -116,6 +118,7 @@ export {
 } from './adapters/blazegraph.js';
 export {
   SparqlHttpStore,
+  DEFAULT_SPARQL_HTTP_TIMEOUT_MS,
   type SparqlHttpStoreOptions,
   type SparqlHttpQueryOptions,
   type SparqlHttpSlowQueryEvent,

--- a/packages/storage/src/store-operation-timeout.ts
+++ b/packages/storage/src/store-operation-timeout.ts
@@ -1,9 +1,28 @@
 export const STORE_OPERATION_TIMEOUT_CODE = 'STORE_OPERATION_TIMEOUT' as const;
 
+export type StoreOperationOutcome = 'not_started' | 'indeterminate';
+
+/**
+ * Structural timeout shape accepted across package/prototype boundaries.
+ * Only `code` is required; every other field is optional because the guard
+ * deliberately supports older or re-wrapped errors that retained the stable
+ * code but not the concrete class prototype or metadata.
+ */
+export interface StoreOperationTimeoutErrorLike {
+  code: typeof STORE_OPERATION_TIMEOUT_CODE;
+  retryable?: true;
+  message?: string;
+  backend?: string;
+  operation?: string;
+  timeoutMs?: number;
+  outcome?: StoreOperationOutcome;
+}
+
 export interface StoreOperationTimeoutErrorOptions {
   backend: string;
   operation: string;
   timeoutMs?: number;
+  outcome?: StoreOperationOutcome;
   message?: string;
   cause?: unknown;
 }
@@ -15,12 +34,13 @@ export interface StoreOperationTimeoutErrorOptions {
  * that already recognize the platform timeout shape; `code` is the stable DKG
  * contract used by HTTP routes and async job classifiers.
  */
-export class StoreOperationTimeoutError extends Error {
+export class StoreOperationTimeoutError extends Error implements StoreOperationTimeoutErrorLike {
   readonly code = STORE_OPERATION_TIMEOUT_CODE;
   readonly retryable = true as const;
   readonly backend: string;
   readonly operation: string;
   readonly timeoutMs?: number;
+  readonly outcome: StoreOperationOutcome;
 
   constructor(options: StoreOperationTimeoutErrorOptions) {
     const suffix = options.timeoutMs === undefined ? '' : ` after ${options.timeoutMs}ms`;
@@ -33,14 +53,26 @@ export class StoreOperationTimeoutError extends Error {
     this.backend = options.backend;
     this.operation = options.operation;
     this.timeoutMs = options.timeoutMs;
+    this.outcome = options.outcome ?? 'indeterminate';
   }
 }
 
 export function isStoreOperationTimeoutError(
   error: unknown,
-): error is StoreOperationTimeoutError {
-  if (error instanceof StoreOperationTimeoutError) return true;
+): error is StoreOperationTimeoutErrorLike {
   if (!error || typeof error !== 'object') return false;
-  const shaped = error as { code?: unknown; retryable?: unknown };
-  return shaped.code === STORE_OPERATION_TIMEOUT_CODE && shaped.retryable !== false;
+  const shaped = error as Record<string, unknown>;
+  return shaped.code === STORE_OPERATION_TIMEOUT_CODE
+    && (shaped.retryable === undefined || shaped.retryable === true)
+    && (shaped.message === undefined || typeof shaped.message === 'string')
+    && (shaped.backend === undefined || typeof shaped.backend === 'string')
+    && (shaped.operation === undefined || typeof shaped.operation === 'string')
+    && (shaped.timeoutMs === undefined || (
+      typeof shaped.timeoutMs === 'number' && Number.isFinite(shaped.timeoutMs)
+    ))
+    && (
+      shaped.outcome === undefined
+      || shaped.outcome === 'not_started'
+      || shaped.outcome === 'indeterminate'
+    );
 }

--- a/packages/storage/src/store-operation-timeout.ts
+++ b/packages/storage/src/store-operation-timeout.ts
@@ -1,0 +1,46 @@
+export const STORE_OPERATION_TIMEOUT_CODE = 'STORE_OPERATION_TIMEOUT' as const;
+
+export interface StoreOperationTimeoutErrorOptions {
+  backend: string;
+  operation: string;
+  timeoutMs?: number;
+  message?: string;
+  cause?: unknown;
+}
+
+/**
+ * Typed retryable deadline failure emitted by triple-store adapters.
+ *
+ * `name` intentionally remains `TimeoutError` for compatibility with callers
+ * that already recognize the platform timeout shape; `code` is the stable DKG
+ * contract used by HTTP routes and async job classifiers.
+ */
+export class StoreOperationTimeoutError extends Error {
+  readonly code = STORE_OPERATION_TIMEOUT_CODE;
+  readonly retryable = true as const;
+  readonly backend: string;
+  readonly operation: string;
+  readonly timeoutMs?: number;
+
+  constructor(options: StoreOperationTimeoutErrorOptions) {
+    const suffix = options.timeoutMs === undefined ? '' : ` after ${options.timeoutMs}ms`;
+    super(
+      options.message
+        ?? `${options.backend} ${options.operation} exceeded its store deadline${suffix}`,
+      options.cause === undefined ? undefined : { cause: options.cause },
+    );
+    this.name = 'TimeoutError';
+    this.backend = options.backend;
+    this.operation = options.operation;
+    this.timeoutMs = options.timeoutMs;
+  }
+}
+
+export function isStoreOperationTimeoutError(
+  error: unknown,
+): error is StoreOperationTimeoutError {
+  if (error instanceof StoreOperationTimeoutError) return true;
+  if (!error || typeof error !== 'object') return false;
+  const shaped = error as { code?: unknown; retryable?: unknown };
+  return shaped.code === STORE_OPERATION_TIMEOUT_CODE && shaped.retryable !== false;
+}

--- a/packages/storage/test/blazegraph.unit.test.ts
+++ b/packages/storage/test/blazegraph.unit.test.ts
@@ -382,7 +382,12 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     const s = new BlazegraphStore(baseUrl, { timeout: 20 });
 
     const outcome = await outcomeWithin(run(s), 200);
-    expect(outcome).toMatchObject({ name: 'TimeoutError' });
+    expect(outcome).toMatchObject({
+      name: 'TimeoutError',
+      code: 'STORE_OPERATION_TIMEOUT',
+      retryable: true,
+      backend: 'blazegraph',
+    });
     expect(seenSignal?.aborted).toBe(true);
   });
 

--- a/packages/storage/test/blazegraph.unit.test.ts
+++ b/packages/storage/test/blazegraph.unit.test.ts
@@ -5,7 +5,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { performance } from 'node:perf_hooks';
 import { BlazegraphStore } from '../src/adapters/blazegraph.js';
-import { getExternalStorePrioritySchedulerSnapshot } from '../src/store-priority-scheduler.js';
+import {
+  externalStorePriorityScheduler,
+  getExternalStorePrioritySchedulerSnapshot,
+} from '../src/store-priority-scheduler.js';
 
 async function waitForCondition(
   predicate: () => boolean,
@@ -355,23 +358,27 @@ describe('BlazegraphStore (mocked HTTP)', () => {
   it.each([
     {
       name: 'SELECT',
+      operation: 'query',
       run: (store: BlazegraphStore) => store.query('SELECT ?s WHERE { ?s ?p ?o }'),
     },
     {
       name: 'CONSTRUCT',
+      operation: 'construct',
       run: (store: BlazegraphStore) => store.query('CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }'),
     },
     {
       name: 'UPDATE',
+      operation: 'update',
       run: (store: BlazegraphStore) => store.update('DELETE WHERE { ?s ?p ?o }'),
     },
     {
       name: 'bulk insert',
+      operation: 'insert',
       run: (store: BlazegraphStore) => store.insert([
         { subject: 'http://s', predicate: 'http://p', object: '"o"', graph: 'http://g' },
       ]),
     },
-  ])('applies its end-to-end timeout to an in-flight $name fetch', async ({ run }) => {
+  ])('applies its end-to-end timeout to an in-flight $name fetch', async ({ operation, run }) => {
     let seenSignal: AbortSignal | undefined;
     setFetch(async (_url, init) => {
       seenSignal = init?.signal ?? undefined;
@@ -387,8 +394,43 @@ describe('BlazegraphStore (mocked HTTP)', () => {
       code: 'STORE_OPERATION_TIMEOUT',
       retryable: true,
       backend: 'blazegraph',
+      operation,
+      timeoutMs: 20,
+      outcome: 'indeterminate',
     });
     expect(seenSignal?.aborted).toBe(true);
+  });
+
+  it('classifies a deadline that expires before scheduler admission as not started', async () => {
+    const maxConcurrent = getExternalStorePrioritySchedulerSnapshot().maxConcurrent;
+    const releases: Array<() => void> = [];
+    const blockers = Array.from({ length: maxConcurrent }, (_, index) =>
+      externalStorePriorityScheduler.run('ack', `test.blocker.${index}`, () =>
+        new Promise<void>((resolve) => {
+          releases.push(resolve);
+        })));
+    try {
+      await waitForCondition(
+        () => releases.length === maxConcurrent,
+        'scheduler blockers were not all admitted',
+      );
+      const store = new BlazegraphStore(baseUrl, { timeout: 20 });
+      const outcome = await outcomeWithin(store.insert([
+        { subject: 'http://s', predicate: 'http://p', object: '"o"', graph: 'http://g' },
+      ]), 200);
+
+      expect(outcome).toMatchObject({
+        code: 'STORE_OPERATION_TIMEOUT',
+        backend: 'blazegraph',
+        operation: 'insert',
+        timeoutMs: 20,
+        outcome: 'not_started',
+      });
+      expect(fetchCalls).toHaveLength(0);
+    } finally {
+      releases.forEach((release) => release());
+      await Promise.all(blockers);
+    }
   });
 
   it('reports TimeoutError when fetch rejects after the deadline clock but before its timer runs', async () => {

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -397,6 +397,38 @@ describe('SparqlHttpStore (test server)', () => {
     }
   });
 
+  it('emits complete timeout metadata for a timed-out mutation', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          'abort',
+          () => reject(init.signal?.reason),
+          { once: true },
+        );
+      })) as typeof fetch;
+    try {
+      const store = new SparqlHttpStore({
+        queryEndpoint: 'http://example.test/query',
+        updateEndpoint: 'http://example.test/update',
+        timeout: 5,
+      });
+      await expect(store.insert([
+        { subject: 'http://s', predicate: 'http://p', object: '"o"', graph: 'http://g' },
+      ])).rejects.toMatchObject({
+        name: 'TimeoutError',
+        code: 'STORE_OPERATION_TIMEOUT',
+        retryable: true,
+        backend: 'sparql-http',
+        operation: 'insert',
+        timeoutMs: 5,
+        outcome: 'indeterminate',
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('rejects a partial managed Oxigraph SELECT response when the native deadline cancels it', async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = (async () => new Response(
@@ -440,6 +472,53 @@ describe('SparqlHttpStore (test server)', () => {
         backend: 'oxigraph-server',
         operation: 'construct',
       });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('rejects a managed Oxigraph cancellation body on a non-OK response', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(
+      'query failed\nThe SPARQL operation has been cancelled',
+      { status: 500 },
+    )) as typeof fetch;
+    try {
+      const managed = new SparqlHttpStore({
+        queryEndpoint: 'http://managed-oxigraph.test/query',
+        managedByDkg: true,
+      });
+      await expect(managed.query('SELECT ?s WHERE { ?s ?p ?o }')).rejects.toMatchObject({
+        code: 'STORE_OPERATION_TIMEOUT',
+        backend: 'oxigraph-server',
+        operation: 'query',
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('does not apply the managed Oxigraph cancellation policy to generic endpoints', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(
+      'query failed\nThe SPARQL operation has been cancelled',
+      { status: 500 },
+    )) as typeof fetch;
+    try {
+      const generic = new SparqlHttpStore({
+        queryEndpoint: 'http://generic-sparql.test/query',
+      });
+      let failure: unknown;
+      try {
+        await generic.query('SELECT ?s WHERE { ?s ?p ?o }');
+      } catch (error) {
+        failure = error;
+      }
+      expect(failure).toBeInstanceOf(Error);
+      expect(failure).toMatchObject({
+        message: expect.stringContaining('SPARQL HTTP query failed (500)'),
+      });
+      expect((failure as { code?: unknown }).code).toBeUndefined();
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -459,6 +459,94 @@ describe('SparqlHttpStore (test server)', () => {
     }
   });
 
+  it('classifies a concurrent write and new work during query-triggered recovery', async () => {
+    const originalFetch = globalThis.fetch;
+    let recovery = { recovering: false, generation: 0 };
+    let fetchCalls = 0;
+    let resolveQueryStarted!: () => void;
+    let resolveUpdateStarted!: () => void;
+    let rejectUpdate!: (error: unknown) => void;
+    const queryStarted = new Promise<void>((resolve) => { resolveQueryStarted = resolve; });
+    const updateStarted = new Promise<void>((resolve) => { resolveUpdateStarted = resolve; });
+
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+      fetchCalls += 1;
+      const body = String(init?.body ?? '');
+      if (recovery.generation > 0 && !recovery.recovering) {
+        return new Response(JSON.stringify({ head: {}, boolean: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/sparql-results+json' },
+        });
+      }
+      if (body.startsWith('INSERT')) {
+        resolveUpdateStarted();
+        return await new Promise<Response>((_resolve, reject) => {
+          rejectUpdate = reject;
+          init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), { once: true });
+        });
+      }
+      resolveQueryStarted();
+      return await new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), { once: true });
+      });
+    }) as typeof fetch;
+
+    try {
+      const managed = new SparqlHttpStore({
+        queryEndpoint: 'http://managed-oxigraph.test/query',
+        updateEndpoint: 'http://managed-oxigraph.test/update',
+        managedOxigraph: true,
+        timeout: 100,
+        getRecoveryState: () => recovery,
+        onClientTimeout: (operation) => {
+          if (operation !== 'query') return;
+          recovery = { recovering: true, generation: 1 };
+          rejectUpdate(new TypeError('fetch failed: managed server restarted'));
+        },
+      });
+
+      const query = managed.query('SELECT ?s WHERE { ?s ?p ?o }');
+      const queryFailure = query.catch((error) => error);
+      await queryStarted;
+      const update = managed.insert([{
+        subject: 'http://ex.org/s',
+        predicate: 'http://ex.org/p',
+        object: '"value"',
+        graph: 'http://ex.org/g',
+      }]);
+      const updateFailure = update.catch((error) => error);
+      await updateStarted;
+
+      expect(await queryFailure).toMatchObject({
+        code: 'STORE_OPERATION_TIMEOUT',
+        operation: 'query',
+        outcome: 'indeterminate',
+      });
+      expect(await updateFailure).toMatchObject({
+        code: 'STORE_OPERATION_TIMEOUT',
+        backend: 'oxigraph-server',
+        operation: 'insert',
+        outcome: 'indeterminate',
+      });
+
+      await expect(managed.query('ASK { ?s ?p ?o }')).rejects.toMatchObject({
+        code: 'STORE_OPERATION_TIMEOUT',
+        operation: 'query',
+        outcome: 'not_started',
+      });
+      expect(fetchCalls).toBe(2);
+
+      recovery = { recovering: false, generation: 1 };
+      await expect(managed.query('ASK { ?s ?p ?o }')).resolves.toMatchObject({
+        type: 'boolean',
+        value: true,
+      });
+      expect(fetchCalls).toBe(3);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('rejects a partial managed Oxigraph SELECT response when the native deadline cancels it', async () => {
     const originalFetch = globalThis.fetch;
     const onClientTimeout = vi.fn();

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -379,13 +379,67 @@ describe('SparqlHttpStore (test server)', () => {
     }) as typeof fetch;
     try {
       const store = new SparqlHttpStore({ queryEndpoint: 'http://example.test/query', timeout: 5 });
-      await expect(store.query('SELECT ?s WHERE { ?s ?p ?o }')).rejects.toBeDefined();
+      await expect(store.query('SELECT ?s WHERE { ?s ?p ?o }')).rejects.toMatchObject({
+        name: 'TimeoutError',
+        code: 'STORE_OPERATION_TIMEOUT',
+        retryable: true,
+        backend: 'sparql-http',
+        operation: 'query',
+      });
       expect(active).toBe(0);
 
       await expect(store.query('SELECT ?s WHERE { ?s ?p ?o }')).resolves.toMatchObject({
         type: 'bindings',
       });
       expect(maxActive).toBe(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('rejects a partial managed Oxigraph SELECT response when the native deadline cancels it', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(
+      '{"head":{"vars":["s"]},"results":{"bindings":[The SPARQL operation has been cancelled',
+      { status: 200, headers: { 'Content-Type': 'application/sparql-results+json' } },
+    )) as typeof fetch;
+    try {
+      const managed = new SparqlHttpStore({
+        queryEndpoint: 'http://managed-oxigraph.test/query',
+        managedByDkg: true,
+      });
+      await expect(managed.query('SELECT ?s WHERE { ?s ?p ?o }')).rejects.toMatchObject({
+        name: 'TimeoutError',
+        code: 'STORE_OPERATION_TIMEOUT',
+        retryable: true,
+        backend: 'oxigraph-server',
+        operation: 'query',
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('rejects rather than parsing a partial managed Oxigraph CONSTRUCT response', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(
+      '<http://s> <http://p> "partial" <http://g> .\nThe SPARQL operation has been cancelled',
+      { status: 200, headers: { 'Content-Type': 'application/n-quads' } },
+    )) as typeof fetch;
+    try {
+      const managed = new SparqlHttpStore({
+        queryEndpoint: 'http://managed-oxigraph.test/query',
+        managedByDkg: true,
+      });
+      await expect(
+        managed.query('CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }'),
+      ).rejects.toMatchObject({
+        name: 'TimeoutError',
+        code: 'STORE_OPERATION_TIMEOUT',
+        retryable: true,
+        backend: 'oxigraph-server',
+        operation: 'construct',
+      });
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -429,8 +429,39 @@ describe('SparqlHttpStore (test server)', () => {
     }
   });
 
+  it('notifies managed Oxigraph recovery when the client query deadline fires', async () => {
+    const originalFetch = globalThis.fetch;
+    const timedOutOperations: string[] = [];
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          'abort',
+          () => reject(init.signal?.reason),
+          { once: true },
+        );
+      })) as typeof fetch;
+    try {
+      const store = new SparqlHttpStore({
+        queryEndpoint: 'http://managed-oxigraph.test/query',
+        managedOxigraph: true,
+        timeout: 5,
+        onClientTimeout: (operation) => timedOutOperations.push(operation),
+      });
+      await expect(store.query('SELECT ?s WHERE { ?s ?p ?o }')).rejects.toMatchObject({
+        code: 'STORE_OPERATION_TIMEOUT',
+        backend: 'oxigraph-server',
+        operation: 'query',
+        timeoutMs: 5,
+      });
+      expect(timedOutOperations).toEqual(['query']);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('rejects a partial managed Oxigraph SELECT response when the native deadline cancels it', async () => {
     const originalFetch = globalThis.fetch;
+    const onClientTimeout = vi.fn();
     globalThis.fetch = (async () => new Response(
       '{"head":{"vars":["s"]},"results":{"bindings":[The SPARQL operation has been cancelled',
       { status: 200, headers: { 'Content-Type': 'application/sparql-results+json' } },
@@ -439,6 +470,7 @@ describe('SparqlHttpStore (test server)', () => {
       const managed = new SparqlHttpStore({
         queryEndpoint: 'http://managed-oxigraph.test/query',
         managedByDkg: true,
+        onClientTimeout,
       });
       await expect(managed.query('SELECT ?s WHERE { ?s ?p ?o }')).rejects.toMatchObject({
         name: 'TimeoutError',
@@ -447,7 +479,35 @@ describe('SparqlHttpStore (test server)', () => {
         backend: 'oxigraph-server',
         operation: 'query',
       });
+      expect(onClientTimeout).not.toHaveBeenCalled();
     } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('preserves managed Oxigraph timeout semantics behind GraphSetIndexStore', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(
+      'query failed\nThe SPARQL operation has been cancelled',
+      { status: 500 },
+    )) as typeof fetch;
+    const managed = await createTripleStore({
+      backend: 'sparql-http',
+      options: {
+        queryEndpoint: 'http://managed-oxigraph.test/query',
+        managedByDkg: true,
+        managedOxigraph: true,
+      },
+      graphSetIndex: true,
+    });
+    try {
+      await expect(managed.query('SELECT ?s WHERE { ?s ?p ?o }')).rejects.toMatchObject({
+        code: 'STORE_OPERATION_TIMEOUT',
+        backend: 'oxigraph-server',
+        operation: 'query',
+      });
+    } finally {
+      await managed.close();
       globalThis.fetch = originalFetch;
     }
   });

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -547,6 +547,50 @@ describe('SparqlHttpStore (test server)', () => {
     }
   });
 
+  it('classifies an in-flight write after recovery has already completed', async () => {
+    const originalFetch = globalThis.fetch;
+    let recovery = { recovering: false, generation: 0 };
+    let rejectWrite!: (error: unknown) => void;
+    let markWriteStarted!: () => void;
+    const writeStarted = new Promise<void>((resolve) => { markWriteStarted = resolve; });
+    globalThis.fetch = (async () => await new Promise<Response>((_resolve, reject) => {
+      rejectWrite = reject;
+      markWriteStarted();
+    })) as typeof fetch;
+
+    try {
+      const managed = new SparqlHttpStore({
+        queryEndpoint: 'http://managed-oxigraph.test/query',
+        updateEndpoint: 'http://managed-oxigraph.test/update',
+        managedOxigraph: true,
+        timeout: 5_000,
+        getRecoveryState: () => recovery,
+      });
+      const writeFailure = managed.insert([{
+        subject: 'http://ex.org/s',
+        predicate: 'http://ex.org/p',
+        object: '"value"',
+        graph: 'http://ex.org/g',
+      }]).catch((error) => error);
+      await writeStarted;
+
+      // The transport rejects only after the supervisor is healthy again.
+      // The generation change is therefore the sole evidence that this
+      // in-flight write crossed a recovery boundary.
+      recovery = { recovering: false, generation: 1 };
+      rejectWrite(new TypeError('socket closed by completed recovery'));
+
+      expect(await writeFailure).toMatchObject({
+        code: 'STORE_OPERATION_TIMEOUT',
+        backend: 'oxigraph-server',
+        operation: 'insert',
+        outcome: 'indeterminate',
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('rejects a partial managed Oxigraph SELECT response when the native deadline cancels it', async () => {
     const originalFetch = globalThis.fetch;
     const onClientTimeout = vi.fn();


### PR DESCRIPTION
## Summary

- launch managed Oxigraph with a 25s native query deadline and 30s client deadline by default
- derive a safe native deadline from operator client-timeout overrides, and keep the client deadline at least 5s later
- reject Oxigraph 0.5.x streamed cancellation bodies before partial SELECT/CONSTRUCT results can be parsed as complete
- recover a managed Oxigraph process when its later HTTP client deadline fires, covering evaluator paths that do not honor native cancellation promptly
- expose typed retryable store-timeout errors for managed Oxigraph, generic SPARQL HTTP, and Blazegraph
- return a consistent 503 contract from query and Knowledge Asset routes:
  - `STORE_SCHEDULER_BUSY` / `outcome: not_started`
  - `STORE_OPERATION_TIMEOUT` / `outcome: indeterminate`
- document the backend-specific deadline behavior and safe idempotent retry guidance

## Why

An SPARQL HTTP client timeout closes the request but does not guarantee that a managed Oxigraph query stops executing. Oxigraph's native deadline cancels cooperative evaluator paths first. If that has not completed before the later client deadline, DKG re-verifies ownership of the local listener, terminates only the managed Oxigraph process, and lets the existing supervisor restart it. This prevents a pathological query from leaving the store stalled indefinitely.

Blazegraph is covered by the same typed HTTP/DEVX contract. Its existing 30s client / 120s server deadline remains intentionally wider because Blazegraph may stream a partial 200 response when its server deadline fires. DKG does not restart operator-managed Blazegraph instances.

## Upgrade note

The normal daemon restart during a 10.0.14 update is required so managed Oxigraph is relaunched with `--timeout-s` and the recovery hook. No new operator setting is required for the safe defaults.

## Validation

- all 7 review threads addressed, replied to, and resolved
- CLI full suite before the recovery follow-up: 232 files passed, 3,411 tests passed, 12 skipped
- storage full suite after the recovery follow-up: 490 passed, 27 skipped
- managed Oxigraph + real-process supervisor suites: 44 passed, 1 skipped; targeted supervisor rerun: 18 passed, 1 skipped
- real Oxigraph 0.5.8 Cartesian fallback test: typed timeout at 1,004ms, recovery requested and completed, immediate ASK succeeded after restart
- systemd-style wrapper test proves recovery targets the verified Oxigraph listener PID rather than only its wrapper
- route coverage includes GenUI plus create/WM/VM Knowledge Asset timeout boundaries
- CLI typecheck passed; storage build/typecheck passed; git diff check passed
