### PR TITLE
chore(release): finalize 10.0.14 mainnet preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,32 +4,9 @@ All notable changes to the DKG V10 node are documented here. The format is based
 
 ## [Unreleased]
 
-### Async publisher — resolution-aware automatic retries (#2270)
+## [10.0.14] - 2026-08-25
 
-Failed async-publisher jobs that may have submitted a transaction are no longer
-left in indefinite limbo. Recovery asks the chain what actually happened and acts on
-the answer: a transaction proven absent releases the job for a fresh attempt, a
-recognized one is finalized from its on-chain evidence, and anything unproven stays
-held. A job is never re-sent on a guess, so the same Knowledge Asset cannot be
-published twice.
-
-#### Upgrading
-
-| Change | Impact | Action |
-| --- | --- | --- |
-| `AsyncLiftPublisherConfig.chainRecoveryResolver` is replaced by `chainProofResolver` | **Node operators are not affected** — the node wires this itself. This only affects code that constructs `TripleStoreAsyncLiftPublisher` directly from the `@origintrail-official/dkg-publisher` package. The field was renamed and its callback contract changed: it now receives a lookup and returns a verdict (`recovered` / `reverted` / `not-found` / `pending` / `inconclusive`) rather than a job and a nullable result. A configuration still carrying the old key is **rejected at construction** rather than ignored, because a publisher that silently lost its resolver would hold every job forever with nothing to explain why | If you embed the publisher package directly, rename the field and adapt the callback to the verdict contract. If you run a node, no action |
-| Jobs already stuck at upgrade time may need one manual clear | Recovery needs to know whether a held job was creating or updating an asset. Jobs recorded **before** this upgrade do not carry that marker, and the node will not guess: it reports them as needing operator action instead of promising an automatic retry it cannot deliver. Only jobs that were already failed-and-held at the moment of upgrade are affected; everything enqueued afterwards records the marker automatically | Run `dkg publisher jobs --status failed` after upgrading. For any job listed there, verify its transaction on-chain, then clear it by id with `POST /api/publisher/clear-job {"jobId":"<id>"}` (the targeted clear; `dkg publisher clear <status>` is the bulk form and deliberately skips held jobs). Most deployments will have none |
-
-#### Scope
-
-This release implements a deliberately narrow, safe subset of #2270: automatic retry
-is limited to failures that are provably safe to re-run, plus chain-proof resolution
-of transaction-bearing failures. The configurable per-code and per-resolution retry
-policy described in the issue is **not** part of this release.
-
-## [10.0.14] - 2026-08-14
-
-A selected-public convergence release. An Edge node can opt a bounded set of publicly readable Context Graphs into RFC-64: an operator-approved graph-complete provider drives bounded native Shared Memory recovery, while Verifiable Memory remains independently derived from finalized blockchain inventory. Both lanes continue across partial progress and provider gaps, and VM recovery batches assets by bounded byte/quad footprint instead of treating an arbitrarily large graph as one transfer. Signed SWM inventory remains shadow evidence in this release and does not drive receiver synchronization. RFC-64 remains operator-selected and public-only: a valid non-empty bootstrap manifest activates its selected scope when `enabled` is omitted, while an absent block or explicit `enabled: false` remains dormant. Private encrypted live sharing is unchanged, and private catalog-based cold join is not part of this release. **No smart-contract changes or deployments are required.**
+A selected-public convergence and publisher-recovery release. An Edge node can opt a bounded set of publicly readable Context Graphs into RFC-64: an operator-approved graph-complete provider drives bounded native Shared Memory recovery, while Verifiable Memory remains independently derived from finalized blockchain inventory. Both lanes continue across partial progress and provider gaps, and VM recovery batches assets by bounded byte/quad footprint instead of treating an arbitrarily large graph as one transfer. The async publisher now resolves transaction-bearing failures from chain evidence and never re-sends a job on a guess. Operators can select the mined-receipt confirmation depth; the default is one confirmation. Signed SWM inventory remains shadow evidence in this release and does not drive receiver synchronization. RFC-64 remains operator-selected and public-only: a valid non-empty bootstrap manifest activates its selected scope when `enabled` is omitted, while an absent block or explicit `enabled: false` remains dormant. Private encrypted live sharing is unchanged, and private catalog-based cold join is not part of this release. **No smart-contract changes or deployments are required.**
 
 ### Upgrading from 10.0.13
 
@@ -41,6 +18,9 @@ A selected-public convergence release. An Edge node can opt a bounded set of pub
 | Selected VM recovery uses bounded footprint-aware batches | Multiple small assets can share one recovery request, while byte, quad and heap estimates keep large transfers bounded | No action; the scheduler derives safe batches from authoritative or conservative size evidence |
 | Persisted user subscriptions rehydrate on daemon startup | An operator-selected graph resumes automatically after restart instead of remaining a dormant database row | Set `DKG_CONTEXT_GRAPH_SUBSCRIPTION_REHYDRATION_ENABLED=false` only as an emergency kill-switch |
 | Dashboard SQLite schema 32 → 33 | Selected-VM cursors are fenced by deployment identity; v32 optimization cursors are discarded so a redeploy cannot reuse another chain deployment's numeric IDs or watermark | No action; the graph data is retained and selected VM reconciliation safely resumes from chain inventory |
+| `chain.finalityConfirmations` controls mined-receipt finality | The receipt block counts as confirmation 1. The default of `1` releases a publisher wallet as soon as the receipt block is canonical, with no successor-block reorganization buffer. Larger values wait for more blocks and reduce throughput | Keep the default only when lower latency is worth the reorganization risk. Set a larger positive integer when reversal resistance is more important than publish speed |
+| `AsyncLiftPublisherConfig.chainRecoveryResolver` is replaced by `chainProofResolver` | **Node operators are not affected** — the node wires this itself. This affects code that constructs `TripleStoreAsyncLiftPublisher` directly from `@origintrail-official/dkg-publisher`. The callback now receives a lookup and returns `recovered`, `reverted`, `not-found`, `pending`, or `inconclusive`. The old key is rejected instead of ignored | If you embed the publisher package directly, rename the field and adapt the callback to the verdict contract. If you run a node, no action |
+| Jobs already stuck at upgrade time may need one manual clear | Recovery needs to know whether a held job was creating or updating an asset. Jobs recorded before this upgrade do not carry that marker, so the node reports them as needing operator action instead of guessing. Jobs enqueued after the upgrade record the marker automatically | Run `dkg publisher jobs --status failed`. After verifying a legacy held job on chain, clear that exact job with `POST /api/publisher/clear-job {"jobId":"<id>"}`. Bulk clear deliberately skips held jobs |
 
 ### Added
 
@@ -54,12 +34,14 @@ A selected-public convergence release. An Edge node can opt a bounded set of pub
 - **Selected manifests activate the RFC-64 lane directly** (#2272): a valid accepted non-empty bootstrap manifest with `enabled` omitted is active by default, while an absent block and explicit `enabled: false` stay dormant. This removes a redundant configuration switch without expanding an Edge node beyond its operator-selected Context Graphs.
 - **Cold selected CG bindings resolve directly from chain state** (#2205): a fresh receiver can map the configured public graph to its numeric on-chain identity without relying on pre-existing ontology/store metadata, and ambiguous or stale bindings fail closed.
 - **Publisher workspace-head writes remain on the StorageACK lane** (#2178), preventing unrelated normal-lane store work from delaying acknowledgement-critical state.
+- **Mined-receipt finality is operator-selected** (#2310): `chain.finalityConfirmations` is a positive integer used consistently for receipt finality and recovery proof snapshots. Confirmation 1 is the receipt block itself and is the default; larger values trade publisher-wallet throughput for a deeper reorganization buffer.
 - **Process-level store concurrency respects host CPU capacity** (#2277): `DKG_STORE_MAX_CONCURRENT` is capped at the runtime's available parallelism on hosts with at least two logical CPUs; single-vCPU hosts retain the two-slot minimum needed for the default ACK reservation. Explicitly lower environment values and constructor overrides remain unchanged.
 - **Prime Agent legacy chat memory migrates to numbered, graph-scoped working memory** (#2151, #2153) without mistaking orphan lifecycle rows for legacy drafts.
 
 ### Fixed
 
 - **Node information no longer exposes configured RPC endpoints** (#2211); status retains health and failover evidence without serializing endpoint credentials.
+- **Async publisher recovery is chain-proof aware** (#2270, #2300, #2303, #2304, #2307, #2310): a transaction proven absent can safely retry, a recognized transaction finalizes from on-chain evidence, and an unproven transaction stays held. Recovery never re-sends on a guess, and transaction-bearing jobs retain the signer and nonce evidence needed for reconciliation.
 - **Selected SWM and VM recovery no longer stop after the first partial result** (#2146, #2210), and selected work is not displaced indefinitely by unrelated background synchronization (#2182).
 - **A finalized public Knowledge Asset no longer remains duplicated across SWM and VM** (#2262): both arrival orders use current chain status plus the complete public/private commitment to retire only an exact stale SWM twin; ambiguous, newer or changed SWM remains untouched.
 - **VM recovery cursors cannot cross deployment boundaries** (#2184); upgrading drops only the unsafe optimization cursor, never SWM or VM content.
@@ -68,6 +50,10 @@ A selected-public convergence release. An Edge node can opt a bounded set of pub
 
 - **No contract changes.** No Solidity source, ABI, or deployment-registry update is required.
 - RFC-64 remains dormant when `rfc64PublicCatalog` is absent or `enabled` is explicitly `false`. When `enabled` is omitted, activation requires one bounded, network-matching, accepted public-policy bootstrap manifest. Edge scope remains operator-selected; Core nodes retain their separate coverage responsibilities.
+
+### Validation
+
+- A distributed two-receiver release run used DKG commit `c7afca89baa58f101738c37ff774b63211123ca4` and harness commit `f79c2d887845841816d46f20cd4c2b3bbace0bdb`. It published 500/500 Shared Memory assets and 497/500 Verifiable Memory assets. Both remote Edge nodes synchronized every published asset with zero missing or mismatched pairs. The operator accepted the three unresolved VM cases as a documented release waiver; this evidence is not a strict 500/500 pass. See [the sanitized run report](docs/reports/testnet-release-10.0.14-distributed-500-20260824.md).
 
 ### Known limitations
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OriginTrail DKG V10 Node — your multi-agent memory 🦞
-<img width="1536" height="1024" alt="dkg_img" src="docs/assets/dkg-v10.png" />
+<video src="https://github.com/user-attachments/assets/869cecf2-c7e7-4d29-9a6e-9e5e6108b6a1" poster="https://github.com/OriginTrail/dkg/raw/main/docs/assets/dkg-v10.png" width="1536" autoplay loop muted playsinline controls>
+  <img width="1536" height="1024" alt="dkg_img" src="docs/assets/dkg-v10.png" />
+</video>
 
 [![CI](https://github.com/OriginTrail/dkg/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/OriginTrail/dkg/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@origintrail-official/dkg?label=npm)](https://www.npmjs.com/package/@origintrail-official/dkg)

--- a/docs/reports/testnet-release-10.0.14-distributed-500-20260824.md
+++ b/docs/reports/testnet-release-10.0.14-distributed-500-20260824.md
@@ -1,0 +1,65 @@
+# DKG 10.0.14 distributed 500-asset release run
+
+## Summary
+
+The release run completed the full Shared Memory cohort and synchronized every
+published asset to two remote Edge nodes. The Verifiable Memory cohort published
+497 of 500 planned assets. The harness therefore closed the run as
+`INCONCLUSIVE`, with reason `insufficient-publishes`. The operator accepted this
+result as release evidence with a documented waiver. It must not be described as
+a strict 500/500 pass.
+
+## Tested revisions
+
+| Component | Revision |
+| --- | --- |
+| DKG | `c7afca89baa58f101738c37ff774b63211123ca4` |
+| Blackbox harness | `f79c2d887845841816d46f20cd4c2b3bbace0bdb` |
+| Run | `open-20260824-0e360` |
+
+The DKG revision is the merge commit for OriginTrail/dkg#2310 on
+`testnet-canary`. The harness revision is on the
+`OriginTrail/dkg-blackbox-harness` main branch.
+
+## Topology and result
+
+The source and both remote participants ran as Edge nodes. The two admitted
+remote participants were Branimir's macOS node and Jurij's WSL node.
+
+| Cohort | Source published | Branimir synchronized | Jurij synchronized |
+| --- | ---: | ---: | ---: |
+| Shared Memory | 500/500 | 500/500 | 500/500 |
+| Verifiable Memory | 497/500 | 497/497 published | 497/497 published |
+
+Both receivers had zero missing, mismatched, excluded, pending, or relabelled
+eligible pairs. All three evidence chains were contiguous and matched the
+declared plan. The observed source sealing rates were 18.50 Shared Memory assets
+per minute and 28.97 Verifiable Memory assets per minute, measured from the first
+to the last sealed asset in each cohort.
+
+## Unresolved VM cases
+
+- VM ordinal 426 completed create and Shared Memory share, then failed the VM
+  lift during publisher validation with `canonicalization_failed`. It was
+  non-retryable and no transaction or nonce was created.
+- VM ordinal 922 failed in the same way: create and Shared Memory share
+  completed, then VM lift canonicalization failed before transaction submission.
+- VM ordinal 918 finalized its VM lift, but the harness could not resolve a
+  Verifiable Memory assertion graph. The strict grader recorded
+  `NO_ASSERTION_GRAPH` and did not seal the asset.
+
+These cases produced 497/500 published VM assets. The receivers synchronized all
+497 published VM assets, so the run found no receiver convergence defect.
+
+## Evidence integrity
+
+The full evidence remains in the release operator's preserved run directory.
+Only aggregate facts are recorded in this report.
+
+| Artifact | SHA-256 |
+| --- | --- |
+| `verdict.json` | `2e9287bf4bc0c94ffe53d3323a7d7a644fcb466400534e8bc53471334ab58a24` |
+| Curator fact chain | `eebcc373d87713b77cb9f2135d5d2c9fd3fec75a6938880c4ffae16f8bc4f235` |
+
+No authentication material, wallet material, transactions, publisher bodies, or
+raw API envelopes are included in this report.


### PR DESCRIPTION
## Summary

- reconcile the current `main` documentation change into `testnet-canary`
- finalize the 10.0.14 changelog, including configurable finality and its reorg risk
- add the sanitized distributed 500-asset harness report and the accepted three-VM waiver

## Validation

- DKG tested revision: `c7afca89baa58f101738c37ff774b63211123ca4`
- harness tested revision: `f79c2d887845841816d46f20cd4c2b3bbace0bdb`
- source and both remote participants: SWM 500/500
- source and both remote participants: VM 497/500 published assets
- the two remote participants converged on all 497 published VM assets with zero missing, mismatch, or exclusion defects
- three VM cases are explicitly documented and waived; this is not represented as a strict 500/500 pass

## Checks

- `pnpm release:verify-versions --version 10.0.14`
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `git diff --check`

No runtime, contract, ABI, deployment, or network configuration files change in this PR.