### PR TITLE
fix(agent): cache context graph listings for 60s

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -980,7 +980,11 @@ export class DKGAgentBase {
     Number(process.env['DKG_VM_RECONCILE_CONFIRMATION_DEPTH']) || 5;
 
   static readonly LIST_CONTEXT_GRAPHS_CACHE_TTL_MS =
-    readNonNegativeNumberEnv('DKG_LIST_CONTEXT_GRAPHS_CACHE_TTL_MS', 5_000);
+    // A full catalogue scan enriches every globally known graph and is
+    // intentionally expensive. Keep repeat UI/CLI reads off the store for one
+    // minute by default; operators can still shorten the window or set it to
+    // zero through the existing environment override.
+    readNonNegativeNumberEnv('DKG_LIST_CONTEXT_GRAPHS_CACHE_TTL_MS', 60_000);
   static readonly LIST_CONTEXT_GRAPHS_CACHE_MAX =
     Math.max(1, Number(process.env['DKG_LIST_CONTEXT_GRAPHS_CACHE_MAX']) || 32);
   static readonly LIST_CONTEXT_GRAPHS_ROW_BUDGET_MS =

--- a/packages/agent/test/list-context-graphs-cache-config.test.ts
+++ b/packages/agent/test/list-context-graphs-cache-config.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { DKGAgentBase } from '../src/dkg-agent-base.js';
+
+describe('context-graph catalogue cache configuration', () => {
+  it('uses a 60-second cache window by default', () => {
+    expect(DKGAgentBase.LIST_CONTEXT_GRAPHS_CACHE_TTL_MS).toBe(60_000);
+  });
+});

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
       "test/query-source-labels.test.ts",
       "test/query-source-coverage.test.ts",
       "test/context-graph-on-chain-id-source-labels.test.ts",
+      "test/list-context-graphs-cache-config.test.ts",
       "test/confirmed-meta-source-labels.test.ts",
       "test/sync-envelope-cursor.test.ts",
       "test/w2-ual-parity.test.ts",


### PR DESCRIPTION
## Summary

- raise the default `listContextGraphs` cache TTL from 5 seconds to 60 seconds
- preserve the existing `DKG_LIST_CONTEXT_GRAPHS_CACHE_TTL_MS` override, including `0` to disable caching
- leave cache size, caller scoping, monotonic expiry, and mutation invalidation unchanged
- add the default-value regression to the fast unit lane

## Why

A catalogue read scans and enriches every globally known Context Graph. On nodes with hundreds of definitions, a 5-second default lets normal UI and CLI refreshes repeatedly drive the same expensive scan and trigger list-budget failures. The 60-second production hotfix kept repeat reads beyond the old TTL off the scan path without changing authorization or write semantics.

## Validation

- `pnpm --filter @origintrail-official/dkg-agent run build`
- focused unit test passed
- live check: a cold listing took 5.6s; a repeat eight seconds later took 2.4s and reused the cache, proving the new window survives the former 5-second expiry

Designed for the 10.0.15 release line.