### PR TITLE
Retain async promote failure diagnostics before cleanup

### DIFF
--- a/packages/cli/src/daemon/worker/async-promote-worker.ts
+++ b/packages/cli/src/daemon/worker/async-promote-worker.ts
@@ -59,6 +59,12 @@ export interface PromoteMemoryGraphChangedEvent {
   counts?: { triples?: number };
 }
 
+/**
+ * Logging is strictly best-effort: sinks may be synchronous or asynchronous,
+ * but worker progress never waits for them and sink failures are discarded.
+ */
+export type PromoteWorkerLogger = (message: string) => void | Promise<void>;
+
 export interface PromoteWorkerConfig {
   /** The host DKG agent — provides the queue + the sync `promote` call. */
   agent: DKGAgent;
@@ -81,7 +87,7 @@ export interface PromoteWorkerConfig {
   /** Deterministic time source for tests. */
   now?: () => number;
   /** Defaults to `console.warn`. The daemon passes its own logger. */
-  log?: (msg: string) => void;
+  log?: PromoteWorkerLogger;
   /** Defaults to a no-op. The daemon passes its `memoryGraphChanged` emitter. */
   emitMemoryGraphChanged?: (event: PromoteMemoryGraphChangedEvent) => void;
   /**
@@ -131,6 +137,107 @@ export type ClassifiedPromoteError = {
   message?: string;
 };
 
+const PROMOTE_STEP_TAG = /^\[promote:([^\]]*)\]\s*/;
+const PROMOTE_DIAGNOSTIC_STAGES = new Set([
+  'ensureSubGraphRegistered',
+  'assertGraphScopedLifecycleWritable',
+  'knowledgeAssetPrivateQuads',
+  'assertionScopedQuads',
+  'assertTrustedCatalogTriplesAllowed',
+  'encodeWorkspaceGossipPayload',
+]);
+// Only producer-owned, source-defined identities are safe to retain verbatim.
+// Arbitrary upstream name/code strings can be credentials even when they are
+// syntactically simple, so everything outside these closed sets becomes unknown.
+const SAFE_ERROR_NAMES = new Set([
+  'Error',
+  'DKGError',
+  'DKGUserError',
+  'DKGInternalError',
+  'PayloadTooLargeError',
+  'SwmGossipPayloadTooLargeError',
+  'CuratorUnconfirmedError',
+  'CuratorRejectedError',
+  'AssertionNotPersistedError',
+]);
+const SAFE_ERROR_CODES = new Set([
+  'PAYLOAD_TOO_LARGE',
+  'SWM_GOSSIP_PAYLOAD_TOO_LARGE',
+  'CURATOR_UNCONFIRMED',
+  'CURATOR_REJECTED',
+  'ASSERTION_NOT_PERSISTED',
+]);
+
+function untagPromoteMessage(message: string): string {
+  return message.replace(PROMOTE_STEP_TAG, '');
+}
+
+function diagnosticPromoteStage(message: string): string {
+  const candidate = PROMOTE_STEP_TAG.exec(message)?.[1];
+  return candidate !== undefined && PROMOTE_DIAGNOSTIC_STAGES.has(candidate)
+    ? candidate
+    : 'unknown';
+}
+
+function safeErrorIdentity(
+  err: unknown,
+  field: 'name' | 'code',
+  allowed: ReadonlySet<string>,
+): string | undefined {
+  if ((typeof err !== 'object' && typeof err !== 'function') || err === null) return undefined;
+  try {
+    const value = Reflect.get(err, field);
+    return typeof value === 'string' && allowed.has(value) ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function bestEffortLog(log: PromoteWorkerLogger, message: string): void {
+  try {
+    void Promise.resolve(log(message)).catch(() => {});
+  } catch {
+    // Logging must never delay or alter queue state transitions.
+  }
+}
+
+/**
+ * Emit privacy-bounded evidence before queue.fail() makes a terminal row
+ * externally clearable. Diagnostics are best-effort and can never change the
+ * promote state transition, even when the injected logger fails synchronously
+ * or asynchronously.
+ */
+function logPromoteAttemptFailure(input: {
+  job: PromoteJob;
+  err: unknown;
+  message: string;
+  classified: ClassifiedPromoteError;
+  promoteStarted: boolean;
+  log: PromoteWorkerLogger;
+}): void {
+  try {
+    bestEffortLog(
+      input.log,
+      `[async-promote-worker] ${JSON.stringify({
+        event: 'async_promote_attempt_failed',
+        schemaVersion: 1,
+        jobId: input.job.jobId,
+        attempt: input.job.attempt.count,
+        maxAttempts: input.job.attempt.maxRetries,
+        promoteStartedMarkerPersisted: input.promoteStarted,
+        swmCommitObserved: false,
+        stage: diagnosticPromoteStage(input.message),
+        classification: input.classified.classification,
+        retryable: input.classified.retryable,
+        errorName: safeErrorIdentity(input.err, 'name', SAFE_ERROR_NAMES) ?? 'unknown',
+        errorCode: safeErrorIdentity(input.err, 'code', SAFE_ERROR_CODES) ?? 'unknown',
+      })}`,
+    );
+  } catch {
+    // Diagnostics must never prevent fail-closed queue bookkeeping.
+  }
+}
+
 /**
  * Map a promote error message to a `PromoteAttemptError` classification.
  * Seeded from the three rc.10 Graphify import patterns documented in
@@ -149,7 +256,7 @@ export function classifyPromoteError(err: unknown): ClassifiedPromoteError {
   // classifier trigger token (e.g. the step "encodeWorkspaceGossipPayload" would otherwise make
   // every error from it match the "gossip" cap-check). We classify on the ORIGINAL error text;
   // the tag stays on the operator-facing message. The tag is single (idempotent, innermost wins).
-  const untagged = (raw ?? '').replace(/^\[promote:[^\]]*\]\s*/, '');
+  const untagged = untagPromoteMessage(raw ?? '');
   const message = untagged.toLowerCase();
   const code =
     err && typeof err === 'object' && 'code' in err
@@ -215,7 +322,7 @@ export async function runPromoteJob(
     ) => Promise<{ promotedCount: number }>;
     now: () => number;
     heartbeatIntervalMs: number;
-    log: (msg: string) => void;
+    log: PromoteWorkerLogger;
     emitMemoryGraphChanged?: (event: PromoteMemoryGraphChangedEvent) => void;
   },
 ): Promise<{
@@ -242,7 +349,10 @@ export async function runPromoteJob(
           // Expected when the job has already succeeded/failed and the lease was cleared.
           return;
         }
-        log(`Heartbeat error for ${job.jobId}: ${err instanceof Error ? err.message : String(err)}`);
+        bestEffortLog(
+          log,
+          `Heartbeat error for ${job.jobId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
       });
     }, heartbeatIntervalMs);
     if (heartbeatTimer.unref) heartbeatTimer.unref();
@@ -261,6 +371,14 @@ export async function runPromoteJob(
     } catch (err: unknown) {
       const classified = classifyPromoteError(err);
       const message = err instanceof Error ? err.message : String(err);
+      logPromoteAttemptFailure({
+        job,
+        err,
+        message,
+        classified,
+        promoteStarted: promoteStartedMarked,
+        log,
+      });
       const attemptError: PromoteAttemptError = {
         message,
         retryable: classified.retryable,
@@ -271,7 +389,7 @@ export async function runPromoteJob(
         await queue.fail(job.jobId, claimToken, attemptError);
       } catch (failErr: unknown) {
         if (failErr instanceof PromoteJobLeaseError) {
-          log(`Lease lost while recording failure for ${job.jobId}: ${message}`);
+          bestEffortLog(log, `Lease lost while recording failure for ${job.jobId}: ${message}`);
         } else {
           throw failErr;
         }
@@ -311,7 +429,8 @@ export async function runPromoteJob(
         bookkeepingErr instanceof Error
           ? bookkeepingErr.message
           : String(bookkeepingErr);
-      log(
+      bestEffortLog(
+        log,
         `PARTIAL-PROMOTE-AMBIGUITY: jobId=${job.jobId} ` +
           `assertion.promote() returned successfully (promotedCount=${result.promotedCount}) ` +
           `but post-promote bookkeeping failed: ${message}. ` +
@@ -340,7 +459,10 @@ export async function runPromoteJob(
           counts: { triples: result.promotedCount },
         });
       } catch (emitErr: unknown) {
-        log(`memoryGraphChanged emit failed for ${job.jobId}: ${emitErr instanceof Error ? emitErr.message : String(emitErr)}`);
+        bestEffortLog(
+          log,
+          `memoryGraphChanged emit failed for ${job.jobId}: ${emitErr instanceof Error ? emitErr.message : String(emitErr)}`,
+        );
       }
     }
 
@@ -371,7 +493,8 @@ export function createPromoteWorkerSupervisor(config: PromoteWorkerConfig): Prom
   }
   const shutdownTimeoutMs = config.shutdownTimeoutMs ?? 30_000;
   const now = config.now ?? (() => Date.now());
-  const log = config.log ?? ((msg: string) => console.warn(`[promote-worker] ${msg}`));
+  const log: PromoteWorkerLogger =
+    config.log ?? ((msg: string) => console.warn(`[promote-worker] ${msg}`));
   const workerIdPrefix = config.workerIdPrefix ?? `daemon-${process.pid}`;
   const slots: WorkerSlot[] = Array.from({ length: concurrency }, (_, i) => ({
     workerId: `${workerIdPrefix}-slot-${i}`,
@@ -397,7 +520,10 @@ export function createPromoteWorkerSupervisor(config: PromoteWorkerConfig): Prom
   async function tickSlot(slot: WorkerSlot): Promise<boolean> {
     if (shuttingDown || slot.inFlight) return false;
     const claimed = await config.agent.promoteQueue.claimNext(slot.workerId).catch((err: unknown) => {
-      log(`claimNext error on ${slot.workerId}: ${err instanceof Error ? err.message : String(err)}`);
+      bestEffortLog(
+        log,
+        `claimNext error on ${slot.workerId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
       return null;
     });
     if (!claimed) return false;
@@ -445,7 +571,7 @@ export function createPromoteWorkerSupervisor(config: PromoteWorkerConfig): Prom
         }
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err);
-        log(`Worker ${slot.workerId} crashed processing ${claimed.jobId}: ${message}`);
+        bestEffortLog(log, `Worker ${slot.workerId} crashed processing ${claimed.jobId}: ${message}`);
         if (claimed.lease) {
           try {
             await config.agent.promoteQueue.fail(claimed.jobId, claimed.lease.claimToken, {
@@ -457,9 +583,13 @@ export function createPromoteWorkerSupervisor(config: PromoteWorkerConfig): Prom
           } catch (failErr: unknown) {
             const failMessage = failErr instanceof Error ? failErr.message : String(failErr);
             if (failErr instanceof PromoteJobLeaseError) {
-              log(`Lease lost while parking crashed job ${claimed.jobId}: ${failMessage}`);
+              bestEffortLog(
+                log,
+                `Lease lost while parking crashed job ${claimed.jobId}: ${failMessage}`,
+              );
             } else {
-              log(
+              bestEffortLog(
+                log,
                 `Failed to park crashed job ${claimed.jobId}; next startup recovery must reconcile it: ` +
                   `${failMessage}`,
               );
@@ -518,7 +648,10 @@ export function createPromoteWorkerSupervisor(config: PromoteWorkerConfig): Prom
       try {
         const summary = await config.agent.promoteQueue.recoverOnStartup();
         if (summary.reclaimed > 0 || summary.abandoned > 0) {
-          log(`recoverOnStartup: reclaimed=${summary.reclaimed} abandoned=${summary.abandoned}`);
+          bestEffortLog(
+            log,
+            `recoverOnStartup: reclaimed=${summary.reclaimed} abandoned=${summary.abandoned}`,
+          );
         }
       } catch (err: unknown) {
         started = false;
@@ -560,7 +693,8 @@ export function createPromoteWorkerSupervisor(config: PromoteWorkerConfig): Prom
       if (result === 'timeout') {
         const active = activeShutdownSlotCount() || activeAtStop;
         counters.interruptedAtShutdown += active;
-        log(
+        bestEffortLog(
+          log,
           `Shutdown timeout (${shutdownTimeoutMs}ms) reached; ${active} in-flight promote(s) abandoned to next-boot recovery`,
         );
       }

--- a/packages/cli/test/async-promote-worker.test.ts
+++ b/packages/cli/test/async-promote-worker.test.ts
@@ -2,11 +2,11 @@
  * Async-promote worker — unit tests.
  *
  * The worker module exports three concerns we test in isolation:
- *   - `classifyPromoteError(err)` — pure mapping (10 tests).
+ *   - `classifyPromoteError(err)` — pure mapping.
  *   - `runPromoteJob(...)` — per-job lifecycle including commit-marker
- *     bookkeeping and outcome reporting (8 tests).
+ *     bookkeeping and outcome reporting.
  *   - `createPromoteWorkerSupervisor(...)` — multi-slot polling +
- *     shutdown drain (6 tests).
+ *     shutdown drain.
  *
  * Backed by a real `TripleStoreAsyncPromoteQueue` against an in-memory
  * `OxigraphStore`. The `agent.assertion.promote` call is a stub
@@ -20,6 +20,7 @@ import {
   type AsyncPromoteQueue,
   type PromoteJob,
   type PromoteRequest,
+  type PromoteTerminalJobClearer,
 } from '@origintrail-official/dkg-publisher';
 import {
   classifyPromoteError,
@@ -39,6 +40,15 @@ function deferred<T = void>(): {
     reject = rej;
   });
   return { promise, resolve, reject };
+}
+
+const PROMOTE_FAILURE_LOG_PREFIX = '[async-promote-worker] ';
+
+function promoteFailureDiagnostics(logs: readonly string[]): Record<string, unknown>[] {
+  return logs
+    .filter((line) => line.startsWith(PROMOTE_FAILURE_LOG_PREFIX))
+    .map((line) => JSON.parse(line.slice(PROMOTE_FAILURE_LOG_PREFIX.length)) as Record<string, unknown>)
+    .filter((entry) => entry['event'] === 'async_promote_attempt_failed');
 }
 
 describe('classifyPromoteError', () => {
@@ -307,18 +317,32 @@ describe('runPromoteJob', () => {
       job,
       queue,
       workerId: 'worker-test',
-      runPromote: async () => {
+      runPromote: async (_request, markPromoteStarted) => {
+        await markPromoteStarted();
         throw new Error('fetch failed');
       },
       now: () => now,
       heartbeatIntervalMs: 0,
-      log: () => {},
+      log: (message) => logs.push(message),
     });
     expect(result.outcome).toBe('failed_retrying');
     expect(result.error?.classification).toBe('transient');
     const final = await queue.getStatus(job.jobId);
     expect(final?.state).toBe('failed_retrying');
     expect(final?.attempt.nextRetryAt).toBeGreaterThan(now);
+    expect(promoteFailureDiagnostics(logs)).toEqual([
+      expect.objectContaining({
+        event: 'async_promote_attempt_failed',
+        jobId: job.jobId,
+        attempt: 1,
+        maxAttempts: 3,
+        promoteStartedMarkerPersisted: true,
+        swmCommitObserved: false,
+        stage: 'unknown',
+        classification: 'transient',
+        retryable: true,
+      }),
+    ]);
   });
 
   it('on cap_exceeded error, transitions to failed (terminal)', async () => {
@@ -351,10 +375,231 @@ describe('runPromoteJob', () => {
       },
       now: () => now,
       heartbeatIntervalMs: 0,
-      log: () => {},
+      log: (message) => logs.push(message),
     });
     expect(result.outcome).toBe('failed_terminal');
     expect(result.error?.classification).toBe('fatal');
+    expect((await queue.getStatus(job.jobId))?.state).toBe('failed');
+    expect(promoteFailureDiagnostics(logs)).toEqual([
+      expect.objectContaining({
+        promoteStartedMarkerPersisted: false,
+        swmCommitObserved: false,
+        classification: 'fatal',
+        retryable: false,
+      }),
+    ]);
+  });
+
+  it('logs bounded tagged failure evidence that survives terminal cleanup without leaking the message', async () => {
+    const job = await enqueueAndClaim();
+    const sensitiveMessage = 'query failed for secret-sentinel and https://rpc.example/private-key';
+    const failure = Object.assign(
+      new Error(`[promote:assertionScopedQuads] ${sensitiveMessage}`),
+      { name: 'CuratorRejectedError', code: 'CURATOR_REJECTED' },
+    );
+    const order: string[] = [];
+    let diagnosticPresentWhenFailBegan = false;
+    const fail = queue.fail.bind(queue);
+    queue.fail = async (jobId, claimToken, error) => {
+      order.push('queue.fail.begin');
+      diagnosticPresentWhenFailBegan = promoteFailureDiagnostics(logs).length === 1;
+      await fail(jobId, claimToken, error);
+      order.push('queue.fail.end');
+    };
+
+    const result = await runPromoteJob({
+      job,
+      queue,
+      workerId: 'worker-test',
+      runPromote: async (_request, markPromoteStarted) => {
+        await markPromoteStarted();
+        throw failure;
+      },
+      now: () => now,
+      heartbeatIntervalMs: 0,
+      log: (message) => {
+        order.push('diagnostic');
+        logs.push(message);
+      },
+    });
+
+    expect(result.outcome).toBe('failed_terminal');
+    expect(order).toEqual(['diagnostic', 'queue.fail.begin', 'queue.fail.end']);
+    expect(diagnosticPresentWhenFailBegan).toBe(true);
+    const diagnostics = promoteFailureDiagnostics(logs);
+    expect(diagnostics).toEqual([
+      {
+        event: 'async_promote_attempt_failed',
+        schemaVersion: 1,
+        jobId: job.jobId,
+        attempt: 1,
+        maxAttempts: 3,
+        promoteStartedMarkerPersisted: true,
+        swmCommitObserved: false,
+        stage: 'assertionScopedQuads',
+        classification: 'fatal',
+        retryable: false,
+        errorName: 'CuratorRejectedError',
+        errorCode: 'CURATOR_REJECTED',
+      },
+    ]);
+    expect(diagnostics[0]).not.toHaveProperty('messageFingerprint');
+    expect(logs.join('\n')).not.toContain('secret-sentinel');
+    expect(logs.join('\n')).not.toContain('rpc.example');
+
+    const clearer = queue as AsyncPromoteQueue & PromoteTerminalJobClearer;
+    await expect(clearer.clearTerminalJob(job.jobId)).resolves.toEqual({ outcome: 'cleared' });
+    await expect(queue.getStatus(job.jobId)).resolves.toBeNull();
+    expect(promoteFailureDiagnostics(logs)).toEqual(diagnostics);
+  });
+
+  it('maps unowned stages and unsafe error identity to bounded unknown values', async () => {
+    const job = await enqueueAndClaim();
+    const sensitiveMessage = 'opaque secret-sentinel failure';
+    const alphanumericSecretToken = 'AKIAIOSFODNN7EXAMPLE';
+    const failure = Object.assign(new Error(`[promote:callerControlled] ${sensitiveMessage}`), {
+      name: `Error${alphanumericSecretToken}`,
+      code: alphanumericSecretToken,
+    });
+
+    await runPromoteJob({
+      job,
+      queue,
+      workerId: 'worker-test',
+      runPromote: async (_request, markPromoteStarted) => {
+        await markPromoteStarted();
+        throw failure;
+      },
+      now: () => now,
+      heartbeatIntervalMs: 0,
+      log: (message) => logs.push(message),
+    });
+
+    expect(promoteFailureDiagnostics(logs)).toEqual([
+      expect.objectContaining({
+        stage: 'unknown',
+        errorName: 'unknown',
+        errorCode: 'unknown',
+      }),
+    ]);
+    expect(promoteFailureDiagnostics(logs)[0]).not.toHaveProperty('messageFingerprint');
+    expect(logs.join('\n')).not.toContain('secret-sentinel');
+    expect(logs.join('\n')).not.toContain(alphanumericSecretToken);
+    expect((await queue.getStatus(job.jobId))?.state).toBe('failed');
+  });
+
+  it('keeps fail-closed queue bookkeeping intact when the diagnostic logger throws', async () => {
+    const job = await enqueueAndClaim();
+
+    const result = await runPromoteJob({
+      job,
+      queue,
+      workerId: 'worker-test',
+      runPromote: async (_request, markPromoteStarted) => {
+        await markPromoteStarted();
+        throw new Error('[promote:assertionScopedQuads] unknown fatal failure');
+      },
+      now: () => now,
+      heartbeatIntervalMs: 0,
+      log: () => {
+        throw new Error('logger unavailable');
+      },
+    });
+
+    expect(result).toMatchObject({
+      outcome: 'failed_terminal',
+      error: { classification: 'fatal', retryable: false },
+    });
+    expect((await queue.getStatus(job.jobId))?.state).toBe('failed');
+  });
+
+  it('does not wait for an unresolved logger before queue.fail reaches terminal state', async () => {
+    const job = await enqueueAndClaim();
+    const pendingLog = deferred<void>();
+    let loggerSettled = false;
+    void pendingLog.promise.then(() => {
+      loggerSettled = true;
+    });
+
+    const fail = queue.fail.bind(queue);
+    let failCompleted = false;
+    queue.fail = async (jobId, claimToken, error) => {
+      await fail(jobId, claimToken, error);
+      failCompleted = true;
+    };
+
+    const resultPromise = runPromoteJob({
+      job,
+      queue,
+      workerId: 'worker-test',
+      runPromote: async (_request, markPromoteStarted) => {
+        await markPromoteStarted();
+        throw new Error('[promote:assertionScopedQuads] unknown fatal failure');
+      },
+      now: () => now,
+      heartbeatIntervalMs: 0,
+      log: () => pendingLog.promise,
+    });
+    let runSettled = false;
+    void resultPromise.then(
+      () => {
+        runSettled = true;
+      },
+      () => {
+        runSettled = true;
+      },
+    );
+
+    try {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(loggerSettled).toBe(false);
+      expect(failCompleted).toBe(true);
+      expect(runSettled).toBe(true);
+      expect((await queue.getStatus(job.jobId))?.state).toBe('failed');
+    } finally {
+      pendingLog.resolve();
+    }
+
+    await expect(resultPromise).resolves.toMatchObject({
+      outcome: 'failed_terminal',
+      error: { classification: 'fatal', retryable: false },
+    });
+  });
+
+  it('does not await an async diagnostic logger and absorbs its rejection', async () => {
+    const job = await enqueueAndClaim();
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown): void => {
+      unhandledRejections.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    try {
+      const result = await runPromoteJob({
+        job,
+        queue,
+        workerId: 'worker-test',
+        runPromote: async (_request, markPromoteStarted) => {
+          await markPromoteStarted();
+          throw new Error('[promote:assertionScopedQuads] unknown fatal failure');
+        },
+        now: () => now,
+        heartbeatIntervalMs: 0,
+        log: async () => {
+          throw new Error('async logger unavailable');
+        },
+      });
+
+      expect(result).toMatchObject({
+        outcome: 'failed_terminal',
+        error: { classification: 'fatal', retryable: false },
+      });
+      expect((await queue.getStatus(job.jobId))?.state).toBe('failed');
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
   });
 
   it('after maxRetries transient failures in a row, settles in failed (terminal)', async () => {


### PR DESCRIPTION
## Summary

- emit one structured `async_promote_attempt_failed` diagnostic before the async promote queue records a failed attempt
- retain only bounded, privacy-safe evidence: attempt position, persisted outer markers, allowlisted promote stage, classification, and semantically allowlisted error identity
- keep unknown failures fatal/non-retryable and make every worker log sink no-throw, fire-and-forget, and non-blocking

## Why

During live SCAN qualification, one legal successor promotion failed fatally. SCAN correctly recorded the terminal customer state and then cleared the native DKG job, but the original DKG error was no longer available for root-cause analysis. Retrying that unknown failure is unsafe because promotion may have partially or fully mutated SWM before throwing.

This change preserves enough durable, privacy-safe log evidence to classify any recurrence before terminal-job cleanup can race it away. It does not recover, retry, or otherwise alter promotion semantics.

## Related work

- SCAN qualification separately fails fast when the customer-visible publication state becomes terminal, instead of waiting for its full drain deadline.
- The existing held qualification record remains preserved; no database repair or blind DKG recovery is part of this PR.
- Publisher-owned canonical promote-stage parsing is tracked in #2314.
- Logger-boundary normalization and diagnostics test-file decomposition are tracked in #2315.

## Files changed

- `packages/cli/src/daemon/worker/async-promote-worker.ts`
  - emit a no-throw pre-`queue.fail()` JSON diagnostic for every failed attempt
  - allowlist publisher-owned promote stages and source-defined safe error name/code identities
  - exclude raw messages and deterministic raw-message fingerprints
  - absorb synchronous throws, async rejections, and unresolved logger promises without delaying queue bookkeeping
- `packages/cli/test/async-promote-worker.test.ts`
  - prove retrying and terminal diagnostics, stage/error allowlisting, secret non-leakage, absent raw-message fingerprints, logger-failure isolation, pre-marker evidence, exact pre-`queue.fail()` ordering, and evidence survival after terminal-job cleanup

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg exec vitest run test/async-promote-worker.test.ts` — 33/33 passed
- [x] `pnpm --filter @origintrail-official/dkg build`
- [x] exact workspace dependency build required by the CLI build
- [x] `git diff --check`
- [x] final clean-worktree and exact two-file scope audit

## Review status

- [x] arbitrary token-shaped error identities collapse to `unknown`
- [x] raw error text and dictionary-testable raw-message fingerprints are absent
- [x] the event exists before `queue.fail()` begins and survives terminal cleanup
- [x] throwing, rejecting, and unresolved log sinks cannot delay or alter terminal queue state
- [x] pre-marker failure proves `promoteStartedMarkerPersisted=false`
- [x] non-blocking structural findings deferred to #2314 and #2315

## Deployment note

Merging this branch does not itself activate a fleet node. After review, the exact squash merge must be built, content-sealed, and deployed through the controlled fleet update path, then verified against DKG, Blazegraph, and SCAN health before a fresh qualification campaign.

## Out of scope

- changing unknown-error retry classification
- automatic `/recover` or database edits
- moving the `promoteStarted` marker
- queue or status API schema changes
- raw error-message logging or raw-message fingerprinting

