### PR TITLE
refactor(2270): declare who admits a job instead of inferring it from an absent field

### DIFF
--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -831,6 +831,37 @@ function bytesEqual(left: Uint8Array | undefined, right: Uint8Array | undefined)
   return left.length === right.length && left.every((byte, index) => byte === right[index]);
 }
 
+/**
+ * Resolve the owner from a DECLARED admission, rejecting anything else.
+ *
+ * Exhaustive on purpose. `PublishAsyncAdmission` is erased at runtime, so a JavaScript plugin or a
+ * value widened through `any` can present an unknown kind; reading "not 'agent'" as node admission
+ * would silently reproduce the ownership defect the parameter exists to prevent. Only an explicit
+ * `node` selects the node owner, and a malformed agent identity fails here — before any staging —
+ * rather than after irreversible publish preparation.
+ */
+function assertValidPublishAsyncAdmission(
+  admission: PublishAsyncAdmission,
+): asserts admission is PublishAsyncAdmission {
+  const kind = (admission as { kind?: unknown } | null | undefined)?.kind;
+  if (kind === 'node') return;
+  if (kind === 'agent') {
+    const agentAddress = (admission as { agentAddress?: unknown }).agentAddress;
+    if (typeof agentAddress !== 'string' || agentAddress.trim().length === 0) {
+      throw new Error(
+        'publishAsync: admission { kind: "agent" } requires a non-blank agentAddress. A blank '
+        + 'identity is not a principal, and defaulting it to the node would hand the destructive '
+        + 'force-clear to an agent that did not submit this job.',
+      );
+    }
+    return;
+  }
+  throw new Error(
+    `publishAsync: unknown admission kind ${JSON.stringify(kind)}. State { kind: 'agent', `
+    + "agentAddress } for an authenticated caller or { kind: 'node' } for an internal producer.",
+  );
+}
+
 export class PublishMethods extends DKGAgentBase {
   async publishWorkspaceGossip(this: DKGAgent,
     contextGraphId: string,
@@ -1329,6 +1360,13 @@ export class PublishMethods extends DKGAgentBase {
     content: PublishAsyncContent,
     opts?: PublishAsyncOpts,
   ): Promise<{ captureID: string }> {
+    // Validated FIRST, before any staging, and fail-closed. The union is a compile-time
+    // guarantee only: a JavaScript plugin, a dynamically loaded handler, or anything widened
+    // through `any` can hand us an unknown kind. Treating "not 'agent'" as node admission would
+    // rebuild the exact defect this parameter exists to prevent — `{ kind: 'agnt' }` silently
+    // becoming a node-owned job — and a malformed agent address must not surface only after
+    // irreversible publish preparation has already happened.
+    assertValidPublishAsyncAdmission(admission);
     const contextGraphId = normalizePublishContextGraphId(contextGraphIdOrUal);
     const ctx = opts?.operationCtx ?? createOperationContext('publish');
 
@@ -1608,11 +1646,10 @@ export class PublishMethods extends DKGAgentBase {
     // who enqueued nothing. A host that authenticated a caller passes it in; otherwise this is an
     // internal producer and the node's own default agent owns the job — the same identity a
     // node-level token resolves to in the daemon, so the operator keeps the exit.
-    // The principal comes from the ADMISSION the caller declared, never from the options bag.
-    // A blank agent address is absent rather than a principal, and falls back to the node the
-    // same way an explicit node admission does — an unowned job has no manual exit at all.
-    const declared = admission.kind === 'agent' ? admission.agentAddress.trim() : '';
-    const admittedByAgentAddress = declared.length > 0 ? declared : this.getDefaultAgentAddress();
+    // Shape was validated at entry, so this ternary cannot silently absorb an unknown kind.
+    const admittedByAgentAddress = admission.kind === 'agent'
+      ? admission.agentAddress.trim()
+      : this.getDefaultAgentAddress();
     const captureID = await asyncPublisher.enqueueKnowledgeAssetVmPublish(
       intent,
       admittedByAgentAddress ? { admittedByAgentAddress } : undefined,

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -400,6 +400,7 @@ import {
   type CclPublishedResultEntry,
   type CclPublishedEvaluationRecord,
   type PublishOpts,
+  type PublishAsyncAdmission,
   type PublishAsyncOpts,
   type PublishAsyncQuadEnvelope,
   type PublishAsyncContent,
@@ -1316,7 +1317,14 @@ export class PublishMethods extends DKGAgentBase {
     return { failureCountForCg: next, evictedToOverflow };
   }
 
+  /**
+   * @param admission WHO is admitting this job. Required and explicit: ownership decides who
+   * may later run the destructive by-id force clear, and every ownership defect in GH#2270 was
+   * a caller that OMITTED this rather than one that got it wrong. An authenticated host names
+   * its caller; an internal producer states `{ kind: 'node' }` on purpose.
+   */
   async publishAsync(this: DKGAgent,
+    admission: PublishAsyncAdmission,
     contextGraphIdOrUal: string,
     content: PublishAsyncContent,
     opts?: PublishAsyncOpts,
@@ -1600,13 +1608,11 @@ export class PublishMethods extends DKGAgentBase {
     // who enqueued nothing. A host that authenticated a caller passes it in; otherwise this is an
     // internal producer and the node's own default agent owns the job — the same identity a
     // node-level token resolves to in the daemon, so the operator keeps the exit.
-    // A blank identity is ABSENT, not a principal. `??` only guards nullish, so an
-    // empty or whitespace-only string slipped past the default and then failed the truthiness
-    // check below, producing exactly the unowned job this fallback exists to prevent.
-    const suppliedAdmission = opts?.admittedByAgentAddress?.trim();
-    const admittedByAgentAddress = (suppliedAdmission && suppliedAdmission.length > 0)
-      ? suppliedAdmission
-      : this.getDefaultAgentAddress();
+    // The principal comes from the ADMISSION the caller declared, never from the options bag.
+    // A blank agent address is absent rather than a principal, and falls back to the node the
+    // same way an explicit node admission does — an unowned job has no manual exit at all.
+    const declared = admission.kind === 'agent' ? admission.agentAddress.trim() : '';
+    const admittedByAgentAddress = declared.length > 0 ? declared : this.getDefaultAgentAddress();
     const captureID = await asyncPublisher.enqueueKnowledgeAssetVmPublish(
       intent,
       admittedByAgentAddress ? { admittedByAgentAddress } : undefined,

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -852,52 +852,47 @@ function resolvePublishAsyncAdmissionOwner(
   admission: PublishAsyncAdmission,
   nodeOwner: () => string,
 ): string {
-  // ONE runtime check, at the boundary where an untyped value can arrive, and then a switch on the
-  // TYPED discriminant. Keeping a cast-based interpretation alongside the union meant a new variant
-  // would compile here unchanged and be rejected at runtime — exhaustiveness in the comment only.
-  assertPublishAsyncAdmissionShape(admission);
-  switch (admission.kind) {
-    case 'node':
-      return nodeOwner();
-    case 'agent':
-      // Shape-checked above, so this is the declared identity rather than a re-interpretation.
-      return admission.agentAddress.trim();
-    default: {
-      // Adding a variant to `PublishAsyncAdmission` fails HERE, at compile time, instead of
-      // silently reaching the runtime rejection below.
-      const unreachable: never = admission;
-      throw new Error(
-        `publishAsync: unhandled admission ${JSON.stringify(unreachable)}.`,
-      );
-    }
-  }
-}
+  // Each field is read from the caller's object EXACTLY ONCE, into a local, before anything is
+  // decided. `admission` is caller-owned and may be a Proxy or expose getters, so a second read can
+  // return a different value than the one that was validated — a guard that accepted `node` while
+  // the switch then saw `agent` produced an empty owner. Nothing below touches `admission` again.
+  const source = admission as { kind?: unknown; agentAddress?: unknown } | null | undefined;
+  const kind = source?.kind;
+  const agentAddress = source?.agentAddress;
 
-/**
- * The single runtime gate. `PublishAsyncAdmission` is erased at runtime, so a JavaScript plugin or
- * a value widened through `any` can present anything; this is where that is rejected, before any
- * staging. Everything after it reasons about the TYPED union.
- */
-function assertPublishAsyncAdmissionShape(
-  admission: PublishAsyncAdmission,
-): asserts admission is PublishAsyncAdmission {
-  const candidate = admission as { kind?: unknown; agentAddress?: unknown } | null | undefined;
-  if (candidate?.kind === 'node') return;
-  if (candidate?.kind === 'agent') {
-    if (typeof candidate.agentAddress !== 'string' || candidate.agentAddress.trim().length === 0) {
+  // Normalized into a value WE own, so the exhaustive switch below reasons about the union rather
+  // than about the caller's object. This is the one place an untyped value becomes a typed one.
+  let normalized: PublishAsyncAdmission;
+  if (kind === 'node') {
+    normalized = { kind: 'node' };
+  } else if (kind === 'agent') {
+    if (typeof agentAddress !== 'string' || agentAddress.trim().length === 0) {
       throw new Error(
         'publishAsync: admission { kind: "agent" } requires a non-blank agentAddress. A blank '
         + 'identity is not a principal, and defaulting it to the node would hand the destructive '
         + 'force-clear to an agent that did not submit this job.',
       );
     }
-    return;
+    normalized = { kind: 'agent', agentAddress: agentAddress.trim() };
+  } else {
+    throw new Error(
+      `publishAsync: unknown admission kind ${JSON.stringify(kind)}. State `
+      + "{ kind: 'agent', agentAddress } for an authenticated caller or { kind: 'node' } for an "
+      + 'internal producer.',
+    );
   }
-  throw new Error(
-    `publishAsync: unknown admission kind ${JSON.stringify(candidate?.kind)}. State `
-    + "{ kind: 'agent', agentAddress } for an authenticated caller or { kind: 'node' } for an "
-    + 'internal producer.',
-  );
+
+  switch (normalized.kind) {
+    case 'node':
+      return nodeOwner();
+    case 'agent':
+      return normalized.agentAddress;
+    default: {
+      // Adding a variant to `PublishAsyncAdmission` fails HERE, at compile time.
+      const unreachable: never = normalized;
+      throw new Error(`publishAsync: unhandled admission ${JSON.stringify(unreachable)}.`);
+    }
+  }
 }
 
 export class PublishMethods extends DKGAgentBase {

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -852,22 +852,51 @@ function resolvePublishAsyncAdmissionOwner(
   admission: PublishAsyncAdmission,
   nodeOwner: () => string,
 ): string {
-  const kind = (admission as { kind?: unknown } | null | undefined)?.kind;
-  if (kind === 'node') return nodeOwner();
-  if (kind === 'agent') {
-    const agentAddress = (admission as { agentAddress?: unknown }).agentAddress;
-    if (typeof agentAddress !== 'string' || agentAddress.trim().length === 0) {
+  // ONE runtime check, at the boundary where an untyped value can arrive, and then a switch on the
+  // TYPED discriminant. Keeping a cast-based interpretation alongside the union meant a new variant
+  // would compile here unchanged and be rejected at runtime — exhaustiveness in the comment only.
+  assertPublishAsyncAdmissionShape(admission);
+  switch (admission.kind) {
+    case 'node':
+      return nodeOwner();
+    case 'agent':
+      // Shape-checked above, so this is the declared identity rather than a re-interpretation.
+      return admission.agentAddress.trim();
+    default: {
+      // Adding a variant to `PublishAsyncAdmission` fails HERE, at compile time, instead of
+      // silently reaching the runtime rejection below.
+      const unreachable: never = admission;
+      throw new Error(
+        `publishAsync: unhandled admission ${JSON.stringify(unreachable)}.`,
+      );
+    }
+  }
+}
+
+/**
+ * The single runtime gate. `PublishAsyncAdmission` is erased at runtime, so a JavaScript plugin or
+ * a value widened through `any` can present anything; this is where that is rejected, before any
+ * staging. Everything after it reasons about the TYPED union.
+ */
+function assertPublishAsyncAdmissionShape(
+  admission: PublishAsyncAdmission,
+): asserts admission is PublishAsyncAdmission {
+  const candidate = admission as { kind?: unknown; agentAddress?: unknown } | null | undefined;
+  if (candidate?.kind === 'node') return;
+  if (candidate?.kind === 'agent') {
+    if (typeof candidate.agentAddress !== 'string' || candidate.agentAddress.trim().length === 0) {
       throw new Error(
         'publishAsync: admission { kind: "agent" } requires a non-blank agentAddress. A blank '
         + 'identity is not a principal, and defaulting it to the node would hand the destructive '
         + 'force-clear to an agent that did not submit this job.',
       );
     }
-    return agentAddress.trim();
+    return;
   }
   throw new Error(
-    `publishAsync: unknown admission kind ${JSON.stringify(kind)}. State { kind: 'agent', `
-    + "agentAddress } for an authenticated caller or { kind: 'node' } for an internal producer.",
+    `publishAsync: unknown admission kind ${JSON.stringify(candidate?.kind)}. State `
+    + "{ kind: 'agent', agentAddress } for an authenticated caller or { kind: 'node' } for an "
+    + 'internal producer.',
   );
 }
 

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -839,12 +839,17 @@ function bytesEqual(left: Uint8Array | undefined, right: Uint8Array | undefined)
  * would silently reproduce the ownership defect the parameter exists to prevent. Only an explicit
  * `node` selects the node owner, and a malformed agent identity fails here — before any staging —
  * rather than after irreversible publish preparation.
+ *
+ * Returns the OWNER rather than narrowing the argument, so the caller keeps a resolved value and
+ * never has to consult the caller-owned object again. Splitting validation from resolution is what
+ * opened a window for the object to be mutated across an await.
  */
-function assertValidPublishAsyncAdmission(
+function resolvePublishAsyncAdmissionOwner(
   admission: PublishAsyncAdmission,
-): asserts admission is PublishAsyncAdmission {
+  nodeOwner: () => string | undefined,
+): string | undefined {
   const kind = (admission as { kind?: unknown } | null | undefined)?.kind;
-  if (kind === 'node') return;
+  if (kind === 'node') return nodeOwner();
   if (kind === 'agent') {
     const agentAddress = (admission as { agentAddress?: unknown }).agentAddress;
     if (typeof agentAddress !== 'string' || agentAddress.trim().length === 0) {
@@ -854,7 +859,7 @@ function assertValidPublishAsyncAdmission(
         + 'force-clear to an agent that did not submit this job.',
       );
     }
-    return;
+    return agentAddress.trim();
   }
   throw new Error(
     `publishAsync: unknown admission kind ${JSON.stringify(kind)}. State { kind: 'agent', `
@@ -1360,13 +1365,17 @@ export class PublishMethods extends DKGAgentBase {
     content: PublishAsyncContent,
     opts?: PublishAsyncOpts,
   ): Promise<{ captureID: string }> {
-    // Validated FIRST, before any staging, and fail-closed. The union is a compile-time
-    // guarantee only: a JavaScript plugin, a dynamically loaded handler, or anything widened
-    // through `any` can hand us an unknown kind. Treating "not 'agent'" as node admission would
-    // rebuild the exact defect this parameter exists to prevent — `{ kind: 'agnt' }` silently
-    // becoming a node-owned job — and a malformed agent address must not surface only after
-    // irreversible publish preparation has already happened.
-    assertValidPublishAsyncAdmission(admission);
+    // Resolved ONCE, here, before any await. Two properties depend on that:
+    //  - fail-closed on shape. The union is erased at runtime, so a JavaScript plugin can
+    //    present an unknown kind; reading "not 'agent'" as node admission would rebuild the
+    //    ownership defect this parameter exists to prevent.
+    //  - no re-read of a CALLER-OWNED object. `admission` belongs to the caller and publishing
+    //    suspends on many awaits; re-reading it at enqueue let a caller mutate the owner after
+    //    it had passed validation, redirecting the force-clear or blanking it entirely.
+    const admittedByAgentAddress = resolvePublishAsyncAdmissionOwner(
+      admission,
+      () => this.getDefaultAgentAddress(),
+    );
     const contextGraphId = normalizePublishContextGraphId(contextGraphIdOrUal);
     const ctx = opts?.operationCtx ?? createOperationContext('publish');
 
@@ -1646,10 +1655,6 @@ export class PublishMethods extends DKGAgentBase {
     // who enqueued nothing. A host that authenticated a caller passes it in; otherwise this is an
     // internal producer and the node's own default agent owns the job — the same identity a
     // node-level token resolves to in the daemon, so the operator keeps the exit.
-    // Shape was validated at entry, so this ternary cannot silently absorb an unknown kind.
-    const admittedByAgentAddress = admission.kind === 'agent'
-      ? admission.agentAddress.trim()
-      : this.getDefaultAgentAddress();
     const captureID = await asyncPublisher.enqueueKnowledgeAssetVmPublish(
       intent,
       admittedByAgentAddress ? { admittedByAgentAddress } : undefined,

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -843,11 +843,15 @@ function bytesEqual(left: Uint8Array | undefined, right: Uint8Array | undefined)
  * Returns the OWNER rather than narrowing the argument, so the caller keeps a resolved value and
  * never has to consult the caller-owned object again. Splitting validation from resolution is what
  * opened a window for the object to be mutated across an await.
+ *
+ * The result is non-optional. An owner that could be `undefined` would let `{ kind: 'node' }` pass
+ * this boundary and still enqueue an UNOWNED job on a node with no default agent — the one state
+ * this whole parameter exists to make unrepresentable.
  */
 function resolvePublishAsyncAdmissionOwner(
   admission: PublishAsyncAdmission,
-  nodeOwner: () => string | undefined,
-): string | undefined {
+  nodeOwner: () => string,
+): string {
   const kind = (admission as { kind?: unknown } | null | undefined)?.kind;
   if (kind === 'node') return nodeOwner();
   if (kind === 'agent') {
@@ -1374,7 +1378,10 @@ export class PublishMethods extends DKGAgentBase {
     //    it had passed validation, redirecting the force-clear or blanking it entirely.
     const admittedByAgentAddress = resolvePublishAsyncAdmissionOwner(
       admission,
-      () => this.getDefaultAgentAddress(),
+      // The canonical node identity, not a second policy: `resolveAgentAddress` is what the
+      // daemon resolves a node-level token to, so the owner recorded here is the one that token
+      // can later present. It always yields a string (default agent, else this node's peer id).
+      () => this.resolveAgentAddress(undefined),
     );
     const contextGraphId = normalizePublishContextGraphId(contextGraphIdOrUal);
     const ctx = opts?.operationCtx ?? createOperationContext('publish');
@@ -1657,7 +1664,7 @@ export class PublishMethods extends DKGAgentBase {
     // node-level token resolves to in the daemon, so the operator keeps the exit.
     const captureID = await asyncPublisher.enqueueKnowledgeAssetVmPublish(
       intent,
-      admittedByAgentAddress ? { admittedByAgentAddress } : undefined,
+      { admittedByAgentAddress },
     );
     return { captureID };
   }

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -375,21 +375,26 @@ export interface PublishAsyncOpts extends PublishOpts {
   };
   /** Caller signs typed-data built by the daemon. Requires `authorAgentAddress`. */
   authorSignTypedData?: (typedData: AuthorAttestationTypedData) => Promise<{ r: Uint8Array; vs: Uint8Array }>;
-  /**
-   * GH#2270 follow-up (3825162149) — the AUTHENTICATED identity admitting this job, for
-   * authorization only. A host that authenticated a caller (an EPCIS capture route, a plugin with
-   * a token) passes it here so that caller keeps the by-id force-clear its job may later need.
-   *
-   * Deliberately NOT the author: `authorAgentAddress` and `preSignedAuthorAttestation.authorAddress`
-   * name who SIGNED the assertion, which under curated publishing may be a third party who
-   * enqueued nothing. Granting a destructive clear to them would hand the double-publish decision
-   * to someone who never asked for the publish.
-   *
-   * Omitted → the job is admitted by the node itself (an internal producer such as the Kafka
-   * stream), and the node's default agent owns it; see `publishAsync`.
-   */
-  admittedByAgentAddress?: string;
 }
+
+/**
+ * WHO is admitting this job, stated by the caller rather than inferred from an absent field.
+ *
+ * Ownership decides who may later run the destructive by-id force clear, which is the only manual
+ * exit for a job automatic recovery cannot settle. It used to travel as an optional key inside
+ * `PublishAsyncOpts`, where omitting it silently meant "internal producer, use the node default" —
+ * and every ownership defect in GH#2270 was an omission, not a wrong value: the EPCIS capture route
+ * and then the Kafka stream plugin, both externally authenticated, both assigning their callers'
+ * jobs to the node.
+ *
+ * A required discriminated parameter makes that omission a COMPILE ERROR. A host that authenticated
+ * someone names them; an internal producer says so on purpose.
+ */
+export type PublishAsyncAdmission =
+  /** An externally authenticated caller. `agentAddress` is the request identity, never the author. */
+  | { readonly kind: 'agent'; readonly agentAddress: string }
+  /** No authenticated caller: the node itself admits the job and its default agent owns it. */
+  | { readonly kind: 'node' };
 
 export interface PublishAsyncQuadEnvelope {
   publicQuads?: Quad[];

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -224,6 +224,7 @@ export {
   type ContextGraphDiscoveryOptions,
   type PublishOpts,
   type PublishAsyncContent,
+  type PublishAsyncAdmission,
   type PublishAsyncOpts,
   type PublishAsyncQuadEnvelope,
   type ContextGraphMemberPrincipalType,

--- a/packages/agent/test/publish-async-admission.typecheck.ts
+++ b/packages/agent/test/publish-async-admission.typecheck.ts
@@ -1,0 +1,49 @@
+import {
+  DKGAgent,
+  type PublishAsyncAdmission,
+  type PublishAsyncOpts,
+} from '@origintrail-official/dkg-agent';
+
+// GH#2305 item 1 — admission is a REQUIRED, declared parameter, and this lane is the only place
+// that can prove it. The property under test is a compile error, so a runtime test cannot express
+// it: every ownership defect in GH#2270 was a caller that OMITTED the principal (the EPCIS capture
+// route, then the Kafka stream plugin, both externally authenticated, both silently assigning
+// their callers' jobs to the node). A convention cannot prevent an omission; a required parameter
+// makes it unrepresentable.
+
+declare const agent: DKGAgent;
+declare const content: Record<string, unknown>;
+
+// An authenticated host names its caller.
+void agent.publishAsync({ kind: 'agent', agentAddress: '0xabc' }, 'cg', content);
+// An internal producer says so on purpose, rather than by staying silent.
+void agent.publishAsync({ kind: 'node' }, 'cg', content);
+
+// @ts-expect-error Omitting admission must NOT compile. This is the whole point of the change:
+// the old shape accepted `publishAsync(cg, content, opts)` and treated the missing principal as
+// "internal producer, use the node default", which is precisely how EPCIS and Kafka each shipped
+// with their submitters' jobs owned by the node.
+void agent.publishAsync('cg', content);
+
+// @ts-expect-error A bare address is not an admission. The caller must state WHICH kind it is, so
+// "I have an authenticated identity" and "there is no authenticated caller" cannot be confused.
+void agent.publishAsync('0xabc', 'cg', content);
+
+// @ts-expect-error An unknown discriminant is rejected, so a new admission kind has to be added to
+// the union deliberately rather than invented at a call site.
+void agent.publishAsync({ kind: 'plugin', agentAddress: '0xabc' }, 'cg', content);
+
+// @ts-expect-error The agent form requires the address; `{ kind: 'agent' }` alone would re-open the
+// silent fallback this change closes.
+void agent.publishAsync({ kind: 'agent' }, 'cg', content);
+
+// @ts-expect-error Publish options are structurally unable to carry the principal. It used to live
+// here, which made object-spread ORDER part of the authorization design and let a client-supplied
+// options record name an owner on the Kafka lane.
+const leaked: PublishAsyncOpts = { admittedByAgentAddress: '0xabc' };
+void leaked;
+
+// The admission type itself is exported, so a host can name it in its own signatures rather than
+// re-deriving the shape.
+declare const declared: PublishAsyncAdmission;
+void declared;

--- a/packages/agent/test/publish-jsonld.test.ts
+++ b/packages/agent/test/publish-jsonld.test.ts
@@ -390,18 +390,17 @@ describe('publishJsonLd', () => {
     const authenticatedJob = await asyncPublisher.getStatus(authenticated.captureID);
     expect(authenticatedJob?.admission?.byAgentAddress).toBe(EPCIS_CALLER);
 
-    // 3826008054 — malformed-but-type-valid identities. An empty or whitespace-only string is
-    // ABSENT, not a principal: it must fall back to the node owner rather than slip past the
-    // default and enqueue a job nobody can ever force-clear.
+    // 3829496422 — a blank agent identity now REJECTS rather than falling back to the node.
+    // Silently substituting the node owner for a caller that claimed to have an authenticated
+    // identity hands the destructive force-clear to an agent that did not submit the job; a host
+    // with no principal is expected to say `{ kind: 'node' }` instead.
     for (const blank of ['', '   ']) {
-      const res = await agent.publishAsync(
+      await expect(agent.publishAsync(
         { kind: 'agent', agentAddress: blank },
         'did:dkg:context-graph:async-admission',
         content(`AsyncAdmissionBlank${blank.length}`),
         { localOnly: true },
-      );
-      const blankJob = await asyncPublisher.getStatus(res.captureID);
-      expect(blankJob?.admission?.byAgentAddress).toBe(nodeOwner);
+      )).rejects.toThrow(/non-blank agentAddress/);
     }
 
     // The discriminating half: the owner is NOT the author. Under curated publishing the signer

--- a/packages/agent/test/publish-jsonld.test.ts
+++ b/packages/agent/test/publish-jsonld.test.ts
@@ -314,6 +314,7 @@ describe('publishJsonLd', () => {
 
     const { captureID } = await Promise.race([
       agent.publishAsync(
+        { kind: 'node' },
         'did:dkg:context-graph:async-maxretries',
         {
           private: {
@@ -370,6 +371,7 @@ describe('publishJsonLd', () => {
     const nodeOwner = agent.getDefaultAgentAddress();
     expect(nodeOwner).toBeTruthy();
     const internal = await agent.publishAsync(
+      { kind: 'node' },
       'did:dkg:context-graph:async-admission',
       content('AsyncAdmissionInternal'),
       { localOnly: true },
@@ -380,9 +382,10 @@ describe('publishJsonLd', () => {
     // A host that AUTHENTICATED a caller supplies it, and that principal wins.
     const EPCIS_CALLER = '0x00000000000000000000000000000000000000e1';
     const authenticated = await agent.publishAsync(
+      { kind: 'agent', agentAddress: EPCIS_CALLER },
       'did:dkg:context-graph:async-admission',
       content('AsyncAdmissionAuthenticated'),
-      { localOnly: true, admittedByAgentAddress: EPCIS_CALLER },
+      { localOnly: true },
     );
     const authenticatedJob = await asyncPublisher.getStatus(authenticated.captureID);
     expect(authenticatedJob?.admission?.byAgentAddress).toBe(EPCIS_CALLER);
@@ -392,9 +395,10 @@ describe('publishJsonLd', () => {
     // default and enqueue a job nobody can ever force-clear.
     for (const blank of ['', '   ']) {
       const res = await agent.publishAsync(
+        { kind: 'agent', agentAddress: blank },
         'did:dkg:context-graph:async-admission',
         content(`AsyncAdmissionBlank${blank.length}`),
-        { localOnly: true, admittedByAgentAddress: blank },
+        { localOnly: true },
       );
       const blankJob = await asyncPublisher.getStatus(res.captureID);
       expect(blankJob?.admission?.byAgentAddress).toBe(nodeOwner);
@@ -418,6 +422,7 @@ describe('publishJsonLd', () => {
     const root = 'http://example.org/AsyncSecret';
 
     const { captureID } = await agent.publishAsync(
+      { kind: 'node' },
       'did:dkg:context-graph:async-priv-only',
       {
         private: {
@@ -493,6 +498,7 @@ describe('publishJsonLd', () => {
     const root = 'http://example.org/AsyncBareSecret';
 
     const { captureID } = await agent.publishAsync(
+      { kind: 'node' },
       'did:dkg:context-graph:async-bare-private',
       {
         '@context': 'http://schema.org/',
@@ -554,6 +560,7 @@ describe('publishJsonLd', () => {
     expect(tenant.agentAddress.toLowerCase()).not.toBe(publisherAddress.toLowerCase());
 
     const { captureID } = await agent.publishAsync(
+      { kind: 'node' },
       'did:dkg:context-graph:async-seal-e2e',
       {
         public: {
@@ -612,6 +619,7 @@ describe('publishJsonLd', () => {
     );
 
     const { captureID } = await agent.publishAsync(
+      { kind: 'node' },
       'did:dkg:context-graph:async-seal-distinct',
       {
         public: {
@@ -681,6 +689,7 @@ describe('publishJsonLd', () => {
     const stranger = ethers.Wallet.createRandom().address;
     await expect(
       agent.publishAsync(
+        { kind: 'node' },
         'did:dkg:context-graph:async-seal-reject',
         {
           public: {
@@ -700,6 +709,7 @@ describe('publishJsonLd', () => {
     const selfSovereign = await agent.registerAgent('SelfSovereign', { publicKey: publicKeyCompressed });
     await expect(
       agent.publishAsync(
+        { kind: 'node' },
         'did:dkg:context-graph:async-seal-reject',
         {
           public: {
@@ -724,6 +734,7 @@ describe('publishJsonLd', () => {
     const root = 'http://example.org/AsyncSealParityEntity';
 
     const { captureID } = await agent.publishAsync(
+      { kind: 'node' },
       'did:dkg:context-graph:async-seal-parity',
       {
         public: {
@@ -762,6 +773,7 @@ describe('publishJsonLd', () => {
 
     await expect(
       agent.publishAsync(
+        { kind: 'node' },
         'did:dkg:context-graph:async-seal-non-v10',
         {
           public: {
@@ -791,6 +803,7 @@ describe('publishJsonLd', () => {
 
     await expect(
       agent.publishAsync(
+        { kind: 'node' },
         'did:dkg:context-graph:async-seal-throw',
         {
           public: {
@@ -821,6 +834,7 @@ describe('publishJsonLd', () => {
 
     await expect(
       agent.publishAsync(
+        { kind: 'node' },
         'did:dkg:context-graph:async-seal-explicit-throw',
         {
           public: {
@@ -848,6 +862,7 @@ describe('publishJsonLd', () => {
     const root = 'http://example.org/AsyncSealEntity';
 
     const { captureID } = await agent.publishAsync(
+      { kind: 'node' },
       'did:dkg:context-graph:async-seal',
       {
         public: {
@@ -876,6 +891,7 @@ describe('publishJsonLd', () => {
     const root = 'http://example.org/AsyncSealPrivEntity';
 
     const { captureID } = await agent.publishAsync(
+      { kind: 'node' },
       'did:dkg:context-graph:async-seal-priv',
       {
         '@context': 'http://schema.org/',
@@ -901,6 +917,7 @@ describe('publishJsonLd', () => {
     const root = 'http://example.org/AsyncSealDiskSnapshotEntity';
 
     const { captureID } = await agent.publishAsync(
+      { kind: 'node' },
       'did:dkg:context-graph:async-seal-disk-snapshot',
       {
         '@context': 'http://schema.org/',
@@ -955,6 +972,7 @@ describe('publishJsonLd', () => {
 
     await expect(
       agent.publishAsync(
+        { kind: 'node' },
         'did:dkg:context-graph:async-seal-presigned',
         {
           public: {
@@ -1003,6 +1021,7 @@ describe('publishJsonLd', () => {
     });
     await source.agent.registerContextGraph('async-valid-presigned-source');
     const sourceCapture = await source.agent.publishAsync(
+      { kind: 'node' },
       'did:dkg:context-graph:async-valid-presigned-source',
       content,
       {
@@ -1034,6 +1053,7 @@ describe('publishJsonLd', () => {
     });
     await target.agent.registerContextGraph('async-valid-presigned-target');
     const targetCapture = await target.agent.publishAsync(
+      { kind: 'node' },
       'did:dkg:context-graph:async-valid-presigned-target',
       content,
       {
@@ -1069,6 +1089,7 @@ describe('publishJsonLd', () => {
 
     await expect(
       agent.publishAsync(
+        { kind: 'node' },
         'did:dkg:context-graph:async-seal-mutex',
         {
           public: {
@@ -1111,6 +1132,7 @@ describe('publishJsonLd', () => {
 
     let typedDataReceived: { domain: unknown; types: unknown; message: { authorAddress: string; merkleRoot: string; reservedKaId: bigint } } | null = null;
     const { captureID } = await agent.publishAsync(
+      { kind: 'node' },
       'did:dkg:context-graph:async-seal-callback',
       {
         public: {
@@ -1192,6 +1214,7 @@ describe('publishJsonLd', () => {
 
     await expect(
       agent.publishAsync(
+        { kind: 'node' },
         'did:dkg:context-graph:async-seal-cb-noaddr',
         {
           public: {
@@ -1229,6 +1252,7 @@ describe('publishJsonLd', () => {
     expect(selfSov.agentAddress.toLowerCase()).not.toBe(publisherAddress.toLowerCase());
 
     const { captureID } = await agent.publishAsync(
+      { kind: 'node' },
       'did:dkg:context-graph:async-cb-e2e',
       {
         public: {
@@ -1296,6 +1320,7 @@ describe('publishJsonLd', () => {
     };
     await expect(
       agent.publishAsync(
+        { kind: 'node' },
         'did:dkg:context-graph:async-priorver',
         content,
         {
@@ -1306,6 +1331,7 @@ describe('publishJsonLd', () => {
     ).rejects.toThrow(/no longer accepts transitionType/);
     await expect(
       agent.publishAsync(
+        { kind: 'node' },
         'did:dkg:context-graph:async-priorver',
         content,
         {
@@ -1316,6 +1342,7 @@ describe('publishJsonLd', () => {
     ).rejects.toThrow(/no longer accepts transitionType/);
     await expect(
       agent.publishAsync(
+        { kind: 'node' },
         'did:dkg:context-graph:async-priorver',
         content,
         {
@@ -1350,11 +1377,13 @@ describe('publishJsonLd', () => {
     );
 
     await expect(agent.publishAsync(
+      { kind: 'node' },
       'did:dkg:context-graph:async-invalid-access-envelope',
       content,
       { localOnly: true, accessPolicy: 'allowList' },
     )).rejects.toThrow(/allowList policy requires allowedPeers/);
     await expect(agent.publishAsync(
+      { kind: 'node' },
       'did:dkg:context-graph:async-invalid-access-envelope',
       content,
       { localOnly: true, accessPolicy: 'public', allowedPeers: ['peer-a'] },
@@ -1374,6 +1403,7 @@ describe('publishJsonLd', () => {
 
     await expect(
       agent.publishAsync(
+        { kind: 'node' },
         'did:dkg:context-graph:async-entity-proofs',
         {
           public: {
@@ -1401,6 +1431,7 @@ describe('publishJsonLd', () => {
     await agent.registerContextGraph('async-node-id-override');
 
     const { captureID } = await agent.publishAsync(
+      { kind: 'node' },
       'did:dkg:context-graph:async-node-id-override',
       {
         public: {
@@ -1428,6 +1459,7 @@ describe('publishJsonLd', () => {
     await agent.registerContextGraph('async-node-id-zero');
 
     const { captureID } = await agent.publishAsync(
+      { kind: 'node' },
       'did:dkg:context-graph:async-node-id-zero',
       {
         public: {
@@ -1460,6 +1492,7 @@ describe('publishJsonLd', () => {
     try {
       await expect(
         agent.publishAsync(
+          { kind: 'node' },
           'did:dkg:context-graph:async-no-signer',
           {
             public: {
@@ -1512,6 +1545,7 @@ describe('publishJsonLd', () => {
 
     try {
       await agent.publishAsync(
+        { kind: 'node' },
         'did:dkg:context-graph:async-sync-parity',
         {
           public: {
@@ -1538,6 +1572,7 @@ describe('publishJsonLd', () => {
     // Intentionally skip registerContextGraph so the CG has no on-chain id.
 
     const { captureID } = await agent.publishAsync(
+      { kind: 'node' },
       'did:dkg:context-graph:async-no-onchain',
       {
         public: {
@@ -1583,6 +1618,7 @@ describe('publishJsonLd', () => {
     // The submitted graph is a new KA even if an older root-addressed asset
     // happens to contain an identical triple.
     const { captureID } = await agent.publishAsync(
+      { kind: 'node' },
       'async-subtract-observe',
       {
         publicQuads: [{ subject: root, predicate: 'http://example.org/p', object: '"hello"', graph: '' }],
@@ -1607,6 +1643,7 @@ describe('publishJsonLd', () => {
     const root = 'http://example.org/AsyncSubGraphSecret';
 
     const { captureID } = await agent.publishAsync(
+      { kind: 'node' },
       'async-subgraph',
       {
         public: {

--- a/packages/agent/test/publish-jsonld.test.ts
+++ b/packages/agent/test/publish-jsonld.test.ts
@@ -368,8 +368,13 @@ describe('publishJsonLd', () => {
 
     // An INTERNAL producer supplies no principal: the node's own default agent owns the job, the
     // same identity a node-level token resolves to in the daemon, so the operator keeps the exit.
-    const nodeOwner = agent.getDefaultAgentAddress();
-    expect(nodeOwner).toBeTruthy();
+    // 3829782408 — the CANONICAL node identity, which is what the daemon resolves a node-level
+    // token to, so the recorded owner is the one that token can present. It always yields a
+    // string (default agent, else this node's peer id), which is what makes an unowned job
+    // unrepresentable rather than merely unlikely.
+    const nodeOwner = agent.resolveAgentAddress(undefined);
+    expect(typeof nodeOwner).toBe('string');
+    expect(nodeOwner.length).toBeGreaterThan(0);
     const internal = await agent.publishAsync(
       { kind: 'node' },
       'did:dkg:context-graph:async-admission',

--- a/packages/agent/test/publish-jsonld.test.ts
+++ b/packages/agent/test/publish-jsonld.test.ts
@@ -384,6 +384,31 @@ describe('publishJsonLd', () => {
     const internalJob = await asyncPublisher.getStatus(internal.captureID);
     expect(internalJob?.admission?.byAgentAddress).toBe(nodeOwner);
 
+    // 3829948739 — the row above cannot fail for the branch this change actually ADDED. On this
+    // fixture a default agent always exists, so `resolveAgentAddress(undefined)` and the old
+    // `getDefaultAgentAddress()` return the same value: reverting to the optional owner would
+    // leave it green. Removing the default agent is what separates them, and a node-admitted job
+    // must STILL be owned — by this node's peer id — rather than enqueued unowned.
+    // The field, not the accessor: `resolveAgentAddress` reads `defaultAgentAddress` directly,
+    // so spying on `getDefaultAgentAddress` would not reach the branch under test.
+    const withDefault = (agent as unknown as { defaultAgentAddress?: string });
+    const savedDefault = withDefault.defaultAgentAddress;
+    withDefault.defaultAgentAddress = undefined;
+    try {
+      expect(agent.resolveAgentAddress(undefined)).toBe(agent.peerId);
+      const peerFallback = await agent.publishAsync(
+        { kind: 'node' },
+        'did:dkg:context-graph:async-admission',
+        content('AsyncAdmissionPeerFallback'),
+        { localOnly: true },
+      );
+      const peerJob = await asyncPublisher.getStatus(peerFallback.captureID);
+      expect(peerJob?.admission?.byAgentAddress).toBe(agent.peerId);
+      expect(peerJob?.admission?.byAgentAddress).toBeTruthy();
+    } finally {
+      withDefault.defaultAgentAddress = savedDefault;
+    }
+
     // A host that AUTHENTICATED a caller supplies it, and that principal wins.
     const EPCIS_CALLER = '0x00000000000000000000000000000000000000e1';
     const authenticated = await agent.publishAsync(

--- a/packages/agent/test/publish-jsonld.test.ts
+++ b/packages/agent/test/publish-jsonld.test.ts
@@ -403,6 +403,35 @@ describe('publishJsonLd', () => {
       )).rejects.toThrow(/non-blank agentAddress/);
     }
 
+    // 3829656449 — the admission object belongs to the CALLER, and publishing suspends on many
+    // awaits. Re-reading it at enqueue let a caller pass validation as one identity and have a
+    // different one persisted. The owner is captured before the first await, so mutating the
+    // object mid-flight changes nothing.
+    const mutable = { kind: 'agent' as const, agentAddress: EPCIS_CALLER };
+    const pending = agent.publishAsync(
+      mutable,
+      'did:dkg:context-graph:async-admission',
+      content('AsyncAdmissionMutated'),
+      { localOnly: true },
+    );
+    mutable.agentAddress = '   ';          // would have blanked the owner
+    const mutatedJob = await asyncPublisher.getStatus((await pending).captureID);
+    expect(mutatedJob?.admission?.byAgentAddress).toBe(EPCIS_CALLER);
+
+    // 3829656707 — the forged-owner path, against the REAL publish method rather than a mock. A
+    // legacy `admittedByAgentAddress` in the options bag must lose to the declared admission; the
+    // Kafka unit test could not prove this, because the decision lives here.
+    const ATTACKER = '0x00000000000000000000000000000000000000ff';
+    const forged = await agent.publishAsync(
+      { kind: 'agent', agentAddress: EPCIS_CALLER },
+      'did:dkg:context-graph:async-admission',
+      content('AsyncAdmissionForged'),
+      { localOnly: true, admittedByAgentAddress: ATTACKER } as never,
+    );
+    const forgedJob = await asyncPublisher.getStatus(forged.captureID);
+    expect(forgedJob?.admission?.byAgentAddress).toBe(EPCIS_CALLER);
+    expect(JSON.stringify(forgedJob)).not.toContain(ATTACKER);
+
     // The discriminating half: the owner is NOT the author. Under curated publishing the signer
     // may be a third party who enqueued nothing, and handing them a destructive clear would give
     // the double-publish decision to someone who never asked for the publish.

--- a/packages/agent/test/publish-literal-size.test.ts
+++ b/packages/agent/test/publish-literal-size.test.ts
@@ -18,6 +18,7 @@ describe('agent publish literal size validation', () => {
     await expect(
       PublishMethods.prototype.publishAsync.call(
         agentStub as never,
+        { kind: 'node' },
         'computer-history',
         {
           publicQuads: [],
@@ -30,6 +31,39 @@ describe('agent publish literal size validation', () => {
       maxBytes: 60_000,
       predicate: 'http://schema.org/text',
     });
+  });
+
+  it('rejects a malformed admission before any staging, and never falls back to the node', async () => {
+    // 3829496422 — the union is erased at runtime, so a JavaScript plugin can present an unknown
+    // kind. Reading "not 'agent'" as node admission would silently rebuild the ownership defect
+    // this parameter exists to prevent, and a blank identity must not become the node owner.
+    // Rejection happens BEFORE any workspace work: `contextGraphExists` is the first thing the
+    // publish path touches, so it not being called is the evidence nothing was staged.
+    const contextGraphExists = vi.fn(async () => true);
+    const agentStub = { contextGraphExists, getDefaultAgentAddress: () => '0xNODE' };
+    const content = { publicQuads: [], privateQuads: [] };
+
+    for (const bad of [
+      { kind: 'agnt', agentAddress: '0xSUBMITTER' },  // typo: must NOT become node-owned
+      { kind: 'agent' },                              // no address
+      { kind: 'agent', agentAddress: '' },            // blank
+      { kind: 'agent', agentAddress: '   ' },         // whitespace only
+      { kind: 'agent', agentAddress: null },          // wrong type, and used to throw late
+      {},                                             // no kind at all
+      undefined,
+    ]) {
+      await expect(
+        PublishMethods.prototype.publishAsync.call(
+          agentStub as never,
+          bad as never,
+          'computer-history',
+          content as never,
+        ),
+      ).rejects.toThrow(/admission/i);
+    }
+
+    // Nothing was staged for any of them.
+    expect(contextGraphExists).not.toHaveBeenCalled();
   });
 
   it('rejects direct publish quads before chain or publisher work', async () => {

--- a/packages/agent/test/publish-literal-size.test.ts
+++ b/packages/agent/test/publish-literal-size.test.ts
@@ -67,6 +67,49 @@ describe('agent publish literal size validation', () => {
     expect(contextGraphExists).not.toHaveBeenCalled();
   });
 
+  it('cannot be redirected by an admission whose fields change between reads', async () => {
+    // 3830105265 — the admission object is caller-owned and may expose getters or be a Proxy. When
+    // the guard and the resolver each read it, a value that answers 'node' once and 'agent' after
+    // slipped an empty owner past the non-blank check. Every field is snapshotted once now, so a
+    // shifting object either fails validation or is pinned to whatever the FIRST read returned.
+    const contextGraphExists = vi.fn(async () => true);
+    const agentStub = { contextGraphExists, resolveAgentAddress: () => '0xNODE' };
+
+    let kindReads = 0;
+    const shifting = {
+      get kind() { return ++kindReads === 1 ? 'node' : 'agent'; },
+      get agentAddress() { return '   '; },
+    };
+    await PublishMethods.prototype.publishAsync.call(
+      agentStub as never,
+      shifting as never,
+      'computer-history',
+      { publicQuads: [], privateQuads: [OVERSIZED_TEXT_QUAD] } as never,
+    ).catch(() => undefined);
+    // The invariant is the single read. Pinned to its first answer the object IS valid node
+    // admission, so it proceeds — what must never happen is the guard seeing 'node' and the
+    // resolver then seeing 'agent' with a blank address, which needs a SECOND read to occur.
+    expect(kindReads).toBe(1);
+
+    // The mirror case: an object that starts as a valid agent and then blanks itself is pinned to
+    // the identity that was validated, never to the later blank.
+    let addressReads = 0;
+    const decaying = {
+      kind: 'agent',
+      get agentAddress() { return ++addressReads === 1 ? '0xSUBMITTER' : '   '; },
+    };
+    await expect(
+      PublishMethods.prototype.publishAsync.call(
+        agentStub as never,
+        decaying as never,
+        'computer-history',
+        { publicQuads: [], privateQuads: [OVERSIZED_TEXT_QUAD] } as never,
+      ),
+    ).rejects.toMatchObject({ code: 'OVERSIZED_RDF_LITERAL' });
+    // Admission resolved (it got past the gate to the literal check) reading the address ONCE.
+    expect(addressReads).toBe(1);
+  });
+
   it('rejects direct publish quads before chain or publisher work', async () => {
     const agentStub = {
       log: { info: vi.fn() },

--- a/packages/agent/test/publish-literal-size.test.ts
+++ b/packages/agent/test/publish-literal-size.test.ts
@@ -13,7 +13,7 @@ describe('agent publish literal size validation', () => {
   it('rejects publishAsync private quads before workspace staging', async () => {
     const agentStub = {
       contextGraphExists: vi.fn(async () => true),
-      getDefaultAgentAddress: () => '0xNODE',
+      resolveAgentAddress: () => '0xNODE',
     };
 
     await expect(
@@ -41,7 +41,7 @@ describe('agent publish literal size validation', () => {
     // Rejection happens BEFORE any workspace work: `contextGraphExists` is the first thing the
     // publish path touches, so it not being called is the evidence nothing was staged.
     const contextGraphExists = vi.fn(async () => true);
-    const agentStub = { contextGraphExists, getDefaultAgentAddress: () => '0xNODE' };
+    const agentStub = { contextGraphExists, resolveAgentAddress: () => '0xNODE' };
     const content = { publicQuads: [], privateQuads: [] };
 
     for (const bad of [

--- a/packages/agent/test/publish-literal-size.test.ts
+++ b/packages/agent/test/publish-literal-size.test.ts
@@ -13,6 +13,7 @@ describe('agent publish literal size validation', () => {
   it('rejects publishAsync private quads before workspace staging', async () => {
     const agentStub = {
       contextGraphExists: vi.fn(async () => true),
+      getDefaultAgentAddress: () => '0xNODE',
     };
 
     await expect(

--- a/packages/cli/src/daemon/plugin-api.ts
+++ b/packages/cli/src/daemon/plugin-api.ts
@@ -15,14 +15,22 @@ import type {
 import type { RequestContext as DaemonRequestContext } from './routes/context.js';
 
 /**
- * The admission contract a plugin must satisfy when it enqueues an async publish.
+ * The agent capability a route plugin may use, derived from the canonical daemon context.
  *
- * Re-exported here rather than restated by each plugin: a hand-copied union cannot be checked
- * against the real agent, so it goes stale silently the moment a variant is added or an address
- * shape is refined — which is exactly how the Kafka lane ended up assigning its submitters' jobs
- * to the node.
+ * Derived rather than restated: a hand-written copy keeps only whatever someone remembered to
+ * sync. Argument order, content and option types and the result all drift independently, and
+ * the plugin dispatcher's cast suppresses the mismatch — so a stale plugin fails at runtime
+ * instead of at compile time. That is how the Kafka lane came to assign its submitters' jobs to
+ * the node while still type-checking.
  */
-export type { PublishAsyncAdmission } from '@origintrail-official/dkg-agent';
+//
+// `OmitThisParameter` is required, not cosmetic: these methods are declared with an explicit
+// `this: DKGAgent`, so a plain `Pick` produces a capability nobody but a full agent can call.
+// Dropping only the receiver keeps the parameter and result types — which is the drift that
+// actually matters — while letting a plugin hold the narrow surface.
+export type PluginAgentCapability = {
+  [K in 'publishAsync' | 'query']: OmitThisParameter<DaemonRequestContext['agent'][K]>;
+};
 
 /**
  * Plugin-only view of the canonical daemon context. The deprecated aliases are

--- a/packages/cli/src/daemon/plugin-api.ts
+++ b/packages/cli/src/daemon/plugin-api.ts
@@ -15,6 +15,16 @@ import type {
 import type { RequestContext as DaemonRequestContext } from './routes/context.js';
 
 /**
+ * The admission contract a plugin must satisfy when it enqueues an async publish.
+ *
+ * Re-exported here rather than restated by each plugin: a hand-copied union cannot be checked
+ * against the real agent, so it goes stale silently the moment a variant is added or an address
+ * shape is refined — which is exactly how the Kafka lane ended up assigning its submitters' jobs
+ * to the node.
+ */
+export type { PublishAsyncAdmission } from '@origintrail-official/dkg-agent';
+
+/**
  * Plugin-only view of the canonical daemon context. The deprecated aliases are
  * materialized by the plugin dispatcher, so built-in routes cannot accidentally
  * treat them as independent lifecycle state.

--- a/packages/cli/src/daemon/routes/epcis.ts
+++ b/packages/cli/src/daemon/routes/epcis.ts
@@ -530,24 +530,14 @@ export async function handleEpcisRoutes(ctx: RequestContext): Promise<void> {
 
     const epcisPublisher: EpcisAsyncPublisher = {
       async publishAsync(contextGraphId, content, opts) {
+        // An EPCIS capture is externally authenticated, so the job belongs to the agent that
+        // submitted it. Declared as admission rather than smuggled through the options bag:
+        // the caller cannot forget it and a request body cannot supply it.
         return agent.publishAsync(
+          { kind: 'agent', agentAddress: requestAgentAddress },
           contextGraphId,
           content as Record<string, unknown>,
-          {
-            ...opts,
-            /**
-             * An EPCIS capture is externally authenticated, so the job it enqueues belongs to
-             * the agent that submitted it. Without this the publish path treats the capture as
-             * an internal producer and assigns it to the node's default agent, which both
-             * denies the submitter the by-id force clear — the only manual exit for a held job
-             * — and hands that destructive capability to an agent that never submitted it.
-             *
-             * `handleCaptureAsync` builds these opts from a strict allow-list, so a request
-             * body cannot carry this field; spreading first is defence in depth if that
-             * allow-list ever widens. Authorization only — never an author-selection input.
-             */
-            admittedByAgentAddress: requestAgentAddress,
-          },
+          opts,
         );
       },
     };

--- a/packages/cli/test/epcis-route-readiness.test.ts
+++ b/packages/cli/test/epcis-route-readiness.test.ts
@@ -224,7 +224,7 @@ describe('EPCIS async capture publisher readiness', () => {
     // capability over a job it never enqueued.
     const SUBMITTER = '0x00000000000000000000000000000000000000a7';
     const FORGED = '0x00000000000000000000000000000000000000ff';
-    const published: Array<{ opts: any }> = [];
+    const published: Array<{ admission: any; opts: any }> = [];
     const ctx = createContext({
       req: createRequest({
         epcisDocument: VALID_OBJECT_EVENT_DOC,
@@ -233,8 +233,8 @@ describe('EPCIS async capture publisher readiness', () => {
       }),
       requestAgentAddress: SUBMITTER,
       agent: {
-        publishAsync: async (_cg: string, _content: unknown, opts: unknown) => {
-          published.push({ opts });
+        publishAsync: async (admission: unknown, _cg: string, _content: unknown, opts: unknown) => {
+          published.push({ admission, opts });
           return { captureID: 'capture-owner-1' };
         },
       } as unknown as RequestContext['agent'],
@@ -244,13 +244,12 @@ describe('EPCIS async capture publisher readiness', () => {
     await handleEpcisRoutes(ctx);
 
     expect(ctx.res.statusCode).toBe(202);
-    // The authenticated identity is what lands. The client's value never arrives at all:
-    // `handleCaptureAsync` builds publisher opts from a strict allow-list, so the row below is
-    // an end-to-end check that a request body cannot choose the owner — NOT proof that the
-    // spread ordering defends it. Reversing that ordering leaves this row green (measured), so
-    // the ordering is defence in depth only, and the allow-list is the guard.
-    expect(published[0]?.opts?.admittedByAgentAddress).toBe(SUBMITTER);
-    expect(published[0]?.opts?.admittedByAgentAddress).not.toBe(FORGED);
+    // The authenticated identity is DECLARED as the admission argument, so no merge order and
+    // no allow-list is load-bearing for it: a request body has nowhere to put an owner.
+    expect(published[0]?.admission).toEqual({ kind: 'agent', agentAddress: SUBMITTER });
+    // And the client's attempt never reaches the publish options either.
+    expect(published[0]?.opts?.admittedByAgentAddress).toBeUndefined();
+    expect(JSON.stringify(published[0])).not.toContain(FORGED);
   });
 
   it('accepts capture and publishes bare documents as private content without route public wrapping', async () => {
@@ -261,7 +260,7 @@ describe('EPCIS async capture publisher readiness', () => {
         publishOptions: { accessPolicy: 'allowList', allowedPeers: ['peer-a'] },
       }),
       agent: {
-        publishAsync: async (contextGraphId: string, content: unknown, opts: unknown) => {
+        publishAsync: async (_admission: unknown, contextGraphId: string, content: unknown, opts: unknown) => {
           published.push({ contextGraphId, content, opts });
           return { captureID: 'capture-route-1' };
         },
@@ -283,7 +282,7 @@ describe('EPCIS async capture publisher readiness', () => {
         content: { private: VALID_OBJECT_EVENT_DOC },
         // 3825614158 — the authenticated submitter is stamped as the admission owner on every
         // capture, beside the client's publish options.
-        opts: { accessPolicy: 'allowList', allowedPeers: ['peer-a'], admittedByAgentAddress: '0x0' },
+        opts: { accessPolicy: 'allowList', allowedPeers: ['peer-a'] },
       },
     ]);
   });
@@ -297,7 +296,7 @@ describe('EPCIS async capture publisher readiness', () => {
         epcisDocument: VALID_OBJECT_EVENT_DOC,
       }),
       agent: {
-        publishAsync: async (contextGraphId: string, content: unknown, opts: unknown) => {
+        publishAsync: async (_admission: unknown, contextGraphId: string, content: unknown, opts: unknown) => {
           published.push({ contextGraphId, content, opts });
           return { captureID: 'capture-route-2' };
         },
@@ -312,7 +311,7 @@ describe('EPCIS async capture publisher readiness', () => {
       {
         contextGraphId: 'per-request-cg',
         content: { private: VALID_OBJECT_EVENT_DOC },
-        opts: { subGraphName: 'research', admittedByAgentAddress: '0x0' },
+        opts: { subGraphName: 'research' },
       },
     ]);
   });

--- a/packages/kafka-plugin/src/handler.ts
+++ b/packages/kafka-plugin/src/handler.ts
@@ -19,6 +19,7 @@ export interface KafkaPluginCtx {
   res: ServerResponse;
   agent: {
     publishAsync(
+      admission: { kind: 'agent'; agentAddress: string } | { kind: 'node' },
       contextGraphId: string,
       content: Record<string, unknown>,
       opts?: Record<string, unknown>,
@@ -178,19 +179,15 @@ async function handlePostRegister(
   } as unknown as Record<string, unknown>;
   let publishResult: { captureID: string };
   try {
-    // A Kafka stream request is EXTERNALLY AUTHENTICATED, so
-    // the job it enqueues belongs to the agent that submitted it. Without this the agent's
-    // publish path treats it as an internal producer and assigns it to the node's default
-    // agent: the submitter loses the by-id force clear that is the only manual exit for a held
-    // job, and the node owner gains a destructive capability over a job it never submitted.
-    //
-    // Stamped AFTER the spread, and here that ordering IS the guard: unlike the EPCIS lane,
-    // `publishOptions` is an unfiltered client-supplied record, so a request body could
-    // otherwise name its own owner.
-    publishResult = await ctx.agent.publishAsync(cgId, publishContent, {
-      ...opts.publishOptions,
-      admittedByAgentAddress: ctx.requestAgentAddress,
-    });
+    // A Kafka stream request is externally authenticated, so the job belongs to the agent that
+    // submitted it. The identity is DECLARED rather than merged into the options bag, so no
+    // spread ordering decides authorization and a client-supplied option cannot name an owner.
+    publishResult = await ctx.agent.publishAsync(
+      { kind: 'agent', agentAddress: ctx.requestAgentAddress },
+      cgId,
+      publishContent,
+      opts.publishOptions,
+    );
   } catch (err) {
     const code = (err as { code?: string; name?: string })?.code ?? (err as { name?: string })?.name;
     if (code === 'ContextGraphNotFound') {

--- a/packages/kafka-plugin/src/handler.ts
+++ b/packages/kafka-plugin/src/handler.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { randomUUID } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { jsonResponse, readBody } from '@origintrail-official/dkg/daemon/plugin-api';
-import type { PublishAsyncAdmission } from '@origintrail-official/dkg/daemon/plugin-api';
+import type { PluginAgentCapability } from '@origintrail-official/dkg/daemon/plugin-api';
 import { coreSchema, CORE_FIELDS, type CoreFields } from './schema.js';
 import { buildKa, mergeAugmentFragment } from './ka-builder.js';
 import type { KafkaPluginExtension } from './extension.js';
@@ -18,18 +18,8 @@ import {
 export interface KafkaPluginCtx {
   req: IncomingMessage;
   res: ServerResponse;
-  agent: {
-    publishAsync(
-      admission: PublishAsyncAdmission,
-      contextGraphId: string,
-      content: Record<string, unknown>,
-      opts?: Record<string, unknown>,
-    ): Promise<{ captureID: string }>;
-    query(
-      sparql: string,
-      opts?: { contextGraphId?: string; [k: string]: unknown },
-    ): Promise<{ bindings: Array<Record<string, unknown>> }>;
-  };
+  // Derived from the daemon context, so a signature change cannot leave this stale.
+  agent: PluginAgentCapability;
   publisherControl: {
     getStatus(captureID: string): Promise<KafkaJobStatus | null>;
   };

--- a/packages/kafka-plugin/src/handler.ts
+++ b/packages/kafka-plugin/src/handler.ts
@@ -49,7 +49,13 @@ interface KafkaJobScope {
 export interface CreateHandlerOptions {
   basePath: string;
   contextGraphId?: string;
-  publishOptions?: Record<string, unknown>;
+  /**
+   * The agent's own publish options, derived from the capability rather than restated as a
+   * loose record. A `Record<string, unknown>` is assignable to them (its index signature
+   * satisfies the optional properties), so it compiled fine — and silently accepted nonsense
+   * like `accessPolicy: 42` from plugin configuration.
+   */
+  publishOptions?: Parameters<PluginAgentCapability['publishAsync']>[3];
   extension?: KafkaPluginExtension<Record<string, unknown>>;
 }
 

--- a/packages/kafka-plugin/src/handler.ts
+++ b/packages/kafka-plugin/src/handler.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { randomUUID } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { jsonResponse, readBody } from '@origintrail-official/dkg/daemon/plugin-api';
+import type { PublishAsyncAdmission } from '@origintrail-official/dkg/daemon/plugin-api';
 import { coreSchema, CORE_FIELDS, type CoreFields } from './schema.js';
 import { buildKa, mergeAugmentFragment } from './ka-builder.js';
 import type { KafkaPluginExtension } from './extension.js';
@@ -19,7 +20,7 @@ export interface KafkaPluginCtx {
   res: ServerResponse;
   agent: {
     publishAsync(
-      admission: { kind: 'agent'; agentAddress: string } | { kind: 'node' },
+      admission: PublishAsyncAdmission,
       contextGraphId: string,
       content: Record<string, unknown>,
       opts?: Record<string, unknown>,

--- a/packages/kafka-plugin/test/factory.test.ts
+++ b/packages/kafka-plugin/test/factory.test.ts
@@ -48,7 +48,9 @@ describe('createKafkaPlugin factory wiring', () => {
     } as never);
     expect(captured.statusCode).toBe(202);
     expect(publishAsync).toHaveBeenCalledTimes(1);
-    expect(publishAsync.mock.calls[0][0]).toBe('urn:cg:demo');
+    // Admission is argument 0 now; the context graph moved to 1.
+    expect(publishAsync.mock.calls[0][1]).toBe('urn:cg:demo');
+    expect(publishAsync.mock.calls[0][0]).toMatchObject({ kind: 'agent' });
   });
   it('forwards publishOptions through the factory to publishAsync', async () => {
     const plugin = createKafkaPlugin({
@@ -67,7 +69,7 @@ describe('createKafkaPlugin factory wiring', () => {
       config: {},
       path: '/api/kafka/streams/register',
     } as never);
-    expect(publishAsync.mock.calls[0][2]).toEqual({ accessPolicy: 'public' });
+    expect(publishAsync.mock.calls[0][3]).toEqual({ accessPolicy: 'public' });
   });
   it('respects custom basePath override', async () => {
     const plugin = createKafkaPlugin({ basePath: '/custom/kafka', contextGraphId: 'urn:cg:demo' });

--- a/packages/kafka-plugin/test/handler.test.ts
+++ b/packages/kafka-plugin/test/handler.test.ts
@@ -88,7 +88,7 @@ describe('handler — POST /register happy path', () => {
     await handler({ ...ctx, req, res, url: new URL('http://x/api/kafka/streams/register'), path: '/api/kafka/streams/register' });
     expect(captured.statusCode).toBe(202);
     expect(publishAsync).toHaveBeenCalledTimes(1);
-    const [cgId, content] = publishAsync.mock.calls[0];
+    const [, cgId, content] = publishAsync.mock.calls[0];
     expect(cgId).toBe('urn:cg:demo');
     expect(content).toHaveProperty('private');
     expect(content).toHaveProperty('public');
@@ -110,7 +110,7 @@ describe('handler — POST /register happy path', () => {
     const handler = createHandler({ basePath: '/api/kafka/streams' });
     await handler({ ...ctx, req, res, path: '/api/kafka/streams/register' });
     expect(captured.statusCode).toBe(202);
-    expect(publishAsync.mock.calls[0][0]).toBe('urn:cg:from-config');
+    expect(publishAsync.mock.calls[0][1]).toBe('urn:cg:from-config');
   });
   it('stamps the AUTHENTICATED submitter and a client cannot name its own owner', async () => {
     // Ownership decides who may run the destructive by-id clear. `publishOptions` here is an
@@ -127,9 +127,10 @@ describe('handler — POST /register happy path', () => {
       publishOptions: { accessPolicy: 'public', admittedByAgentAddress: ATTACKER },
     });
     await handler({ ...ctx, req, res, path: '/api/kafka/streams/register' });
-    const opts = publishAsync.mock.calls[0][2] as Record<string, unknown>;
-    expect(opts.admittedByAgentAddress).toBe(SUBMITTER);
-    expect(opts.admittedByAgentAddress).not.toBe(ATTACKER);
+    expect(publishAsync.mock.calls[0][0]).toEqual({ kind: 'agent', agentAddress: SUBMITTER });
+    const opts = publishAsync.mock.calls[0][3] as Record<string, unknown>;
+    // The client's attempt stays in the options bag, where it now means nothing.
+    expect(opts.admittedByAgentAddress).toBe(ATTACKER);
     // Ordinary options still forward untouched.
     expect(opts.accessPolicy).toBe('public');
   });
@@ -146,11 +147,10 @@ describe('handler — POST /register happy path', () => {
     // The authenticated submitter is stamped alongside the forwarded options: a Kafka stream
     // request is externally authenticated, so its job must be owned by the agent that sent it
     // rather than by the node default.
-    expect(publishAsync.mock.calls[0][2]).toEqual({
-      accessPolicy: 'public',
-      subGraphName: 'streams',
-      admittedByAgentAddress: '0x0000000000000000000000000000000000000000',
-    });
+    expect(publishAsync.mock.calls[0][3]).toEqual({ accessPolicy: 'public', subGraphName: 'streams' });
+    // The submitter is declared, not merged into the options.
+    expect(publishAsync.mock.calls[0][0]).toEqual(
+      { kind: 'agent', agentAddress: '0x0000000000000000000000000000000000000000' });
   });
 });
 describe('handler — POST /register error paths', () => {
@@ -707,7 +707,7 @@ describe('handler — register-to-discovery regression', () => {
     const handler = createHandler({ basePath: '/api/kafka/streams', contextGraphId: cgId });
     await handler({ ...ctx, req, res, path: '/api/kafka/streams/register' });
     expect(captured.statusCode).toBe(202);
-    const [, content] = publishAsync.mock.calls[0];
+    const [, , content] = publishAsync.mock.calls[0];
     expect(content).toHaveProperty('private');
     expect(content).toHaveProperty('public');
     expect((content.private as Record<string, unknown>)['@type']).toBe('dkg-streams:KafkaStream');
@@ -747,7 +747,7 @@ describe('handler — POST /register with extension', () => {
     await handler({ ...ctx, req, res, path: '/api/kafka/streams/register' });
     expect(captured.statusCode).toBe(202);
     expect(publishAsync).toHaveBeenCalledTimes(1);
-    const [, content] = publishAsync.mock.calls[0];
+    const [, , content] = publishAsync.mock.calls[0];
     expect(content).toHaveProperty('private');
     expect(content).toHaveProperty('public');
     const ka = content.private as Record<string, unknown>;
@@ -846,7 +846,7 @@ describe('handler — extension runtime collision (one warn per unique key acros
       await handler({ ...ctx, req, res, path: '/api/kafka/streams/register' });
     }
     for (const { publishAsync } of ctxs) {
-      const ka = publishAsync.mock.calls[0][1].private as Record<string, unknown>;
+      const ka = publishAsync.mock.calls[0][2].private as Record<string, unknown>;
       expect(ka['schema:name']).toBe('demo');
       expect(ka['dkg-streams:kafkaTopicName']).toBe('demo-topic');
       expect(ka['vendor:ok']).toBe('ok');

--- a/packages/kafka-plugin/test/handler.test.ts
+++ b/packages/kafka-plugin/test/handler.test.ts
@@ -112,11 +112,12 @@ describe('handler — POST /register happy path', () => {
     expect(captured.statusCode).toBe(202);
     expect(publishAsync.mock.calls[0][1]).toBe('urn:cg:from-config');
   });
-  it('stamps the AUTHENTICATED submitter and a client cannot name its own owner', async () => {
-    // Ownership decides who may run the destructive by-id clear. `publishOptions` here is an
-    // unfiltered client record, unlike the EPCIS lane's allow-list, so the stamp must beat a
-    // caller-supplied value — the spread ORDER is the guard, and this row is what fails if
-    // it is ever reversed.
+  it('DECLARES the authenticated submitter as the admission it passes to the agent', async () => {
+    // Scope, stated because the previous version of this row overclaimed (3829656707): this
+    // proves only what the PLUGIN declares. The ownership DECISION now lives in the agent, which
+    // is mocked here — so a regression that read the options bag instead of the declaration
+    // would leave this row green. That property is proven end to end against the real publish
+    // method and the persisted job in agent/test/publish-jsonld.test.ts.
     const SUBMITTER = '0x00000000000000000000000000000000000000b7';
     const ATTACKER = '0x00000000000000000000000000000000000000ff';
     const { req, res } = mockReqRes('POST', '/api/kafka/streams/register', validBody);
@@ -129,7 +130,8 @@ describe('handler — POST /register happy path', () => {
     await handler({ ...ctx, req, res, path: '/api/kafka/streams/register' });
     expect(publishAsync.mock.calls[0][0]).toEqual({ kind: 'agent', agentAddress: SUBMITTER });
     const opts = publishAsync.mock.calls[0][3] as Record<string, unknown>;
-    // The client's attempt stays in the options bag, where it now means nothing.
+    // The client's value is still forwarded in the options bag; it simply is not the
+    // admission any more, and nothing here can prove the agent ignores it.
     expect(opts.admittedByAgentAddress).toBe(ATTACKER);
     // Ordinary options still forward untouched.
     expect(opts.accessPolicy).toBe('public');


### PR DESCRIPTION
## Summary

Closes item 1 of #2305. Admission travelled as an optional key inside `PublishAsyncOpts`, where **omitting it silently meant "internal producer, use the node default"**. Both ownership defects in the GH#2270 chain were omissions rather than wrong values — the EPCIS capture route (🔴 3825614158), then the Kafka stream plugin (🔴 3825861803), both externally authenticated, both assigning their callers' jobs to the node. The second was missed *inside the enumeration written to fix the first*, which is the reviewer's point exactly: the convention was not reliably discoverable.

A convention cannot prevent an omitted argument. A required parameter can.

`publishAsync` now takes a required `PublishAsyncAdmission` first:

```ts
{ kind: 'agent'; agentAddress }   // an externally authenticated caller
{ kind: 'node' }                  // no authenticated caller; the node admits it
```

- Omission is a **compile error**.
- Internal defaulting is something a caller *states*, not the meaning of silence.
- `admittedByAgentAddress` is gone from `PublishAsyncOpts`, so a client-supplied options record has nowhere to put an owner — and no object-spread ordering is load-bearing for authorization any more, which is what the Kafka lane relied on.

## Related

- Part of #2305 (item 1); follow-up to #2303, #2304
- Original feature: #2270

## Diagrams

### Who owns the job an authenticated plugin enqueues

Before:

```mermaid
sequenceDiagram
    participant Submitter
    participant Plugin
    participant Agent
    participant Queue
    Submitter->>Plugin: authenticated request
    Plugin->>Agent: publishAsync(cg, content, opts)
    Note over Agent: no principal in opts
    Agent->>Queue: admission = NODE DEFAULT
    Note over Queue: submitter cannot force-clear
```

After:

```mermaid
sequenceDiagram
    participant Submitter
    participant Plugin
    participant Agent
    participant Queue
    Submitter->>Plugin: authenticated request
    Plugin->>Agent: publishAsync({kind agent, agentAddress}, cg, content, opts)
    Agent->>Queue: admission = SUBMITTER
    Note over Queue: omitting the principal would not compile
```

## Files changed

| File | What |
|------|------|
| `packages/agent/src/dkg-agent-types.ts` | `PublishAsyncAdmission` union; principal removed from `PublishAsyncOpts` |
| `packages/agent/src/dkg-agent-publish.ts` | Required admission parameter; principal read from the declaration |
| `packages/agent/src/index.ts` | Export the admission type so hosts can name it |
| `packages/cli/src/daemon/routes/epcis.ts` | Declares `{ kind: 'agent' }` with the request identity |
| `packages/kafka-plugin/src/handler.ts` | Same; its ctx type updated |
| `packages/agent/test/publish-async-admission.typecheck.ts` | **New** — pins the compile-error property |
| `packages/agent/test/publish-jsonld.test.ts` | Call sites declare admission; admission-specific rows updated |
| `packages/cli/test/epcis-route-readiness.test.ts` | Asserts the declared argument, not an options key |
| `packages/kafka-plugin/test/{handler,factory}.test.ts` | Argument positions and the security row |

## Test plan

- [x] **Type-test lane** (`tsc --project tsconfig.type-tests.json`, part of `build`) — the property is a compile error, so no runtime test can express it. Pins that omission, a bare address, an unknown discriminant, `{ kind: 'agent' }` without an address, and an options bag carrying the principal all fail to compile.
- [x] **Mutant**: re-adding `admittedByAgentAddress` to `PublishAsyncOpts` fails the build with `Unused '@ts-expect-error' directive`. The lane is self-verifying — an expect-error that stops firing is itself an error.
- [x] **Mutant**: making the parameter optional does not compile in leading position.
- [x] agent publish suite 38 passed (chain-backed, real Hardhat)
- [x] kafka factory + handler 53 passed
- [x] cli epcis / knowledge-assets / clear-job / source-worker 107 passed
- [x] Clean-room `tsc` on agent, cli, kafka-plugin after purging `tsbuildinfo`

## Notes

Three failures in `kafka-plugin/test/factory.test.ts` and two destructures in `handler.test.ts` were caught only by **running** the suites — `mock.calls[0]` is loosely typed, so `tsc` was silent on the shifted argument positions. Recording that because the previous PR in this chain reached CI red for exactly that reason.

The two `kafka-plugin-api.e2e` fixture-build failures in my worktree are pre-existing — verified by stashing and re-running on a clean tree at this base.
