### PR TITLE
fix(2270): the Kafka submitter owns its job, and immutable means enforced

### DIFF
--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -1600,7 +1600,13 @@ export class PublishMethods extends DKGAgentBase {
     // who enqueued nothing. A host that authenticated a caller passes it in; otherwise this is an
     // internal producer and the node's own default agent owns the job — the same identity a
     // node-level token resolves to in the daemon, so the operator keeps the exit.
-    const admittedByAgentAddress = opts?.admittedByAgentAddress ?? this.getDefaultAgentAddress();
+    // A blank identity is ABSENT, not a principal. `??` only guards nullish, so an
+    // empty or whitespace-only string slipped past the default and then failed the truthiness
+    // check below, producing exactly the unowned job this fallback exists to prevent.
+    const suppliedAdmission = opts?.admittedByAgentAddress?.trim();
+    const admittedByAgentAddress = (suppliedAdmission && suppliedAdmission.length > 0)
+      ? suppliedAdmission
+      : this.getDefaultAgentAddress();
     const captureID = await asyncPublisher.enqueueKnowledgeAssetVmPublish(
       intent,
       admittedByAgentAddress ? { admittedByAgentAddress } : undefined,

--- a/packages/agent/test/publish-jsonld.test.ts
+++ b/packages/agent/test/publish-jsonld.test.ts
@@ -387,6 +387,19 @@ describe('publishJsonLd', () => {
     const authenticatedJob = await asyncPublisher.getStatus(authenticated.captureID);
     expect(authenticatedJob?.admission?.byAgentAddress).toBe(EPCIS_CALLER);
 
+    // 3826008054 — malformed-but-type-valid identities. An empty or whitespace-only string is
+    // ABSENT, not a principal: it must fall back to the node owner rather than slip past the
+    // default and enqueue a job nobody can ever force-clear.
+    for (const blank of ['', '   ']) {
+      const res = await agent.publishAsync(
+        'did:dkg:context-graph:async-admission',
+        content(`AsyncAdmissionBlank${blank.length}`),
+        { localOnly: true, admittedByAgentAddress: blank },
+      );
+      const blankJob = await asyncPublisher.getStatus(res.captureID);
+      expect(blankJob?.admission?.byAgentAddress).toBe(nodeOwner);
+    }
+
     // The discriminating half: the owner is NOT the author. Under curated publishing the signer
     // may be a third party who enqueued nothing, and handing them a destructive clear would give
     // the double-publish decision to someone who never asked for the publish.

--- a/packages/cli/src/daemon/routes/epcis.ts
+++ b/packages/cli/src/daemon/routes/epcis.ts
@@ -536,19 +536,15 @@ export async function handleEpcisRoutes(ctx: RequestContext): Promise<void> {
           {
             ...opts,
             /**
-             * GH#2270 follow-up (3825614158) — an EPCIS capture is EXTERNALLY AUTHENTICATED, so
-             * the job it enqueues belongs to the agent that submitted it. Without this the
-             * agent's own publish path treats the capture as an internal producer and assigns
-             * it to the node's default agent: the submitting agent then loses the by-id force
-             * clear that is the only manual exit for a held job, and the node owner gains a
-             * destructive capability over a job it never enqueued.
+             * An EPCIS capture is externally authenticated, so the job it enqueues belongs to
+             * the agent that submitted it. Without this the publish path treats the capture as
+             * an internal producer and assigns it to the node's default agent, which both
+             * denies the submitter the by-id force clear — the only manual exit for a held job
+             * — and hands that destructive capability to an agent that never submitted it.
              *
-             * Unforgeable because `handleCaptureAsync` builds `opts` from a strict ALLOW-LIST
-             * (accessPolicy, allowedPeers, subGraphName — see packages/epcis/src/handlers.ts),
-             * so a request body cannot carry this field here at all. Spreading first is
-             * defence in depth against that allow-list ever being widened, NOT the guard
-             * itself — reversing the order today changes nothing, and a test cannot prove
-             * otherwise. It is authorization only and never reaches author selection.
+             * `handleCaptureAsync` builds these opts from a strict allow-list, so a request
+             * body cannot carry this field; spreading first is defence in depth if that
+             * allow-list ever widens. Authorization only — never an author-selection input.
              */
             admittedByAgentAddress: requestAgentAddress,
           },

--- a/packages/kafka-plugin/src/handler.ts
+++ b/packages/kafka-plugin/src/handler.ts
@@ -178,7 +178,19 @@ async function handlePostRegister(
   } as unknown as Record<string, unknown>;
   let publishResult: { captureID: string };
   try {
-    publishResult = await ctx.agent.publishAsync(cgId, publishContent, opts.publishOptions);
+    // A Kafka stream request is EXTERNALLY AUTHENTICATED, so
+    // the job it enqueues belongs to the agent that submitted it. Without this the agent's
+    // publish path treats it as an internal producer and assigns it to the node's default
+    // agent: the submitter loses the by-id force clear that is the only manual exit for a held
+    // job, and the node owner gains a destructive capability over a job it never submitted.
+    //
+    // Stamped AFTER the spread, and here that ordering IS the guard: unlike the EPCIS lane,
+    // `publishOptions` is an unfiltered client-supplied record, so a request body could
+    // otherwise name its own owner.
+    publishResult = await ctx.agent.publishAsync(cgId, publishContent, {
+      ...opts.publishOptions,
+      admittedByAgentAddress: ctx.requestAgentAddress,
+    });
   } catch (err) {
     const code = (err as { code?: string; name?: string })?.code ?? (err as { name?: string })?.name;
     if (code === 'ContextGraphNotFound') {

--- a/packages/kafka-plugin/test/handler.test.ts
+++ b/packages/kafka-plugin/test/handler.test.ts
@@ -112,6 +112,28 @@ describe('handler — POST /register happy path', () => {
     expect(captured.statusCode).toBe(202);
     expect(publishAsync.mock.calls[0][0]).toBe('urn:cg:from-config');
   });
+  it('stamps the AUTHENTICATED submitter and a client cannot name its own owner', async () => {
+    // Ownership decides who may run the destructive by-id clear. `publishOptions` here is an
+    // unfiltered client record, unlike the EPCIS lane's allow-list, so the stamp must beat a
+    // caller-supplied value — the spread ORDER is the guard, and this row is what fails if
+    // it is ever reversed.
+    const SUBMITTER = '0x00000000000000000000000000000000000000b7';
+    const ATTACKER = '0x00000000000000000000000000000000000000ff';
+    const { req, res } = mockReqRes('POST', '/api/kafka/streams/register', validBody);
+    const { ctx, publishAsync } = mockCtx({ requestAgentAddress: SUBMITTER });
+    const handler = createHandler({
+      basePath: '/api/kafka/streams',
+      contextGraphId: 'urn:cg:demo',
+      publishOptions: { accessPolicy: 'public', admittedByAgentAddress: ATTACKER },
+    });
+    await handler({ ...ctx, req, res, path: '/api/kafka/streams/register' });
+    const opts = publishAsync.mock.calls[0][2] as Record<string, unknown>;
+    expect(opts.admittedByAgentAddress).toBe(SUBMITTER);
+    expect(opts.admittedByAgentAddress).not.toBe(ATTACKER);
+    // Ordinary options still forward untouched.
+    expect(opts.accessPolicy).toBe('public');
+  });
+
   it('forwards factoryOptions.publishOptions to agent.publishAsync', async () => {
     const { req, res } = mockReqRes('POST', '/api/kafka/streams/register', validBody);
     const { ctx, publishAsync } = mockCtx();
@@ -121,7 +143,14 @@ describe('handler — POST /register happy path', () => {
       publishOptions: { accessPolicy: 'public', subGraphName: 'streams' },
     });
     await handler({ ...ctx, req, res, path: '/api/kafka/streams/register' });
-    expect(publishAsync.mock.calls[0][2]).toEqual({ accessPolicy: 'public', subGraphName: 'streams' });
+    // The authenticated submitter is stamped alongside the forwarded options: a Kafka stream
+    // request is externally authenticated, so its job must be owned by the agent that sent it
+    // rather than by the node default.
+    expect(publishAsync.mock.calls[0][2]).toEqual({
+      accessPolicy: 'public',
+      subGraphName: 'streams',
+      admittedByAgentAddress: '0x0000000000000000000000000000000000000000',
+    });
   });
 });
 describe('handler — POST /register error paths', () => {

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -114,6 +114,7 @@ import {
   liftJobCheckedNonce,
   liftJobCheckedSigner,
   liftJobOperationKindMarker,
+  assertNoImmutableLiftJobFieldChange,
   normalizePersistedLiftJobRequest,
   buildLiftJobAcceptedReset,
   pinnedPublishIdentityKaId,
@@ -2538,6 +2539,12 @@ export class TripleStoreAsyncLiftPublisher
   private mergeJob(current: LiftJob, status: LiftJobState, data: Partial<LiftJob>): LiftJob {
     const now = this.now();
     if (current.status !== status) assertLiftJobTransition(current.status, status);
+    // The immutable set is ENFORCED here, not merely declared.
+    // `LIFT_JOB_IMMUTABLE_FIELDS` documented that these never change, but this merge spread the
+    // caller's patch straight over the record, so a transition could silently replace any of
+    // them. That became an authorization hole the moment `admission` joined the set: moving the
+    // owner moves the right to run the destructive pending-transaction clear.
+    assertNoImmutableLiftJobFieldChange(current, data);
 
     const merged = {
       ...current,

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -2539,12 +2539,6 @@ export class TripleStoreAsyncLiftPublisher
   private mergeJob(current: LiftJob, status: LiftJobState, data: Partial<LiftJob>): LiftJob {
     const now = this.now();
     if (current.status !== status) assertLiftJobTransition(current.status, status);
-    // The immutable set is ENFORCED here, not merely declared.
-    // `LIFT_JOB_IMMUTABLE_FIELDS` documented that these never change, but this merge spread the
-    // caller's patch straight over the record, so a transition could silently replace any of
-    // them. That became an authorization hole the moment `admission` joined the set: moving the
-    // owner moves the right to run the destructive pending-transaction clear.
-    assertNoImmutableLiftJobFieldChange(current, data);
 
     const merged = {
       ...current,
@@ -2557,7 +2551,7 @@ export class TripleStoreAsyncLiftPublisher
       },
     } as LiftJob;
 
-    return {
+    const next = {
       ...merged,
       timestamps: {
         ...merged.timestamps,
@@ -2570,6 +2564,13 @@ export class TripleStoreAsyncLiftPublisher
         updatedAt: now,
       },
     } as LiftJob;
+    // The immutable set is ENFORCED here, not merely declared, and it is checked against the
+    // MERGE'S OWN OUTPUT rather than the caller's patch. Reasoning about the patch is what
+    // made earlier versions of this guard wrong twice: an explicit `undefined` is spread, not
+    // skipped, and an omitted nested key only survives where the merge deep-merges that
+    // object -- true for `timestamps`, false for `retries`. Reading the result cannot drift.
+    assertNoImmutableLiftJobFieldChange(current, next);
+    return next;
   }
 
   /**

--- a/packages/publisher/src/async-lift-publisher-utils.ts
+++ b/packages/publisher/src/async-lift-publisher-utils.ts
@@ -3,6 +3,7 @@ import {
   LIFT_AUTHORITY_TYPES,
   LIFT_TRANSITION_TYPES,
 } from './lift-job.js';
+import { LIFT_JOB_IMMUTABLE_FIELDS } from './lift-job.js';
 import type {
   KnowledgeAssetVmPublishJobRequest,
   KnowledgeAssetVmPublishRequest,
@@ -382,6 +383,35 @@ export function createKnowledgeAssetVmPublishJobRequest(
     jobType: 'knowledge-asset-vm-publish',
     knowledgeAssetVmPublish: request,
   };
+}
+
+/**
+ * Enforce {@link LIFT_JOB_IMMUTABLE_FIELDS} at the WRITE boundary.
+ *
+ * That list said these fields never change; nothing checked it, and
+ * the transition merge spread a caller's patch straight over the record. Harmless-looking while the
+ * set was identity and budget, it became an AUTHORIZATION hole when `admission` joined: whoever can
+ * pass an `admission` through a transition can move the right to run the destructive
+ * pending-transaction clear onto themselves.
+ *
+ * A patch that omits a field, or repeats its current value, is not a change. Nested entries
+ * ('timestamps.acceptedAt') are compared at that key only, so an ordinary timestamps patch that
+ * does not touch `acceptedAt` still passes.
+ */
+export function assertNoImmutableLiftJobFieldChange(current: LiftJob, patch: Partial<LiftJob>): void {
+  for (const field of LIFT_JOB_IMMUTABLE_FIELDS) {
+    const [head, nested] = field.split('.') as [keyof LiftJob, string | undefined];
+    if (!(head in patch)) continue;
+    const patchHead = (patch as unknown as Record<string, unknown>)[head as string];
+    const currentHead = (current as unknown as Record<string, unknown>)[head as string];
+    const incoming = nested ? (patchHead as Record<string, unknown> | undefined)?.[nested] : patchHead;
+    if (incoming === undefined) continue;
+    const existing = nested ? (currentHead as Record<string, unknown> | undefined)?.[nested] : currentHead;
+    if (JSON.stringify(incoming) === JSON.stringify(existing)) continue;
+    throw new Error(
+      `LiftJob ${current.jobId}: ${field} is immutable and cannot be changed by a transition`,
+    );
+  }
 }
 
 export function isKnowledgeAssetVmPublishJobRequest(

--- a/packages/publisher/src/async-lift-publisher-utils.ts
+++ b/packages/publisher/src/async-lift-publisher-utils.ts
@@ -388,35 +388,27 @@ export function createKnowledgeAssetVmPublishJobRequest(
 /**
  * Enforce {@link LIFT_JOB_IMMUTABLE_FIELDS} at the WRITE boundary.
  *
- * That list said these fields never change; nothing checked it, and
- * the transition merge spread a caller's patch straight over the record. Harmless-looking while the
- * set was identity and budget, it became an AUTHORIZATION hole when `admission` joined: whoever can
- * pass an `admission` through a transition can move the right to run the destructive
- * pending-transaction clear onto themselves.
+ * That list said these fields never change; nothing checked it, and the transition merge spread a
+ * caller's patch straight over the record. Harmless-looking while the set was identity and budget,
+ * it became an AUTHORIZATION hole when `admission` joined: whoever can pass an `admission` through
+ * a transition can move the right to run the destructive pending-transaction clear onto themselves.
  *
- * A patch that omits a field, or repeats its current value, is not a change. Nested entries
- * ('timestamps.acceptedAt') are compared at that key only, so an ordinary timestamps patch that
- * does not touch `acceptedAt` still passes.
+ * Compares the EFFECTIVE post-merge value against the current one, never the shape of the patch.
+ * Reasoning about the patch is what made the first two versions of this guard wrong: an explicit
+ * `undefined` is spread rather than skipped, and an omitted nested key only survives where the
+ * merge deep-merges that object -- true for `timestamps`, false for `retries`, which is replaced
+ * wholesale. Reading the merge's own output cannot drift from the merge.
  */
-export function assertNoImmutableLiftJobFieldChange(current: LiftJob, patch: Partial<LiftJob>): void {
+export function assertNoImmutableLiftJobFieldChange(current: LiftJob, next: LiftJob): void {
   for (const field of LIFT_JOB_IMMUTABLE_FIELDS) {
     const [head, nested] = field.split('.') as [keyof LiftJob, string | undefined];
-    if (!(head in patch)) continue;
-    const patchHead = (patch as unknown as Record<string, unknown>)[head as string];
-    const currentHead = (current as unknown as Record<string, unknown>)[head as string];
-    // PRESENCE, not definedness. The merge below does not skip an explicit `undefined` — it
-    // spreads it — so treating undefined as 'nothing supplied' let a patch ERASE the very
-    // field this guard protects. `{ admission: undefined }` would have removed the owner and
-    // stranded a held job with nobody able to clear it.
-    if (nested) {
-      // A nested patch that never mentions the key changes nothing; one that mentions it,
-      // even as undefined, is a write.
-      if (patchHead === undefined) continue;
-      if (!(nested in (patchHead as Record<string, unknown>))) continue;
-    }
-    const incoming = nested ? (patchHead as Record<string, unknown>)[nested] : patchHead;
-    const existing = nested ? (currentHead as Record<string, unknown> | undefined)?.[nested] : currentHead;
-    if (JSON.stringify(incoming) === JSON.stringify(existing)) continue;
+    const read = (job: LiftJob): unknown => {
+      const value = (job as unknown as Record<string, unknown>)[head as string];
+      return nested ? (value as Record<string, unknown> | undefined)?.[nested] : value;
+    };
+    const before = read(current);
+    const after = read(next);
+    if (JSON.stringify(before) === JSON.stringify(after)) continue;
     throw new Error(
       `LiftJob ${current.jobId}: ${field} is immutable and cannot be changed by a transition`,
     );

--- a/packages/publisher/src/async-lift-publisher-utils.ts
+++ b/packages/publisher/src/async-lift-publisher-utils.ts
@@ -404,8 +404,17 @@ export function assertNoImmutableLiftJobFieldChange(current: LiftJob, patch: Par
     if (!(head in patch)) continue;
     const patchHead = (patch as unknown as Record<string, unknown>)[head as string];
     const currentHead = (current as unknown as Record<string, unknown>)[head as string];
-    const incoming = nested ? (patchHead as Record<string, unknown> | undefined)?.[nested] : patchHead;
-    if (incoming === undefined) continue;
+    // PRESENCE, not definedness. The merge below does not skip an explicit `undefined` — it
+    // spreads it — so treating undefined as 'nothing supplied' let a patch ERASE the very
+    // field this guard protects. `{ admission: undefined }` would have removed the owner and
+    // stranded a held job with nobody able to clear it.
+    if (nested) {
+      // A nested patch that never mentions the key changes nothing; one that mentions it,
+      // even as undefined, is a write.
+      if (patchHead === undefined) continue;
+      if (!(nested in (patchHead as Record<string, unknown>))) continue;
+    }
+    const incoming = nested ? (patchHead as Record<string, unknown>)[nested] : patchHead;
     const existing = nested ? (currentHead as Record<string, unknown> | undefined)?.[nested] : currentHead;
     if (JSON.stringify(incoming) === JSON.stringify(existing)) continue;
     throw new Error(

--- a/packages/publisher/src/async-lift-retry-disposition.ts
+++ b/packages/publisher/src/async-lift-retry-disposition.ts
@@ -28,6 +28,7 @@ import {
   queuedLiftOperationKind,
   type PersistedFailedJob,
 } from './async-lift-publisher-utils.js';
+import { knowledgeAssetAgentAddressesEqual } from '@origintrail-official/dkg-core';
 import { getLiftJobFailurePolicy, isTerminalLiftJobState } from './lift-job.js';
 import type { LiftJob, LiftJobFailureCode } from './lift-job.js';
 // Type-only, and erased at emit — the reverse edge (types importing `LiftJobRetryProjection`
@@ -363,9 +364,12 @@ export function resolveHeldJobSettlementCapability(wiring: {
 function ownsLiftJobAdmissionLane(job: LiftJob, agentAddress: string | undefined): boolean {
   if (!agentAddress) return false;
   const admittedBy = job.admission?.byAgentAddress;
-  return typeof admittedBy === 'string'
-    && admittedBy.length > 0
-    && admittedBy.toLowerCase() === agentAddress.toLowerCase();
+  if (typeof admittedBy !== 'string' || admittedBy.length === 0) return false;
+  // The REPOSITORY's identity equality, not a second definition. A bespoke
+  // `toLowerCase()` folded case for legacy non-EVM identities (peer IDs) too, which the
+  // canonical helper deliberately compares byte-for-byte: on a destructive authorization
+  // boundary that silently widened who counts as the owner.
+  return knowledgeAssetAgentAddressesEqual(admittedBy, agentAddress);
 }
 
 /**

--- a/packages/publisher/test/async-lift-retry-disposition-2270.test.ts
+++ b/packages/publisher/test/async-lift-retry-disposition-2270.test.ts
@@ -213,6 +213,29 @@ describe('GH#2270 failed-job retry disposition', () => {
     });
   });
 
+  it('matches owners with the CANONICAL identity policy, not a bespoke lowercase [3826008043]', () => {
+    // EVM addresses are case-folded; legacy non-EVM identities (peer IDs) are byte-for-byte. A
+    // bespoke `toLowerCase()` folded both, which on a destructive authorization boundary widened
+    // who counts as the owner.
+    const held = (owner: string) => ({
+      status: 'failed',
+      failure: { resolution: 'retry_recovery' },
+      admission: { byAgentAddress: owner },
+      request: { jobType: 'lift', lift: {} },
+    } as unknown as LiftJob);
+    const override = (requestedBy: string) => ({ pendingTransactionOverride: { requestedBy } });
+
+    // EVM: case-insensitive, both directions.
+    const EVM = '0xAbCdEf0000000000000000000000000000001234';
+    expect(isTargetedClearableLiftJob(held(EVM), override(EVM.toLowerCase()))).toBe(true);
+    expect(isTargetedClearableLiftJob(held(EVM.toLowerCase()), override(EVM))).toBe(true);
+
+    // Legacy peer id: case-SENSITIVE. This is the row a bespoke lowercase gets wrong.
+    const PEER = '12D3KooWAbLiM6Xy2TfXtFpUrXqttnTSuctW8Lo1mkauaijsNrWw';
+    expect(isTargetedClearableLiftJob(held(PEER), override(PEER))).toBe(true);
+    expect(isTargetedClearableLiftJob(held(PEER), override(PEER.toLowerCase()))).toBe(false);
+  });
+
   it('names the two settlement ROLES explicitly, without inferring either from wiring [3825614002]', () => {
     // 3825614002 — the role used to be re-derived inside the decision method from which
     // collaborators happened to be installed, so the same oracle meant different things depending

--- a/packages/publisher/test/async-lift-terminal-clear.test.ts
+++ b/packages/publisher/test/async-lift-terminal-clear.test.ts
@@ -117,8 +117,12 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     // 🔴 3824353569 — the ENQUEUING CALLER owns the override, not the resolved author. Curated
     // publishing lets those differ (GH#1778), so the fixture makes them differ: the curator who
     // admitted the job may clear it; an authenticated token for the AUTHOR may not.
-    const CALLER = '0xCCcCCc00000000000000000000000000000000Cc';
-    const AUTHOR = '0xAAaAAa00000000000000000000000000000000Aa';
+    // 🔴 3825861808 — THREE distinct identities. The previous fixture gave the payload caller
+    // and the admission owner the same address, so a regression that authorized from
+    // `callerAgentAddress` would have stayed green on a destructive cross-agent clear.
+    const OWNER = '0xCCcCCc00000000000000000000000000000000Cc';   // the admission stamp
+    const PAYLOAD_CALLER = '0xDDdDDd00000000000000000000000000000000Dd'; // GH#1778 hint only
+    const AUTHOR = '0xAAaAAa00000000000000000000000000000000Aa';   // resolved author
     const p = createPublisher();
     // The curator's `callerAgentAddress` stays in the request (it is the GH#1778 author-resolution
     // hint), but the ENTITLEMENT comes only from the explicit admission stamp (3825162149) — the
@@ -126,8 +130,8 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     // from handing the override to a third-party author.
     const jobId = await driveToTerminalFailed(p, {
       agentAddress: AUTHOR,
-      callerAgentAddress: CALLER,
-    }, { admittedByAgentAddress: CALLER });
+      callerAgentAddress: PAYLOAD_CALLER,
+    }, { admittedByAgentAddress: OWNER });
     const job = await p.getStatus(jobId);
     if (!job || !('failure' in job)) throw new Error('expected a failed job');
     const mutated = { ...job, failure: { ...job.failure, resolution: 'retry_recovery' } };
@@ -149,8 +153,16 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     })).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
     expect((await p.getStatus(jobId))?.status).toBe('failed');
 
+    // The row that was missing: the PAYLOAD caller is not the owner either. Admission is the
+    // sole entitlement, so the GH#1778 hint sitting in the request grants nothing — this is
+    // what fails if ownership ever falls back to reading the payload.
     expect(await p.clearTerminalJob(jobId, {
-      pendingTransactionOverride: { requestedBy: CALLER },
+      pendingTransactionOverride: { requestedBy: PAYLOAD_CALLER },
+    })).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
+    expect((await p.getStatus(jobId))?.status).toBe('failed');
+
+    expect(await p.clearTerminalJob(jobId, {
+      pendingTransactionOverride: { requestedBy: OWNER },
     })).toEqual({ outcome: 'cleared' });
     expect(await p.getStatus(jobId)).toBeNull();
   });
@@ -185,6 +197,49 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     expect(await p.clearTerminalJob(jobId, {
       pendingTransactionOverride: { requestedBy: NODE },
     })).toEqual({ outcome: 'cleared' });
+  });
+
+  it('an UNOWNED job grants the override to nobody, including its payload caller [3825861808]', async () => {
+    // Fail-closed half. A record with no admission stamp (one admitted before ownership existed,
+    // or by a path that never stamped) has nobody to match. If ownership ever fell back to the
+    // payload's `callerAgentAddress`, this is the row that catches it: that identity is present,
+    // and it must still be refused.
+    const PAYLOAD_CALLER = '0xDDdDDd00000000000000000000000000000000Dd';
+    const p = createPublisher();
+    const jobId = await driveToTerminalFailed(p, { callerAgentAddress: PAYLOAD_CALLER });
+    const job = await p.getStatus(jobId);
+    if (!job || !('failure' in job)) throw new Error('expected a failed job');
+    expect(job.admission).toBeUndefined();
+    const mutated = { ...job, failure: { ...job.failure, resolution: 'retry_recovery' } };
+    await store.deleteByPattern({ subject: jobSubject(jobId), graph: DEFAULT_CONTROL_GRAPH_URI });
+    await store.insert(serializeJob(mutated as typeof job, DEFAULT_CONTROL_GRAPH_URI));
+
+    expect(await p.clearTerminalJob(jobId, {
+      pendingTransactionOverride: { requestedBy: PAYLOAD_CALLER },
+    })).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
+    expect((await p.getStatus(jobId))?.status).toBe('failed');
+  });
+
+  it('refuses to REASSIGN the admission owner through a transition [3825861806]', async () => {
+    // 🔴 3825861806 — `LIFT_JOB_IMMUTABLE_FIELDS` declared admission immutable; nothing enforced it,
+    // and the transition merge spread the caller's patch straight over the record. Moving the owner
+    // moves the right to run the destructive clear, so this is an authorization boundary, not a
+    // data-integrity nicety.
+    const OWNER = '0xCCcCCc00000000000000000000000000000000Cc';
+    const ATTACKER = '0xEEeEEe00000000000000000000000000000000Ee';
+    const p = createPublisher();
+    const jobId = await driveToValidated(p, {}, { admittedByAgentAddress: OWNER });
+
+    await expect(p.update(jobId, 'broadcast', {
+      broadcast: bx,
+      admission: { byAgentAddress: ATTACKER },
+    } as never)).rejects.toThrow(/admission is immutable/);
+
+    // The owner is unchanged on the persisted record, so the entitlement did not move.
+    expect((await p.getStatus(jobId))?.admission).toEqual({ byAgentAddress: OWNER });
+    // Re-stating the SAME owner is not a change and must still be allowed.
+    await p.update(jobId, 'broadcast', { broadcast: bx, admission: { byAgentAddress: OWNER } } as never);
+    expect((await p.getStatus(jobId))?.admission).toEqual({ byAgentAddress: OWNER });
   });
 
   it('but BULK clear still leaves a retry_recovery failed job alone', async () => {

--- a/packages/publisher/test/async-lift-terminal-clear.test.ts
+++ b/packages/publisher/test/async-lift-terminal-clear.test.ts
@@ -242,6 +242,42 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     expect((await p.getStatus(jobId))?.admission).toEqual({ byAgentAddress: OWNER });
   });
 
+  it('refuses an explicit `undefined` for an immutable field, which would ERASE it', async () => {
+    // The merge spreads the patch, so an explicit `undefined` overwrites rather than being skipped.
+    // Treating it as "nothing supplied" let a transition delete the owner outright — worse than
+    // reassigning it, because the job is then held with nobody able to clear it at all.
+    const OWNER = '0xCCcCCc00000000000000000000000000000000Cc';
+    const p = createPublisher();
+    const jobId = await driveToValidated(p, {}, { admittedByAgentAddress: OWNER });
+    const before = await p.getStatus(jobId);
+
+    await expect(p.update(jobId, 'broadcast', {
+      broadcast: bx,
+      admission: undefined,
+    } as never)).rejects.toThrow(/admission is immutable/);
+
+    await expect(p.update(jobId, 'broadcast', {
+      broadcast: bx,
+      timestamps: { acceptedAt: undefined },
+    } as never)).rejects.toThrow(/timestamps.acceptedAt is immutable/);
+
+    await expect(p.update(jobId, 'broadcast', {
+      broadcast: bx,
+      retries: { maxRetries: undefined },
+    } as never)).rejects.toThrow(/retries.maxRetries is immutable/);
+
+    // Nothing was persisted by any of the three refusals.
+    const after = await p.getStatus(jobId);
+    expect(after?.admission).toEqual({ byAgentAddress: OWNER });
+    expect(after?.status).toBe(before?.status);
+    expect(after?.timestamps.acceptedAt).toBe(before?.timestamps.acceptedAt);
+    expect(after?.retries.maxRetries).toBe(before?.retries.maxRetries);
+
+    // An ordinary timestamps patch that never mentions `acceptedAt` is still allowed.
+    await p.update(jobId, 'broadcast', { broadcast: bx, timestamps: { updatedAt: 12_345 } } as never);
+    expect((await p.getStatus(jobId))?.timestamps.acceptedAt).toBe(before?.timestamps.acceptedAt);
+  });
+
   it('but BULK clear still leaves a retry_recovery failed job alone', async () => {
     // The discriminating half: the fix must move only the targeted lane. If both lanes had been
     // relaxed, routine cleanup could delete a job whose transaction may still land.

--- a/packages/publisher/test/async-lift-terminal-clear.test.ts
+++ b/packages/publisher/test/async-lift-terminal-clear.test.ts
@@ -273,6 +273,26 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     expect(after?.timestamps.acceptedAt).toBe(before?.timestamps.acceptedAt);
     expect(after?.retries.maxRetries).toBe(before?.retries.maxRetries);
 
+    // 3828732842 — a PARTIAL nested patch. `retries` is replaced wholesale by the merge (unlike
+    // `timestamps`, which is deep-merged), so omitting `maxRetries` erased the budget while a
+    // presence-based guard saw "key not mentioned, nothing changed".
+    await expect(p.update(jobId, 'broadcast', {
+      broadcast: bx,
+      retries: { retryCount: 3 },
+    } as never)).rejects.toThrow(/retries.maxRetries is immutable/);
+
+    // 3828701108 — erasing the PARENT object takes the immutable child with it.
+    await expect(p.update(jobId, 'broadcast', {
+      broadcast: bx,
+      retries: undefined,
+    } as never)).rejects.toThrow(/retries.maxRetries is immutable/);
+    // ...but NOT for `timestamps`, and the asymmetry is real rather than an oversight: the merge
+    // coalesces `data.timestamps ?? {}`, so an undefined parent there preserves the children. The
+    // guard reads the merge's output, so it agrees with whatever the merge actually does instead
+    // of asserting a rule the merge does not follow.
+    await p.update(jobId, 'broadcast', { broadcast: bx, timestamps: undefined } as never);
+    expect((await p.getStatus(jobId))?.timestamps.acceptedAt).toBe(before?.timestamps.acceptedAt);
+
     // Nested VALUE changes, not just erasures — and the sibling in the same object must still
     // be writable, which is what separates "reject this key" from "reject this object".
     await expect(p.update(jobId, 'broadcast', {

--- a/packages/publisher/test/async-lift-terminal-clear.test.ts
+++ b/packages/publisher/test/async-lift-terminal-clear.test.ts
@@ -273,6 +273,26 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     expect(after?.timestamps.acceptedAt).toBe(before?.timestamps.acceptedAt);
     expect(after?.retries.maxRetries).toBe(before?.retries.maxRetries);
 
+    // Nested VALUE changes, not just erasures — and the sibling in the same object must still
+    // be writable, which is what separates "reject this key" from "reject this object".
+    await expect(p.update(jobId, 'broadcast', {
+      broadcast: bx,
+      retries: { retryCount: 0, maxRetries: 999 },
+    } as never)).rejects.toThrow(/retries.maxRetries is immutable/);
+    await expect(p.update(jobId, 'broadcast', {
+      broadcast: bx,
+      timestamps: { acceptedAt: 1 },
+    } as never)).rejects.toThrow(/timestamps.acceptedAt is immutable/);
+    // The mutable sibling goes through, with the immutable one untouched.
+    await p.update(jobId, 'broadcast', {
+      broadcast: bx,
+      retries: { retryCount: 3, maxRetries: before!.retries.maxRetries },
+    } as never);
+    expect((await p.getStatus(jobId))?.retries).toMatchObject({
+      retryCount: 3,
+      maxRetries: before?.retries.maxRetries,
+    });
+
     // An ordinary timestamps patch that never mentions `acceptedAt` is still allowed.
     await p.update(jobId, 'broadcast', { broadcast: bx, timestamps: { updatedAt: 12_345 } } as never);
     expect((await p.getStatus(jobId))?.timestamps.acceptedAt).toBe(before?.timestamps.acceptedAt);


### PR DESCRIPTION
## Summary

Post-merge review of #2303 surfaced four 🔴 that I did not answer before merging. Two are real defects now on `testnet-canary`; two are tests that could not fail. All four are addressed here.

- **Kafka submitters lost ownership of their jobs.** The plugin is externally authenticated and already had the identity (`handler.ts:39`, used at line 410), but never passed it, so its jobs were owned by the node's default agent — the submitter lost the by-id force clear, and the node owner gained a destructive capability over a job it never submitted. #2303 classified Kafka as "a genuinely internal producer", in the very enumeration written to fix having missed EPCIS.
- **`admission` was declared immutable but nothing enforced it.** `mergeJob` spread the caller's patch straight over the record, so a transition could reassign the owner — and with it the right to run the destructive clear. Not reachable from any HTTP route today (nothing feeds caller data into `update()`), which is why this is a follow-up and not a revert.
- **A blank identity produced an unowned job.** `??` guards nullish only, so `admittedByAgentAddress: ''` slipped past the node-owner default and then failed the truthiness check — under a test whose name promised "every publishAsync job is owned".
- **Ownership matching used a bespoke `toLowerCase()`**, which case-folded legacy non-EVM peer ids that the canonical repository policy compares exactly, silently widening who counted as the owner.

## Related

- Follow-up to #2303 (merged as `a79cfb269`)
- Part of GH#2270

## Diagrams

### Admission ownership for an externally authenticated producer

Before:

```mermaid
sequenceDiagram
    participant Submitter
    participant KafkaPlugin
    participant Agent
    participant Queue
    Submitter->>KafkaPlugin: authenticated request (requestAgentAddress known)
    KafkaPlugin->>Agent: publishAsync(cg, content, publishOptions)
    Note over Agent: no principal supplied
    Agent->>Queue: enqueue, admission = NODE DEFAULT
    Note over Queue: submitter cannot force-clear
    Note over Queue: node owner can
```

After:

```mermaid
sequenceDiagram
    participant Submitter
    participant KafkaPlugin
    participant Agent
    participant Queue
    Submitter->>KafkaPlugin: authenticated request (requestAgentAddress known)
    KafkaPlugin->>Agent: publishAsync(cg, content, {...publishOptions, admittedByAgentAddress})
    Agent->>Queue: enqueue, admission = SUBMITTER
    Note over Queue: submitter owns its own exit
```

### Reassigning the owner through a transition

Before:

```mermaid
sequenceDiagram
    participant Caller
    participant Publisher
    participant Store
    Caller->>Publisher: update(job, 'validated', {admission: ownerB})
    Publisher->>Publisher: mergeJob spreads patch over record
    Publisher->>Store: persist, owner = ownerB
    Note over Store: clear authority moved
```

After:

```mermaid
sequenceDiagram
    participant Caller
    participant Publisher
    participant Store
    Caller->>Publisher: update(job, 'validated', {admission: ownerB})
    Publisher->>Publisher: assertNoImmutableLiftJobFieldChange
    Publisher--xCaller: throws — admission is immutable
    Note over Store: owner unchanged
```

## Files changed

| File | What |
|------|------|
| `packages/kafka-plugin/src/handler.ts` | Stamp the authenticated submitter; after the spread, which here is the guard |
| `packages/publisher/src/async-lift-publisher-impl.ts` | Enforce the immutable set before the transition merge |
| `packages/publisher/src/async-lift-publisher-utils.ts` | `assertNoImmutableLiftJobFieldChange`, nested-path aware |
| `packages/publisher/src/async-lift-retry-disposition.ts` | Canonical identity equality for ownership |
| `packages/agent/src/dkg-agent-publish.ts` | Blank identity is absent, not a principal |
| `packages/cli/src/daemon/routes/epcis.ts` | Comment trimmed of review archaeology |
| `packages/publisher/test/async-lift-terminal-clear.test.ts` | Three distinct identities; fail-closed unowned row; reassignment refused |
| `packages/publisher/test/async-lift-retry-disposition-2270.test.ts` | Both identity forms for the equality policy |
| `packages/agent/test/publish-jsonld.test.ts` | Blank and whitespace identities |

## Test plan

- [x] Four serial mutants, each killing exactly its named rows and reverted verified-clean:
  - immutability guard removed → reassignment row fails
  - payload-caller fallback reinstated → fail-closed unowned row fails
  - bespoke lowercase restored → legacy peer-id row fails
  - nullish-only default restored → blank-identity row fails (`expected undefined`)
- [x] Publisher suite: 2012 passed
- [x] Affected CLI suites: 97 passed
- [x] Chain-backed agent admission test passed
- [x] Clean-room `tsc` on publisher, agent, cli, kafka-plugin after purging `tsbuildinfo`

## Deliberately not fixed here

Exercising the production runtime's `canSettleHeldJob` (🔴 3826007807). Killing that mutant needs chain-capable adapters; without a chain config the capability answers false for everything, so the cheap version of the test would itself be non-discriminating — the same defect being reported, one level down. This is the same gap as the daemon-to-runtime bridge (🟡 3825162282), and both are held together rather than covered by tests that cannot fail.

Also held, with reasoning on their threads: the enqueue-boundary construction invariant, caller-declared settlement roles, moving the admission field out of `PublishAsyncOpts` (superseded by a host-side binding wrapper), and a sweep of review archaeology in already-merged comments.

