### PR TITLE
fix(api): classify the adapter-wrapped SPARQL 4xx as a client error (#1758)

### DIFF
--- a/packages/cli/src/daemon/routes/query-error.ts
+++ b/packages/cli/src/daemon/routes/query-error.ts
@@ -1,0 +1,75 @@
+/**
+ * Query-error classification policy for `/api/query`.
+ *
+ * Extracted from routes/query.ts (PR #2330 review): that file is a ~1.4k-line
+ * mixed-purpose route, and the policy had grown into two cooperating exported
+ * helpers with an implicit ordering dependency between them. One classifier
+ * owns it now — typed errors are a terminal branch, legacy message matching
+ * applies only to untyped ones — so there is a single place to add a rule and
+ * no way to place it wrongly.
+ */
+import { isSparqlHttpResponseError } from "@origintrail-official/dkg-storage";
+
+/**
+ * Upstream statuses that mean "the SPARQL the caller sent is malformed".
+ *
+ * Deliberately NOT every 4xx. A configured store can answer 401/403 for stale
+ * daemon credentials, 404 for a misconfigured endpoint, or 429 when throttling
+ * us — those are server/integration faults, and reporting them as 400 would
+ * tell the caller their query is invalid and suppress the retry or operator
+ * remediation that would actually fix it.
+ */
+const MALFORMED_QUERY_STATUSES = new Set([400, 422]);
+
+/**
+ * Legacy message families, for errors with no typed carrier.
+ *
+ * GH#1758 was a silent re-regression of #889 precisely because this condition
+ * lived inline inside a catch block, so nothing could assert on it.
+ */
+export function isClientQueryError(msg: string): boolean {
+  return (
+    
+        msg.startsWith("SPARQL rejected:") ||
+        msg.startsWith("Parse error") ||
+        // #889: oxigraph surfaces SPARQL syntax errors as
+        // `error at <line>:<col>: expected one of ...` (e.g. a missing
+        // closing brace or an incomplete triple). These are client input
+        // errors, not server faults — classify them as 400 to match the
+        // existing `SPARQL rejected:` / `must start with ...` handling
+        // instead of letting them fall through to a 500.
+        /^error at \d+:\d+:/.test(msg) ||
+        /must start with (SELECT|CONSTRUCT|ASK|DESCRIBE)/i.test(msg) ||
+        msg.includes("was removed in V10") ||
+        msg.includes("agentAddress is required") ||
+        msg.includes("requires a contextGraphId") ||
+        msg.includes("cannot be combined with") ||
+        msg.startsWith("Scoped query violation:") ||
+        // A-1 review: DKGAgent.query throws these when the caller sends
+        // a non-string `agentAddress` / `callerAgentAddress` in the
+        // body. Classify as 400 so malformed input is a clean client
+        // error instead of a 500.
+        msg.startsWith("query: 'agentAddress' must be a string") ||
+        msg.startsWith("query: 'callerAgentAddress' must be a string") ||
+        // P-13 review: `resolveViewGraphs` validates `minTrust` now,
+        // so direct callers that forward a string / out-of-range
+        // value get a 400 instead of a 500.
+        msg.startsWith("Invalid minTrust")
+  );
+}
+
+/**
+ * Should `/api/query` answer 400 for this thrown error?
+ *
+ * `true` renders a 400; `false` rethrows as a server fault. A typed SPARQL
+ * HTTP response is terminal — its status decides, and message matching is not
+ * consulted, so a store rejecting US can never be reported as the caller's bad
+ * query.
+ */
+export function isClientQueryFailure(err: unknown): boolean {
+  if (isSparqlHttpResponseError(err)) {
+    return MALFORMED_QUERY_STATUSES.has(err.status);
+  }
+  const msg = (err as { message?: unknown })?.message;
+  return typeof msg === "string" && isClientQueryError(msg);
+}

--- a/packages/cli/src/daemon/routes/query-error.ts
+++ b/packages/cli/src/daemon/routes/query-error.ts
@@ -8,18 +8,25 @@
  * applies only to untyped ones — so there is a single place to add a rule and
  * no way to place it wrongly.
  */
-import { isSparqlHttpResponseError } from "@origintrail-official/dkg-storage";
-
 /**
- * Upstream statuses that mean "the SPARQL the caller sent is malformed".
- *
- * Deliberately NOT every 4xx. A configured store can answer 401/403 for stale
- * daemon credentials, 404 for a misconfigured endpoint, or 429 when throttling
- * us — those are server/integration faults, and reporting them as 400 would
- * tell the caller their query is invalid and suppress the retry or operator
- * remediation that would actually fix it.
+ * Recognised structurally rather than by importing `@origintrail-official/dkg-query`.
+ * The cli package does not depend on it directly (the error arrives through the
+ * agent), and adding a dependency would put this change behind the CODEOWNERS
+ * gate on the per-package manifests for no behavioural gain. Source of truth for
+ * the constant is `packages/query/src/caller-sparql-error.ts`.
  */
-const MALFORMED_QUERY_STATUSES = new Set([400, 422]);
+const CALLER_SPARQL_REJECTED_CODE = "CALLER_SPARQL_REJECTED";
+
+function isCallerSparqlRejected(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const c = err as { code?: unknown; status?: unknown; message?: unknown };
+  return (
+    c.code === CALLER_SPARQL_REJECTED_CODE &&
+    typeof c.status === "number" &&
+    Number.isFinite(c.status) &&
+    typeof c.message === "string"
+  );
+}
 
 /**
  * Legacy message families, for errors with no typed carrier.
@@ -27,7 +34,7 @@ const MALFORMED_QUERY_STATUSES = new Set([400, 422]);
  * GH#1758 was a silent re-regression of #889 precisely because this condition
  * lived inline inside a catch block, so nothing could assert on it.
  */
-export function isClientQueryError(msg: string): boolean {
+function isLegacyClientQueryMessage(msg: string): boolean {
   return (
     
         msg.startsWith("SPARQL rejected:") ||
@@ -61,15 +68,20 @@ export function isClientQueryError(msg: string): boolean {
 /**
  * Should `/api/query` answer 400 for this thrown error?
  *
- * `true` renders a 400; `false` rethrows as a server fault. A typed SPARQL
- * HTTP response is terminal — its status decides, and message matching is not
- * consulted, so a store rejecting US can never be reported as the caller's bad
- * query.
+ * `true` renders a 400; `false` rethrows as a server fault.
+ *
+ * A bare upstream status is NOT sufficient (PR #2330 review): one request also
+ * runs engine-generated queries for access control, graph resolution and
+ * metadata scans, and a store rejecting one of those with 400 is an
+ * integration fault, not a malformed caller query. The query engine marks the
+ * single store call that carried caller-supplied SPARQL; only that marker — or
+ * a legacy message family with no typed carrier — yields a 400.
+ *
+ * This is the sole exported classifier. The legacy message matcher stays
+ * private so the provenance-first rule cannot be bypassed.
  */
 export function isClientQueryFailure(err: unknown): boolean {
-  if (isSparqlHttpResponseError(err)) {
-    return MALFORMED_QUERY_STATUSES.has(err.status);
-  }
+  if (isCallerSparqlRejected(err)) return true;
   const msg = (err as { message?: unknown })?.message;
-  return typeof msg === "string" && isClientQueryError(msg);
+  return typeof msg === "string" && isLegacyClientQueryMessage(msg);
 }

--- a/packages/cli/src/daemon/routes/query-error.ts
+++ b/packages/cli/src/daemon/routes/query-error.ts
@@ -8,6 +8,8 @@
  * applies only to untyped ones — so there is a single place to add a rule and
  * no way to place it wrongly.
  */
+import { isSparqlHttpResponseError } from "@origintrail-official/dkg-storage";
+
 /**
  * Recognised structurally rather than by importing `@origintrail-official/dkg-query`.
  * The cli package does not depend on it directly (the error arrives through the
@@ -81,7 +83,18 @@ function isLegacyClientQueryMessage(msg: string): boolean {
  * private so the provenance-first rule cannot be bypassed.
  */
 export function isClientQueryFailure(err: unknown): boolean {
+  // 1. Provenance wins: the engine marked this as the caller's own SPARQL.
   if (isCallerSparqlRejected(err)) return true;
+
+  // 2. A TYPED store error that was NOT marked is terminal — it came from an
+  //    engine-generated query, so it is a server fault no matter what its
+  //    rendered message happens to look like. Without this, a store rejection
+  //    whose body contained e.g. "Query must start with SELECT" would fall
+  //    through to the legacy families below and be reported as the caller's
+  //    fault, defeating the provenance rule (PR #2330 review).
+  if (isSparqlHttpResponseError(err)) return false;
+
+  // 3. Legacy families, for errors with no typed carrier at all.
   const msg = (err as { message?: unknown })?.message;
   return typeof msg === "string" && isLegacyClientQueryMessage(msg);
 }

--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -363,6 +363,53 @@ class ApiQueryCallerDisconnectedError extends Error {
  * by `/api/query`. Exported so the route boundary can be tested without
  * replacing the real query engine with a hand-typed error stub.
  */
+/**
+ * Is this thrown message a CLIENT input error (400) rather than a server
+ * fault (500)?
+ *
+ * Extracted from the /api/query catch block so it can be regression-tested
+ * directly — GH#1758 was a silent re-regression of #889, and there was no
+ * unit-level guard because the condition lived inline inside a catch.
+ */
+export function isClientQueryError(msg: string): boolean {
+  return (
+    
+        msg.startsWith("SPARQL rejected:") ||
+        msg.startsWith("Parse error") ||
+        // #889: oxigraph surfaces SPARQL syntax errors as
+        // `error at <line>:<col>: expected one of ...` (e.g. a missing
+        // closing brace or an incomplete triple). These are client input
+        // errors, not server faults — classify them as 400 to match the
+        // existing `SPARQL rejected:` / `must start with ...` handling
+        // instead of letting them fall through to a 500.
+        /^error at \d+:\d+:/.test(msg) ||
+        // #1758: the store adapter wraps the upstream response as
+        // `SPARQL HTTP <query|construct|update> failed (<status>): <body>`
+        // (packages/storage/src/adapters/sparql-http.ts:387/671/716), which
+        // buries the parse error mid-string so the anchored pattern above
+        // cannot see it. Classify on the wrapped 4xx status instead of the
+        // English text, so a malformed query is a 400 on both the direct and
+        // the wrapped path.
+        /^SPARQL HTTP \w+ failed \(4\d\d\):/.test(msg) ||
+        /must start with (SELECT|CONSTRUCT|ASK|DESCRIBE)/i.test(msg) ||
+        msg.includes("was removed in V10") ||
+        msg.includes("agentAddress is required") ||
+        msg.includes("requires a contextGraphId") ||
+        msg.includes("cannot be combined with") ||
+        msg.startsWith("Scoped query violation:") ||
+        // A-1 review: DKGAgent.query throws these when the caller sends
+        // a non-string `agentAddress` / `callerAgentAddress` in the
+        // body. Classify as 400 so malformed input is a clean client
+        // error instead of a 500.
+        msg.startsWith("query: 'agentAddress' must be a string") ||
+        msg.startsWith("query: 'callerAgentAddress' must be a string") ||
+        // P-13 review: `resolveViewGraphs` validates `minTrust` now,
+        // so direct callers that forward a string / out-of-range
+        // value get a 400 instead of a 500.
+        msg.startsWith("Invalid minTrust")
+  );
+}
+
 export function createApiQueryRequestLifecycle(
   req: IncomingMessage,
   res: ServerResponse,
@@ -698,33 +745,7 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
       }
       tracker.fail(ctx, err);
       const msg = err?.message ?? "";
-      if (
-        msg.startsWith("SPARQL rejected:") ||
-        msg.startsWith("Parse error") ||
-        // #889: oxigraph surfaces SPARQL syntax errors as
-        // `error at <line>:<col>: expected one of ...` (e.g. a missing
-        // closing brace or an incomplete triple). These are client input
-        // errors, not server faults — classify them as 400 to match the
-        // existing `SPARQL rejected:` / `must start with ...` handling
-        // instead of letting them fall through to a 500.
-        /^error at \d+:\d+:/.test(msg) ||
-        /must start with (SELECT|CONSTRUCT|ASK|DESCRIBE)/i.test(msg) ||
-        msg.includes("was removed in V10") ||
-        msg.includes("agentAddress is required") ||
-        msg.includes("requires a contextGraphId") ||
-        msg.includes("cannot be combined with") ||
-        msg.startsWith("Scoped query violation:") ||
-        // A-1 review: DKGAgent.query throws these when the caller sends
-        // a non-string `agentAddress` / `callerAgentAddress` in the
-        // body. Classify as 400 so malformed input is a clean client
-        // error instead of a 500.
-        msg.startsWith("query: 'agentAddress' must be a string") ||
-        msg.startsWith("query: 'callerAgentAddress' must be a string") ||
-        // P-13 review: `resolveViewGraphs` validates `minTrust` now,
-        // so direct callers that forward a string / out-of-range
-        // value get a 400 instead of a 500.
-        msg.startsWith("Invalid minTrust")
-      ) {
+      if (isClientQueryError(msg)) {
         return jsonResponse(res, 400, { error: msg });
       }
       throw err;

--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -17,7 +17,7 @@ import {
   type IncomingMessage,
   type ServerResponse,
 } from "node:http";
-import { isSparqlHttpResponseError } from "@origintrail-official/dkg-storage";
+import { isClientQueryError, isClientQueryFailure } from "./query-error.js";
 import { createHash, randomUUID } from "node:crypto";
 import {
   appendFile,
@@ -360,69 +360,6 @@ class ApiQueryCallerDisconnectedError extends Error {
 }
 
 /**
- * Upstream statuses that mean "the SPARQL the caller sent is malformed".
- *
- * Deliberately NOT every 4xx (PR #2330 review). A configured store can answer
- * 401/403 for stale daemon credentials, 404 for a misconfigured endpoint, or
- * 429 when throttling us — those are server/integration faults, and reporting
- * them as 400 would tell the caller their query is invalid and suppress the
- * retry or operator remediation that would actually fix it.
- */
-const MALFORMED_QUERY_STATUSES = new Set([400, 422]);
-
-/**
- * Classify a thrown store error using the upstream status carried as DATA.
- *
- * Returns `undefined` when the error is not a typed SPARQL HTTP response, so
- * the caller can fall back to the legacy message families below.
- */
-export function classifySparqlHttpError(err: unknown): 400 | 500 | undefined {
-  if (!isSparqlHttpResponseError(err)) return undefined;
-  return MALFORMED_QUERY_STATUSES.has(err.status) ? 400 : 500;
-}
-
-/**
- * Is this thrown message a CLIENT input error (400) rather than a server
- * fault (500)?
- *
- * Message-based, and kept only for the legacy families below that have no
- * typed carrier. Extracted from the /api/query catch block so it can be
- * regression-tested directly — GH#1758 was a silent re-regression of #889,
- * and there was no unit-level guard because the condition lived inline
- * inside a catch.
- */
-export function isClientQueryError(msg: string): boolean {
-  return (
-    
-        msg.startsWith("SPARQL rejected:") ||
-        msg.startsWith("Parse error") ||
-        // #889: oxigraph surfaces SPARQL syntax errors as
-        // `error at <line>:<col>: expected one of ...` (e.g. a missing
-        // closing brace or an incomplete triple). These are client input
-        // errors, not server faults — classify them as 400 to match the
-        // existing `SPARQL rejected:` / `must start with ...` handling
-        // instead of letting them fall through to a 500.
-        /^error at \d+:\d+:/.test(msg) ||
-        /must start with (SELECT|CONSTRUCT|ASK|DESCRIBE)/i.test(msg) ||
-        msg.includes("was removed in V10") ||
-        msg.includes("agentAddress is required") ||
-        msg.includes("requires a contextGraphId") ||
-        msg.includes("cannot be combined with") ||
-        msg.startsWith("Scoped query violation:") ||
-        // A-1 review: DKGAgent.query throws these when the caller sends
-        // a non-string `agentAddress` / `callerAgentAddress` in the
-        // body. Classify as 400 so malformed input is a clean client
-        // error instead of a 500.
-        msg.startsWith("query: 'agentAddress' must be a string") ||
-        msg.startsWith("query: 'callerAgentAddress' must be a string") ||
-        // P-13 review: `resolveViewGraphs` validates `minTrust` now,
-        // so direct callers that forward a string / out-of-range
-        // value get a 400 instead of a 500.
-        msg.startsWith("Invalid minTrust")
-  );
-}
-
-/**
  * Own the HTTP-disconnect signal and the exact store-admission options passed
  * by `/api/query`. Exported so the route boundary can be tested without
  * replacing the real query engine with a hand-typed error stub.
@@ -762,14 +699,9 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
       }
       tracker.fail(ctx, err);
       const msg = err?.message ?? "";
-      // #1758 — prefer the typed upstream status over message matching. A
-      // malformed query (400/422) is the caller's fault; 401/403/404/429 mean
-      // the STORE rejected us and must stay a server error.
-      const byStatus = classifySparqlHttpError(err);
-      if (byStatus === 400) {
-        return jsonResponse(res, 400, { error: msg });
-      }
-      if (byStatus === undefined && isClientQueryError(msg)) {
+      // #1758 — one classifier: a typed upstream status decides, otherwise
+      // legacy message families apply. See ./query-error.ts.
+      if (isClientQueryFailure(err)) {
         return jsonResponse(res, 400, { error: msg });
       }
       throw err;

--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -17,7 +17,7 @@ import {
   type IncomingMessage,
   type ServerResponse,
 } from "node:http";
-import { isClientQueryError, isClientQueryFailure } from "./query-error.js";
+import { isClientQueryFailure } from "./query-error.js";
 import { createHash, randomUUID } from "node:crypto";
 import {
   appendFile,

--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -17,6 +17,7 @@ import {
   type IncomingMessage,
   type ServerResponse,
 } from "node:http";
+import { isSparqlHttpResponseError } from "@origintrail-official/dkg-storage";
 import { createHash, randomUUID } from "node:crypto";
 import {
   appendFile,
@@ -359,17 +360,36 @@ class ApiQueryCallerDisconnectedError extends Error {
 }
 
 /**
- * Own the HTTP-disconnect signal and the exact store-admission options passed
- * by `/api/query`. Exported so the route boundary can be tested without
- * replacing the real query engine with a hand-typed error stub.
+ * Upstream statuses that mean "the SPARQL the caller sent is malformed".
+ *
+ * Deliberately NOT every 4xx (PR #2330 review). A configured store can answer
+ * 401/403 for stale daemon credentials, 404 for a misconfigured endpoint, or
+ * 429 when throttling us — those are server/integration faults, and reporting
+ * them as 400 would tell the caller their query is invalid and suppress the
+ * retry or operator remediation that would actually fix it.
  */
+const MALFORMED_QUERY_STATUSES = new Set([400, 422]);
+
+/**
+ * Classify a thrown store error using the upstream status carried as DATA.
+ *
+ * Returns `undefined` when the error is not a typed SPARQL HTTP response, so
+ * the caller can fall back to the legacy message families below.
+ */
+export function classifySparqlHttpError(err: unknown): 400 | 500 | undefined {
+  if (!isSparqlHttpResponseError(err)) return undefined;
+  return MALFORMED_QUERY_STATUSES.has(err.status) ? 400 : 500;
+}
+
 /**
  * Is this thrown message a CLIENT input error (400) rather than a server
  * fault (500)?
  *
- * Extracted from the /api/query catch block so it can be regression-tested
- * directly — GH#1758 was a silent re-regression of #889, and there was no
- * unit-level guard because the condition lived inline inside a catch.
+ * Message-based, and kept only for the legacy families below that have no
+ * typed carrier. Extracted from the /api/query catch block so it can be
+ * regression-tested directly — GH#1758 was a silent re-regression of #889,
+ * and there was no unit-level guard because the condition lived inline
+ * inside a catch.
  */
 export function isClientQueryError(msg: string): boolean {
   return (
@@ -383,14 +403,6 @@ export function isClientQueryError(msg: string): boolean {
         // existing `SPARQL rejected:` / `must start with ...` handling
         // instead of letting them fall through to a 500.
         /^error at \d+:\d+:/.test(msg) ||
-        // #1758: the store adapter wraps the upstream response as
-        // `SPARQL HTTP <query|construct|update> failed (<status>): <body>`
-        // (packages/storage/src/adapters/sparql-http.ts:387/671/716), which
-        // buries the parse error mid-string so the anchored pattern above
-        // cannot see it. Classify on the wrapped 4xx status instead of the
-        // English text, so a malformed query is a 400 on both the direct and
-        // the wrapped path.
-        /^SPARQL HTTP \w+ failed \(4\d\d\):/.test(msg) ||
         /must start with (SELECT|CONSTRUCT|ASK|DESCRIBE)/i.test(msg) ||
         msg.includes("was removed in V10") ||
         msg.includes("agentAddress is required") ||
@@ -410,6 +422,11 @@ export function isClientQueryError(msg: string): boolean {
   );
 }
 
+/**
+ * Own the HTTP-disconnect signal and the exact store-admission options passed
+ * by `/api/query`. Exported so the route boundary can be tested without
+ * replacing the real query engine with a hand-typed error stub.
+ */
 export function createApiQueryRequestLifecycle(
   req: IncomingMessage,
   res: ServerResponse,
@@ -745,7 +762,14 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
       }
       tracker.fail(ctx, err);
       const msg = err?.message ?? "";
-      if (isClientQueryError(msg)) {
+      // #1758 — prefer the typed upstream status over message matching. A
+      // malformed query (400/422) is the caller's fault; 401/403/404/429 mean
+      // the STORE rejected us and must stay a server error.
+      const byStatus = classifySparqlHttpError(err);
+      if (byStatus === 400) {
+        return jsonResponse(res, 400, { error: msg });
+      }
+      if (byStatus === undefined && isClientQueryError(msg)) {
         return jsonResponse(res, 400, { error: msg });
       }
       throw err;

--- a/packages/cli/test/query-client-error-classification.test.ts
+++ b/packages/cli/test/query-client-error-classification.test.ts
@@ -89,3 +89,35 @@ describe('isClientQueryFailure — legacy message families (GH#1758)', () => {
     expect(isClientQueryFailure(new Error(''))).toBe(false);
   });
 });
+
+// PR #2330 review — the provenance rule must hold even when a typed store
+// error's MESSAGE happens to match a legacy family. Without a terminal branch
+// for unmarked typed errors, an engine-internal rejection whose body contained
+// "Query must start with SELECT" would fall through and be blamed on the caller.
+describe('isClientQueryFailure — typed non-caller errors are terminal (GH#1758)', () => {
+  const legacyLookalikes = [
+    'SPARQL rejected: no',
+    'Parse error near line 2',
+    'Query must start with SELECT',
+    'error at 1:15: expected one of REDUCED',
+    "query: 'agentAddress' must be a string",
+    'Invalid minTrust value',
+  ];
+
+  for (const body of legacyLookalikes) {
+    it(`does not classify an unmarked typed 400 whose body reads "${body.slice(0, 28)}…"`, () => {
+      expect(isClientQueryFailure(new SparqlHttpResponseError('query', 400, body))).toBe(false);
+    });
+  }
+
+  it('holds for 422 as well', () => {
+    expect(isClientQueryFailure(new SparqlHttpResponseError('query', 422, 'Parse error near line 2'))).toBe(false);
+  });
+
+  it('but the SAME message still classifies when it has no typed carrier', () => {
+    // The legacy families are for untyped errors; they must keep working.
+    for (const body of legacyLookalikes) {
+      expect(isClientQueryFailure(new Error(body))).toBe(true);
+    }
+  });
+});

--- a/packages/cli/test/query-client-error-classification.test.ts
+++ b/packages/cli/test/query-client-error-classification.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { SparqlHttpResponseError } from '@origintrail-official/dkg-storage';
-import { classifySparqlHttpError, isClientQueryError } from '../src/daemon/routes/query.js';
+import {
+  SPARQL_HTTP_RESPONSE_ERROR_CODE,
+  SparqlHttpResponseError,
+} from '@origintrail-official/dkg-storage';
+import { isClientQueryError, isClientQueryFailure } from '../src/daemon/routes/query-error.js';
 
 // GH#1758 — invalid SPARQL was AGAIN reported as HTTP 500, a silent
 // re-regression of #889.
@@ -17,11 +20,11 @@ import { classifySparqlHttpError, isClientQueryError } from '../src/daemon/route
 // credentials, 404 for a bad endpoint, or 429 when throttling us. Those are
 // server/integration faults. The upstream status is now carried as data on a
 // typed error rather than recovered from the message with a regex.
-describe('classifySparqlHttpError — typed upstream status (GH#1758)', () => {
+describe('isClientQueryFailure — typed upstream status (GH#1758)', () => {
   it('maps a malformed-query status to 400', () => {
     for (const status of [400, 422]) {
       const err = new SparqlHttpResponseError('query', status, 'error at 1:15: expected one of REDUCED');
-      expect(classifySparqlHttpError(err)).toBe(400);
+      expect(isClientQueryFailure(err)).toBe(true);
     }
   });
 
@@ -31,40 +34,78 @@ describe('classifySparqlHttpError — typed upstream status (GH#1758)', () => {
     // remediation that would actually fix it.
     for (const status of [401, 403, 404, 429]) {
       const err = new SparqlHttpResponseError('query', status, 'Unauthorized');
-      expect(classifySparqlHttpError(err)).toBe(500);
+      expect(isClientQueryFailure(err)).toBe(false);
     }
   });
 
   it('keeps 5xx as a server error', () => {
     for (const status of [500, 502, 503]) {
-      expect(classifySparqlHttpError(new SparqlHttpResponseError('query', status, 'boom'))).toBe(500);
+      expect(isClientQueryFailure(new SparqlHttpResponseError('query', status, 'boom'))).toBe(false);
     }
   });
 
   it('classifies every operation the adapter throws for', () => {
     for (const op of ['query', 'construct', 'update']) {
-      expect(classifySparqlHttpError(new SparqlHttpResponseError(op, 400, 'bad'))).toBe(400);
-      expect(classifySparqlHttpError(new SparqlHttpResponseError(op, 401, 'nope'))).toBe(500);
+      expect(isClientQueryFailure(new SparqlHttpResponseError(op, 400, 'bad'))).toBe(true);
+      expect(isClientQueryFailure(new SparqlHttpResponseError(op, 401, 'nope'))).toBe(false);
     }
   });
 
-  it('returns undefined for anything untyped, so legacy matching still runs', () => {
-    expect(classifySparqlHttpError(new Error('SPARQL HTTP query failed (400): x'))).toBeUndefined();
-    expect(classifySparqlHttpError(new Error('ECONNREFUSED'))).toBeUndefined();
-    expect(classifySparqlHttpError(undefined)).toBeUndefined();
-    expect(classifySparqlHttpError(null)).toBeUndefined();
+  it('falls through to legacy message matching for anything untyped', () => {
+    // An untyped error whose TEXT looks wrapped is no longer trusted — the
+    // over-broad message rule the review rejected must stay gone.
+    expect(isClientQueryFailure(new Error('SPARQL HTTP query failed (400): x'))).toBe(false);
+    expect(isClientQueryFailure(new Error('ECONNREFUSED'))).toBe(false);
+    expect(isClientQueryFailure(undefined)).toBe(false);
+    expect(isClientQueryFailure(null)).toBe(false);
+    // ...but a legacy family still classifies.
+    expect(isClientQueryFailure(new Error('SPARQL rejected: no'))).toBe(true);
   });
 
-  it('recognises a structurally-equivalent error across a realm boundary', () => {
-    // Workers / bundling can break `instanceof`; the duck-typed branch keeps
+  it('recognises a structurally-complete error across a realm boundary', () => {
+    // Workers / bundling can break `instanceof`; the structural branch keeps
     // classification working when the class identity does not survive.
     const plain = Object.assign(new Error('SPARQL HTTP query failed (400): bad'), {
-      name: 'SparqlHttpResponseError',
+      code: SPARQL_HTTP_RESPONSE_ERROR_CODE,
       status: 400,
       operation: 'query',
       responseExcerpt: 'bad',
     });
-    expect(classifySparqlHttpError(plain)).toBe(400);
+    expect(isClientQueryFailure(plain)).toBe(true);
+  });
+
+  // PR #2330 review — the guard used to accept a name + numeric status and then
+  // narrow to the full class, so a consumer could reach `err.operation` on a
+  // value that had none. Every promised field is validated now.
+  it('rejects an impostor that carries only the discriminant and a status', () => {
+    expect(isClientQueryFailure({ code: SPARQL_HTTP_RESPONSE_ERROR_CODE, status: 400 })).toBe(false);
+  });
+
+  it('rejects a partial shape missing any single promised field', () => {
+    const full = {
+      code: SPARQL_HTTP_RESPONSE_ERROR_CODE,
+      status: 400,
+      operation: 'query',
+      responseExcerpt: 'bad',
+      message: 'SPARQL HTTP query failed (400): bad',
+    };
+    for (const drop of ['status', 'operation', 'responseExcerpt', 'message'] as const) {
+      const partial: Record<string, unknown> = { ...full };
+      delete partial[drop];
+      expect(isClientQueryFailure(partial)).toBe(false);
+    }
+  });
+
+  it('rejects an object using the old name-based discriminant', () => {
+    // The class name is mutable and was never a safe discriminant.
+    expect(isClientQueryFailure({ name: 'SparqlHttpResponseError', status: 400 })).toBe(false);
+  });
+
+  it('rejects a non-finite status', () => {
+    expect(isClientQueryFailure({
+      code: SPARQL_HTTP_RESPONSE_ERROR_CODE, status: NaN,
+      operation: 'query', responseExcerpt: 'x', message: 'y',
+    })).toBe(false);
   });
 
   it('preserves the rendered message, so log greps keep working', () => {

--- a/packages/cli/test/query-client-error-classification.test.ts
+++ b/packages/cli/test/query-client-error-classification.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { isClientQueryError } from '../src/daemon/routes/query.js';
+
+// GH#1758 — invalid SPARQL was AGAIN reported as HTTP 500, a silent
+// re-regression of #889.
+//
+// #889 added an anchored `/^error at \d+:\d+:/` pattern, which matches only
+// when oxigraph's parse error is the WHOLE message. The store adapter wraps it
+// as `SPARQL HTTP query failed (400): error at 1:15: …`
+// (packages/storage/src/adapters/sparql-http.ts:387/671/716), burying the
+// parse error mid-string, so the anchor stopped matching and the error fell
+// through to a 500. The condition lived inline inside a catch block, so
+// nothing could regression-test it — hence this file, and the extraction of
+// `isClientQueryError`.
+describe('isClientQueryError — wrapped upstream status (GH#1758)', () => {
+  it('classifies the adapter-wrapped 400 the issue reports', () => {
+    expect(isClientQueryError(
+      'SPARQL HTTP query failed (400): error at 1:15: expected one of REDUCED, [_]',
+    )).toBe(true);
+  });
+
+  it('classifies the wrapped form for every operation the adapter throws', () => {
+    for (const op of ['query', 'construct', 'update']) {
+      expect(isClientQueryError(`SPARQL HTTP ${op} failed (400): error at 1:15: bad`)).toBe(true);
+    }
+  });
+
+  it('classifies other 4xx statuses as client errors', () => {
+    expect(isClientQueryError('SPARQL HTTP query failed (413): payload too large')).toBe(true);
+    expect(isClientQueryError('SPARQL HTTP query failed (422): unprocessable')).toBe(true);
+  });
+
+  it('does NOT classify a wrapped 5xx as a client error', () => {
+    // A store-side fault must stay a 500 — the caller's query was fine.
+    expect(isClientQueryError('SPARQL HTTP query failed (500): internal error')).toBe(false);
+    expect(isClientQueryError('SPARQL HTTP query failed (503): unavailable')).toBe(false);
+  });
+
+  it('still classifies the bare #889 form (unwrapped)', () => {
+    expect(isClientQueryError('error at 1:15: expected one of REDUCED, [_]')).toBe(true);
+  });
+
+  it('keeps the pre-existing client-error families', () => {
+    expect(isClientQueryError('SPARQL rejected: no')).toBe(true);
+    expect(isClientQueryError('Parse error near line 2')).toBe(true);
+    expect(isClientQueryError('Query must start with SELECT')).toBe(true);
+    expect(isClientQueryError("query: 'agentAddress' must be a string")).toBe(true);
+    expect(isClientQueryError('Invalid minTrust value')).toBe(true);
+  });
+
+  it('leaves genuine server faults alone', () => {
+    expect(isClientQueryError('ECONNREFUSED 127.0.0.1:7878')).toBe(false);
+    expect(isClientQueryError('store timeout after 30000ms')).toBe(false);
+    expect(isClientQueryError('')).toBe(false);
+  });
+});

--- a/packages/cli/test/query-client-error-classification.test.ts
+++ b/packages/cli/test/query-client-error-classification.test.ts
@@ -1,142 +1,91 @@
 import { describe, expect, it } from 'vitest';
-import {
-  SPARQL_HTTP_RESPONSE_ERROR_CODE,
-  SparqlHttpResponseError,
-} from '@origintrail-official/dkg-storage';
-import { isClientQueryError, isClientQueryFailure } from '../src/daemon/routes/query-error.js';
+import { SparqlHttpResponseError } from '@origintrail-official/dkg-storage';
+import { isClientQueryFailure } from '../src/daemon/routes/query-error.js';
 
 // GH#1758 — invalid SPARQL was AGAIN reported as HTTP 500, a silent
-// re-regression of #889.
+// re-regression of #889. #889's anchored `/^error at \d+:\d+:/` matched only
+// when oxigraph's parse error was the WHOLE message; the store adapter wraps it
+// mid-string, so the anchor stopped matching.
 //
-// #889 added an anchored `/^error at \d+:\d+:/` pattern, which matches only
-// when oxigraph's parse error is the WHOLE message. The store adapter wrapped
-// it as `SPARQL HTTP query failed (400): error at 1:15: …`, burying the parse
-// error mid-string, so the anchor stopped matching and the error fell through
-// to a 500. The condition also lived inline inside a catch block, so nothing
-// could regression-test it.
-//
-// PR #2330 review: the first fix classified EVERY wrapped 4xx as a client
-// error, which is wrong — a store can answer 401/403 for stale daemon
-// credentials, 404 for a bad endpoint, or 429 when throttling us. Those are
-// server/integration faults. The upstream status is now carried as data on a
-// typed error rather than recovered from the message with a regex.
-describe('isClientQueryFailure — typed upstream status (GH#1758)', () => {
-  it('maps a malformed-query status to 400', () => {
+// PR #2330 review, round 3: an upstream 400 alone does NOT prove the CALLER's
+// query was malformed. One `/api/query` request also runs engine-generated
+// queries for access control, graph resolution and metadata scans. A store that
+// rejects one of THOSE with 400 is an integration fault; answering 400 blames
+// the caller and suppresses operator remediation. The query engine now marks
+// the single store call carrying caller-supplied SPARQL, and only that marker
+// classifies.
+const callerRejected = (status: number) =>
+  Object.assign(new Error(`SPARQL HTTP query failed (${status}): error at 1:15: bad`), {
+    code: 'CALLER_SPARQL_REJECTED',
+    status,
+  });
+
+describe('isClientQueryFailure — caller-SPARQL provenance (GH#1758)', () => {
+  it('classifies a marked caller-query rejection as a client error', () => {
     for (const status of [400, 422]) {
-      const err = new SparqlHttpResponseError('query', status, 'error at 1:15: expected one of REDUCED');
-      expect(isClientQueryFailure(err)).toBe(true);
+      expect(isClientQueryFailure(callerRejected(status))).toBe(true);
     }
   });
 
-  it('keeps store-rejects-us statuses as server errors', () => {
-    // The PR #2330 review case: telling the caller their query is invalid when
-    // the store rejected OUR credentials suppresses the retry / operator
-    // remediation that would actually fix it.
+  it('does NOT classify an unmarked store 400 — it may be an engine-internal query', () => {
+    // The review's case: an access-check or graph-resolution query rejected by
+    // the configured backend surfaces as the same typed 400. That is a server
+    // fault and must not be reported as the caller's bad SPARQL.
+    expect(isClientQueryFailure(new SparqlHttpResponseError('query', 400, 'backend incompatibility'))).toBe(false);
+    expect(isClientQueryFailure(new SparqlHttpResponseError('query', 422, 'unprocessable'))).toBe(false);
+  });
+
+  it('does not classify store-rejects-us statuses either', () => {
     for (const status of [401, 403, 404, 429]) {
-      const err = new SparqlHttpResponseError('query', status, 'Unauthorized');
-      expect(isClientQueryFailure(err)).toBe(false);
+      expect(isClientQueryFailure(new SparqlHttpResponseError('query', status, 'nope'))).toBe(false);
     }
   });
 
-  it('keeps 5xx as a server error', () => {
+  it('does not classify 5xx', () => {
     for (const status of [500, 502, 503]) {
       expect(isClientQueryFailure(new SparqlHttpResponseError('query', status, 'boom'))).toBe(false);
     }
   });
 
-  it('classifies every operation the adapter throws for', () => {
-    for (const op of ['query', 'construct', 'update']) {
-      expect(isClientQueryFailure(new SparqlHttpResponseError(op, 400, 'bad'))).toBe(true);
-      expect(isClientQueryFailure(new SparqlHttpResponseError(op, 401, 'nope'))).toBe(false);
-    }
+  it('requires the full marker shape, not just the code', () => {
+    expect(isClientQueryFailure({ code: 'CALLER_SPARQL_REJECTED' })).toBe(false);
+    expect(isClientQueryFailure({ code: 'CALLER_SPARQL_REJECTED', status: 'x', message: 'y' })).toBe(false);
+    expect(isClientQueryFailure({ code: 'CALLER_SPARQL_REJECTED', status: NaN, message: 'y' })).toBe(false);
   });
 
-  it('falls through to legacy message matching for anything untyped', () => {
-    // An untyped error whose TEXT looks wrapped is no longer trusted — the
-    // over-broad message rule the review rejected must stay gone.
-    expect(isClientQueryFailure(new Error('SPARQL HTTP query failed (400): x'))).toBe(false);
-    expect(isClientQueryFailure(new Error('ECONNREFUSED'))).toBe(false);
+  it('ignores nullish and non-object inputs', () => {
     expect(isClientQueryFailure(undefined)).toBe(false);
     expect(isClientQueryFailure(null)).toBe(false);
-    // ...but a legacy family still classifies.
-    expect(isClientQueryFailure(new Error('SPARQL rejected: no'))).toBe(true);
-  });
-
-  it('recognises a structurally-complete error across a realm boundary', () => {
-    // Workers / bundling can break `instanceof`; the structural branch keeps
-    // classification working when the class identity does not survive.
-    const plain = Object.assign(new Error('SPARQL HTTP query failed (400): bad'), {
-      code: SPARQL_HTTP_RESPONSE_ERROR_CODE,
-      status: 400,
-      operation: 'query',
-      responseExcerpt: 'bad',
-    });
-    expect(isClientQueryFailure(plain)).toBe(true);
-  });
-
-  // PR #2330 review — the guard used to accept a name + numeric status and then
-  // narrow to the full class, so a consumer could reach `err.operation` on a
-  // value that had none. Every promised field is validated now.
-  it('rejects an impostor that carries only the discriminant and a status', () => {
-    expect(isClientQueryFailure({ code: SPARQL_HTTP_RESPONSE_ERROR_CODE, status: 400 })).toBe(false);
-  });
-
-  it('rejects a partial shape missing any single promised field', () => {
-    const full = {
-      code: SPARQL_HTTP_RESPONSE_ERROR_CODE,
-      status: 400,
-      operation: 'query',
-      responseExcerpt: 'bad',
-      message: 'SPARQL HTTP query failed (400): bad',
-    };
-    for (const drop of ['status', 'operation', 'responseExcerpt', 'message'] as const) {
-      const partial: Record<string, unknown> = { ...full };
-      delete partial[drop];
-      expect(isClientQueryFailure(partial)).toBe(false);
-    }
-  });
-
-  it('rejects an object using the old name-based discriminant', () => {
-    // The class name is mutable and was never a safe discriminant.
-    expect(isClientQueryFailure({ name: 'SparqlHttpResponseError', status: 400 })).toBe(false);
-  });
-
-  it('rejects a non-finite status', () => {
-    expect(isClientQueryFailure({
-      code: SPARQL_HTTP_RESPONSE_ERROR_CODE, status: NaN,
-      operation: 'query', responseExcerpt: 'x', message: 'y',
-    })).toBe(false);
-  });
-
-  it('preserves the rendered message, so log greps keep working', () => {
-    expect(new SparqlHttpResponseError('query', 400, 'error at 1:15: bad').message)
-      .toBe('SPARQL HTTP query failed (400): error at 1:15: bad');
+    expect(isClientQueryFailure('a string')).toBe(false);
   });
 });
 
-describe('isClientQueryError — legacy message families (GH#1758)', () => {
+describe('isClientQueryFailure — legacy message families (GH#1758)', () => {
   it('still classifies the bare #889 parse error', () => {
-    expect(isClientQueryError('error at 1:15: expected one of REDUCED, [_]')).toBe(true);
-  });
-
-  it('no longer blanket-classifies a wrapped 4xx by message', () => {
-    // Status now travels as data. Message matching must not resurrect the
-    // over-broad rule the review rejected.
-    expect(isClientQueryError('SPARQL HTTP query failed (401): Unauthorized')).toBe(false);
-    expect(isClientQueryError('SPARQL HTTP query failed (429): slow down')).toBe(false);
+    expect(isClientQueryFailure(new Error('error at 1:15: expected one of REDUCED, [_]'))).toBe(true);
   });
 
   it('keeps the pre-existing client-error families', () => {
-    expect(isClientQueryError('SPARQL rejected: no')).toBe(true);
-    expect(isClientQueryError('Parse error near line 2')).toBe(true);
-    expect(isClientQueryError('Query must start with SELECT')).toBe(true);
-    expect(isClientQueryError("query: 'agentAddress' must be a string")).toBe(true);
-    expect(isClientQueryError('Invalid minTrust value')).toBe(true);
+    for (const msg of [
+      'SPARQL rejected: no',
+      'Parse error near line 2',
+      'Query must start with SELECT',
+      "query: 'agentAddress' must be a string",
+      'Invalid minTrust value',
+    ]) {
+      expect(isClientQueryFailure(new Error(msg))).toBe(true);
+    }
+  });
+
+  it('does not resurrect the over-broad wrapped-status message rule', () => {
+    // An untyped error whose TEXT looks wrapped must not classify — provenance
+    // is what decides now, not the rendered message.
+    expect(isClientQueryFailure(new Error('SPARQL HTTP query failed (400): x'))).toBe(false);
   });
 
   it('leaves genuine server faults alone', () => {
-    expect(isClientQueryError('ECONNREFUSED 127.0.0.1:7878')).toBe(false);
-    expect(isClientQueryError('store timeout after 30000ms')).toBe(false);
-    expect(isClientQueryError('')).toBe(false);
+    expect(isClientQueryFailure(new Error('ECONNREFUSED 127.0.0.1:7878'))).toBe(false);
+    expect(isClientQueryFailure(new Error('store timeout after 30000ms'))).toBe(false);
+    expect(isClientQueryFailure(new Error(''))).toBe(false);
   });
 });

--- a/packages/cli/test/query-client-error-classification.test.ts
+++ b/packages/cli/test/query-client-error-classification.test.ts
@@ -1,43 +1,88 @@
 import { describe, expect, it } from 'vitest';
-import { isClientQueryError } from '../src/daemon/routes/query.js';
+import { SparqlHttpResponseError } from '@origintrail-official/dkg-storage';
+import { classifySparqlHttpError, isClientQueryError } from '../src/daemon/routes/query.js';
 
 // GH#1758 — invalid SPARQL was AGAIN reported as HTTP 500, a silent
 // re-regression of #889.
 //
 // #889 added an anchored `/^error at \d+:\d+:/` pattern, which matches only
-// when oxigraph's parse error is the WHOLE message. The store adapter wraps it
-// as `SPARQL HTTP query failed (400): error at 1:15: …`
-// (packages/storage/src/adapters/sparql-http.ts:387/671/716), burying the
-// parse error mid-string, so the anchor stopped matching and the error fell
-// through to a 500. The condition lived inline inside a catch block, so
-// nothing could regression-test it — hence this file, and the extraction of
-// `isClientQueryError`.
-describe('isClientQueryError — wrapped upstream status (GH#1758)', () => {
-  it('classifies the adapter-wrapped 400 the issue reports', () => {
-    expect(isClientQueryError(
-      'SPARQL HTTP query failed (400): error at 1:15: expected one of REDUCED, [_]',
-    )).toBe(true);
-  });
-
-  it('classifies the wrapped form for every operation the adapter throws', () => {
-    for (const op of ['query', 'construct', 'update']) {
-      expect(isClientQueryError(`SPARQL HTTP ${op} failed (400): error at 1:15: bad`)).toBe(true);
+// when oxigraph's parse error is the WHOLE message. The store adapter wrapped
+// it as `SPARQL HTTP query failed (400): error at 1:15: …`, burying the parse
+// error mid-string, so the anchor stopped matching and the error fell through
+// to a 500. The condition also lived inline inside a catch block, so nothing
+// could regression-test it.
+//
+// PR #2330 review: the first fix classified EVERY wrapped 4xx as a client
+// error, which is wrong — a store can answer 401/403 for stale daemon
+// credentials, 404 for a bad endpoint, or 429 when throttling us. Those are
+// server/integration faults. The upstream status is now carried as data on a
+// typed error rather than recovered from the message with a regex.
+describe('classifySparqlHttpError — typed upstream status (GH#1758)', () => {
+  it('maps a malformed-query status to 400', () => {
+    for (const status of [400, 422]) {
+      const err = new SparqlHttpResponseError('query', status, 'error at 1:15: expected one of REDUCED');
+      expect(classifySparqlHttpError(err)).toBe(400);
     }
   });
 
-  it('classifies other 4xx statuses as client errors', () => {
-    expect(isClientQueryError('SPARQL HTTP query failed (413): payload too large')).toBe(true);
-    expect(isClientQueryError('SPARQL HTTP query failed (422): unprocessable')).toBe(true);
+  it('keeps store-rejects-us statuses as server errors', () => {
+    // The PR #2330 review case: telling the caller their query is invalid when
+    // the store rejected OUR credentials suppresses the retry / operator
+    // remediation that would actually fix it.
+    for (const status of [401, 403, 404, 429]) {
+      const err = new SparqlHttpResponseError('query', status, 'Unauthorized');
+      expect(classifySparqlHttpError(err)).toBe(500);
+    }
   });
 
-  it('does NOT classify a wrapped 5xx as a client error', () => {
-    // A store-side fault must stay a 500 — the caller's query was fine.
-    expect(isClientQueryError('SPARQL HTTP query failed (500): internal error')).toBe(false);
-    expect(isClientQueryError('SPARQL HTTP query failed (503): unavailable')).toBe(false);
+  it('keeps 5xx as a server error', () => {
+    for (const status of [500, 502, 503]) {
+      expect(classifySparqlHttpError(new SparqlHttpResponseError('query', status, 'boom'))).toBe(500);
+    }
   });
 
-  it('still classifies the bare #889 form (unwrapped)', () => {
+  it('classifies every operation the adapter throws for', () => {
+    for (const op of ['query', 'construct', 'update']) {
+      expect(classifySparqlHttpError(new SparqlHttpResponseError(op, 400, 'bad'))).toBe(400);
+      expect(classifySparqlHttpError(new SparqlHttpResponseError(op, 401, 'nope'))).toBe(500);
+    }
+  });
+
+  it('returns undefined for anything untyped, so legacy matching still runs', () => {
+    expect(classifySparqlHttpError(new Error('SPARQL HTTP query failed (400): x'))).toBeUndefined();
+    expect(classifySparqlHttpError(new Error('ECONNREFUSED'))).toBeUndefined();
+    expect(classifySparqlHttpError(undefined)).toBeUndefined();
+    expect(classifySparqlHttpError(null)).toBeUndefined();
+  });
+
+  it('recognises a structurally-equivalent error across a realm boundary', () => {
+    // Workers / bundling can break `instanceof`; the duck-typed branch keeps
+    // classification working when the class identity does not survive.
+    const plain = Object.assign(new Error('SPARQL HTTP query failed (400): bad'), {
+      name: 'SparqlHttpResponseError',
+      status: 400,
+      operation: 'query',
+      responseExcerpt: 'bad',
+    });
+    expect(classifySparqlHttpError(plain)).toBe(400);
+  });
+
+  it('preserves the rendered message, so log greps keep working', () => {
+    expect(new SparqlHttpResponseError('query', 400, 'error at 1:15: bad').message)
+      .toBe('SPARQL HTTP query failed (400): error at 1:15: bad');
+  });
+});
+
+describe('isClientQueryError — legacy message families (GH#1758)', () => {
+  it('still classifies the bare #889 parse error', () => {
     expect(isClientQueryError('error at 1:15: expected one of REDUCED, [_]')).toBe(true);
+  });
+
+  it('no longer blanket-classifies a wrapped 4xx by message', () => {
+    // Status now travels as data. Message matching must not resurrect the
+    // over-broad rule the review rejected.
+    expect(isClientQueryError('SPARQL HTTP query failed (401): Unauthorized')).toBe(false);
+    expect(isClientQueryError('SPARQL HTTP query failed (429): slow down')).toBe(false);
   });
 
   it('keeps the pre-existing client-error families', () => {

--- a/packages/cli/test/query-route-lifecycle.test.ts
+++ b/packages/cli/test/query-route-lifecycle.test.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'node:events';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  SparqlHttpResponseError,
   StoreOperationTimeoutError,
   StoreSchedulerBusyError,
 } from '@origintrail-official/dkg-storage';
@@ -373,5 +374,60 @@ describe('/api/query request lifecycle', () => {
     });
     expect(busyTracker.cancel).toHaveBeenCalledTimes(1);
     expect(busyTracker.fail).not.toHaveBeenCalled();
+  });
+
+  // GH#1758 / PR #2330 review — the adapter, the engine marker and the
+  // classifier are each covered, but nothing proved `/api/query` USES the
+  // marker. Reverting the route to inline message matching would leave all of
+  // those green while a malformed caller query escaped as HTTP 500 again.
+  it('renders a marked caller-SPARQL rejection as HTTP 400', async () => {
+    const req = new RequestStub();
+    const res = new ResponseStub();
+    const tracker = {
+      start: vi.fn(),
+      startPhase: vi.fn(),
+      completePhase: vi.fn(),
+      complete: vi.fn(),
+      fail: vi.fn(),
+      cancel: vi.fn(),
+    };
+
+    // Structurally complete marker — what DKGQueryEngine throws when the store
+    // rejects caller-supplied SPARQL with 400/422.
+    const marked = Object.assign(
+      new Error('SPARQL HTTP query failed (400): error at 1:15: expected one of REDUCED'),
+      { code: 'CALLER_SPARQL_REJECTED', status: 400 },
+    );
+
+    await handleQueryRoutes(queryRouteContext(req, res, {
+      query: vi.fn(async () => { throw marked; }),
+    }, tracker));
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toMatchObject({ error: marked.message });
+  });
+
+  it('does NOT render an UNMARKED typed store rejection as a caller error', async () => {
+    // The converse: an engine-generated query rejected by the backend is an
+    // integration fault and must stay a server error, even at 400 and even
+    // when its body reads like a legacy client-error family.
+    const req = new RequestStub();
+    const res = new ResponseStub();
+    const tracker = {
+      start: vi.fn(),
+      startPhase: vi.fn(),
+      completePhase: vi.fn(),
+      complete: vi.fn(),
+      fail: vi.fn(),
+      cancel: vi.fn(),
+    };
+
+    const unmarked = new SparqlHttpResponseError('query', 400, 'Query must start with SELECT');
+
+    await expect(handleQueryRoutes(queryRouteContext(req, res, {
+      query: vi.fn(async () => { throw unmarked; }),
+    }, tracker))).rejects.toBe(unmarked);
+
+    expect(res.statusCode).not.toBe(400);
   });
 });

--- a/packages/query/src/caller-sparql-error.ts
+++ b/packages/query/src/caller-sparql-error.ts
@@ -27,11 +27,31 @@ export class CallerSparqlRejectedError extends Error {
   }
 }
 
-/** True when `err` carries the caller-SPARQL-rejected contract. */
-export function isCallerSparqlRejectedError(err: unknown): err is CallerSparqlRejectedError {
+/**
+ * The contract a cross-boundary consumer may rely on.
+ *
+ * PR #2330 review — the guard used to narrow to the concrete class while
+ * validating only `code`, `status` and `message`, so
+ * `{ code, status, message }` satisfied it and TypeScript then permitted
+ * `err.name.toUpperCase()` on a value with no `name`. Narrow to the shape
+ * actually validated instead. Mirrors `SparqlHttpResponseErrorLike` in the
+ * storage package.
+ */
+export interface CallerSparqlRejectedErrorLike {
+  readonly code: typeof CALLER_SPARQL_REJECTED_CODE;
+  readonly status: number;
+  readonly message: string;
+}
+
+/**
+ * True when `err` carries the caller-SPARQL-rejected contract — either as the
+ * concrete class, or structurally when `instanceof` cannot survive the
+ * boundary. Every field the interface promises is validated.
+ */
+export function isCallerSparqlRejectedError(err: unknown): err is CallerSparqlRejectedErrorLike {
   if (err instanceof CallerSparqlRejectedError) return true;
   if (typeof err !== 'object' || err === null) return false;
-  const c = err as { code?: unknown; status?: unknown; message?: unknown };
+  const c = err as Partial<Record<keyof CallerSparqlRejectedErrorLike, unknown>>;
   return (
     c.code === CALLER_SPARQL_REJECTED_CODE &&
     typeof c.status === 'number' &&

--- a/packages/query/src/caller-sparql-error.ts
+++ b/packages/query/src/caller-sparql-error.ts
@@ -1,0 +1,41 @@
+/**
+ * Provenance for "the SPARQL the CALLER sent was rejected".
+ *
+ * GH#1758 / PR #2330 review — the daemon route used to classify any typed
+ * SPARQL HTTP 400/422 as a client error. That is unsound: a single
+ * `/api/query` request also runs engine-generated queries for access control,
+ * graph resolution and metadata scans, and a store that rejects one of THOSE
+ * (backend dialect incompatibility, say) produces the same typed 400. Reporting
+ * it as HTTP 400 blames the caller for an integration fault and suppresses the
+ * retry or operator remediation that would actually fix it.
+ *
+ * Only the query engine knows which store call carried caller-supplied SPARQL,
+ * so it marks that one. The route classifies on this marker, never on a bare
+ * upstream status.
+ */
+export const CALLER_SPARQL_REJECTED_CODE = 'CALLER_SPARQL_REJECTED';
+
+export class CallerSparqlRejectedError extends Error {
+  readonly code = CALLER_SPARQL_REJECTED_CODE;
+  /** Upstream status that rejected it (400 / 422). */
+  readonly status: number;
+
+  constructor(message: string, status: number, options?: { cause?: unknown }) {
+    super(message, options as ErrorOptions);
+    this.name = 'CallerSparqlRejectedError';
+    this.status = status;
+  }
+}
+
+/** True when `err` carries the caller-SPARQL-rejected contract. */
+export function isCallerSparqlRejectedError(err: unknown): err is CallerSparqlRejectedError {
+  if (err instanceof CallerSparqlRejectedError) return true;
+  if (typeof err !== 'object' || err === null) return false;
+  const c = err as { code?: unknown; status?: unknown; message?: unknown };
+  return (
+    c.code === CALLER_SPARQL_REJECTED_CODE &&
+    typeof c.status === 'number' &&
+    Number.isFinite(c.status) &&
+    typeof c.message === 'string'
+  );
+}

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -1,3 +1,8 @@
+import { isSparqlHttpResponseError } from '@origintrail-official/dkg-storage';
+import { CallerSparqlRejectedError } from './caller-sparql-error.js';
+
+/** Upstream statuses that mean the SUBMITTED query was malformed. */
+const MALFORMED_CALLER_QUERY_STATUSES = new Set([400, 422]);
 import type {
   TripleStore,
   Quad,
@@ -1202,7 +1207,21 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
     sparql: string,
     reads: StoreReadLane,
   ): Promise<QueryResult> {
-    const result = await reads.query(sparql);
+    // GH#1758 — this is the ONLY place caller-supplied SPARQL reaches the
+    // store; every other `.query(...)` in this engine runs a server-generated
+    // query (access checks, graph resolution, metadata scans). Mark a store
+    // rejection HERE so the HTTP boundary can answer 400 for a malformed
+    // caller query without also blaming the caller when an engine-internal
+    // query is rejected by the configured backend (PR #2330 review).
+    let result;
+    try {
+      result = await reads.query(sparql);
+    } catch (err) {
+      if (isSparqlHttpResponseError(err) && MALFORMED_CALLER_QUERY_STATUSES.has(err.status)) {
+        throw new CallerSparqlRejectedError(err.message, err.status, { cause: err });
+      }
+      throw err;
+    }
 
     if (result.type === 'bindings') {
       if (result.bindings.length === 0) {

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -556,8 +556,12 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
         const sharedMemorySparql = swmGraphs.length > 0
           ? (wrapWithGraphUnion(sparql, swmGraphs) ?? wrapWithGraph(sparql, sharedMemoryGraph))
           : wrapWithGraph(sparql, sharedMemoryGraph);
-        const dataResult = await reads.query(dataSparql);
-        const smResult = await reads.query(sharedMemorySparql);
+        // Both are graph-wrapped forms of the CALLER's query, so they carry
+        // the same provenance as execAndNormalize (PR #2330 review — this
+        // branch previously bypassed the marker, leaving the original 500 for
+        // any `includeSharedMemory` request with malformed SPARQL).
+        const dataResult = await this.execCallerQuery(dataSparql, reads);
+        const smResult = await this.execCallerQuery(sharedMemorySparql, reads);
         return mergeSharedMemoryAndDataResults(dataResult, smResult);
       }
       if (options?.graphSuffix === '_shared_memory') {
@@ -1203,25 +1207,34 @@ export class DKGQueryEngine implements GraphAwareQueryEngine {
     return uris;
   }
 
-  private async execAndNormalize(
-    sparql: string,
-    reads: StoreReadLane,
-  ): Promise<QueryResult> {
-    // GH#1758 — this is the ONLY place caller-supplied SPARQL reaches the
-    // store; every other `.query(...)` in this engine runs a server-generated
-    // query (access checks, graph resolution, metadata scans). Mark a store
-    // rejection HERE so the HTTP boundary can answer 400 for a malformed
-    // caller query without also blaming the caller when an engine-internal
-    // query is rejected by the configured backend (PR #2330 review).
-    let result;
+  /**
+   * Execute CALLER-derived SPARQL and mark a store rejection with provenance.
+   *
+   * GH#1758 — every caller-derived store execution must go through here.
+   * Engine-generated queries (access checks, graph resolution, metadata scans)
+   * deliberately do NOT, so the HTTP boundary can answer 400 for a malformed
+   * caller query without blaming the caller when the configured backend
+   * rejects an internal one.
+   *
+   * Only 400/422 are translated: 401/403/404/429 and 5xx mean the store
+   * rejected US and stay server faults (PR #2330 review).
+   */
+  private async execCallerQuery(sparql: string, reads: StoreReadLane) {
     try {
-      result = await reads.query(sparql);
+      return await reads.query(sparql);
     } catch (err) {
       if (isSparqlHttpResponseError(err) && MALFORMED_CALLER_QUERY_STATUSES.has(err.status)) {
         throw new CallerSparqlRejectedError(err.message, err.status, { cause: err });
       }
       throw err;
     }
+  }
+
+  private async execAndNormalize(
+    sparql: string,
+    reads: StoreReadLane,
+  ): Promise<QueryResult> {
+    const result = await this.execCallerQuery(sparql, reads);
 
     if (result.type === 'bindings') {
       if (result.bindings.length === 0) {

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -5,6 +5,7 @@ export {
   CALLER_SPARQL_REJECTED_CODE,
   CallerSparqlRejectedError,
   isCallerSparqlRejectedError,
+  type CallerSparqlRejectedErrorLike,
 } from './caller-sparql-error.js';
 export { QueryHandler, type QueryHandlerDeps } from './query-handler.js';
 export {

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1,6 +1,11 @@
 export * from './query-engine.js';
 export * from './query-types.js';
 export { DKGQueryEngine, resolveViewGraphs, type ViewResolution } from './dkg-query-engine.js';
+export {
+  CALLER_SPARQL_REJECTED_CODE,
+  CallerSparqlRejectedError,
+  isCallerSparqlRejectedError,
+} from './caller-sparql-error.js';
 export { QueryHandler, type QueryHandlerDeps } from './query-handler.js';
 export {
   validateReadOnlySparql,

--- a/packages/query/test/caller-sparql-provenance.test.ts
+++ b/packages/query/test/caller-sparql-provenance.test.ts
@@ -42,12 +42,10 @@ describe('CallerSparqlRejectedError contract (GH#1758)', () => {
     expect(isCallerSparqlRejectedError(undefined)).toBe(false);
   });
 
-  it('does not claim a non-malformed status', () => {
-    // The engine only constructs this for 400/422; nothing else may be marked
-    // as "the caller's query was bad".
-    const e = new CallerSparqlRejectedError('m', 400);
-    expect([400, 422]).toContain(e.status);
-  });
+  // NOTE: the 400/422 gate is a property of the ENGINE, not of this class, so
+  // it is asserted in the wiring suite below against a real store rejection.
+  // Asserting it on a hand-constructed instance here would be tautological
+  // (PR #2330 review).
 });
 
 // ── The WIRING, not just the contract ──────────────────────────────────────
@@ -64,9 +62,14 @@ import { DKGQueryEngine } from '../src/dkg-query-engine.js';
 describe('DKGQueryEngine marks caller-query rejections (GH#1758 wiring)', () => {
   class RejectingStore extends OxigraphStore {
     rejectMatching: RegExp | null = null;
+    rejectStatus = 400;
+    /** How many times a rejection actually fired — so a test cannot silently
+     *  pass without exercising the path it claims to cover. */
+    rejections = 0;
     override async query(sparql: string, options?: any): Promise<any> {
       if (this.rejectMatching && this.rejectMatching.test(sparql)) {
-        throw new SparqlHttpResponseError('query', 400, 'error at 1:15: expected one of REDUCED');
+        this.rejections += 1;
+        throw new SparqlHttpResponseError('query', this.rejectStatus, 'error at 1:15: expected one of REDUCED');
       }
       return super.query(sparql, options);
     }
@@ -92,23 +95,83 @@ describe('DKGQueryEngine marks caller-query rejections (GH#1758 wiring)', () => 
     expect((failure as { cause?: unknown }).cause).toBeInstanceOf(SparqlHttpResponseError);
   });
 
-  it('does NOT mark a store 400 that came from a non-caller query', async () => {
-    const store = new RejectingStore();
-    const engine = new DKGQueryEngine(store);
-    // Reject something the caller never wrote — an engine-generated shape.
-    store.rejectMatching = /contentScopeVersion|dkg\.io\/ontology/;
+  it('propagates a NON-malformed status unmarked, even from the caller query', () => {
+    // The gate is 400/422 only. 401/403/404/429 and 5xx mean the store rejected
+    // US and must stay server faults (PR #2330 review — the previous assertion
+    // was tautological and would have passed if the engine translated these).
+    for (const status of [401, 403, 404, 429, 500, 503]) {
+      const store = new RejectingStore();
+      store.rejectMatching = /CALLER_MARKER/;
+      store.rejectStatus = status;
+      const engine = new DKGQueryEngine(store);
 
-    let failure: unknown;
-    try {
-      await engine.query('SELECT ?s WHERE { ?s ?p ?o }', { contextGraphId: 'cg-1' });
-    } catch (err) {
-      failure = err;
+      let failure: unknown;
+      return engine
+        .query('SELECT ?s WHERE { ?s ?p ?o . # CALLER_MARKER\n }')
+        .then(
+          () => { throw new Error(`expected a rejection for status ${status}`); },
+          (err) => { failure = err; },
+        )
+        .then(() => {
+          expect(failure).toBeInstanceOf(SparqlHttpResponseError);
+          expect(isCallerSparqlRejectedError(failure)).toBe(false);
+          expect((failure as SparqlHttpResponseError).status).toBe(status);
+        });
     }
+  });
 
-    // Either it succeeded (no internal query matched) or it failed UNMARKED —
-    // what must never happen is the caller being blamed for it.
-    if (failure !== undefined) {
-      expect(isCallerSparqlRejectedError(failure)).toBe(false);
+  it('does NOT mark an ENGINE-generated query rejection, and the rejection really happens', () => {
+    // PR #2330 review — the previous version allowed the query to SUCCEED, so
+    // it could pass without the path under test ever running. `view:
+    // 'working-memory'` makes the engine issue its own `_meta` sub-graph
+    // lookup (`SELECT ?name WHERE { GRAPH <…/_meta> { ?subGraph a … } }`),
+    // which the caller never wrote. Rejecting THAT must not be blamed on them.
+    const store = new RejectingStore();
+    store.rejectMatching = /\?subGraph a/;
+    const engine = new DKGQueryEngine(store);
+
+    return engine
+      .query('SELECT ?s WHERE { ?s ?p ?o }', {
+        contextGraphId: 'cg-1',
+        view: 'working-memory',
+        agentAddress: `0x${'1'.repeat(40)}`,
+      })
+      .then(
+        () => { throw new Error('expected the engine-generated query to reject'); },
+        (err) => {
+          expect(store.rejections).toBeGreaterThan(0);
+          expect(isCallerSparqlRejectedError(err)).toBe(false);
+          expect(err).toBeInstanceOf(SparqlHttpResponseError);
+        },
+      );
+  });
+
+  it('marks the includeSharedMemory branch too, which used to bypass the helper', async () => {
+    // PR #2330 review — `includeSharedMemory` executes two graph-wrapped forms
+    // of the CALLER's query directly, outside execAndNormalize, so malformed
+    // SPARQL on that supported path still produced an unmarked error and the
+    // original HTTP 500.
+    for (const marker of ['data', 'sharedMemory']) {
+      const store = new RejectingStore();
+      // Reject only the data graph, or only the shared-memory graph.
+      store.rejectMatching = marker === 'data' ? /GRAPH <[^>]*cg-1> / : /_shared_memory/;
+      const engine = new DKGQueryEngine(store);
+
+      let failure: unknown;
+      try {
+        await engine.query('SELECT ?s WHERE { ?s ?p ?o }', {
+          contextGraphId: 'cg-1',
+          includeSharedMemory: true,
+        });
+      } catch (err) {
+        failure = err;
+      }
+
+      expect(store.rejections, `${marker}: rejection never fired`).toBeGreaterThan(0);
+      expect(isCallerSparqlRejectedError(failure), `${marker}: not marked`).toBe(true);
+      expect((failure as CallerSparqlRejectedError).status).toBe(400);
     }
   });
 });
+
+

--- a/packages/query/test/caller-sparql-provenance.test.ts
+++ b/packages/query/test/caller-sparql-provenance.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CALLER_SPARQL_REJECTED_CODE,
+  CallerSparqlRejectedError,
+  isCallerSparqlRejectedError,
+} from '../src/caller-sparql-error.js';
+
+// GH#1758 / PR #2330 review — a store 400 is only a CLIENT error when it came
+// from executing caller-supplied SPARQL. The same request also runs
+// engine-generated queries (access control, graph resolution, metadata scans),
+// and a backend rejecting one of those is an integration fault. This contract
+// is what lets the HTTP boundary tell the two apart.
+describe('CallerSparqlRejectedError contract (GH#1758)', () => {
+  it('carries the discriminant and the upstream status', () => {
+    const e = new CallerSparqlRejectedError('SPARQL HTTP query failed (400): bad', 400);
+    expect(e.code).toBe(CALLER_SPARQL_REJECTED_CODE);
+    expect(e.status).toBe(400);
+    expect(e).toBeInstanceOf(Error);
+    expect(isCallerSparqlRejectedError(e)).toBe(true);
+  });
+
+  it('preserves the original error as cause for diagnosis', () => {
+    const cause = new Error('SPARQL HTTP query failed (400): error at 1:15');
+    const e = new CallerSparqlRejectedError(cause.message, 400, { cause });
+    expect((e as { cause?: unknown }).cause).toBe(cause);
+    // The rendered message is unchanged, so log greps keep working.
+    expect(e.message).toBe(cause.message);
+  });
+
+  it('recognises a structurally-complete marker across a realm boundary', () => {
+    // The daemon route checks this shape without importing the class.
+    expect(isCallerSparqlRejectedError(
+      Object.assign(new Error('x'), { code: CALLER_SPARQL_REJECTED_CODE, status: 422 }),
+    )).toBe(true);
+  });
+
+  it('rejects partial or wrong shapes', () => {
+    expect(isCallerSparqlRejectedError({ code: CALLER_SPARQL_REJECTED_CODE })).toBe(false);
+    expect(isCallerSparqlRejectedError({ code: 'SOMETHING_ELSE', status: 400, message: 'x' })).toBe(false);
+    expect(isCallerSparqlRejectedError(new Error('plain'))).toBe(false);
+    expect(isCallerSparqlRejectedError(null)).toBe(false);
+    expect(isCallerSparqlRejectedError(undefined)).toBe(false);
+  });
+
+  it('does not claim a non-malformed status', () => {
+    // The engine only constructs this for 400/422; nothing else may be marked
+    // as "the caller's query was bad".
+    const e = new CallerSparqlRejectedError('m', 400);
+    expect([400, 422]).toContain(e.status);
+  });
+});
+
+// ── The WIRING, not just the contract ──────────────────────────────────────
+//
+// A mutation check showed the contract test above and the route's
+// classification test both stay green if the engine stops marking the caller
+// query — each verifies a piece, neither verifies the seam. This drives a real
+// DKGQueryEngine against a store that rejects with a typed 400 and asserts the
+// engine translates it, which is the behaviour /api/query depends on.
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { SparqlHttpResponseError } from '@origintrail-official/dkg-storage';
+import { DKGQueryEngine } from '../src/dkg-query-engine.js';
+
+describe('DKGQueryEngine marks caller-query rejections (GH#1758 wiring)', () => {
+  class RejectingStore extends OxigraphStore {
+    rejectMatching: RegExp | null = null;
+    override async query(sparql: string, options?: any): Promise<any> {
+      if (this.rejectMatching && this.rejectMatching.test(sparql)) {
+        throw new SparqlHttpResponseError('query', 400, 'error at 1:15: expected one of REDUCED');
+      }
+      return super.query(sparql, options);
+    }
+  }
+
+  it('translates a store 400 on the CALLER query into the marked error', async () => {
+    const store = new RejectingStore();
+    const engine = new DKGQueryEngine(store);
+    // Only the caller's own SELECT is rejected.
+    store.rejectMatching = /CALLER_MARKER/;
+
+    let failure: unknown;
+    try {
+      await engine.query('SELECT ?s WHERE { ?s ?p ?o . # CALLER_MARKER\n }');
+    } catch (err) {
+      failure = err;
+    }
+
+    expect(failure).toBeDefined();
+    expect(isCallerSparqlRejectedError(failure)).toBe(true);
+    expect((failure as CallerSparqlRejectedError).status).toBe(400);
+    // The original is preserved for diagnosis.
+    expect((failure as { cause?: unknown }).cause).toBeInstanceOf(SparqlHttpResponseError);
+  });
+
+  it('does NOT mark a store 400 that came from a non-caller query', async () => {
+    const store = new RejectingStore();
+    const engine = new DKGQueryEngine(store);
+    // Reject something the caller never wrote — an engine-generated shape.
+    store.rejectMatching = /contentScopeVersion|dkg\.io\/ontology/;
+
+    let failure: unknown;
+    try {
+      await engine.query('SELECT ?s WHERE { ?s ?p ?o }', { contextGraphId: 'cg-1' });
+    } catch (err) {
+      failure = err;
+    }
+
+    // Either it succeeded (no internal query matched) or it failed UNMARKED —
+    // what must never happen is the caller being blamed for it.
+    if (failure !== undefined) {
+      expect(isCallerSparqlRejectedError(failure)).toBe(false);
+    }
+  });
+});

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -85,6 +85,43 @@ function raceAgainstAbort<T>(work: Promise<T>, signal: AbortSignal | undefined):
 const DEFAULT_SLOW_QUERY_THRESHOLD_MS = 10_000;
 const DEFAULT_SLOW_QUERY_SAMPLE_RATE = 1;
 const MANAGED_LIST_GRAPHS_CACHE_MS = 30_000;
+/**
+ * A non-OK response from the configured SPARQL endpoint.
+ *
+ * GH#1758 — the upstream status used to be rendered into the message and then
+ * recovered at the HTTP boundary with a regex, which coupled the daemon route
+ * to this file's exact diagnostic wording. Carrying `status` as data lets the
+ * route distinguish "the caller's SPARQL was malformed" (400/422) from
+ * "the store rejected US" (401/403/404/429) without string matching.
+ *
+ * `message` is unchanged from the previous template so existing log greps and
+ * error-message assertions keep working.
+ */
+export class SparqlHttpResponseError extends Error {
+  readonly status: number;
+  readonly operation: string;
+  readonly responseExcerpt: string;
+
+  constructor(operation: string, status: number, responseExcerpt: string) {
+    super(`SPARQL HTTP ${operation} failed (${status}): ${responseExcerpt}`);
+    this.name = 'SparqlHttpResponseError';
+    this.status = status;
+    this.operation = operation;
+    this.responseExcerpt = responseExcerpt;
+  }
+}
+
+/** True when `err` is a SparqlHttpResponseError, across realm boundaries. */
+export function isSparqlHttpResponseError(err: unknown): err is SparqlHttpResponseError {
+  return (
+    err instanceof SparqlHttpResponseError ||
+    (typeof err === 'object' &&
+      err !== null &&
+      (err as { name?: unknown }).name === 'SparqlHttpResponseError' &&
+      typeof (err as { status?: unknown }).status === 'number')
+  );
+}
+
 export const DEFAULT_SPARQL_HTTP_TIMEOUT_MS = 30_000;
 const monotonicNow = (): number => performance.now();
 
@@ -384,7 +421,7 @@ export class SparqlHttpStore implements TripleStore {
           // Keep scheduler admission until the response body has settled too;
           // otherwise retries can dispatch while an error body is unwinding.
           const text = await res.text().catch(() => '');
-          throw new Error(`SPARQL HTTP ${operation} failed (${res.status}): ${text.slice(0, 300)}`);
+          throw new SparqlHttpResponseError(operation, res.status, text.slice(0, 300));
         }
       } catch (error) {
         if (signal.aborted) {
@@ -668,7 +705,7 @@ export class SparqlHttpStore implements TripleStore {
                 operation: 'query',
                 tolerateReadFailure: true,
               });
-              throw new Error(`SPARQL HTTP query failed (${res.status}): ${text.slice(0, 300)}`);
+              throw new SparqlHttpResponseError('query', res.status, text.slice(0, 300));
             }
 
             const text = await readSparqlResponseText(res, {
@@ -713,7 +750,7 @@ export class SparqlHttpStore implements TripleStore {
             operation: 'construct',
             tolerateReadFailure: true,
           });
-          throw new Error(`SPARQL HTTP construct failed (${res.status}): ${text.slice(0, 300)}`);
+          throw new SparqlHttpResponseError('construct', res.status, text.slice(0, 300));
         }
         const text = await readSparqlResponseText(res, {
           maxResponseBytes: options?.maxResponseBytes,

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -98,6 +98,8 @@ const MANAGED_LIST_GRAPHS_CACHE_MS = 30_000;
  * error-message assertions keep working.
  */
 export class SparqlHttpResponseError extends Error {
+  /** Stable discriminant for cross-boundary recognition. */
+  readonly code = SPARQL_HTTP_RESPONSE_ERROR_CODE;
   readonly status: number;
   readonly operation: string;
   readonly responseExcerpt: string;
@@ -111,14 +113,43 @@ export class SparqlHttpResponseError extends Error {
   }
 }
 
-/** True when `err` is a SparqlHttpResponseError, across realm boundaries. */
-export function isSparqlHttpResponseError(err: unknown): err is SparqlHttpResponseError {
+/** Stable discriminant, so the guard does not key off a mutable class name. */
+export const SPARQL_HTTP_RESPONSE_ERROR_CODE = 'SPARQL_HTTP_RESPONSE';
+
+/**
+ * The contract a cross-boundary consumer may rely on.
+ *
+ * PR #2330 review — the previous guard narrowed to the concrete class after
+ * checking only `name` and `status`, so `{ name: 'SparqlHttpResponseError',
+ * status: 400 }` satisfied it and TypeScript then permitted
+ * `err.operation.toUpperCase()` on a value with no `operation`. Narrow to the
+ * shape actually validated instead.
+ */
+export interface SparqlHttpResponseErrorLike {
+  readonly code: typeof SPARQL_HTTP_RESPONSE_ERROR_CODE;
+  readonly status: number;
+  readonly operation: string;
+  readonly responseExcerpt: string;
+  readonly message: string;
+}
+
+/**
+ * True when `err` carries the full SPARQL HTTP response contract — either as
+ * the concrete class, or structurally when `instanceof` cannot survive the
+ * boundary (workers, duplicate module instances). EVERY field the interface
+ * promises is validated.
+ */
+export function isSparqlHttpResponseError(err: unknown): err is SparqlHttpResponseErrorLike {
+  if (err instanceof SparqlHttpResponseError) return true;
+  if (typeof err !== 'object' || err === null) return false;
+  const c = err as Partial<Record<keyof SparqlHttpResponseErrorLike, unknown>>;
   return (
-    err instanceof SparqlHttpResponseError ||
-    (typeof err === 'object' &&
-      err !== null &&
-      (err as { name?: unknown }).name === 'SparqlHttpResponseError' &&
-      typeof (err as { status?: unknown }).status === 'number')
+    c.code === SPARQL_HTTP_RESPONSE_ERROR_CODE &&
+    typeof c.status === 'number' &&
+    Number.isFinite(c.status) &&
+    typeof c.operation === 'string' &&
+    typeof c.responseExcerpt === 'string' &&
+    typeof c.message === 'string'
   );
 }
 

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -124,6 +124,8 @@ export {
   type SparqlHttpSlowQueryEvent,
   SparqlHttpResponseError,
   isSparqlHttpResponseError,
+  SPARQL_HTTP_RESPONSE_ERROR_CODE,
+  type SparqlHttpResponseErrorLike,
 } from './adapters/sparql-http.js';
 export {
   ContextGraphManager,

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -122,6 +122,8 @@ export {
   type SparqlHttpStoreOptions,
   type SparqlHttpQueryOptions,
   type SparqlHttpSlowQueryEvent,
+  SparqlHttpResponseError,
+  isSparqlHttpResponseError,
 } from './adapters/sparql-http.js';
 export {
   ContextGraphManager,

--- a/packages/storage/test/sparql-http-response-error.test.ts
+++ b/packages/storage/test/sparql-http-response-error.test.ts
@@ -33,9 +33,14 @@ describe('SparqlHttpStore — typed non-OK responses (GH#1758)', () => {
   });
 
   async function queryError(): Promise<unknown> {
+    return runError((store) => store.query('SELECT WHERE {'));
+  }
+
+  /** Drive any store operation against the failing endpoint and return its error. */
+  async function runError(op: (store: SparqlHttpStore) => Promise<unknown>): Promise<unknown> {
     const store = new SparqlHttpStore({ queryEndpoint: endpoint, updateEndpoint: endpoint });
     try {
-      await store.query('SELECT WHERE {');
+      await op(store);
       return undefined;
     } catch (err) {
       return err;
@@ -71,4 +76,46 @@ describe('SparqlHttpStore — typed non-OK responses (GH#1758)', () => {
     const err = await queryError() as Error;
     expect(err.message).toMatch(/^SPARQL HTTP query failed \(400\): error at 1:15/);
   });
+
+  // PR #2330 review — the contract is implemented at THREE independent throw
+  // sites and this suite reached only the SELECT one. CONSTRUCT in particular
+  // is part of the caller-query behaviour #1758 repairs: if it returned to
+  // throwing a plain Error, a malformed CONSTRUCT rejected by an external store
+  // would surface as HTTP 500 again with every other test still green.
+  const operations: Array<{
+    label: string;
+    operation: string;
+    run: (store: SparqlHttpStore) => Promise<unknown>;
+  }> = [
+    { label: 'SELECT', operation: 'query', run: (s) => s.query('SELECT WHERE {') },
+    {
+      label: 'CONSTRUCT',
+      operation: 'construct',
+      run: (s) => s.query('CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }'),
+    },
+    {
+      label: 'UPDATE',
+      operation: 'update',
+      run: (s) => s.update('INSERT DATA { <urn:a> <urn:b> <urn:c> }'),
+    },
+  ];
+
+  for (const { label, operation, run } of operations) {
+    it(`${label} throws the typed contract on a non-OK response`, async () => {
+      const err = await runError(run);
+      expect(isSparqlHttpResponseError(err), `${label} was not typed`).toBe(true);
+      const typed = err as SparqlHttpResponseError;
+      expect(typed.status).toBe(400);
+      expect(typed.operation).toBe(operation);
+      expect(typed.responseExcerpt).toContain('error at 1:15');
+      expect(typed.message).toMatch(new RegExp(`^SPARQL HTTP ${operation} failed \\(400\\):`));
+    });
+
+    it(`${label} carries a store-rejects-us status unmarked as malformed`, async () => {
+      respond = { status: 401, body: 'Unauthorized' };
+      const err = await runError(run);
+      expect(isSparqlHttpResponseError(err)).toBe(true);
+      expect((err as SparqlHttpResponseError).status).toBe(401);
+    });
+  }
 });

--- a/packages/storage/test/sparql-http-response-error.test.ts
+++ b/packages/storage/test/sparql-http-response-error.test.ts
@@ -1,0 +1,74 @@
+import { createServer, type Server } from 'node:http';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  SparqlHttpResponseError,
+  SparqlHttpStore,
+  isSparqlHttpResponseError,
+} from '../src/adapters/sparql-http.js';
+
+// GH#1758 / PR #2330 review — the daemon route classifies malformed SPARQL by
+// reading `status` off the thrown error. That only holds if the adapter really
+// throws the typed error for a non-OK upstream response, so this pins the seam
+// against a real HTTP endpoint. Without it, a change to the adapter's error
+// shape would silently push invalid SPARQL back to HTTP 500 while every
+// classifier unit test stayed green.
+describe('SparqlHttpStore — typed non-OK responses (GH#1758)', () => {
+  let server: Server;
+  let endpoint: string;
+  let respond: { status: number; body: string };
+
+  beforeEach(async () => {
+    respond = { status: 400, body: 'error at 1:15: expected one of REDUCED, [_]' };
+    server = createServer((_req, res) => {
+      res.writeHead(respond.status, { 'Content-Type': 'text/plain' });
+      res.end(respond.body);
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const addr = server.address() as { port: number };
+    endpoint = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  async function queryError(): Promise<unknown> {
+    const store = new SparqlHttpStore({ queryEndpoint: endpoint, updateEndpoint: endpoint });
+    try {
+      await store.query('SELECT WHERE {');
+      return undefined;
+    } catch (err) {
+      return err;
+    }
+  }
+
+  it('throws a typed error carrying the upstream 400 for a parse failure', async () => {
+    const err = await queryError();
+    expect(isSparqlHttpResponseError(err)).toBe(true);
+    expect((err as SparqlHttpResponseError).status).toBe(400);
+    expect((err as SparqlHttpResponseError).operation).toBe('query');
+    expect((err as SparqlHttpResponseError).responseExcerpt).toContain('error at 1:15');
+  });
+
+  it('carries the upstream status for a store-rejects-us response', async () => {
+    respond = { status: 401, body: 'Unauthorized' };
+    const err = await queryError();
+    expect(isSparqlHttpResponseError(err)).toBe(true);
+    expect((err as SparqlHttpResponseError).status).toBe(401);
+  });
+
+  it('carries the upstream status for a throttling response', async () => {
+    respond = { status: 429, body: 'slow down' };
+    expect((await queryError() as SparqlHttpResponseError).status).toBe(429);
+  });
+
+  it('carries the upstream status for a server fault', async () => {
+    respond = { status: 503, body: 'unavailable' };
+    expect((await queryError() as SparqlHttpResponseError).status).toBe(503);
+  });
+
+  it('keeps the rendered message stable for existing log greps', async () => {
+    const err = await queryError() as Error;
+    expect(err.message).toMatch(/^SPARQL HTTP query failed \(400\): error at 1:15/);
+  });
+});

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -1,12 +1,15 @@
 import { createServer, type Server, type ServerResponse } from 'node:http';
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import {
+  STORE_OPERATION_TIMEOUT_CODE,
   SparqlHttpStore,
   createTripleStore,
   getExternalStorePrioritySchedulerSnapshot,
+  isSparqlHttpResponseError,
   tryReplaceGraphAtomically,
   tryReplaceSubjectAtomically,
   type Quad,
+  type SparqlHttpResponseErrorLike,
   type SparqlHttpSlowQueryEvent,
 } from '../src/index.js';
 
@@ -710,7 +713,16 @@ describe('SparqlHttpStore (test server)', () => {
       expect(failure).toMatchObject({
         message: expect.stringContaining('SPARQL HTTP query failed (500)'),
       });
-      expect((failure as { code?: unknown }).code).toBeUndefined();
+      // GH#1758 — this used to assert `code === undefined` as a proxy for "the
+      // managed cancellation policy did not apply". Non-OK responses now carry
+      // a typed `SPARQL_HTTP_RESPONSE` discriminant so the daemon can classify
+      // malformed queries by upstream status, so assert the guarantee directly
+      // instead: it must NOT be the timeout the managed path produces, and it
+      // must not be tagged as an oxigraph-server backend failure.
+      expect((failure as { code?: unknown }).code).not.toBe(STORE_OPERATION_TIMEOUT_CODE);
+      expect((failure as { backend?: unknown }).backend).toBeUndefined();
+      expect(isSparqlHttpResponseError(failure)).toBe(true);
+      expect((failure as SparqlHttpResponseErrorLike).status).toBe(500);
     } finally {
       globalThis.fetch = originalFetch;
     }


### PR DESCRIPTION
## Summary

`POST /api/query` with invalid SPARQL returned **HTTP 500 instead of 400** — a silent re-regression of #889.

#889 added an anchored `` /^error at \d+:\d+:/ `` pattern, which matches only when oxigraph’s parse error is the *whole* message. The store adapter wraps it as `SPARQL HTTP query failed (400): error at 1:15: …` (`packages/storage/src/adapters/sparql-http.ts:387/671/716`), burying the parse error mid-string — so the anchor stopped matching and the error fell through to a 500.

## Changes

- Classify on the wrapped upstream **status** rather than English text, so the fix does not depend on oxigraph’s wording. A wrapped `4xx` is a client error; a wrapped `5xx` stays a server fault.
- Extract the condition into an exported `isClientQueryError`. It lived inline inside a `catch`, which is exactly why #889 could regress with no test noticing — there was nothing addressable to assert against.

## Test Plan

- [x] New `packages/cli/test/query-client-error-classification.test.ts` — 7 cases, including the wrapped 5xx that must **stay** a 500.
- [x] **Mutation-tested**: deleting the new pattern fails three cases.
- [x] cli: 241 files pass, 0 failed.

Closes #1758

🤖 Generated with [Claude Code](https://claude.com/claude-code)