### PR TITLE
fix(node-ui): load and execute profile query catalogs

### DIFF
--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -625,12 +625,14 @@ export function postQueryDeduped(body: Record<string, unknown>): Promise<{ resul
   return promise;
 }
 
+export type QueryExecutionView = 'working-memory' | 'shared-working-memory' | 'verifiable-memory';
+
 export const executeQuery = (
   sparql: string,
   contextGraphId?: string,
   includeSharedMemory?: boolean,
   graphSuffix?: '_shared_memory',
-  view?: 'verified-memory' | 'shared-working-memory',
+  view?: QueryExecutionView,
   // Opt the CG-scoped allow-list into the assertion partitions. Without it the
   // daemon restricts `GRAPH ?g { … }` to the static set
   // { <cg>, <cg>/_meta, <cg>/_shared_memory_meta } (see the long note on
@@ -679,6 +681,20 @@ export const writeProfileQueryCatalog = (
   post<any>('/api/profile/query-catalog/write', {
     contextGraphId,
     quads,
+  });
+
+export interface ProfileQueryCatalogReadResponse {
+  contextGraphId: string;
+  graph: string;
+  result: {
+    type: 'bindings';
+    bindings: Array<Record<string, unknown>>;
+  };
+}
+
+export const readProfileQueryCatalog = (contextGraphId: string) =>
+  post<ProfileQueryCatalogReadResponse>('/api/profile/query-catalog/read', {
+    contextGraphId,
   });
 
 // --- Knowledge Assets (OT-RFC-43 §10.5 — GitHub-shaped KA surface) ---

--- a/packages/node-ui/src/ui/hooks/useProjectProfile.ts
+++ b/packages/node-ui/src/ui/hooks/useProjectProfile.ts
@@ -11,7 +11,7 @@
  * default profile — this keeps the UI functional for any project.
  */
 import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
-import { executeQuery } from '../api.js';
+import { executeQuery, readProfileQueryCatalog, type QueryExecutionView } from '../api.js';
 import { ROOT_SLUG_SENTINEL } from '../lib/subGraphs.js';
 
 async function runProjectQuery(
@@ -24,6 +24,13 @@ async function runProjectQuery(
   // Preserve the raw shape here — `stripLiteral` / `stripIri` normalise
   // each cell via `bindingValue`, which handles both.
   return ((r?.result?.bindings as any[]) ?? []) as Array<Record<string, unknown>>;
+}
+
+async function readProjectQueryCatalog(
+  contextGraphId: string,
+): Promise<Array<Record<string, unknown>>> {
+  const response = await readProfileQueryCatalog(contextGraphId);
+  return response.result.bindings;
 }
 
 export interface SubGraphBinding {
@@ -103,6 +110,8 @@ export interface SavedQuery {
   sparql: string;
   resultColumn: string;
   rank: number;
+  /** Memory projection required by this query contract. */
+  view?: QueryExecutionView;
 }
 
 export interface QueryCatalog {
@@ -271,43 +280,33 @@ WHERE {
 GROUP BY ?chip ?subGraph ?type ?predicate ?label`;
 }
 
-function buildQueryCatalogsQuery(contextGraphId: string): string {
-  return `PREFIX prof: <${PROFILE_NS}>
-PREFIX schema: <http://schema.org/>
-SELECT ?catalog ?subGraph ?name ?description ?rank
-WHERE {
-  GRAPH ?g {
-    ?catalog a prof:QueryCatalog ;
-             prof:forSubGraph ?subGraph .
-    OPTIONAL { ?catalog prof:displayName ?name }
-    OPTIONAL { ?catalog schema:description ?description }
-    OPTIONAL { ?catalog prof:rank ?rank }
-  }
-  ${metaGraphFilter(contextGraphId)}
-}`;
-}
-
-function buildSavedQueriesQuery(contextGraphId: string): string {
-  return `PREFIX prof: <${PROFILE_NS}>
-PREFIX schema: <http://schema.org/>
-SELECT ?q ?subGraph ?catalog ?name ?description ?sparql ?column ?rank
-WHERE {
-  GRAPH ?g {
-    ?q a prof:SavedQuery ;
-       prof:forSubGraph ?subGraph ;
-       prof:sparqlQuery ?sparql .
-    OPTIONAL { ?q prof:inCatalog ?catalog }
-    OPTIONAL { ?q prof:displayName ?name }
-    OPTIONAL { ?q schema:description ?description }
-    OPTIONAL { ?q prof:resultColumn ?column }
-    OPTIONAL { ?q prof:rank ?rank }
-  }
-  ${metaGraphFilter(contextGraphId)}
-}`;
-}
-
 interface QueryCatalogRowShape extends Record<string, unknown> {}
 interface SavedQueryRowShape extends Record<string, unknown> {}
+
+function savedQueryExecutionView(
+  row: SavedQueryRowShape,
+  queryIri: string,
+  catalogIri: string,
+): QueryExecutionView | undefined {
+  const declared = stripLiteral(row.executionView ?? row.view);
+  if (
+    declared === 'working-memory'
+    || declared === 'shared-working-memory'
+    || declared === 'verifiable-memory'
+  ) {
+    return declared;
+  }
+
+  // ListenerBoi's query contracts are authored against its projected working
+  // memory. The Rust typed adapter already pins this same view; keep the Node
+  // UI compatible with existing v1-v3 catalogs, which predate an explicit
+  // executionView triple in the profile schema.
+  if (queryIri.startsWith('urn:listenerboi:query:') || catalogIri.startsWith('urn:listenerboi:catalog:')) {
+    return 'working-memory';
+  }
+
+  return undefined;
+}
 
 export function buildQueryCatalogState(
   catalogRows: readonly QueryCatalogRowShape[],
@@ -354,6 +353,7 @@ export function buildQueryCatalogState(
         sparql: stripLiteral(row.sparql),
         resultColumn: stripLiteral(row.column) || '',
         rank: parseInt10(row.rank) || 99,
+        view: savedQueryExecutionView(row, qIri, catalogIri),
       };
     })
     .filter(q => q.subGraph && q.sparql)
@@ -494,14 +494,17 @@ export function useProjectProfile(contextGraphId: string | undefined): ProjectPr
       setLoading(true);
       setError(undefined);
       try {
-        const [rootRows, sgRows, typeRows, viewRows, chipRows, catalogRows, queryRows] = await Promise.all([
+        const [rootRows, sgRows, typeRows, viewRows, chipRows, queryCatalogRows] = await Promise.all([
           runProjectQuery(buildProfileRootQuery(contextGraphId), contextGraphId).catch(() => []),
           runProjectQuery(buildSubGraphBindingsQuery(contextGraphId), contextGraphId).catch(() => []),
           runProjectQuery(buildTypeBindingsQuery(contextGraphId), contextGraphId).catch(() => []),
           runProjectQuery(buildViewConfigsQuery(contextGraphId), contextGraphId).catch(() => []),
           runProjectQuery(buildFilterChipsQuery(contextGraphId), contextGraphId).catch(() => []),
-          runProjectQuery(buildQueryCatalogsQuery(contextGraphId), contextGraphId).catch(() => []),
-          runProjectQuery(buildSavedQueriesQuery(contextGraphId), contextGraphId).catch(() => []),
+          // Query catalogs live in the local `.../meta/query-catalog` graph,
+          // which is intentionally outside the scoped `/api/query` graph
+          // allow-list. Use the dedicated profile endpoint so persisted
+          // catalogs are not silently mistaken for an empty result.
+          readProjectQueryCatalog(contextGraphId),
         ]);
         if (cancelled) return;
 
@@ -597,6 +600,17 @@ export function useProjectProfile(contextGraphId: string | undefined): ProjectPr
         }
         chipsBySgRef.current = chipsBySg;
 
+        const catalogRows = queryCatalogRows.map(row => ({
+          catalog: row.catalog,
+          subGraph: row.subGraph,
+          name: row.catalogName,
+          description: row.catalogDescription,
+          rank: row.catalogRank,
+        }));
+        const queryRows = queryCatalogRows.map(row => ({
+          ...row,
+          column: row.resultColumn,
+        }));
         const queryCatalogState = buildQueryCatalogState(catalogRows, queryRows);
         setQueryCatalogs(queryCatalogState.queryCatalogs);
         setSavedQueries(queryCatalogState.savedQueries);

--- a/packages/node-ui/src/ui/views/project/components/query.tsx
+++ b/packages/node-ui/src/ui/views/project/components/query.tsx
@@ -348,16 +348,18 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
   const runQuery = useCallback(() => {
     const next = draftQuery.trim();
     if (!next) return;
-    setActiveCatalogQueryKey(null);
+    const rerunningCatalogQuery = activeCatalogQueryKey !== null && next === activeQuery;
+    const nextView = rerunningCatalogQuery ? activeQueryView : undefined;
+    if (!rerunningCatalogQuery) setActiveCatalogQueryKey(null);
     setSaveMessage(null);
     setSaveError(null);
-    if (next === activeQuery && activeQueryView === undefined) {
+    if (next === activeQuery && activeQueryView === nextView) {
       refresh();
       return;
     }
-    setActiveQueryView(undefined);
+    setActiveQueryView(nextView);
     setActiveQuery(next);
-  }, [activeQuery, activeQueryView, draftQuery, refresh]);
+  }, [activeCatalogQueryKey, activeQuery, activeQueryView, draftQuery, refresh]);
 
   const resetQuery = useCallback(() => {
     setDraftQuery(defaultQuery);

--- a/packages/node-ui/src/ui/views/project/components/query.tsx
+++ b/packages/node-ui/src/ui/views/project/components/query.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState, useCallback, useEffect } from 'react';
 import type { ReactNode } from 'react';
 import { useFetch } from '../../../hooks.js';
-import { executeQuery, writeProfileQueryCatalog } from '../../../api.js';
+import { executeQuery, writeProfileQueryCatalog, type QueryExecutionView } from '../../../api.js';
 import { useProjectProfileContext, type QueryCatalog } from '../../../hooks/useProjectProfile.js';
 import { EmptyState } from '../../../components/ContextGraphPrimitives.js';
 
@@ -287,6 +287,7 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
   const defaultQuery = useMemo(() => contextGraphQueryTemplate(contextGraphId), [contextGraphId]);
   const [draftQuery, setDraftQuery] = useState(defaultQuery);
   const [activeQuery, setActiveQuery] = useState(defaultQuery);
+  const [activeQueryView, setActiveQueryView] = useState<QueryExecutionView | undefined>();
   const [activeCatalogQueryKey, setActiveCatalogQueryKey] = useState<string | null>(null);
   const [localSavedCatalogs, setLocalSavedCatalogs] = useState<QueryCatalog[]>([]);
   const [saveOpen, setSaveOpen] = useState(false);
@@ -308,6 +309,7 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
   useEffect(() => {
     setDraftQuery(defaultQuery);
     setActiveQuery(defaultQuery);
+    setActiveQueryView(undefined);
     setActiveCatalogQueryKey(null);
     setLocalSavedCatalogs([]);
     setSaveOpen(false);
@@ -318,8 +320,8 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
   }, [defaultQuery]);
 
   const { data, loading, error, refresh } = useFetch(
-    () => executeQuery(activeQuery, contextGraphId),
-    [activeQuery, contextGraphId],
+    () => executeQuery(activeQuery, contextGraphId, undefined, undefined, activeQueryView),
+    [activeQuery, activeQueryView, contextGraphId],
     0,
   );
 
@@ -349,35 +351,41 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
     setActiveCatalogQueryKey(null);
     setSaveMessage(null);
     setSaveError(null);
-    if (next === activeQuery) {
+    if (next === activeQuery && activeQueryView === undefined) {
       refresh();
       return;
     }
+    setActiveQueryView(undefined);
     setActiveQuery(next);
-  }, [activeQuery, draftQuery, refresh]);
+  }, [activeQuery, activeQueryView, draftQuery, refresh]);
 
   const resetQuery = useCallback(() => {
     setDraftQuery(defaultQuery);
     setActiveCatalogQueryKey(null);
     setSaveMessage(null);
     setSaveError(null);
-    if (activeQuery === defaultQuery) refresh();
-    else setActiveQuery(defaultQuery);
-  }, [activeQuery, defaultQuery, refresh]);
+    if (activeQuery === defaultQuery && activeQueryView === undefined) {
+      refresh();
+      return;
+    }
+    setActiveQueryView(undefined);
+    setActiveQuery(defaultQuery);
+  }, [activeQuery, activeQueryView, defaultQuery, refresh]);
 
-  const runCatalogQuery = useCallback((key: string, sparql: string) => {
+  const runCatalogQuery = useCallback((key: string, sparql: string, view?: QueryExecutionView) => {
     const next = sparql.trim();
     if (!next) return;
     setActiveCatalogQueryKey(key);
     setDraftQuery(next);
     setSaveMessage(null);
     setSaveError(null);
-    if (activeQuery === next) {
+    if (activeQuery === next && activeQueryView === view) {
       refresh();
       return;
     }
+    setActiveQueryView(view);
     setActiveQuery(next);
-  }, [activeQuery, refresh]);
+  }, [activeQuery, activeQueryView, refresh]);
 
   const openSaveForm = useCallback(() => {
     const firstLine = draftQuery.trim().split('\n').find(line => line.trim());
@@ -495,7 +503,9 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
                   <div className="v10-cg-query-list">
                     {catalog.queries.map((q) => {
                       const key = `${q.subGraph}|${q.catalogSlug}|${q.slug}`;
-                      const isActive = activeCatalogQueryKey === key && activeQuery === q.sparql;
+                      const isActive = activeCatalogQueryKey === key
+                        && activeQuery === q.sparql
+                        && activeQueryView === q.view;
                       const chipLabel = q.description ? `${q.name}. ${q.description}` : q.name;
                       return (
                         <button
@@ -504,7 +514,7 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
                           className={`v10-cg-query-chip${isActive ? ' active' : ''}`}
                           title={chipLabel}
                           aria-label={`Load query: ${chipLabel}`}
-                          onClick={() => runCatalogQuery(key, q.sparql)}
+                          onClick={() => runCatalogQuery(key, q.sparql, q.view)}
                         >
                           <span className="v10-cg-query-chip-title">{q.name}</span>
                           {q.description && <span className="v10-cg-query-chip-desc">{q.description}</span>}
@@ -651,4 +661,3 @@ export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: stri
     </div>
   );
 }
-

--- a/packages/node-ui/src/ui/views/project/components/subgraph.tsx
+++ b/packages/node-ui/src/ui/views/project/components/subgraph.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useCallback, useEffect, Suspense } from 'react';
-import { executeQuery, fetchSubGraphs, type SubGraphInfo } from '../../../api.js';
+import { executeQuery, fetchSubGraphs, type QueryExecutionView, type SubGraphInfo } from '../../../api.js';
 import { useMemoryEntities, canonicalEntityUri, type TrustLevel, type MemoryEntity, type Triple, type LayeredTriple } from '../../../hooks/useMemoryEntities.js';
 import { useProjectProfileContext } from '../../../hooks/useProjectProfile.js';
 import { useAgentsContext } from '../../../hooks/useAgents.js';
@@ -1403,12 +1403,18 @@ export function SubGraphDetailView({
     setQueryError(null);
   }, []);
 
-  const runQuery = useCallback(async (q: { slug: string; sparql: string; resultColumn: string; name: string }) => {
+  const runQuery = useCallback(async (q: {
+    slug: string;
+    sparql: string;
+    resultColumn: string;
+    name: string;
+    view?: QueryExecutionView;
+  }) => {
     setQueryLoading(true);
     setQueryError(null);
     setActiveQuerySlug(q.slug);
     try {
-      const r = await executeQuery(q.sparql, contextGraphId);
+      const r = await executeQuery(q.sparql, contextGraphId, undefined, undefined, q.view);
       const bindings = (r as any)?.result?.bindings ?? [];
       const col = q.resultColumn || 'uri';
       const ids = new Set<string>();

--- a/packages/node-ui/test/context-graph-query-catalog.test.ts
+++ b/packages/node-ui/test/context-graph-query-catalog.test.ts
@@ -240,6 +240,35 @@ describe('ContextGraphQueryView', () => {
       'working-memory',
     );
 
+    const runButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent === 'Run');
+    expect(runButton).toBeTruthy();
+
+    apiMocks.executeQuery.mockClear();
+    await act(async () => {
+      runButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(apiMocks.executeQuery).toHaveBeenLastCalledWith(
+      expect.stringContaining('schema.org/name'),
+      'cg-test',
+      undefined,
+      undefined,
+      'working-memory',
+    );
+
+    apiMocks.executeQuery.mockClear();
+    await act(async () => {
+      setFieldValue(textarea, `${textarea.value}\n# edited`);
+      runButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(apiMocks.executeQuery).toHaveBeenLastCalledWith(
+      expect.stringContaining('# edited'),
+      'cg-test',
+      undefined,
+      undefined,
+      undefined,
+    );
+
     await act(async () => { root.unmount(); });
   });
 

--- a/packages/node-ui/test/context-graph-query-catalog.test.ts
+++ b/packages/node-ui/test/context-graph-query-catalog.test.ts
@@ -198,6 +198,7 @@ describe('ContextGraphQueryView', () => {
           sparql: 'SELECT ?doc WHERE { GRAPH ?g { ?doc <http://schema.org/name> ?name } } LIMIT 5',
           resultColumn: 'doc',
           rank: 1,
+          view: 'working-memory',
         }],
       }],
     });
@@ -231,6 +232,13 @@ describe('ContextGraphQueryView', () => {
 
     const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
     expect(textarea.value).toContain('schema.org/name');
+    expect(apiMocks.executeQuery).toHaveBeenLastCalledWith(
+      expect.stringContaining('schema.org/name'),
+      'cg-test',
+      undefined,
+      undefined,
+      'working-memory',
+    );
 
     await act(async () => { root.unmount(); });
   });

--- a/packages/node-ui/test/ui-api-pure.test.ts
+++ b/packages/node-ui/test/ui-api-pure.test.ts
@@ -24,6 +24,7 @@ import {
   fetchSuccessRates,
   fetchExtractionStatus,
   executeQuery,
+  readProfileQueryCatalog,
   listAssertions,
   ensureContextGraphOnChain,
   fetchAssertionUals,
@@ -316,6 +317,26 @@ describe('UI API tests', () => {
       const body = JSON.parse(call?.body ?? '{}');
       expect(body.sparql).toBe('SELECT * WHERE { ?s ?p ?o }');
       expect(body.contextGraphId).toBe('cg-1');
+    });
+
+    it('executeQuery sends the daemon working-memory view', async () => {
+      await executeQuery(
+        'SELECT ?incident WHERE { ?incident ?p ?o }',
+        'cg-listenerboi',
+        undefined,
+        undefined,
+        'working-memory',
+      );
+      const call = requestLog.find(r => r.method === 'POST' && r.url.includes('/api/query'));
+      expect(JSON.parse(call?.body ?? '{}').view).toBe('working-memory');
+    });
+
+    it('readProfileQueryCatalog uses the dedicated profile endpoint', async () => {
+      await readProfileQueryCatalog('cg-listenerboi');
+      const call = requestLog.find(
+        r => r.method === 'POST' && r.url.includes('/api/profile/query-catalog/read'),
+      );
+      expect(JSON.parse(call?.body ?? '{}')).toEqual({ contextGraphId: 'cg-listenerboi' });
     });
 
     it('knowledgeAssetPublish rejects non-decimal publisher identity overrides before POSTing', async () => {

--- a/packages/node-ui/test/use-project-profile.test.ts
+++ b/packages/node-ui/test/use-project-profile.test.ts
@@ -6,14 +6,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { buildQueryCatalogState, useProjectProfile, type ProjectProfile } from '../src/ui/hooks/useProjectProfile.js';
 import { ROOT_SLUG_SENTINEL } from '../src/ui/lib/subGraphs.js';
+import { readProfileQueryCatalog } from '../src/ui/api.js';
 
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
 vi.mock('../src/ui/api.js', () => ({
-  // The hook fires four SPARQL queries on mount; every one resolves to
-  // empty so the profile falls back to defaults (which is all we need
-  // for the resolver-level Root assertion).
   executeQuery: vi.fn(async () => ({ result: { bindings: [] } })),
+  readProfileQueryCatalog: vi.fn(async () => ({
+    contextGraphId: 'cg-test',
+    graph: 'did:dkg:context-graph:cg-test/meta/query-catalog',
+    result: { type: 'bindings', bindings: [] },
+  })),
 }));
 
 describe('buildQueryCatalogState', () => {
@@ -114,6 +117,11 @@ describe('useProjectProfile — forSubGraph Root binding (S3, Codex Bug E)', () 
     document.body.appendChild(container);
     root = createRoot(container);
     captured = null;
+    vi.mocked(readProfileQueryCatalog).mockResolvedValue({
+      contextGraphId: 'cg-test',
+      graph: 'did:dkg:context-graph:cg-test/meta/query-catalog',
+      result: { type: 'bindings', bindings: [] },
+    });
   });
 
   afterEach(() => {
@@ -162,5 +170,60 @@ describe('useProjectProfile — forSubGraph Root binding (S3, Codex Bug E)', () 
     expect(binding!.slug).toBe('recipes');
     expect(binding!.displayName).toBe('recipes');
     expect(binding!.icon).toBe('•');
+  });
+
+  it('loads saved queries through the dedicated profile catalog endpoint', async () => {
+    vi.mocked(readProfileQueryCatalog).mockResolvedValueOnce({
+      contextGraphId: 'cg-test',
+      graph: 'did:dkg:context-graph:cg-test/meta/query-catalog',
+      result: {
+        type: 'bindings',
+        bindings: [{
+          q: 'urn:listenerboi:query:open-incidents',
+          subGraph: 'incidents',
+          catalog: 'urn:listenerboi:catalog:investigations',
+          name: 'Open incidents',
+          description: 'Find incidents that still need attention.',
+          sparql: 'SELECT ?incident WHERE { ?incident ?p ?o }',
+          resultColumn: 'incident',
+          rank: '1',
+          catalogName: 'ListenerBoi investigations',
+          catalogDescription: 'Reusable incident investigation queries.',
+          catalogRank: '2',
+        }],
+      },
+    });
+
+    await act(async () => {
+      root.render(React.createElement(Probe, { contextGraphId: 'cg-test' }));
+    });
+    await act(async () => { await Promise.resolve(); });
+
+    expect(readProfileQueryCatalog).toHaveBeenCalledWith('cg-test');
+    expect(captured!.error).toBeUndefined();
+    expect(captured!.queryCatalogs).toEqual([expect.objectContaining({
+      slug: 'investigations',
+      name: 'ListenerBoi investigations',
+      description: 'Reusable incident investigation queries.',
+      rank: 2,
+      queries: [expect.objectContaining({
+        slug: 'open-incidents',
+        name: 'Open incidents',
+        resultColumn: 'incident',
+        view: 'working-memory',
+      })],
+    })]);
+  });
+
+  it('surfaces catalog read failures instead of reporting an empty catalog', async () => {
+    vi.mocked(readProfileQueryCatalog).mockRejectedValueOnce(new Error('catalog read failed'));
+
+    await act(async () => {
+      root.render(React.createElement(Probe, { contextGraphId: 'cg-test' }));
+    });
+    await act(async () => { await Promise.resolve(); });
+
+    expect(captured!.error).toBe('catalog read failed');
+    expect(captured!.loading).toBe(false);
   });
 });


### PR DESCRIPTION
## What changed

- Load profile query catalogs through `/api/profile/query-catalog/read` instead of the general `/api/query` route.
- Carry an optional daemon memory view on saved-query contracts.
- Execute saved queries with that view from both the Query Catalogue and Subgraph Explorer.
- Preserve the selected catalog view when **Run** reruns unchanged SPARQL; edited text returns to ordinary ad-hoc semantics.
- Align the UI view type with the daemon's accepted values: `working-memory`, `shared-working-memory`, and `verifiable-memory`.
- Preserve current semantics for built-in presets, ad-hoc SPARQL, and ordinary user-saved queries.
- Keep existing ListenerBoi v1-v3 catalogs compatible by inferring `working-memory` from their stable query/catalog URNs; an explicit `executionView` or `view` binding takes precedence.

## Root cause

Profile query catalogs are stored in the local `.../meta/query-catalog` graph, which is intentionally outside the general Context Graph query allow-list. The UI therefore interpreted a successful empty response as “no saved queries.”

After the catalogs became visible, the UI still executed their SPARQL without the memory projection required by the contract. ListenerBoi's Rust typed-query adapter executes these contracts against `working-memory`, while the UI used the daemon default view, so valid queries such as **Open incidents** returned zero rows.

## Impact

Saved ListenerBoi investigation queries are now visible and run with the same memory semantics as the Rust adapter. On a live ListenerBoi Semantic Memory Canary graph, both Open incidents catalog entries returned 5 projected rows representing 3 distinct open incidents.

## Validation

- `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/use-project-profile.test.ts test/ui-api-pure.test.ts test/context-graph-query-catalog.test.ts` — 77 passed
- `pnpm --filter @origintrail-official/dkg-node-ui run build`
- `pnpm --filter @origintrail-official/dkg-node-ui run build:ui`
- `git diff --check origin/main...HEAD`
- Manual verification against local DKG 10.0.13 (`9151aee81`) and ListenerBoi Semantic Memory Canary
