### PR TITLE
fix(core,cli): align context-graph ID validation and bound keystore KDF params

### DIFF
--- a/packages/cli/src/daemon/handle-request.ts
+++ b/packages/cli/src/daemon/handle-request.ts
@@ -202,7 +202,6 @@ import {
   isLoopbackClientIp,
   isLoopbackRateLimitExemptPath,
   shouldBypassRateLimitForLoopbackTraffic,
-  isValidContextGraphId,
   shortId,
   sleep,
   deriveBlockExplorerUrl,

--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -1928,28 +1928,19 @@ export function shouldBypassRateLimitForLoopbackTraffic(ip: string, pathname: st
   return isLoopbackClientIp(ip) && isLoopbackRateLimitExemptPath(pathname);
 }
 
+/**
+ * Boolean adapter over the single context-graph ID policy in
+ * `@origintrail-official/dkg-core`. This deliberately holds no rules of its own:
+ * it previously carried a second copy (length limit, character whitelist and the
+ * segment-aware traversal check described in CLI-16), which drifted from the
+ * core validator — core was missing the segment check while 26 route call sites
+ * reached it via `validateRequiredContextGraphId`. Keeping the boolean shape for
+ * existing callers, but `validateContextGraphId` now owns the policy, so a
+ * future change to the character set or the length cap has exactly one home.
+ */
 export function isValidContextGraphId(id: string): boolean {
-  if (!id || typeof id !== "string") return false;
-  if (id.length > 256) return false;
-  // CLI-16 (
-  // reject path-traversal patterns where it actually matters — i.e.
-  // segments that the OS / URL resolver will interpret as the
-  // parent / current directory. The character whitelist below
-  // allows `.` and `/` because URNs / DIDs / URLs legitimately
-  // contain version markers like `v1..2`, schema fragments like
-  // `https://example.com/a..b`, etc.
-  //
-  // The earlier blanket `id.includes('..')` check broke those
-  // legitimate identifiers without adding any defence-in-depth: a
-  // segment-aware check is both stricter (still rejects every real
-  // traversal) and tighter (does not produce false-positive 4xx
-  // for valid context-graph IDs that happen to contain `..` inside
-  // a single segment).
-  for (const seg of id.split("/")) {
-    if (seg === "." || seg === "..") return false;
-  }
-  // Allow URNs, DIDs, simple slug-like identifiers, and URIs
-  return /^[\w:/.@\-]+$/.test(id);
+  if (typeof id !== "string") return false;
+  return validateContextGraphId(id).valid;
 }
 
 /**

--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -1620,7 +1620,6 @@ export function readBodyBuffer(
 
 // ─── CORS / rate-limit / validation helpers ───────────────────────────
 
-
 export function buildCorsAllowlist(
   config: DkgConfig,
   boundPort: number,
@@ -1926,21 +1925,6 @@ export function isLoopbackRateLimitExemptPath(pathname: string): boolean {
 
 export function shouldBypassRateLimitForLoopbackTraffic(ip: string, pathname: string): boolean {
   return isLoopbackClientIp(ip) && isLoopbackRateLimitExemptPath(pathname);
-}
-
-/**
- * Boolean adapter over the single context-graph ID policy in
- * `@origintrail-official/dkg-core`. This deliberately holds no rules of its own:
- * it previously carried a second copy (length limit, character whitelist and the
- * segment-aware traversal check described in CLI-16), which drifted from the
- * core validator — core was missing the segment check while 26 route call sites
- * reached it via `validateRequiredContextGraphId`. Keeping the boolean shape for
- * existing callers, but `validateContextGraphId` now owns the policy, so a
- * future change to the character set or the length cap has exactly one home.
- */
-export function isValidContextGraphId(id: string): boolean {
-  if (typeof id !== "string") return false;
-  return validateContextGraphId(id).valid;
 }
 
 /**

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -292,7 +292,6 @@ import {
   isLoopbackClientIp,
   isLoopbackRateLimitExemptPath,
   shouldBypassRateLimitForLoopbackTraffic,
-  isValidContextGraphId,
   shortId,
   sleep,
   deriveBlockExplorerUrl,

--- a/packages/cli/src/daemon/routes/agent-chat.ts
+++ b/packages/cli/src/daemon/routes/agent-chat.ts
@@ -223,7 +223,6 @@ import {
   isLoopbackClientIp,
   isLoopbackRateLimitExemptPath,
   shouldBypassRateLimitForLoopbackTraffic,
-  isValidContextGraphId,
   shortId,
   sleep,
   deriveBlockExplorerUrl,

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -233,7 +233,6 @@ import {
   isLoopbackClientIp,
   isLoopbackRateLimitExemptPath,
   shouldBypassRateLimitForLoopbackTraffic,
-  isValidContextGraphId,
   shortId,
   sleep,
   deriveBlockExplorerUrl,
@@ -619,7 +618,7 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
     const id = parsed.id ?? parsed.contextGraphId;
     if (!id || !name)
       return jsonResponse(res, 400, { error: 'Missing "id" or "name"' });
-    if (!isValidContextGraphId(id))
+    if (!validateContextGraphId(id).valid)
       return jsonResponse(res, 400, { error: "Invalid context graph id" });
     const parsedPcaAccountId = parseOptionalPcaAccountId(parsed);
     if (parsedPcaAccountId.error) {

--- a/packages/cli/src/daemon/routes/epcis.ts
+++ b/packages/cli/src/daemon/routes/epcis.ts
@@ -211,7 +211,6 @@ import {
   isLoopbackClientIp,
   isLoopbackRateLimitExemptPath,
   shouldBypassRateLimitForLoopbackTraffic,
-  isValidContextGraphId,
   shortId,
   sleep,
   deriveBlockExplorerUrl,

--- a/packages/cli/src/daemon/routes/local-agents.ts
+++ b/packages/cli/src/daemon/routes/local-agents.ts
@@ -209,7 +209,6 @@ import {
   isLoopbackClientIp,
   isLoopbackRateLimitExemptPath,
   shouldBypassRateLimitForLoopbackTraffic,
-  isValidContextGraphId,
   shortId,
   sleep,
   deriveBlockExplorerUrl,

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -234,7 +234,6 @@ import {
   isLoopbackClientIp,
   isLoopbackRateLimitExemptPath,
   shouldBypassRateLimitForLoopbackTraffic,
-  isValidContextGraphId,
   shortId,
   sleep,
   deriveBlockExplorerUrl,

--- a/packages/cli/src/daemon/routes/openclaw.ts
+++ b/packages/cli/src/daemon/routes/openclaw.ts
@@ -209,7 +209,6 @@ import {
   isLoopbackClientIp,
   isLoopbackRateLimitExemptPath,
   shouldBypassRateLimitForLoopbackTraffic,
-  isValidContextGraphId,
   shortId,
   sleep,
   deriveBlockExplorerUrl,

--- a/packages/cli/src/daemon/routes/publisher.ts
+++ b/packages/cli/src/daemon/routes/publisher.ts
@@ -213,7 +213,6 @@ import {
   isLoopbackClientIp,
   isLoopbackRateLimitExemptPath,
   shouldBypassRateLimitForLoopbackTraffic,
-  isValidContextGraphId,
   shortId,
   sleep,
   deriveBlockExplorerUrl,

--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -221,7 +221,6 @@ import {
   isLoopbackClientIp,
   isLoopbackRateLimitExemptPath,
   shouldBypassRateLimitForLoopbackTraffic,
-  isValidContextGraphId,
   shortId,
   sleep,
   deriveBlockExplorerUrl,

--- a/packages/cli/src/daemon/routes/shared-assertion-helpers.ts
+++ b/packages/cli/src/daemon/routes/shared-assertion-helpers.ts
@@ -8,6 +8,7 @@
 
 import type { ServerResponse } from "node:http";
 import {
+  validateContextGraphId,
   validateSubGraphName,
   validateAssertionName,
   isSafeIri,
@@ -33,7 +34,6 @@ import {
   isNoFundedPublisherWalletLike,
   safeDecodeURIComponent,
   normalizeContextGraphIdOrUri,
-  isValidContextGraphId,
 } from '../http-utils.js';
 import { getExtractionStatusRecord } from '../../extraction-status.js';
 import type { RequestContext } from './context.js';
@@ -612,7 +612,7 @@ export async function resolveImportedArtifact(
   if (!contextGraphId) {
     throw new ImportArtifactRouteError(400, '"contextGraphId" is required');
   }
-  if (!isValidContextGraphId(contextGraphId)) {
+  if (!validateContextGraphId(contextGraphId).valid) {
     throw new ImportArtifactRouteError(400, 'Invalid contextGraphId');
   }
 

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -224,7 +224,6 @@ import {
   isLoopbackClientIp,
   isLoopbackRateLimitExemptPath,
   shouldBypassRateLimitForLoopbackTraffic,
-  isValidContextGraphId,
   shortId,
   sleep,
   deriveBlockExplorerUrl,
@@ -701,7 +700,7 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
   const contextGraphMembersMatch = path.match(/^\/api\/context-graph\/([^/]+)\/members$/);
   if (req.method === "GET" && contextGraphMembersMatch) {
     const contextGraphId = decodeURIComponent(contextGraphMembersMatch[1]);
-    if (!isValidContextGraphId(contextGraphId)) {
+    if (!validateContextGraphId(contextGraphId).valid) {
       return jsonResponse(res, 400, { error: 'Invalid context graph id' });
     }
     return jsonResponse(res, 200, {

--- a/packages/cli/src/keystore.ts
+++ b/packages/cli/src/keystore.ts
@@ -58,6 +58,23 @@ const MIN_SCRYPT_P = 1;
 const REQUIRED_DKLEN = 32;
 const MIN_SALT_BYTES = 16;
 
+/**
+ * Upper bounds, the counterpart to the minimums above. The minimums stop a
+ * keystore from advertising a cost so low that the KDF is cheap to attack; the
+ * maximums stop one from advertising a cost so high that simply loading the
+ * file exhausts the process before any passphrase is checked. scrypt's working
+ * set is 128 * N * r bytes: this CLI writes N=2^18, r=8, i.e. exactly 256 MiB,
+ * so the ceiling is set one doubling above that to leave room for keystores
+ * written by other tools at a higher cost, while still bounding the allocation.
+ */
+const MAX_SCRYPT_MEMORY_BYTES = 512 * 1024 * 1024;
+const MAX_SCRYPT_P = 16;
+
+/** scrypt requires N to be a power of two; a non-power-of-two throws deep in OpenSSL. */
+function isPowerOfTwo(value: number): boolean {
+  return Number.isSafeInteger(value) && value > 0 && (value & (value - 1)) === 0;
+}
+
 /** @internal Allow tests to use lighter scrypt params to avoid memory limits */
 export function _setScryptN(n: number) { SCRYPT_N = n; }
 
@@ -143,6 +160,26 @@ export async function decryptKeystore(
   if (typeof kdfparams.p !== "number" || kdfparams.p < MIN_SCRYPT_P) {
     throw new Error(
       `Refusing to load weak keystore: KDF parameters below minimum (p=${kdfparams.p} < ${MIN_SCRYPT_P}). scrypt p too low.`,
+    );
+  }
+  // Counterpart to the minimums above: reject parameters whose declared cost is
+  // too high to service. `n` must also be a power of two — scrypt requires it,
+  // and a non-power-of-two otherwise fails deep inside OpenSSL with an opaque
+  // error rather than a diagnosable one here.
+  if (!isPowerOfTwo(kdfparams.n)) {
+    throw new Error(
+      `Refusing to load keystore: scrypt N must be a power of two (got n=${kdfparams.n}).`,
+    );
+  }
+  const estimatedMemoryBytes = 128 * kdfparams.n * kdfparams.r;
+  if (!Number.isSafeInteger(estimatedMemoryBytes) || estimatedMemoryBytes > MAX_SCRYPT_MEMORY_BYTES) {
+    throw new Error(
+      `Refusing to load keystore: KDF memory cost above maximum (n=${kdfparams.n}, r=${kdfparams.r} implies ${estimatedMemoryBytes} bytes > ${MAX_SCRYPT_MEMORY_BYTES}). scrypt memory cost too high.`,
+    );
+  }
+  if (kdfparams.p > MAX_SCRYPT_P) {
+    throw new Error(
+      `Refusing to load keystore: KDF parameters above maximum (p=${kdfparams.p} > ${MAX_SCRYPT_P}). scrypt p too high.`,
     );
   }
   if (kdfparams.dklen !== REQUIRED_DKLEN) {

--- a/packages/cli/src/keystore.ts
+++ b/packages/cli/src/keystore.ts
@@ -60,23 +60,81 @@ const MIN_SALT_BYTES = 16;
 
 /**
  * Upper bounds, the counterpart to the minimums above. The minimums stop a
- * keystore from advertising a cost so low that the KDF is cheap to attack; the
- * maximums stop one from advertising a cost so high that simply loading the
- * file exhausts the process before any passphrase is checked. scrypt's working
- * set is 128 * N * r bytes: this CLI writes N=2^18, r=8, i.e. exactly 256 MiB,
- * so the ceiling is set one doubling above that to leave room for keystores
- * written by other tools at a higher cost, while still bounding the allocation.
+ * keystore advertising a cost cheap enough to attack; the maximums stop one
+ * advertising a cost too expensive to service, which would let a file exhaust
+ * the process before any passphrase is checked.
+ *
+ * ONE policy governs both what we accept and what we execute. Splitting those
+ * apart is what made the previous revision wrong in both directions:
+ *
+ *  - `deriveKey` passed a hardcoded `maxmem` of 256 MiB while this CLI writes
+ *    N=2^18, r=8 — a working set of *exactly* 256 MiB. OpenSSL's check is
+ *    `workingSet + overhead <= maxmem`, so the CLI's own production parameters
+ *    were rejected with `ERR_CRYPTO_INVALID_SCRYPT_PARAMS` ("memory limit
+ *    exceeded"). The test suite never caught it because it lowers N to 2^15.
+ *  - An acceptance ceiling above the execution budget would admit parameters
+ *    that then fail inside OpenSSL rather than at our own diagnosable boundary.
+ *
+ * So: `MAX_SCRYPT_WORKING_SET_BYTES` is the largest working set we accept, and
+ * the execution budget is derived from it with an allowance for OpenSSL's own
+ * overhead (measured at ~0.3% of the working set; 8 MiB is generous at the
+ * ceiling). Everything that needs a limit reads one of these two.
  */
-const MAX_SCRYPT_MEMORY_BYTES = 512 * 1024 * 1024;
+const MAX_SCRYPT_WORKING_SET_BYTES = 512 * 1024 * 1024;
+const SCRYPT_OVERHEAD_ALLOWANCE_BYTES = 8 * 1024 * 1024;
+const SCRYPT_EXECUTION_MAXMEM_BYTES =
+  MAX_SCRYPT_WORKING_SET_BYTES + SCRYPT_OVERHEAD_ALLOWANCE_BYTES;
 const MAX_SCRYPT_P = 16;
+
+/** scrypt's working set, the quantity both the ceiling and OpenSSL bound. */
+function scryptWorkingSetBytes(n: number, r: number): number {
+  return 128 * n * r;
+}
 
 /** scrypt requires N to be a power of two; a non-power-of-two throws deep in OpenSSL. */
 function isPowerOfTwo(value: number): boolean {
   return Number.isSafeInteger(value) && value > 0 && (value & (value - 1)) === 0;
 }
 
+/**
+ * Sole owner of the upper-bound policy. Throws a diagnosable error for any
+ * parameter set we will not service, so nothing reaches OpenSSL that could only
+ * fail there. Lower bounds stay inline in `decryptKeystore` alongside their
+ * existing "weak keystore" wording.
+ */
+function assertScryptCostWithinLimits(n: number, r: number, p: number): void {
+  if (!isPowerOfTwo(n)) {
+    throw new Error(
+      `Refusing to load keystore: scrypt N must be a power of two (got n=${n}).`,
+    );
+  }
+  const workingSetBytes = scryptWorkingSetBytes(n, r);
+  if (!Number.isSafeInteger(workingSetBytes) || workingSetBytes > MAX_SCRYPT_WORKING_SET_BYTES) {
+    throw new Error(
+      `Refusing to load keystore: KDF memory cost above maximum (n=${n}, r=${r} implies ${workingSetBytes} bytes > ${MAX_SCRYPT_WORKING_SET_BYTES}). scrypt memory cost too high.`,
+    );
+  }
+  if (p > MAX_SCRYPT_P) {
+    throw new Error(
+      `Refusing to load keystore: KDF parameters above maximum (p=${p} > ${MAX_SCRYPT_P}). scrypt p too high.`,
+    );
+  }
+}
+
 /** @internal Allow tests to use lighter scrypt params to avoid memory limits */
 export function _setScryptN(n: number) { SCRYPT_N = n; }
+
+/** @internal Exposes the KDF cost policy so tests can pin it without deriving. */
+export function _scryptCostPolicy() {
+  return {
+    maxWorkingSetBytes: MAX_SCRYPT_WORKING_SET_BYTES,
+    executionMaxmemBytes: SCRYPT_EXECUTION_MAXMEM_BYTES,
+    maxP: MAX_SCRYPT_P,
+    productionWorkingSetBytes: scryptWorkingSetBytes(2 ** 18, SCRYPT_R),
+    workingSetBytes: scryptWorkingSetBytes,
+    assertWithinLimits: assertScryptCostWithinLimits,
+  };
+}
 
 function deriveKey(
   passphrase: string,
@@ -87,7 +145,7 @@ function deriveKey(
     N: params?.N ?? SCRYPT_N,
     r: params?.r ?? SCRYPT_R,
     p: params?.p ?? SCRYPT_P,
-    maxmem: 256 * 1024 * 1024,
+    maxmem: SCRYPT_EXECUTION_MAXMEM_BYTES,
   });
 }
 
@@ -162,26 +220,10 @@ export async function decryptKeystore(
       `Refusing to load weak keystore: KDF parameters below minimum (p=${kdfparams.p} < ${MIN_SCRYPT_P}). scrypt p too low.`,
     );
   }
-  // Counterpart to the minimums above: reject parameters whose declared cost is
-  // too high to service. `n` must also be a power of two — scrypt requires it,
-  // and a non-power-of-two otherwise fails deep inside OpenSSL with an opaque
-  // error rather than a diagnosable one here.
-  if (!isPowerOfTwo(kdfparams.n)) {
-    throw new Error(
-      `Refusing to load keystore: scrypt N must be a power of two (got n=${kdfparams.n}).`,
-    );
-  }
-  const estimatedMemoryBytes = 128 * kdfparams.n * kdfparams.r;
-  if (!Number.isSafeInteger(estimatedMemoryBytes) || estimatedMemoryBytes > MAX_SCRYPT_MEMORY_BYTES) {
-    throw new Error(
-      `Refusing to load keystore: KDF memory cost above maximum (n=${kdfparams.n}, r=${kdfparams.r} implies ${estimatedMemoryBytes} bytes > ${MAX_SCRYPT_MEMORY_BYTES}). scrypt memory cost too high.`,
-    );
-  }
-  if (kdfparams.p > MAX_SCRYPT_P) {
-    throw new Error(
-      `Refusing to load keystore: KDF parameters above maximum (p=${kdfparams.p} > ${MAX_SCRYPT_P}). scrypt p too high.`,
-    );
-  }
+  // Counterpart to the minimums above. Single policy owner — see
+  // `assertScryptCostWithinLimits`; nothing that could only fail inside OpenSSL
+  // is allowed past this point.
+  assertScryptCostWithinLimits(kdfparams.n, kdfparams.r, kdfparams.p);
   if (kdfparams.dklen !== REQUIRED_DKLEN) {
     throw new Error(
       `Refusing to load weak keystore: dklen must be ${REQUIRED_DKLEN} for AES-256-GCM (got ${kdfparams.dklen}). invalid dklen.`,

--- a/packages/cli/src/keystore.ts
+++ b/packages/cli/src/keystore.ts
@@ -34,118 +34,129 @@ export interface EncryptedKeystore {
   id: string;
 }
 
-let SCRYPT_N = 2 ** 18;
-const SCRYPT_R = 8;
-const SCRYPT_P = 1;
-const DKLEN = 32;
-
 /**
- * CLI-1 (
- * MUST enforce on the (untrusted) `kdfparams` block before deriving
- * a key. Without these, an attacker who can write a keystore file
- * can advertise toy scrypt parameters (e.g. N=256, r=1) and force the
- * loader to brute-force in O(1). Production scrypt minimums per
- * draft RFC and OWASP cheat-sheet:
- *   - N ≥ 2^15 (32 768 iterations) — production floor
- *   - r ≥ 8                          — memory-hardness factor
- *   - p ≥ 1                          — parallelism floor
- *   - dklen == 32                    — exact match for AES-256-GCM
- *   - salt ≥ 16 bytes                — defeats precomputed rainbow
- */
-const MIN_SCRYPT_N = 2 ** 15;
-const MIN_SCRYPT_R = 8;
-const MIN_SCRYPT_P = 1;
-const REQUIRED_DKLEN = 32;
-const MIN_SALT_BYTES = 16;
-
-/**
- * Upper bounds, the counterpart to the minimums above. The minimums stop a
- * keystore advertising a cost cheap enough to attack; the maximums stop one
- * advertising a cost too expensive to service, which would let a file exhaust
- * the process before any passphrase is checked.
+ * Single owner of the scrypt KDF policy: production parameters, lower and upper
+ * bounds, the derived execution budget, and the cost validation that guards it.
+ * Encryption, derivation, validation, and the tests all consume THIS object —
+ * there is deliberately no second representation to drift from it.
  *
- * ONE policy governs both what we accept and what we execute. Splitting those
- * apart is what made the previous revision wrong in both directions:
+ * Lower bounds (CLI-1): what we MUST enforce on the (untrusted) `kdfparams`
+ * block before deriving a key. Without these, an attacker who can write a
+ * keystore file can advertise toy scrypt parameters (e.g. N=256, r=1) and force
+ * the loader to brute-force in O(1). Production scrypt minimums per draft RFC
+ * and OWASP cheat-sheet: N ≥ 2^15, r ≥ 8, p ≥ 1, dklen == 32 (AES-256-GCM),
+ * salt ≥ 16 bytes.
  *
- *  - `deriveKey` passed a hardcoded `maxmem` of 256 MiB while this CLI writes
- *    N=2^18, r=8 — a working set of *exactly* 256 MiB. OpenSSL's check is
- *    `workingSet + overhead <= maxmem`, so the CLI's own production parameters
- *    were rejected with `ERR_CRYPTO_INVALID_SCRYPT_PARAMS` ("memory limit
- *    exceeded"). The test suite never caught it because it lowers N to 2^15.
+ * Upper bounds: the counterpart. The minimums stop a keystore advertising a
+ * cost cheap enough to attack; the maximums stop one advertising a cost too
+ * expensive to service, which would let a file exhaust the process before any
+ * passphrase is checked.
+ *
+ * The acceptance ceiling and the execution budget are ONE policy. Splitting
+ * them is what made two prior revisions wrong:
+ *  - `deriveKey` passed a hardcoded `maxmem` of 256 MiB while production writes
+ *    N=2^18, r=8 — a working set of *exactly* 256 MiB. OpenSSL enforces
+ *    `workingSet + overhead <= maxmem`, so the module's own production
+ *    parameters failed with `ERR_CRYPTO_INVALID_SCRYPT_PARAMS` ("memory limit
+ *    exceeded"). The suite never caught it because it lowers N to 2^15.
  *  - An acceptance ceiling above the execution budget would admit parameters
- *    that then fail inside OpenSSL rather than at our own diagnosable boundary.
- *
- * So: `MAX_SCRYPT_WORKING_SET_BYTES` is the largest working set we accept, and
- * the execution budget is derived from it with an allowance for OpenSSL's own
- * overhead (measured at ~0.3% of the working set; 8 MiB is generous at the
- * ceiling). Everything that needs a limit reads one of these two.
+ *    that then fail inside OpenSSL rather than at our diagnosable boundary.
+ * So `executionMaxmemBytes` is derived from `maxWorkingSetBytes` plus an
+ * allowance for OpenSSL's own overhead (measured at ~0.3% of the working set;
+ * 8 MiB is generous at the ceiling).
  */
-const MAX_SCRYPT_WORKING_SET_BYTES = 512 * 1024 * 1024;
-const SCRYPT_OVERHEAD_ALLOWANCE_BYTES = 8 * 1024 * 1024;
-const SCRYPT_EXECUTION_MAXMEM_BYTES =
-  MAX_SCRYPT_WORKING_SET_BYTES + SCRYPT_OVERHEAD_ALLOWANCE_BYTES;
-const MAX_SCRYPT_P = 16;
-
-/** scrypt's working set, the quantity both the ceiling and OpenSSL bound. */
-function scryptWorkingSetBytes(n: number, r: number): number {
-  return 128 * n * r;
+export interface ScryptKdfPolicy {
+  /** Parameters this module writes when creating a keystore. */
+  readonly production: { readonly n: number; readonly r: number; readonly p: number };
+  readonly minN: number;
+  readonly minR: number;
+  readonly minP: number;
+  readonly maxP: number;
+  readonly requiredDklen: number;
+  readonly minSaltBytes: number;
+  /** Largest scrypt working set (128 * N * r bytes) we accept. */
+  readonly maxWorkingSetBytes: number;
+  /** `maxmem` handed to OpenSSL: the ceiling plus its bounded overhead. */
+  readonly executionMaxmemBytes: number;
+  /** scrypt's working set — the quantity both the ceiling and OpenSSL bound. */
+  workingSetBytes(n: number, r: number): number;
+  /**
+   * Throws a diagnosable error for any parameter set we will not service, so
+   * nothing reaches OpenSSL that could only fail there. (Lower bounds live in
+   * `decryptKeystore` beside their established "weak keystore" wording.)
+   */
+  assertCostWithinLimits(n: number, r: number, p: number): void;
 }
+
+const SCRYPT_OVERHEAD_ALLOWANCE_BYTES = 8 * 1024 * 1024;
 
 /** scrypt requires N to be a power of two; a non-power-of-two throws deep in OpenSSL. */
 function isPowerOfTwo(value: number): boolean {
   return Number.isSafeInteger(value) && value > 0 && (value & (value - 1)) === 0;
 }
 
+export const SCRYPT_KDF_POLICY: ScryptKdfPolicy = Object.freeze({
+  production: Object.freeze({ n: 2 ** 18, r: 8, p: 1 }),
+  minN: 2 ** 15,
+  minR: 8,
+  minP: 1,
+  maxP: 16,
+  requiredDklen: 32,
+  minSaltBytes: 16,
+  maxWorkingSetBytes: 512 * 1024 * 1024,
+  executionMaxmemBytes: 512 * 1024 * 1024 + SCRYPT_OVERHEAD_ALLOWANCE_BYTES,
+  workingSetBytes(n: number, r: number): number {
+    return 128 * n * r;
+  },
+  assertCostWithinLimits(n: number, r: number, p: number): void {
+    if (!isPowerOfTwo(n)) {
+      throw new Error(
+        `Refusing to load keystore: scrypt N must be a power of two (got n=${n}).`,
+      );
+    }
+    const workingSetBytes = SCRYPT_KDF_POLICY.workingSetBytes(n, r);
+    if (!Number.isSafeInteger(workingSetBytes) || workingSetBytes > SCRYPT_KDF_POLICY.maxWorkingSetBytes) {
+      throw new Error(
+        `Refusing to load keystore: KDF memory cost above maximum (n=${n}, r=${r} implies ${workingSetBytes} bytes > ${SCRYPT_KDF_POLICY.maxWorkingSetBytes}). scrypt memory cost too high.`,
+      );
+    }
+    if (p > SCRYPT_KDF_POLICY.maxP) {
+      throw new Error(
+        `Refusing to load keystore: KDF parameters above maximum (p=${p} > ${SCRYPT_KDF_POLICY.maxP}). scrypt p too high.`,
+      );
+    }
+  },
+});
+
+// The policy's production cost must itself be serviceable — enforced at module
+// load so the invariant cannot silently rot behind a constant edit.
+SCRYPT_KDF_POLICY.assertCostWithinLimits(
+  SCRYPT_KDF_POLICY.production.n,
+  SCRYPT_KDF_POLICY.production.r,
+  SCRYPT_KDF_POLICY.production.p,
+);
+
 /**
- * Sole owner of the upper-bound policy. Throws a diagnosable error for any
- * parameter set we will not service, so nothing reaches OpenSSL that could only
- * fail there. Lower bounds stay inline in `decryptKeystore` alongside their
- * existing "weak keystore" wording.
+ * The N actually used for NEW keystores. Initialized from the immutable policy;
+ * only the test seam below may change it (production N ~ 256 MiB per derivation
+ * OOMs CI workers running parallel shards). The production default itself lives
+ * on `SCRYPT_KDF_POLICY.production` and cannot be reassigned.
  */
-function assertScryptCostWithinLimits(n: number, r: number, p: number): void {
-  if (!isPowerOfTwo(n)) {
-    throw new Error(
-      `Refusing to load keystore: scrypt N must be a power of two (got n=${n}).`,
-    );
-  }
-  const workingSetBytes = scryptWorkingSetBytes(n, r);
-  if (!Number.isSafeInteger(workingSetBytes) || workingSetBytes > MAX_SCRYPT_WORKING_SET_BYTES) {
-    throw new Error(
-      `Refusing to load keystore: KDF memory cost above maximum (n=${n}, r=${r} implies ${workingSetBytes} bytes > ${MAX_SCRYPT_WORKING_SET_BYTES}). scrypt memory cost too high.`,
-    );
-  }
-  if (p > MAX_SCRYPT_P) {
-    throw new Error(
-      `Refusing to load keystore: KDF parameters above maximum (p=${p} > ${MAX_SCRYPT_P}). scrypt p too high.`,
-    );
-  }
-}
+let activeScryptN = SCRYPT_KDF_POLICY.production.n;
 
 /** @internal Allow tests to use lighter scrypt params to avoid memory limits */
-export function _setScryptN(n: number) { SCRYPT_N = n; }
-
-/** @internal Exposes the KDF cost policy so tests can pin it without deriving. */
-export function _scryptCostPolicy() {
-  return {
-    maxWorkingSetBytes: MAX_SCRYPT_WORKING_SET_BYTES,
-    executionMaxmemBytes: SCRYPT_EXECUTION_MAXMEM_BYTES,
-    maxP: MAX_SCRYPT_P,
-    productionWorkingSetBytes: scryptWorkingSetBytes(2 ** 18, SCRYPT_R),
-    workingSetBytes: scryptWorkingSetBytes,
-    assertWithinLimits: assertScryptCostWithinLimits,
-  };
-}
+export function _setScryptN(n: number) { activeScryptN = n; }
 
 function deriveKey(
   passphrase: string,
   salt: Buffer,
   params?: { N?: number; r?: number; p?: number; dklen?: number },
 ): Buffer {
-  return scryptSync(passphrase, salt, params?.dklen ?? DKLEN, {
-    N: params?.N ?? SCRYPT_N,
-    r: params?.r ?? SCRYPT_R,
-    p: params?.p ?? SCRYPT_P,
-    maxmem: SCRYPT_EXECUTION_MAXMEM_BYTES,
+  return scryptSync(passphrase, salt, params?.dklen ?? SCRYPT_KDF_POLICY.requiredDklen, {
+    N: params?.N ?? activeScryptN,
+    r: params?.r ?? SCRYPT_KDF_POLICY.production.r,
+    p: params?.p ?? SCRYPT_KDF_POLICY.production.p,
+    maxmem: SCRYPT_KDF_POLICY.executionMaxmemBytes,
   });
 }
 
@@ -174,10 +185,10 @@ export async function encryptKeystore(
       tag: tag.toString('hex'),
       kdf: 'scrypt',
       kdfparams: {
-        n: SCRYPT_N,
-        r: SCRYPT_R,
-        p: SCRYPT_P,
-        dklen: DKLEN,
+        n: activeScryptN,
+        r: SCRYPT_KDF_POLICY.production.r,
+        p: SCRYPT_KDF_POLICY.production.p,
+        dklen: SCRYPT_KDF_POLICY.requiredDklen,
         salt: salt.toString('hex'),
       },
     },
@@ -198,35 +209,35 @@ export async function decryptKeystore(
   // CLI-1 (
   // calling scryptSync. Previously, weak params either (a) produced a
   // generic "Decryption failed" (because `deriveKey` always re-derived
-  // with the global SCRYPT_N regardless of what the file advertised —
+  // with the module-global N regardless of what the file advertised —
   // a related bug) or (b) handed pathological values to OpenSSL and
   // crashed with ERR_OUT_OF_RANGE. Either way the operator had no way
   // to know the keystore was forged with an attackable cost factor.
   // We now reject up-front with a crisp "weak keystore" error so the
   // caller can refuse to load the file instead of silently accepting
   // a downgraded KDF.
-  if (typeof kdfparams.n !== "number" || kdfparams.n < MIN_SCRYPT_N) {
+  if (typeof kdfparams.n !== "number" || kdfparams.n < SCRYPT_KDF_POLICY.minN) {
     throw new Error(
-      `Refusing to load weak keystore: KDF parameters below minimum (n=${kdfparams.n} < ${MIN_SCRYPT_N}). scrypt cost too low.`,
+      `Refusing to load weak keystore: KDF parameters below minimum (n=${kdfparams.n} < ${SCRYPT_KDF_POLICY.minN}). scrypt cost too low.`,
     );
   }
-  if (typeof kdfparams.r !== "number" || kdfparams.r < MIN_SCRYPT_R) {
+  if (typeof kdfparams.r !== "number" || kdfparams.r < SCRYPT_KDF_POLICY.minR) {
     throw new Error(
-      `Refusing to load weak keystore: KDF parameters below minimum (r=${kdfparams.r} < ${MIN_SCRYPT_R}). scrypt r too low.`,
+      `Refusing to load weak keystore: KDF parameters below minimum (r=${kdfparams.r} < ${SCRYPT_KDF_POLICY.minR}). scrypt r too low.`,
     );
   }
-  if (typeof kdfparams.p !== "number" || kdfparams.p < MIN_SCRYPT_P) {
+  if (typeof kdfparams.p !== "number" || kdfparams.p < SCRYPT_KDF_POLICY.minP) {
     throw new Error(
-      `Refusing to load weak keystore: KDF parameters below minimum (p=${kdfparams.p} < ${MIN_SCRYPT_P}). scrypt p too low.`,
+      `Refusing to load weak keystore: KDF parameters below minimum (p=${kdfparams.p} < ${SCRYPT_KDF_POLICY.minP}). scrypt p too low.`,
     );
   }
   // Counterpart to the minimums above. Single policy owner — see
-  // `assertScryptCostWithinLimits`; nothing that could only fail inside OpenSSL
-  // is allowed past this point.
-  assertScryptCostWithinLimits(kdfparams.n, kdfparams.r, kdfparams.p);
-  if (kdfparams.dklen !== REQUIRED_DKLEN) {
+  // `SCRYPT_KDF_POLICY.assertCostWithinLimits`; nothing that could only fail
+  // inside OpenSSL is allowed past this point.
+  SCRYPT_KDF_POLICY.assertCostWithinLimits(kdfparams.n, kdfparams.r, kdfparams.p);
+  if (kdfparams.dklen !== SCRYPT_KDF_POLICY.requiredDklen) {
     throw new Error(
-      `Refusing to load weak keystore: dklen must be ${REQUIRED_DKLEN} for AES-256-GCM (got ${kdfparams.dklen}). invalid dklen.`,
+      `Refusing to load weak keystore: dklen must be ${SCRYPT_KDF_POLICY.requiredDklen} for AES-256-GCM (got ${kdfparams.dklen}). invalid dklen.`,
     );
   }
   // compute saltHex into a local FIRST, defensively
@@ -241,7 +252,7 @@ export async function decryptKeystore(
   // explicitly reject odd-length hex strings
   // before decoding. `Buffer.from('aa…', 'hex')` silently drops the
   // dangling nibble, so a 33-character salt would advertise 16.5 bytes
-  // (>= MIN_SALT_BYTES under integer division) and slip through the
+  // (>= SCRYPT_KDF_POLICY.minSaltBytes under integer division) and slip through the
   // length floor while actually deriving from a 16-byte salt with the
   // last nibble silently lost. We catch that here so the caller sees
   // the same "weak keystore" error class as other malformed values.
@@ -252,19 +263,19 @@ export async function decryptKeystore(
     && saltHex.length % 2 === 0;
   if (
     !saltHexLooksWellFormed
-    || saltHex.length / 2 < MIN_SALT_BYTES
+    || saltHex.length / 2 < SCRYPT_KDF_POLICY.minSaltBytes
   ) {
     const advertisedBytes = Math.floor(saltHex.length / 2);
     throw new Error(
-      `Refusing to load weak keystore: salt too short or malformed (${advertisedBytes} bytes < ${MIN_SALT_BYTES}). weak keystore.`,
+      `Refusing to load weak keystore: salt too short or malformed (${advertisedBytes} bytes < ${SCRYPT_KDF_POLICY.minSaltBytes}). weak keystore.`,
     );
   }
 
   const salt = Buffer.from(kdfparams.salt, 'hex');
   // Derive with the params actually advertised by the file (now that
   // we've gated them above). The previous code ignored kdfparams and
-  // always used the global SCRYPT_N, which was both a correctness bug
-  // (any keystore with N != SCRYPT_N would fail to decrypt even with
+  // always used the module-global N, which was both a correctness bug
+  // (any keystore whose advertised N differed would fail to decrypt even with
   // the right passphrase) and the reason a weak-N keystore returned
   // "Decryption failed" instead of "weak keystore".
   const key = deriveKey(passphrase, salt, {

--- a/packages/cli/src/keystore.ts
+++ b/packages/cli/src/keystore.ts
@@ -114,6 +114,21 @@ export const SCRYPT_KDF_POLICY: ScryptKdfPolicy = Object.freeze({
         `Refusing to load keystore: scrypt N must be a power of two (got n=${n}).`,
       );
     }
+    // JSON admits fractional numbers, and `8.5` passes every >=/<= comparison
+    // below while OpenSSL rejects it with an opaque ERR_OUT_OF_RANGE. Integer
+    // checks here keep the whole contract at this boundary: nothing reaches
+    // scrypt that can only fail inside it. (`n` is covered by the power-of-two
+    // check above, which implies a safe integer.)
+    if (!Number.isSafeInteger(r)) {
+      throw new Error(
+        `Refusing to load keystore: scrypt r must be an integer (got r=${r}).`,
+      );
+    }
+    if (!Number.isSafeInteger(p)) {
+      throw new Error(
+        `Refusing to load keystore: scrypt p must be an integer (got p=${p}).`,
+      );
+    }
     const workingSetBytes = SCRYPT_KDF_POLICY.workingSetBytes(n, r);
     if (!Number.isSafeInteger(workingSetBytes) || workingSetBytes > SCRYPT_KDF_POLICY.maxWorkingSetBytes) {
       throw new Error(

--- a/packages/cli/test/keystore.test.ts
+++ b/packages/cli/test/keystore.test.ts
@@ -112,6 +112,43 @@ describe('decryptKeystore error handling', () => {
       /weak keystore/,
     );
   });
+
+  it('rejects keystore declaring a KDF memory cost above the ceiling', async () => {
+    // The existing minimums stop a file advertising a cost cheap enough to
+    // attack. This is the other end: scrypt's working set is 128 * N * r, so
+    // N=2**30 with r=8 asks the loader for ~1 TiB before the passphrase is ever
+    // checked. Rejected up-front with a diagnosable error instead.
+    const ks = await encryptKeystore(TEST_KEY, PASSPHRASE);
+    ks.crypto.kdfparams.n = 2 ** 30;
+    await expect(decryptKeystore(ks, PASSPHRASE)).rejects.toThrow(
+      /memory cost too high/,
+    );
+  });
+
+  it('rejects keystore declaring a non-power-of-two scrypt N', async () => {
+    // scrypt requires N to be a power of two; without this check the value is
+    // handed to OpenSSL and fails there with an opaque error.
+    const ks = await encryptKeystore(TEST_KEY, PASSPHRASE);
+    ks.crypto.kdfparams.n = (2 ** 15) + 1;
+    await expect(decryptKeystore(ks, PASSPHRASE)).rejects.toThrow(
+      /power of two/,
+    );
+  });
+
+  it('rejects keystore declaring a parallelism factor above the ceiling', async () => {
+    const ks = await encryptKeystore(TEST_KEY, PASSPHRASE);
+    ks.crypto.kdfparams.p = 1024;
+    await expect(decryptKeystore(ks, PASSPHRASE)).rejects.toThrow(
+      /p too high/,
+    );
+  });
+
+  it('still accepts the parameters this CLI itself writes', async () => {
+    // Guards the ceiling against being set below our own defaults: the CLI
+    // writes N=2**18, r=8, which is exactly 256 MiB of working set.
+    const ks = await encryptKeystore(TEST_KEY, PASSPHRASE);
+    await expect(decryptKeystore(ks, PASSPHRASE)).resolves.toBeDefined();
+  });
 });
 
 describe('isEncryptedKeystore', () => {

--- a/packages/cli/test/keystore.test.ts
+++ b/packages/cli/test/keystore.test.ts
@@ -165,6 +165,23 @@ describe('decryptKeystore error handling', () => {
     await expect(decryptKeystore(ks, PASSPHRASE)).rejects.toThrow(/Decryption failed/);
   }, 120000);
 
+  it.each([
+    ['r', 8.5, /r must be an integer/],
+    ['r', Number.NaN, /r must be an integer/],
+    ['p', 1.5, /p must be an integer/],
+    ['p', Number.POSITIVE_INFINITY, /p must be an integer/],
+  ] as const)(
+    'rejects non-integer numeric kdf %s=%s at the policy boundary',
+    async (field, value, message) => {
+      // JSON admits fractional numbers; 8.5 and 1.5 satisfy every >=/<= bound
+      // and previously reached OpenSSL, which rejects them with an opaque
+      // ERR_OUT_OF_RANGE instead of a diagnosable keystore error.
+      const ks = await encryptKeystore(TEST_KEY, PASSPHRASE);
+      ks.crypto.kdfparams[field] = value;
+      await expect(decryptKeystore(ks, PASSPHRASE)).rejects.toThrow(message);
+    },
+  );
+
   it('pins the intended ceilings as literals, independent of the implementation', () => {
     // Every other assertion reads the policy object; if the object itself
     // drifted (512 MiB quietly becoming 512 GiB), those would follow it.

--- a/packages/cli/test/keystore.test.ts
+++ b/packages/cli/test/keystore.test.ts
@@ -4,7 +4,7 @@ import {
   decryptKeystore,
   isEncryptedKeystore,
   _setScryptN,
-  _scryptCostPolicy,
+  SCRYPT_KDF_POLICY,
   type EncryptedKeystore,
 } from '../src/keystore.js';
 
@@ -17,7 +17,7 @@ beforeAll(() => {
   // exercising a parameter set that the production-hardened loader
   // accepts (a previous value of 2^14 was below the floor and would
   // now correctly be refused as a weak keystore).
-  _setScryptN(2 ** 15);
+  _setScryptN(SCRYPT_KDF_POLICY.minN);
 });
 
 const TEST_KEY = 'aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344';
@@ -118,7 +118,8 @@ describe('decryptKeystore error handling', () => {
     // Boundary, not a wild value: n/r chosen so the working set is exactly one
     // scrypt block over MAX_WORKING_SET. A ceiling raised or lowered by any
     // amount fails this pair, which a 2**30 smoke test would not.
-    const { maxWorkingSetBytes, workingSetBytes } = _scryptCostPolicy();
+    const { maxWorkingSetBytes } = SCRYPT_KDF_POLICY;
+    const workingSetBytes = SCRYPT_KDF_POLICY.workingSetBytes.bind(SCRYPT_KDF_POLICY);
     const overN = (maxWorkingSetBytes / (128 * 8)) * 2; // r=8 => 2x ceiling
     expect(workingSetBytes(overN, 8)).toBeGreaterThan(maxWorkingSetBytes);
     const ks = await encryptKeystore(TEST_KEY, PASSPHRASE);
@@ -133,7 +134,8 @@ describe('decryptKeystore error handling', () => {
     // Proves the ceiling is inclusive without allocating it: dklen is validated
     // after the cost policy, so an invalid dklen stops execution before scrypt.
     // The error text discriminates — a memory rejection would name the cost.
-    const { maxWorkingSetBytes, workingSetBytes } = _scryptCostPolicy();
+    const { maxWorkingSetBytes } = SCRYPT_KDF_POLICY;
+    const workingSetBytes = SCRYPT_KDF_POLICY.workingSetBytes.bind(SCRYPT_KDF_POLICY);
     const atN = maxWorkingSetBytes / (128 * 8);
     expect(workingSetBytes(atN, 8)).toBe(maxWorkingSetBytes);
     const ks = await encryptKeystore(TEST_KEY, PASSPHRASE);
@@ -144,7 +146,7 @@ describe('decryptKeystore error handling', () => {
   });
 
   it('accepts p at the ceiling and rejects p one above it', async () => {
-    const { maxP } = _scryptCostPolicy();
+    const { maxP } = SCRYPT_KDF_POLICY;
     const atCeiling = await encryptKeystore(TEST_KEY, PASSPHRASE);
     atCeiling.crypto.kdfparams.p = maxP;
     atCeiling.crypto.kdfparams.dklen = 16;
@@ -167,37 +169,45 @@ describe('decryptKeystore error handling', () => {
     );
   });
 
-  it('budgets enough memory for the CLI production parameters to actually derive', async () => {
-    // The regression this pins is a shipped one: `deriveKey` passed a hardcoded
-    // maxmem of 256 MiB while production N=2**18, r=8 needs a working set of
-    // exactly 256 MiB, and OpenSSL bounds `workingSet + overhead <= maxmem`.
-    // Production keystores therefore failed with ERR_CRYPTO_INVALID_SCRYPT_PARAMS.
-    // The suite lowers N to 2**15, so no round-trip test could ever catch it —
-    // this asserts the policy arithmetic instead, which is where the bug lived.
-    const { executionMaxmemBytes, productionWorkingSetBytes, maxWorkingSetBytes, assertWithinLimits } =
-      _scryptCostPolicy();
-    expect(productionWorkingSetBytes).toBe(128 * (2 ** 18) * 8);
-    expect(productionWorkingSetBytes).toBeLessThanOrEqual(maxWorkingSetBytes);
+  it('budgets enough memory for the production parameters to actually derive', async () => {
+    // The regression this pins shipped: `deriveKey` passed a hardcoded maxmem of
+    // 256 MiB while production N=2**18, r=8 needs a working set of exactly
+    // 256 MiB, and OpenSSL bounds `workingSet + overhead <= maxmem` — so the
+    // module's own parameters failed with ERR_CRYPTO_INVALID_SCRYPT_PARAMS.
+    // The suite lowers N, so no round-trip test could catch it; this asserts
+    // the policy arithmetic, which is where the bug lived. All values come from
+    // the ONE production-consumed policy object — there is no separate
+    // test-facing copy left to drift.
+    const { production, executionMaxmemBytes, maxWorkingSetBytes } = SCRYPT_KDF_POLICY;
+    const productionWorkingSet = SCRYPT_KDF_POLICY.workingSetBytes(production.n, production.r);
+    expect(productionWorkingSet).toBeLessThanOrEqual(maxWorkingSetBytes);
     // Strictly greater: equality is exactly what OpenSSL rejects.
-    expect(executionMaxmemBytes).toBeGreaterThan(productionWorkingSetBytes);
+    expect(executionMaxmemBytes).toBeGreaterThan(productionWorkingSet);
     expect(executionMaxmemBytes).toBeGreaterThan(maxWorkingSetBytes);
     // And production parameters must pass the acceptance policy unchanged.
-    expect(() => assertWithinLimits(2 ** 18, 8, 1)).not.toThrow();
+    expect(() =>
+      SCRYPT_KDF_POLICY.assertCostWithinLimits(production.n, production.r, production.p),
+    ).not.toThrow();
   });
 
-  it('round-trips a keystore at the CLI production parameters', async () => {
+  it('round-trips a keystore at the production parameters the policy declares', async () => {
     // Must go through encryptKeystore/decryptKeystore — i.e. through deriveKey —
-    // or it proves nothing. A direct scryptSync call using the policy constant
+    // or it proves nothing: a direct scryptSync call using the policy constant
     // passes even when deriveKey ignores that constant, which is precisely the
-    // divergence that shipped. Allocates the real 256 MiB production working
-    // set once; the suite otherwise runs at N=2**15 to stay parallel-safe.
-    _setScryptN(2 ** 18);
+    // divergence that shipped. Restoring the override to the POLICY's production
+    // N (not a literal) also pins that encryption cannot emit a different
+    // production value than the policy reports: the emitted kdfparams must
+    // equal SCRYPT_KDF_POLICY.production exactly. Allocates the real 256 MiB
+    // working set once; the suite otherwise runs at minN to stay parallel-safe.
+    _setScryptN(SCRYPT_KDF_POLICY.production.n);
     try {
       const ks = await encryptKeystore(TEST_KEY, PASSPHRASE);
-      expect(ks.crypto.kdfparams.n).toBe(2 ** 18);
+      expect(ks.crypto.kdfparams.n).toBe(SCRYPT_KDF_POLICY.production.n);
+      expect(ks.crypto.kdfparams.r).toBe(SCRYPT_KDF_POLICY.production.r);
+      expect(ks.crypto.kdfparams.p).toBe(SCRYPT_KDF_POLICY.production.p);
       expect(await decryptKeystore(ks, PASSPHRASE)).toBe(TEST_KEY);
     } finally {
-      _setScryptN(2 ** 15);
+      _setScryptN(SCRYPT_KDF_POLICY.minN);
     }
   });
 });

--- a/packages/cli/test/keystore.test.ts
+++ b/packages/cli/test/keystore.test.ts
@@ -131,9 +131,10 @@ describe('decryptKeystore error handling', () => {
   });
 
   it('accepts a KDF memory cost exactly at the declared ceiling', async () => {
-    // Proves the ceiling is inclusive without allocating it: dklen is validated
-    // after the cost policy, so an invalid dklen stops execution before scrypt.
-    // The error text discriminates — a memory rejection would name the cost.
+    // Cheap acceptance-policy half: dklen is validated after the cost policy,
+    // so an invalid dklen stops execution before scrypt. The error text
+    // discriminates — a memory rejection would name the cost. The execution
+    // half — that OpenSSL actually serves this cost — is the test below.
     const { maxWorkingSetBytes } = SCRYPT_KDF_POLICY;
     const workingSetBytes = SCRYPT_KDF_POLICY.workingSetBytes.bind(SCRYPT_KDF_POLICY);
     const atN = maxWorkingSetBytes / (128 * 8);
@@ -143,6 +144,35 @@ describe('decryptKeystore error handling', () => {
     ks.crypto.kdfparams.r = 8;
     ks.crypto.kdfparams.dklen = 16;
     await expect(decryptKeystore(ks, PASSPHRASE)).rejects.toThrow(/dklen/);
+  });
+
+  it('executes real scrypt at the exact accepted ceiling', async () => {
+    // The policy promises every accepted cost is executable; this reaches
+    // OpenSSL at the maximum accepted working set. The keystore is encrypted
+    // cheaply, then re-advertises the at-ceiling parameters: derivation now
+    // produces a WRONG key, so reaching the AES tag check ("Decryption
+    // failed") proves scrypt ran the full 512 MiB cost under
+    // `executionMaxmemBytes`. An insufficient overhead allowance fails
+    // differently and fails this test — OpenSSL raises
+    // ERR_CRYPTO_INVALID_SCRYPT_PARAMS before any key exists. One expensive
+    // derivation total; vitest runs same-file tests serially, so the
+    // allocation never overlaps the production round-trip below.
+    const { maxWorkingSetBytes } = SCRYPT_KDF_POLICY;
+    const atN = maxWorkingSetBytes / (128 * 8);
+    const ks = await encryptKeystore(TEST_KEY, PASSPHRASE);
+    ks.crypto.kdfparams.n = atN;
+    ks.crypto.kdfparams.r = 8;
+    await expect(decryptKeystore(ks, PASSPHRASE)).rejects.toThrow(/Decryption failed/);
+  }, 120000);
+
+  it('pins the intended ceilings as literals, independent of the implementation', () => {
+    // Every other assertion reads the policy object; if the object itself
+    // drifted (512 MiB quietly becoming 512 GiB), those would follow it.
+    // These are the review-approved numbers, restated as literals.
+    expect(SCRYPT_KDF_POLICY.maxWorkingSetBytes).toBe(512 * 1024 * 1024);
+    expect(SCRYPT_KDF_POLICY.maxP).toBe(16);
+    expect(SCRYPT_KDF_POLICY.production).toEqual({ n: 2 ** 18, r: 8, p: 1 });
+    expect(SCRYPT_KDF_POLICY.minN).toBe(2 ** 15);
   });
 
   it('accepts p at the ceiling and rejects p one above it', async () => {

--- a/packages/cli/test/keystore.test.ts
+++ b/packages/cli/test/keystore.test.ts
@@ -4,6 +4,7 @@ import {
   decryptKeystore,
   isEncryptedKeystore,
   _setScryptN,
+  _scryptCostPolicy,
   type EncryptedKeystore,
 } from '../src/keystore.js';
 
@@ -113,15 +114,46 @@ describe('decryptKeystore error handling', () => {
     );
   });
 
-  it('rejects keystore declaring a KDF memory cost above the ceiling', async () => {
-    // The existing minimums stop a file advertising a cost cheap enough to
-    // attack. This is the other end: scrypt's working set is 128 * N * r, so
-    // N=2**30 with r=8 asks the loader for ~1 TiB before the passphrase is ever
-    // checked. Rejected up-front with a diagnosable error instead.
+  it('rejects a KDF memory cost immediately above the declared ceiling', async () => {
+    // Boundary, not a wild value: n/r chosen so the working set is exactly one
+    // scrypt block over MAX_WORKING_SET. A ceiling raised or lowered by any
+    // amount fails this pair, which a 2**30 smoke test would not.
+    const { maxWorkingSetBytes, workingSetBytes } = _scryptCostPolicy();
+    const overN = (maxWorkingSetBytes / (128 * 8)) * 2; // r=8 => 2x ceiling
+    expect(workingSetBytes(overN, 8)).toBeGreaterThan(maxWorkingSetBytes);
     const ks = await encryptKeystore(TEST_KEY, PASSPHRASE);
-    ks.crypto.kdfparams.n = 2 ** 30;
+    ks.crypto.kdfparams.n = overN;
+    ks.crypto.kdfparams.r = 8;
     await expect(decryptKeystore(ks, PASSPHRASE)).rejects.toThrow(
       /memory cost too high/,
+    );
+  });
+
+  it('accepts a KDF memory cost exactly at the declared ceiling', async () => {
+    // Proves the ceiling is inclusive without allocating it: dklen is validated
+    // after the cost policy, so an invalid dklen stops execution before scrypt.
+    // The error text discriminates — a memory rejection would name the cost.
+    const { maxWorkingSetBytes, workingSetBytes } = _scryptCostPolicy();
+    const atN = maxWorkingSetBytes / (128 * 8);
+    expect(workingSetBytes(atN, 8)).toBe(maxWorkingSetBytes);
+    const ks = await encryptKeystore(TEST_KEY, PASSPHRASE);
+    ks.crypto.kdfparams.n = atN;
+    ks.crypto.kdfparams.r = 8;
+    ks.crypto.kdfparams.dklen = 16;
+    await expect(decryptKeystore(ks, PASSPHRASE)).rejects.toThrow(/dklen/);
+  });
+
+  it('accepts p at the ceiling and rejects p one above it', async () => {
+    const { maxP } = _scryptCostPolicy();
+    const atCeiling = await encryptKeystore(TEST_KEY, PASSPHRASE);
+    atCeiling.crypto.kdfparams.p = maxP;
+    atCeiling.crypto.kdfparams.dklen = 16;
+    await expect(decryptKeystore(atCeiling, PASSPHRASE)).rejects.toThrow(/dklen/);
+
+    const overCeiling = await encryptKeystore(TEST_KEY, PASSPHRASE);
+    overCeiling.crypto.kdfparams.p = maxP + 1;
+    await expect(decryptKeystore(overCeiling, PASSPHRASE)).rejects.toThrow(
+      /p too high/,
     );
   });
 
@@ -135,19 +167,38 @@ describe('decryptKeystore error handling', () => {
     );
   });
 
-  it('rejects keystore declaring a parallelism factor above the ceiling', async () => {
-    const ks = await encryptKeystore(TEST_KEY, PASSPHRASE);
-    ks.crypto.kdfparams.p = 1024;
-    await expect(decryptKeystore(ks, PASSPHRASE)).rejects.toThrow(
-      /p too high/,
-    );
+  it('budgets enough memory for the CLI production parameters to actually derive', async () => {
+    // The regression this pins is a shipped one: `deriveKey` passed a hardcoded
+    // maxmem of 256 MiB while production N=2**18, r=8 needs a working set of
+    // exactly 256 MiB, and OpenSSL bounds `workingSet + overhead <= maxmem`.
+    // Production keystores therefore failed with ERR_CRYPTO_INVALID_SCRYPT_PARAMS.
+    // The suite lowers N to 2**15, so no round-trip test could ever catch it —
+    // this asserts the policy arithmetic instead, which is where the bug lived.
+    const { executionMaxmemBytes, productionWorkingSetBytes, maxWorkingSetBytes, assertWithinLimits } =
+      _scryptCostPolicy();
+    expect(productionWorkingSetBytes).toBe(128 * (2 ** 18) * 8);
+    expect(productionWorkingSetBytes).toBeLessThanOrEqual(maxWorkingSetBytes);
+    // Strictly greater: equality is exactly what OpenSSL rejects.
+    expect(executionMaxmemBytes).toBeGreaterThan(productionWorkingSetBytes);
+    expect(executionMaxmemBytes).toBeGreaterThan(maxWorkingSetBytes);
+    // And production parameters must pass the acceptance policy unchanged.
+    expect(() => assertWithinLimits(2 ** 18, 8, 1)).not.toThrow();
   });
 
-  it('still accepts the parameters this CLI itself writes', async () => {
-    // Guards the ceiling against being set below our own defaults: the CLI
-    // writes N=2**18, r=8, which is exactly 256 MiB of working set.
-    const ks = await encryptKeystore(TEST_KEY, PASSPHRASE);
-    await expect(decryptKeystore(ks, PASSPHRASE)).resolves.toBeDefined();
+  it('round-trips a keystore at the CLI production parameters', async () => {
+    // Must go through encryptKeystore/decryptKeystore — i.e. through deriveKey —
+    // or it proves nothing. A direct scryptSync call using the policy constant
+    // passes even when deriveKey ignores that constant, which is precisely the
+    // divergence that shipped. Allocates the real 256 MiB production working
+    // set once; the suite otherwise runs at N=2**15 to stay parallel-safe.
+    _setScryptN(2 ** 18);
+    try {
+      const ks = await encryptKeystore(TEST_KEY, PASSPHRASE);
+      expect(ks.crypto.kdfparams.n).toBe(2 ** 18);
+      expect(await decryptKeystore(ks, PASSPHRASE)).toBe(TEST_KEY);
+    } finally {
+      _setScryptN(2 ** 15);
+    }
   });
 });
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -584,8 +584,12 @@ export function contextGraphCatalogUri(contextGraphId: string): string {
   return `did:dkg:context-graph:${contextGraphId}/_catalog`;
 }
 
-export function validateContextGraphId(id: string): { valid: boolean; reason?: string } {
-  if (!id || id.length === 0) return { valid: false, reason: 'Context graph ID cannot be empty' };
+export function validateContextGraphId(id: unknown): { valid: boolean; reason?: string } {
+  // Accepts `unknown` so route handlers can pass JSON-derived values straight
+  // through: the type boundary is part of the ONE canonical policy rather than
+  // living in per-caller adapters that each restate it.
+  if (typeof id !== 'string') return { valid: false, reason: 'Context graph ID must be a string' };
+  if (id.length === 0) return { valid: false, reason: 'Context graph ID cannot be empty' };
   if (id.length > 256) return { valid: false, reason: 'Context graph ID exceeds 256 characters' };
   if (!/^[\w:/.@\-]+$/.test(id)) return { valid: false, reason: 'Context graph ID contains disallowed characters (allowed: alphanumeric, _, :, /, ., @, -)' };
   // The character class above permits both `/` and `.`, because legitimate IDs

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -588,6 +588,15 @@ export function validateContextGraphId(id: string): { valid: boolean; reason?: s
   if (!id || id.length === 0) return { valid: false, reason: 'Context graph ID cannot be empty' };
   if (id.length > 256) return { valid: false, reason: 'Context graph ID exceeds 256 characters' };
   if (!/^[\w:/.@\-]+$/.test(id)) return { valid: false, reason: 'Context graph ID contains disallowed characters (allowed: alphanumeric, _, :, /, ., @, -)' };
+  // The character class above permits both `/` and `.`, because legitimate IDs
+  // are URN/DID/URI-shaped and need them. That combination also admits relative
+  // path segments, which no legitimate ID uses and which do not survive being
+  // joined into a storage namespace or URI with a stable meaning. Reject the
+  // segments themselves rather than the characters, so ordinary IDs like
+  // `did:dkg:context-graph:acme.example/v1` stay valid.
+  if (id.split('/').some((segment) => segment === '.' || segment === '..')) {
+    return { valid: false, reason: 'Context graph ID cannot contain "." or ".." path segments' };
+  }
   return { valid: true };
 }
 

--- a/packages/core/test/constants.test.ts
+++ b/packages/core/test/constants.test.ts
@@ -224,6 +224,25 @@ describe('validateContextGraphId', () => {
     expect(validateContextGraphId('user@domain').valid).toBe(true);
   });
 
+  it('rejects relative path segments while keeping dots inside a segment valid', () => {
+    // The character whitelist permits both `/` and `.` because URN/DID/URI-shaped
+    // IDs need them, which also admits `.`/`..` as whole segments. This mirrors
+    // the segment-aware check `isValidContextGraphId` already applies at the HTTP
+    // boundary, so the two validators agree rather than diverging in strictness.
+    expect(validateContextGraphId('victim/../secret').valid).toBe(false);
+    expect(validateContextGraphId('../secret').valid).toBe(false);
+    expect(validateContextGraphId('victim/./secret').valid).toBe(false);
+    expect(validateContextGraphId('..').valid).toBe(false);
+    expect(validateContextGraphId('.').valid).toBe(false);
+
+    // Dots WITHIN a segment are legitimate and must keep working — version
+    // markers and hostname-shaped identifiers both rely on them.
+    expect(validateContextGraphId('did:dkg:context-graph:acme.example/v1').valid).toBe(true);
+    expect(validateContextGraphId('graph/v1..2').valid).toBe(true);
+    expect(validateContextGraphId('a..b').valid).toBe(true);
+    expect(validateContextGraphId('my.graph').valid).toBe(true);
+  });
+
   it('reserves structural partition segments for new IDs without breaking legacy reads', () => {
     for (const id of [
       'victim/_meta',


### PR DESCRIPTION
Two small, independent input-bounds gaps. Both are defence-in-depth — neither is reachable as a failure today by an ordinary caller, but both leave a validator weaker than its sibling.

### 1. `core`: two context-graph ID validators disagreed on strictness

`validateContextGraphId` (core) and `isValidContextGraphId` (cli/http-utils) validate the same thing, but only the latter applied a segment-aware check. The character whitelist permits `/` and `.` because URN/DID/URI-shaped IDs need them — which also admits `.` and `..` as whole segments.

That matters because **26 route call sites** reach the core validator via `validateRequiredContextGraphId`, i.e. the weaker of the two.

Fix rejects the *segments* rather than the characters, so ordinary IDs keep working:

| Input | Before | After |
|---|---|---|
| `victim/../secret` | valid | rejected |
| `did:dkg:context-graph:acme.example/v1` | valid | valid |
| `graph/v1..2` | valid | valid |

This aligns core with the check the CLI already had, rather than introducing a new rule.

### 2. `cli`: keystore KDF parameters had a floor but no ceiling

Loading already enforces minimum scrypt parameters — those stop a file advertising a cost cheap enough to attack. There was no maximum, so a file could advertise a cost too expensive to service: scrypt's working set is `128 * N * r`, so `N=2^30, r=8` asks the loader for ~1 TiB before the passphrase is ever checked.

Adds:
- a memory ceiling (512 MiB) on the implied working set
- a parallelism ceiling on `p`
- a power-of-two check on `N` — scrypt requires it, and without the check the value reaches OpenSSL and fails there with an opaque error rather than a diagnosable one

Both ceilings sit **above** the parameters this CLI itself writes (`N=2^18, r=8`, exactly 256 MiB). A regression test pins that, so the ceiling can't later be tightened below our own output.

### Tests

`packages/core` constants — **49 passing**, incl. new cases for rejected segments and for dots that must stay valid.
`packages/cli` keystore — **20 passing**, incl. 3 new bound cases and the self-compatibility guard.

Verified the new tests are real discriminators: on the unmodified base, 3 of them fail. (The `p` case is instructive — it takes ~64s to fail there, because the unbounded value is actually run.)
