### PR TITLE
feat(rfc64): private SWM catalog Release 1

### DIFF
--- a/devnet/rfc64-cp1-private-swm-recovery/.gitignore
+++ b/devnet/rfc64-cp1-private-swm-recovery/.gitignore
@@ -1,0 +1,1 @@
+artifacts/

--- a/devnet/rfc64-cp1-private-swm-recovery/README.md
+++ b/devnet/rfc64-cp1-private-swm-recovery/README.md
@@ -1,0 +1,14 @@
+# RFC-64 Release 1 private SWM recovery canary
+
+This canary starts two real `DKGAgent` operating-system processes. Both nodes
+accept one invite-only policy and its exact member roster. The receiver first
+rejects an unbound peer. The harness then installs the explicit peer-to-agent
+bindings, publishes 32 SWM assets, and requires exact 32/32 semantic recovery.
+
+Run from the repository root after committing all source changes:
+
+```sh
+pnpm run test:m1:rfc64-private-swm-recovery
+```
+
+The canary does not enable VM recovery. VM support belongs to the next release.

--- a/devnet/rfc64-cp1-private-swm-recovery/launch-live.ts
+++ b/devnet/rfc64-cp1-private-swm-recovery/launch-live.ts
@@ -1,0 +1,18 @@
+import { resolve } from 'node:path';
+
+import { readCleanRepositoryHead } from '../rfc64-persistence-lifecycle/evidence.js';
+import {
+  buildGate2RuntimeManifestV1,
+  installGate2RuntimeLaunchReceiptV1,
+  runGate2CleanRuntimeBuildV1,
+} from '../rfc64-gate2-multi-asset-completeness/runtime-provenance.ts';
+
+const repoRoot = resolve(import.meta.dirname, '../..');
+const sourceCommit = readCleanRepositoryHead(repoRoot);
+runGate2CleanRuntimeBuildV1(repoRoot);
+if (readCleanRepositoryHead(repoRoot) !== sourceCommit) {
+  throw new Error('private SWM canary source HEAD changed during the clean runtime build');
+}
+const manifest = buildGate2RuntimeManifestV1(repoRoot, sourceCommit);
+installGate2RuntimeLaunchReceiptV1({ manifest, sourceCommit });
+await import('./run.ts');

--- a/devnet/rfc64-cp1-private-swm-recovery/package.json
+++ b/devnet/rfc64-cp1-private-swm-recovery/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@devnet/rfc64-cp1-private-swm-recovery",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Two-process RFC-64 Release 1 private Context Graph SWM recovery canary.",
+  "dependencies": {
+    "@origintrail-official/dkg-core": "workspace:*",
+    "ethers": "6.16.0"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "live": "node --import tsx launch-live.ts"
+  }
+}

--- a/devnet/rfc64-cp1-private-swm-recovery/run.ts
+++ b/devnet/rfc64-cp1-private-swm-recovery/run.ts
@@ -1,0 +1,469 @@
+import { rmSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import process from 'node:process';
+
+import {
+  CONTEXT_GRAPH_POLICY_OBJECT_TYPE_V1,
+  CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
+  assertCanonicalGraphScopedAuthorSealV1,
+  buildAuthorAttestationTypedData,
+  computeContextGraphPolicyObjectDigestV1,
+  type AuthorCatalogScopeV1,
+  type CanonicalGraphScopedAuthorSealV1,
+  type ContextGraphIdV1,
+  type ContextGraphPolicyV1,
+  type DecimalU64V1,
+  type DecimalU256V1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type MemberRosterV1,
+  type NetworkIdV1,
+  type UnsignedControlEnvelopeV1,
+} from '@origintrail-official/dkg-core';
+import { ethers } from 'ethers';
+
+import {
+  atomicWriteExactBytes,
+} from '../rfc64-persistence-lifecycle/evidence.js';
+import {
+  ChildProcessRegistry,
+  cleanupPreservingPrimaryFailure,
+} from '../rfc64-persistence-lifecycle/process-lifecycle.js';
+import {
+  Gate2AgentChild,
+  type Gate2AgentEvent,
+} from '../rfc64-gate2-multi-asset-completeness/agent-child.js';
+import {
+  consumeGate2RuntimeLaunchReceiptV1,
+} from '../rfc64-gate2-multi-asset-completeness/runtime-provenance.ts';
+import {
+  assertGate2HarnessReadyV1,
+  assertGate2HarnessSourceStateV1,
+  connectGate2HarnessAgentsV1,
+  createGate2TwoAgentDataDirsV1,
+  spawnGate2HarnessAgentV1,
+} from '../rfc64-gate2-multi-asset-completeness/two-agent-harness.ts';
+import { canonicalDocument, type CanonicalValue } from
+  '../rfc64-gate2-multi-asset-completeness/src/canonical.ts';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../..');
+const ARTIFACT = process.env.DKG_RFC64_PRIVATE_CP1_ARTIFACT
+  ?? join(import.meta.dirname, 'artifacts/cp1-private-swm-recovery.json');
+const NETWORK_ID = 'otp:20430' as NetworkIdV1;
+const ZERO_U64 = '0' as DecimalU64V1;
+const ONE_U64 = '1' as DecimalU64V1;
+const ZERO_U256 = '0' as DecimalU256V1;
+const CONTEXT_GRAPH_ID =
+  '0x1111111111111111111111111111111111111111/cp1-private-swm' as ContextGraphIdV1;
+const OWNER_PRIVATE_KEY = `0x${'64'.repeat(32)}`;
+const RECEIVER_PRIVATE_KEY = `0x${'65'.repeat(32)}`;
+const OWNER_WALLET = new ethers.Wallet(OWNER_PRIVATE_KEY);
+const RECEIVER_WALLET = new ethers.Wallet(RECEIVER_PRIVATE_KEY);
+const OWNER = OWNER_WALLET.address.toLowerCase() as EvmAddressV1;
+const RECEIVER = RECEIVER_WALLET.address.toLowerCase() as EvmAddressV1;
+const KAV10 = '0x4444444444444444444444444444444444444444';
+const ASSET_COUNT = 32;
+const ASSERTION_ROOT =
+  '0x8d7a7be6029c98db1a7300bf47008c90084d5de4a3b97a68c043c0ea4773609f';
+const PROJECTION_NQUADS =
+  '<https://example.org/alice> <https://schema.org/age> '
+  + '"42"^^<http://www.w3.org/2001/XMLSchema#integer> .\n'
+  + '<https://example.org/alice> <https://schema.org/name> "Alice" .\n';
+const DEPLOYMENT = Object.freeze({
+  networkId: NETWORK_ID,
+  assertedAtChainId: '20430',
+  assertedAtKav10Address: KAV10,
+});
+
+const POLICY = privatePolicy();
+const POLICY_DIGEST = computeContextGraphPolicyObjectDigestV1(
+  unsignedOwnerPolicyEnvelope(POLICY),
+);
+const ROSTER = privateRoster(POLICY_DIGEST);
+
+async function execute(): Promise<void> {
+  const launch = consumeGate2RuntimeLaunchReceiptV1();
+  const head = assertGate2HarnessSourceStateV1(
+    REPO_ROOT,
+    launch.sourceCommit,
+    launch.manifest,
+  );
+  rmSync(ARTIFACT, { force: true });
+  const dataDirs = createGate2TwoAgentDataDirsV1('cp1-private');
+  const registry = new ChildProcessRegistry(20_000);
+  let primaryFailure: unknown;
+  let operationFailed = true;
+  try {
+    const author = spawnGate2HarnessAgentV1({
+      role: 'author',
+      catalogLocalAgentAddress: OWNER,
+      dataDir: dataDirs.author,
+      registry,
+      repoRoot: REPO_ROOT,
+      runtimeManifestDigest: launch.manifest.manifestDigest,
+      sourceCommit: head,
+    });
+    const receiver = spawnGate2HarnessAgentV1({
+      role: 'receiver',
+      catalogLocalAgentAddress: RECEIVER,
+      dataDir: dataDirs.receiver,
+      registry,
+      repoRoot: REPO_ROOT,
+      runtimeManifestDigest: launch.manifest.manifestDigest,
+      sourceCommit: head,
+    });
+    const [authorReady, receiverReady] = await Promise.all([
+      author.waitFor('ready'),
+      receiver.waitFor('ready'),
+    ]);
+    assertGate2HarnessReadyV1(authorReady, 'author', launch.manifest.manifestDigest);
+    assertGate2HarnessReadyV1(receiverReady, 'receiver', launch.manifest.manifestDigest);
+    requireCapabilities(authorReady, 'author');
+    requireCapabilities(receiverReady, 'receiver');
+    const authorPeerId = requiredString(authorReady.peerId, 'author peer ID');
+    const receiverPeerId = requiredString(receiverReady.peerId, 'receiver peer ID');
+    if (authorPeerId === receiverPeerId) throw new Error('private canary peer IDs are equal');
+    await connectGate2HarnessAgentsV1(author, receiver, authorReady, receiverReady, 'cp1-private');
+
+    await Promise.all([
+      acceptPrivatePolicy(author, 'author-policy'),
+      acceptPrivatePolicy(receiver, 'receiver-policy'),
+    ]);
+    const genesis = output(await author.request(
+      'publishCatalogGenesis',
+      'private-genesis',
+      'operation-completed',
+      {
+        scope: catalogScope(),
+        authorPrivateKey: OWNER_PRIVATE_KEY,
+        issuedAt: '1773900000000',
+        catalogIssuerDelegationEffectiveAt: '1773899999000',
+        catalogIssuerDelegationExpiresAt: '1774000000000',
+      },
+    ), 'private genesis');
+
+    const assets = await Promise.all(Array.from({ length: ASSET_COUNT }, async (_, index) => ({
+      assertionCoordinate: `cp1-private-asset-${String(index).padStart(2, '0')}`,
+      projectionNQuads: PROJECTION_NQUADS,
+      seal: await authorSeal(1_000n + BigInt(index)),
+    })));
+    let previousHead = stagedHead(genesis, 'private genesis');
+    let publication: Record<string, unknown> | null = null;
+    // RFC-64 ordinary successors change exactly one KA. Grow the exact live
+    // set through 32 valid successors, then announce only the final head.
+    for (let index = 0; index < assets.length; index += 1) {
+      publication = output(await author.request(
+        'publishCatalogExactSetSuccessor',
+        `private-successor-${index + 1}`,
+        'operation-completed',
+        {
+          previousHead,
+          authorPrivateKey: OWNER_PRIVATE_KEY,
+          catalogIssuerAuthorization: genesis.catalogIssuerAuthorization,
+          assets: assets.slice(0, index + 1),
+          deployment: DEPLOYMENT,
+          issuedAt: String(1773900001000 + index),
+        },
+      ), `private successor ${index + 1}`);
+      previousHead = stagedHead(publication, `private successor ${index + 1}`);
+    }
+    if (publication === null) throw new Error('private successor publication is missing');
+    const announcement = record(publication.announcement, 'private successor announcement');
+    exact(announcement.policyDigest, POLICY_DIGEST, 'private announcement policy digest');
+
+    const denied = output(await author.request(
+      'announce',
+      'private-unbound-denial',
+      'operation-completed',
+      { announcement, peers: [receiverPeerId] },
+    ), 'unbound announcement denial');
+    exact(denied.announcedPeers, [], 'unbound announcement accepted peers');
+    const deniedPeers = array(denied.failedPeers, 'unbound announcement failed peers');
+    exact(deniedPeers.length, 1, 'unbound announcement failure count');
+    exact(
+      record(deniedPeers[0], 'unbound announcement failure').peerId,
+      receiverPeerId,
+      'unbound announcement failed peer',
+    );
+
+    await Promise.all([
+      bindPeer(author, receiverPeerId, RECEIVER, 'author-bind-receiver'),
+      bindPeer(receiver, authorPeerId, OWNER, 'receiver-bind-author'),
+    ]);
+    const delivery = output(await author.request(
+      'announce',
+      'private-authorized-announce',
+      'operation-completed',
+      { announcement, peers: [receiverPeerId] },
+    ), 'authorized announcement');
+    exact(delivery.announcedPeers, [receiverPeerId], 'authorized announcement peers');
+    exact(delivery.failedPeers, [], 'authorized announcement failures');
+    await receiver.request('awaitReceiverIdle', 'private-receiver-idle', 'receiver-idle');
+
+    const headDigest = requiredDigest(publication.headObjectDigest, 'private head digest');
+    const synchronization = output(await receiver.request(
+      'exactInventoryReadback',
+      'private-inventory',
+      'operation-completed',
+      { catalogHeadDigest: headDigest },
+    ), 'private inventory');
+    const rows = array(synchronization.rows, 'private inventory rows');
+    exact(rows.length, ASSET_COUNT, 'private recovered row count');
+    exact(synchronization.inventoryRowCount, ASSET_COUNT, 'private inventory row count');
+    exact(synchronization.activatedTripleCount, ASSET_COUNT * 2, 'private activated triples');
+    exact(synchronization.appliedHeadStatus, 'applied', 'private applied head status');
+    for (const [index, value] of rows.entries()) {
+      const row = record(value, `private row ${index}`);
+      const semantic = output(await receiver.request(
+        'semanticGraphReadback',
+        `private-semantic-${index}`,
+        'operation-completed',
+        { swmGraph: requiredString(row.swmGraph, `private row ${index} graph`) },
+      ), `private semantic ${index}`);
+      exact(semantic.projectionNQuads, PROJECTION_NQUADS, `private semantic ${index}`);
+    }
+
+    const [authorStopped, receiverStopped] = await Promise.all([
+      author.stop('private-author-stop'),
+      receiver.stop('private-receiver-stop'),
+    ]);
+    const testedHeadCommit = assertGate2HarnessSourceStateV1(
+      REPO_ROOT,
+      head,
+      launch.manifest,
+    );
+    const artifact = Object.freeze({
+      accessPolicy: 1,
+      assetsPublished: ASSET_COUNT,
+      assetsRecovered: rows.length,
+      deniedUnboundPeer: true,
+      processBoundary: {
+        authorExitCode: authorStopped.exit.code,
+        authorPid: requiredPid(author.child.pid, 'author PID'),
+        receiverExitCode: receiverStopped.exit.code,
+        receiverPid: requiredPid(receiver.child.pid, 'receiver PID'),
+      },
+      policyDigest: POLICY_DIGEST,
+      repository: { testedHeadCommit, trackedSourceClean: true },
+      runtimeManifestDigest: launch.manifest.manifestDigest,
+      schemaVersion: 'dkg-rfc64-cp1-private-swm-recovery-v1',
+      status: 'PASS',
+      vmRecoveryEnabled: false,
+    });
+    const publicationReceipt = atomicWriteExactBytes(
+      ARTIFACT,
+      new TextEncoder().encode(canonicalDocument(artifact as unknown as CanonicalValue)),
+    );
+    process.stdout.write(
+      `[rfc64-private-cp1] PASS assets=${ASSET_COUNT}/${ASSET_COUNT} `
+      + `artifact=${ARTIFACT} sha256=${publicationReceipt.sha256}\n`,
+    );
+    operationFailed = false;
+  } catch (error) {
+    primaryFailure = error;
+  } finally {
+    await cleanupPreservingPrimaryFailure({
+      operationFailed,
+      primaryFailure,
+      cleanup: () => registry.terminateAllThenCleanup(() => {
+        rmSync(dataDirs.author, { recursive: true, force: true });
+        rmSync(dataDirs.receiver, { recursive: true, force: true });
+      }),
+      reportSecondaryFailure: (primary, secondary) => {
+        process.stderr.write(
+          `[rfc64-private-cp1] cleanup failure after ${String(primary)}: ${String(secondary)}\n`,
+        );
+      },
+    });
+  }
+}
+
+function privatePolicy(): ContextGraphPolicyV1 {
+  return Object.freeze({
+    networkId: NETWORK_ID,
+    contextGraphId: CONTEXT_GRAPH_ID,
+    governanceChainId: null,
+    governanceContractAddress: null,
+    ownershipTransitionDigest: null,
+    era: ZERO_U64,
+    version: ZERO_U64,
+    previousPolicyDigest: null,
+    accessPolicy: 1,
+    publishPolicy: 1,
+    publishAuthority: null,
+    publishAuthorityAccountId: ZERO_U256,
+    projectionId: CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
+    administrativeDelegationDigest: null,
+    source: {
+      kind: 'owner-signed-unregistered',
+      ownerAddress: OWNER,
+      ownerAuthorityEra: ZERO_U64,
+    } as const,
+    effectiveAt: ZERO_U64,
+    issuedAt: ZERO_U64,
+  });
+}
+
+function privateRoster(policyDigest: Digest32V1): MemberRosterV1 {
+  return Object.freeze({
+    networkId: NETWORK_ID,
+    contextGraphId: CONTEXT_GRAPH_ID,
+    ownershipTransitionDigest: null,
+    era: ZERO_U64,
+    version: ZERO_U64,
+    previousRosterDigest: null,
+    policyDigest,
+    administrativeDelegationDigest: null,
+    members: [
+      { agentAddress: OWNER, roles: ['holder', 'provider'] as const },
+      { agentAddress: RECEIVER, roles: ['holder', 'provider'] as const },
+    ].sort((left, right) => left.agentAddress.localeCompare(right.agentAddress)),
+    issuedAt: ZERO_U64,
+  });
+}
+
+function unsignedOwnerPolicyEnvelope(policy: ContextGraphPolicyV1): UnsignedControlEnvelopeV1 {
+  return {
+    issuer: OWNER,
+    objectType: CONTEXT_GRAPH_POLICY_OBJECT_TYPE_V1,
+    payload: policy,
+    signatureEvidence: { kind: 'none' },
+    signatureSuite: 'eip191-personal-sign-digest-v1',
+  } as unknown as UnsignedControlEnvelopeV1;
+}
+
+function catalogScope(): AuthorCatalogScopeV1 {
+  return Object.freeze({
+    networkId: NETWORK_ID,
+    contextGraphId: CONTEXT_GRAPH_ID,
+    governanceChainId: null,
+    governanceContractAddress: null,
+    ownershipTransitionDigest: null,
+    subGraphName: null,
+    authorAddress: OWNER,
+    era: ZERO_U64,
+    bucketCount: ONE_U64,
+  });
+}
+
+async function acceptPrivatePolicy(child: Gate2AgentChild, requestId: string): Promise<void> {
+  const accepted = output(await child.request(
+    'acceptPolicySnapshot',
+    requestId,
+    'operation-completed',
+    { policy: POLICY, policyDigest: POLICY_DIGEST, roster: ROSTER },
+  ), `${requestId} result`);
+  exact(accepted.policyDigest, POLICY_DIGEST, `${requestId} digest`);
+}
+
+async function bindPeer(
+  child: Gate2AgentChild,
+  peerId: string,
+  agentAddress: EvmAddressV1,
+  requestId: string,
+): Promise<void> {
+  const binding = output(await child.request(
+    'bindCatalogPeerAgent',
+    requestId,
+    'operation-completed',
+    { peerId, agentAddress },
+  ), `${requestId} result`);
+  exact(binding.peerId, peerId, `${requestId} peer ID`);
+  exact(binding.agentAddress, agentAddress, `${requestId} agent address`);
+}
+
+async function authorSeal(kaNumber: bigint): Promise<CanonicalGraphScopedAuthorSealV1> {
+  const kaId = ((BigInt(OWNER) << 96n) | kaNumber).toString();
+  const typedData = buildAuthorAttestationTypedData({
+    chainId: BigInt(DEPLOYMENT.assertedAtChainId),
+    kav10Address: DEPLOYMENT.assertedAtKav10Address as never,
+    merkleRoot: ethers.getBytes(ASSERTION_ROOT),
+    authorAddress: OWNER,
+    reservedKaId: BigInt(kaId),
+  });
+  const signature = ethers.Signature.from(await OWNER_WALLET.signTypedData(
+    typedData.domain,
+    typedData.types,
+    typedData.message,
+  ));
+  const seal = {
+    assertionMerkleRoot: ASSERTION_ROOT,
+    authorAddress: OWNER,
+    authorAttestationR: signature.r,
+    authorAttestationVS: signature.yParityAndS,
+    authorSchemeVersion: '1',
+    assertedAtChainId: DEPLOYMENT.assertedAtChainId,
+    assertedAtKav10Address: KAV10,
+    reservedKaId: kaId,
+    assertionFinalizedAt: '2026-07-19T12:34:56.789Z',
+    contentScopeVersion: '2',
+    kaUal: `did:dkg:${NETWORK_ID}/${OWNER}/${kaNumber}`,
+    assertionVersion: '1',
+    publicTripleCount: '2',
+    privateTripleCount: '0',
+    privateMerkleRoot: null,
+  } as unknown as CanonicalGraphScopedAuthorSealV1;
+  assertCanonicalGraphScopedAuthorSealV1(seal);
+  return seal;
+}
+
+function stagedHead(value: Record<string, unknown>, label: string): Record<string, unknown> {
+  return {
+    objectDigest: requiredDigest(value.headObjectDigest, `${label} object digest`),
+    signatureVariantDigest: requiredDigest(
+      value.signatureVariantDigest,
+      `${label} signature variant digest`,
+    ),
+  };
+}
+
+function requireCapabilities(event: Gate2AgentEvent, role: string): void {
+  const capabilities = record(event.capabilities, `${role} capabilities`);
+  for (const name of [
+    'acceptPolicySnapshot',
+    'announce',
+    'exactInventoryReadback',
+    'publishPolicyBoundExactSetSuccessor',
+    'publishPolicyBoundGenesis',
+  ]) exact(capabilities[name], true, `${role} capability ${name}`);
+}
+
+function output(event: Gate2AgentEvent, label: string): Record<string, unknown> {
+  return record(event.output, `${label} output`);
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function array(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) throw new TypeError(`${label} must be an array`);
+  return value;
+}
+
+function requiredString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0) throw new TypeError(`${label} is missing`);
+  return value;
+}
+
+function requiredDigest(value: unknown, label: string): Digest32V1 {
+  const result = requiredString(value, label);
+  if (!/^0x[0-9a-f]{64}$/u.test(result)) throw new TypeError(`${label} is not a digest`);
+  return result as Digest32V1;
+}
+
+function requiredPid(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 1) throw new TypeError(`${label} missing`);
+  return value as number;
+}
+
+function exact(actual: unknown, expected: unknown, label: string): void {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`${label} mismatch: ${JSON.stringify(actual)} != ${JSON.stringify(expected)}`);
+  }
+}
+
+await execute();

--- a/devnet/rfc64-cp1-private-swm-recovery/tsconfig.json
+++ b/devnet/rfc64-cp1-private-swm-recovery/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "rootDir": "../..",
+    "skipLibCheck": true,
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": [
+    "*.ts",
+    "../rfc64-gate2-multi-asset-completeness/agent-child.ts",
+    "../rfc64-gate2-multi-asset-completeness/model.ts",
+    "../rfc64-gate2-multi-asset-completeness/runtime-provenance.ts",
+    "../rfc64-gate2-multi-asset-completeness/two-agent-harness.ts",
+    "../rfc64-persistence-lifecycle/evidence.ts",
+    "../rfc64-persistence-lifecycle/process-lifecycle.ts"
+  ]
+}

--- a/devnet/rfc64-gate2-multi-asset-completeness/adapter-process.ts
+++ b/devnet/rfc64-gate2-multi-asset-completeness/adapter-process.ts
@@ -60,6 +60,8 @@ const masterKeyHex = process.env.DKG_RFC64_GATE2_AGENT_MASTER_KEY_HEX;
 const runtimeBuildManifestDigest = process.env.DKG_RFC64_GATE2_RUNTIME_MANIFEST_DIGEST;
 const finalizedVmConfigInput = process.env.DKG_RFC64_GATE2_FINALIZED_VM_CONFIG;
 const networkChainIdInput = process.env.DKG_RFC64_GATE2_NETWORK_CHAIN_ID;
+const localCatalogAgentAddressInput =
+  process.env.DKG_RFC64_GATE2_CATALOG_LOCAL_AGENT_ADDRESS;
 if (role !== 'author' && role !== 'receiver') throw new Error('adapter role is required');
 if (!dataDirInput) throw new Error('DKG_RFC64_GATE2_ADAPTER_DATA_DIR is required');
 if (!masterKeyHex || !/^[0-9a-f]{64}$/u.test(masterKeyHex)) {
@@ -75,6 +77,7 @@ let agent: DKGAgent | undefined;
 let finalizedVmRuntime: Readonly<FinalizedVmHarnessRuntimeV1> | undefined;
 let stopping = false;
 let commandTail = Promise.resolve();
+const peerCatalogAgentAddresses = new Map<string, EvmAddressV1>();
 
 interface Command {
   readonly command: string;
@@ -135,6 +138,12 @@ async function boot(): Promise<void> {
   if (networkChainIdInput !== undefined) {
     assertNetworkIdV1(networkChainIdInput);
   }
+  const localCatalogAgentAddress = localCatalogAgentAddressInput === undefined
+    ? null
+    : canonicalNonZeroEvmAddress(
+        localCatalogAgentAddressInput,
+        'DKG_RFC64_GATE2_CATALOG_LOCAL_AGENT_ADDRESS',
+      );
   if (
     finalizedVmConfig !== null
     && networkChainIdInput !== RFC64_GATE2_DEPLOYMENT.networkId
@@ -160,6 +169,13 @@ async function boot(): Promise<void> {
     durableSyncEnabled: false,
     agentProfileHeartbeatMs: 0,
     rfc64CatalogDeploymentProfile: RFC64_GATE2_DEPLOYMENT as never,
+    ...(localCatalogAgentAddress === null ? {} : {
+      rfc64CatalogAccessPolicyAuthority: {
+        localAgentAddress: localCatalogAgentAddress,
+        resolveRemoteAgentAddress: async (remotePeerId: string) =>
+          peerCatalogAgentAddresses.get(remotePeerId) ?? null,
+      },
+    }),
     ...(networkChainAdapter === undefined ? {} : { chainAdapter: networkChainAdapter }),
     ...(finalizedVmRuntime === undefined ? {} : {
       chainConfig: {
@@ -224,6 +240,24 @@ async function handle(command: Command): Promise<void> {
   }
   const currentAgent = requireAgent();
   switch (command.command) {
+    case 'bindCatalogPeerAgent': {
+      const input = plainRecord(command.input, 'bindCatalogPeerAgent input');
+      const peerId = requiredString(input.peerId, 'bindCatalogPeerAgent.peerId');
+      if (Buffer.byteLength(peerId, 'utf8') > 256) {
+        throw new Error('bindCatalogPeerAgent.peerId is too long');
+      }
+      const agentAddress = canonicalNonZeroEvmAddress(
+        input.agentAddress,
+        'bindCatalogPeerAgent.agentAddress',
+      );
+      const current = peerCatalogAgentAddresses.get(peerId);
+      if (current !== undefined && current !== agentAddress) {
+        throw new Error('bindCatalogPeerAgent cannot replace an existing peer binding');
+      }
+      peerCatalogAgentAddresses.set(peerId, agentAddress);
+      emitOperationResult(command, { agentAddress, peerId });
+      return;
+    }
     case 'dial': {
       const input = plainRecord(command.input, 'dial input');
       const address = requiredString(input.multiaddr, 'dial.multiaddr');
@@ -1053,6 +1087,18 @@ function requiredString(value: unknown, label: string): string {
     throw new TypeError(`${label} must be a bounded non-empty string`);
   }
   return value;
+}
+
+function canonicalNonZeroEvmAddress(value: unknown, label: string): EvmAddressV1 {
+  const input = requiredString(value, label);
+  if (!ethers.isAddress(input)) {
+    throw new TypeError(`${label} must be a non-zero EVM address`);
+  }
+  const canonical = ethers.getAddress(input).toLowerCase();
+  if (canonical === ethers.ZeroAddress.toLowerCase()) {
+    throw new TypeError(`${label} must be a non-zero EVM address`);
+  }
+  return canonical as EvmAddressV1;
 }
 
 function requiredDigest(value: unknown, label: string): Digest32V1 {

--- a/devnet/rfc64-gate2-multi-asset-completeness/two-agent-harness.ts
+++ b/devnet/rfc64-gate2-multi-asset-completeness/two-agent-harness.ts
@@ -55,6 +55,7 @@ export function assertGate2HarnessSourceStateV1(
 }
 
 export function spawnGate2HarnessAgentV1(input: {
+  readonly catalogLocalAgentAddress?: string;
   readonly dataDir: string;
   readonly finalizedVmConfigJson?: string;
   readonly networkChainId?: string;
@@ -82,6 +83,12 @@ export function spawnGate2HarnessAgentV1(input: {
         DKG_RFC64_GATE2_AGENT_MASTER_KEY_HEX: ROLE_MASTER_KEYS[input.role],
         DKG_RFC64_GATE2_RUNTIME_MANIFEST_DIGEST: input.runtimeManifestDigest,
         DKG_RFC64_GATE2_RUNTIME_SOURCE_COMMIT: input.sourceCommit,
+        ...(input.catalogLocalAgentAddress === undefined
+          ? {}
+          : {
+              DKG_RFC64_GATE2_CATALOG_LOCAL_AGENT_ADDRESS:
+                input.catalogLocalAgentAddress,
+            }),
         ...(input.networkChainId === undefined
           ? {}
           : { DKG_RFC64_GATE2_NETWORK_CHAIN_ID: input.networkChainId }),

--- a/docs/use-dkg/rfc64-selected-public-catalog.md
+++ b/docs/use-dkg/rfc64-selected-public-catalog.md
@@ -121,6 +121,64 @@ deterministic harness and must exactly match the selected network.
 Its `networkId` and numeric `assertedAtChainId` are checked against the same
 effective chain identity before subscriptions, stores, or agent startup begin.
 
+### Experimental Release 1: selected private SWM
+
+`rfc64Catalog` is the additive policy-neutral form. Release 1 lets a current
+member recover SWM for one explicitly selected owner-signed, unregistered
+private CG from one pinned complete provider. It does not recover private VM
+or registered private CGs yet. A registered private policy stops activation;
+support for registered private CGs is part of Release 2.
+
+The bounded operator shape is:
+
+```json
+{
+  "rfc64Catalog": {
+    "bootstrap": {
+      "acceptedPolicies": [
+        {
+          "policyEnvelope": "<canonical independently verified ContextGraphPolicyV1 envelope>",
+          "rosterEnvelope": "<canonical independently verified MemberRosterV1 envelope>",
+          "completeSwmProviders": ["12D3Koo...private-provider"],
+          "targets": [
+            {
+              "authorAddress": "0x...catalog-author",
+              "providers": ["12D3Koo...private-provider"]
+            }
+          ]
+        }
+      ]
+    },
+    "accessPolicyAuthority": {
+      "localAgentAddress": "0x...current-local-member",
+      "peerAgentBindings": [
+        {
+          "peerId": "12D3Koo...private-provider",
+          "agentAddress": "0x...current-roster-provider"
+        }
+      ]
+    }
+  }
+}
+```
+
+The envelope strings above stand for full JSON objects; they are abbreviated
+only to keep the example readable. `peerAgentBindings` is manual operator trust,
+not discovery output. Every private target or complete provider needs an exact
+binding to a current roster member with the `provider` role. The local address
+must also be a current member. The daemon rejects a missing or conflicting
+policy, roster, provider binding, network, or local membership before it starts.
+
+Release 1 does not follow roster successors automatically. When a member is
+removed, install the new independently verified policy/roster snapshot, remove
+obsolete peer bindings, and restart the node. This fences the removed peer from
+new Release-1 transfers. Content already received by that member cannot be
+revoked.
+
+`rfc64PublicCatalog` remains valid. If both blocks select the same CG, their
+canonical policy, targets, and completeness assertion must be identical; a
+conflict stops activation.
+
 ## Verify activation
 
 Restart the daemon and inspect `GET /api/status`:

--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
     "test:m1:rfc64-public-swm-parity:verify": "node --import tsx devnet/rfc64-cp1-public-swm-parity/verify-live.ts",
     "test:m1:rfc64-public-swm-parity:unit": "node --import tsx --test devnet/rfc64-cp1-public-swm-parity/verifier.test.ts",
     "typecheck:m1:rfc64-public-swm-parity": "tsc --project devnet/rfc64-cp1-public-swm-parity/tsconfig.json",
+    "test:m1:rfc64-private-swm-recovery": "node --import tsx devnet/rfc64-cp1-private-swm-recovery/launch-live.ts",
+    "typecheck:m1:rfc64-private-swm-recovery": "tsc --project devnet/rfc64-cp1-private-swm-recovery/tsconfig.json",
     "test:devnet:v10-core-flows": "vitest run --config devnet/v10-core-flows/vitest.config.ts",
     "test:devnet:v10-e2e": "vitest run --config devnet/v10-end-to-end/vitest.config.ts",
     "test:devnet:v10-stress": "vitest run --config devnet/v10-stress/vitest.config.ts",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -36,6 +36,8 @@
     "./dist/rfc64/control-object-store-v1.js": null,
     "./dist/rfc64/catalog-access-policy-v1.js": null,
     "./dist/rfc64/catalog-authority-config-v1.js": null,
+    "./dist/rfc64/catalog-native-scoped-read-capability-v1-internal.js": null,
+    "./dist/rfc64/catalog-native-scoped-read-provider-v1.js": null,
     "./dist/rfc64/catalog-peers-v1.js": null,
     "./dist/rfc64/catalog-transport-authorization-v1.js": null,
     "./dist/rfc64/catalog-transport-wire-v1-internal.js": null,

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -122,6 +122,8 @@ const publicRfc64Modules = [
 const blockedRfc64Modules = [
   'catalog-access-policy-v1.js',
   'catalog-authority-config-v1.js',
+  'catalog-native-scoped-read-capability-v1-internal.js',
+  'catalog-native-scoped-read-provider-v1.js',
   'catalog-peers-v1.js',
   'catalog-transport-authorization-v1.js',
   'catalog-transport-wire-v1-internal.js',

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -579,6 +579,7 @@ import {
   type SharedMemorySyncResult,
   type SwmSnapshotCoverage,
   type DKGAgentConfig,
+  type ResolvedDKGAgentConfig,
   type ReplicationEvent,
   type SyncReconcilerProbe,
   type SyncReconcilerBackoff,
@@ -636,7 +637,7 @@ import {
 const DEFAULT_HOST_MODE_RECONCILE_JITTER_RATIO = 0.15;
 const RFC64_SELECTED_SWM_ADMISSION_PRIORITY = 2_000;
 
-function resolveAgentSyncGlobalBackpressure(config: DKGAgentConfig) {
+function resolveAgentSyncGlobalBackpressure(config: ResolvedDKGAgentConfig) {
   // `trackSyncContextGraph()` mutates this list when an Edge explicitly
   // subscribes or starts a foreground catch-up. Those operator-selected graphs
   // need the same admission guarantee as an RFC-64 pinned scope: otherwise a
@@ -653,7 +654,7 @@ function resolveAgentSyncGlobalBackpressure(config: DKGAgentConfig) {
     ...config,
     selectedRecoveryContextGraphIds: [...new Set([
       ...resolveRfc64SelectedRecoveryContextGraphIdsV1(
-        config.rfc64PublicCatalogBootstrap,
+        config.rfc64CatalogBootstrap ?? config.rfc64PublicCatalogBootstrap,
       ),
       ...edgeSelectedContextGraphIds,
     ])],
@@ -4223,7 +4224,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   ): readonly string[] {
     const selected = new Set(this.config.syncContextGraphs ?? []);
     return resolveRfc64SelectedRecoveryContextGraphIdsForProviderV1(
-      this.config.rfc64PublicCatalogBootstrap,
+      this.config.rfc64CatalogBootstrap ?? this.config.rfc64PublicCatalogBootstrap,
       remotePeer,
     ).filter((contextGraphId) => selected.has(contextGraphId));
   }
@@ -4457,10 +4458,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const sharedMemorySyncPlans = new Map<string, Promise<SharedMemorySyncContextGraphPlan>>();
     const prioritySharedMemorySyncPlans = new Map<string, Promise<SharedMemorySyncContextGraphPlan>>();
     const automaticPeerSweep = source === 'on-connect' || source === 'reconcile';
-    const remotePeerIsCompleteSwmProvider = this.config.rfc64PublicCatalogBootstrap
-      ?.acceptedPublicPolicies.some(
+    const acceptedPolicies = this.config.rfc64CatalogBootstrap?.acceptedPolicies
+      ?? this.config.rfc64PublicCatalogBootstrap?.acceptedPublicPolicies
+      ?? [];
+    const remotePeerIsCompleteSwmProvider = acceptedPolicies.some(
         ({ completeSwmProviders = [] }) => completeSwmProviders.includes(remotePeer),
-      ) ?? false;
+      );
     const getSharedMemorySyncPlan = (peerId: string): Promise<SharedMemorySyncContextGraphPlan> => {
       let plan = sharedMemorySyncPlans.get(peerId);
       if (!plan) {

--- a/packages/agent/src/dkg-agent-rfc64-catalog-bootstrap.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog-bootstrap.ts
@@ -14,6 +14,8 @@ import {
 import { DKGAgentBase } from './dkg-agent-base.js';
 import type { DKGAgent } from './dkg-agent.js';
 import type {
+  Rfc64CatalogBootstrapConfigV1,
+  Rfc64CatalogBootstrapPolicyV1,
   Rfc64PublicCatalogBootstrapConfigV1,
   Rfc64PublicCatalogBootstrapScopeV1,
 } from './dkg-agent-types.js';
@@ -66,7 +68,10 @@ interface MutableTargetStatusV1 {
 }
 
 interface BootstrapStateV1 {
-  readonly config: Readonly<Rfc64PublicCatalogBootstrapConfigV1>;
+  readonly config: Readonly<{
+    readonly acceptedPolicies: readonly Rfc64CatalogBootstrapPolicyV1[];
+    readonly retryIntervalMs?: number;
+  }>;
   readonly targets: MutableTargetStatusV1[];
   readonly ctx: OperationContext;
   closed: boolean;
@@ -87,22 +92,30 @@ const STATES = new WeakMap<DKGAgent, BootstrapStateV1>();
  * reservation.
  */
 export function resolveRfc64SelectedRecoveryContextGraphIdsV1(
-  config: Readonly<Rfc64PublicCatalogBootstrapConfigV1> | undefined,
+  config: Readonly<Rfc64CatalogBootstrapConfigV1 | Rfc64PublicCatalogBootstrapConfigV1>
+    | undefined,
 ): readonly string[] {
   if (config === undefined) return Object.freeze([]);
-  return Object.freeze(config.acceptedPublicPolicies
-    .filter(({ completeSwmProviders = [] }) => completeSwmProviders.length > 0)
+  return Object.freeze(acceptedPoliciesV1(config)
+    .filter(({ policyEnvelope, completeSwmProviders = [] }) => (
+      policyEnvelope.payload.accessPolicy === 0
+      && completeSwmProviders.length > 0
+    ))
     .map(({ policyEnvelope }) => policyEnvelope.payload.contextGraphId));
 }
 
 /** Selected recovery scopes for which one peer is explicitly graph-complete. */
 export function resolveRfc64SelectedRecoveryContextGraphIdsForProviderV1(
-  config: Readonly<Rfc64PublicCatalogBootstrapConfigV1> | undefined,
+  config: Readonly<Rfc64CatalogBootstrapConfigV1 | Rfc64PublicCatalogBootstrapConfigV1>
+    | undefined,
   providerPeerId: string,
 ): readonly string[] {
   if (config === undefined) return Object.freeze([]);
-  return Object.freeze(config.acceptedPublicPolicies
-    .filter(({ completeSwmProviders = [] }) => completeSwmProviders.includes(providerPeerId))
+  return Object.freeze(acceptedPoliciesV1(config)
+    .filter(({ policyEnvelope, completeSwmProviders = [] }) => (
+      policyEnvelope.payload.accessPolicy === 0
+      && completeSwmProviders.includes(providerPeerId)
+    ))
     .map(({ policyEnvelope }) => policyEnvelope.payload.contextGraphId));
 }
 
@@ -116,30 +129,38 @@ export class Rfc64CatalogBootstrapMethods extends DKGAgentBase {
     this: DKGAgent,
     contextGraphId: string,
   ): readonly string[] {
-    const config = this.config.rfc64PublicCatalogBootstrap;
+    const config = this.config.rfc64CatalogBootstrap
+      ?? this.config.rfc64PublicCatalogBootstrap;
     if (config === undefined) return Object.freeze([]);
-    const policy = config.acceptedPublicPolicies.find(
+    const policy = acceptedPoliciesV1(config).find(
       ({ policyEnvelope }) => policyEnvelope.payload.contextGraphId === contextGraphId,
     );
-    return policy?.completeSwmProviders ?? Object.freeze([]);
+    return policy?.policyEnvelope.payload.accessPolicy === 0
+      ? policy.completeSwmProviders ?? Object.freeze([])
+      : Object.freeze([]);
   }
 
   /** Accept pinned policies and start the first bounded provider pass. */
   startRfc64PublicCatalogBootstrapV1(this: DKGAgent, ctx: OperationContext): void {
-    const config = this.config.rfc64PublicCatalogBootstrap;
+    const config = this.resolveRuntimeRfc64CatalogBootstrapV1();
     if (config === undefined || STATES.has(this)) return;
     const service = this.rfc64PublicCatalogServiceV1;
     if (service === undefined) {
       throw new Error('RFC-64 bootstrap requires the public catalog service');
     }
-    for (const accepted of config.acceptedPublicPolicies) {
+    for (const accepted of config.acceptedPolicies) {
       service.acceptPolicySnapshot({
         policy: accepted.policyEnvelope.payload,
         policyDigest: computeContextGraphPolicyObjectDigestV1(accepted.policyEnvelope),
+        roster: accepted.rosterEnvelope?.payload,
       });
     }
-    const targets = config.acceptedPublicPolicies.flatMap(({ policyEnvelope, targets }) => (
-      targets.map((target) => ({
+    const targets = config.acceptedPolicies.flatMap(({
+      policyEnvelope,
+      targets: policyTargets,
+      completeSwmProviders = [],
+    }) => (
+      policyTargets.map((target) => ({
         scope: Object.freeze({
           networkId: policyEnvelope.payload.networkId,
           contextGraphId: policyEnvelope.payload.contextGraphId,
@@ -147,7 +168,12 @@ export class Rfc64CatalogBootstrapMethods extends DKGAgentBase {
           authorAddress: target.authorAddress,
           catalogEra: policyEnvelope.payload.era,
         }),
-        providers: target.providers,
+        // Release 1 private recovery is deliberately single-provider. The
+        // graph-complete provider is the only source used for every signed
+        // author catalog; configured target candidates do not widen it.
+        providers: policyEnvelope.payload.accessPolicy === 1
+          ? completeSwmProviders
+          : target.providers,
       }))
     ));
     const state: BootstrapStateV1 = {
@@ -256,8 +282,10 @@ export class Rfc64CatalogBootstrapMethods extends DKGAgentBase {
     state.abortController = abortController;
     try {
       const completeSwmProviders = [...new Set(
-        state.config.acceptedPublicPolicies.flatMap(
-          ({ completeSwmProviders: providers = [] }) => providers,
+        state.config.acceptedPolicies.flatMap(
+          ({ policyEnvelope, completeSwmProviders: providers = [] }) => (
+            policyEnvelope.payload.accessPolicy === 0 ? providers : []
+          ),
         ),
       )];
       await mapWithConcurrency(
@@ -357,6 +385,29 @@ export class Rfc64CatalogBootstrapMethods extends DKGAgentBase {
     target.lastError = lastError;
     target.updatedAtMs = Date.now();
   }
+
+  private resolveRuntimeRfc64CatalogBootstrapV1(
+    this: DKGAgent,
+  ): BootstrapStateV1['config'] | undefined {
+    const current = this.config.rfc64CatalogBootstrap;
+    if (current !== undefined) return current;
+    const legacy = this.config.rfc64PublicCatalogBootstrap;
+    if (legacy === undefined) return undefined;
+    return Object.freeze({
+      acceptedPolicies: legacy.acceptedPublicPolicies,
+      ...(legacy.retryIntervalMs === undefined
+        ? {}
+        : { retryIntervalMs: legacy.retryIntervalMs }),
+    });
+  }
+}
+
+function acceptedPoliciesV1(
+  config: Readonly<Rfc64CatalogBootstrapConfigV1 | Rfc64PublicCatalogBootstrapConfigV1>,
+): readonly Rfc64CatalogBootstrapPolicyV1[] {
+  return 'acceptedPolicies' in config
+    ? config.acceptedPolicies
+    : config.acceptedPublicPolicies;
 }
 
 function snapshotTargetStatusV1(

--- a/packages/agent/src/dkg-agent-rfc64-catalog.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog.ts
@@ -756,6 +756,11 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
     const resolveScopedReadCapability = createRfc64CatalogNativeScopedReadProviderV1({
       controlObjects: persistence.controlObjects,
       kaBundles: persistence.kaBundles,
+      resolveAcceptedPolicySnapshot: (networkId, contextGraphId) =>
+        this.requireRfc64PublicCatalogServiceV1().acceptedPolicySnapshot(
+          networkId,
+          contextGraphId,
+        ),
     });
     return Object.freeze({
       readCatalogObjectByDigest: async (objectDigest: Digest32V1) => {

--- a/packages/agent/src/dkg-agent-rfc64-catalog.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog.ts
@@ -99,6 +99,7 @@ import {
   RFC64_PUBLIC_CATALOG_HEAD_ANNOUNCEMENT_KIND_V1,
   type Rfc64PublicCatalogHeadAnnouncementV1,
 } from './rfc64/public-catalog-transport-v1.js';
+import { createRfc64CatalogNativeScopedReadProviderV1 } from './rfc64/catalog-native-scoped-read-provider-v1.js';
 
 /** Minimal EIP-191 EOA signer (ethers.Wallet-compatible) for author-catalog objects. */
 export interface Rfc64CatalogAuthorSignerV1 {
@@ -518,11 +519,6 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
     const scope = deriveAuthorCatalogScopeFromHeadV1(history.previousHead.payload);
     const heldPolicy = service.acceptedPolicySnapshotForCatalogScope(scope);
     const policyDigest = heldPolicy.policyDigest;
-    if (heldPolicy.policy.accessPolicy === 1 && peers.length > 0) {
-      throw new Error(
-        'RFC-64 private catalog peer fan-out requires scope-bound private content transport',
-      );
-    }
     const authorAddress = params.author.address.toLowerCase() as EvmAddressV1;
     if (authorAddress !== scope.authorAddress) {
       throw new Error('RFC-64 successor author must equal the exact predecessor author');
@@ -757,6 +753,10 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
         announcement.networkId,
         signal,
       );
+    const resolveScopedReadCapability = createRfc64CatalogNativeScopedReadProviderV1({
+      controlObjects: persistence.controlObjects,
+      kaBundles: persistence.kaBundles,
+    });
     return Object.freeze({
       readCatalogObjectByDigest: async (objectDigest: Digest32V1) => {
         const stored = await persistence.controlObjects.getVerifiedObjectByDigest({
@@ -766,6 +766,7 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
         return stored?.envelope ?? null;
       },
       readKaBundleByDigest: persistence.kaBundles.readKaBundleByDigest,
+      resolveScopedReadCapability,
       createReconciler: (clients: Readonly<Rfc64PublicCatalogReconcilerClientsV1>) => {
         const chainConfig = this.config.chainConfig;
         const beforeAppliedHeadCommit = createRfc64FinalizedPolicyAgentPrecommitV1({

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -2866,12 +2866,15 @@ export class SwmHostModeMethods extends DKGAgentBase {
     contextGraphId: string,
   ): boolean {
     if (!(this.config.syncContextGraphs ?? []).includes(contextGraphId)) return false;
-    return this.config.rfc64PublicCatalogBootstrap?.acceptedPublicPolicies.some(
+    const acceptedPolicies = this.config.rfc64CatalogBootstrap?.acceptedPolicies
+      ?? this.config.rfc64PublicCatalogBootstrap?.acceptedPublicPolicies
+      ?? [];
+    return acceptedPolicies.some(
       ({ policyEnvelope }) => (
         policyEnvelope.payload.accessPolicy === 0
         && policyEnvelope.payload.contextGraphId === contextGraphId
       ),
-    ) ?? false;
+    );
   }
 
   isRfc64SelectedVmReconcileTargetAllowed(
@@ -2934,8 +2937,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // intentionally do not become member subscriptions (no gossip fan-out or
       // durable subscription row), but finalized VM must still be reconciled
       // from the canonical on-chain ordinal inventory.
-      for (const { policyEnvelope } of this.config.rfc64PublicCatalogBootstrap
-        ?.acceptedPublicPolicies ?? []) {
+      const acceptedPolicies = this.config.rfc64CatalogBootstrap?.acceptedPolicies
+        ?? this.config.rfc64PublicCatalogBootstrap?.acceptedPublicPolicies
+        ?? [];
+      for (const { policyEnvelope } of acceptedPolicies) {
         const localCgId = policyEnvelope.payload.contextGraphId;
         if (
           !eligible.includes(localCgId)

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -41,6 +41,7 @@ import type {
   SubGraphNameV1,
   TimestampMsV1,
   UnsignedContextGraphPolicyEnvelopeV1,
+  UnsignedMemberRosterEnvelopeV1,
 } from '@origintrail-official/dkg-core';
 import type {
   PhaseCallback,
@@ -60,6 +61,7 @@ import type { SwmHostModeStoreLimits } from './swm/host-mode-store.js';
 import type { KaNumberAllocator } from './allocator.js';
 import type { SyncPhase } from './sync/auth/request-build.js';
 import type {
+  Rfc64CatalogActivationInputV1,
   Rfc64PublicCatalogActivationInputV1,
   ResolvedRfc64PublicCatalogAutoPublishPolicyV1,
 } from './rfc64/public-catalog-activation-config-v1.js';
@@ -1368,6 +1370,25 @@ export interface Rfc64PublicCatalogBootstrapConfigV1 {
   readonly retryIntervalMs?: number;
 }
 
+/**
+ * One policy-neutral, operator-verified RFC-64 catalog selection.  The
+ * canonical roster envelope is present exactly for invite-only policies; its
+ * payload is bound to the exact policy object digest before agent startup.
+ */
+export interface Rfc64CatalogBootstrapPolicyV1 {
+  readonly policyEnvelope: UnsignedContextGraphPolicyEnvelopeV1;
+  readonly rosterEnvelope?: UnsignedMemberRosterEnvelopeV1;
+  readonly targets: readonly Rfc64PublicCatalogBootstrapTargetV1[];
+  /** Release 1 requires exactly one graph-complete provider for private SWM. */
+  readonly completeSwmProviders?: readonly string[];
+}
+
+/** Explicit policy-neutral cold-start manifest used by additive `rfc64Catalog`. */
+export interface Rfc64CatalogBootstrapConfigV1 {
+  readonly acceptedPolicies: readonly Rfc64CatalogBootstrapPolicyV1[];
+  readonly retryIntervalMs?: number;
+}
+
 export interface DKGAgentConfig {
   name: string;
   /** Selected genesis document. Defaults to the compatibility Base testnet genesis. */
@@ -1387,6 +1408,12 @@ export interface DKGAgentConfig {
    * RFC-64 catalog policy. Omission preserves the legacy open-only lane.
    */
   rfc64CatalogAccessPolicyAuthority?: Rfc64CatalogAccessPolicyAuthorityConfigV1;
+  /**
+   * Additive policy-neutral RFC-64 activation. It can select public and
+   * invite-only CGs. Existing selected-public callers may continue to use
+   * `rfc64PublicCatalogActivation`.
+   */
+  rfc64CatalogActivation?: Rfc64CatalogActivationInputV1;
   /**
    * Canonical selected-public activation resolved through the versioned,
    * side-effect-free activation surface. Mutually exclusive with the legacy
@@ -1857,6 +1884,7 @@ export type ResolvedDKGAgentConfig =
     | 'syncBackoffBaseMs'
     | 'syncBackoffMaxMs'
     | 'syncBackoffJitter'
+    | 'rfc64CatalogActivation'
     | 'rfc64PublicCatalogActivation'
     | 'rfc64PublicCatalogAutoPublish'
     | 'rfc64PublicCatalogBootstrap'
@@ -1867,6 +1895,7 @@ export type ResolvedDKGAgentConfig =
     storageAckTiming: StorageAckTiming;
     syncReconcilerTiming: SyncReconcilerTiming;
     rfc64CatalogDeploymentProfile?: Readonly<CatalogSealDeploymentProfileV1>;
+    rfc64CatalogBootstrap?: Readonly<Rfc64CatalogBootstrapConfigV1>;
     rfc64PublicCatalogAutoPublishPolicy?: ResolvedRfc64PublicCatalogAutoPublishPolicyV1;
     rfc64PublicCatalogBootstrap?: Readonly<Rfc64PublicCatalogBootstrapConfigV1>;
   };

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -364,6 +364,8 @@ import {
   type SharedMemorySyncResult,
   type DKGAgentConfig,
   type Rfc64CatalogAccessPolicyAuthorityConfigV1,
+  type Rfc64CatalogBootstrapConfigV1,
+  type Rfc64CatalogBootstrapPolicyV1,
   type DKGAgentACKTransportOptions,
   type ImportedArtifactByteStore,
   type ReplicationEvent,
@@ -418,8 +420,8 @@ import { Rfc64CatalogAutoPublishMethods } from './dkg-agent-rfc64-catalog-auto-p
 import { Rfc64CatalogBootstrapMethods } from './dkg-agent-rfc64-catalog-bootstrap.js';
 import { Rfc64CatalogUpsertMethods } from './dkg-agent-rfc64-catalog-upsert.js';
 import {
+  resolveRfc64CatalogActivationsV1,
   resolveRfc64PublicCatalogActivationChainIdentityV1,
-  resolveRfc64PublicCatalogActivationInputV1,
   resolveRfc64PublicCatalogControlsV1,
 } from './rfc64/public-catalog-activation-config-v1.js';
 import { Rfc64CatalogSyncMethods } from './dkg-agent-rfc64-catalog-sync.js';
@@ -480,6 +482,8 @@ export type {
   CatchupSyncDiagnostics,
   DKGAgentConfig,
   Rfc64CatalogAccessPolicyAuthorityConfigV1,
+  Rfc64CatalogBootstrapConfigV1,
+  Rfc64CatalogBootstrapPolicyV1,
   DKGAgentACKTransportOptions,
   ImportedArtifactByteStore,
 };
@@ -825,12 +829,14 @@ export class DKGAgent extends DKGAgentBase {
     const chainIdentity = resolveRfc64PublicCatalogActivationChainIdentityV1(
       constructedAgentChainId,
     );
+    const activations = resolveRfc64CatalogActivationsV1({
+      catalog: normalizedConfig.rfc64CatalogActivation,
+      publicCatalog: normalizedConfig.rfc64PublicCatalogActivation,
+    }, chainIdentity);
+    const catalogActivation = activations.catalog;
     const activation = normalizedConfig.rfc64PublicCatalogActivation === undefined
       ? undefined
-      : resolveRfc64PublicCatalogActivationInputV1(
-        normalizedConfig.rfc64PublicCatalogActivation,
-        chainIdentity,
-      );
+      : activations.publicCatalog;
     const rfc64PublicCatalogControls = resolveRfc64PublicCatalogControlsV1({
       activation,
       legacyDeploymentProfile: normalizedConfig.rfc64CatalogDeploymentProfile,
@@ -842,7 +848,7 @@ export class DKGAgent extends DKGAgentBase {
       syncContextGraphs: [
         ...new Set([
           ...(normalizedConfig.syncContextGraphs ?? []),
-          ...(activation?.selectedContextGraphs ?? []),
+          ...catalogActivation.selectedContextGraphs,
         ]),
       ],
     };
@@ -852,13 +858,48 @@ export class DKGAgent extends DKGAgentBase {
     if (rfc64PublicCatalogControls.requiresDataDir && !config.dataDir) {
       throw new TypeError('rfc64PublicCatalogBootstrap requires dataDir');
     }
-    const rfc64CatalogDeploymentProfile = rfc64PublicCatalogControls.deploymentProfile;
-    const rfc64CatalogAccessPolicyAuthority = snapshotRfc64CatalogAccessPolicyAuthorityV1(
+    if (catalogActivation.bootstrap !== undefined && !config.dataDir) {
+      throw new TypeError('rfc64Catalog bootstrap requires dataDir');
+    }
+    if (
+      catalogActivation.deploymentProfile !== undefined
+      && rfc64PublicCatalogControls.deploymentProfile !== undefined
+      && JSON.stringify(catalogActivation.deploymentProfile)
+        !== JSON.stringify(rfc64PublicCatalogControls.deploymentProfile)
+    ) {
+      throw new TypeError('RFC-64 catalog deployment profiles conflict');
+    }
+    const rfc64CatalogDeploymentProfile = catalogActivation.deploymentProfile
+      ?? rfc64PublicCatalogControls.deploymentProfile;
+    const legacyRfc64CatalogAccessPolicyAuthority = snapshotRfc64CatalogAccessPolicyAuthorityV1(
       config.rfc64CatalogAccessPolicyAuthority,
     );
+    if (
+      legacyRfc64CatalogAccessPolicyAuthority !== undefined
+      && catalogActivation.accessPolicyAuthority !== undefined
+    ) {
+      throw new TypeError(
+        'rfc64Catalog.accessPolicyAuthority is mutually exclusive with the legacy function authority',
+      );
+    }
+    const activationPeerAgentBindings = catalogActivation.accessPolicyAuthority === undefined
+      ? undefined
+      : new Map(catalogActivation.accessPolicyAuthority.peerAgentBindings.map(
+        ({ peerId, agentAddress }) => [peerId, agentAddress] as const,
+      ));
+    const rfc64CatalogAccessPolicyAuthority = legacyRfc64CatalogAccessPolicyAuthority
+      ?? (catalogActivation.accessPolicyAuthority === undefined
+        ? undefined
+        : snapshotRfc64CatalogAccessPolicyAuthorityV1({
+          localAgentAddress: catalogActivation.accessPolicyAuthority.localAgentAddress,
+          resolveRemoteAgentAddress: async (remotePeerId) => (
+            activationPeerAgentBindings!.get(remotePeerId) ?? null
+          ),
+        }));
     const rfc64PublicCatalogAutoPublishPolicy =
       rfc64PublicCatalogControls.autoPublishPolicy;
     const rfc64PublicCatalogBootstrap = rfc64PublicCatalogControls.bootstrap;
+    const rfc64CatalogBootstrap = catalogActivation.bootstrap;
     let wallet: DKGAgentWallet;
     if (config.dataDir) {
       try {
@@ -921,6 +962,7 @@ export class DKGAgent extends DKGAgentBase {
     };
     const configWithoutRfc64CatalogControls = { ...config };
     delete configWithoutRfc64CatalogControls.rfc64PublicCatalogActivation;
+    delete configWithoutRfc64CatalogControls.rfc64CatalogActivation;
     delete configWithoutRfc64CatalogControls.rfc64CatalogDeploymentProfile;
     delete configWithoutRfc64CatalogControls.rfc64PublicCatalogAutoPublish;
     delete configWithoutRfc64CatalogControls.rfc64PublicCatalogBootstrap;
@@ -936,6 +978,7 @@ export class DKGAgent extends DKGAgentBase {
       networkIdentity,
       rfc64CatalogAccessPolicyAuthority,
       rfc64CatalogDeploymentProfile,
+      rfc64CatalogBootstrap,
       rfc64PublicCatalogAutoPublishPolicy,
       rfc64PublicCatalogBootstrap,
       contextGraphSubscriptionRehydrationEnabled,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -217,6 +217,8 @@ export {
   StaleSenderKeyTargetError,
   type DKGAgentConfig,
   type Rfc64CatalogAccessPolicyAuthorityConfigV1,
+  type Rfc64CatalogBootstrapConfigV1,
+  type Rfc64CatalogBootstrapPolicyV1,
   type DKGAgentACKTransportOptions,
   type ContextGraphSub,
   type ContextGraphSyncMode,

--- a/packages/agent/src/rfc64/catalog-authority-config-v1.ts
+++ b/packages/agent/src/rfc64/catalog-authority-config-v1.ts
@@ -4,7 +4,10 @@ import {
   assertCanonicalChainId,
   assertCanonicalEvmAddress,
   assertNetworkIdV1,
+  canonicalizeUnsignedMemberRosterEnvelopeBytesV1,
   canonicalizeUnsignedContextGraphPolicyEnvelopeBytesV1,
+  computeContextGraphPolicyObjectDigestV1,
+  parseCanonicalUnsignedMemberRosterEnvelopeV1,
   parseCanonicalUnsignedContextGraphPolicyEnvelopeV1,
   type CatalogSealDeploymentProfileV1,
   type EvmAddressV1,
@@ -13,6 +16,8 @@ import {
 import { ethers } from 'ethers';
 
 import type {
+  Rfc64CatalogBootstrapConfigV1,
+  Rfc64CatalogBootstrapPolicyV1,
   Rfc64CatalogAccessPolicyAuthorityConfigV1,
   Rfc64PublicCatalogAutoPublishConfigV1,
   Rfc64PublicCatalogBootstrapConfigV1,
@@ -25,6 +30,177 @@ const MAX_RFC64_BOOTSTRAP_TARGETS_V1 = 256;
 const MAX_RFC64_BOOTSTRAP_PROVIDERS_V1 = 8;
 const DEFAULT_RFC64_BOOTSTRAP_RETRY_INTERVAL_MS_V1 = 30_000;
 const MAX_RFC64_BOOTSTRAP_RETRY_INTERVAL_MS_V1 = 3_600_000;
+
+/**
+ * Detach and validate the additive policy-neutral cold-start manifest.
+ *
+ * Like the selected-public V1 manifest, these envelopes are pinned outputs of
+ * an independent operator authority check. This boundary still parses their
+ * canonical object types and binds a private roster to the exact policy
+ * digest. It never treats a roster payload without its control-envelope
+ * issuer/objectType boundary as authority.
+ */
+export function snapshotRfc64CatalogBootstrapConfigV1(
+  input: Rfc64CatalogBootstrapConfigV1 | undefined,
+): Readonly<Rfc64CatalogBootstrapConfigV1> | undefined {
+  if (input === undefined) return undefined;
+  assertPlainExactObject(
+    input,
+    'rfc64Catalog.bootstrap',
+    ['acceptedPolicies', 'retryIntervalMs'],
+    ['acceptedPolicies'],
+  );
+  if (
+    !Array.isArray(input.acceptedPolicies)
+    || input.acceptedPolicies.length > MAX_RFC64_BOOTSTRAP_POLICIES_V1
+  ) {
+    throw new TypeError(
+      `rfc64Catalog.bootstrap.acceptedPolicies must contain at most `
+      + `${MAX_RFC64_BOOTSTRAP_POLICIES_V1} policies`,
+    );
+  }
+
+  const policyKeys = new Set<string>();
+  const targetKeys = new Set<string>();
+  let totalTargets = 0;
+  const acceptedPolicies = input.acceptedPolicies.map((entry, index) => {
+    const label = `rfc64Catalog.bootstrap.acceptedPolicies[${index}]`;
+    assertPlainExactObject(
+      entry,
+      label,
+      ['completeSwmProviders', 'policyEnvelope', 'rosterEnvelope', 'targets'],
+      ['policyEnvelope', 'targets'],
+    );
+    const candidate = entry as unknown as Rfc64CatalogBootstrapPolicyV1;
+    const policyEnvelope = parseCanonicalUnsignedContextGraphPolicyEnvelopeV1(
+      canonicalizeUnsignedContextGraphPolicyEnvelopeBytesV1(candidate.policyEnvelope),
+    );
+    const policy = policyEnvelope.payload;
+    const policyDigest = computeContextGraphPolicyObjectDigestV1(policyEnvelope);
+    if (
+      policy.accessPolicy === 1
+      && policy.source.kind !== 'owner-signed-unregistered'
+    ) {
+      throw new TypeError(
+        'rfc64Catalog private Release 1 supports only owner-signed unregistered policies',
+      );
+    }
+    const key = `${policy.networkId}\n${policy.contextGraphId}`;
+    if (policyKeys.has(key)) {
+      throw new TypeError('rfc64Catalog.bootstrap policies must be unique by graph');
+    }
+    policyKeys.add(key);
+
+    let rosterEnvelope: Rfc64CatalogBootstrapPolicyV1['rosterEnvelope'];
+    if (policy.accessPolicy === 0) {
+      if (candidate.rosterEnvelope !== undefined) {
+        throw new TypeError('rfc64Catalog public policies forbid rosterEnvelope');
+      }
+    } else {
+      if (candidate.rosterEnvelope === undefined) {
+        throw new TypeError('rfc64Catalog private policies require rosterEnvelope');
+      }
+      rosterEnvelope = parseCanonicalUnsignedMemberRosterEnvelopeV1(
+        canonicalizeUnsignedMemberRosterEnvelopeBytesV1(candidate.rosterEnvelope),
+      );
+      const roster = rosterEnvelope.payload;
+      if (
+        roster.networkId !== policy.networkId
+        || roster.contextGraphId !== policy.contextGraphId
+        || roster.ownershipTransitionDigest !== policy.ownershipTransitionDigest
+        || roster.era !== policy.era
+        || roster.policyDigest !== policyDigest
+        || roster.administrativeDelegationDigest !== policy.administrativeDelegationDigest
+      ) {
+        throw new TypeError(
+          'rfc64Catalog rosterEnvelope is not bound to the exact accepted policy',
+        );
+      }
+    }
+
+    if (!Array.isArray(candidate.targets)) {
+      throw new TypeError(`${label}.targets must be an array`);
+    }
+    totalTargets += candidate.targets.length;
+    if (totalTargets > MAX_RFC64_BOOTSTRAP_TARGETS_V1) {
+      throw new TypeError(
+        `rfc64Catalog.bootstrap targets must contain at most `
+        + `${MAX_RFC64_BOOTSTRAP_TARGETS_V1} catalogs`,
+      );
+    }
+    const targets = candidate.targets.map((target, targetIndex) => {
+      assertPlainExactObject(
+        target,
+        `${label}.targets[${targetIndex}]`,
+        ['authorAddress', 'providers'],
+        ['authorAddress', 'providers'],
+      );
+      const targetCandidate = target as unknown as Rfc64PublicCatalogBootstrapTargetV1;
+      assertCanonicalEvmAddress(targetCandidate.authorAddress, 'bootstrap target authorAddress');
+      if (targetCandidate.authorAddress === `0x${'0'.repeat(40)}`) {
+        throw new TypeError('rfc64Catalog.bootstrap authorAddress must be nonzero');
+      }
+      const providers = snapshotBootstrapProviders(
+        targetCandidate.providers,
+        `acceptedPolicies[${index}].targets[${targetIndex}].providers`,
+        'rfc64Catalog.bootstrap',
+      );
+      const targetKey = `${key}\n${targetCandidate.authorAddress}\n${policy.era}`;
+      if (targetKeys.has(targetKey)) {
+        throw new TypeError('rfc64Catalog.bootstrap targets must be unique by author scope');
+      }
+      targetKeys.add(targetKey);
+      return Object.freeze({ authorAddress: targetCandidate.authorAddress, providers });
+    });
+    const completeSwmProviders = candidate.completeSwmProviders === undefined
+      ? undefined
+      : snapshotBootstrapProviders(
+        candidate.completeSwmProviders,
+        `acceptedPolicies[${index}].completeSwmProviders`,
+        'rfc64Catalog.bootstrap',
+      );
+    if (policy.accessPolicy === 1 && completeSwmProviders?.length !== 1) {
+      throw new TypeError(
+        'rfc64Catalog private Release 1 policies require exactly one completeSwmProvider',
+      );
+    }
+    if (policy.accessPolicy === 1) {
+      const completeProvider = completeSwmProviders![0]!;
+      const rosterMembers = new Set(
+        rosterEnvelope!.payload.members.map(({ agentAddress }) => agentAddress),
+      );
+      for (const target of targets) {
+        if (!rosterMembers.has(target.authorAddress)) {
+          throw new TypeError(
+            'rfc64Catalog private catalog target author is not a current roster member',
+          );
+        }
+        if (target.providers.length !== 1 || target.providers[0] !== completeProvider) {
+          throw new TypeError(
+            'rfc64Catalog private Release 1 targets must use the one completeSwmProvider',
+          );
+        }
+      }
+    }
+    return Object.freeze({
+      policyEnvelope: deepFreezePlain(policyEnvelope),
+      ...(rosterEnvelope === undefined
+        ? {}
+        : { rosterEnvelope: deepFreezePlain(rosterEnvelope) }),
+      targets: Object.freeze(targets),
+      ...(completeSwmProviders === undefined ? {} : { completeSwmProviders }),
+    });
+  });
+
+  const retryIntervalMs = snapshotBootstrapRetryIntervalMs(
+    input.retryIntervalMs,
+    'rfc64Catalog.bootstrap',
+  );
+  return Object.freeze({
+    acceptedPolicies: Object.freeze(acceptedPolicies),
+    retryIntervalMs,
+  });
+}
 
 /** Detach a locally configured deployment tuple from caller-owned state. */
 export function snapshotRfc64CatalogDeploymentProfileV1(
@@ -250,18 +426,10 @@ export function snapshotRfc64PublicCatalogBootstrapConfigV1(
     });
   });
 
-  const retryIntervalMs = input.retryIntervalMs
-    ?? DEFAULT_RFC64_BOOTSTRAP_RETRY_INTERVAL_MS_V1;
-  if (
-    !Number.isSafeInteger(retryIntervalMs)
-    || retryIntervalMs < 0
-    || retryIntervalMs > MAX_RFC64_BOOTSTRAP_RETRY_INTERVAL_MS_V1
-    || (retryIntervalMs > 0 && retryIntervalMs < 1_000)
-  ) {
-    throw new TypeError(
-      'rfc64PublicCatalogBootstrap.retryIntervalMs must be 0 or 1000..3600000',
-    );
-  }
+  const retryIntervalMs = snapshotBootstrapRetryIntervalMs(
+    input.retryIntervalMs,
+    'rfc64PublicCatalogBootstrap',
+  );
   return Object.freeze({
     acceptedPublicPolicies: Object.freeze(policies),
     retryIntervalMs,
@@ -278,18 +446,38 @@ function snapshotTimestamp(value: unknown, label: string): TimestampMsV1 {
   return value as TimestampMsV1;
 }
 
-function snapshotBootstrapProviders(input: readonly string[], label: string): readonly string[] {
+function snapshotBootstrapProviders(
+  input: readonly string[],
+  label: string,
+  rootLabel = 'rfc64PublicCatalogBootstrap',
+): readonly string[] {
   const providers = snapshotRfc64PublicCatalogAnnouncementPeersV1(input);
   if (
     providers.length === 0
     || providers.length > MAX_RFC64_BOOTSTRAP_PROVIDERS_V1
   ) {
     throw new TypeError(
-      `rfc64PublicCatalogBootstrap.${label} must contain 1..`
+      `${rootLabel}.${label} must contain 1..`
       + `${MAX_RFC64_BOOTSTRAP_PROVIDERS_V1} peers`,
     );
   }
   return providers;
+}
+
+function snapshotBootstrapRetryIntervalMs(
+  input: number | undefined,
+  label: string,
+): number {
+  const retryIntervalMs = input ?? DEFAULT_RFC64_BOOTSTRAP_RETRY_INTERVAL_MS_V1;
+  if (
+    !Number.isSafeInteger(retryIntervalMs)
+    || retryIntervalMs < 0
+    || retryIntervalMs > MAX_RFC64_BOOTSTRAP_RETRY_INTERVAL_MS_V1
+    || (retryIntervalMs > 0 && retryIntervalMs < 1_000)
+  ) {
+    throw new TypeError(`${label}.retryIntervalMs must be 0 or 1000..3600000`);
+  }
+  return retryIntervalMs;
 }
 
 function assertPlainExactObject(

--- a/packages/agent/src/rfc64/catalog-native-scoped-read-capability-v1-internal.ts
+++ b/packages/agent/src/rfc64/catalog-native-scoped-read-capability-v1-internal.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type {
+  Digest32V1,
+  SignedControlEnvelopeV1,
+} from '@origintrail-official/dkg-core';
+
+import type { Rfc64PublicCatalogNativeFetchScopeV1 } from './public-catalog-native-transport-v1.js';
+
+declare const RFC64_SCOPED_READ_CAPABILITY_BRAND_V1: unique symbol;
+
+/** Process-local capability. It is not a serializable authority token. */
+export interface Rfc64CatalogNativeScopedReadCapabilityV1 {
+  readonly [RFC64_SCOPED_READ_CAPABILITY_BRAND_V1]: true;
+  readonly scope: Rfc64PublicCatalogNativeFetchScopeV1;
+  readonly readCatalogObjectByDigest: (
+    objectDigest: Digest32V1,
+  ) => Promise<SignedControlEnvelopeV1 | null>;
+  readonly readKaBundleByDigest: (
+    blobDigest: Digest32V1,
+  ) => Promise<Uint8Array | null>;
+}
+
+const MINTED_CAPABILITIES = new WeakSet<object>();
+
+export function mintRfc64CatalogNativeScopedReadCapabilityV1(input: {
+  readonly scope: Rfc64PublicCatalogNativeFetchScopeV1;
+  readonly readCatalogObjectByDigest: Rfc64CatalogNativeScopedReadCapabilityV1['readCatalogObjectByDigest'];
+  readonly readKaBundleByDigest: Rfc64CatalogNativeScopedReadCapabilityV1['readKaBundleByDigest'];
+}): Rfc64CatalogNativeScopedReadCapabilityV1 {
+  const capability = Object.freeze({
+    scope: Object.freeze({ ...input.scope }),
+    readCatalogObjectByDigest: input.readCatalogObjectByDigest,
+    readKaBundleByDigest: input.readKaBundleByDigest,
+  }) as unknown as Rfc64CatalogNativeScopedReadCapabilityV1;
+  MINTED_CAPABILITIES.add(capability as object);
+  return capability;
+}
+
+export function isMintedRfc64CatalogNativeScopedReadCapabilityV1(
+  value: unknown,
+): value is Rfc64CatalogNativeScopedReadCapabilityV1 {
+  return typeof value === 'object'
+    && value !== null
+    && MINTED_CAPABILITIES.has(value);
+}

--- a/packages/agent/src/rfc64/catalog-native-scoped-read-capability-v1-internal.ts
+++ b/packages/agent/src/rfc64/catalog-native-scoped-read-capability-v1-internal.ts
@@ -7,7 +7,9 @@ import type {
 
 import type { Rfc64PublicCatalogNativeFetchScopeV1 } from './public-catalog-native-transport-v1.js';
 
-declare const RFC64_SCOPED_READ_CAPABILITY_BRAND_V1: unique symbol;
+const RFC64_SCOPED_READ_CAPABILITY_BRAND_V1: unique symbol = Symbol(
+  'rfc64-catalog-native-scoped-read-capability-v1',
+);
 
 /** Process-local capability. It is not a serializable authority token. */
 export interface Rfc64CatalogNativeScopedReadCapabilityV1 {
@@ -21,26 +23,35 @@ export interface Rfc64CatalogNativeScopedReadCapabilityV1 {
   ) => Promise<Uint8Array | null>;
 }
 
-const MINTED_CAPABILITIES = new WeakSet<object>();
-
 export function mintRfc64CatalogNativeScopedReadCapabilityV1(input: {
   readonly scope: Rfc64PublicCatalogNativeFetchScopeV1;
   readonly readCatalogObjectByDigest: Rfc64CatalogNativeScopedReadCapabilityV1['readCatalogObjectByDigest'];
   readonly readKaBundleByDigest: Rfc64CatalogNativeScopedReadCapabilityV1['readKaBundleByDigest'];
 }): Rfc64CatalogNativeScopedReadCapabilityV1 {
+  if (typeof input.readCatalogObjectByDigest !== 'function') {
+    throw new TypeError('scoped catalog object reader must be callable');
+  }
+  if (typeof input.readKaBundleByDigest !== 'function') {
+    throw new TypeError('scoped KA bundle reader must be callable');
+  }
   const capability = Object.freeze({
+    [RFC64_SCOPED_READ_CAPABILITY_BRAND_V1]: true as const,
     scope: Object.freeze({ ...input.scope }),
     readCatalogObjectByDigest: input.readCatalogObjectByDigest,
     readKaBundleByDigest: input.readKaBundleByDigest,
-  }) as unknown as Rfc64CatalogNativeScopedReadCapabilityV1;
-  MINTED_CAPABILITIES.add(capability as object);
+  });
   return capability;
 }
 
 export function isMintedRfc64CatalogNativeScopedReadCapabilityV1(
   value: unknown,
 ): value is Rfc64CatalogNativeScopedReadCapabilityV1 {
-  return typeof value === 'object'
-    && value !== null
-    && MINTED_CAPABILITIES.has(value);
+  if (typeof value !== 'object' || value === null) return false;
+  try {
+    return (value as Record<PropertyKey, unknown>)[
+      RFC64_SCOPED_READ_CAPABILITY_BRAND_V1
+    ] === true;
+  } catch {
+    return false;
+  }
 }

--- a/packages/agent/src/rfc64/catalog-native-scoped-read-provider-v1.ts
+++ b/packages/agent/src/rfc64/catalog-native-scoped-read-provider-v1.ts
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Provider-side scope proof for RFC-64 native private content reads.
+ *
+ * The durable stores are intentionally digest keyed and shared by all context
+ * graphs. This adapter is the only bridge from an authorized private wire
+ * scope to those stores. It first closes one exact bounded signed head and then
+ * exposes only the control-object and bundle digests reachable from that head.
+ */
+
+import {
+  AUTHOR_CATALOG_BUCKET_OBJECT_TYPE_V1,
+  AUTHOR_CATALOG_DIRECTORY_NODE_OBJECT_TYPE_V1,
+  AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
+  AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1,
+  MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1,
+  ZERO_DIGEST32_V1,
+  assertAuthorCatalogBucketScopeBindingV1,
+  assertAuthorCatalogDirectoryNodeScopeBindingV1,
+  assertAuthorCatalogHeadScopeBindingV1,
+  assertSignedAuthorCatalogBucketEnvelopeV1,
+  assertSignedAuthorCatalogDirectoryNodeEnvelopeV1,
+  assertSignedAuthorCatalogHeadEnvelopeV1,
+  assertSignedAuthorCatalogIssuerDelegationEnvelopeV1,
+  canonicalizeAuthorCatalogBucketPayloadBytesV1,
+  decodeOpaqueKaBundleV1,
+  deriveAuthorCatalogScopeFromHeadV1,
+  readVerifiedAuthorCatalogBucketDescriptorV1,
+  verifyAuthorCatalogDirectoryPathV1,
+  type AuthorCatalogScopeV1,
+  type Digest32V1,
+  type SignedAuthorCatalogBucketEnvelopeV1,
+  type SignedAuthorCatalogDirectoryNodeEnvelopeV1,
+  type SignedAuthorCatalogHeadEnvelopeV1,
+  type SignedAuthorCatalogIssuerDelegationEnvelopeV1,
+} from '@origintrail-official/dkg-core';
+import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dkg-chain';
+
+import {
+  verifyAuthorCatalogRowAuthorshipV1,
+} from './catalog-row-authorship.js';
+import { mintRfc64CatalogNativeScopedReadCapabilityV1 } from './catalog-native-scoped-read-capability-v1-internal.js';
+import type { Rfc64ControlObjectOperationsV1 } from './control-object-store-v1.js';
+import type { Rfc64KaBundleOperationsV1 } from './ka-bundle-store-v1.js';
+import {
+  assertRfc64PublicCatalogExactSetBundleBytesV1,
+  type ResolveRfc64CatalogNativeScopedReadCapabilityV1,
+  type Rfc64CatalogNativeScopedReadCapabilityV1,
+  type Rfc64PublicCatalogNativeFetchScopeV1,
+} from './public-catalog-native-transport-v1.js';
+
+export interface Rfc64CatalogNativeScopedReadProviderOptionsV1 {
+  readonly controlObjects: Pick<Rfc64ControlObjectOperationsV1, 'getVerifiedObjectByDigest'>;
+  readonly kaBundles: Pick<Rfc64KaBundleOperationsV1, 'readKaBundleByDigest'>;
+}
+
+/**
+ * Create a resolver for the currently supported bounded root lane: one
+ * directory node, zero or one bucket, and 0..1,024 exact rows.
+ */
+export function createRfc64CatalogNativeScopedReadProviderV1(
+  options: Rfc64CatalogNativeScopedReadProviderOptionsV1,
+): ResolveRfc64CatalogNativeScopedReadCapabilityV1 {
+  if (
+    typeof options?.controlObjects?.getVerifiedObjectByDigest !== 'function'
+    || typeof options?.kaBundles?.readKaBundleByDigest !== 'function'
+  ) {
+    throw new TypeError('RFC-64 scoped read provider dependencies are incomplete');
+  }
+  return async (scope) => {
+    try {
+      return await resolveExactBoundedHeadCapability(options, scope);
+    } catch {
+      // Invalid, missing, cross-scope, or corrupt closures all have the same
+      // externally observable result. Do not make the resolver a digest oracle.
+      return null;
+    }
+  };
+}
+
+async function resolveExactBoundedHeadCapability(
+  options: Rfc64CatalogNativeScopedReadProviderOptionsV1,
+  requestedScope: Readonly<Rfc64PublicCatalogNativeFetchScopeV1>,
+): Promise<Rfc64CatalogNativeScopedReadCapabilityV1> {
+  const scope = snapshotScope(requestedScope);
+  const storedHead = await readStored(options, scope.catalogHeadObjectDigest);
+  if (storedHead === null) throw new Error('requested catalog head is not stored');
+  assertSignedAuthorCatalogHeadEnvelopeV1(storedHead.envelope);
+  const head = storedHead.envelope;
+  assertExactRequestedBoundedHead(head, scope);
+  const catalogScope = deriveAuthorCatalogScopeFromHeadV1(head.payload);
+  assertAuthorCatalogHeadScopeBindingV1(head.payload, catalogScope);
+
+  const storedDelegation = await readStored(
+    options,
+    head.payload.catalogIssuerDelegationDigest,
+  );
+  if (storedDelegation === null) throw new Error('catalog issuer delegation is not stored');
+  assertSignedAuthorCatalogIssuerDelegationEnvelopeV1(storedDelegation.envelope);
+  const delegation = storedDelegation.envelope;
+  assertDirectAuthorCatalogIssuerDelegationBinding(delegation, head, catalogScope);
+
+  const storedDirectory = await readStored(options, head.payload.directoryRootDigest);
+  if (storedDirectory === null) throw new Error('catalog directory root is not stored');
+  assertSignedAuthorCatalogDirectoryNodeEnvelopeV1(
+    storedDirectory.envelope,
+    head.payload.bucketCount,
+  );
+  const directory = storedDirectory.envelope;
+  assertAuthorCatalogDirectoryNodeScopeBindingV1(directory.payload, catalogScope);
+  if (
+    directory.objectDigest !== head.payload.directoryRootDigest
+    || directory.issuer !== head.issuer
+  ) {
+    throw new Error('catalog directory identity or issuer differs from its head');
+  }
+  const directoryProof = verifyAuthorCatalogDirectoryPathV1(
+    head,
+    [directory],
+    '0' as never,
+  );
+  const descriptor = readVerifiedAuthorCatalogBucketDescriptorV1(directoryProof, head);
+
+  const allowedControlObjects = new Map<Digest32V1, string>([
+    [head.objectDigest as Digest32V1, AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1],
+    [delegation.objectDigest as Digest32V1, AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1],
+    [directory.objectDigest as Digest32V1, AUTHOR_CATALOG_DIRECTORY_NODE_OBJECT_TYPE_V1],
+  ]);
+  const allowedBundles = new Map<Digest32V1, number>();
+
+  if (head.payload.totalRows === '0') {
+    if (
+      descriptor.bucketId !== '0'
+      || descriptor.bucketDigest !== ZERO_DIGEST32_V1
+      || descriptor.rowCount !== '0'
+      || descriptor.byteLength !== '0'
+    ) {
+      throw new Error('empty head directory descriptor is not canonical');
+    }
+  } else {
+    const storedBucket = await readStored(options, descriptor.bucketDigest);
+    if (storedBucket === null) throw new Error('catalog bucket is not stored');
+    assertSignedAuthorCatalogBucketEnvelopeV1(storedBucket.envelope);
+    const bucket = storedBucket.envelope;
+    assertExactBoundedBucket(bucket, head, directory, descriptor, catalogScope);
+    assertRfc64PublicCatalogExactSetBundleBytesV1(
+      bucket.payload.rows.map((row) => row.transfer.byteLength),
+    );
+    for (const row of bucket.payload.rows) {
+      verifyAuthorCatalogRowAuthorshipV1({
+        catalogIssuerDelegation: delegation,
+        catalogIssuerDelegationSignature: storedDelegation.issuerSignature,
+        parentAuthorAgentEvidence: null,
+        catalogHead: head,
+        catalogHeadSignature: storedHead.issuerSignature,
+        directoryPathEnvelopes: [directory],
+        directoryPathSignatures: [storedDirectory.issuerSignature],
+        directoryPathProof: directoryProof,
+        catalogBucket: bucket,
+        catalogBucketSignature: storedBucket.issuerSignature,
+        targetKaId: row.kaId,
+      });
+      const byteLength = Number(BigInt(row.transfer.byteLength));
+      const previous = allowedBundles.get(row.transfer.blobDigest);
+      if (previous !== undefined && previous !== byteLength) {
+        throw new Error('one bundle digest is committed with conflicting byte lengths');
+      }
+      allowedBundles.set(row.transfer.blobDigest, byteLength);
+    }
+    allowedControlObjects.set(
+      bucket.objectDigest as Digest32V1,
+      AUTHOR_CATALOG_BUCKET_OBJECT_TYPE_V1,
+    );
+  }
+
+  return mintRfc64CatalogNativeScopedReadCapabilityV1({
+    scope,
+    readCatalogObjectByDigest: async (objectDigest) => {
+      const expectedType = allowedControlObjects.get(objectDigest);
+      if (expectedType === undefined) return null;
+      const stored = await readStored(options, objectDigest);
+      if (
+        stored === null
+        || stored.envelope.objectDigest !== objectDigest
+        || stored.envelope.objectType !== expectedType
+      ) {
+        throw new Error('stored catalog closure changed after capability resolution');
+      }
+      return stored.envelope;
+    },
+    readKaBundleByDigest: async (blobDigest) => {
+      const expectedByteLength = allowedBundles.get(blobDigest);
+      if (expectedByteLength === undefined) return null;
+      const bundle = await options.kaBundles.readKaBundleByDigest(blobDigest);
+      if (bundle === null) return null;
+      const decoded = decodeOpaqueKaBundleV1(bundle);
+      if (
+        decoded.blobDigest !== blobDigest
+        || bundle.byteLength !== expectedByteLength
+      ) {
+        throw new Error('stored KA bundle differs from the exact signed catalog row');
+      }
+      return bundle;
+    },
+  });
+}
+
+async function readStored(
+  options: Rfc64CatalogNativeScopedReadProviderOptionsV1,
+  objectDigest: Digest32V1,
+) {
+  return options.controlObjects.getVerifiedObjectByDigest({
+    objectDigest,
+    verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+  });
+}
+
+function snapshotScope(
+  input: Readonly<Rfc64PublicCatalogNativeFetchScopeV1>,
+): Readonly<Rfc64PublicCatalogNativeFetchScopeV1> {
+  return Object.freeze({
+    networkId: input.networkId,
+    contextGraphId: input.contextGraphId,
+    subGraphName: input.subGraphName,
+    authorAddress: input.authorAddress,
+    catalogEra: input.catalogEra,
+    catalogVersion: input.catalogVersion,
+    policyDigest: input.policyDigest,
+    catalogHeadObjectDigest: input.catalogHeadObjectDigest,
+  });
+}
+
+function assertExactRequestedBoundedHead(
+  head: SignedAuthorCatalogHeadEnvelopeV1,
+  scope: Readonly<Rfc64PublicCatalogNativeFetchScopeV1>,
+): void {
+  const totalRows = Number(BigInt(head.payload.totalRows));
+  if (
+    head.objectDigest !== scope.catalogHeadObjectDigest
+    || head.payload.networkId !== scope.networkId
+    || head.payload.contextGraphId !== scope.contextGraphId
+    || head.payload.subGraphName !== scope.subGraphName
+    || head.payload.authorAddress !== scope.authorAddress
+    || head.payload.era !== scope.catalogEra
+    || head.payload.version !== scope.catalogVersion
+    || head.payload.bucketCount !== '1'
+    || head.payload.directoryHeight !== '0'
+    || !Number.isSafeInteger(totalRows)
+    || totalRows < 0
+    || totalRows > MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1
+  ) {
+    throw new Error('stored head differs from the exact requested bounded catalog scope');
+  }
+}
+
+function assertExactBoundedBucket(
+  bucket: SignedAuthorCatalogBucketEnvelopeV1,
+  head: SignedAuthorCatalogHeadEnvelopeV1,
+  directory: SignedAuthorCatalogDirectoryNodeEnvelopeV1,
+  descriptor: ReturnType<typeof readVerifiedAuthorCatalogBucketDescriptorV1>,
+  catalogScope: Readonly<AuthorCatalogScopeV1>,
+): void {
+  assertAuthorCatalogBucketScopeBindingV1(bucket.payload, catalogScope);
+  if (
+    directory.objectDigest !== head.payload.directoryRootDigest
+    || descriptor.bucketId !== '0'
+    || descriptor.bucketDigest === ZERO_DIGEST32_V1
+    || bucket.objectDigest !== descriptor.bucketDigest
+    || bucket.issuer !== head.issuer
+    || bucket.payload.bucketId !== descriptor.bucketId
+    || bucket.payload.rows.length.toString() !== descriptor.rowCount
+    || bucket.payload.rows.length.toString() !== head.payload.totalRows
+    || canonicalizeAuthorCatalogBucketPayloadBytesV1(bucket.payload).byteLength.toString()
+      !== descriptor.byteLength
+  ) {
+    throw new Error('stored bucket differs from the exact signed directory/head closure');
+  }
+}
+
+/** Release 1 accepts only a direct author-signed catalog issuer grant. */
+function assertDirectAuthorCatalogIssuerDelegationBinding(
+  delegation: SignedAuthorCatalogIssuerDelegationEnvelopeV1,
+  head: SignedAuthorCatalogHeadEnvelopeV1,
+  catalogScope: Readonly<AuthorCatalogScopeV1>,
+): void {
+  const left = delegation.payload;
+  const right = head.payload;
+  if (
+    delegation.objectDigest !== right.catalogIssuerDelegationDigest
+    || delegation.issuer !== left.authorAddress
+    || left.authorAuthorityEvidenceDigest !== null
+    || left.catalogIssuerKey !== head.issuer
+    || left.networkId !== right.networkId
+    || left.contextGraphId !== right.contextGraphId
+    || left.governanceChainId !== right.governanceChainId
+    || left.governanceContractAddress !== right.governanceContractAddress
+    || left.ownershipTransitionDigest !== right.ownershipTransitionDigest
+    || left.subGraphName !== right.subGraphName
+    || left.authorAddress !== right.authorAddress
+    || left.catalogEra !== right.era
+    || left.networkId !== catalogScope.networkId
+    || left.contextGraphId !== catalogScope.contextGraphId
+    || left.governanceChainId !== catalogScope.governanceChainId
+    || left.governanceContractAddress !== catalogScope.governanceContractAddress
+    || left.ownershipTransitionDigest !== catalogScope.ownershipTransitionDigest
+    || left.subGraphName !== catalogScope.subGraphName
+    || left.authorAddress !== catalogScope.authorAddress
+    || left.catalogEra !== catalogScope.era
+    || (left.catalogEra === '0') !== (left.previousDelegationDigest === null)
+    || BigInt(right.issuedAt) < BigInt(left.effectiveAt)
+    || BigInt(right.issuedAt) >= BigInt(left.expiresAt)
+  ) {
+    throw new Error('catalog issuer delegation is not the exact direct-author authority for head');
+  }
+}

--- a/packages/agent/src/rfc64/catalog-native-scoped-read-provider-v1.ts
+++ b/packages/agent/src/rfc64/catalog-native-scoped-read-provider-v1.ts
@@ -40,6 +40,7 @@ import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dk
 import {
   verifyAuthorCatalogRowAuthorshipV1,
 } from './catalog-row-authorship.js';
+import type { AcceptedRfc64CatalogAccessSnapshotV1 } from './catalog-access-policy-v1.js';
 import { mintRfc64CatalogNativeScopedReadCapabilityV1 } from './catalog-native-scoped-read-capability-v1-internal.js';
 import type { Rfc64ControlObjectOperationsV1 } from './control-object-store-v1.js';
 import type { Rfc64KaBundleOperationsV1 } from './ka-bundle-store-v1.js';
@@ -53,7 +54,18 @@ import {
 export interface Rfc64CatalogNativeScopedReadProviderOptionsV1 {
   readonly controlObjects: Pick<Rfc64ControlObjectOperationsV1, 'getVerifiedObjectByDigest'>;
   readonly kaBundles: Pick<Rfc64KaBundleOperationsV1, 'readKaBundleByDigest'>;
+  /** Accepted-current authority; never derive policy scope from the request. */
+  readonly resolveAcceptedPolicySnapshot: (
+    networkId: Rfc64PublicCatalogNativeFetchScopeV1['networkId'],
+    contextGraphId: Rfc64PublicCatalogNativeFetchScopeV1['contextGraphId'],
+  ) => AcceptedRfc64CatalogAccessSnapshotV1 | null
+    | Promise<AcceptedRfc64CatalogAccessSnapshotV1 | null>;
 }
+
+type Rfc64CatalogNativePrivateAuthorityScopeV1 = Pick<
+  Rfc64PublicCatalogNativeFetchScopeV1,
+  'networkId' | 'contextGraphId' | 'authorAddress' | 'catalogEra' | 'policyDigest'
+>;
 
 /**
  * Create a resolver for the currently supported bounded root lane: one
@@ -65,6 +77,7 @@ export function createRfc64CatalogNativeScopedReadProviderV1(
   if (
     typeof options?.controlObjects?.getVerifiedObjectByDigest !== 'function'
     || typeof options?.kaBundles?.readKaBundleByDigest !== 'function'
+    || typeof options?.resolveAcceptedPolicySnapshot !== 'function'
   ) {
     throw new TypeError('RFC-64 scoped read provider dependencies are incomplete');
   }
@@ -84,6 +97,7 @@ async function resolveExactBoundedHeadCapability(
   requestedScope: Readonly<Rfc64PublicCatalogNativeFetchScopeV1>,
 ): Promise<Rfc64CatalogNativeScopedReadCapabilityV1> {
   const scope = snapshotScope(requestedScope);
+  const accepted = await requireAcceptedCurrentPrivateScope(options, scope);
   const storedHead = await readStored(options, scope.catalogHeadObjectDigest);
   if (storedHead === null) throw new Error('requested catalog head is not stored');
   assertSignedAuthorCatalogHeadEnvelopeV1(storedHead.envelope);
@@ -91,6 +105,7 @@ async function resolveExactBoundedHeadCapability(
   assertExactRequestedBoundedHead(head, scope);
   const catalogScope = deriveAuthorCatalogScopeFromHeadV1(head.payload);
   assertAuthorCatalogHeadScopeBindingV1(head.payload, catalogScope);
+  assertAcceptedPolicyMatchesCatalogScope(accepted, catalogScope, scope.policyDigest);
 
   const storedDelegation = await readStored(
     options,
@@ -174,9 +189,11 @@ async function resolveExactBoundedHeadCapability(
     );
   }
 
+  await requireAcceptedCurrentPrivateCatalogScope(options, catalogScope, scope.policyDigest);
   return mintRfc64CatalogNativeScopedReadCapabilityV1({
     scope,
     readCatalogObjectByDigest: async (objectDigest) => {
+      await requireAcceptedCurrentPrivateCatalogScope(options, catalogScope, scope.policyDigest);
       const expectedType = allowedControlObjects.get(objectDigest);
       if (expectedType === undefined) return null;
       const stored = await readStored(options, objectDigest);
@@ -190,6 +207,7 @@ async function resolveExactBoundedHeadCapability(
       return stored.envelope;
     },
     readKaBundleByDigest: async (blobDigest) => {
+      await requireAcceptedCurrentPrivateCatalogScope(options, catalogScope, scope.policyDigest);
       const expectedByteLength = allowedBundles.get(blobDigest);
       if (expectedByteLength === undefined) return null;
       const bundle = await options.kaBundles.readKaBundleByDigest(blobDigest);
@@ -204,6 +222,73 @@ async function resolveExactBoundedHeadCapability(
       return bundle;
     },
   });
+}
+
+async function requireAcceptedCurrentPrivateScope(
+  options: Rfc64CatalogNativeScopedReadProviderOptionsV1,
+  scope: Readonly<Rfc64CatalogNativePrivateAuthorityScopeV1>,
+): Promise<Readonly<AcceptedRfc64CatalogAccessSnapshotV1>> {
+  const accepted = await options.resolveAcceptedPolicySnapshot(
+    scope.networkId,
+    scope.contextGraphId,
+  );
+  if (
+    accepted === null
+    || accepted.policyDigest !== scope.policyDigest
+    || accepted.policy.accessPolicy !== 1
+    || accepted.policy.networkId !== scope.networkId
+    || accepted.policy.contextGraphId !== scope.contextGraphId
+    || accepted.policy.era !== scope.catalogEra
+    || accepted.roster === null
+    || accepted.roster.networkId !== accepted.policy.networkId
+    || accepted.roster.contextGraphId !== accepted.policy.contextGraphId
+    || accepted.roster.ownershipTransitionDigest
+      !== accepted.policy.ownershipTransitionDigest
+    || accepted.roster.era !== accepted.policy.era
+    || accepted.roster.policyDigest !== accepted.policyDigest
+    || accepted.roster.administrativeDelegationDigest
+      !== accepted.policy.administrativeDelegationDigest
+    || !accepted.roster.members.some(
+      (member) => member.agentAddress === scope.authorAddress,
+    )
+  ) {
+    throw new Error('requested private catalog scope is not accepted-current authority');
+  }
+  return accepted;
+}
+
+async function requireAcceptedCurrentPrivateCatalogScope(
+  options: Rfc64CatalogNativeScopedReadProviderOptionsV1,
+  catalogScope: Readonly<AuthorCatalogScopeV1>,
+  policyDigest: Digest32V1,
+): Promise<void> {
+  const accepted = await requireAcceptedCurrentPrivateScope(options, {
+    networkId: catalogScope.networkId,
+    contextGraphId: catalogScope.contextGraphId,
+    authorAddress: catalogScope.authorAddress,
+    catalogEra: catalogScope.era,
+    policyDigest,
+  });
+  assertAcceptedPolicyMatchesCatalogScope(accepted, catalogScope, policyDigest);
+}
+
+function assertAcceptedPolicyMatchesCatalogScope(
+  accepted: Readonly<AcceptedRfc64CatalogAccessSnapshotV1>,
+  catalogScope: Readonly<AuthorCatalogScopeV1>,
+  policyDigest: Digest32V1,
+): void {
+  const policy = accepted.policy;
+  if (
+    accepted.policyDigest !== policyDigest
+    || policy.networkId !== catalogScope.networkId
+    || policy.contextGraphId !== catalogScope.contextGraphId
+    || policy.governanceChainId !== catalogScope.governanceChainId
+    || policy.governanceContractAddress !== catalogScope.governanceContractAddress
+    || policy.ownershipTransitionDigest !== catalogScope.ownershipTransitionDigest
+    || policy.era !== catalogScope.era
+  ) {
+    throw new Error('accepted-current policy differs from the exact private catalog scope');
+  }
 }
 
 async function readStored(

--- a/packages/agent/src/rfc64/finalized-policy-agent-precommit-v1.ts
+++ b/packages/agent/src/rfc64/finalized-policy-agent-precommit-v1.ts
@@ -2,12 +2,15 @@ import {
   assertCanonicalDecimalU256,
   assertCanonicalDigest,
   canonicalizeContextGraphPolicyPayloadV1,
+  canonicalizeMemberRosterPayloadV1,
   parseCanonicalContextGraphPolicyPayloadV1,
+  parseCanonicalMemberRosterPayloadV1,
   type AuthorCatalogScopeV1,
   type ChainIdV1,
   type ContextGraphIdV1,
   type DecimalU256V1,
   type EvmAddressV1,
+  type MemberRosterV1,
 } from '@origintrail-official/dkg-core';
 import { createStrictCurrentFinalizedEvmSnapshotScopeV1 } from '@origintrail-official/dkg-chain';
 
@@ -55,31 +58,56 @@ export async function resolveRfc64FinalizedPolicyAgentPrecommitV1(
     plan.catalogScope,
   );
   let policy: AcceptedRfc64CatalogAccessSnapshotV1['policy'];
+  let roster: Readonly<MemberRosterV1> | null;
   try {
+    assertCanonicalDigest(plan.policyDigest, 'RFC-64 finalized precommit plan policy digest');
     assertCanonicalDigest(
       untrustedAcceptedPolicy.policyDigest,
       'RFC-64 finalized precommit policy digest',
     );
+    if (untrustedAcceptedPolicy.policyDigest !== plan.policyDigest) {
+      throw new Error('accepted-current policy generation differs from the transfer plan');
+    }
     policy = parseCanonicalContextGraphPolicyPayloadV1(
       canonicalizeContextGraphPolicyPayloadV1(untrustedAcceptedPolicy.policy),
     );
+    roster = untrustedAcceptedPolicy.roster === null
+      ? null
+      : parseCanonicalMemberRosterPayloadV1(
+        canonicalizeMemberRosterPayloadV1(untrustedAcceptedPolicy.roster),
+      );
+    assertAcceptedPolicyMatchesPlanV1(policy, plan.catalogScope);
+    assertRosterMatchesAcceptedPolicyV1(
+      roster,
+      policy,
+      untrustedAcceptedPolicy.policyDigest,
+      plan.catalogScope.authorAddress,
+    );
   } catch (cause) {
-    throw new Error('RFC-64 finalized precommit accepted policy is not canonical', { cause });
+    const detail = cause instanceof Error ? `: ${cause.message}` : '';
+    throw new Error(
+      `RFC-64 finalized precommit accepted policy is not canonical${detail}`,
+      { cause },
+    );
+  }
+  if (policy.accessPolicy === 1 && policy.source.kind === 'finalized-chain') {
+    throw new Error(
+      'RFC-64 Release 1 does not activate registered private catalog inventories',
+    );
   }
   if (policy.source.kind !== 'finalized-chain') return null;
-  if (untrustedAcceptedPolicy.roster !== null) {
+  if (roster !== null) {
     throw new Error('RFC-64 finalized precommit public policy forbids a private member roster');
   }
   const acceptedPolicy = Object.freeze({
     policy,
     policyDigest: untrustedAcceptedPolicy.policyDigest,
-    roster: null,
+    roster,
   });
   const chainId = policy.governanceChainId;
   const contextGraphStorageAddress = policy.governanceContractAddress;
   if (
-    policy.accessPolicy !== 0
-    || chainId === null
+    chainId === null
     || contextGraphStorageAddress === null
   ) {
     throw new Error('RFC-64 finalized precommit requires one public finalized policy');
@@ -137,7 +165,10 @@ export function createRfc64FinalizedPolicyAgentPrecommitV1(
       plan,
       signal,
     );
-    if (resolved === null) return;
+    if (resolved === null) {
+      assertPlanPolicyAndRosterCurrentV1(options, plan);
+      return;
+    }
     const snapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
       chainId: resolved.chainId,
       endpoints: resolved.rpcEndpoints,
@@ -165,5 +196,99 @@ export function createRfc64FinalizedPolicyAgentPrecommitV1(
         session,
       ),
     );
+    assertAcceptedSnapshotStillCurrentV1(options, plan, resolved.acceptedPolicy);
   });
+}
+
+function assertPlanPolicyAndRosterCurrentV1(
+  options: Rfc64FinalizedPolicyAgentPrecommitResolutionOptionsV1,
+  plan: Readonly<Rfc64PublicCatalogNativeBeforeAppliedHeadCommitPlanV1>,
+): void {
+  const current = options.acceptedPolicySnapshotForCatalogScope(plan.catalogScope);
+  assertCanonicalDigest(current.policyDigest, 'RFC-64 current precommit policy digest');
+  if (current.policyDigest !== plan.policyDigest) {
+    throw new Error('RFC-64 accepted policy changed during catalog precommit');
+  }
+  const policy = parseCanonicalContextGraphPolicyPayloadV1(
+    canonicalizeContextGraphPolicyPayloadV1(current.policy),
+  );
+  const roster = current.roster === null
+    ? null
+    : parseCanonicalMemberRosterPayloadV1(
+      canonicalizeMemberRosterPayloadV1(current.roster),
+    );
+  assertAcceptedPolicyMatchesPlanV1(policy, plan.catalogScope);
+  assertRosterMatchesAcceptedPolicyV1(
+    roster,
+    policy,
+    current.policyDigest,
+    plan.catalogScope.authorAddress,
+  );
+}
+
+function assertAcceptedPolicyMatchesPlanV1(
+  policy: AcceptedRfc64CatalogAccessSnapshotV1['policy'],
+  scope: Readonly<AuthorCatalogScopeV1>,
+): void {
+  if (
+    policy.networkId !== scope.networkId
+    || policy.contextGraphId !== scope.contextGraphId
+    || policy.governanceChainId !== scope.governanceChainId
+    || policy.governanceContractAddress !== scope.governanceContractAddress
+    || policy.ownershipTransitionDigest !== scope.ownershipTransitionDigest
+    || policy.era !== scope.era
+  ) {
+    throw new Error('accepted policy differs from the exact catalog scope');
+  }
+}
+
+function assertRosterMatchesAcceptedPolicyV1(
+  roster: Readonly<MemberRosterV1> | null,
+  policy: AcceptedRfc64CatalogAccessSnapshotV1['policy'],
+  policyDigest: AcceptedRfc64CatalogAccessSnapshotV1['policyDigest'],
+  authorAddress: EvmAddressV1,
+): void {
+  if (policy.accessPolicy === 0) {
+    if (roster !== null) {
+      throw new Error('public RFC-64 policy forbids a private member roster');
+    }
+    return;
+  }
+  if (
+    roster === null
+    || roster.networkId !== policy.networkId
+    || roster.contextGraphId !== policy.contextGraphId
+    || roster.ownershipTransitionDigest !== policy.ownershipTransitionDigest
+    || roster.era !== policy.era
+    || roster.policyDigest !== policyDigest
+    || roster.administrativeDelegationDigest !== policy.administrativeDelegationDigest
+    || !roster.members.some((member) => member.agentAddress === authorAddress)
+  ) {
+    throw new Error(
+      'private RFC-64 precommit requires the exact current policy-bound roster and author membership',
+    );
+  }
+}
+
+function assertAcceptedSnapshotStillCurrentV1(
+  options: Rfc64FinalizedPolicyAgentPrecommitResolutionOptionsV1,
+  plan: Readonly<Rfc64PublicCatalogNativeBeforeAppliedHeadCommitPlanV1>,
+  expected: Readonly<AcceptedRfc64CatalogAccessSnapshotV1>,
+): void {
+  const current = options.acceptedPolicySnapshotForCatalogScope(plan.catalogScope);
+  if (
+    current.policyDigest !== plan.policyDigest
+    || current.policyDigest !== expected.policyDigest
+    || canonicalizeContextGraphPolicyPayloadV1(current.policy)
+      !== canonicalizeContextGraphPolicyPayloadV1(expected.policy)
+    || (current.roster === null) !== (expected.roster === null)
+    || (
+      current.roster !== null
+      && expected.roster !== null
+      && canonicalizeMemberRosterPayloadV1(current.roster)
+        !== canonicalizeMemberRosterPayloadV1(expected.roster)
+    )
+  ) {
+    throw new Error('RFC-64 accepted policy or roster changed during catalog precommit');
+  }
 }

--- a/packages/agent/src/rfc64/public-catalog-activation-config-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-activation-config-v1.ts
@@ -2,21 +2,26 @@
 
 import {
   assertCanonicalChainId,
+  assertCanonicalEvmAddress,
   assertNetworkIdV1,
   type CatalogSealDeploymentProfileV1,
   type ChainIdV1,
+  type EvmAddressV1,
   type NetworkIdV1,
 } from '@origintrail-official/dkg-core';
 
 import type {
+  Rfc64CatalogBootstrapConfigV1,
   Rfc64PublicCatalogAutoPublishConfigV1,
   Rfc64PublicCatalogBootstrapConfigV1,
 } from '../dkg-agent-types.js';
 import {
+  snapshotRfc64CatalogBootstrapConfigV1,
   snapshotRfc64CatalogDeploymentProfileV1,
   snapshotRfc64PublicCatalogAutoPublishConfigV1,
   snapshotRfc64PublicCatalogBootstrapConfigV1,
 } from './catalog-authority-config-v1.js';
+import { snapshotRfc64PublicCatalogAnnouncementPeersV1 } from './catalog-peers-v1.js';
 
 const MAX_SELECTED_PUBLIC_CONTEXT_GRAPHS_V1 = 64;
 const RFC64_PUBLIC_CATALOG_ACTIVATION_FIELDS_V1 = new Set([
@@ -25,6 +30,13 @@ const RFC64_PUBLIC_CATALOG_ACTIVATION_FIELDS_V1 = new Set([
   'deploymentProfile',
   'enabled',
 ]);
+const RFC64_CATALOG_ACTIVATION_FIELDS_V1 = new Set([
+  'accessPolicyAuthority',
+  'bootstrap',
+  'deploymentProfile',
+  'enabled',
+]);
+const ZERO_ADDRESS_V1 = `0x${'0'.repeat(40)}`;
 
 function assertRfc64PublicCatalogActivationConfigV1(
   input: unknown,
@@ -41,16 +53,75 @@ function assertRfc64PublicCatalogActivationConfigV1(
   }
 }
 
+function assertRfc64CatalogActivationConfigV1(
+  input: unknown,
+): asserts input is Rfc64CatalogActivationConfigV1 {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new TypeError('rfc64Catalog must be a plain object');
+  }
+  const prototype = Object.getPrototypeOf(input);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError('rfc64Catalog must be a plain object');
+  }
+  if (Object.keys(input).some((key) => !RFC64_CATALOG_ACTIVATION_FIELDS_V1.has(key))) {
+    throw new TypeError('rfc64Catalog has unknown fields');
+  }
+}
+
 /**
  * Narrow side-effect-free package surface for daemon/operator activation.
  * Consumers that only normalize RFC-64 configuration must not import the full
  * DKGAgent runtime (which owns process-global scheduler observability).
  */
 export {
+  snapshotRfc64CatalogBootstrapConfigV1,
   snapshotRfc64CatalogDeploymentProfileV1,
   snapshotRfc64PublicCatalogAutoPublishConfigV1,
   snapshotRfc64PublicCatalogBootstrapConfigV1,
 };
+
+export interface Rfc64CatalogPeerAgentBindingV1 {
+  readonly peerId: string;
+  readonly agentAddress: EvmAddressV1;
+}
+
+/** Manual Release-1 peer identity trust root. No registry inference is allowed. */
+export interface Rfc64CatalogActivationAccessPolicyAuthorityV1 {
+  readonly localAgentAddress: EvmAddressV1;
+  readonly peerAgentBindings: readonly Rfc64CatalogPeerAgentBindingV1[];
+}
+
+/** Additive policy-neutral activation for selected public and private CGs. */
+export interface Rfc64CatalogActivationConfigV1 {
+  readonly enabled?: boolean;
+  readonly deploymentProfile?: CatalogSealDeploymentProfileV1;
+  readonly accessPolicyAuthority?: Rfc64CatalogActivationAccessPolicyAuthorityV1;
+  readonly bootstrap?: Rfc64CatalogBootstrapConfigV1;
+}
+
+export interface ResolvedRfc64CatalogActivationConfigV1 {
+  readonly enabled: boolean;
+  readonly selectedContextGraphs: readonly string[];
+  readonly selectedPublicContextGraphs: readonly string[];
+  readonly selectedPrivateContextGraphs: readonly string[];
+  readonly deploymentProfile?: Readonly<CatalogSealDeploymentProfileV1>;
+  readonly accessPolicyAuthority?: Readonly<{
+    readonly localAgentAddress: EvmAddressV1;
+    readonly peerAgentBindings: readonly Readonly<Rfc64CatalogPeerAgentBindingV1>[];
+  }>;
+  readonly bootstrap?: Readonly<Rfc64CatalogBootstrapConfigV1>;
+}
+
+export type Rfc64CatalogActivationInputV1 =
+  | Rfc64CatalogActivationConfigV1
+  | ResolvedRfc64CatalogActivationConfigV1;
+
+export interface ResolvedRfc64CatalogActivationsV1 {
+  /** Policy-neutral union used by the Release-1 runtime. */
+  readonly catalog: ResolvedRfc64CatalogActivationConfigV1;
+  /** Compatibility projection used by the existing public status/producer path. */
+  readonly publicCatalog: ResolvedRfc64PublicCatalogActivationConfigV1;
+}
 
 /**
  * One operator-owned selected-public activation. The accepted bootstrap
@@ -155,6 +226,29 @@ function requireRfc64PublicCatalogActivationChainIdentityV1(
   });
 }
 
+function requireRfc64CatalogActivationChainIdentityV1(
+  chainIdentity: Rfc64PublicCatalogActivationChainIdentityV1,
+): Readonly<Required<Rfc64PublicCatalogActivationChainIdentityV1>> {
+  const selectedNetworkId = chainIdentity.networkId;
+  if (selectedNetworkId === undefined) {
+    throw new TypeError('enabled rfc64Catalog requires an effective network id');
+  }
+  assertNetworkIdV1(selectedNetworkId, 'RFC-64 activation networkId');
+  const selectedEvmChainId = chainIdentity.evmChainId;
+  if (selectedEvmChainId === undefined) {
+    throw new TypeError('enabled rfc64Catalog requires a numeric EVM chain id');
+  }
+  assertCanonicalChainId(selectedEvmChainId, 'RFC-64 activation evmChainId');
+  const derived = resolveRfc64PublicCatalogActivationChainIdentityV1(selectedNetworkId);
+  if (derived.evmChainId !== selectedEvmChainId) {
+    throw new TypeError('RFC-64 activation network and EVM chain ids differ');
+  }
+  return Object.freeze({
+    networkId: selectedNetworkId,
+    evmChainId: selectedEvmChainId,
+  });
+}
+
 /**
  * Resolve the complete fail-closed operator activation into exact agent
  * inputs. This function owns the cross-field invariants so every daemon uses
@@ -241,6 +335,353 @@ export function resolveRfc64PublicCatalogActivationConfigV1(
     autoPublish,
     bootstrap,
   });
+}
+
+/** Resolve one additive public/private selection and its manual authority map. */
+export function resolveRfc64CatalogActivationConfigV1(
+  activation: Rfc64CatalogActivationConfigV1 | undefined,
+  chainIdentity: Rfc64PublicCatalogActivationChainIdentityV1,
+): ResolvedRfc64CatalogActivationConfigV1 {
+  if (activation === undefined) return disabledRfc64CatalogActivationV1();
+  assertRfc64CatalogActivationConfigV1(activation);
+  if (activation.enabled !== undefined && typeof activation.enabled !== 'boolean') {
+    throw new TypeError('rfc64Catalog.enabled must be a boolean');
+  }
+  if (activation.enabled === false) return disabledRfc64CatalogActivationV1();
+
+  const bootstrap = snapshotRfc64CatalogBootstrapConfigV1(activation.bootstrap);
+  if (bootstrap === undefined || bootstrap.acceptedPolicies.length === 0) {
+    throw new TypeError(
+      'enabled rfc64Catalog requires a non-empty bootstrap.acceptedPolicies manifest',
+    );
+  }
+  const { networkId, evmChainId } = requireRfc64CatalogActivationChainIdentityV1(
+    chainIdentity,
+  );
+  for (const accepted of bootstrap.acceptedPolicies) {
+    if (accepted.policyEnvelope.payload.networkId !== networkId) {
+      throw new TypeError(
+        'rfc64Catalog policy network differs from the daemon effective chain id',
+      );
+    }
+  }
+
+  const deploymentProfile = snapshotRfc64CatalogDeploymentProfileV1(
+    activation.deploymentProfile,
+  );
+  if (deploymentProfile !== undefined) {
+    if (deploymentProfile.networkId !== networkId) {
+      throw new TypeError(
+        'rfc64Catalog deployment network differs from the daemon effective chain id',
+      );
+    }
+    if (deploymentProfile.assertedAtChainId !== evmChainId) {
+      throw new TypeError(
+        'rfc64Catalog deployment EVM chain id differs from the daemon effective chain id',
+      );
+    }
+  }
+
+  const selectedPublicContextGraphs: string[] = [];
+  const selectedPrivateContextGraphs: string[] = [];
+  for (const accepted of bootstrap.acceptedPolicies) {
+    const policy = accepted.policyEnvelope.payload;
+    (policy.accessPolicy === 0
+      ? selectedPublicContextGraphs
+      : selectedPrivateContextGraphs).push(policy.contextGraphId);
+  }
+  const accessPolicyAuthority = snapshotRfc64CatalogActivationAccessPolicyAuthorityV1(
+    activation.accessPolicyAuthority,
+  );
+  validatePrivateActivationAuthorityV1(
+    bootstrap,
+    selectedPrivateContextGraphs,
+    accessPolicyAuthority,
+  );
+  return Object.freeze({
+    enabled: true,
+    selectedContextGraphs: Object.freeze([
+      ...selectedPublicContextGraphs,
+      ...selectedPrivateContextGraphs,
+    ]),
+    selectedPublicContextGraphs: Object.freeze(selectedPublicContextGraphs),
+    selectedPrivateContextGraphs: Object.freeze(selectedPrivateContextGraphs),
+    deploymentProfile,
+    accessPolicyAuthority,
+    bootstrap,
+  });
+}
+
+/** Resolve raw or already-resolved additive input at the agent boundary. */
+export function resolveRfc64CatalogActivationInputV1(
+  input: Rfc64CatalogActivationInputV1 | undefined,
+  chainIdentity: Rfc64PublicCatalogActivationChainIdentityV1,
+): ResolvedRfc64CatalogActivationConfigV1 {
+  if (
+    input !== undefined
+    && Object.prototype.hasOwnProperty.call(input, 'selectedContextGraphs')
+  ) {
+    const resolvedInput = input as ResolvedRfc64CatalogActivationConfigV1;
+    if (resolvedInput.enabled === false) {
+      if (
+        resolvedInput.selectedContextGraphs.length !== 0
+        || resolvedInput.selectedPublicContextGraphs.length !== 0
+        || resolvedInput.selectedPrivateContextGraphs.length !== 0
+        || resolvedInput.bootstrap !== undefined
+        || resolvedInput.deploymentProfile !== undefined
+        || resolvedInput.accessPolicyAuthority !== undefined
+      ) {
+        throw new TypeError('disabled rfc64Catalog activation must not carry controls');
+      }
+      return disabledRfc64CatalogActivationV1();
+    }
+    const resolved = resolveRfc64CatalogActivationConfigV1({
+      enabled: resolvedInput.enabled,
+      deploymentProfile: resolvedInput.deploymentProfile,
+      accessPolicyAuthority: resolvedInput.accessPolicyAuthority,
+      bootstrap: resolvedInput.bootstrap,
+    }, chainIdentity);
+    if (
+      !sameStrings(resolvedInput.selectedContextGraphs, resolved.selectedContextGraphs)
+      || !sameStrings(
+        resolvedInput.selectedPublicContextGraphs,
+        resolved.selectedPublicContextGraphs,
+      )
+      || !sameStrings(
+        resolvedInput.selectedPrivateContextGraphs,
+        resolved.selectedPrivateContextGraphs,
+      )
+    ) {
+      throw new TypeError('rfc64Catalog selected graphs differ from the bootstrap manifest');
+    }
+    return resolved;
+  }
+  return resolveRfc64CatalogActivationConfigV1(
+    input as Rfc64CatalogActivationConfigV1 | undefined,
+    chainIdentity,
+  );
+}
+
+/**
+ * Normalize the additive and compatibility blocks into one runtime manifest.
+ * Disjoint selections are unioned. An overlap is accepted only when its policy,
+ * targets, and completeness assertion are byte-for-byte equal after canonical
+ * snapshotting.
+ */
+export function resolveRfc64CatalogActivationsV1(
+  input: {
+    readonly catalog?: Rfc64CatalogActivationInputV1;
+    readonly publicCatalog?: Rfc64PublicCatalogActivationInputV1;
+  },
+  chainIdentity: Rfc64PublicCatalogActivationChainIdentityV1,
+): ResolvedRfc64CatalogActivationsV1 {
+  const catalog = resolveRfc64CatalogActivationInputV1(input.catalog, chainIdentity);
+  const publicCatalog = resolveRfc64PublicCatalogActivationInputV1(
+    input.publicCatalog,
+    chainIdentity,
+  );
+  if (!catalog.enabled && !publicCatalog.enabled) {
+    return Object.freeze({ catalog, publicCatalog });
+  }
+
+  const byGraph = new Map<string, Rfc64CatalogBootstrapConfigV1['acceptedPolicies'][number]>();
+  for (const accepted of catalog.bootstrap?.acceptedPolicies ?? []) {
+    byGraph.set(accepted.policyEnvelope.payload.contextGraphId, accepted);
+  }
+  for (const acceptedPublic of publicCatalog.bootstrap?.acceptedPublicPolicies ?? []) {
+    const accepted = Object.freeze({
+      policyEnvelope: acceptedPublic.policyEnvelope,
+      targets: acceptedPublic.targets,
+      ...(acceptedPublic.completeSwmProviders === undefined
+        ? {}
+        : { completeSwmProviders: acceptedPublic.completeSwmProviders }),
+    });
+    const contextGraphId = accepted.policyEnvelope.payload.contextGraphId;
+    const current = byGraph.get(contextGraphId);
+    if (current !== undefined && JSON.stringify(current) !== JSON.stringify(accepted)) {
+      throw new TypeError(
+        `rfc64Catalog and rfc64PublicCatalog conflict for selected graph ${contextGraphId}`,
+      );
+    }
+    byGraph.set(contextGraphId, current ?? accepted);
+  }
+
+  const deploymentProfile = mergeDeploymentProfilesV1(
+    catalog.deploymentProfile,
+    publicCatalog.deploymentProfile,
+  );
+  const retryIntervals = [
+    catalog.bootstrap?.retryIntervalMs,
+    publicCatalog.bootstrap?.retryIntervalMs,
+  ].filter((value): value is number => value !== undefined);
+  if (new Set(retryIntervals).size > 1) {
+    throw new TypeError(
+      'rfc64Catalog and rfc64PublicCatalog bootstrap retry intervals conflict',
+    );
+  }
+  const acceptedPolicies = [...byGraph.values()];
+  const selectedPublicContextGraphs = acceptedPolicies
+    .filter(({ policyEnvelope }) => policyEnvelope.payload.accessPolicy === 0)
+    .map(({ policyEnvelope }) => policyEnvelope.payload.contextGraphId);
+  const selectedPrivateContextGraphs = acceptedPolicies
+    .filter(({ policyEnvelope }) => policyEnvelope.payload.accessPolicy === 1)
+    .map(({ policyEnvelope }) => policyEnvelope.payload.contextGraphId);
+  const mergedCatalog = Object.freeze({
+    enabled: true,
+    selectedContextGraphs: Object.freeze([
+      ...selectedPublicContextGraphs,
+      ...selectedPrivateContextGraphs,
+    ]),
+    selectedPublicContextGraphs: Object.freeze(selectedPublicContextGraphs),
+    selectedPrivateContextGraphs: Object.freeze(selectedPrivateContextGraphs),
+    deploymentProfile,
+    accessPolicyAuthority: catalog.accessPolicyAuthority,
+    bootstrap: Object.freeze({
+      acceptedPolicies: Object.freeze(acceptedPolicies),
+      retryIntervalMs: retryIntervals[0] ?? 30_000,
+    }),
+  });
+  return Object.freeze({ catalog: mergedCatalog, publicCatalog });
+}
+
+function disabledRfc64CatalogActivationV1(): ResolvedRfc64CatalogActivationConfigV1 {
+  return Object.freeze({
+    enabled: false,
+    selectedContextGraphs: Object.freeze([]),
+    selectedPublicContextGraphs: Object.freeze([]),
+    selectedPrivateContextGraphs: Object.freeze([]),
+  });
+}
+
+function snapshotRfc64CatalogActivationAccessPolicyAuthorityV1(
+  input: Rfc64CatalogActivationAccessPolicyAuthorityV1 | undefined,
+): ResolvedRfc64CatalogActivationConfigV1['accessPolicyAuthority'] {
+  if (input === undefined) return undefined;
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new TypeError('rfc64Catalog.accessPolicyAuthority must be a plain object');
+  }
+  const prototype = Object.getPrototypeOf(input);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError('rfc64Catalog.accessPolicyAuthority must be a plain object');
+  }
+  const keys = Object.keys(input).sort();
+  if (
+    keys.length !== 2
+    || keys[0] !== 'localAgentAddress'
+    || keys[1] !== 'peerAgentBindings'
+  ) {
+    throw new TypeError('rfc64Catalog.accessPolicyAuthority has unknown or missing fields');
+  }
+  assertCanonicalEvmAddress(input.localAgentAddress, 'localAgentAddress');
+  if (input.localAgentAddress === ZERO_ADDRESS_V1) {
+    throw new TypeError('rfc64Catalog.accessPolicyAuthority.localAgentAddress must be nonzero');
+  }
+  if (!Array.isArray(input.peerAgentBindings)) {
+    throw new TypeError('rfc64Catalog.accessPolicyAuthority.peerAgentBindings must be an array');
+  }
+  const seenPeers = new Set<string>();
+  const peerAgentBindings = input.peerAgentBindings.map((binding, index) => {
+    if (binding === null || typeof binding !== 'object' || Array.isArray(binding)) {
+      throw new TypeError(`rfc64Catalog peerAgentBindings[${index}] must be a plain object`);
+    }
+    const bindingPrototype = Object.getPrototypeOf(binding);
+    const bindingKeys = Object.keys(binding).sort();
+    if (
+      (bindingPrototype !== Object.prototype && bindingPrototype !== null)
+      || bindingKeys.length !== 2
+      || bindingKeys[0] !== 'agentAddress'
+      || bindingKeys[1] !== 'peerId'
+    ) {
+      throw new TypeError(
+        `rfc64Catalog peerAgentBindings[${index}] has unknown or missing fields`,
+      );
+    }
+    const [peerId] = snapshotRfc64PublicCatalogAnnouncementPeersV1([binding.peerId]);
+    assertCanonicalEvmAddress(binding.agentAddress, `peerAgentBindings[${index}].agentAddress`);
+    if (binding.agentAddress === ZERO_ADDRESS_V1) {
+      throw new TypeError('rfc64Catalog peer binding agentAddress must be nonzero');
+    }
+    if (seenPeers.has(peerId!)) {
+      throw new TypeError('rfc64Catalog peerAgentBindings must be unique by peerId');
+    }
+    seenPeers.add(peerId!);
+    return Object.freeze({ peerId: peerId!, agentAddress: binding.agentAddress });
+  });
+  return Object.freeze({
+    localAgentAddress: input.localAgentAddress,
+    peerAgentBindings: Object.freeze(peerAgentBindings),
+  });
+}
+
+function validatePrivateActivationAuthorityV1(
+  bootstrap: Readonly<Rfc64CatalogBootstrapConfigV1>,
+  selectedPrivateContextGraphs: readonly string[],
+  authority: ResolvedRfc64CatalogActivationConfigV1['accessPolicyAuthority'],
+): void {
+  if (selectedPrivateContextGraphs.length === 0) {
+    if (authority !== undefined) {
+      throw new TypeError(
+        'rfc64Catalog.accessPolicyAuthority requires at least one selected private policy',
+      );
+    }
+    return;
+  }
+  if (authority === undefined) {
+    throw new TypeError('selected private rfc64Catalog requires accessPolicyAuthority');
+  }
+  const bindings = new Map(
+    authority.peerAgentBindings.map(({ peerId, agentAddress }) => [peerId, agentAddress]),
+  );
+  const usedPeers = new Set<string>();
+  for (const accepted of bootstrap.acceptedPolicies) {
+    if (accepted.policyEnvelope.payload.accessPolicy !== 1) continue;
+    const roster = accepted.rosterEnvelope!.payload;
+    const members = new Map(roster.members.map((member) => [member.agentAddress, member]));
+    if (!members.has(authority.localAgentAddress)) {
+      throw new TypeError(
+        'rfc64Catalog localAgentAddress is not a current member of every selected private CG',
+      );
+    }
+    const providers = new Set([
+      ...(accepted.completeSwmProviders ?? []),
+      ...accepted.targets.flatMap((target) => target.providers),
+    ]);
+    for (const peerId of providers) {
+      usedPeers.add(peerId);
+      const agentAddress = bindings.get(peerId);
+      if (agentAddress === undefined) {
+        throw new TypeError(
+          `rfc64Catalog private provider ${peerId} has no exact peerAgentBinding`,
+        );
+      }
+      if (!members.get(agentAddress)?.roles.includes('provider')) {
+        throw new TypeError(
+          `rfc64Catalog private provider ${peerId} is not a current roster provider`,
+        );
+      }
+    }
+  }
+  for (const peerId of bindings.keys()) {
+    if (!usedPeers.has(peerId)) {
+      throw new TypeError(
+        `rfc64Catalog peerAgentBinding ${peerId} is outside the selected private provider set`,
+      );
+    }
+  }
+}
+
+function mergeDeploymentProfilesV1(
+  left: Readonly<CatalogSealDeploymentProfileV1> | undefined,
+  right: Readonly<CatalogSealDeploymentProfileV1> | undefined,
+): Readonly<CatalogSealDeploymentProfileV1> | undefined {
+  if (left !== undefined && right !== undefined && JSON.stringify(left) !== JSON.stringify(right)) {
+    throw new TypeError('rfc64Catalog and rfc64PublicCatalog deployment profiles conflict');
+  }
+  return left ?? right;
+}
+
+function sameStrings(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
 /**

--- a/packages/agent/src/rfc64/public-catalog-activation-config-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-activation-config-v1.ts
@@ -633,10 +633,12 @@ function validatePrivateActivationAuthorityV1(
     authority.peerAgentBindings.map(({ peerId, agentAddress }) => [peerId, agentAddress]),
   );
   const usedPeers = new Set<string>();
+  const currentMemberAddresses = new Set<EvmAddressV1>();
   for (const accepted of bootstrap.acceptedPolicies) {
     if (accepted.policyEnvelope.payload.accessPolicy !== 1) continue;
     const roster = accepted.rosterEnvelope!.payload;
     const members = new Map(roster.members.map((member) => [member.agentAddress, member]));
+    for (const member of roster.members) currentMemberAddresses.add(member.agentAddress);
     if (!members.has(authority.localAgentAddress)) {
       throw new TypeError(
         'rfc64Catalog localAgentAddress is not a current member of every selected private CG',
@@ -661,10 +663,10 @@ function validatePrivateActivationAuthorityV1(
       }
     }
   }
-  for (const peerId of bindings.keys()) {
-    if (!usedPeers.has(peerId)) {
+  for (const [peerId, agentAddress] of bindings) {
+    if (!usedPeers.has(peerId) && !currentMemberAddresses.has(agentAddress)) {
       throw new TypeError(
-        `rfc64Catalog peerAgentBinding ${peerId} is outside the selected private provider set`,
+        `rfc64Catalog peerAgentBinding ${peerId} is not a current member of any selected private CG`,
       );
     }
   }

--- a/packages/agent/src/rfc64/public-catalog-current-head-discovery-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-current-head-discovery-v1.ts
@@ -59,6 +59,9 @@ import {
 
 export const RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V1 =
   '/dkg/catalog/1/author-head/current' as const;
+/** Accepted-current, member-authorized discovery for invite-only catalogs. */
+export const RFC64_PRIVATE_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V2 =
+  '/dkg/catalog/2/author-head-availability' as const;
 export const RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1 =
   'rfc64-author-catalog-current-head-query-v1' as const;
 
@@ -232,12 +235,19 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
       this.router.register(
         RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V1,
         async (data, peerId, handlerOptions) =>
-          this.handleQuery(data, peerId.toString(), handlerOptions?.signal),
+          this.handleQuery(data, peerId.toString(), false, handlerOptions?.signal),
+        { maxReadBytes: RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_MAX_BYTES_V1 },
+      );
+      this.router.register(
+        RFC64_PRIVATE_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V2,
+        async (data, peerId, handlerOptions) =>
+          this.handleQuery(data, peerId.toString(), true, handlerOptions?.signal),
         { maxReadBytes: RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_MAX_BYTES_V1 },
       );
     } catch (cause) {
       this.#started = false;
       this.router.unregister(RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V1);
+      this.router.unregister(RFC64_PRIVATE_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V2);
       throw cause;
     }
   }
@@ -246,6 +256,7 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
     if (!this.#started) return;
     this.#started = false;
     this.router.unregister(RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V1);
+    this.router.unregister(RFC64_PRIVATE_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V2);
   }
 
   async discoverCurrentCatalogHead(
@@ -256,15 +267,22 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
     this.requireStarted();
     const remotePeerId = snapshotPeerId(remotePeerIdInput);
     const query = parseQuery(encodeQuery(queryInput));
-    await this.requireOpenPolicy('current-head-discovery-outbound', remotePeerId, query);
+    const authorization = await this.requireCurrentPolicy(
+      'current-head-discovery-outbound',
+      remotePeerId,
+      query,
+    );
+    const protocol = authorization.accessPolicy === 0
+      ? RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V1
+      : RFC64_PRIVATE_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V2;
     const response = await this.router.send(
       remotePeerId,
-      RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V1,
+      protocol,
       encodeQuery(query),
       sendOptions,
     );
     const announcement = parseResponse(response);
-    await this.requireOpenPolicy('current-head-discovery-outbound', remotePeerId, query);
+    await this.requireCurrentPolicy('current-head-discovery-outbound', remotePeerId, query);
     if (announcement === null) return null;
     assertAnnouncementMatchesQuery(announcement, query);
     return announcement;
@@ -273,6 +291,7 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
   private async handleQuery(
     data: Uint8Array,
     remotePeerIdInput: string,
+    allowPrivate: boolean,
     signal?: AbortSignal,
   ): Promise<Uint8Array> {
     throwIfAborted(signal);
@@ -280,10 +299,11 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
     const remotePeerId = snapshotPeerId(remotePeerIdInput);
     const query = parseQuery(data);
     for (let attempt = 0; attempt < CURRENT_HEAD_SNAPSHOT_MAX_ATTEMPTS; attempt += 1) {
-      const authorization = await this.openPolicyOrNull(
+      const authorization = await this.currentPolicyOrNull(
         'current-head-discovery-inbound',
         remotePeerId,
         query,
+        allowPrivate,
       );
       if (authorization === null) {
         return Uint8Array.of(CURRENT_HEAD_DENIED);
@@ -309,10 +329,11 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
       throwIfAborted(signal);
       if (confirmedDigest !== currentDigest) continue;
 
-      if (await this.openPolicyOrNull(
+      if (await this.currentPolicyOrNull(
         'current-head-discovery-inbound',
         remotePeerId,
         query,
+        allowPrivate,
       ) === null) {
         return Uint8Array.of(CURRENT_HEAD_DENIED);
       }
@@ -383,13 +404,15 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
     return announcementFromHead(envelope, query.policyDigest);
   }
 
-  private async openPolicyOrNull(
+  private async currentPolicyOrNull(
     operation: Rfc64PublicCatalogCurrentHeadDiscoveryOperationV1,
     remotePeerId: string,
     query: Rfc64PublicCatalogCurrentHeadQueryV1,
+    allowPrivate: boolean,
   ): Promise<Rfc64PublicCatalogCurrentHeadAuthorizationV1 | null> {
     try {
-      return await this.requireOpenPolicy(operation, remotePeerId, query);
+      const authorization = await this.requireCurrentPolicy(operation, remotePeerId, query);
+      return !allowPrivate && authorization.accessPolicy === 1 ? null : authorization;
     } catch (cause) {
       if (
         cause instanceof Rfc64PublicCatalogCurrentHeadDiscoveryErrorV1
@@ -399,7 +422,7 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
     }
   }
 
-  private async requireOpenPolicy(
+  private async requireCurrentPolicy(
     operation: Rfc64PublicCatalogCurrentHeadDiscoveryOperationV1,
     remotePeerId: string,
     query: Rfc64PublicCatalogCurrentHeadQueryV1,
@@ -419,10 +442,13 @@ export class Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1 {
     try {
       authorization = await this.#authorizeCatalogOperation(input);
     } catch (cause) {
-      fail('catalog-discovery-policy-denied', 'public catalog discovery authorization failed', cause);
+      fail('catalog-discovery-policy-denied', 'catalog discovery authorization failed', cause);
     }
-    if (authorization === null || authorization.accessPolicy !== 0) {
-      fail('catalog-discovery-policy-denied', 'current-head discovery is not authorized by public policy');
+    if (
+      authorization === null
+      || (authorization.accessPolicy !== 0 && authorization.accessPolicy !== 1)
+    ) {
+      fail('catalog-discovery-policy-denied', 'current-head discovery is not access-policy authorized');
     }
     try {
       assertCanonicalDigest(authorization.policyDigest, 'authorized policyDigest');

--- a/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
@@ -153,6 +153,8 @@ export interface Rfc64PublicCatalogNativePrecommitRowPlanV1 {
 /** Generic same-process barrier plan executed after semantic post-read and before head CAS. */
 export interface Rfc64PublicCatalogNativeBeforeAppliedHeadCommitPlanV1 {
   readonly catalogScope: Readonly<AuthorCatalogScopeV1>;
+  /** Exact accepted-current generation that authorized every fetched byte. */
+  readonly policyDigest: Digest32V1;
   readonly catalogHeadDigest: Digest32V1;
   readonly inventoryDigest: Digest32V1;
   /** Strictly increasing by mathematical KA ID. */
@@ -517,6 +519,7 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
     await this.runBeforeAppliedHeadCommitV1(
       Object.freeze({
         catalogScope: trustedCatalogScope,
+        policyDigest: announcement.policyDigest,
         catalogHeadDigest: head.objectDigest as Digest32V1,
         inventoryDigest,
         rows: Object.freeze([]),
@@ -986,6 +989,7 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
     await this.runBeforeAppliedHeadCommitV1(
       Object.freeze({
         catalogScope: trustedCatalogScope,
+        policyDigest: announcement.policyDigest,
         catalogHeadDigest: head.objectDigest as Digest32V1,
         inventoryDigest: completion.inventoryDigest,
         rows: Object.freeze(preparedRows.map((prepared) => Object.freeze({

--- a/packages/agent/src/rfc64/public-catalog-native-transport-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-transport-v1.ts
@@ -47,10 +47,12 @@ import type {
 import {
   normalizeRfc64CatalogTransportAuthorizerV1,
   recheckCurrentRfc64CatalogPolicyAfterAwaitV1,
-  withAuthorizedCurrentRfc64CatalogPolicyV1,
-  withCurrentRfc64CatalogPolicyV1,
 } from './catalog-transport-authorization-v1.js';
 import type { Rfc64AuthorizedCatalogWorkResultV1 } from './catalog-transport-authorization-v1.js';
+import {
+  isMintedRfc64CatalogNativeScopedReadCapabilityV1,
+  type Rfc64CatalogNativeScopedReadCapabilityV1,
+} from './catalog-native-scoped-read-capability-v1-internal.js';
 import {
   assertRfc64ExactIssuerSignatureProofV1,
   createRfc64CatalogTransportWireAdapterV1,
@@ -64,11 +66,19 @@ export const RFC64_PUBLIC_CATALOG_OBJECT_FETCH_PROTOCOL_V1 =
   '/dkg/catalog/1/control-object/by-digest' as const;
 export const RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_PROTOCOL_V1 =
   '/dkg/catalog/1/ka-bundle/by-digest' as const;
+export const RFC64_CATALOG_OBJECT_FETCH_PROTOCOL_V2 =
+  '/dkg/catalog/2/control-object/by-scope' as const;
+export const RFC64_CATALOG_BUNDLE_FETCH_PROTOCOL_V2 =
+  '/dkg/catalog/2/ka-bundle/by-scope' as const;
 
 export const RFC64_PUBLIC_CATALOG_OBJECT_FETCH_KIND_V1 =
   'rfc64-public-catalog-object-fetch-v1' as const;
 export const RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_KIND_V1 =
   'rfc64-public-catalog-bundle-fetch-v1' as const;
+export const RFC64_CATALOG_OBJECT_FETCH_KIND_V2 =
+  'rfc64-catalog-object-fetch-v2' as const;
+export const RFC64_CATALOG_BUNDLE_FETCH_KIND_V2 =
+  'rfc64-catalog-bundle-fetch-v2' as const;
 
 export const RFC64_PUBLIC_CATALOG_NATIVE_FETCH_REQUEST_MAX_BYTES_V1 = 4 * 1024;
 export const RFC64_PUBLIC_CATALOG_OBJECT_FETCH_RESPONSE_MAX_BYTES_V1 =
@@ -195,6 +205,11 @@ export type Rfc64PublicCatalogNativeOperationV1 =
   | 'ka-bundle-fetch-outbound'
   | 'ka-bundle-fetch-inbound';
 
+type Rfc64CatalogNativeContentProtocolV1 =
+  | 'select-outbound'
+  | 'public-v1'
+  | 'scoped-v2';
+
 export interface Rfc64PublicCatalogNativeAuthorizationInputV1 {
   readonly operation: Rfc64PublicCatalogNativeOperationV1;
   readonly remotePeerId: string;
@@ -213,15 +228,38 @@ export interface FetchedRfc64PublicCatalogObjectV1 {
   readonly issuerSignature: VerifiedControlEnvelopeIssuerSignatureV1;
 }
 
+/**
+ * One provider capability bound to one exact accepted catalog head.
+ *
+ * Private content MUST be exposed through this contract. The resolver mints a
+ * capability only after it has proved that the exact head belongs to the
+ * requested network/CG/catalog scope. The transport independently compares the
+ * returned scope with the canonical wire request before either digest lookup is
+ * called. This keeps a digest from becoming a cross-CG read capability.
+ */
+export type { Rfc64CatalogNativeScopedReadCapabilityV1 } from './catalog-native-scoped-read-capability-v1-internal.js';
+
+export type ResolveRfc64CatalogNativeScopedReadCapabilityV1 = (
+  scope: Readonly<Rfc64PublicCatalogNativeFetchScopeV1>,
+) => Promise<Rfc64CatalogNativeScopedReadCapabilityV1 | null>;
+
 export interface Rfc64PublicCatalogNativeTransportOptionsV1 {
-  /** Provider-side exact immutable catalog-object lookup. */
-  readonly readCatalogObjectByDigest: (
+  /**
+   * Provider-side exact immutable catalog-object lookup for public V1
+   * compatibility. It is never used for private content.
+   */
+  readonly readCatalogObjectByDigest?: (
     objectDigest: Digest32V1,
   ) => Promise<SignedControlEnvelopeV1 | null>;
-  /** Provider-side exact immutable bundle lookup. */
-  readonly readKaBundleByDigest: (
+  /** Public V1 compatibility lookup. It is never used for private content. */
+  readonly readKaBundleByDigest?: (
     blobDigest: Digest32V1,
   ) => Promise<Uint8Array | null>;
+  /**
+   * Provider-side private-capable lookup. A capability is valid for exactly
+   * the supplied accepted-current head scope and no other graph or head.
+   */
+  readonly resolveScopedReadCapability?: ResolveRfc64CatalogNativeScopedReadCapabilityV1;
   /** Preferred V2 contract: the accepted-current access-policy registry. */
   readonly authorizeCatalogOperation?: Rfc64CatalogAccessPolicyRegistryV1['authorize'];
   /** @deprecated Gate-1 compatibility until the service wiring migrates. */
@@ -263,11 +301,23 @@ export class Rfc64PublicCatalogNativeTransportV1 {
     private readonly router: ProtocolRouter,
     private readonly options: Rfc64PublicCatalogNativeTransportOptionsV1,
   ) {
-    if (typeof options?.readCatalogObjectByDigest !== 'function') {
-      fail('catalog-native-input', 'readCatalogObjectByDigest must be a function');
+    if (
+      typeof options?.readCatalogObjectByDigest !== 'function'
+      && typeof options?.resolveScopedReadCapability !== 'function'
+    ) {
+      fail(
+        'catalog-native-input',
+        'readCatalogObjectByDigest or resolveScopedReadCapability must be a function',
+      );
     }
-    if (typeof options.readKaBundleByDigest !== 'function') {
-      fail('catalog-native-input', 'readKaBundleByDigest must be a function');
+    if (
+      typeof options.readKaBundleByDigest !== 'function'
+      && typeof options.resolveScopedReadCapability !== 'function'
+    ) {
+      fail(
+        'catalog-native-input',
+        'readKaBundleByDigest or resolveScopedReadCapability must be a function',
+      );
     }
     this.#authorizeCatalogOperation = normalizeRfc64CatalogTransportAuthorizerV1({
       current: options.authorizeCatalogOperation,
@@ -283,24 +333,49 @@ export class Rfc64PublicCatalogNativeTransportV1 {
     return this.#started;
   }
 
+  /** True only when this provider can serve exact-scope private reads. */
+  get privateScopeBoundReadsConfigured(): boolean {
+    return typeof this.options.resolveScopedReadCapability === 'function';
+  }
+
   start(): void {
     if (this.#started) return;
     this.#started = true;
     try {
       this.router.register(
         RFC64_PUBLIC_CATALOG_OBJECT_FETCH_PROTOCOL_V1,
-        async (data, peerId) => this.handleCatalogObjectFetch(data, peerId.toString()),
+        async (data, peerId) => this.handleCatalogObjectFetch(
+          data,
+          peerId.toString(),
+          'public-v1',
+        ),
         { maxReadBytes: RFC64_PUBLIC_CATALOG_NATIVE_FETCH_REQUEST_MAX_BYTES_V1 },
       );
       this.router.register(
         RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_PROTOCOL_V1,
-        async (data, peerId) => this.handleBundleFetch(data, peerId.toString()),
+        async (data, peerId) => this.handleBundleFetch(data, peerId.toString(), 'public-v1'),
+        { maxReadBytes: RFC64_PUBLIC_CATALOG_NATIVE_FETCH_REQUEST_MAX_BYTES_V1 },
+      );
+      this.router.register(
+        RFC64_CATALOG_OBJECT_FETCH_PROTOCOL_V2,
+        async (data, peerId) => this.handleCatalogObjectFetch(
+          data,
+          peerId.toString(),
+          'scoped-v2',
+        ),
+        { maxReadBytes: RFC64_PUBLIC_CATALOG_NATIVE_FETCH_REQUEST_MAX_BYTES_V1 },
+      );
+      this.router.register(
+        RFC64_CATALOG_BUNDLE_FETCH_PROTOCOL_V2,
+        async (data, peerId) => this.handleBundleFetch(data, peerId.toString(), 'scoped-v2'),
         { maxReadBytes: RFC64_PUBLIC_CATALOG_NATIVE_FETCH_REQUEST_MAX_BYTES_V1 },
       );
     } catch (cause) {
       this.#started = false;
       this.router.unregister(RFC64_PUBLIC_CATALOG_OBJECT_FETCH_PROTOCOL_V1);
       this.router.unregister(RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_PROTOCOL_V1);
+      this.router.unregister(RFC64_CATALOG_OBJECT_FETCH_PROTOCOL_V2);
+      this.router.unregister(RFC64_CATALOG_BUNDLE_FETCH_PROTOCOL_V2);
       throw cause;
     }
   }
@@ -310,6 +385,8 @@ export class Rfc64PublicCatalogNativeTransportV1 {
     this.#started = false;
     this.router.unregister(RFC64_PUBLIC_CATALOG_OBJECT_FETCH_PROTOCOL_V1);
     this.router.unregister(RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_PROTOCOL_V1);
+    this.router.unregister(RFC64_CATALOG_OBJECT_FETCH_PROTOCOL_V2);
+    this.router.unregister(RFC64_CATALOG_BUNDLE_FETCH_PROTOCOL_V2);
   }
 
   async fetchCatalogObject(
@@ -324,18 +401,31 @@ export class Rfc64PublicCatalogNativeTransportV1 {
       'catalog-object-fetch-outbound',
       remotePeerId,
       request,
-      () => this.router.send(
-        remotePeerId,
-        RFC64_PUBLIC_CATALOG_OBJECT_FETCH_PROTOCOL_V1,
-        encodeRequest(request),
-        sendOptions,
-      ),
+      'select-outbound',
+      (authorization) => {
+        const privateContent = authorization.accessPolicy === 1;
+        return this.router.send(
+          remotePeerId,
+          privateContent
+            ? RFC64_CATALOG_OBJECT_FETCH_PROTOCOL_V2
+            : RFC64_PUBLIC_CATALOG_OBJECT_FETCH_PROTOCOL_V1,
+          privateContent
+            ? encodePrivateObjectRequest(request)
+            : encodeRequest(request),
+          sendOptions,
+        );
+      },
     );
     const envelope = parseCatalogObjectResponse(response);
     if (envelope === null) return null;
     assertCatalogObjectMatchesRequest(envelope, request);
     const issuerSignature = await recheckCurrentRfc64CatalogPolicyAfterAwaitV1(
-      () => this.requireCatalogPolicy('catalog-object-fetch-outbound', remotePeerId, request),
+      () => this.assertCatalogPolicyCurrent(
+        'catalog-object-fetch-outbound',
+        remotePeerId,
+        request,
+        'select-outbound',
+      ),
       () => this.verifyExactIssuerSignature(envelope),
     );
     return Object.freeze({ envelope: deepFreeze(envelope), issuerSignature });
@@ -360,12 +450,20 @@ export class Rfc64PublicCatalogNativeTransportV1 {
       'ka-bundle-fetch-outbound',
       remotePeerId,
       request,
-      () => this.router.send(
-        remotePeerId,
-        RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_PROTOCOL_V1,
-        encodeRequest(request),
-        sendOptions,
-      ),
+      'select-outbound',
+      (authorization) => {
+        const privateContent = authorization.accessPolicy === 1;
+        return this.router.send(
+          remotePeerId,
+          privateContent
+            ? RFC64_CATALOG_BUNDLE_FETCH_PROTOCOL_V2
+            : RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_PROTOCOL_V1,
+          privateContent
+            ? encodePrivateBundleRequest(request)
+            : encodeRequest(request),
+          sendOptions,
+        );
+      },
     );
     const bundle = parseBundleResponse(response, request);
     return bundle;
@@ -374,19 +472,36 @@ export class Rfc64PublicCatalogNativeTransportV1 {
   private async handleCatalogObjectFetch(
     data: Uint8Array,
     remotePeerIdInput: string,
+    protocol: Exclude<Rfc64CatalogNativeContentProtocolV1, 'select-outbound'>,
   ): Promise<Uint8Array> {
     this.requireStarted();
     const remotePeerId = snapshotPeerId(remotePeerIdInput);
-    const request = parseCatalogObjectRequest(data);
+    const request = protocol === 'public-v1'
+      ? parseCatalogObjectRequest(data)
+      : parsePrivateCatalogObjectRequest(data);
     const served = await this.withAuthorizedCurrentCatalogPolicy(
       'catalog-object-fetch-inbound',
       remotePeerId,
       request,
-      async () => {
-        const envelope = await this.options.readCatalogObjectByDigest(request.targetObjectDigest);
+      protocol,
+      async (authorization) => {
+        const envelope = await this.readCatalogObject(
+          authorization,
+          remotePeerId,
+          request,
+          protocol,
+        );
         if (envelope === null) return null;
         assertCatalogObjectMatchesRequest(envelope, request);
-        await this.verifyExactIssuerSignature(envelope);
+        await recheckCurrentRfc64CatalogPolicyAfterAwaitV1(
+          () => this.assertCatalogPolicyCurrent(
+            'catalog-object-fetch-inbound',
+            remotePeerId,
+            request,
+            protocol,
+          ),
+          () => this.verifyExactIssuerSignature(envelope),
+        );
         const bytes = canonicalizeSignedControlEnvelopeBytes(envelope);
         if (bytes.byteLength + 1 > RFC64_PUBLIC_CATALOG_OBJECT_FETCH_RESPONSE_MAX_BYTES_V1) {
           fail('catalog-native-resource-refused', 'catalog object exceeds the response ceiling');
@@ -403,10 +518,13 @@ export class Rfc64PublicCatalogNativeTransportV1 {
   private async handleBundleFetch(
     data: Uint8Array,
     remotePeerIdInput: string,
+    protocol: Exclude<Rfc64CatalogNativeContentProtocolV1, 'select-outbound'>,
   ): Promise<Uint8Array> {
     this.requireStarted();
     const remotePeerId = snapshotPeerId(remotePeerIdInput);
-    const request = parseBundleRequest(data);
+    const request = protocol === 'public-v1'
+      ? parseBundleRequest(data)
+      : parsePrivateBundleRequest(data);
     if (BigInt(request.byteLength) + 1n
       > BigInt(RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_RESPONSE_MAX_BYTES_V1)) {
       fail('catalog-native-resource-refused', 'requested KA bundle exceeds the response ceiling');
@@ -415,8 +533,14 @@ export class Rfc64PublicCatalogNativeTransportV1 {
       'ka-bundle-fetch-inbound',
       remotePeerId,
       request,
-      async () => {
-        const bundle = await this.options.readKaBundleByDigest(request.blobDigest);
+      protocol,
+      async (authorization) => {
+        const bundle = await this.readKaBundle(
+          authorization,
+          remotePeerId,
+          request,
+          protocol,
+        );
         if (bundle === null) return null;
         assertExactBundle(bundle, request);
         return foundResponse(bundle);
@@ -433,12 +557,28 @@ export class Rfc64PublicCatalogNativeTransportV1 {
     remotePeerId: string,
     request: Rfc64PublicCatalogObjectFetchRequestV1
       | Rfc64PublicCatalogBundleFetchRequestV1,
-    work: () => Value | Promise<Value>,
+    protocol: Rfc64CatalogNativeContentProtocolV1,
+    work: (
+      authorization: Rfc64PublicCatalogNativeAuthorizationV1,
+    ) => Value | Promise<Value>,
   ): Promise<Rfc64AuthorizedCatalogWorkResultV1<Value>> {
-    return withAuthorizedCurrentRfc64CatalogPolicyV1(
-      () => this.isCatalogPolicyAuthorized(operation, remotePeerId, request),
-      work,
-    );
+    let authorization: Rfc64PublicCatalogNativeAuthorizationV1;
+    try {
+      authorization = await this.requireCatalogPolicy(
+        operation,
+        remotePeerId,
+        request,
+        protocol,
+      );
+    } catch (cause) {
+      if (isPolicyDenied(cause)) return Object.freeze({ authorized: false });
+      throw cause;
+    }
+    const value = await work(authorization);
+    if (!await this.isCatalogPolicyAuthorized(operation, remotePeerId, request, protocol)) {
+      return Object.freeze({ authorized: false });
+    }
+    return Object.freeze({ authorized: true, value });
   }
 
   private async isCatalogPolicyAuthorized(
@@ -446,9 +586,10 @@ export class Rfc64PublicCatalogNativeTransportV1 {
     remotePeerId: string,
     request: Rfc64PublicCatalogObjectFetchRequestV1
       | Rfc64PublicCatalogBundleFetchRequestV1,
+    protocol: Rfc64CatalogNativeContentProtocolV1,
   ): Promise<boolean> {
     try {
-      await this.requireCatalogPolicy(operation, remotePeerId, request);
+      await this.requireCatalogPolicy(operation, remotePeerId, request, protocol);
       return true;
     } catch (cause) {
       if (
@@ -464,12 +605,32 @@ export class Rfc64PublicCatalogNativeTransportV1 {
     remotePeerId: string,
     request: Rfc64PublicCatalogObjectFetchRequestV1
       | Rfc64PublicCatalogBundleFetchRequestV1,
-    work: () => Value | Promise<Value>,
+    protocol: Rfc64CatalogNativeContentProtocolV1,
+    work: (
+      authorization: Rfc64PublicCatalogNativeAuthorizationV1,
+    ) => Value | Promise<Value>,
   ): Promise<Value> {
-    return withCurrentRfc64CatalogPolicyV1(
-      () => this.requireCatalogPolicy(operation, remotePeerId, request),
-      work,
-    );
+    return (async () => {
+      const authorization = await this.requireCatalogPolicy(
+        operation,
+        remotePeerId,
+        request,
+        protocol,
+      );
+      const value = await work(authorization);
+      await this.assertCatalogPolicyCurrent(operation, remotePeerId, request, protocol);
+      return value;
+    })();
+  }
+
+  private async assertCatalogPolicyCurrent(
+    operation: Rfc64PublicCatalogNativeOperationV1,
+    remotePeerId: string,
+    request: Rfc64PublicCatalogObjectFetchRequestV1
+      | Rfc64PublicCatalogBundleFetchRequestV1,
+    protocol: Rfc64CatalogNativeContentProtocolV1,
+  ): Promise<void> {
+    await this.requireCatalogPolicy(operation, remotePeerId, request, protocol);
   }
 
   private async requireCatalogPolicy(
@@ -477,7 +638,8 @@ export class Rfc64PublicCatalogNativeTransportV1 {
     remotePeerId: string,
     request: Rfc64PublicCatalogObjectFetchRequestV1
       | Rfc64PublicCatalogBundleFetchRequestV1,
-  ): Promise<void> {
+    protocol: Rfc64CatalogNativeContentProtocolV1,
+  ): Promise<Rfc64PublicCatalogNativeAuthorizationV1> {
     let authorization: Rfc64PublicCatalogNativeAuthorizationV1 | null;
     try {
       authorization = await this.#authorizeCatalogOperation(Object.freeze({
@@ -492,17 +654,7 @@ export class Rfc64PublicCatalogNativeTransportV1 {
     } catch (cause) {
       fail('catalog-native-policy-denied', 'catalog access-policy authorization failed', cause);
     }
-    // The native content protocols resolve objects and bundles purely by the digest carried in the
-    // request, out of a store that is shared by every context graph on this node, and nothing on the
-    // serve path binds what is served back to the context graph that authorized the request. Admitting
-    // a private cell (accessPolicy === 1) here would therefore let any peer authorized under ANY public
-    // cell this node happens to hold read another graph's control objects and KA bundles by digest
-    // alone, and would leave a removed member's remembered digests a permanent read capability.
-    // Public cells are safe because their content is open by definition. Serving private content needs
-    // the serve path to be scope-bound first (heads carry networkId/contextGraphId, buckets carry
-    // catalogScopeDigest, bundles bind only via row membership in the announced head) — that is a
-    // design slice for the private-CG milestone, not a widening of this gate.
-    if (authorization === null || authorization.accessPolicy !== 0) {
+    if (authorization === null) {
       fail('catalog-native-policy-denied', 'catalog content fetch is not access-policy authorized');
     }
     try {
@@ -513,6 +665,116 @@ export class Rfc64PublicCatalogNativeTransportV1 {
     if (authorization.policyDigest !== request.policyDigest) {
       fail('catalog-native-policy-denied', 'catalog policy generation is stale or mismatched');
     }
+    if (protocol === 'public-v1' && authorization.accessPolicy !== 0) {
+      fail('catalog-native-policy-denied', 'private catalog content is forbidden on V1 protocols');
+    }
+    if (
+      protocol === 'scoped-v2'
+      && typeof this.options.resolveScopedReadCapability !== 'function'
+    ) {
+      fail(
+        'catalog-native-policy-denied',
+        'V2 catalog content requires an exact-scope read capability',
+      );
+    }
+    return authorization;
+  }
+
+  private async readCatalogObject(
+    authorization: Rfc64PublicCatalogNativeAuthorizationV1,
+    remotePeerId: string,
+    request: Rfc64PublicCatalogObjectFetchRequestV1,
+    protocol: Exclude<Rfc64CatalogNativeContentProtocolV1, 'select-outbound'>,
+  ): Promise<SignedControlEnvelopeV1 | null> {
+    if (protocol === 'public-v1') {
+      if (authorization.accessPolicy !== 0 || this.options.readCatalogObjectByDigest === undefined) {
+        fail('catalog-native-policy-denied', 'V1 catalog object read is not public-capable');
+      }
+      return recheckCurrentRfc64CatalogPolicyAfterAwaitV1(
+        () => this.assertCatalogPolicyCurrent(
+          'catalog-object-fetch-inbound',
+          remotePeerId,
+          request,
+          protocol,
+        ),
+        () => this.options.readCatalogObjectByDigest!(request.targetObjectDigest),
+      );
+    }
+    const capability = await this.resolveExactScopedReadCapability(
+      'catalog-object-fetch-inbound',
+      remotePeerId,
+      request,
+      protocol,
+    );
+    if (capability === null) return null;
+    return recheckCurrentRfc64CatalogPolicyAfterAwaitV1(
+      () => this.assertCatalogPolicyCurrent(
+        'catalog-object-fetch-inbound',
+        remotePeerId,
+        request,
+        protocol,
+      ),
+      () => capability.readCatalogObjectByDigest(request.targetObjectDigest),
+    );
+  }
+
+  private async readKaBundle(
+    authorization: Rfc64PublicCatalogNativeAuthorizationV1,
+    remotePeerId: string,
+    request: Rfc64PublicCatalogBundleFetchRequestV1,
+    protocol: Exclude<Rfc64CatalogNativeContentProtocolV1, 'select-outbound'>,
+  ): Promise<Uint8Array | null> {
+    if (protocol === 'public-v1') {
+      if (authorization.accessPolicy !== 0 || this.options.readKaBundleByDigest === undefined) {
+        fail('catalog-native-policy-denied', 'V1 KA bundle read is not public-capable');
+      }
+      return recheckCurrentRfc64CatalogPolicyAfterAwaitV1(
+        () => this.assertCatalogPolicyCurrent(
+          'ka-bundle-fetch-inbound',
+          remotePeerId,
+          request,
+          protocol,
+        ),
+        () => this.options.readKaBundleByDigest!(request.blobDigest),
+      );
+    }
+    const capability = await this.resolveExactScopedReadCapability(
+      'ka-bundle-fetch-inbound',
+      remotePeerId,
+      request,
+      protocol,
+    );
+    if (capability === null) return null;
+    return recheckCurrentRfc64CatalogPolicyAfterAwaitV1(
+      () => this.assertCatalogPolicyCurrent(
+        'ka-bundle-fetch-inbound',
+        remotePeerId,
+        request,
+        protocol,
+      ),
+      () => capability.readKaBundleByDigest(request.blobDigest),
+    );
+  }
+
+  private async resolveExactScopedReadCapability(
+    operation: 'catalog-object-fetch-inbound' | 'ka-bundle-fetch-inbound',
+    remotePeerId: string,
+    request: Rfc64PublicCatalogObjectFetchRequestV1
+      | Rfc64PublicCatalogBundleFetchRequestV1,
+    protocol: 'scoped-v2',
+  ): Promise<Rfc64CatalogNativeScopedReadCapabilityV1 | null> {
+    const resolve = this.options.resolveScopedReadCapability;
+    if (resolve === undefined) {
+      fail('catalog-native-policy-denied', 'exact-scope read capability is not configured');
+    }
+    const expectedScope = fetchScope(request);
+    const capability = await recheckCurrentRfc64CatalogPolicyAfterAwaitV1(
+      () => this.assertCatalogPolicyCurrent(operation, remotePeerId, request, protocol),
+      () => resolve(expectedScope),
+    );
+    if (capability === null) return null;
+    assertExactScopedReadCapability(capability, expectedScope);
+    return capability;
   }
 
   private async verifyExactIssuerSignature(
@@ -561,9 +823,71 @@ function parseCatalogObjectRequest(input: Uint8Array): Rfc64PublicCatalogObjectF
   return validateObjectRequest(parsed);
 }
 
+function encodePrivateObjectRequest(
+  request: Rfc64PublicCatalogObjectFetchRequestV1,
+): Uint8Array {
+  return encodeRequest({ ...request, kind: RFC64_CATALOG_OBJECT_FETCH_KIND_V2 });
+}
+
+function parsePrivateCatalogObjectRequest(
+  input: Uint8Array,
+): Rfc64PublicCatalogObjectFetchRequestV1 {
+  const snapshot = snapshotExactWireRecord(
+    parseRequest(input, OBJECT_REQUEST_KEYS),
+    OBJECT_REQUEST_KEYS,
+  );
+  const scope = validateScope(snapshot, RFC64_CATALOG_OBJECT_FETCH_KIND_V2);
+  if (
+    typeof snapshot.targetObjectType !== 'string'
+    || snapshot.targetObjectType.length < 1
+    || UTF8.encode(snapshot.targetObjectType).byteLength > 256
+  ) {
+    fail('catalog-native-wire', 'targetObjectType is empty or oversized');
+  }
+  try {
+    assertCanonicalDigest(snapshot.targetObjectDigest, 'targetObjectDigest');
+  } catch (cause) {
+    fail('catalog-native-wire', 'targetObjectDigest is invalid', cause);
+  }
+  return Object.freeze({
+    ...scope,
+    kind: RFC64_PUBLIC_CATALOG_OBJECT_FETCH_KIND_V1,
+    targetObjectType: snapshot.targetObjectType,
+    targetObjectDigest: snapshot.targetObjectDigest,
+  }) as Rfc64PublicCatalogObjectFetchRequestV1;
+}
+
 function parseBundleRequest(input: Uint8Array): Rfc64PublicCatalogBundleFetchRequestV1 {
   const parsed = parseRequest(input, BUNDLE_REQUEST_KEYS);
   return validateBundleRequest(parsed);
+}
+
+function encodePrivateBundleRequest(
+  request: Rfc64PublicCatalogBundleFetchRequestV1,
+): Uint8Array {
+  return encodeRequest({ ...request, kind: RFC64_CATALOG_BUNDLE_FETCH_KIND_V2 });
+}
+
+function parsePrivateBundleRequest(
+  input: Uint8Array,
+): Rfc64PublicCatalogBundleFetchRequestV1 {
+  const snapshot = snapshotExactWireRecord(
+    parseRequest(input, BUNDLE_REQUEST_KEYS),
+    BUNDLE_REQUEST_KEYS,
+  );
+  const scope = validateScope(snapshot, RFC64_CATALOG_BUNDLE_FETCH_KIND_V2);
+  try {
+    assertCanonicalDigest(snapshot.blobDigest, 'blobDigest');
+    assertCanonicalDecimalU64(snapshot.byteLength, 'byteLength');
+  } catch (cause) {
+    fail('catalog-native-wire', 'bundle request contains an invalid digest or length', cause);
+  }
+  return Object.freeze({
+    ...scope,
+    kind: RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_KIND_V1,
+    blobDigest: snapshot.blobDigest,
+    byteLength: snapshot.byteLength,
+  }) as Rfc64PublicCatalogBundleFetchRequestV1;
 }
 
 function validateObjectRequest(value: unknown): Rfc64PublicCatalogObjectFetchRequestV1 {
@@ -606,7 +930,9 @@ function validateBundleRequest(value: unknown): Rfc64PublicCatalogBundleFetchReq
 function validateScope(
   value: unknown,
   kind: typeof RFC64_PUBLIC_CATALOG_OBJECT_FETCH_KIND_V1
-    | typeof RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_KIND_V1,
+    | typeof RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_KIND_V1
+    | typeof RFC64_CATALOG_OBJECT_FETCH_KIND_V2
+    | typeof RFC64_CATALOG_BUNDLE_FETCH_KIND_V2,
 ): Rfc64PublicCatalogNativeFetchScopeV1 {
   if (!isPlainRecord(value) || value.kind !== kind) {
     fail('catalog-native-wire', `catalog native request kind must be ${kind}`);
@@ -737,6 +1063,68 @@ function assertExactBundle(
     if (cause instanceof Rfc64PublicCatalogNativeTransportErrorV1) throw cause;
     fail('catalog-native-object-mismatch', 'KA bundle is not one exact opaque bundle', cause);
   }
+}
+
+function fetchScope(
+  request: Rfc64PublicCatalogObjectFetchRequestV1
+    | Rfc64PublicCatalogBundleFetchRequestV1,
+): Readonly<Rfc64PublicCatalogNativeFetchScopeV1> {
+  return Object.freeze({
+    networkId: request.networkId,
+    contextGraphId: request.contextGraphId,
+    subGraphName: request.subGraphName,
+    authorAddress: request.authorAddress,
+    catalogEra: request.catalogEra,
+    catalogVersion: request.catalogVersion,
+    policyDigest: request.policyDigest,
+    catalogHeadObjectDigest: request.catalogHeadObjectDigest,
+  });
+}
+
+function assertExactScopedReadCapability(
+  capability: Rfc64CatalogNativeScopedReadCapabilityV1,
+  expectedScope: Readonly<Rfc64PublicCatalogNativeFetchScopeV1>,
+): void {
+  if (
+    !isMintedRfc64CatalogNativeScopedReadCapabilityV1(capability)
+    || typeof capability.readCatalogObjectByDigest !== 'function'
+    || typeof capability.readKaBundleByDigest !== 'function'
+    || !isPlainRecord(capability.scope)
+  ) {
+    fail('catalog-native-policy-denied', 'scoped read resolver returned an invalid capability');
+  }
+  let actualScope: Readonly<Rfc64PublicCatalogNativeFetchScopeV1>;
+  try {
+    actualScope = validateScope(
+      {
+        ...capability.scope,
+        kind: RFC64_PUBLIC_CATALOG_OBJECT_FETCH_KIND_V1,
+      },
+      RFC64_PUBLIC_CATALOG_OBJECT_FETCH_KIND_V1,
+    );
+  } catch (cause) {
+    fail('catalog-native-policy-denied', 'scoped read capability has an invalid scope', cause);
+  }
+  if (
+    actualScope.networkId !== expectedScope.networkId
+    || actualScope.contextGraphId !== expectedScope.contextGraphId
+    || actualScope.subGraphName !== expectedScope.subGraphName
+    || actualScope.authorAddress !== expectedScope.authorAddress
+    || actualScope.catalogEra !== expectedScope.catalogEra
+    || actualScope.catalogVersion !== expectedScope.catalogVersion
+    || actualScope.policyDigest !== expectedScope.policyDigest
+    || actualScope.catalogHeadObjectDigest !== expectedScope.catalogHeadObjectDigest
+  ) {
+    fail(
+      'catalog-native-policy-denied',
+      'scoped read capability does not match the exact requested catalog head scope',
+    );
+  }
+}
+
+function isPolicyDenied(cause: unknown): boolean {
+  return cause instanceof Rfc64PublicCatalogNativeTransportErrorV1
+    && cause.code === 'catalog-native-policy-denied';
 }
 
 function foundResponse(payload: Uint8Array): Uint8Array {

--- a/packages/agent/src/rfc64/public-catalog-service-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-service-v1.ts
@@ -84,9 +84,6 @@ import {
 import {
   type Rfc64BoundedPublicRootCatalogTrustedScopeResolverV1,
 } from './public-catalog-native-reconciler-v1.js';
-import {
-  deriveRfc64PublicRootCatalogScopeV1,
-} from './public-open-catalog-scope-v1.js';
 import type {
   Rfc64PublicCatalogIssuerAuthorizationV1,
 } from './public-catalog-successor-producer-v1.js';
@@ -152,7 +149,9 @@ export interface Rfc64PublicCatalogReconcilerClientsV1 {
 
 export interface Rfc64PublicCatalogServiceNativeOptionsV1 extends Pick<
   Rfc64PublicCatalogNativeTransportOptionsV1,
-  'readCatalogObjectByDigest' | 'readKaBundleByDigest'
+  | 'readCatalogObjectByDigest'
+  | 'readKaBundleByDigest'
+  | 'resolveScopedReadCapability'
 > {
   /** Construct exactly one reconciler around the service-owned transports. */
   readonly createReconciler: (
@@ -293,6 +292,7 @@ export class Rfc64PublicCatalogServiceV1 {
       : new Rfc64PublicCatalogNativeTransportV1(options.router, {
         readCatalogObjectByDigest: options.native.readCatalogObjectByDigest,
         readKaBundleByDigest: options.native.readKaBundleByDigest,
+        resolveScopedReadCapability: options.native.resolveScopedReadCapability,
         authorizeCatalogOperation: this.#policies.authorize,
         verifyIssuerSignature: this.#verifyIssuerSignature,
       });
@@ -444,7 +444,11 @@ export class Rfc64PublicCatalogServiceV1 {
     }
     assertAcceptedPolicyMatchesCatalogScope(this.#policies, heldPolicy, scope);
     const peers = snapshotRfc64PublicCatalogAnnouncementPeersV1(input.peers);
-    assertSupportedCatalogFanout(heldPolicy, peers);
+    assertSupportedCatalogFanout(
+      heldPolicy,
+      peers,
+      this.#nativeTransport?.privateScopeBoundReadsConfigured === true,
+    );
     return this.#publishAuthorCatalogGenesis(input, heldPolicy, peers);
   }
 
@@ -548,7 +552,11 @@ export class Rfc64PublicCatalogServiceV1 {
     );
     const peers = snapshotRfc64PublicCatalogAnnouncementPeersV1(input.peers);
     const heldPolicy = this.#assertAcceptedCatalogAnnouncement(announcement);
-    assertSupportedCatalogFanout(heldPolicy, peers);
+    assertSupportedCatalogFanout(
+      heldPolicy,
+      peers,
+      this.#nativeTransport?.privateScopeBoundReadsConfigured === true,
+    );
     return this.#announceCatalogHeadSnapshot(announcement, peers);
   }
 
@@ -717,9 +725,23 @@ export class Rfc64PublicCatalogServiceV1 {
       return null;
     }
     const record = this.#policies.lookup(input.networkId, input.contextGraphId);
-    if (record === null || record.policy.accessPolicy !== 0) return null;
+    if (record === null || record.policyDigest !== input.policyDigest) return null;
+    const authorization = await this.#policies.authorize(Object.freeze({
+      operation: input.operation === 'current-head-discovery-inbound'
+        ? 'fetch-inbound'
+        : 'fetch-outbound',
+      remotePeerId: input.remotePeerId,
+      networkId: input.networkId,
+      contextGraphId: input.contextGraphId,
+      policyDigest: input.policyDigest,
+    }));
+    if (
+      authorization === null
+      || authorization.policyDigest !== record.policyDigest
+      || authorization.accessPolicy !== record.policy.accessPolicy
+    ) return null;
     return Object.freeze({
-      accessPolicy: 0,
+      accessPolicy: authorization.accessPolicy,
       policyDigest: record.policyDigest,
       trustedCatalogScope,
     });
@@ -752,7 +774,7 @@ export class Rfc64PublicCatalogServiceV1 {
     const record = this.#policies.lookup(input.networkId, input.contextGraphId);
     if (record === null) {
       throw new Error(
-        'RFC-64 current-head query is not bound to the accepted public root policy',
+        'RFC-64 current-head query is not bound to an accepted policy snapshot',
       );
     }
     try {
@@ -764,10 +786,27 @@ export class Rfc64PublicCatalogServiceV1 {
       })) {
         throw new Error('catalog author is not authorized by the accepted policy');
       }
-      return deriveRfc64PublicRootCatalogScopeV1(input, record.policy);
+      if (
+        record.policy.networkId !== input.networkId
+        || record.policy.contextGraphId !== input.contextGraphId
+        || record.policy.era !== input.catalogEra
+      ) {
+        throw new Error('catalog identity differs from the accepted policy');
+      }
+      return Object.freeze({
+        networkId: record.policy.networkId,
+        contextGraphId: record.policy.contextGraphId,
+        governanceChainId: record.policy.governanceChainId,
+        governanceContractAddress: record.policy.governanceContractAddress,
+        ownershipTransitionDigest: record.policy.ownershipTransitionDigest,
+        subGraphName: input.subGraphName,
+        authorAddress: input.authorAddress,
+        era: record.policy.era,
+        bucketCount: '1',
+      }) as Readonly<AuthorCatalogScopeV1>;
     } catch (cause) {
       throw new Error(
-        'RFC-64 current-head query is not bound to the accepted public root policy',
+        'RFC-64 current-head query is not bound to the accepted policy snapshot',
         { cause },
       );
     }
@@ -813,8 +852,13 @@ export class Rfc64PublicCatalogServiceV1 {
 function assertSupportedCatalogFanout(
   heldPolicy: AcceptedRfc64CatalogAccessSnapshotV1,
   peers: readonly string[],
+  privateScopeBoundReadsConfigured: boolean,
 ): void {
-  if (heldPolicy.policy.accessPolicy === 1 && peers.length > 0) {
+  if (
+    heldPolicy.policy.accessPolicy === 1
+    && peers.length > 0
+    && !privateScopeBoundReadsConfigured
+  ) {
     throw new Error(
       'RFC-64 private catalog peer fan-out requires scope-bound private content transport',
     );
@@ -874,6 +918,7 @@ function assertAcceptedPolicyMatchesCatalogScope(
     || policy.governanceChainId !== scope.governanceChainId
     || policy.governanceContractAddress !== scope.governanceContractAddress
     || policy.ownershipTransitionDigest !== scope.ownershipTransitionDigest
+    || policy.era !== scope.era
     || !registry.isSwmAuthorAuthorized({
       networkId: scope.networkId,
       contextGraphId: scope.contextGraphId,
@@ -882,7 +927,7 @@ function assertAcceptedPolicyMatchesCatalogScope(
     })
   ) {
     throw new Error(
-      'RFC-64 policy snapshot is not bound to the exact catalog network, CG, governance scope, and author',
+      'RFC-64 policy snapshot is not bound to the exact catalog network, CG, governance scope, era, and author',
     );
   }
 }

--- a/packages/agent/test/rfc64-catalog-native-scoped-read-provider-v1.test.ts
+++ b/packages/agent/test/rfc64-catalog-native-scoped-read-provider-v1.test.ts
@@ -1,0 +1,212 @@
+import {
+  KA_TRANSFER_CHUNK_SIZE_V1,
+  KA_TRANSFER_CODEC_V1,
+  KA_TRANSFER_PROJECTION_V1,
+  assertAuthorCatalogRowV1,
+  computeKaChunkTreeRootV1,
+  encodeOpaqueKaBundleV1,
+  type AuthorCatalogRowV1,
+  type AuthorCatalogScopeV1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type SignedControlEnvelopeV1,
+} from '@origintrail-official/dkg-core';
+import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dkg-chain';
+import { ethers } from 'ethers';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  produceEmptyAuthorCatalogGenesisV1,
+  produceSparseAuthorCatalogSuccessorV1,
+} from '../src/rfc64/author-catalog-producer.js';
+import { createRfc64CatalogNativeScopedReadProviderV1 } from '../src/rfc64/catalog-native-scoped-read-provider-v1.js';
+import { produceDirectAuthorCatalogIssuerDelegationV1 } from '../src/rfc64/public-catalog-issuer-delegation-v1.js';
+import type { Rfc64PublicCatalogNativeFetchScopeV1 } from '../src/rfc64/public-catalog-native-transport-v1.js';
+
+const WALLET = new ethers.Wallet(`0x${'65'.repeat(32)}`);
+const AUTHOR = WALLET.address.toLowerCase() as EvmAddressV1;
+const CONTEXT_GRAPH_ID =
+  '0x1111111111111111111111111111111111111111/private-scoped-provider';
+const POLICY_DIGEST = `0x${'73'.repeat(32)}` as Digest32V1;
+const SEAL_DIGEST = `0x${'44'.repeat(32)}` as Digest32V1;
+const UTF8 = new TextEncoder();
+
+async function providerFixture() {
+  const catalogScope = {
+    networkId: 'otp:20430',
+    contextGraphId: CONTEXT_GRAPH_ID,
+    governanceChainId: null,
+    governanceContractAddress: null,
+    ownershipTransitionDigest: null,
+    subGraphName: null,
+    authorAddress: AUTHOR,
+    era: '0',
+    bucketCount: '1',
+  } as AuthorCatalogScopeV1;
+  const signer = {
+    issuer: AUTHOR,
+    signDigest: (digest: Uint8Array) => WALLET.signMessage(digest),
+  };
+  const delegation = await produceDirectAuthorCatalogIssuerDelegationV1({
+    scope: catalogScope,
+    signer,
+    effectiveAt: '1773899999000' as never,
+    expiresAt: '1774000000000' as never,
+    catalogHeadIssuedAt: '1773900000000' as never,
+  });
+  const genesis = await produceEmptyAuthorCatalogGenesisV1({
+    scope: catalogScope,
+    catalogIssuerDelegationDigest:
+      delegation.authorization.catalogIssuerDelegation.objectDigest as Digest32V1,
+    issuedAt: '1773900000000' as never,
+    signer,
+  });
+  const bundle = encodeOpaqueKaBundleV1(
+    UTF8.encode('<https://example.org/private> <https://schema.org/name> "Private" .\n'),
+    new Uint8Array(),
+  );
+  const row = {
+    kaId: ((BigInt(AUTHOR) << 96n) | 1n).toString(),
+    assertionCoordinate: 'private-release-1',
+    assertionVersion: '1',
+    projectionId: KA_TRANSFER_PROJECTION_V1,
+    projectionDigest: `0x${'11'.repeat(32)}`,
+    sealDigest: SEAL_DIGEST,
+    transfer: {
+      codec: KA_TRANSFER_CODEC_V1,
+      projectionId: KA_TRANSFER_PROJECTION_V1,
+      projectionDigest: `0x${'11'.repeat(32)}`,
+      byteLength: bundle.bundleBytes.byteLength.toString(),
+      chunkSize: KA_TRANSFER_CHUNK_SIZE_V1,
+      chunkCount: '1',
+      blobDigest: bundle.blobDigest,
+      chunkTreeRoot: computeKaChunkTreeRootV1(bundle.bundleBytes),
+    },
+  } as unknown as AuthorCatalogRowV1;
+  assertAuthorCatalogRowV1(row);
+  const successor = await produceSparseAuthorCatalogSuccessorV1({
+    previousHead: genesis.head,
+    previousDirectoryPath: genesis.directoryPath,
+    previousBucket: null,
+    selectedBucketId: '0' as never,
+    nextRows: [row],
+    issuedAt: '1773900001000' as never,
+    signer,
+  });
+  const envelopes: SignedControlEnvelopeV1[] = [
+    delegation.authorization.catalogIssuerDelegation,
+    ...successor.stagedObjects,
+  ];
+  const stored = new Map<string, {
+    readonly envelope: SignedControlEnvelopeV1;
+    readonly issuerSignature: Awaited<ReturnType<typeof verifyControlEnvelopeIssuerSignatureV1>>;
+  }>();
+  for (const envelope of envelopes) {
+    stored.set(envelope.objectDigest, {
+      envelope,
+      issuerSignature: await verifyControlEnvelopeIssuerSignatureV1(envelope),
+    });
+  }
+  const unrelated = genesis.head;
+  stored.set(unrelated.objectDigest, {
+    envelope: unrelated,
+    issuerSignature: await verifyControlEnvelopeIssuerSignatureV1(unrelated),
+  });
+  const controlRead = vi.fn(async ({ objectDigest }: { objectDigest: Digest32V1 }) =>
+    stored.get(objectDigest) ?? null);
+  const bundleRead = vi.fn(async (blobDigest: Digest32V1) =>
+    blobDigest === bundle.blobDigest ? bundle.bundleBytes : null);
+  const resolve = createRfc64CatalogNativeScopedReadProviderV1({
+    controlObjects: { getVerifiedObjectByDigest: controlRead } as never,
+    kaBundles: { readKaBundleByDigest: bundleRead },
+  });
+  const scope = Object.freeze({
+    networkId: successor.head.payload.networkId,
+    contextGraphId: successor.head.payload.contextGraphId,
+    subGraphName: successor.head.payload.subGraphName,
+    authorAddress: successor.head.payload.authorAddress,
+    catalogEra: successor.head.payload.era,
+    catalogVersion: successor.head.payload.version,
+    policyDigest: POLICY_DIGEST,
+    catalogHeadObjectDigest: successor.head.objectDigest as Digest32V1,
+  }) satisfies Rfc64PublicCatalogNativeFetchScopeV1;
+  return {
+    bundle,
+    bundleRead,
+    controlRead,
+    delegation: delegation.authorization.catalogIssuerDelegation,
+    genesis,
+    resolve,
+    scope,
+    stored,
+    successor,
+  };
+}
+
+describe('RFC-64 catalog native scoped read provider v1', () => {
+  it('closes one exact signed bounded head and exposes only its reachable digests', async () => {
+    const fixture = await providerFixture();
+    const capability = await fixture.resolve(fixture.scope);
+    expect(capability).not.toBeNull();
+    expect(capability?.scope).toEqual(fixture.scope);
+
+    await expect(capability?.readCatalogObjectByDigest(
+      fixture.successor.directoryPath[0]!.objectDigest as Digest32V1,
+    )).resolves.toEqual(fixture.successor.directoryPath[0]);
+    await expect(capability?.readCatalogObjectByDigest(
+      fixture.successor.bucket!.objectDigest as Digest32V1,
+    )).resolves.toEqual(fixture.successor.bucket);
+    await expect(capability?.readCatalogObjectByDigest(
+      fixture.delegation.objectDigest as Digest32V1,
+    )).resolves.toEqual(fixture.delegation);
+    await expect(capability?.readKaBundleByDigest(fixture.bundle.blobDigest))
+      .resolves.toEqual(fixture.bundle.bundleBytes);
+
+    // This is a valid signed object in the same shared store, but it is not in
+    // the requested successor closure.
+    await expect(capability?.readCatalogObjectByDigest(
+      fixture.genesis.head.objectDigest as Digest32V1,
+    )).resolves.toBeNull();
+    await expect(capability?.readKaBundleByDigest(
+      `0x${'91'.repeat(32)}` as Digest32V1,
+    )).resolves.toBeNull();
+  });
+
+  it.each([
+    {
+      label: 'context graph',
+      mutate: (scope: Rfc64PublicCatalogNativeFetchScopeV1) => ({
+        ...scope,
+        contextGraphId:
+          '0x1111111111111111111111111111111111111111/other-private' as never,
+      }),
+    },
+    {
+      label: 'head digest',
+      mutate: (scope: Rfc64PublicCatalogNativeFetchScopeV1) => ({
+        ...scope,
+        catalogHeadObjectDigest: `0x${'92'.repeat(32)}` as Digest32V1,
+      }),
+    },
+    {
+      label: 'catalog version',
+      mutate: (scope: Rfc64PublicCatalogNativeFetchScopeV1) => ({
+        ...scope,
+        catalogVersion: '2' as never,
+      }),
+    },
+  ])('refuses a mismatched $label without granting a capability', async ({ mutate }) => {
+    const fixture = await providerFixture();
+    await expect(fixture.resolve(mutate(fixture.scope))).resolves.toBeNull();
+    expect(fixture.bundleRead).not.toHaveBeenCalled();
+  });
+
+  it('refuses a closure when its exact direct-author delegation is absent', async () => {
+    const fixture = await providerFixture();
+    const delegationDigest = fixture.delegation.objectDigest;
+    fixture.controlRead.mockImplementation(async ({ objectDigest }) =>
+      objectDigest === delegationDigest ? null : fixture.stored.get(objectDigest) ?? null);
+    await expect(fixture.resolve(fixture.scope)).resolves.toBeNull();
+    expect(fixture.bundleRead).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/test/rfc64-catalog-native-scoped-read-provider-v1.test.ts
+++ b/packages/agent/test/rfc64-catalog-native-scoped-read-provider-v1.test.ts
@@ -2,6 +2,7 @@ import {
   KA_TRANSFER_CHUNK_SIZE_V1,
   KA_TRANSFER_CODEC_V1,
   KA_TRANSFER_PROJECTION_V1,
+  CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
   assertAuthorCatalogRowV1,
   computeKaChunkTreeRootV1,
   encodeOpaqueKaBundleV1,
@@ -9,6 +10,8 @@ import {
   type AuthorCatalogScopeV1,
   type Digest32V1,
   type EvmAddressV1,
+  type ContextGraphPolicyV1,
+  type MemberRosterV1,
   type SignedControlEnvelopeV1,
 } from '@origintrail-official/dkg-core';
 import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dkg-chain';
@@ -31,7 +34,52 @@ const POLICY_DIGEST = `0x${'73'.repeat(32)}` as Digest32V1;
 const SEAL_DIGEST = `0x${'44'.repeat(32)}` as Digest32V1;
 const UTF8 = new TextEncoder();
 
-async function providerFixture() {
+function acceptedPrivatePolicy(options: {
+  era?: string;
+  includeAuthor?: boolean;
+} = {}) {
+  const era = options.era ?? '0';
+  const policy = {
+    networkId: 'otp:20430',
+    contextGraphId: CONTEXT_GRAPH_ID,
+    governanceChainId: null,
+    governanceContractAddress: null,
+    ownershipTransitionDigest: null,
+    era,
+    version: '0',
+    previousPolicyDigest: null,
+    accessPolicy: 1,
+    publishPolicy: 1,
+    publishAuthority: null,
+    publishAuthorityAccountId: '0',
+    projectionId: CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
+    administrativeDelegationDigest: null,
+    source: {
+      kind: 'owner-signed-unregistered',
+      ownerAddress: AUTHOR,
+      ownerAuthorityEra: era,
+    },
+    effectiveAt: '0',
+    issuedAt: '0',
+  } as ContextGraphPolicyV1;
+  const roster = {
+    networkId: policy.networkId,
+    contextGraphId: policy.contextGraphId,
+    ownershipTransitionDigest: policy.ownershipTransitionDigest,
+    era: policy.era,
+    version: '0',
+    previousRosterDigest: null,
+    policyDigest: POLICY_DIGEST,
+    administrativeDelegationDigest: policy.administrativeDelegationDigest,
+    members: options.includeAuthor === false
+      ? []
+      : [{ agentAddress: AUTHOR, roles: ['holder', 'provider'] }],
+    issuedAt: '0',
+  } as MemberRosterV1;
+  return Object.freeze({ policy, policyDigest: POLICY_DIGEST, roster });
+}
+
+async function providerFixture(accepted = acceptedPrivatePolicy()) {
   const catalogScope = {
     networkId: 'otp:20430',
     contextGraphId: CONTEXT_GRAPH_ID,
@@ -119,6 +167,7 @@ async function providerFixture() {
   const resolve = createRfc64CatalogNativeScopedReadProviderV1({
     controlObjects: { getVerifiedObjectByDigest: controlRead } as never,
     kaBundles: { readKaBundleByDigest: bundleRead },
+    resolveAcceptedPolicySnapshot: async () => accepted,
   });
   const scope = Object.freeze({
     networkId: successor.head.payload.networkId,
@@ -206,6 +255,18 @@ describe('RFC-64 catalog native scoped read provider v1', () => {
     const delegationDigest = fixture.delegation.objectDigest;
     fixture.controlRead.mockImplementation(async ({ objectDigest }) =>
       objectDigest === delegationDigest ? null : fixture.stored.get(objectDigest) ?? null);
+    await expect(fixture.resolve(fixture.scope)).resolves.toBeNull();
+    expect(fixture.bundleRead).not.toHaveBeenCalled();
+  });
+
+  it('refuses a retained head from an old accepted-policy era', async () => {
+    const fixture = await providerFixture(acceptedPrivatePolicy({ era: '1' }));
+    await expect(fixture.resolve(fixture.scope)).resolves.toBeNull();
+    expect(fixture.bundleRead).not.toHaveBeenCalled();
+  });
+
+  it('refuses a head whose author is absent from the current private roster', async () => {
+    const fixture = await providerFixture(acceptedPrivatePolicy({ includeAuthor: false }));
     await expect(fixture.resolve(fixture.scope)).resolves.toBeNull();
     expect(fixture.bundleRead).not.toHaveBeenCalled();
   });

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -325,7 +325,7 @@ function privateCatalogPolicy(): ContextGraphPolicyV1 {
     governanceChainId: null,
     governanceContractAddress: null,
     ownershipTransitionDigest: null,
-    era: '7',
+    era: '0',
     version: '0',
     previousPolicyDigest: null,
     accessPolicy: 1,
@@ -2091,11 +2091,12 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       catalogIssuerDelegationEffectiveAt: DELEGATION_EFFECTIVE_AT,
       catalogIssuerDelegationExpiresAt: MULTI_DELEGATION_EXPIRES_AT,
     } as const;
-    await expect(configured.publishAuthorCatalogGenesisV1({
+    const published = await configured.publishAuthorCatalogGenesisV1({
       ...privateGenesis,
       peers: ['12D3KooPrivateReceiver'],
-    })).rejects.toThrow(/private catalog peer fan-out requires scope-bound/u);
-    const published = await configured.publishAuthorCatalogGenesisV1(privateGenesis);
+    });
+    expect(published.announcedPeers).toEqual([]);
+    expect(published.failedPeers).toHaveLength(1);
     expect(published.announcement).toMatchObject({
       policyDigest,
       subGraphName: 'service-lane',
@@ -2120,11 +2121,12 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     } as const;
     await expect(configured.publishOpenAuthorCatalogExactSetSuccessorV1(privateSuccessor))
       .rejects.toThrow(/public\/open compatibility successor requires the root lane/u);
-    await expect(configured.publishAuthorCatalogExactSetSuccessorV1({
+    const successor = await configured.publishAuthorCatalogExactSetSuccessorV1({
       ...privateSuccessor,
       peers: ['12D3KooPrivateReceiver'],
-    })).rejects.toThrow(/private catalog peer fan-out requires scope-bound/u);
-    const successor = await configured.publishAuthorCatalogExactSetSuccessorV1(privateSuccessor);
+    });
+    expect(successor.announcedPeers).toEqual([]);
+    expect(successor.failedPeers).toHaveLength(1);
     expect(successor).toMatchObject({
       announcement: {
         policyDigest,

--- a/packages/agent/test/rfc64-finalized-policy-agent-precommit-v1.test.ts
+++ b/packages/agent/test/rfc64-finalized-policy-agent-precommit-v1.test.ts
@@ -1,4 +1,8 @@
-import type { ContextGraphPolicyV1 } from '@origintrail-official/dkg-core';
+import type {
+  ContextGraphPolicyV1,
+  Digest32V1,
+  MemberRosterV1,
+} from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -18,6 +22,7 @@ import {
   RFC64_VM_KA_STORAGE,
   RFC64_VM_NETWORK_ID,
   RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID,
+  RFC64_VM_POLICY_DIGEST,
 } from './support/rfc64-finalized-vm-placement-fixture.js';
 import {
   acceptedRfc64VmPolicySnapshot,
@@ -99,6 +104,50 @@ function acceptedPolicyWith(
   });
 }
 
+function privateOwnerSnapshot(policyDigest = RFC64_VM_POLICY_DIGEST) {
+  const accepted = acceptedRfc64VmPolicySnapshot();
+  const policy = Object.freeze({
+    ...accepted.policy,
+    governanceChainId: null,
+    governanceContractAddress: null,
+    accessPolicy: 1 as const,
+    source: Object.freeze({
+      kind: 'owner-signed-unregistered' as const,
+      ownerAddress: RFC64_VM_AUTHOR,
+      ownerAuthorityEra: '0' as const,
+    }),
+  });
+  const roster = Object.freeze({
+    networkId: policy.networkId,
+    contextGraphId: policy.contextGraphId,
+    ownershipTransitionDigest: policy.ownershipTransitionDigest,
+    era: policy.era,
+    version: '0',
+    previousRosterDigest: null,
+    policyDigest,
+    administrativeDelegationDigest: policy.administrativeDelegationDigest,
+    members: Object.freeze([Object.freeze({
+      agentAddress: RFC64_VM_AUTHOR,
+      roles: Object.freeze(['provider'] as const),
+    })]),
+    issuedAt: '1700000000000',
+  }) satisfies MemberRosterV1;
+  return Object.freeze({ policy, policyDigest, roster });
+}
+
+function privateOwnerPlan(policyDigest = RFC64_VM_POLICY_DIGEST) {
+  const base = rfc64FinalizedVmPrecommitPlan();
+  return Object.freeze({
+    ...base,
+    policyDigest,
+    catalogScope: Object.freeze({
+      ...base.catalogScope,
+      governanceChainId: null,
+      governanceContractAddress: null,
+    }),
+  });
+}
+
 describe('RFC-64 finalized policy agent precommit', () => {
   it('accepts a chain-bound SWM catalog without invoking VM materialization', async () => {
     const getOnChainContextGraphId = vi.fn(async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID);
@@ -161,12 +210,86 @@ describe('RFC-64 finalized policy agent precommit', () => {
       getEvmChainId,
     });
 
+    const finalizedPlan = rfc64FinalizedVmPrecommitPlan();
     await expect(handler(
-      rfc64FinalizedVmPrecommitPlan(),
+      Object.freeze({
+        ...finalizedPlan,
+        catalogScope: Object.freeze({
+          ...finalizedPlan.catalogScope,
+          governanceChainId: null,
+          governanceContractAddress: null,
+        }),
+      }),
       new AbortController().signal,
     )).resolves.toBeUndefined();
     expect(getOnChainContextGraphId).not.toHaveBeenCalled();
     expect(getEvmChainId).not.toHaveBeenCalled();
+  });
+
+  it('accepts a private unregistered SWM catalog only with its exact current roster', async () => {
+    const current = privateOwnerSnapshot();
+    const acceptedPolicySnapshotForCatalogScope = vi.fn(() => current);
+    const getOnChainContextGraphId = vi.fn(async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID);
+    const getEvmChainId = vi.fn(async () => BigInt(RFC64_VM_CHAIN_ID));
+    const handler = createRfc64FinalizedPolicyAgentPrecommitV1({
+      ...options(),
+      acceptedPolicySnapshotForCatalogScope,
+      getOnChainContextGraphId,
+      getEvmChainId,
+    });
+
+    await expect(handler(
+      privateOwnerPlan(),
+      new AbortController().signal,
+    )).resolves.toBeUndefined();
+    expect(acceptedPolicySnapshotForCatalogScope).toHaveBeenCalledTimes(2);
+    expect(getOnChainContextGraphId).not.toHaveBeenCalled();
+    expect(getEvmChainId).not.toHaveBeenCalled();
+  });
+
+  it('rejects private SWM when the roster is missing or the policy changes before commit', async () => {
+    const exact = privateOwnerSnapshot();
+    const missingRoster = createRfc64FinalizedPolicyAgentPrecommitV1({
+      ...options(),
+      acceptedPolicySnapshotForCatalogScope: () => Object.freeze({
+        ...exact,
+        roster: null,
+      }),
+    });
+    await expect(missingRoster(
+      privateOwnerPlan(),
+      new AbortController().signal,
+    )).rejects.toThrow(/exact current policy-bound roster/u);
+
+    const successorDigest = `0x${'a7'.repeat(32)}` as Digest32V1;
+    const acceptedPolicySnapshotForCatalogScope = vi.fn()
+      .mockReturnValueOnce(exact)
+      .mockReturnValue(privateOwnerSnapshot(successorDigest));
+    const changed = createRfc64FinalizedPolicyAgentPrecommitV1({
+      ...options(),
+      acceptedPolicySnapshotForCatalogScope,
+    });
+    await expect(changed(
+      privateOwnerPlan(),
+      new AbortController().signal,
+    )).rejects.toThrow(/accepted policy changed/u);
+  });
+
+  it('fails closed for registered private catalogs in Release 1', async () => {
+    const base = acceptedRfc64VmPolicySnapshot();
+    const privateFinalized = Object.freeze({
+      ...base,
+      policy: Object.freeze({ ...base.policy, accessPolicy: 1 as const }),
+      roster: privateOwnerSnapshot().roster,
+    });
+    const handler = createRfc64FinalizedPolicyAgentPrecommitV1({
+      ...options(),
+      acceptedPolicySnapshotForCatalogScope: () => privateFinalized,
+    });
+    await expect(handler(
+      rfc64FinalizedVmPrecommitPlan(),
+      new AbortController().signal,
+    )).rejects.toThrow(/does not activate registered private/u);
   });
 
   it('rejects a missing CG mapping or a different live chain', async () => {

--- a/packages/agent/test/rfc64-precommit-owner-attribution.test.ts
+++ b/packages/agent/test/rfc64-precommit-owner-attribution.test.ts
@@ -114,6 +114,7 @@ function plan(): Rfc64PublicCatalogNativeBeforeAppliedHeadCommitPlanV1 {
       era: '0',
       bucketCount: '1',
     }),
+    policyDigest: RFC64_VM_POLICY_DIGEST,
     catalogHeadDigest: `0x${'91'.repeat(32)}`,
     inventoryDigest: `0x${'92'.repeat(32)}`,
     rows: Object.freeze([]),

--- a/packages/agent/test/rfc64-private-catalog-activation-config-v1.test.ts
+++ b/packages/agent/test/rfc64-private-catalog-activation-config-v1.test.ts
@@ -33,6 +33,7 @@ const LOCAL = '0x2222222222222222222222222222222222222222' as EvmAddressV1;
 const PROVIDER = '0x3333333333333333333333333333333333333333' as EvmAddressV1;
 const OUTSIDER = '0x4444444444444444444444444444444444444444' as EvmAddressV1;
 const PROVIDER_PEER = '12D3KooPrivateProvider';
+const HOLDER_PEER = '12D3KooPrivateHolder';
 
 function policy(contextGraphId: ContextGraphIdV1, accessPolicy: 0 | 1): ContextGraphPolicyV1 {
   return {
@@ -224,6 +225,25 @@ describe('RFC-64 Release 1 private catalog activation', () => {
     expect(() => resolveRfc64CatalogActivationConfigV1(privateActivation({
       roster: rosterEnvelope(envelope, { providerRole: false }),
     }), chainIdentity)).toThrow(/not a current roster provider/u);
+  });
+
+  it('allows a provider to bind a holder-only current member for inbound reads', () => {
+    const activation = privateActivation({ localAgentAddress: PROVIDER });
+    const resolved = resolveRfc64CatalogActivationConfigV1({
+      ...activation,
+      accessPolicyAuthority: {
+        ...activation.accessPolicyAuthority,
+        peerAgentBindings: [
+          ...activation.accessPolicyAuthority.peerAgentBindings,
+          { peerId: HOLDER_PEER, agentAddress: LOCAL },
+        ],
+      },
+    }, chainIdentity);
+
+    expect(resolved.accessPolicyAuthority?.peerAgentBindings).toContainEqual({
+      peerId: HOLDER_PEER,
+      agentAddress: LOCAL,
+    });
   });
 
   it('keeps every private target on the one complete provider and in the roster', () => {

--- a/packages/agent/test/rfc64-private-catalog-activation-config-v1.test.ts
+++ b/packages/agent/test/rfc64-private-catalog-activation-config-v1.test.ts
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import {
+  CONTEXT_GRAPH_POLICY_OBJECT_TYPE_V1,
+  CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
+  MEMBER_ROSTER_OBJECT_TYPE_V1,
+  computeContextGraphPolicyObjectDigestV1,
+  type ContextGraphIdV1,
+  type ContextGraphPolicyV1,
+  type EvmAddressV1,
+  type MemberRosterV1,
+  type NetworkIdV1,
+  type UnsignedContextGraphPolicyEnvelopeV1,
+  type UnsignedMemberRosterEnvelopeV1,
+} from '@origintrail-official/dkg-core';
+
+import {
+  resolveRfc64CatalogActivationConfigV1,
+  resolveRfc64CatalogActivationsV1,
+  resolveRfc64PublicCatalogActivationChainIdentityV1,
+} from '../src/rfc64/public-catalog-activation-config-v1.js';
+
+const NETWORK = 'otp:20430' as NetworkIdV1;
+const PRIVATE_CG = (
+  '0x1111111111111111111111111111111111111111/private-release-1'
+) as ContextGraphIdV1;
+const PUBLIC_CG = (
+  '0x1111111111111111111111111111111111111111/public-compat'
+) as ContextGraphIdV1;
+const OWNER = '0x1111111111111111111111111111111111111111' as EvmAddressV1;
+const LOCAL = '0x2222222222222222222222222222222222222222' as EvmAddressV1;
+const PROVIDER = '0x3333333333333333333333333333333333333333' as EvmAddressV1;
+const OUTSIDER = '0x4444444444444444444444444444444444444444' as EvmAddressV1;
+const PROVIDER_PEER = '12D3KooPrivateProvider';
+
+function policy(contextGraphId: ContextGraphIdV1, accessPolicy: 0 | 1): ContextGraphPolicyV1 {
+  return {
+    networkId: NETWORK,
+    contextGraphId,
+    governanceChainId: null,
+    governanceContractAddress: null,
+    ownershipTransitionDigest: null,
+    era: '0',
+    version: '0',
+    previousPolicyDigest: null,
+    accessPolicy,
+    publishPolicy: 1,
+    publishAuthority: null,
+    publishAuthorityAccountId: '0',
+    projectionId: CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
+    administrativeDelegationDigest: null,
+    source: {
+      kind: 'owner-signed-unregistered',
+      ownerAddress: OWNER,
+      ownerAuthorityEra: '0',
+    },
+    effectiveAt: '0',
+    issuedAt: '0',
+  };
+}
+
+function policyEnvelope(input: ContextGraphPolicyV1): UnsignedContextGraphPolicyEnvelopeV1 {
+  return {
+    issuer: OWNER,
+    objectType: CONTEXT_GRAPH_POLICY_OBJECT_TYPE_V1,
+    payload: input,
+    signatureEvidence: { kind: 'none' },
+    signatureSuite: 'eip191-personal-sign-digest-v1',
+  };
+}
+
+function rosterEnvelope(
+  acceptedPolicyEnvelope: UnsignedContextGraphPolicyEnvelopeV1,
+  options: { localMember?: boolean; providerRole?: boolean } = {},
+): UnsignedMemberRosterEnvelopeV1 {
+  const policyDigest = computeContextGraphPolicyObjectDigestV1(acceptedPolicyEnvelope);
+  const payload: MemberRosterV1 = {
+    networkId: acceptedPolicyEnvelope.payload.networkId,
+    contextGraphId: acceptedPolicyEnvelope.payload.contextGraphId,
+    ownershipTransitionDigest: acceptedPolicyEnvelope.payload.ownershipTransitionDigest,
+    era: acceptedPolicyEnvelope.payload.era,
+    version: '0',
+    previousRosterDigest: null,
+    policyDigest,
+    administrativeDelegationDigest:
+      acceptedPolicyEnvelope.payload.administrativeDelegationDigest,
+    members: [
+      ...(options.localMember === false
+        ? []
+        : [{ agentAddress: LOCAL, roles: ['holder'] as const }]),
+      {
+        agentAddress: PROVIDER,
+        roles: options.providerRole === false
+          ? ['holder'] as const
+          : ['holder', 'provider'] as const,
+      },
+    ],
+    issuedAt: '0',
+  };
+  return {
+    issuer: OWNER,
+    objectType: MEMBER_ROSTER_OBJECT_TYPE_V1,
+    payload,
+    signatureEvidence: { kind: 'none' },
+    signatureSuite: 'eip191-personal-sign-digest-v1',
+  };
+}
+
+function privateActivation(options: {
+  roster?: UnsignedMemberRosterEnvelopeV1;
+  localAgentAddress?: EvmAddressV1;
+  boundAgentAddress?: EvmAddressV1;
+} = {}) {
+  const envelope = policyEnvelope(policy(PRIVATE_CG, 1));
+  return {
+    bootstrap: {
+      acceptedPolicies: [{
+        policyEnvelope: envelope,
+        rosterEnvelope: options.roster ?? rosterEnvelope(envelope),
+        targets: [{ authorAddress: PROVIDER, providers: [PROVIDER_PEER] }],
+        completeSwmProviders: [PROVIDER_PEER],
+      }],
+      retryIntervalMs: 1_000,
+    },
+    accessPolicyAuthority: {
+      localAgentAddress: options.localAgentAddress ?? LOCAL,
+      peerAgentBindings: [{
+        peerId: PROVIDER_PEER,
+        agentAddress: options.boundAgentAddress ?? PROVIDER,
+      }],
+    },
+  } as const;
+}
+
+const chainIdentity = resolveRfc64PublicCatalogActivationChainIdentityV1(NETWORK);
+
+describe('RFC-64 Release 1 private catalog activation', () => {
+  it('accepts one exact private policy, roster, provider, and local member', () => {
+    const resolved = resolveRfc64CatalogActivationConfigV1(
+      privateActivation(),
+      chainIdentity,
+    );
+
+    expect(resolved).toMatchObject({
+      enabled: true,
+      selectedContextGraphs: [PRIVATE_CG],
+      selectedPublicContextGraphs: [],
+      selectedPrivateContextGraphs: [PRIVATE_CG],
+      accessPolicyAuthority: {
+        localAgentAddress: LOCAL,
+        peerAgentBindings: [{ peerId: PROVIDER_PEER, agentAddress: PROVIDER }],
+      },
+    });
+    expect(resolved.bootstrap?.acceptedPolicies[0]?.rosterEnvelope?.payload.policyDigest)
+      .toBe(computeContextGraphPolicyObjectDigestV1(
+        resolved.bootstrap.acceptedPolicies[0]!.policyEnvelope,
+      ));
+    expect(Object.isFrozen(resolved.bootstrap?.acceptedPolicies[0]?.rosterEnvelope)).toBe(true);
+  });
+
+  it('rejects registered private policies before the Release 1 runtime starts', () => {
+    const registeredPolicy: ContextGraphPolicyV1 = {
+      ...policy(PRIVATE_CG, 1),
+      governanceChainId: '20430',
+      governanceContractAddress: OUTSIDER,
+      source: {
+        kind: 'finalized-chain',
+        chainId: '20430',
+        contractAddress: OUTSIDER,
+        blockNumber: '42',
+        blockHash: `0x${'55'.repeat(32)}`,
+      },
+    };
+    const registeredEnvelope = policyEnvelope(registeredPolicy);
+    const activation = privateActivation({
+      roster: rosterEnvelope(registeredEnvelope),
+    });
+    expect(() => resolveRfc64CatalogActivationConfigV1({
+      ...activation,
+      bootstrap: {
+        ...activation.bootstrap,
+        acceptedPolicies: [{
+          ...activation.bootstrap.acceptedPolicies[0],
+          policyEnvelope: registeredEnvelope,
+        }],
+      },
+    }, chainIdentity)).toThrow(/only owner-signed unregistered policies/u);
+  });
+
+  it('fails closed on missing or policy-mismatched private roster authority', () => {
+    const activation = privateActivation();
+    expect(() => resolveRfc64CatalogActivationConfigV1({
+      ...activation,
+      bootstrap: {
+        acceptedPolicies: [{
+          ...activation.bootstrap.acceptedPolicies[0],
+          rosterEnvelope: undefined,
+        }],
+      },
+    } as never, chainIdentity)).toThrow(/private policies require rosterEnvelope/u);
+
+    const mismatched = rosterEnvelope(policyEnvelope(policy(PUBLIC_CG, 1)));
+    expect(() => resolveRfc64CatalogActivationConfigV1(
+      privateActivation({ roster: mismatched }),
+      chainIdentity,
+    )).toThrow(/not bound to the exact accepted policy/u);
+  });
+
+  it('requires exact bound current provider and local membership', () => {
+    expect(() => resolveRfc64CatalogActivationConfigV1({
+      ...privateActivation(),
+      accessPolicyAuthority: {
+        localAgentAddress: LOCAL,
+        peerAgentBindings: [],
+      },
+    }, chainIdentity)).toThrow(/has no exact peerAgentBinding/u);
+
+    const envelope = policyEnvelope(policy(PRIVATE_CG, 1));
+    expect(() => resolveRfc64CatalogActivationConfigV1(privateActivation({
+      roster: rosterEnvelope(envelope, { localMember: false }),
+    }), chainIdentity)).toThrow(/localAgentAddress is not a current member/u);
+
+    expect(() => resolveRfc64CatalogActivationConfigV1(privateActivation({
+      roster: rosterEnvelope(envelope, { providerRole: false }),
+    }), chainIdentity)).toThrow(/not a current roster provider/u);
+  });
+
+  it('keeps every private target on the one complete provider and in the roster', () => {
+    const activation = privateActivation();
+    expect(() => resolveRfc64CatalogActivationConfigV1({
+      ...activation,
+      bootstrap: {
+        ...activation.bootstrap,
+        acceptedPolicies: [{
+          ...activation.bootstrap.acceptedPolicies[0],
+          targets: [{ authorAddress: PROVIDER, providers: ['12D3KooOtherProvider'] }],
+        }],
+      },
+    }, chainIdentity)).toThrow(/must use the one completeSwmProvider/u);
+
+    expect(() => resolveRfc64CatalogActivationConfigV1({
+      ...activation,
+      bootstrap: {
+        ...activation.bootstrap,
+        acceptedPolicies: [{
+          ...activation.bootstrap.acceptedPolicies[0],
+          targets: [{ authorAddress: OUTSIDER, providers: [PROVIDER_PEER] }],
+        }],
+      },
+    }, chainIdentity)).toThrow(/target author is not a current roster member/u);
+  });
+
+  it('keeps public compatibility, unions disjoint blocks, and rejects overlap conflicts', () => {
+    const publicEnvelope = policyEnvelope(policy(PUBLIC_CG, 0));
+    const publicCatalog = {
+      bootstrap: {
+        acceptedPublicPolicies: [{ policyEnvelope: publicEnvelope, targets: [] }],
+        retryIntervalMs: 1_000,
+      },
+    } as const;
+    const union = resolveRfc64CatalogActivationsV1({
+      catalog: privateActivation(),
+      publicCatalog,
+    }, chainIdentity);
+    expect(union.catalog.selectedContextGraphs).toEqual([PUBLIC_CG, PRIVATE_CG]);
+    expect(union.publicCatalog.selectedContextGraphs).toEqual([PUBLIC_CG]);
+
+    const conflictingPublic = {
+      bootstrap: {
+        acceptedPublicPolicies: [{
+          policyEnvelope: policyEnvelope(policy(PRIVATE_CG, 0)),
+          targets: [],
+        }],
+        retryIntervalMs: 1_000,
+      },
+    } as const;
+    expect(() => resolveRfc64CatalogActivationsV1({
+      catalog: privateActivation(),
+      publicCatalog: conflictingPublic,
+    }, chainIdentity)).toThrow(/conflict for selected graph/u);
+  });
+});

--- a/packages/agent/test/rfc64-private-catalog-native-scoped-transport-v1.test.ts
+++ b/packages/agent/test/rfc64-private-catalog-native-scoped-transport-v1.test.ts
@@ -1,0 +1,421 @@
+import {
+  AUTHOR_CATALOG_DIRECTORY_NODE_OBJECT_TYPE_V1,
+  ProtocolRouter,
+  encodeOpaqueKaBundleV1,
+  type AuthorCatalogScopeV1,
+  type ContextGraphIdV1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type SignedControlEnvelopeV1,
+} from '@origintrail-official/dkg-core';
+import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dkg-chain';
+import { ethers } from 'ethers';
+import { describe, expect, it, vi } from 'vitest';
+
+import { produceEmptyAuthorCatalogGenesisV1 } from '../src/rfc64/author-catalog-producer.js';
+import {
+  RFC64_CATALOG_BUNDLE_FETCH_PROTOCOL_V2,
+  RFC64_CATALOG_OBJECT_FETCH_PROTOCOL_V2,
+  RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_KIND_V1,
+  RFC64_PUBLIC_CATALOG_OBJECT_FETCH_KIND_V1,
+  RFC64_PUBLIC_CATALOG_OBJECT_FETCH_PROTOCOL_V1,
+  Rfc64PublicCatalogNativeTransportV1,
+  encodeRfc64PublicCatalogObjectFetchRequestV1,
+  type Rfc64CatalogNativeScopedReadCapabilityV1,
+  type Rfc64PublicCatalogNativeFetchScopeV1,
+} from '../src/rfc64/public-catalog-native-transport-v1.js';
+import { mintRfc64CatalogNativeScopedReadCapabilityV1 } from '../src/rfc64/catalog-native-scoped-read-capability-v1-internal.js';
+import { createRfc64CatalogAccessPolicyRegistryFixture } from './support/rfc64-catalog-access-policy-fixture.js';
+
+const AUTHOR_WALLET = new ethers.Wallet(`0x${'65'.repeat(32)}`);
+const AUTHOR = AUTHOR_WALLET.address.toLowerCase() as EvmAddressV1;
+const LOCAL_MEMBER = '0x3333333333333333333333333333333333333333' as EvmAddressV1;
+const REMOTE_MEMBER = '0x4444444444444444444444444444444444444444' as EvmAddressV1;
+const CURATOR = '0x5555555555555555555555555555555555555555' as EvmAddressV1;
+const POLICY_DIGEST = `0x${'73'.repeat(32)}` as Digest32V1;
+const DELEGATION_DIGEST = `0x${'74'.repeat(32)}` as Digest32V1;
+const UTF8 = new TextEncoder();
+
+type NativeHandler = (data: Uint8Array, peerId: { toString(): string }) => Promise<Uint8Array>;
+
+class MemoryProtocolRouter {
+  readonly handlers = new Map<string, NativeHandler>();
+  readonly sentProtocols: string[] = [];
+  remote: MemoryProtocolRouter | null = null;
+
+  constructor(readonly peerId: string) {}
+
+  register(protocol: string, handler: NativeHandler): void {
+    this.handlers.set(protocol, handler);
+  }
+
+  unregister(protocol: string): void {
+    this.handlers.delete(protocol);
+  }
+
+  async send(
+    _remotePeerId: string,
+    protocol: string,
+    data: Uint8Array,
+  ): Promise<Uint8Array> {
+    this.sentProtocols.push(protocol);
+    const handler = this.remote?.handlers.get(protocol);
+    if (handler === undefined) throw new Error(`missing in-memory handler for ${protocol}`);
+    return handler(data, { toString: () => this.peerId });
+  }
+}
+
+function routerPair(): readonly [MemoryProtocolRouter, MemoryProtocolRouter] {
+  const provider = new MemoryProtocolRouter('provider-peer');
+  const receiver = new MemoryProtocolRouter('receiver-peer');
+  provider.remote = receiver;
+  receiver.remote = provider;
+  return [provider, receiver];
+}
+
+async function contentFixture() {
+  const produced = await produceEmptyAuthorCatalogGenesisV1({
+    scope: {
+      networkId: 'otp:20430',
+      contextGraphId: '0x1111111111111111111111111111111111111111/private-scoped',
+      governanceChainId: null,
+      governanceContractAddress: null,
+      ownershipTransitionDigest: null,
+      subGraphName: 'member-subgraph',
+      authorAddress: AUTHOR,
+      era: '0',
+      bucketCount: '1',
+    } as AuthorCatalogScopeV1,
+    catalogIssuerDelegationDigest: DELEGATION_DIGEST,
+    issuedAt: '1773900000000',
+    signer: {
+      issuer: AUTHOR,
+      signDigest: async (digest) => AUTHOR_WALLET.signMessage(digest),
+    },
+  });
+  const catalogObjects = new Map<string, SignedControlEnvelopeV1>(
+    produced.stagedObjects.map((envelope) => [envelope.objectDigest, envelope]),
+  );
+  const bundle = encodeOpaqueKaBundleV1(UTF8.encode('private payload'), new Uint8Array());
+  const scope = Object.freeze({
+    networkId: produced.head.payload.networkId,
+    contextGraphId: produced.head.payload.contextGraphId,
+    subGraphName: produced.head.payload.subGraphName,
+    authorAddress: produced.head.payload.authorAddress,
+    catalogEra: produced.head.payload.era,
+    catalogVersion: produced.head.payload.version,
+    policyDigest: POLICY_DIGEST,
+    catalogHeadObjectDigest: produced.head.objectDigest,
+  }) satisfies Rfc64PublicCatalogNativeFetchScopeV1;
+  return { produced, catalogObjects, bundle, scope };
+}
+
+function privateRegistry(
+  localAgentAddress: EvmAddressV1,
+  remoteAgentAddress: EvmAddressV1,
+  contextGraphId: ContextGraphIdV1,
+) {
+  return createRfc64CatalogAccessPolicyRegistryFixture({
+    localAgentAddress,
+    remoteAgentAddress,
+    contextGraphId,
+    accessPolicy: 1,
+    publishPolicy: 0,
+    policyDigest: POLICY_DIGEST,
+    ownerAddress: AUTHOR,
+    curatorAddress: CURATOR,
+  });
+}
+
+function capability(
+  scope: Rfc64PublicCatalogNativeFetchScopeV1,
+  readCatalogObjectByDigest: Rfc64CatalogNativeScopedReadCapabilityV1['readCatalogObjectByDigest'],
+  readKaBundleByDigest: Rfc64CatalogNativeScopedReadCapabilityV1['readKaBundleByDigest'],
+): Rfc64CatalogNativeScopedReadCapabilityV1 {
+  return mintRfc64CatalogNativeScopedReadCapabilityV1({
+    scope,
+    readCatalogObjectByDigest,
+    readKaBundleByDigest,
+  });
+}
+
+function requestCatalogObject(
+  scope: Rfc64PublicCatalogNativeFetchScopeV1,
+  objectDigest: Digest32V1,
+) {
+  return {
+    ...scope,
+    kind: RFC64_PUBLIC_CATALOG_OBJECT_FETCH_KIND_V1,
+    targetObjectType: AUTHOR_CATALOG_DIRECTORY_NODE_OBJECT_TYPE_V1,
+    targetObjectDigest: objectDigest,
+  } as const;
+}
+
+describe('RFC-64 private exact-scope native transport', () => {
+  it('serves catalog objects and bundles between current provider members', async () => {
+    const fixture = await contentFixture();
+    const [providerRouter, receiverRouter] = routerPair();
+    const readObject = vi.fn(async (digest: Digest32V1) => fixture.catalogObjects.get(digest) ?? null);
+    const readBundle = vi.fn(async (digest: Digest32V1) =>
+      digest === fixture.bundle.blobDigest ? fixture.bundle.bundleBytes : null);
+    const resolveCapability = vi.fn(async (scope: Rfc64PublicCatalogNativeFetchScopeV1) =>
+      capability(scope, readObject, readBundle));
+    const providerPolicy = privateRegistry(
+      LOCAL_MEMBER,
+      REMOTE_MEMBER,
+      fixture.scope.contextGraphId,
+    );
+    const receiverPolicy = privateRegistry(
+      REMOTE_MEMBER,
+      LOCAL_MEMBER,
+      fixture.scope.contextGraphId,
+    );
+    const provider = new Rfc64PublicCatalogNativeTransportV1(
+      providerRouter as unknown as ProtocolRouter,
+      {
+        resolveScopedReadCapability: resolveCapability,
+        authorizeCatalogOperation: providerPolicy.authorize,
+        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+      },
+    );
+    const receiver = new Rfc64PublicCatalogNativeTransportV1(
+      receiverRouter as unknown as ProtocolRouter,
+      {
+        readCatalogObjectByDigest: async () => null,
+        readKaBundleByDigest: async () => null,
+        authorizeCatalogOperation: receiverPolicy.authorize,
+        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+      },
+    );
+    provider.start();
+    receiver.start();
+
+    expect(provider.privateScopeBoundReadsConfigured).toBe(true);
+    const root = fixture.produced.directoryPath[0]!;
+    await expect(receiver.fetchCatalogObject(
+      providerRouter.peerId,
+      requestCatalogObject(fixture.scope, root.objectDigest as Digest32V1),
+    )).resolves.toMatchObject({ envelope: root });
+    await expect(receiver.fetchKaBundle(providerRouter.peerId, {
+      ...fixture.scope,
+      kind: RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_KIND_V1,
+      blobDigest: fixture.bundle.blobDigest,
+      byteLength: fixture.bundle.bundleBytes.byteLength.toString() as never,
+    })).resolves.toEqual(fixture.bundle.bundleBytes);
+    expect(resolveCapability).toHaveBeenCalledTimes(2);
+    expect(readObject).toHaveBeenCalledWith(root.objectDigest);
+    expect(readBundle).toHaveBeenCalledWith(fixture.bundle.blobDigest);
+    expect(receiverRouter.sentProtocols).toEqual([
+      RFC64_CATALOG_OBJECT_FETCH_PROTOCOL_V2,
+      RFC64_CATALOG_BUNDLE_FETCH_PROTOCOL_V2,
+    ]);
+
+    const v1Response = await receiverRouter.send(
+      providerRouter.peerId,
+      RFC64_PUBLIC_CATALOG_OBJECT_FETCH_PROTOCOL_V1,
+      encodeRfc64PublicCatalogObjectFetchRequestV1(
+        requestCatalogObject(fixture.scope, root.objectDigest as Digest32V1),
+      ),
+    );
+    expect(v1Response).toEqual(Uint8Array.of(2));
+    expect(resolveCapability).toHaveBeenCalledTimes(2);
+
+    receiver.stop();
+    provider.stop();
+  });
+
+  it.each([
+    { label: 'outsider', providerAuthorization: async () => null },
+    {
+      label: 'cross-CG member',
+      providerAuthorization: undefined,
+    },
+  ])('denies $label before scoped capability resolution or digest lookup', async ({ label, providerAuthorization }) => {
+    const fixture = await contentFixture();
+    const [providerRouter, receiverRouter] = routerPair();
+    const readObject = vi.fn(async () => null);
+    const resolveCapability = vi.fn(async (scope: Rfc64PublicCatalogNativeFetchScopeV1) =>
+      capability(scope, readObject, async () => null));
+    const providerPolicy = privateRegistry(
+      LOCAL_MEMBER,
+      REMOTE_MEMBER,
+      fixture.scope.contextGraphId,
+    );
+    const provider = new Rfc64PublicCatalogNativeTransportV1(
+      providerRouter as unknown as ProtocolRouter,
+      {
+        resolveScopedReadCapability: resolveCapability,
+        authorizeCatalogOperation: providerAuthorization ?? providerPolicy.authorize,
+        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+      },
+    );
+    const receiver = new Rfc64PublicCatalogNativeTransportV1(
+      receiverRouter as unknown as ProtocolRouter,
+      {
+        readCatalogObjectByDigest: async () => null,
+        readKaBundleByDigest: async () => null,
+        authorizeCatalogOperation: async () => ({ accessPolicy: 1, policyDigest: POLICY_DIGEST }),
+        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+      },
+    );
+    provider.start();
+    receiver.start();
+    const requestScope = label === 'cross-CG member'
+      ? {
+          ...fixture.scope,
+          contextGraphId:
+            '0x1111111111111111111111111111111111111111/another-private-cg' as ContextGraphIdV1,
+        }
+      : fixture.scope;
+
+    await expect(receiver.fetchCatalogObject(
+      providerRouter.peerId,
+      requestCatalogObject(
+        requestScope,
+        fixture.produced.directoryPath[0]!.objectDigest as Digest32V1,
+      ),
+    )).rejects.toThrow(/policy/u);
+    expect(resolveCapability).not.toHaveBeenCalled();
+    expect(readObject).not.toHaveBeenCalled();
+
+    receiver.stop();
+    provider.stop();
+  });
+
+  it('rechecks current private membership after capability resolution and before digest lookup', async () => {
+    const fixture = await contentFixture();
+    const [providerRouter, receiverRouter] = routerPair();
+    const readObject = vi.fn(async () => fixture.produced.directoryPath[0]!);
+    let current = true;
+    const provider = new Rfc64PublicCatalogNativeTransportV1(
+      providerRouter as unknown as ProtocolRouter,
+      {
+        resolveScopedReadCapability: async (scope) => {
+          current = false;
+          return capability(scope, readObject, async () => null);
+        },
+        authorizeCatalogOperation: async () => current
+          ? { accessPolicy: 1, policyDigest: POLICY_DIGEST }
+          : null,
+        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+      },
+    );
+    const receiver = new Rfc64PublicCatalogNativeTransportV1(
+      receiverRouter as unknown as ProtocolRouter,
+      {
+        readCatalogObjectByDigest: async () => null,
+        readKaBundleByDigest: async () => null,
+        authorizeCatalogOperation: async () => ({ accessPolicy: 1, policyDigest: POLICY_DIGEST }),
+        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+      },
+    );
+    provider.start();
+    receiver.start();
+
+    await expect(receiver.fetchCatalogObject(
+      providerRouter.peerId,
+      requestCatalogObject(
+        fixture.scope,
+        fixture.produced.directoryPath[0]!.objectDigest as Digest32V1,
+      ),
+    )).rejects.toThrow(/policy/u);
+    expect(readObject).not.toHaveBeenCalled();
+
+    receiver.stop();
+    provider.stop();
+  });
+
+  it.each([
+    {
+      label: 'catalog head',
+      mutate: (scope: Rfc64PublicCatalogNativeFetchScopeV1) => ({
+        ...scope,
+        catalogHeadObjectDigest: `0x${'99'.repeat(32)}` as Digest32V1,
+      }),
+    },
+    {
+      label: 'subgraph scope',
+      mutate: (scope: Rfc64PublicCatalogNativeFetchScopeV1) => ({
+        ...scope,
+        subGraphName: 'another-subgraph' as never,
+      }),
+    },
+  ])('rejects a capability for the wrong $label before digest lookup', async ({ mutate }) => {
+    const fixture = await contentFixture();
+    const [providerRouter, receiverRouter] = routerPair();
+    const readObject = vi.fn(async () => fixture.produced.directoryPath[0]!);
+    const provider = new Rfc64PublicCatalogNativeTransportV1(
+      providerRouter as unknown as ProtocolRouter,
+      {
+        resolveScopedReadCapability: async () =>
+          capability(fixture.scope, readObject, async () => null),
+        authorizeCatalogOperation: async () => ({ accessPolicy: 1, policyDigest: POLICY_DIGEST }),
+        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+      },
+    );
+    const receiver = new Rfc64PublicCatalogNativeTransportV1(
+      receiverRouter as unknown as ProtocolRouter,
+      {
+        readCatalogObjectByDigest: async () => null,
+        readKaBundleByDigest: async () => null,
+        authorizeCatalogOperation: async () => ({ accessPolicy: 1, policyDigest: POLICY_DIGEST }),
+        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+      },
+    );
+    provider.start();
+    receiver.start();
+
+    await expect(receiver.fetchCatalogObject(
+      providerRouter.peerId,
+      requestCatalogObject(
+        mutate(fixture.scope),
+        fixture.produced.directoryPath[0]!.objectDigest as Digest32V1,
+      ),
+    )).rejects.toThrow(/exact requested catalog head scope/u);
+    expect(readObject).not.toHaveBeenCalled();
+
+    receiver.stop();
+    provider.stop();
+  });
+
+  it('keeps legacy digest-only reads compatible for public V1', async () => {
+    const fixture = await contentFixture();
+    const [providerRouter, receiverRouter] = routerPair();
+    const readObject = vi.fn(async (digest: Digest32V1) => fixture.catalogObjects.get(digest) ?? null);
+    const publicAuthorization = async () => ({ accessPolicy: 0 as const, policyDigest: POLICY_DIGEST });
+    const provider = new Rfc64PublicCatalogNativeTransportV1(
+      providerRouter as unknown as ProtocolRouter,
+      {
+        readCatalogObjectByDigest: readObject,
+        readKaBundleByDigest: async () => null,
+        authorizeCatalogOperation: publicAuthorization,
+        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+      },
+    );
+    const receiver = new Rfc64PublicCatalogNativeTransportV1(
+      receiverRouter as unknown as ProtocolRouter,
+      {
+        readCatalogObjectByDigest: async () => null,
+        readKaBundleByDigest: async () => null,
+        authorizeCatalogOperation: publicAuthorization,
+        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+      },
+    );
+    provider.start();
+    receiver.start();
+
+    const root = fixture.produced.directoryPath[0]!;
+    await expect(receiver.fetchCatalogObject(
+      providerRouter.peerId,
+      requestCatalogObject(fixture.scope, root.objectDigest as Digest32V1),
+    )).resolves.toMatchObject({ envelope: root });
+    expect(provider.privateScopeBoundReadsConfigured).toBe(false);
+    expect(readObject).toHaveBeenCalledWith(root.objectDigest);
+    expect(receiverRouter.sentProtocols).toEqual([
+      RFC64_PUBLIC_CATALOG_OBJECT_FETCH_PROTOCOL_V1,
+    ]);
+
+    receiver.stop();
+    provider.stop();
+  });
+});

--- a/packages/agent/test/rfc64-public-catalog-current-head-discovery-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-current-head-discovery-v1.test.ts
@@ -21,6 +21,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { produceEmptyAuthorCatalogGenesisV1 } from '../src/rfc64/author-catalog-producer.js';
 import { snapshotRfc64ExactWireRecordV1 } from '../src/rfc64/catalog-transport-wire-v1-internal.js';
 import {
+  RFC64_PRIVATE_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V2,
   RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V1,
   RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1,
   Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1,
@@ -239,6 +240,52 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
       authorizeOpenCatalogOperation: legacy,
       verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
     })).toThrow(/exactly one catalog access-policy authorizer/u);
+  });
+
+  it('routes invite-only discovery to v2 and keeps private queries off the public handler', async () => {
+    const handlers = new Map<string, (
+      data: Uint8Array,
+      peerId: { toString(): string },
+    ) => Promise<Uint8Array>>();
+    const send = vi.fn(async () => Uint8Array.of(0));
+    const router = {
+      register(protocol: string, handler: (typeof handlers extends Map<string, infer H> ? H : never)) {
+        handlers.set(protocol, handler);
+      },
+      unregister(protocol: string) { handlers.delete(protocol); },
+      send,
+    } as unknown as ProtocolRouter;
+    const authorizeCatalogOperation = vi.fn(async () => Object.freeze({
+      ...directAuthorization(),
+      accessPolicy: 1 as const,
+    }));
+    const transport = new Rfc64PublicCatalogCurrentHeadDiscoveryTransportV1(router, {
+      controlObjects: { getVerifiedObjectByDigest: vi.fn(async () => null) },
+      readCurrentAppliedCatalogHeadDigest: vi.fn(async () => null),
+      authorizeCatalogOperation,
+      verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+    });
+    transport.start();
+    const query = Object.freeze({
+      kind: RFC64_PUBLIC_CATALOG_CURRENT_HEAD_QUERY_KIND_V1,
+      ...discoveryScope(),
+      policyDigest: POLICY_DIGEST,
+    }) satisfies Rfc64PublicCatalogCurrentHeadQueryV1;
+
+    await expect(transport.discoverCurrentCatalogHead('provider-peer', query))
+      .resolves.toBeNull();
+    expect(send).toHaveBeenCalledWith(
+      'provider-peer',
+      RFC64_PRIVATE_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V2,
+      expect.any(Uint8Array),
+      undefined,
+    );
+    await expect(handlers.get(RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V1)!(
+      encodeRfc64PublicCatalogCurrentHeadQueryV1(query),
+      { toString: () => 'requester-peer' },
+    )).resolves.toEqual(Uint8Array.of(2));
+    expect(authorizeCatalogOperation).toHaveBeenCalled();
+    transport.stop();
   });
 
   it('treats an unsorted expected-key declaration as an exact key set', () => {
@@ -761,27 +808,6 @@ describe('RFC-64 public catalog current-head discovery v1', () => {
     expect(readCurrentAppliedCatalogHeadDigest).toHaveBeenCalledTimes(2);
     expect(authorizeCatalogOperation).toHaveBeenCalledTimes(2);
     transport.stop();
-  });
-
-  it('rejects a non-root discovery claim through the shared public scope derivation', async () => {
-    const [node, persistence] = await Promise.all([
-      startNode(),
-      openPersistence('scope-derivation'),
-    ]);
-    const service = new Rfc64PublicCatalogServiceV1({
-      router: new ProtocolRouter(node),
-      controlObjects: persistence.controlObjects,
-      currentHeadDiscovery: { readCurrentAppliedCatalogHeadDigest: async () => null },
-      transportTimeoutMs: 1_000,
-    });
-    services.push(service);
-    acceptPolicy(service);
-    service.start();
-
-    await expect(service.discoverCurrentCatalogHead({
-      remotePeerId: 'unreachable-peer',
-      scope: Object.freeze({ ...discoveryScope(), subGraphName: 'nested' as const }),
-    })).rejects.toThrow(/accepted public root policy/);
   });
 
   it('rejects a canonical requester-side response outside the exact query scope', async () => {

--- a/packages/agent/test/rfc64-public-catalog-native-transport-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-transport-v1.test.ts
@@ -97,10 +97,8 @@ describe('RFC-64 public catalog native content transport v1', () => {
     ])).toThrow(/exceed.*ceiling/);
   });
 
-  // Only the publicly-readable cells are servable over the native content protocols: the serve path
-  // resolves by digest out of an agent-wide store and is not bound back to the authorizing graph, so
-  // private content stays denied (see requireCatalogPolicy). publishPolicy must not affect this —
-  // it governs finalized-VM admission only, never read/SWM authorization.
+  // The legacy V1 digest protocols remain public-only. publishPolicy must not
+  // affect this — it governs finalized-VM admission, never read authorization.
   it.each([
     { accessPolicy: 0 as const, publishPolicy: 0 as const },
     { accessPolicy: 0 as const, publishPolicy: 1 as const },
@@ -221,6 +219,9 @@ describe('RFC-64 public catalog native content transport v1', () => {
     expect(authorAuthorizations).toEqual([
       'catalog-object-fetch-inbound',
       'catalog-object-fetch-inbound',
+      'catalog-object-fetch-inbound',
+      'catalog-object-fetch-inbound',
+      'ka-bundle-fetch-inbound',
       'ka-bundle-fetch-inbound',
       'ka-bundle-fetch-inbound',
     ]);
@@ -280,7 +281,7 @@ describe('RFC-64 public catalog native content transport v1', () => {
     expect(providerRead).not.toHaveBeenCalled();
   }, 15_000);
 
-  it('denies a private-policy request before provider lookup on both content protocols', async () => {
+  it('denies a private-policy request before provider lookup on both V1 content protocols', async () => {
     const [authorNode, receiverNode] = await Promise.all([startNode(), startNode()]);
     await connect(receiverNode, authorNode);
     const providerObjectRead = vi.fn(async () => null);
@@ -290,10 +291,8 @@ describe('RFC-64 public catalog native content transport v1', () => {
       {
         readCatalogObjectByDigest: providerObjectRead,
         readKaBundleByDigest: providerBundleRead,
-        // A provider that has itself accepted a private cell must STILL refuse to serve that cell's
-        // content over the native protocols. The serve path resolves purely by the digest in the
-        // request, out of a store shared by every graph on the node, so serving private content here
-        // would hand it to anyone authorized under any public cell the node happens to hold.
+        // A provider that accepted a private cell must still refuse that cell
+        // over the legacy digest-only V1 protocols.
         authorizeCatalogOperation: async () => ({
           accessPolicy: 1,
           policyDigest: POLICY_DIGEST,
@@ -398,7 +397,9 @@ describe('RFC-64 public catalog native content transport v1', () => {
       code: 'catalog-native-policy-denied',
     });
     expect(providerRead).toHaveBeenCalledOnce();
-    expect(providerAuthorizationChecks).toBe(2);
+    // Route selection checks the policy before choosing V1 or V2. The V1
+    // handler then checks before and after the awaited provider read.
+    expect(providerAuthorizationChecks).toBe(3);
   }, 15_000);
 
   it('rechecks current authorization after the outbound bundle-fetch await', async () => {

--- a/packages/agent/test/rfc64-public-catalog-service-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-service-v1.test.ts
@@ -31,6 +31,8 @@ import {
   RFC64_PUBLIC_CATALOG_CURRENT_HEAD_DISCOVERY_PROTOCOL_V1,
 } from '../src/rfc64/public-catalog-current-head-discovery-v1.js';
 import {
+  RFC64_CATALOG_BUNDLE_FETCH_PROTOCOL_V2,
+  RFC64_CATALOG_OBJECT_FETCH_PROTOCOL_V2,
   RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_KIND_V1,
   RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_PROTOCOL_V1,
   RFC64_PUBLIC_CATALOG_OBJECT_FETCH_PROTOCOL_V1,
@@ -375,7 +377,7 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
           ownershipTransitionDigest: policy.ownershipTransitionDigest,
           subGraphName: 'service-lane',
           authorAddress: OTHER_WALLET.address.toLowerCase() as EvmAddressV1,
-          era: '7',
+          era: policy.era,
           bucketCount: '1',
         })).toBe(policyDigest);
       }
@@ -388,6 +390,59 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
       policyDigest: `0x${'f'.repeat(64)}` as Digest32V1,
     }))).rejects.toThrow(/requires a current member roster/);
     await service.close();
+  });
+
+  it('allows private fan-out only when exact scope-bound native reads are configured', async () => {
+    const policy = catalogPolicy(`${CONTEXT_GRAPH_ID}-private-fanout`, 1, 1);
+    const policyDigest = `0x${'2b'.repeat(32)}` as Digest32V1;
+    const createService = (scopeBound: boolean) => {
+      const router = new RecordingRouter();
+      router.sendResponse = async () => Uint8Array.of(1);
+      const service = new Rfc64PublicCatalogServiceV1({
+        router: router.asProtocolRouter(),
+        controlObjects: controlObjects(),
+        accessPolicyAuthority: {
+          localAgentAddress: AUTHOR,
+          resolveRemoteAgentAddress: async () => (
+            OTHER_WALLET.address.toLowerCase() as EvmAddressV1
+          ),
+        },
+        native: {
+          ...nativeOptions(() => inertReconciler()),
+          ...(scopeBound ? { resolveScopedReadCapability: async () => null } : {}),
+        },
+      });
+      service.acceptPolicySnapshot({
+        policy,
+        policyDigest,
+        roster: memberRoster(policy, policyDigest),
+      });
+      service.start();
+      return { router, service };
+    };
+    const unscoped = createService(false);
+    await expect(unscoped.service.announceCatalogHead({
+      announcement: {
+        ...announcement(policyDigest),
+        contextGraphId: policy.contextGraphId,
+      },
+      peers: ['private-provider'],
+    })).rejects.toThrow(/requires scope-bound private content transport/u);
+    expect(unscoped.router.events.some((event) => event.startsWith('send:'))).toBe(false);
+    await unscoped.service.close();
+
+    const scoped = createService(true);
+    await expect(scoped.service.announceCatalogHead({
+      announcement: {
+        ...announcement(policyDigest),
+        contextGraphId: policy.contextGraphId,
+      },
+      peers: ['private-provider'],
+    })).resolves.toMatchObject({
+      announcedPeers: ['private-provider'],
+      failedPeers: [],
+    });
+    await scoped.service.close();
   });
 
   it('denies a private-cell author that is absent from the current member roster', async () => {
@@ -429,7 +484,7 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
       catalogIssuerDelegationEffectiveAt: DELEGATION_EFFECTIVE_AT,
       catalogIssuerDelegationExpiresAt: DELEGATION_EXPIRES_AT,
       peers: [],
-    })).rejects.toThrow(/not bound to the exact catalog network, CG, governance scope, and author/);
+    })).rejects.toThrow(/not bound to the exact catalog network, CG, governance scope, era, and author/);
 
     // Receive side (#assertAcceptedCatalogAnnouncement): an announcement naming an off-roster author
     // must not resolve a trusted catalog scope.
@@ -799,6 +854,8 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
     expect(router.events.filter((event) => event.startsWith('register:'))).toEqual([
       `register:${RFC64_PUBLIC_CATALOG_OBJECT_FETCH_PROTOCOL_V1}`,
       `register:${RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_PROTOCOL_V1}`,
+      `register:${RFC64_CATALOG_OBJECT_FETCH_PROTOCOL_V2}`,
+      `register:${RFC64_CATALOG_BUNDLE_FETCH_PROTOCOL_V2}`,
       `register:${RFC64_PUBLIC_CATALOG_HEAD_ANNOUNCEMENT_PROTOCOL_V1}`,
       `register:${RFC64_PUBLIC_CATALOG_HEAD_FETCH_PROTOCOL_V1}`,
     ]);
@@ -826,6 +883,14 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
     expect(countEvent(
       router,
       `unregister:${RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_PROTOCOL_V1}`,
+    )).toBe(1);
+    expect(countEvent(
+      router,
+      `unregister:${RFC64_CATALOG_OBJECT_FETCH_PROTOCOL_V2}`,
+    )).toBe(1);
+    expect(countEvent(
+      router,
+      `unregister:${RFC64_CATALOG_BUNDLE_FETCH_PROTOCOL_V2}`,
     )).toBe(1);
     expect(countEvent(
       router,
@@ -873,6 +938,8 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
     expect(router.handlers.has(RFC64_PUBLIC_CATALOG_HEAD_FETCH_PROTOCOL_V1)).toBe(true);
     expect(router.handlers.has(RFC64_PUBLIC_CATALOG_OBJECT_FETCH_PROTOCOL_V1)).toBe(true);
     expect(router.handlers.has(RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_PROTOCOL_V1)).toBe(true);
+    expect(router.handlers.has(RFC64_CATALOG_OBJECT_FETCH_PROTOCOL_V2)).toBe(true);
+    expect(router.handlers.has(RFC64_CATALOG_BUNDLE_FETCH_PROTOCOL_V2)).toBe(true);
 
     await expect(clients!.headTransport.fetchCatalogHead('peer-b', head)).resolves.toBeNull();
     await expect(clients!.contentTransport.fetchKaBundle('peer-b', {
@@ -905,6 +972,8 @@ describe('RFC-64 public catalog service v1 lifecycle ownership', () => {
       RFC64_PUBLIC_CATALOG_HEAD_FETCH_PROTOCOL_V1,
       RFC64_PUBLIC_CATALOG_OBJECT_FETCH_PROTOCOL_V1,
       RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_PROTOCOL_V1,
+      RFC64_CATALOG_OBJECT_FETCH_PROTOCOL_V2,
+      RFC64_CATALOG_BUNDLE_FETCH_PROTOCOL_V2,
     ]) {
       expect(countEvent(router, `unregister:${protocolId}`)).toBe(1);
     }

--- a/packages/agent/test/support/rfc64-finalized-vm-precommit-fixture.ts
+++ b/packages/agent/test/support/rfc64-finalized-vm-precommit-fixture.ts
@@ -52,6 +52,7 @@ Readonly<Rfc64PublicCatalogNativeBeforeAppliedHeadCommitPlanV1> {
       era: '0',
       bucketCount: '1',
     } satisfies AuthorCatalogScopeV1),
+    policyDigest: RFC64_VM_POLICY_DIGEST,
     catalogHeadDigest: RFC64_VM_CATALOG_HEAD_DIGEST,
     inventoryDigest: RFC64_VM_INVENTORY_DIGEST,
     rows: Object.freeze([]),

--- a/packages/agent/test/sync-backpressure.test.ts
+++ b/packages/agent/test/sync-backpressure.test.ts
@@ -1910,7 +1910,7 @@ describe('sync global backpressure', () => {
         syncGlobalQueueLimit: 6,
         rfc64PublicCatalogBootstrap: {
           acceptedPublicPolicies: [{
-            policyEnvelope: { payload: { contextGraphId: selectedCg } },
+            policyEnvelope: { payload: { contextGraphId: selectedCg, accessPolicy: 0 } },
             completeSwmProviders: ['12D3KooWSelectedProvider'],
           }],
         },
@@ -2113,7 +2113,7 @@ describe('sync global backpressure', () => {
         syncGlobalQueueLimit: 4,
         rfc64PublicCatalogBootstrap: {
           acceptedPublicPolicies: [{
-            policyEnvelope: { payload: { contextGraphId } },
+            policyEnvelope: { payload: { contextGraphId, accessPolicy: 0 } },
             completeSwmProviders: [],
           }],
         },

--- a/packages/agent/test/vm-reconcile-self-prime.test.ts
+++ b/packages/agent/test/vm-reconcile-self-prime.test.ts
@@ -166,17 +166,23 @@ describe('GH #1098 — VM reconcile sweep self-primes onChainId for a pre-subscr
     const selected = 'rfc64-selected-vm';
     const acceptedButUnselected = 'rfc64-accepted-only';
     const syncScopedButUnaccepted = 'rfc64-sync-only';
-    const serializedPolicy = (contextGraphId: string) => JSON.parse(JSON.stringify({
+    const privateSelected = 'rfc64-private-selected';
+    const serializedPolicy = (contextGraphId: string, accessPolicy = 0) => JSON.parse(JSON.stringify({
       policyEnvelope: {
-        payload: { accessPolicy: 0, contextGraphId },
+        payload: { accessPolicy, contextGraphId },
       },
       targets: [],
     }));
-    (internals as any).config.syncContextGraphs = [selected, syncScopedButUnaccepted];
-    (internals as any).config.rfc64PublicCatalogBootstrap = {
-      acceptedPublicPolicies: [
+    (internals as any).config.syncContextGraphs = [
+      selected,
+      syncScopedButUnaccepted,
+      privateSelected,
+    ];
+    (internals as any).config.rfc64CatalogBootstrap = {
+      acceptedPolicies: [
         serializedPolicy(selected),
         serializedPolicy(acceptedButUnselected),
+        serializedPolicy(privateSelected, 1),
       ],
     };
     // Discovery may leave a passive bookkeeping row. That row is not member

--- a/packages/agent/vitest.rfc64-unit-tests.ts
+++ b/packages/agent/vitest.rfc64-unit-tests.ts
@@ -31,6 +31,8 @@ export const RFC64_UNIT_TESTS = [
   "test/rfc64-public-catalog-gate1.integration.test.ts",
   "test/rfc64-dkg-agent-native-wiring.integration.test.ts",
   "test/rfc64-public-catalog-native-transport-v1.test.ts",
+  "test/rfc64-private-catalog-native-scoped-transport-v1.test.ts",
+  "test/rfc64-catalog-native-scoped-read-provider-v1.test.ts",
   "test/rfc64-public-catalog-native-reconciler-v1.test.ts",
   "test/rfc64-public-catalog-native-gate1.integration.test.ts",
   "test/rfc64-public-catalog-inventory-completeness-v1.test.ts",
@@ -38,5 +40,6 @@ export const RFC64_UNIT_TESTS = [
   "test/rfc64-public-catalog-successor-producer-v1.test.ts",
   "test/rfc64-dkg-agent-successor-publication.integration.test.ts",
   "test/rfc64-catalog-access-policy-v1.test.ts",
+  "test/rfc64-private-catalog-activation-config-v1.test.ts",
   "test/rfc64-policy-cell-v1.test.ts",
 ] as const;

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -11,8 +11,11 @@ import type {
   SyncResponderSnapshotLimitsConfig,
 } from '@origintrail-official/dkg-agent';
 import {
+  resolveRfc64CatalogActivationsV1,
+  type ResolvedRfc64CatalogActivationConfigV1,
   resolveRfc64PublicCatalogActivationChainIdentityV1,
   resolveRfc64PublicCatalogActivationConfigV1,
+  type Rfc64CatalogActivationConfigV1,
   type ResolvedRfc64PublicCatalogActivationConfigV1,
   type Rfc64PublicCatalogActivationChainIdentityV1,
   type Rfc64PublicCatalogActivationConfigV1,
@@ -528,6 +531,9 @@ export type ResolvedRfc64PublicCatalogActivationConfig =
   ResolvedRfc64PublicCatalogActivationConfigV1;
 export type Rfc64PublicCatalogActivationChainIdentity =
   Rfc64PublicCatalogActivationChainIdentityV1;
+export type Rfc64CatalogActivationConfig = Rfc64CatalogActivationConfigV1;
+export type ResolvedRfc64CatalogActivationConfig =
+  ResolvedRfc64CatalogActivationConfigV1;
 
 export interface LoggingConfig {
   /** Emit detailed KA publish lifecycle logs. Default: false. */
@@ -624,6 +630,12 @@ export interface DkgConfig {
   contextGraphs?: string[];
   /** Opt-in, bounded RFC-64 catalog activation for explicitly selected public CGs. */
   rfc64PublicCatalog?: Rfc64PublicCatalogActivationConfig;
+  /**
+   * Additive, bounded RFC-64 activation for explicitly selected public or
+   * invite-only CGs. Private Release 1 selections require a manual policy,
+   * roster, and exact peer-to-agent authority map.
+   */
+  rfc64Catalog?: Rfc64CatalogActivationConfig;
   /**
    * Explicitly trusted context graphs that daemon startup may create locally
    * instead of treating as remote subscription targets. Intended for local
@@ -1175,6 +1187,17 @@ export function resolveRfc64PublicCatalogActivation(
     config.rfc64PublicCatalog,
     chainIdentity,
   );
+}
+
+/** Resolve the policy-neutral union and the compatibility public projection. */
+export function resolveRfc64CatalogActivations(
+  config: Pick<DkgConfig, 'rfc64Catalog' | 'rfc64PublicCatalog'>,
+  chainIdentity: Rfc64PublicCatalogActivationChainIdentity,
+) {
+  return resolveRfc64CatalogActivationsV1({
+    catalog: config.rfc64Catalog,
+    publicCatalog: config.rfc64PublicCatalog,
+  }, chainIdentity);
 }
 
 export { resolveRfc64PublicCatalogActivationChainIdentityV1 };

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -131,7 +131,7 @@ import {
   resolveNetworkDefaultContextGraphs,
   isPublisherRuntimeEnabled,
   resolvePublisherRetryTuning,
-  resolveRfc64PublicCatalogActivation,
+  resolveRfc64CatalogActivations,
   resolveRfc64PublicCatalogActivationChainIdentityV1,
   resolveSharedMemoryTtlMs,
   resolveStorageAckTiming,
@@ -1332,15 +1332,17 @@ export async function runDaemonInner(
   // network manifest fails before subscriptions, stores, wallets, or agent
   // runtime construction begin. The same immutable chainBase is reused below.
   const chainBase = resolveChainConfig(config, network);
-  const rfc64PublicCatalog = resolveRfc64PublicCatalogActivation(
+  const rfc64CatalogActivations = resolveRfc64CatalogActivations(
     config,
     resolveRfc64PublicCatalogActivationChainIdentityV1(chainBase?.chainId),
   );
+  const rfc64Catalog = rfc64CatalogActivations.catalog;
+  const rfc64PublicCatalog = rfc64CatalogActivations.publicCatalog;
   const syncContextGraphs = [
     ...new Set([
       ...resolveContextGraphs(config),
       ...resolveNetworkDefaultContextGraphs(network),
-      ...rfc64PublicCatalog.selectedContextGraphs,
+      ...rfc64Catalog.selectedContextGraphs,
     ]),
   ];
 
@@ -1784,6 +1786,11 @@ export async function runDaemonInner(
       ? undefined
       : rfc64PublicCatalog.enabled
         ? config.rfc64PublicCatalog
+        : { enabled: false },
+    rfc64CatalogActivation: config.rfc64Catalog === undefined
+      ? undefined
+      : rfc64Catalog.enabled
+        ? config.rfc64Catalog
         : { enabled: false },
     maxRehydratedContextGraphSubscriptions: config.maxRehydratedContextGraphSubscriptions,
     contextGraphSubscriptionRehydrationEnabled,
@@ -3686,6 +3693,7 @@ export async function runDaemonInner(
         publisherControl,
         publisherState,
         config,
+        rfc64Catalog,
         rfc64PublicCatalog,
         startedAt,
         dashDb,

--- a/packages/cli/src/daemon/routes/context.ts
+++ b/packages/cli/src/daemon/routes/context.ts
@@ -17,6 +17,7 @@ import type {
 } from '@origintrail-official/dkg-node-ui';
 import type {
   DkgConfig,
+  ResolvedRfc64CatalogActivationConfig,
   ResolvedRfc64PublicCatalogActivationConfig,
   loadNetworkConfig,
 } from '../../config.js';
@@ -68,6 +69,8 @@ export interface RequestContext {
   publisherState: PublisherState;
   config: DkgConfig;
   /** Immutable RFC-64 activation resolved once during daemon startup. */
+  rfc64Catalog?: ResolvedRfc64CatalogActivationConfig;
+  /** Compatibility projection for the selected-public operator surface. */
   rfc64PublicCatalog: ResolvedRfc64PublicCatalogActivationConfig;
   startedAt: number;
   dashDb: DashboardDB;

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -773,6 +773,13 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
     // snapshot. A missing field is broken request-context wiring, not a disabled
     // feature, so keep the RequestContext contract strict here.
     const rfc64PublicCatalogActivation = ctx.rfc64PublicCatalog;
+    const rfc64CatalogActivation = ctx.rfc64Catalog ?? {
+      enabled: rfc64PublicCatalogActivation.enabled,
+      selectedContextGraphs: rfc64PublicCatalogActivation.selectedContextGraphs,
+      selectedPublicContextGraphs: rfc64PublicCatalogActivation.selectedContextGraphs,
+      selectedPrivateContextGraphs: [],
+      accessPolicyAuthority: undefined,
+    };
     const rfc64PublicCatalogService =
       rfc64PublicCatalogActivation.enabled
       && typeof agent.rfc64PublicCatalogStatsV1 === 'function'
@@ -912,6 +919,16 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
         completeSwmProviders: rfc64CompleteSwmProviders,
         service: rfc64PublicCatalogService,
         bootstrap: rfc64PublicCatalogBootstrap,
+      },
+      // Local operator projection only. Never expose roster members, peer-to-
+      // wallet bindings, or private provider identities through status.
+      rfc64Catalog: {
+        enabled: rfc64CatalogActivation.enabled,
+        selectedContextGraphs: rfc64CatalogActivation.selectedContextGraphs,
+        selectedPublicContextGraphs: rfc64CatalogActivation.selectedPublicContextGraphs,
+        selectedPrivateContextGraphs: rfc64CatalogActivation.selectedPrivateContextGraphs,
+        privateAuthorityConfigured:
+          rfc64CatalogActivation.accessPolicyAuthority !== undefined,
       },
       // Product-default scheduling is deliberately separate from the signed
       // catalog authority surface above. Every explicitly requested CG is

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,6 +310,15 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
+  devnet/rfc64-cp1-private-swm-recovery:
+    dependencies:
+      '@origintrail-official/dkg-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      ethers:
+        specifier: 6.16.0
+        version: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+
   devnet/rfc64-cp1-public-swm-parity:
     dependencies:
       '@origintrail-official/dkg-core':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,7 @@ packages:
   - "devnet/rfc64-gate1-public-open"
   - "devnet/rfc64-gate2-multi-asset-completeness"
   - "devnet/rfc64-cp1-public-swm-parity"
+  - "devnet/rfc64-cp1-private-swm-recovery"
   - "devnet/rfc64-m0-public-baseline"
   - "devnet/pr1386-term-canon"
   - "devnet/pr1385-subgraph-rs"


### PR DESCRIPTION
## Summary

Adds RFC64 Release 1 support for owner-signed, unregistered private Context Graph SWM recovery. Public RFC64 behavior remains compatible.

## Release boundary

- Private SWM recovery: supported
- Registered private policies: fail closed
- Private VM recovery: disabled for Release 1

## Security controls

- Private content uses scoped V2 catalog protocols only.
- V1 public content handlers reject private scopes before storage access.
- Activation requires exact policy and roster binding, local current membership, one pinned complete provider, and explicit peer-to-agent bindings.
- Provider capabilities close and verify the exact signed catalog head and expose only committed closure objects and bundles.
- Commit rechecks the exact policy digest, roster, and current author membership.

## Verification

- 117 focused and regression tests passed.
- Agent build, CLI build/typecheck, canary typechecks, and diff checks passed.
- Live private canary: PASS, 32/32 SWM assets recovered with semantic equality and an unbound-peer denial check.
- Existing public SWM parity canary: PASS.