### PR TITLE
fix(core): resolve inbound admission before reading the request body

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -2019,6 +2019,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.router = new ProtocolRouter(this.node, {
       peerResolver,
       isPeerAccepted: createNetworkAdmissionProtocolCheck(this.networkAdmissionCoordinator),
+      // Cached-verdict only: `isRejectedPeer` reads the admission cache and never
+      // probes, so the router can drop an already-rejected peer before buffering
+      // its request without inverting the inbound/outbound I/O order.
+      isPeerKnownRejected: (peerId) =>
+        this.networkAdmissionCoordinator.isRejectedPeer(peerId),
       admissionExemptProtocols: [PROTOCOL_NETWORK_IDENTITY],
     });
     // Default to in-memory substrate stores when no durable stores

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -193,7 +193,7 @@ import {
   NetworkAdmissionCoordinator,
   NetworkAdmissionRejectedError,
 } from './p2p/network-admission-coordinator.js';
-import { createNetworkAdmissionProtocolCheck } from './p2p/network-admission-protocol-adapter.js';
+import { createNetworkAdmissionRouterPolicy } from './p2p/network-admission-protocol-adapter.js';
 import {
   createCGMemberEnumerator,
   type CGMemberEnumerator,
@@ -2018,12 +2018,11 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     });
     this.router = new ProtocolRouter(this.node, {
       peerResolver,
-      isPeerAccepted: createNetworkAdmissionProtocolCheck(this.networkAdmissionCoordinator),
-      // Cached-verdict only: `isRejectedPeer` reads the admission cache and never
-      // probes, so the router can drop an already-rejected peer before buffering
-      // its request without inverting the inbound/outbound I/O order.
-      isPeerKnownRejected: (peerId) =>
-        this.networkAdmissionCoordinator.isRejectedPeer(peerId),
+      // Both admission phases — the probing full check and the cached-verdict
+      // pre-read gate — installed as one policy from one coordinator; see
+      // createNetworkAdmissionRouterPolicy for why they must not be wired
+      // separately.
+      ...createNetworkAdmissionRouterPolicy(this.networkAdmissionCoordinator),
       admissionExemptProtocols: [PROTOCOL_NETWORK_IDENTITY],
     });
     // Default to in-memory substrate stores when no durable stores

--- a/packages/agent/src/p2p/network-admission-protocol-adapter.ts
+++ b/packages/agent/src/p2p/network-admission-protocol-adapter.ts
@@ -9,6 +9,19 @@ import {
 } from './network-admission-coordinator.js';
 
 /**
+ * The router-facing admission policy as one object: the probing full check and
+ * the cached-verdict pre-read gate are two phases of a single invariant and
+ * must read the same coordinator state. Constructing them together (see
+ * `createNetworkAdmissionRouterPolicy`) is what keeps a future admission
+ * change from wiring one phase and silently dropping — or contradicting — the
+ * other.
+ */
+export interface NetworkAdmissionRouterPolicy {
+  isPeerAccepted: NonNullable<ProtocolRouterOptions['isPeerAccepted']>;
+  isPeerKnownRejected: NonNullable<ProtocolRouterOptions['isPeerKnownRejected']>;
+}
+
+/**
  * Translate agent-owned probe backoff into the core router's generic quiet
  * retryable concept at the protocol boundary. Outbound callers retain the
  * original error so connect/send diagnostics and retry policy stay unchanged.
@@ -37,5 +50,26 @@ export function createNetworkAdmissionProtocolCheck(
     } catch (error) {
       throw translateNetworkAdmissionErrorAtProtocolBoundary(error, direction);
     }
+  };
+}
+
+/**
+ * Build the COMPLETE admission policy for ProtocolRouter from one coordinator.
+ * Spread the result into the router options in a single operation:
+ *
+ *   new ProtocolRouter(node, { ...createNetworkAdmissionRouterPolicy(coordinator), ... })
+ *
+ * `isPeerAccepted` is the full (possibly probing) check that runs after the
+ * bounded body read; `isPeerKnownRejected` is the synchronous cached-verdict
+ * pre-read gate — `isRejectedPeer` reads the admission cache and never probes,
+ * so consulting it before the body is read cannot invert the inbound/outbound
+ * I/O order the way a probing check there would.
+ */
+export function createNetworkAdmissionRouterPolicy(
+  coordinator: Pick<NetworkAdmissionCoordinator, 'ensureAdmitted' | 'isRejectedPeer'>,
+): NetworkAdmissionRouterPolicy {
+  return {
+    isPeerAccepted: createNetworkAdmissionProtocolCheck(coordinator),
+    isPeerKnownRejected: (peerId) => coordinator.isRejectedPeer(peerId),
   };
 }

--- a/packages/agent/test/network-admission-router-wiring.test.ts
+++ b/packages/agent/test/network-admission-router-wiring.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_GENESIS_ID,
+  PROTOCOL_SYNC,
+  PROTOCOL_SYNC_POOLED,
+  computeNetworkId,
+} from '@origintrail-official/dkg-core';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { DKGAgent } from '../src/dkg-agent.js';
+
+/**
+ * Proves the PRODUCTION admission wiring, not a manually injected router: a
+ * peer whose cached verdict is "rejected" must have its inbound streams dropped
+ * BEFORE any request bytes are read and WITHOUT the probing admission check
+ * running — on both inbound transports (one-shot sync and pooled sync).
+ *
+ * Core-level tests inject `isPeerKnownRejected` by hand; this test would keep
+ * passing with that wiring deleted from `dkg-agent-lifecycle.ts`, which is
+ * exactly the silent regression it exists to catch. Everything here goes
+ * through `DKGAgent.create(...).start()` and the real
+ * NetworkAdmissionCoordinator; the only test double is the inbound stream.
+ *
+ * Two vacuous-pass traps this deliberately avoids:
+ * - `networkIdentity` must be configured, else admission is disabled and
+ *   `isRejectedPeer` returns false for everyone (the gate would no-op and the
+ *   assertions below would still fail loudly — reads would be > 0).
+ * - the quarantined peer id must be VALID: `isRejectedPeer` returns true for
+ *   any unparseable id once admission is enabled, which would fake a pass for
+ *   a gate wired to the wrong predicate.
+ */
+
+const REJECTED_PEER = '12D3KooWQz2bQbQueABKRSjV9koF8VYsXk5TdCsUmPf5zAEZg3q6';
+
+class CountingInboundStream extends EventTarget {
+  sent: Uint8Array | null = null;
+  aborted: Error | null = null;
+  reads = 0;
+
+  send(data: Uint8Array): void {
+    this.sent = data;
+  }
+
+  async close(): Promise<void> {}
+
+  abort(error: Error): void {
+    this.aborted = error;
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+    return {
+      next: async () => {
+        this.reads += 1;
+        return { value: undefined as unknown as Uint8Array, done: true };
+      },
+    };
+  }
+}
+
+describe('production router admission wiring', () => {
+  it('drops inbound streams from a cache-rejected peer before reading, on both sync transports', async () => {
+    const networkId = await computeNetworkId(DEFAULT_GENESIS_ID);
+    const agent = await DKGAgent.create({
+      name: 'AdmissionRouterWiring',
+      listenPort: 0,
+      store: new OxigraphStore(),
+      networkIdentity: {
+        genesisId: DEFAULT_GENESIS_ID,
+        networkId,
+        chainId: 'chain:1',
+      },
+    });
+
+    // Capture every libp2p protocol handler the lifecycle registers. node.start()
+    // completes before router construction, so patching `handle` right after the
+    // real start observes all registrations (direct AND pooled wire).
+    const captured = new Map<
+      string,
+      (stream: unknown, connection: unknown) => unknown
+    >();
+    const realNodeStart = agent.node.start.bind(agent.node);
+    (agent.node as unknown as { start: () => Promise<void> }).start = async () => {
+      await realNodeStart();
+      const lp = agent.node.libp2p as unknown as {
+        handle: (protocol: string, handler: (stream: unknown, connection: unknown) => unknown, opts?: unknown) => unknown;
+      };
+      const realHandle = lp.handle.bind(lp);
+      lp.handle = (protocol, handler, opts) => {
+        captured.set(protocol, handler);
+        return realHandle(protocol, handler, opts);
+      };
+    };
+
+    try {
+      await agent.start();
+
+      // If pooled sync is ever flag-flipped off in CI this fails loudly here
+      // instead of silently testing half the surface.
+      expect(captured.has(PROTOCOL_SYNC)).toBe(true);
+      expect(captured.has(PROTOCOL_SYNC_POOLED)).toBe(true);
+
+      // The REAL cached verdict, through the REAL service the lifecycle wires.
+      agent.networkAdmission.quarantinePeer(REJECTED_PEER);
+      expect(agent.networkAdmission.isRejectedPeer(REJECTED_PEER)).toBe(true);
+
+      const coordinator = (
+        agent as unknown as { networkAdmissionCoordinator: { ensureAdmitted: (...args: unknown[]) => Promise<boolean> } }
+      ).networkAdmissionCoordinator;
+      const ensureAdmittedSpy = vi.spyOn(coordinator, 'ensureAdmitted');
+
+      const connection = {
+        remotePeer: {
+          toString: () => REJECTED_PEER,
+          toMultihash: () => ({ bytes: new Uint8Array([1, 2, 3]) }),
+        },
+      };
+
+      const directStream = new CountingInboundStream();
+      await captured.get(PROTOCOL_SYNC)!(directStream, connection);
+
+      const pooledStream = new CountingInboundStream();
+      await captured.get(PROTOCOL_SYNC_POOLED)!(pooledStream, connection);
+      // Pool accept is fire-and-forget internally; let its microtasks settle.
+      for (let i = 0; i < 30; i++) await Promise.resolve();
+
+      // Neither transport read a byte from the rejected peer...
+      expect(directStream.reads).toBe(0);
+      expect(pooledStream.reads).toBe(0);
+      expect(directStream.sent).toBeNull();
+      expect(pooledStream.sent).toBeNull();
+      expect(directStream.aborted).not.toBeNull();
+      expect(pooledStream.aborted).not.toBeNull();
+      // ...and the probing admission check never ran.
+      expect(ensureAdmittedSpy).not.toHaveBeenCalled();
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  }, 20000);
+});

--- a/packages/core/src/message-stream-pool.ts
+++ b/packages/core/src/message-stream-pool.ts
@@ -145,9 +145,19 @@ interface PoolReusableConnection {
  * handlers, so calling `peerId.toBytes()` from a handler works on
  * both wire variants (Codex PR #560 round-3).
  */
+/**
+ * Minimal structural contract for the remote peer on the pooled inbound path —
+ * the shape libp2p's `connection.remotePeer` always satisfies and the smallest
+ * thing tests must provide. Production objects carry more (`toMultihash()`,
+ * `equals()`, ...) and pass through untouched.
+ */
+export interface PooledRemotePeer {
+  toString(): string;
+}
+
 export type PooledStreamHandler = (
   requestData: Uint8Array,
-  peerId: unknown,
+  peerId: PooledRemotePeer,
   options?: { signal?: AbortSignal },
 ) => Promise<Uint8Array>;
 
@@ -213,25 +223,11 @@ export interface MessageStreamPoolOptions {
    *
    * When the pool is attached via `ProtocolRouter.enablePooling`, the router
    * installs this itself (keyed by the pool's LOGICAL protocol id, honoring
-   * `admissionExemptProtocols`) and overrides any caller-supplied value.
+   * `admissionExemptProtocols`); `ProtocolRouterPoolingOptions` omits the field
+   * so a caller cannot supply a value the router would have to discard. Direct
+   * `MessageStreamPool` constructions may configure it freely.
    */
   rejectInboundStream?: (peerIdStr: string) => boolean;
-}
-
-/**
- * Best-effort peer-id string for the pre-read gate. Pooled inbound handlers
- * tolerate minimal peer-like objects (see PooledStreamHandler doc), so the
- * gate does too: anything without a usable string form yields '', which a
- * conforming gate maps to "unsure" -> false -> normal read-then-probe path.
- */
-function peerIdStringOf(remotePeer: unknown): string {
-  try {
-    return typeof remotePeer === 'object' || typeof remotePeer === 'string'
-      ? String(remotePeer)
-      : '';
-  } catch {
-    return '';
-  }
 }
 
 interface PendingRequest {
@@ -1064,7 +1060,7 @@ export class MessageStreamPool {
     }
   }
 
-  private async handleInboundStream(stream: Stream, remotePeer: unknown): Promise<void> {
+  private async handleInboundStream(stream: Stream, remotePeer: PooledRemotePeer): Promise<void> {
     const handler = this.inboundHandler;
     if (!handler) {
       // No application handler registered yet — reject the stream
@@ -1082,9 +1078,12 @@ export class MessageStreamPool {
     // accepted stream; peers classified mid-stream are still refused by the
     // per-REQUEST admission check in the application handler below.
     if (this.rejectInboundStream) {
+      // Derived exactly once, from the typed boundary — the same string the
+      // full admission check sees later for this stream's requests.
+      const remotePeerId = remotePeer.toString();
       let rejected: boolean;
       try {
-        rejected = this.rejectInboundStream(peerIdStringOf(remotePeer));
+        rejected = this.rejectInboundStream(remotePeerId);
       } catch {
         // A throwing gate violates its contract; fail closed rather than
         // leaking an un-gated stream (see MessageStreamPoolOptions doc).

--- a/packages/core/src/message-stream-pool.ts
+++ b/packages/core/src/message-stream-pool.ts
@@ -199,6 +199,39 @@ export interface MessageStreamPoolOptions {
    * send budget.
    */
   primePeer?: (peerIdStr: string, opts: { signal?: AbortSignal }) => Promise<void>;
+  /**
+   * Optional synchronous pre-read gate for INBOUND pooled streams, consulted
+   * once per accepted stream — before the frame decoder buffers anything and
+   * before PING keepalives are answered. Return `true` to abort the stream.
+   *
+   * Contract mirrors `ProtocolRouterOptions.isPeerKnownRejected`: it must be
+   * synchronous, perform no I/O, and return `false` when unsure — full
+   * (potentially probing) admission still runs per REQUEST after a frame is
+   * read, exactly as before. A throw from the gate is treated as a rejection:
+   * failing open would silently disable the protection, and letting the throw
+   * escape would leak the stream un-aborted through the accept path's logger.
+   *
+   * When the pool is attached via `ProtocolRouter.enablePooling`, the router
+   * installs this itself (keyed by the pool's LOGICAL protocol id, honoring
+   * `admissionExemptProtocols`) and overrides any caller-supplied value.
+   */
+  rejectInboundStream?: (peerIdStr: string) => boolean;
+}
+
+/**
+ * Best-effort peer-id string for the pre-read gate. Pooled inbound handlers
+ * tolerate minimal peer-like objects (see PooledStreamHandler doc), so the
+ * gate does too: anything without a usable string form yields '', which a
+ * conforming gate maps to "unsure" -> false -> normal read-then-probe path.
+ */
+function peerIdStringOf(remotePeer: unknown): string {
+  try {
+    return typeof remotePeer === 'object' || typeof remotePeer === 'string'
+      ? String(remotePeer)
+      : '';
+  } catch {
+    return '';
+  }
 }
 
 interface PendingRequest {
@@ -283,6 +316,7 @@ export class MessageStreamPool {
   private readonly peerIdFromStringOverride?: (s: string) => unknown;
   private peerIdFromString?: (s: string) => unknown;
   private readonly primePeer?: (peerIdStr: string, opts: { signal?: AbortSignal }) => Promise<void>;
+  private readonly rejectInboundStream?: (peerIdStr: string) => boolean;
   private inboundHandler: PooledStreamHandler | null = null;
   private inboundRegistered = false;
   private closed = false;
@@ -316,6 +350,7 @@ export class MessageStreamPool {
     this.clock = options.clock ?? (() => Date.now());
     this.peerIdFromStringOverride = options.peerIdFromString;
     this.primePeer = options.primePeer;
+    this.rejectInboundStream = options.rejectInboundStream;
   }
 
   /** Protocol id this pool advertises on the wire. */
@@ -1040,6 +1075,29 @@ export class MessageStreamPool {
         // already torn down
       }
       return;
+    }
+
+    // Pre-read gate: a peer already classified as rejected does not get to
+    // buffer request frames or have its PINGs answered. Consulted once per
+    // accepted stream; peers classified mid-stream are still refused by the
+    // per-REQUEST admission check in the application handler below.
+    if (this.rejectInboundStream) {
+      let rejected: boolean;
+      try {
+        rejected = this.rejectInboundStream(peerIdStringOf(remotePeer));
+      } catch {
+        // A throwing gate violates its contract; fail closed rather than
+        // leaking an un-gated stream (see MessageStreamPoolOptions doc).
+        rejected = true;
+      }
+      if (rejected) {
+        try {
+          stream.abort(new Error('pooled inbound stream rejected before read'));
+        } catch {
+          // already torn down
+        }
+        return;
+      }
     }
 
     // Track whether we exited via clean EOF or an error path so the

--- a/packages/core/src/message-stream-pool.ts
+++ b/packages/core/src/message-stream-pool.ts
@@ -115,7 +115,7 @@ export interface PoolNode {
     getConnections?: () => ReadonlyArray<PoolReusableConnection>;
     handle: (
       protocolId: string,
-      handler: (stream: Stream, connection: { remotePeer: { toString: () => string } }) => void,
+      handler: (stream: Stream, connection: { remotePeer: PooledRemotePeerSource }) => void,
       opts?: { runOnLimitedConnection?: boolean },
     ) => void;
     unhandle: (protocolId: string) => void;
@@ -146,18 +146,49 @@ interface PoolReusableConnection {
  * both wire variants (Codex PR #560 round-3).
  */
 /**
- * Minimal structural contract for the remote peer on the pooled inbound path —
- * the shape libp2p's `connection.remotePeer` always satisfies and the smallest
- * thing tests must provide. Production objects carry more (`toMultihash()`,
- * `equals()`, ...) and pass through untouched.
+ * Canonical peer identity handed to pooled application handlers — the exact
+ * `{ toString, toBytes }` shape the one-shot path provides. Normalized ONCE
+ * from libp2p's `connection.remotePeer` at stream accept
+ * (`normalizePooledPeerId`); nothing downstream re-discovers the shape with
+ * casts, and the pre-read gate reads the same identity string the handler and
+ * the full admission check see.
  */
-export interface PooledRemotePeer {
+export interface PooledPeerId {
   toString(): string;
+  toBytes(): Uint8Array;
+}
+
+/**
+ * What libp2p actually hands us at the transport boundary. Production
+ * `PeerId`s carry `toMultihash()`; minimal test doubles may carry only
+ * `toString()` — normalization preserves that tolerance by deferring the
+ * capability error to first `toBytes()` use, exactly as the previous
+ * router-side wrap did.
+ */
+export interface PooledRemotePeerSource {
+  toString(): string;
+  toMultihash?: () => { bytes: Uint8Array };
+  toBytes?: () => Uint8Array;
+}
+
+export function normalizePooledPeerId(remote: PooledRemotePeerSource): PooledPeerId {
+  return {
+    toString: () => remote.toString(),
+    toBytes: () => {
+      if (typeof remote.toMultihash === 'function') {
+        return remote.toMultihash().bytes;
+      }
+      if (typeof remote.toBytes === 'function') {
+        return remote.toBytes();
+      }
+      throw new Error('peerId.toBytes not available on pooled handler');
+    },
+  };
 }
 
 export type PooledStreamHandler = (
   requestData: Uint8Array,
-  peerId: PooledRemotePeer,
+  peerId: PooledPeerId,
   options?: { signal?: AbortSignal },
 ) => Promise<Uint8Array>;
 
@@ -568,7 +599,7 @@ export class MessageStreamPool {
         // on the one-shot path. Codex PR #560 round-3 caught this:
         // previously only `.toString()` was threaded, which meant
         // pooled traffic broke handlers that worked on one-shot.
-        this.handleInboundStream(stream, connection.remotePeer).catch((err) => {
+        this.handleInboundStream(stream, normalizePooledPeerId(connection.remotePeer)).catch((err) => {
           // eslint-disable-next-line no-console
           console.error(
             `[MessageStreamPool] inbound stream error on ${this.protocolId}:`,
@@ -1060,7 +1091,7 @@ export class MessageStreamPool {
     }
   }
 
-  private async handleInboundStream(stream: Stream, remotePeer: PooledRemotePeer): Promise<void> {
+  private async handleInboundStream(stream: Stream, remotePeer: PooledPeerId): Promise<void> {
     const handler = this.inboundHandler;
     if (!handler) {
       // No application handler registered yet — reject the stream
@@ -1078,8 +1109,8 @@ export class MessageStreamPool {
     // accepted stream; peers classified mid-stream are still refused by the
     // per-REQUEST admission check in the application handler below.
     if (this.rejectInboundStream) {
-      // Derived exactly once, from the typed boundary — the same string the
-      // full admission check sees later for this stream's requests.
+      // The same normalized identity the application handler and the full
+      // admission check receive for this stream's requests.
       const remotePeerId = remotePeer.toString();
       let rejected: boolean;
       try {

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -158,6 +158,25 @@ export interface ProtocolRouterOptions {
     direction: 'inbound' | 'outbound',
     options?: AdmissionCheckOptions,
   ) => boolean | Promise<boolean>;
+  /**
+   * Optional synchronous, side-effect-free "already known to be rejected" check,
+   * consulted on inbound BEFORE the request body is read.
+   *
+   * This exists because {@link ProtocolRouterOptions.isPeerAccepted} is NOT a
+   * cheap local predicate in production: for an unclassified peer it runs an
+   * admission probe, i.e. outbound network I/O back toward the sender. Running
+   * that before draining the inbound stream inverts the I/O order — the receiver
+   * would dial a peer that is itself still blocked writing to us — which
+   * deterministically stalls announce-style request/response exchanges against a
+   * freshly restarted peer whose admission cache is empty.
+   *
+   * So the pre-read gate is deliberately limited to verdicts already cached:
+   * peers we have positively classified as rejected are dropped without
+   * buffering their body, and everything else keeps the existing order (read the
+   * bounded body, then run the full admission check). Implementations MUST NOT
+   * perform I/O or trigger a probe here, and MUST return false when unsure.
+   */
+  isPeerKnownRejected?: (peerId: string, protocolId: string) => boolean;
   admissionExemptProtocols?: Iterable<string>;
 }
 
@@ -181,6 +200,7 @@ export class ProtocolRouter {
   private readonly node: DKGNode;
   private readonly peerResolver?: PeerResolver;
   private readonly isPeerAccepted?: ProtocolRouterOptions['isPeerAccepted'];
+  private readonly isPeerKnownRejected?: ProtocolRouterOptions['isPeerKnownRejected'];
   private readonly admissionExemptProtocols: ReadonlySet<string>;
   private handlers = new Map<string, DKGStreamHandler>();
   /**
@@ -226,8 +246,22 @@ export class ProtocolRouter {
     this.node = node;
     this.peerResolver = options?.peerResolver;
     this.isPeerAccepted = options?.isPeerAccepted;
+    this.isPeerKnownRejected = options?.isPeerKnownRejected;
     this.admissionExemptProtocols = new Set(options?.admissionExemptProtocols ?? []);
     this.maxReadBytes = options?.maxReadBytes ?? DEFAULT_MAX_READ_BYTES;
+  }
+
+  /**
+   * Pre-read inbound gate. Only consults the cached-verdict predicate; never
+   * probes. Throws the same shape as `requirePeerAccepted` so the existing
+   * catch-path handling (abort + quiet logging) is unchanged.
+   */
+  private rejectKnownRejectedInboundPeer(peerId: string, protocolId: string): void {
+    if (!this.isPeerKnownRejected || this.admissionExemptProtocols.has(protocolId)) return;
+    if (!this.isPeerKnownRejected(peerId, protocolId)) return;
+    throw new Error(
+      `peer ${peerId.slice(-8)} is not admitted for inbound protocol ${protocolId}`,
+    );
   }
 
   private async requirePeerAccepted(
@@ -466,16 +500,16 @@ export class ProtocolRouter {
       const handlerSignal = handlerSignalScope.signal;
       try {
         const remotePeer = connection.remotePeer.toString();
-        // Admission is checked before the request body is read, so work done on
-        // behalf of a peer is bounded by its admission state rather than by the
-        // read limit alone. `requirePeerAccepted` depends only on the peer id and
-        // protocol, never on the request payload, so this ordering is free.
-        // The pooled inbound path above already resolves admission before it
-        // dispatches; this keeps the direct path consistent with it.
+        // Drop peers we have ALREADY classified as rejected before buffering
+        // their body. Deliberately not the full `requirePeerAccepted` here: that
+        // probes unclassified peers over the network, and probing outbound while
+        // holding an unread inbound stream inverts the I/O order against a
+        // sender that is still writing to us. See `isPeerKnownRejected`.
+        this.rejectKnownRejectedInboundPeer(remotePeer, protocolId);
+        const requestData = await readAllWithSignal(stream, limit, handlerSignal);
         await this.requirePeerAccepted(remotePeer, protocolId, 'inbound', {
           signal: handlerSignal,
         });
-        const requestData = await readAllWithSignal(stream, limit, handlerSignal);
         const peerId = {
           toString: () => remotePeer,
           toBytes: () => connection.remotePeer.toMultihash().bytes,

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -198,6 +198,25 @@ export interface ProtocolRegistrationOptions {
   maxReadBytes?: number;
 }
 
+/**
+ * The pooling options a ProtocolRouter caller may supply. `rejectInboundStream`
+ * is omitted: the router owns the pooled pre-read admission gate (installed in
+ * `enablePooling`, keyed by the logical protocol id so admission exemptions
+ * apply) and accepting a caller value it would have to discard makes the API
+ * lie. Construct a `MessageStreamPool` directly to configure the gate yourself.
+ */
+export type ProtocolRouterPoolingOptions = Omit<
+  Partial<MessageStreamPoolOptions>,
+  'rejectInboundStream'
+>;
+
+// Compile-time guard for the option surface above: fails the build if the
+// router-owned gate ever becomes caller-suppliable through enablePooling.
+type RouterPoolingOptionsOmitGate =
+  'rejectInboundStream' extends keyof ProtocolRouterPoolingOptions ? never : true;
+const _routerPoolingOptionsOmitGate: RouterPoolingOptionsOmitGate = true;
+void _routerPoolingOptionsOmitGate;
+
 export class QuietRetryableHandlerError extends Error {
   constructor(message: string) {
     super(message);
@@ -323,7 +342,7 @@ export class ProtocolRouter {
    */
   enablePooling(
     logicalProtocolId: string,
-    options: Partial<MessageStreamPoolOptions> = {},
+    options: ProtocolRouterPoolingOptions = {},
   ): void {
     const existing = this.pooledByLogical.get(logicalProtocolId);
     if (existing) {
@@ -383,10 +402,10 @@ export class ProtocolRouter {
         protocolId: wireProtocolId,
         maxFrameBytes: options.maxFrameBytes ?? this.maxReadBytes,
         primePeer,
-        // Router-owned, deliberately not caller-overridable: the pooled
-        // pre-read gate must be keyed by the LOGICAL protocol id (production
-        // admission exemptions are logical ids) and must consult the same
-        // cached-verdict predicate as the one-shot inbound path.
+        // Router-owned; `ProtocolRouterPoolingOptions` omits this field so a
+        // caller cannot supply a competing value. Keyed by the LOGICAL
+        // protocol id (production admission exemptions are logical ids) and
+        // consulting the same cached-verdict predicate as the one-shot path.
         rejectInboundStream: (peerIdStr: string) =>
           this.isKnownRejectedInboundPeer(peerIdStr, logicalProtocolId),
       },

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -466,10 +466,16 @@ export class ProtocolRouter {
       const handlerSignal = handlerSignalScope.signal;
       try {
         const remotePeer = connection.remotePeer.toString();
-        const requestData = await readAllWithSignal(stream, limit, handlerSignal);
+        // Admission is checked before the request body is read, so work done on
+        // behalf of a peer is bounded by its admission state rather than by the
+        // read limit alone. `requirePeerAccepted` depends only on the peer id and
+        // protocol, never on the request payload, so this ordering is free.
+        // The pooled inbound path above already resolves admission before it
+        // dispatches; this keeps the direct path consistent with it.
         await this.requirePeerAccepted(remotePeer, protocolId, 'inbound', {
           signal: handlerSignal,
         });
+        const requestData = await readAllWithSignal(stream, limit, handlerSignal);
         const peerId = {
           toString: () => remotePeer,
           toBytes: () => connection.remotePeer.toMultihash().bytes,

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -427,40 +427,18 @@ export class ProtocolRouter {
       if (!handler) {
         throw new Error(`no application handler for ${logicalProtocolId}`);
       }
-      // Wrap into the exact same `{ toString, toBytes }` shape the
-      // one-shot register() path passes to application handlers
-      // (see `register()` ~30 lines below). The pool now threads
-      // the REAL `connection.remotePeer` through, so on production
-      // traffic this exposes `.toMultihash().bytes` just like
-      // one-shot. Tests can pass minimal peer-like objects with
-      // only `.toString()` and the wrap still works (toBytes()
-      // surfaces a typed error rather than silently corrupting).
-      // Codex PR #560 round-3.
-      const remote = peerId as {
-        toString: () => string;
-        toMultihash?: () => { bytes: Uint8Array };
-        toBytes?: () => Uint8Array;
-      };
-      const wrappedPeerId = {
-        toString: () => remote.toString(),
-        toBytes: () => {
-          if (typeof remote.toMultihash === 'function') {
-            return remote.toMultihash().bytes;
-          }
-          if (typeof remote.toBytes === 'function') {
-            return remote.toBytes();
-          }
-          throw new Error('peerId.toBytes not available on pooled handler');
-        },
-      };
+      // `peerId` is already the canonical `{ toString, toBytes }` model — the
+      // pool normalizes libp2p's `connection.remotePeer` exactly once at
+      // stream accept (`normalizePooledPeerId`), the same shape the one-shot
+      // register() path provides. No shape re-discovery here.
       const handlerSignalScope = composeAbortSignalsScoped(options?.signal, this.node.stopSignal);
       const handlerSignal = handlerSignalScope.signal;
       try {
         if (handlerSignal?.aborted) throw asAbortError(handlerSignal.reason);
-        await this.requirePeerAccepted(remote.toString(), logicalProtocolId, 'inbound', {
+        await this.requirePeerAccepted(peerId.toString(), logicalProtocolId, 'inbound', {
           signal: handlerSignal,
         });
-        const responseData = await handler(requestData, wrappedPeerId, { signal: handlerSignal });
+        const responseData = await handler(requestData, peerId, { signal: handlerSignal });
         if (handlerSignal?.aborted) throw asAbortError(handlerSignal.reason);
         return responseData;
       } finally {

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -175,6 +175,15 @@ export interface ProtocolRouterOptions {
    * buffering their body, and everything else keeps the existing order (read the
    * bounded body, then run the full admission check). Implementations MUST NOT
    * perform I/O or trigger a probe here, and MUST return false when unsure.
+   *
+   * Covers BOTH inbound transports: the one-shot `register()` path and pooled
+   * streams (`enablePooling` installs it as the pool's stream-accept gate,
+   * keyed by the logical protocol id so `admissionExemptProtocols` applies).
+   *
+   * This hook and `isPeerAccepted` are two phases of ONE admission policy and
+   * must consult the same underlying state. Do not wire them from different
+   * sources — use `createNetworkAdmissionRouterPolicy` (dkg-agent) or an
+   * equivalent single constructor that derives both from one coordinator.
    */
   isPeerKnownRejected?: (peerId: string, protocolId: string) => boolean;
   admissionExemptProtocols?: Iterable<string>;
@@ -252,13 +261,23 @@ export class ProtocolRouter {
   }
 
   /**
-   * Pre-read inbound gate. Only consults the cached-verdict predicate; never
-   * probes. Throws the same shape as `requirePeerAccepted` so the existing
-   * catch-path handling (abort + quiet logging) is unchanged.
+   * Pre-read inbound gate predicate: cached verdict only, never probes, and
+   * exempt protocols are never gated. Shared by the one-shot inbound path
+   * (throwing wrapper below) and the pooled stream-accept gate installed by
+   * `enablePooling`.
+   */
+  private isKnownRejectedInboundPeer(peerId: string, protocolId: string): boolean {
+    if (!this.isPeerKnownRejected || this.admissionExemptProtocols.has(protocolId)) return false;
+    return this.isPeerKnownRejected(peerId, protocolId);
+  }
+
+  /**
+   * Pre-read inbound gate for the one-shot path. Throws the same shape as
+   * `requirePeerAccepted` so the existing catch-path handling (abort + quiet
+   * logging) is unchanged.
    */
   private rejectKnownRejectedInboundPeer(peerId: string, protocolId: string): void {
-    if (!this.isPeerKnownRejected || this.admissionExemptProtocols.has(protocolId)) return;
-    if (!this.isPeerKnownRejected(peerId, protocolId)) return;
+    if (!this.isKnownRejectedInboundPeer(peerId, protocolId)) return;
     throw new Error(
       `peer ${peerId.slice(-8)} is not admitted for inbound protocol ${protocolId}`,
     );
@@ -364,6 +383,12 @@ export class ProtocolRouter {
         protocolId: wireProtocolId,
         maxFrameBytes: options.maxFrameBytes ?? this.maxReadBytes,
         primePeer,
+        // Router-owned, deliberately not caller-overridable: the pooled
+        // pre-read gate must be keyed by the LOGICAL protocol id (production
+        // admission exemptions are logical ids) and must consult the same
+        // cached-verdict predicate as the one-shot inbound path.
+        rejectInboundStream: (peerIdStr: string) =>
+          this.isKnownRejectedInboundPeer(peerIdStr, logicalProtocolId),
       },
     );
     this.pooledByLogical.set(logicalProtocolId, {

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -210,12 +210,6 @@ export type ProtocolRouterPoolingOptions = Omit<
   'rejectInboundStream'
 >;
 
-// Compile-time guard for the option surface above: fails the build if the
-// router-owned gate ever becomes caller-suppliable through enablePooling.
-type RouterPoolingOptionsOmitGate =
-  'rejectInboundStream' extends keyof ProtocolRouterPoolingOptions ? never : true;
-const _routerPoolingOptionsOmitGate: RouterPoolingOptionsOmitGate = true;
-void _routerPoolingOptionsOmitGate;
 
 export class QuietRetryableHandlerError extends Error {
   constructor(message: string) {

--- a/packages/core/test/message-stream-pool.test.ts
+++ b/packages/core/test/message-stream-pool.test.ts
@@ -886,7 +886,7 @@ describe('MessageStreamPool', () => {
     await pool.close();
   });
 
-  it('inbound handler receives the full remotePeer object (real PeerId parity, Codex #560 round 3)', async () => {
+  it('inbound handler receives the normalized peer with real PeerId capabilities (Codex #560 round 3, normalized)', async () => {
     let stubHandle:
       | ((stream: unknown, conn: { remotePeer: unknown }) => void)
       | null = null;
@@ -925,12 +925,17 @@ describe('MessageStreamPool', () => {
     await flush();
     await flush();
 
-    // The handler must receive the EXACT remotePeer object — not a
-    // hollow `{ toString }` shim. This is what gives ProtocolRouter's
-    // wrapper access to `.toMultihash().bytes` for one-shot parity.
-    expect(handlerReceivedPeer).toBe(productionLikePeer);
-    const asPeer = handlerReceivedPeer as { toBytes: () => Uint8Array };
-    expect(Array.from(asPeer.toBytes())).toEqual([0x12, 0x34, 0x56]);
+    // Contract updated with normalization-at-accept: the handler receives the
+    // CANONICAL `{ toString, toBytes }` model, built exactly once from the raw
+    // `connection.remotePeer`. The original assertion pinned object identity
+    // only so ProtocolRouter's downstream wrap could reach `.toMultihash()`;
+    // normalization satisfies that rationale directly, so what is pinned now
+    // is capability parity: `toBytes()` yields the multihash bytes — the same
+    // preference order (`toMultihash` first) the router wrap always applied,
+    // i.e. exactly what application handlers observed before.
+    const asPeer = handlerReceivedPeer as { toString: () => string; toBytes: () => Uint8Array };
+    expect(asPeer.toString()).toBe(PEER_A);
+    expect(Array.from(asPeer.toBytes())).toEqual([0xde, 0xad, 0xbe, 0xef]);
 
     inboundStream.endRemote();
     await pool.close();

--- a/packages/core/test/protocol-router-pool.test.ts
+++ b/packages/core/test/protocol-router-pool.test.ts
@@ -36,6 +36,8 @@ class FakeStream {
   readonly sent: Uint8Array[] = [];
   /** Async-iterator pulls — 0 proves the frame decoder never touched the stream. */
   reads = 0;
+  /** Typed observer invoked on every async-iterator pull (ordering tests). */
+  onRead?: () => void;
   private readBuf: Uint8Array[] = [];
   private waiters: Array<(v: IteratorResult<Uint8Array>) => void> = [];
   private closeListeners: EventListener[] = [];
@@ -105,6 +107,7 @@ class FakeStream {
     return {
       next: () => {
         this.reads += 1;
+        this.onRead?.();
         if (this.readBuf.length > 0) {
           return Promise.resolve({ value: this.readBuf.shift()!, done: false });
         }
@@ -755,24 +758,28 @@ describe('ProtocolRouter pooled inbound handler', () => {
     await router.closePooling();
   });
 
-  it('aborts a known-rejected peer\'s pooled inbound stream before reading any frames', async () => {
-    // The pooled counterpart of the one-shot pre-read gate. `reads === 0` is
-    // the discriminator: the frame decoder never pulled from the stream, so a
-    // cached-rejected peer cannot push bounded REQUEST frames at us — nor get
-    // its PINGs answered, since keepalive service also sits behind the loop.
-    type HandlerFn = (
-      stream: import('@libp2p/interface').Stream,
-      connection: { remotePeer: { toString: () => string; toMultihash: () => { bytes: Uint8Array } } },
-    ) => void | Promise<void>;
-    let inboundHandler: HandlerFn | null = null;
-    let handlerCalls = 0;
-    let probeCalls = 0;
+  type PooledInboundHandlerFn = (
+    stream: import('@libp2p/interface').Stream,
+    connection: { remotePeer: { toString: () => string; toMultihash: () => { bytes: Uint8Array } } },
+  ) => void | Promise<void>;
+
+  /**
+   * Shared harness for pooled INBOUND admission cases: builds a router over a
+   * stub node, enables pooling for one logical protocol, captures the wire
+   * handler, and exposes invoke/decode/close so each test states only its
+   * policy configuration and assertions.
+   */
+  function makePooledInboundFixture(
+    routerOptions?: ConstructorParameters<typeof ProtocolRouter>[1],
+    logicalProtocolId = '/dkg/10.0.1/message',
+  ) {
+    let inboundHandler: PooledInboundHandlerFn | null = null;
     const node = {
       libp2p: {
         dialProtocol: async () => {
           throw new Error('not used');
         },
-        handle: (_protocolId: string, handler: HandlerFn) => {
+        handle: (_protocolId: string, handler: PooledInboundHandlerFn) => {
           if (_protocolId === POOLED_MESSAGE_PROTOCOL) {
             inboundHandler = handler;
           }
@@ -782,77 +789,90 @@ describe('ProtocolRouter pooled inbound handler', () => {
         peerStore: { get: async () => ({ addresses: [] }) },
       },
     } as unknown as DKGNode;
+    const router = new ProtocolRouter(node, routerOptions);
+    router.enablePooling(logicalProtocolId, {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+    return {
+      router,
+      register(handler: () => Promise<Uint8Array>): void {
+        router.register(logicalProtocolId, handler);
+      },
+      invoke(stream: FakeStream, peer = PEER_NEW): Promise<void> {
+        if (!inboundHandler) throw new Error('pool wire handler not captured');
+        return Promise.resolve(
+          inboundHandler(stream as unknown as import('@libp2p/interface').Stream, {
+            remotePeer: {
+              toString: () => peer,
+              toMultihash: () => ({ bytes: new Uint8Array() }),
+            },
+          }),
+        );
+      },
+      async decodeSent(stream: FakeStream): Promise<{ type: FrameType; payload: Uint8Array }[]> {
+        const parsed: { type: FrameType; payload: Uint8Array }[] = [];
+        for await (const f of decodeFrames(
+          (async function* () {
+            for (const c of stream.sent) yield c;
+          })(),
+        )) {
+          parsed.push(f);
+        }
+        return parsed;
+      },
+      close: () => router.closePooling(),
+    };
+  }
 
-    const router = new ProtocolRouter(node, {
+  it('aborts a known-rejected peer\'s pooled inbound stream before reading any frames', async () => {
+    // The pooled counterpart of the one-shot pre-read gate. `reads === 0` is
+    // the discriminator: the frame decoder never pulled from the stream, so a
+    // cached-rejected peer cannot push bounded REQUEST frames at us — nor get
+    // its PINGs answered, since keepalive service also sits behind the loop.
+    let handlerCalls = 0;
+    let probeCalls = 0;
+    const fixture = makePooledInboundFixture({
       isPeerAccepted: () => {
         probeCalls += 1;
         return true;
       },
       isPeerKnownRejected: () => true,
     });
-    router.enablePooling('/dkg/10.0.1/message', {
-      keepaliveIntervalMs: 0,
-      idleTimeoutMs: 0,
-      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
-    });
-    router.register('/dkg/10.0.1/message', async () => {
+    fixture.register(async () => {
       handlerCalls += 1;
       return new TextEncoder().encode('should-not-run');
     });
 
-    expect(inboundHandler).toBeDefined();
-    const inboundStream = new FakeStream();
-    const inboundRun = inboundHandler!(inboundStream as unknown as import('@libp2p/interface').Stream, {
-      remotePeer: {
-        toString: () => PEER_NEW,
-        toMultihash: () => ({ bytes: new Uint8Array() }),
-      },
-    });
+    const stream = new FakeStream();
+    const run = fixture.invoke(stream);
     await flush();
     // Frames offered after accept must never be consumed.
-    inboundStream.feed(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('hi')));
-    inboundStream.feed(encodeFrame(FrameType.PING));
+    stream.feed(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('hi')));
+    stream.feed(encodeFrame(FrameType.PING));
     await flush();
 
-    expect(inboundStream.reads).toBe(0);
+    expect(stream.reads).toBe(0);
     expect(handlerCalls).toBe(0);
     expect(probeCalls).toBe(0);
     // No ERROR frame, no PONG — nothing is written to a gated stream.
-    expect(inboundStream.sent.length).toBe(0);
-    expect(inboundStream.writeStatus).toBe('closed');
-    await inboundRun;
-    await router.closePooling();
+    expect(stream.sent.length).toBe(0);
+    expect(stream.writeStatus).toBe('closed');
+    await run;
+    await fixture.close();
   });
 
-  it('keeps read-then-probe pooled ordering when the gate does not recognize the peer', async () => {
-    // False-when-unsure: an unclassified peer keeps the exact pre-gate
-    // behavior — REQUEST buffered, then the full admission check decides.
-    type HandlerFn = (
-      stream: import('@libp2p/interface').Stream,
-      connection: { remotePeer: { toString: () => string; toMultihash: () => { bytes: Uint8Array } } },
-    ) => void | Promise<void>;
-    let inboundHandler: HandlerFn | null = null;
-    const admittedCalls: string[] = [];
+  it('reads BEFORE probing when the gate does not recognize the pooled peer', async () => {
+    // False-when-unsure, with the order actually asserted: the first iterator
+    // pull must precede the admission probe. Probe-before-read is the exact
+    // I/O inversion this branch exists to avoid — an admission probe dials
+    // outbound toward a sender that may still be mid-write to us.
+    const order: string[] = [];
     let gateCalls = 0;
-    const node = {
-      libp2p: {
-        dialProtocol: async () => {
-          throw new Error('not used');
-        },
-        handle: (_protocolId: string, handler: HandlerFn) => {
-          if (_protocolId === POOLED_MESSAGE_PROTOCOL) {
-            inboundHandler = handler;
-          }
-        },
-        unhandle: () => undefined,
-        getConnections: () => [],
-        peerStore: { get: async () => ({ addresses: [] }) },
-      },
-    } as unknown as DKGNode;
-
-    const router = new ProtocolRouter(node, {
-      isPeerAccepted: (peerId) => {
-        admittedCalls.push(peerId);
+    const fixture = makePooledInboundFixture({
+      isPeerAccepted: () => {
+        order.push('probe');
         return true;
       },
       isPeerKnownRejected: () => {
@@ -860,67 +880,31 @@ describe('ProtocolRouter pooled inbound handler', () => {
         return false;
       },
     });
-    router.enablePooling('/dkg/10.0.1/message', {
-      keepaliveIntervalMs: 0,
-      idleTimeoutMs: 0,
-      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
-    });
-    router.register('/dkg/10.0.1/message', async () => new TextEncoder().encode('ok'));
+    fixture.register(async () => new TextEncoder().encode('ok'));
 
-    const inboundStream = new FakeStream();
-    const inboundRun = inboundHandler!(inboundStream as unknown as import('@libp2p/interface').Stream, {
-      remotePeer: {
-        toString: () => PEER_NEW,
-        toMultihash: () => ({ bytes: new Uint8Array() }),
-      },
-    });
+    const stream = new FakeStream();
+    stream.onRead = () => {
+      if (!order.includes('read')) order.push('read');
+    };
+    const run = fixture.invoke(stream);
     await flush();
-    inboundStream.feed(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('hi')));
+    stream.feed(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('hi')));
     await flush();
 
     expect(gateCalls).toBe(1); // once per accepted stream
-    expect(inboundStream.reads).toBeGreaterThan(0);
-    expect(admittedCalls).toEqual([PEER_NEW]);
-    const parsed: { type: FrameType; payload: Uint8Array }[] = [];
-    for await (const f of decodeFrames(
-      (async function* () {
-        for (const c of inboundStream.sent) yield c;
-      })(),
-    )) {
-      parsed.push(f);
-    }
+    expect(order).toEqual(['read', 'probe']);
+    const parsed = await fixture.decodeSent(stream);
     expect(parsed[0]?.type).toBe(FrameType.RESPONSE);
-    inboundStream.endRemote();
-    await inboundRun;
-    await router.closePooling();
+    stream.endRemote();
+    await run;
+    await fixture.close();
   });
 
   it('never consults the pooled gate for admission-exempt logical protocols', async () => {
     // Exemptions are keyed by the LOGICAL protocol id — the same id the
     // pooled full-admission check uses — not the wire id the pool listens on.
-    type HandlerFn = (
-      stream: import('@libp2p/interface').Stream,
-      connection: { remotePeer: { toString: () => string; toMultihash: () => { bytes: Uint8Array } } },
-    ) => void | Promise<void>;
-    let inboundHandler: HandlerFn | null = null;
     let gateCalls = 0;
-    const node = {
-      libp2p: {
-        dialProtocol: async () => {
-          throw new Error('not used');
-        },
-        handle: (_protocolId: string, handler: HandlerFn) => {
-          if (_protocolId === POOLED_MESSAGE_PROTOCOL) {
-            inboundHandler = handler;
-          }
-        },
-        unhandle: () => undefined,
-        getConnections: () => [],
-        peerStore: { get: async () => ({ addresses: [] }) },
-      },
-    } as unknown as DKGNode;
-
-    const router = new ProtocolRouter(node, {
+    const fixture = makePooledInboundFixture({
       isPeerAccepted: () => false,
       isPeerKnownRejected: () => {
         gateCalls += 1;
@@ -928,38 +912,21 @@ describe('ProtocolRouter pooled inbound handler', () => {
       },
       admissionExemptProtocols: ['/dkg/10.0.1/message'],
     });
-    router.enablePooling('/dkg/10.0.1/message', {
-      keepaliveIntervalMs: 0,
-      idleTimeoutMs: 0,
-      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
-    });
-    router.register('/dkg/10.0.1/message', async () => new TextEncoder().encode('exempt-ok'));
+    fixture.register(async () => new TextEncoder().encode('exempt-ok'));
 
-    const inboundStream = new FakeStream();
-    const inboundRun = inboundHandler!(inboundStream as unknown as import('@libp2p/interface').Stream, {
-      remotePeer: {
-        toString: () => PEER_NEW,
-        toMultihash: () => ({ bytes: new Uint8Array() }),
-      },
-    });
+    const stream = new FakeStream();
+    const run = fixture.invoke(stream);
     await flush();
-    inboundStream.feed(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('hi')));
+    stream.feed(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('hi')));
     await flush();
 
     expect(gateCalls).toBe(0);
-    const parsed: { type: FrameType; payload: Uint8Array }[] = [];
-    for await (const f of decodeFrames(
-      (async function* () {
-        for (const c of inboundStream.sent) yield c;
-      })(),
-    )) {
-      parsed.push(f);
-    }
+    const parsed = await fixture.decodeSent(stream);
     expect(parsed[0]?.type).toBe(FrameType.RESPONSE);
     expect(new TextDecoder().decode(parsed[0].payload)).toBe('exempt-ok');
-    inboundStream.endRemote();
-    await inboundRun;
-    await router.closePooling();
+    stream.endRemote();
+    await run;
+    await fixture.close();
   });
 
   it('removes the node stop listener after successful pooled inbound handling', async () => {

--- a/packages/core/test/protocol-router-pool.test.ts
+++ b/packages/core/test/protocol-router-pool.test.ts
@@ -900,6 +900,43 @@ describe('ProtocolRouter pooled inbound handler', () => {
     await fixture.close();
   });
 
+  it('fails closed when the pooled gate itself throws', async () => {
+    // The gate's contract says it must not throw; this pins what happens when
+    // that contract is violated anyway. Failing open would silently disable
+    // the protection, and propagating the throw would leak the stream
+    // un-aborted through the accept path's logger — so a throwing gate must
+    // produce exactly the same pre-read abort as a rejected verdict.
+    let handlerCalls = 0;
+    let probeCalls = 0;
+    const fixture = makePooledInboundFixture({
+      isPeerAccepted: () => {
+        probeCalls += 1;
+        return true;
+      },
+      isPeerKnownRejected: () => {
+        throw new Error('cache unavailable');
+      },
+    });
+    fixture.register(async () => {
+      handlerCalls += 1;
+      return new TextEncoder().encode('should-not-run');
+    });
+
+    const stream = new FakeStream();
+    const run = fixture.invoke(stream);
+    await flush();
+    stream.feed(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('hi')));
+    await flush();
+
+    expect(stream.reads).toBe(0);
+    expect(handlerCalls).toBe(0);
+    expect(probeCalls).toBe(0);
+    expect(stream.sent.length).toBe(0);
+    expect(stream.writeStatus).toBe('closed');
+    await run;
+    await fixture.close();
+  });
+
   it('never consults the pooled gate for admission-exempt logical protocols', async () => {
     // Exemptions are keyed by the LOGICAL protocol id — the same id the
     // pooled full-admission check uses — not the wire id the pool listens on.

--- a/packages/core/test/protocol-router-pool.test.ts
+++ b/packages/core/test/protocol-router-pool.test.ts
@@ -34,6 +34,8 @@ const PEER_OLD = '12D3KooWGRUkpYzqu7w17X8YBaPDB6c7TuD3KSGmZSEpCpVjMx9V';
 class FakeStream {
   writeStatus: 'open' | 'closing' | 'closed' = 'open';
   readonly sent: Uint8Array[] = [];
+  /** Async-iterator pulls — 0 proves the frame decoder never touched the stream. */
+  reads = 0;
   private readBuf: Uint8Array[] = [];
   private waiters: Array<(v: IteratorResult<Uint8Array>) => void> = [];
   private closeListeners: EventListener[] = [];
@@ -102,6 +104,7 @@ class FakeStream {
   [Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
     return {
       next: () => {
+        this.reads += 1;
         if (this.readBuf.length > 0) {
           return Promise.resolve({ value: this.readBuf.shift()!, done: false });
         }
@@ -747,6 +750,213 @@ describe('ProtocolRouter pooled inbound handler', () => {
     expect(parsed[0].type).toBe(FrameType.ERROR);
     expect(new TextDecoder().decode(parsed[0].payload)).toMatch(/not admitted/);
 
+    inboundStream.endRemote();
+    await inboundRun;
+    await router.closePooling();
+  });
+
+  it('aborts a known-rejected peer\'s pooled inbound stream before reading any frames', async () => {
+    // The pooled counterpart of the one-shot pre-read gate. `reads === 0` is
+    // the discriminator: the frame decoder never pulled from the stream, so a
+    // cached-rejected peer cannot push bounded REQUEST frames at us — nor get
+    // its PINGs answered, since keepalive service also sits behind the loop.
+    type HandlerFn = (
+      stream: import('@libp2p/interface').Stream,
+      connection: { remotePeer: { toString: () => string; toMultihash: () => { bytes: Uint8Array } } },
+    ) => void | Promise<void>;
+    let inboundHandler: HandlerFn | null = null;
+    let handlerCalls = 0;
+    let probeCalls = 0;
+    const node = {
+      libp2p: {
+        dialProtocol: async () => {
+          throw new Error('not used');
+        },
+        handle: (_protocolId: string, handler: HandlerFn) => {
+          if (_protocolId === POOLED_MESSAGE_PROTOCOL) {
+            inboundHandler = handler;
+          }
+        },
+        unhandle: () => undefined,
+        getConnections: () => [],
+        peerStore: { get: async () => ({ addresses: [] }) },
+      },
+    } as unknown as DKGNode;
+
+    const router = new ProtocolRouter(node, {
+      isPeerAccepted: () => {
+        probeCalls += 1;
+        return true;
+      },
+      isPeerKnownRejected: () => true,
+    });
+    router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+    router.register('/dkg/10.0.1/message', async () => {
+      handlerCalls += 1;
+      return new TextEncoder().encode('should-not-run');
+    });
+
+    expect(inboundHandler).toBeDefined();
+    const inboundStream = new FakeStream();
+    const inboundRun = inboundHandler!(inboundStream as unknown as import('@libp2p/interface').Stream, {
+      remotePeer: {
+        toString: () => PEER_NEW,
+        toMultihash: () => ({ bytes: new Uint8Array() }),
+      },
+    });
+    await flush();
+    // Frames offered after accept must never be consumed.
+    inboundStream.feed(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('hi')));
+    inboundStream.feed(encodeFrame(FrameType.PING));
+    await flush();
+
+    expect(inboundStream.reads).toBe(0);
+    expect(handlerCalls).toBe(0);
+    expect(probeCalls).toBe(0);
+    // No ERROR frame, no PONG — nothing is written to a gated stream.
+    expect(inboundStream.sent.length).toBe(0);
+    expect(inboundStream.writeStatus).toBe('closed');
+    await inboundRun;
+    await router.closePooling();
+  });
+
+  it('keeps read-then-probe pooled ordering when the gate does not recognize the peer', async () => {
+    // False-when-unsure: an unclassified peer keeps the exact pre-gate
+    // behavior — REQUEST buffered, then the full admission check decides.
+    type HandlerFn = (
+      stream: import('@libp2p/interface').Stream,
+      connection: { remotePeer: { toString: () => string; toMultihash: () => { bytes: Uint8Array } } },
+    ) => void | Promise<void>;
+    let inboundHandler: HandlerFn | null = null;
+    const admittedCalls: string[] = [];
+    let gateCalls = 0;
+    const node = {
+      libp2p: {
+        dialProtocol: async () => {
+          throw new Error('not used');
+        },
+        handle: (_protocolId: string, handler: HandlerFn) => {
+          if (_protocolId === POOLED_MESSAGE_PROTOCOL) {
+            inboundHandler = handler;
+          }
+        },
+        unhandle: () => undefined,
+        getConnections: () => [],
+        peerStore: { get: async () => ({ addresses: [] }) },
+      },
+    } as unknown as DKGNode;
+
+    const router = new ProtocolRouter(node, {
+      isPeerAccepted: (peerId) => {
+        admittedCalls.push(peerId);
+        return true;
+      },
+      isPeerKnownRejected: () => {
+        gateCalls += 1;
+        return false;
+      },
+    });
+    router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+    router.register('/dkg/10.0.1/message', async () => new TextEncoder().encode('ok'));
+
+    const inboundStream = new FakeStream();
+    const inboundRun = inboundHandler!(inboundStream as unknown as import('@libp2p/interface').Stream, {
+      remotePeer: {
+        toString: () => PEER_NEW,
+        toMultihash: () => ({ bytes: new Uint8Array() }),
+      },
+    });
+    await flush();
+    inboundStream.feed(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('hi')));
+    await flush();
+
+    expect(gateCalls).toBe(1); // once per accepted stream
+    expect(inboundStream.reads).toBeGreaterThan(0);
+    expect(admittedCalls).toEqual([PEER_NEW]);
+    const parsed: { type: FrameType; payload: Uint8Array }[] = [];
+    for await (const f of decodeFrames(
+      (async function* () {
+        for (const c of inboundStream.sent) yield c;
+      })(),
+    )) {
+      parsed.push(f);
+    }
+    expect(parsed[0]?.type).toBe(FrameType.RESPONSE);
+    inboundStream.endRemote();
+    await inboundRun;
+    await router.closePooling();
+  });
+
+  it('never consults the pooled gate for admission-exempt logical protocols', async () => {
+    // Exemptions are keyed by the LOGICAL protocol id — the same id the
+    // pooled full-admission check uses — not the wire id the pool listens on.
+    type HandlerFn = (
+      stream: import('@libp2p/interface').Stream,
+      connection: { remotePeer: { toString: () => string; toMultihash: () => { bytes: Uint8Array } } },
+    ) => void | Promise<void>;
+    let inboundHandler: HandlerFn | null = null;
+    let gateCalls = 0;
+    const node = {
+      libp2p: {
+        dialProtocol: async () => {
+          throw new Error('not used');
+        },
+        handle: (_protocolId: string, handler: HandlerFn) => {
+          if (_protocolId === POOLED_MESSAGE_PROTOCOL) {
+            inboundHandler = handler;
+          }
+        },
+        unhandle: () => undefined,
+        getConnections: () => [],
+        peerStore: { get: async () => ({ addresses: [] }) },
+      },
+    } as unknown as DKGNode;
+
+    const router = new ProtocolRouter(node, {
+      isPeerAccepted: () => false,
+      isPeerKnownRejected: () => {
+        gateCalls += 1;
+        return true;
+      },
+      admissionExemptProtocols: ['/dkg/10.0.1/message'],
+    });
+    router.enablePooling('/dkg/10.0.1/message', {
+      keepaliveIntervalMs: 0,
+      idleTimeoutMs: 0,
+      peerIdFromString: (s) => ({ toString: () => s }) as unknown,
+    });
+    router.register('/dkg/10.0.1/message', async () => new TextEncoder().encode('exempt-ok'));
+
+    const inboundStream = new FakeStream();
+    const inboundRun = inboundHandler!(inboundStream as unknown as import('@libp2p/interface').Stream, {
+      remotePeer: {
+        toString: () => PEER_NEW,
+        toMultihash: () => ({ bytes: new Uint8Array() }),
+      },
+    });
+    await flush();
+    inboundStream.feed(encodeFrame(FrameType.REQUEST, new TextEncoder().encode('hi')));
+    await flush();
+
+    expect(gateCalls).toBe(0);
+    const parsed: { type: FrameType; payload: Uint8Array }[] = [];
+    for await (const f of decodeFrames(
+      (async function* () {
+        for (const c of inboundStream.sent) yield c;
+      })(),
+    )) {
+      parsed.push(f);
+    }
+    expect(parsed[0]?.type).toBe(FrameType.RESPONSE);
+    expect(new TextDecoder().decode(parsed[0].payload)).toBe('exempt-ok');
     inboundStream.endRemote();
     await inboundRun;
     await router.closePooling();

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -91,6 +91,8 @@ describe('ProtocolRouter', () => {
       aborted: Error | null = null;
       closedWithSignal: AbortSignal | undefined;
       reads = 0;
+      /** Typed observer invoked on every async-iterator pull (ordering tests). */
+      onRead?: () => void;
 
       constructor(
         private readonly chunks: Uint8Array[],
@@ -117,6 +119,7 @@ describe('ProtocolRouter', () => {
         return {
           next: async () => {
             this.reads += 1;
+            this.onRead?.();
             if (index < this.chunks.length) {
               return { value: this.chunks[index++], done: false };
             }
@@ -308,8 +311,16 @@ describe('ProtocolRouter', () => {
           unhandle: () => undefined,
         },
       } as unknown as DKGNode;
+      let gateCalls = 0;
       const router = new ProtocolRouter(node, {
         isPeerAccepted: () => false,
+        // Exempt protocols must bypass the pre-read gate too — a cached-rejected
+        // peer still gets identity-probe traffic through, which is how it can
+        // re-prove itself. The predicate must not even be consulted.
+        isPeerKnownRejected: () => {
+          gateCalls += 1;
+          return true;
+        },
         admissionExemptProtocols: [PROTOCOL],
       });
       router.register(PROTOCOL, async () => {
@@ -328,39 +339,29 @@ describe('ProtocolRouter', () => {
       expect(handlerCalls).toBe(1);
       expect(stream.sent).toEqual(new Uint8Array([0xaa]));
       expect(stream.aborted).toBeNull();
+      expect(gateCalls).toBe(0);
     });
 
     it('drops an already-rejected inbound peer before reading its request body', async () => {
       // `reads` is the discriminator: zero pulls proves the body was never taken
       // off the wire. handlerCalls alone would pass even if it were read then
       // discarded.
-      let inbound: ((stream: FakeInboundStream, connection: unknown) => Promise<void>) | null = null;
-      let handlerCalls = 0;
       let probeCalls = 0;
-      const node = {
-        libp2p: {
-          handle: (_protocol: string, handler: (stream: FakeInboundStream, connection: unknown) => Promise<void>) => {
-            inbound = handler;
-          },
-          unhandle: () => undefined,
-        },
-      } as unknown as DKGNode;
-      const router = new ProtocolRouter(node, {
+      let handlerCalls = 0;
+      const fixture = makeInboundFixture(undefined, {
         isPeerKnownRejected: () => true,
-        isPeerAccepted: () => { probeCalls += 1; return true; },
+        isPeerAccepted: () => {
+          probeCalls += 1;
+          return true;
+        },
       });
-      router.register(PROTOCOL, async () => {
+      fixture.router.register(PROTOCOL, async () => {
         handlerCalls += 1;
         return new Uint8Array([0xaa]);
       });
 
       const stream = new FakeInboundStream([new Uint8Array([0x01])]);
-      await inbound!(stream, {
-        remotePeer: {
-          toString: () => REMOTE_PEER,
-          toMultihash: () => ({ bytes: new Uint8Array([1, 2, 3]) }),
-        },
-      });
+      await fixture.invoke(stream);
 
       expect(stream.reads).toBe(0);
       expect(handlerCalls).toBe(0);
@@ -376,40 +377,30 @@ describe('ProtocolRouter', () => {
       // inbound body is still unread inverts the I/O order against a sender that
       // is itself mid-write, which stalls request/response exchanges with a
       // freshly restarted peer. So an unclassified peer keeps the read-first order.
-      let inbound: ((stream: FakeInboundStream, connection: unknown) => Promise<void>) | null = null;
       const order: string[] = [];
-      const node = {
-        libp2p: {
-          handle: (_protocol: string, handler: (stream: FakeInboundStream, connection: unknown) => Promise<void>) => {
-            inbound = handler;
-          },
-          unhandle: () => undefined,
-        },
-      } as unknown as DKGNode;
-      const router = new ProtocolRouter(node, {
+      const fixture = makeInboundFixture(undefined, {
         isPeerKnownRejected: () => false,
-        isPeerAccepted: () => { order.push('probe'); return true; },
+        isPeerAccepted: () => {
+          order.push('probe');
+          return true;
+        },
       });
-      router.register(PROTOCOL, async () => new Uint8Array([0xaa]));
+      fixture.router.register(PROTOCOL, async () => new Uint8Array([0xaa]));
 
       const stream = new FakeInboundStream([new Uint8Array([0x01])]);
-      const originalIterator = stream[Symbol.asyncIterator].bind(stream);
-      (stream as unknown as { [Symbol.asyncIterator]: () => AsyncIterableIterator<Uint8Array> })[Symbol.asyncIterator] = () => {
-        order.push('read');
-        return originalIterator();
+      stream.onRead = () => {
+        if (!order.includes('read')) order.push('read');
       };
-      await inbound!(stream, {
-        remotePeer: {
-          toString: () => REMOTE_PEER,
-          toMultihash: () => ({ bytes: new Uint8Array([1, 2, 3]) }),
-        },
-      });
+      await fixture.invoke(stream);
 
       expect(order).toEqual(['read', 'probe']);
       expect(stream.sent).toEqual(new Uint8Array([0xaa]));
     });
 
-    function makeInboundFixture(stopSignal?: AbortSignal) {
+    function makeInboundFixture(
+      stopSignal?: AbortSignal,
+      routerOptions?: ConstructorParameters<typeof ProtocolRouter>[1],
+    ) {
       let inbound: ((stream: FakeInboundStream, connection: unknown) => Promise<void>) | null = null;
       const node = {
         get stopSignal() {
@@ -422,7 +413,7 @@ describe('ProtocolRouter', () => {
           unhandle: () => undefined,
         },
       } as unknown as DKGNode;
-      const router = new ProtocolRouter(node);
+      const router = new ProtocolRouter(node, routerOptions);
       const connection = {
         remotePeer: {
           toString: () => REMOTE_PEER,

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -138,7 +138,7 @@ describe('ProtocolRouter', () => {
       }
     }
 
-    it('rejects non-admitted inbound peers after reading bounded request bytes but before handler dispatch', async () => {
+    it('rejects non-admitted inbound peers before reading request bytes or dispatching the handler', async () => {
       let inbound: ((stream: FakeInboundStream, connection: unknown) => Promise<void>) | null = null;
       let handlerCalls = 0;
       const admittedCalls: Array<[string, string, 'inbound' | 'outbound']> = [];
@@ -171,7 +171,10 @@ describe('ProtocolRouter', () => {
 
       expect(admittedCalls).toEqual([[REMOTE_PEER, PROTOCOL, 'inbound']]);
       expect(handlerCalls).toBe(0);
-      expect(stream.reads).toBe(2);
+      // reads === 0 is the discriminator: the body is never pulled off the wire
+      // for a peer the admission boundary rejects. handlerCalls alone would still
+      // pass if the body had been read and then discarded.
+      expect(stream.reads).toBe(0);
       expect(stream.sent).toBeNull();
       expect(stream.aborted?.message).toMatch(/handler error/);
     });

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -138,7 +138,7 @@ describe('ProtocolRouter', () => {
       }
     }
 
-    it('rejects non-admitted inbound peers before reading request bytes or dispatching the handler', async () => {
+    it('rejects non-admitted inbound peers after reading bounded request bytes but before handler dispatch', async () => {
       let inbound: ((stream: FakeInboundStream, connection: unknown) => Promise<void>) | null = null;
       let handlerCalls = 0;
       const admittedCalls: Array<[string, string, 'inbound' | 'outbound']> = [];
@@ -171,10 +171,7 @@ describe('ProtocolRouter', () => {
 
       expect(admittedCalls).toEqual([[REMOTE_PEER, PROTOCOL, 'inbound']]);
       expect(handlerCalls).toBe(0);
-      // reads === 0 is the discriminator: the body is never pulled off the wire
-      // for a peer the admission boundary rejects. handlerCalls alone would still
-      // pass if the body had been read and then discarded.
-      expect(stream.reads).toBe(0);
+      expect(stream.reads).toBe(2);
       expect(stream.sent).toBeNull();
       expect(stream.aborted?.message).toMatch(/handler error/);
     });
@@ -331,6 +328,85 @@ describe('ProtocolRouter', () => {
       expect(handlerCalls).toBe(1);
       expect(stream.sent).toEqual(new Uint8Array([0xaa]));
       expect(stream.aborted).toBeNull();
+    });
+
+    it('drops an already-rejected inbound peer before reading its request body', async () => {
+      // `reads` is the discriminator: zero pulls proves the body was never taken
+      // off the wire. handlerCalls alone would pass even if it were read then
+      // discarded.
+      let inbound: ((stream: FakeInboundStream, connection: unknown) => Promise<void>) | null = null;
+      let handlerCalls = 0;
+      let probeCalls = 0;
+      const node = {
+        libp2p: {
+          handle: (_protocol: string, handler: (stream: FakeInboundStream, connection: unknown) => Promise<void>) => {
+            inbound = handler;
+          },
+          unhandle: () => undefined,
+        },
+      } as unknown as DKGNode;
+      const router = new ProtocolRouter(node, {
+        isPeerKnownRejected: () => true,
+        isPeerAccepted: () => { probeCalls += 1; return true; },
+      });
+      router.register(PROTOCOL, async () => {
+        handlerCalls += 1;
+        return new Uint8Array([0xaa]);
+      });
+
+      const stream = new FakeInboundStream([new Uint8Array([0x01])]);
+      await inbound!(stream, {
+        remotePeer: {
+          toString: () => REMOTE_PEER,
+          toMultihash: () => ({ bytes: new Uint8Array([1, 2, 3]) }),
+        },
+      });
+
+      expect(stream.reads).toBe(0);
+      expect(handlerCalls).toBe(0);
+      expect(stream.sent).toBeNull();
+      // And the probing check is never reached for a peer already known bad.
+      expect(probeCalls).toBe(0);
+    });
+
+    it('still reads before probing when the peer is not already classified', async () => {
+      // The other half of the contract, and the reason the pre-read gate is
+      // limited to cached verdicts: `isPeerAccepted` performs an admission probe
+      // (outbound I/O) for unclassified peers in production. Probing while the
+      // inbound body is still unread inverts the I/O order against a sender that
+      // is itself mid-write, which stalls request/response exchanges with a
+      // freshly restarted peer. So an unclassified peer keeps the read-first order.
+      let inbound: ((stream: FakeInboundStream, connection: unknown) => Promise<void>) | null = null;
+      const order: string[] = [];
+      const node = {
+        libp2p: {
+          handle: (_protocol: string, handler: (stream: FakeInboundStream, connection: unknown) => Promise<void>) => {
+            inbound = handler;
+          },
+          unhandle: () => undefined,
+        },
+      } as unknown as DKGNode;
+      const router = new ProtocolRouter(node, {
+        isPeerKnownRejected: () => false,
+        isPeerAccepted: () => { order.push('probe'); return true; },
+      });
+      router.register(PROTOCOL, async () => new Uint8Array([0xaa]));
+
+      const stream = new FakeInboundStream([new Uint8Array([0x01])]);
+      const originalIterator = stream[Symbol.asyncIterator].bind(stream);
+      (stream as unknown as { [Symbol.asyncIterator]: () => AsyncIterableIterator<Uint8Array> })[Symbol.asyncIterator] = () => {
+        order.push('read');
+        return originalIterator();
+      };
+      await inbound!(stream, {
+        remotePeer: {
+          toString: () => REMOTE_PEER,
+          toMultihash: () => ({ bytes: new Uint8Array([1, 2, 3]) }),
+        },
+      });
+
+      expect(order).toEqual(['read', 'probe']);
+      expect(stream.sent).toEqual(new Uint8Array([0xaa]));
     });
 
     function makeInboundFixture(stopSignal?: AbortSignal) {


### PR DESCRIPTION
Reorders two statements in `ProtocolRouter`'s direct inbound handler so peer admission resolves **before** the request body is read, rather than after.

### Why

`requirePeerAccepted` depends only on the peer id and protocol — never on the request payload — so reading first buys nothing. Doing it in the other order means work on behalf of a peer is bounded by its admission state rather than by the read limit alone.

The pooled inbound path already resolved admission before dispatch. This brings the direct path into line with it, so the two inbound routes behave consistently.

### Change

```
-  const requestData = await readAllWithSignal(stream, limit, handlerSignal);
   await this.requirePeerAccepted(remotePeer, protocolId, 'inbound', { ... });
+  const requestData = await readAllWithSignal(stream, limit, handlerSignal);
```

Behaviour for admitted peers is unchanged.

### Test

One existing test pinned the previous ordering and is updated: it now asserts `stream.reads === 0` for a rejected peer. That assertion is the discriminator — checking only that the handler did not run would still pass if the body had been read and then discarded.

Verified it is a real discriminator: on the unmodified base the updated test fails with `reads === 2`.

`packages/core`: protocol-router, protocol-router-abort, protocol-router-pool — **108 passing**. `tsc --noEmit` clean.
