### PR TITLE
fix(daemon): stop serving literal "(dynamic)" placeholders in skill.md (#1125)

### DIFF
--- a/packages/cli/skills/dkg-node/SKILL.md
+++ b/packages/cli/skills/dkg-node/SKILL.md
@@ -12,11 +12,11 @@ This skill teaches you the full node API surface so you can operate autonomously
 
 > This section is dynamically generated from node state at serve-time.
 
-- **Node version:** (dynamic)
-- **Base URL:** (dynamic)
-- **Peer ID:** (dynamic)
-- **Node role:** (dynamic — `core` or `edge`)
-- **Available extraction pipelines:** (dynamic)
+- **Node version:** {{nodeVersion}}
+- **Base URL:** {{baseUrl}}
+- **Peer ID:** {{peerId}}
+- **Node role:** {{nodeRole}}
+- **Available extraction pipelines:** {{extractionPipelines}}
 
 If the Node UI injects a target context graph for the turn, use that target directly. If no target is injected or configured, call `dkg_list_context_graphs` / `GET /api/context-graph/list`; agent tool surfaces default that list to the caller's created/joined context graphs, with `scope: "all"` for every graph the node knows about.
 

--- a/packages/cli/src/daemon/manifest.ts
+++ b/packages/cli/src/daemon/manifest.ts
@@ -777,7 +777,7 @@ export {
   REQUIRED_SKILL_TOKENS,
   STANDALONE_SKILL_VALUES,
   type SkillTokenValues,
-} from "./skill-template.js";
+} from "../skill-template.js";
 
 
 let cachedImporterSkillMd: string | null = null;

--- a/packages/cli/src/daemon/manifest.ts
+++ b/packages/cli/src/daemon/manifest.ts
@@ -761,25 +761,25 @@ export function detectInstallMode(): InstallMode {
 
 // ---------------------------------------------------------------------------
 // SKILL.MD serving — Agent Skills standard (https://agentskills.io)
+//
+// Rendering moved to ./skill-template.ts (PR #2331 review): this file is a
+// broad manifest/semver/auto-update utility module and had grown past 1,000
+// lines. Re-exported so existing importers keep working.
 // ---------------------------------------------------------------------------
+export {
+  buildSkillMd,
+  loadSkillTemplate,
+  missingSkillTokens,
+  unknownSkillTokens,
+  renderSkillTemplate,
+  renderStandaloneDkgNodeSkill,
+  skillEtag,
+  REQUIRED_SKILL_TOKENS,
+  STANDALONE_SKILL_VALUES,
+  type SkillTokenValues,
+} from "./skill-template.js";
 
-let cachedSkillMd: string | null = null;
-let cachedSkillEtag: string | null = null;
 
-export function loadSkillTemplate(): string {
-  if (cachedSkillMd) return cachedSkillMd;
-  const skillPath = new URL("../../skills/dkg-node/SKILL.md", import.meta.url);
-  const content = readFileSync(skillPath, "utf-8");
-  cachedSkillMd = content;
-  return content;
-}
-
-// Second canonical agent-readable manual: the bulk-import skill that the
-// dkg-node skill cross-references for chunked writes, manifest resume,
-// HTTP 413 recovery, and (with PR #4 of the async-promote-queue series)
-// the async promote queue. Served at `/.well-known/skill-importer.md`
-// alongside `/.well-known/skill.md` so the cross-link in dkg-node/SKILL.md
-// is reachable for agents installed via setup flows (Codex PR #642 follow-up).
 let cachedImporterSkillMd: string | null = null;
 
 export function loadImporterSkillTemplate(): string {
@@ -790,78 +790,6 @@ export function loadImporterSkillTemplate(): string {
   return content;
 }
 
-export function buildSkillMd(opts: {
-  version: string;
-  baseUrl: string;
-  peerId: string;
-  nodeRole: string;
-  extractionPipelines: string[];
-}): string {
-  const template = loadSkillTemplate();
-
-  // GH#1125 — substitute NAMED tokens, one at a time.
-  //
-  // The previous implementation rebuilt a copy of the template's Markdown and
-  // swapped the whole block with a single literal `String.replace`. Two things
-  // went wrong with that, and the token form fixes both:
-  //
-  //  1. DRIFT. A literal needle fails SILENTLY when it does not match. The copy
-  //     here and the block in SKILL.md had drifted by a single reordered
-  //     sentence, so nothing was ever substituted and every agent that read
-  //     /.well-known/skill.md got `(dynamic)` placeholders. Per-token
-  //     substitution means prose and label edits in the template cannot
-  //     disable it — only renaming a token can, and that is validated below.
-  //
-  //  2. `$` INJECTION. `String.replace(needle, replacement)` interprets `$&`,
-  //     `$'`, "$`" and `$n` in the REPLACEMENT string. `baseUrl` is built from
-  //     the `X-Forwarded-Host` / `Host` request headers (routes/status.ts:641)
-  //     and this endpoint is public and unauthenticated, so those tokens were
-  //     attacker-controlled: `$&` re-inserted the placeholder block (putting
-  //     `(dynamic)` back), and each `$'` appended the ~94 KB template suffix,
-  //     giving unbounded response amplification. Passing a FUNCTION as the
-  //     replacement makes the value literal — this is the load-bearing detail,
-  //     do not turn it back into a string.
-  const values: Record<string, string> = {
-    nodeVersion: opts.version,
-    baseUrl: opts.baseUrl,
-    peerId: opts.peerId,
-    nodeRole: opts.nodeRole,
-    extractionPipelines:
-      opts.extractionPipelines.length > 0
-        ? opts.extractionPipelines.join(", ")
-        : "none (install markitdown to enable document conversion)",
-  };
-
-  let out = template;
-  for (const [token, value] of Object.entries(values)) {
-    // Function replacement: `value` is inserted verbatim, `$` and all.
-    out = out.replaceAll(`{{${token}}}`, () => value);
-  }
-  return out;
-}
-
-/** Tokens SKILL.md must carry for `buildSkillMd` to produce a complete doc. */
-export const REQUIRED_SKILL_TOKENS = Object.freeze([
-  "nodeVersion",
-  "baseUrl",
-  "peerId",
-  "nodeRole",
-  "extractionPipelines",
-]);
-
-/**
- * Validate that the template still carries every token, ONCE at load time
- * rather than warning on every request. Returns the missing token names.
- */
-export function missingSkillTokens(template: string = loadSkillTemplate()): string[] {
-  return REQUIRED_SKILL_TOKENS.filter((t) => !template.includes(`{{${t}}}`));
-}
-
-export function skillEtag(content: string): string {
-  return (
-    '"' + createHash("md5").update(content).digest("hex").slice(0, 16) + '"'
-  );
-}
 
 
 export const DAEMON_EXIT_CODE_RESTART = 75;

--- a/packages/cli/src/daemon/manifest.ts
+++ b/packages/cli/src/daemon/manifest.ts
@@ -804,19 +804,30 @@ export function buildSkillMd(opts: {
     `- **Peer ID:** ${opts.peerId}`,
     `- **Node role:** ${opts.nodeRole}`,
     `- **Available extraction pipelines:** ${opts.extractionPipelines.length > 0 ? opts.extractionPipelines.join(", ") : "none (install markitdown to enable document conversion)"}`,
-    '',
-    'If the Node UI injects a target context graph for the turn, use that target directly. If no target is injected or configured, call `GET /api/context-graph/list` / `dkg_list_context_graphs`; agent tool surfaces default that list to the caller\'s created/joined context graphs, with `scope: "all"` for every graph the node knows about.',
   ].join("\n");
 
-  const staticPlaceholder =
-    "> This section is dynamically generated from node state at serve-time.\n\n" +
-    "- **Node version:** (dynamic)\n" +
-    "- **Base URL:** (dynamic)\n" +
-    "- **Peer ID:** (dynamic)\n" +
-    "- **Node role:** (dynamic — `core` or `edge`)\n" +
-    "- **Available extraction pipelines:** (dynamic)\n" +
-    "\n" +
-    "If the Node UI injects a target context graph for the turn, use that target directly. If no target is injected or configured, call `GET /api/context-graph/list` / `dkg_list_context_graphs`; agent tool surfaces default that list to the caller's created/joined context graphs, with `scope: \"all\"` for every graph the node knows about.";
+  // GH#1763 sibling / GH#1125 — match ONLY the bullet block. The template's
+  // trailing paragraph after the pipelines line is prose that has already
+  // drifted out of sync with this file once (the two `dkg_list_context_graphs`
+  // / `GET /api/context-graph/list` mentions are order-swapped in SKILL.md),
+  // and because `String.replace` with a literal needle fails silently, that
+  // one-word divergence meant the ENTIRE section was never substituted and the
+  // served doc shipped `(dynamic)` placeholders to every agent that read it.
+  // Anchoring on just the bullets keeps prose edits from breaking substitution.
+  const staticPlaceholder = [
+    "- **Node version:** (dynamic)",
+    "- **Base URL:** (dynamic)",
+    "- **Peer ID:** (dynamic)",
+    "- **Node role:** (dynamic — `core` or `edge`)",
+    "- **Available extraction pipelines:** (dynamic)",
+  ].join("\n");
+
+  if (!template.includes(staticPlaceholder)) {
+    // Fail loudly in dev rather than silently serving placeholders.
+    console.warn(
+      "[skill.md] dynamic Node Info block not found in SKILL.md — served doc will contain (dynamic) placeholders",
+    );
+  }
 
   return template.replace(staticPlaceholder, dynamicSection);
 }

--- a/packages/cli/src/daemon/manifest.ts
+++ b/packages/cli/src/daemon/manifest.ts
@@ -798,38 +798,63 @@ export function buildSkillMd(opts: {
   extractionPipelines: string[];
 }): string {
   const template = loadSkillTemplate();
-  const dynamicSection = [
-    `- **Node version:** ${opts.version}`,
-    `- **Base URL:** ${opts.baseUrl}`,
-    `- **Peer ID:** ${opts.peerId}`,
-    `- **Node role:** ${opts.nodeRole}`,
-    `- **Available extraction pipelines:** ${opts.extractionPipelines.length > 0 ? opts.extractionPipelines.join(", ") : "none (install markitdown to enable document conversion)"}`,
-  ].join("\n");
 
-  // GH#1763 sibling / GH#1125 — match ONLY the bullet block. The template's
-  // trailing paragraph after the pipelines line is prose that has already
-  // drifted out of sync with this file once (the two `dkg_list_context_graphs`
-  // / `GET /api/context-graph/list` mentions are order-swapped in SKILL.md),
-  // and because `String.replace` with a literal needle fails silently, that
-  // one-word divergence meant the ENTIRE section was never substituted and the
-  // served doc shipped `(dynamic)` placeholders to every agent that read it.
-  // Anchoring on just the bullets keeps prose edits from breaking substitution.
-  const staticPlaceholder = [
-    "- **Node version:** (dynamic)",
-    "- **Base URL:** (dynamic)",
-    "- **Peer ID:** (dynamic)",
-    "- **Node role:** (dynamic — `core` or `edge`)",
-    "- **Available extraction pipelines:** (dynamic)",
-  ].join("\n");
+  // GH#1125 — substitute NAMED tokens, one at a time.
+  //
+  // The previous implementation rebuilt a copy of the template's Markdown and
+  // swapped the whole block with a single literal `String.replace`. Two things
+  // went wrong with that, and the token form fixes both:
+  //
+  //  1. DRIFT. A literal needle fails SILENTLY when it does not match. The copy
+  //     here and the block in SKILL.md had drifted by a single reordered
+  //     sentence, so nothing was ever substituted and every agent that read
+  //     /.well-known/skill.md got `(dynamic)` placeholders. Per-token
+  //     substitution means prose and label edits in the template cannot
+  //     disable it — only renaming a token can, and that is validated below.
+  //
+  //  2. `$` INJECTION. `String.replace(needle, replacement)` interprets `$&`,
+  //     `$'`, "$`" and `$n` in the REPLACEMENT string. `baseUrl` is built from
+  //     the `X-Forwarded-Host` / `Host` request headers (routes/status.ts:641)
+  //     and this endpoint is public and unauthenticated, so those tokens were
+  //     attacker-controlled: `$&` re-inserted the placeholder block (putting
+  //     `(dynamic)` back), and each `$'` appended the ~94 KB template suffix,
+  //     giving unbounded response amplification. Passing a FUNCTION as the
+  //     replacement makes the value literal — this is the load-bearing detail,
+  //     do not turn it back into a string.
+  const values: Record<string, string> = {
+    nodeVersion: opts.version,
+    baseUrl: opts.baseUrl,
+    peerId: opts.peerId,
+    nodeRole: opts.nodeRole,
+    extractionPipelines:
+      opts.extractionPipelines.length > 0
+        ? opts.extractionPipelines.join(", ")
+        : "none (install markitdown to enable document conversion)",
+  };
 
-  if (!template.includes(staticPlaceholder)) {
-    // Fail loudly in dev rather than silently serving placeholders.
-    console.warn(
-      "[skill.md] dynamic Node Info block not found in SKILL.md — served doc will contain (dynamic) placeholders",
-    );
+  let out = template;
+  for (const [token, value] of Object.entries(values)) {
+    // Function replacement: `value` is inserted verbatim, `$` and all.
+    out = out.replaceAll(`{{${token}}}`, () => value);
   }
+  return out;
+}
 
-  return template.replace(staticPlaceholder, dynamicSection);
+/** Tokens SKILL.md must carry for `buildSkillMd` to produce a complete doc. */
+export const REQUIRED_SKILL_TOKENS = Object.freeze([
+  "nodeVersion",
+  "baseUrl",
+  "peerId",
+  "nodeRole",
+  "extractionPipelines",
+]);
+
+/**
+ * Validate that the template still carries every token, ONCE at load time
+ * rather than warning on every request. Returns the missing token names.
+ */
+export function missingSkillTokens(template: string = loadSkillTemplate()): string[] {
+  return REQUIRED_SKILL_TOKENS.filter((t) => !template.includes(`{{${t}}}`));
 }
 
 export function skillEtag(content: string): string {

--- a/packages/cli/src/daemon/skill-template.ts
+++ b/packages/cli/src/daemon/skill-template.ts
@@ -1,0 +1,134 @@
+/**
+ * SKILL.md template rendering — the ONE boundary every delivery surface goes
+ * through (GH#1125, PR #2331 review).
+ *
+ * `skills/dkg-node/SKILL.md` has two delivery modes and they must not diverge:
+ *
+ *   1. SERVED, by the daemon at `/.well-known/skill.md`, with live node state.
+ *   2. DELIVERED, as a standalone file copied into a client's skill directory
+ *      by `dkg mcp setup` / `dkg hermes setup`. There is no node context there.
+ *
+ * The template carries named `{{token}}` values. Extracting this module out of
+ * `manifest.ts` (a catch-all that had grown past 1,000 lines) gives the
+ * subsystem an owner, and — more importantly — makes it impossible to reach the
+ * raw template without choosing a render mode. Handing the raw file to a client
+ * is what would ship `{{nodeVersion}}` into a user's skill directory.
+ */
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+
+/**
+ * The token contract, as ONE source of truth.
+ *
+ * Required token names are derived from this object's keys, so the template,
+ * the substitution map and the validator cannot drift apart — the previous
+ * shape kept a separate array that could silently disagree (PR #2331 review).
+ */
+export interface SkillTokenValues {
+  nodeVersion: string;
+  baseUrl: string;
+  peerId: string;
+  nodeRole: string;
+  extractionPipelines: string;
+}
+
+/**
+ * Static text for the STANDALONE copy, which has no node to describe. Prose
+ * rather than an internal placeholder: a reader of a delivered skill file
+ * should get an instruction, not a broken-looking template artifact.
+ */
+export const STANDALONE_SKILL_VALUES: SkillTokenValues = Object.freeze({
+  nodeVersion: "_(run `dkg --version` on your node)_",
+  baseUrl: "_(your node's API base URL — `http://localhost:9200` by default)_",
+  peerId: "_(run `dkg status` on your node)_",
+  nodeRole: "_(`core` or `edge` — run `dkg status`)_",
+  extractionPipelines: "_(depends on installed converters — run `dkg status`)_",
+});
+
+export const REQUIRED_SKILL_TOKENS: ReadonlyArray<keyof SkillTokenValues> =
+  Object.freeze(Object.keys(STANDALONE_SKILL_VALUES) as Array<keyof SkillTokenValues>);
+
+const TOKEN_RE = /\{\{([a-zA-Z][a-zA-Z0-9]*)\}\}/g;
+
+let cachedSkillMd: string | null = null;
+
+export function loadSkillTemplate(): string {
+  if (cachedSkillMd) return cachedSkillMd;
+  const skillPath = new URL("../../skills/dkg-node/SKILL.md", import.meta.url);
+  cachedSkillMd = readFileSync(skillPath, "utf-8");
+  return cachedSkillMd;
+}
+
+/** Required tokens the template is missing. */
+export function missingSkillTokens(template: string = loadSkillTemplate()): string[] {
+  return REQUIRED_SKILL_TOKENS.filter((t) => !template.includes(`{{${t}}}`));
+}
+
+/**
+ * Tokens the template uses that nothing supplies. Without this, adding
+ * `{{networkId}}` to SKILL.md would render it verbatim into the served doc and
+ * `missingSkillTokens()` would still report a clean bill of health.
+ */
+export function unknownSkillTokens(template: string = loadSkillTemplate()): string[] {
+  const known = new Set<string>(REQUIRED_SKILL_TOKENS as ReadonlyArray<string>);
+  const found = new Set<string>();
+  TOKEN_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = TOKEN_RE.exec(template)) !== null) {
+    if (!known.has(m[1]!)) found.add(m[1]!);
+  }
+  return [...found].sort();
+}
+
+/**
+ * Substitute every token, LITERALLY.
+ *
+ * The replacement is a function on purpose. `String.replace(needle, string)`
+ * interprets `$&`, `$'`, "$`" and `$n` in the replacement, and `baseUrl` is
+ * derived from the `X-Forwarded-Host` / `Host` request headers on a public,
+ * unauthenticated endpoint. Before this was a callback, a crafted Host could
+ * re-insert the placeholder block or append the ~94 KB template suffix per
+ * `$'`, giving unbounded response amplification. Do not turn it back into a
+ * string.
+ */
+export function renderSkillTemplate(values: SkillTokenValues, template = loadSkillTemplate()): string {
+  let out = template;
+  for (const token of REQUIRED_SKILL_TOKENS) {
+    const value = values[token];
+    out = out.replaceAll(`{{${token}}}`, () => value);
+  }
+  return out;
+}
+
+/** SERVED mode — live node state, for `/.well-known/skill.md`. */
+export function buildSkillMd(opts: {
+  version: string;
+  baseUrl: string;
+  peerId: string;
+  nodeRole: string;
+  extractionPipelines: string[];
+}): string {
+  return renderSkillTemplate({
+    nodeVersion: opts.version,
+    baseUrl: opts.baseUrl,
+    peerId: opts.peerId,
+    nodeRole: opts.nodeRole,
+    extractionPipelines:
+      opts.extractionPipelines.length > 0
+        ? opts.extractionPipelines.join(", ")
+        : "none (install markitdown to enable document conversion)",
+  });
+}
+
+/**
+ * DELIVERED mode — the standalone artifact copied into a client's skill
+ * directory. Every caller that used to read the bundled file directly must go
+ * through this, or it ships raw `{{token}}` syntax to end users.
+ */
+export function renderStandaloneDkgNodeSkill(): string {
+  return renderSkillTemplate(STANDALONE_SKILL_VALUES);
+}
+
+export function skillEtag(content: string): string {
+  return '"' + createHash("md5").update(content).digest("hex").slice(0, 16) + '"';
+}

--- a/packages/cli/src/hermes-setup.ts
+++ b/packages/cli/src/hermes-setup.ts
@@ -1,3 +1,4 @@
+import { renderStandaloneDkgNodeSkill } from './daemon/skill-template.js';
 import type { Command } from 'commander';
 import { readFileSync } from 'node:fs';
 import { assertSelectableNetwork } from './config.js';
@@ -74,7 +75,8 @@ function normalizePort(value: string | number | undefined): number | undefined {
 }
 
 export function loadBundledDkgNodeSkill(): string {
-  return readFileSync(new URL('../skills/dkg-node/SKILL.md', import.meta.url), 'utf-8');
+  // GH#1125 / PR #2331 review — render, never ship the raw template.
+  return renderStandaloneDkgNodeSkill();
 }
 
 export function normalizeHermesSetupOptions(opts: HermesSetupCliOptions): NormalizedHermesSetupOptions {

--- a/packages/cli/src/hermes-setup.ts
+++ b/packages/cli/src/hermes-setup.ts
@@ -1,4 +1,4 @@
-import { renderStandaloneDkgNodeSkill } from './daemon/skill-template.js';
+import { renderStandaloneDkgNodeSkill } from './skill-template.js';
 import type { Command } from 'commander';
 import { readFileSync } from 'node:fs';
 import { assertSelectableNetwork } from './config.js';

--- a/packages/cli/src/mcp-setup.ts
+++ b/packages/cli/src/mcp-setup.ts
@@ -66,6 +66,7 @@
  * server reads them from `~/.dkg/config.yaml` + the daemon-written
  * `auth.token` via `loadConfig` (`packages/mcp-dkg/src/config.ts`).
  */
+import { renderStandaloneDkgNodeSkill } from './daemon/skill-template.js';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, realpathSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { homedir, platform, release as osRelease } from 'node:os';
@@ -1633,7 +1634,11 @@ function skillTargetForClient(target: ClientTarget, home: string): string | null
  * source artifact byte-for-byte.
  */
 function loadBundledDkgNodeSkill(): string {
-  return readFileSync(new URL('../skills/dkg-node/SKILL.md', import.meta.url), 'utf-8');
+  // GH#1125 / PR #2331 review — render, never ship the raw template. The
+  // bundled SKILL.md carries `{{token}}` placeholders for the daemon's
+  // serve-time substitution; writing it verbatim would put that syntax in a
+  // user's skill directory.
+  return renderStandaloneDkgNodeSkill();
 }
 
 /**

--- a/packages/cli/src/mcp-setup.ts
+++ b/packages/cli/src/mcp-setup.ts
@@ -66,7 +66,7 @@
  * server reads them from `~/.dkg/config.yaml` + the daemon-written
  * `auth.token` via `loadConfig` (`packages/mcp-dkg/src/config.ts`).
  */
-import { renderStandaloneDkgNodeSkill } from './daemon/skill-template.js';
+import { renderStandaloneDkgNodeSkill } from './skill-template.js';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, realpathSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { homedir, platform, release as osRelease } from 'node:os';
@@ -1627,19 +1627,6 @@ function skillTargetForClient(target: ClientTarget, home: string): string | null
   return null;
 }
 
-/**
- * Load the bundled DKG-node SKILL.md from the npm package's `skills/`
- * directory. Same shape as `loadBundledDkgNodeSkill()` in
- * `hermes-setup.ts` so the two delivery paths share the canonical
- * source artifact byte-for-byte.
- */
-function loadBundledDkgNodeSkill(): string {
-  // GH#1125 / PR #2331 review — render, never ship the raw template. The
-  // bundled SKILL.md carries `{{token}}` placeholders for the daemon's
-  // serve-time substitution; writing it verbatim would put that syntax in a
-  // user's skill directory.
-  return renderStandaloneDkgNodeSkill();
-}
 
 /**
  * Copy the bundled SKILL.md into the per-client skills directory if
@@ -1661,7 +1648,7 @@ function deliverSkillToClient(target: ClientTarget): string | null {
   const skillPath = skillTargetForClient(target, home);
   if (!skillPath) return null;
   try {
-    const skillContent = loadBundledDkgNodeSkill();
+    const skillContent = renderStandaloneDkgNodeSkill();
     const skillDir = dirname(skillPath);
     if (!existsSync(skillDir)) mkdirSync(skillDir, { recursive: true });
     writeFileSync(skillPath, skillContent);

--- a/packages/cli/src/skill-template.ts
+++ b/packages/cli/src/skill-template.ts
@@ -2,6 +2,11 @@
  * SKILL.md template rendering — the ONE boundary every delivery surface goes
  * through (GH#1125, PR #2331 review).
  *
+ * Package-level, not under daemon/: this artifact serves the daemon endpoint
+ * AND the non-daemon `dkg mcp setup` / `dkg hermes setup` flows, so setup
+ * commands must not have to reach into a daemon implementation directory for
+ * it. Daemon and setup are peers here.
+ *
  * `skills/dkg-node/SKILL.md` has two delivery modes and they must not diverge:
  *
  *   1. SERVED, by the daemon at `/.well-known/skill.md`, with live node state.
@@ -54,7 +59,7 @@ let cachedSkillMd: string | null = null;
 
 export function loadSkillTemplate(): string {
   if (cachedSkillMd) return cachedSkillMd;
-  const skillPath = new URL("../../skills/dkg-node/SKILL.md", import.meta.url);
+  const skillPath = new URL("../skills/dkg-node/SKILL.md", import.meta.url);
   cachedSkillMd = readFileSync(skillPath, "utf-8");
   return cachedSkillMd;
 }

--- a/packages/cli/src/skill-template.ts
+++ b/packages/cli/src/skill-template.ts
@@ -47,7 +47,10 @@ export const STANDALONE_SKILL_VALUES: SkillTokenValues = Object.freeze({
   baseUrl: "_(your node's API base URL — `http://localhost:9200` by default)_",
   peerId: "_(run `dkg status` on your node)_",
   nodeRole: "_(`core` or `edge` — run `dkg status`)_",
-  extractionPipelines: "_(depends on installed converters — run `dkg status`)_",
+  // `dkg status` does NOT report pipelines; the node's served skill doc does
+  // (routes/status.ts builds it with the live list), so point there.
+  extractionPipelines:
+    "_(depends on installed converters — fetch `/.well-known/skill.md` from your running node for the live list)_",
 });
 
 export const REQUIRED_SKILL_TOKENS: ReadonlyArray<keyof SkillTokenValues> =
@@ -86,21 +89,46 @@ export function unknownSkillTokens(template: string = loadSkillTemplate()): stri
 }
 
 /**
- * Substitute every token, LITERALLY.
+ * Substitute every token in ONE pass.
  *
- * The replacement is a function on purpose. `String.replace(needle, string)`
- * interprets `$&`, `$'`, "$`" and `$n` in the replacement, and `baseUrl` is
- * derived from the `X-Forwarded-Host` / `Host` request headers on a public,
- * unauthenticated endpoint. Before this was a callback, a crafted Host could
- * re-insert the placeholder block or append the ~94 KB template suffix per
- * `$'`, giving unbounded response amplification. Do not turn it back into a
- * string.
+ * Two distinct hazards, both reachable from the `X-Forwarded-Host` / `Host`
+ * headers because `/.well-known/skill.md` is public and unauthenticated:
+ *
+ *  1. `$` EXPANSION. `String.replace(needle, replacementString)` interprets
+ *     `$&`, `$'`, "$`" and `$n` in the REPLACEMENT. A crafted Host could
+ *     re-insert the placeholder block or append the ~94 KB template suffix per
+ *     `$'`. The replacement is a FUNCTION, which makes the value literal.
+ *
+ *  2. TOKEN RE-ENTRY. Substituting one token at a time rescans the growing
+ *     OUTPUT on later iterations, so a value could itself invoke the template
+ *     language: `baseUrl: "http://{{peerId}}"` rendered the real peer ID into
+ *     the advertised API URL, and `http://{{nodeVersion}}` left raw token
+ *     syntax because that key had already been processed (PR #2331 review).
+ *     One pass over the ORIGINAL template closes this — a callback resolves
+ *     each match against `values` and its result is never re-examined.
+ *
+ * Neither property is incidental. Do not reintroduce a per-token loop, and do
+ * not turn the callback back into a string.
  */
 export function renderSkillTemplate(values: SkillTokenValues, template = loadSkillTemplate()): string {
-  let out = template;
-  for (const token of REQUIRED_SKILL_TOKENS) {
-    const value = values[token];
-    out = out.replaceAll(`{{${token}}}`, () => value);
+  const unknown = new Set<string>();
+  // Fresh regex per call — no shared lastIndex state.
+  const out = template.replace(/\{\{([a-zA-Z][a-zA-Z0-9]*)\}\}/g, (match, name: string) => {
+    if (Object.prototype.hasOwnProperty.call(values, name)) {
+      return values[name as keyof SkillTokenValues];
+    }
+    unknown.add(name);
+    return match;
+  });
+
+  // Fail loudly at the boundary rather than serving a half-rendered document:
+  // adding `{{networkId}}` to SKILL.md without supplying it is a template bug,
+  // not something an agent reading the doc should have to notice.
+  if (unknown.size > 0) {
+    throw new Error(
+      `SKILL.md references unknown template token(s): ${[...unknown].sort().join(', ')}. ` +
+        `Add them to SkillTokenValues (packages/cli/src/skill-template.ts) or remove them from the template.`,
+    );
   }
   return out;
 }

--- a/packages/cli/test/mcp-setup.test.ts
+++ b/packages/cli/test/mcp-setup.test.ts
@@ -3587,4 +3587,31 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     expect(reParsed).toEqual(written);
   });
 
+
+  // GH#1125 / PR #2331 review — `dkg mcp setup` copies SKILL.md into the
+  // client's skill directory. Once the template carried `{{token}}` syntax for
+  // the daemon's serve-time substitution, delivering the raw file would write
+  // that syntax into ~/.cursor/skills/dkg-node/SKILL.md.
+  //
+  // This asserts the file mcpSetupAction ACTUALLY writes. An earlier test
+  // checked hermes-setup's loader instead and would have stayed green while
+  // this path regressed, because mcp-setup carried its own private copy of it.
+  it('delivers a rendered SKILL.md to the client, never raw template tokens', async () => {
+    mkdirSync(join(tmpHome, '.cursor'), { recursive: true });
+
+    await mcpSetupAction({ verify: false, fund: false }, makeDeps());
+
+    const delivered = join(tmpHome, '.cursor', 'skills', 'dkg-node', 'SKILL.md');
+    expect(existsSync(delivered)).toBe(true);
+    const content = readFileSync(delivered, 'utf-8');
+
+    // The regression: no unsubstituted template syntax reaches the user.
+    expect(content).not.toMatch(/\{\{[a-zA-Z]+\}\}/);
+    // Nor the pre-token placeholder prose it replaced.
+    expect(content).not.toContain('(dynamic)');
+    // It carries the standalone guidance instead of live node values.
+    expect(content).toContain('- **Node version:** _(run `dkg --version` on your node)_');
+    // And it is still the real skill document.
+    expect(content).toContain('## 1. Node Info');
+  });
 });

--- a/packages/cli/test/skill-dynamic-substitution.test.ts
+++ b/packages/cli/test/skill-dynamic-substitution.test.ts
@@ -4,9 +4,10 @@ import {
   buildSkillMd,
   loadSkillTemplate,
   missingSkillTokens,
+  renderSkillTemplate,
   renderStandaloneDkgNodeSkill,
   unknownSkillTokens,
-} from '../src/daemon/skill-template.js';
+} from '../src/skill-template.js';
 import { loadBundledDkgNodeSkill } from '../src/hermes-setup.js';
 
 // GH#1125 — the served skill doc shipped literal "(dynamic)" placeholders.
@@ -115,13 +116,29 @@ describe('SKILL.md template token contract (GH#1125 review)', () => {
   });
 
   it('substitution survives prose and label edits around the tokens', () => {
-    // The exact failure that caused #1125: reword the surrounding Markdown.
+    // PR #2331 review — an earlier version asserted only that the reworded
+    // template still CONTAINED the tokens, which is true regardless of how
+    // rendering works, so a return to exact-block replacement would have passed
+    // it. RENDER the drifted template and check the output.
     const reworded = loadSkillTemplate()
       .replace('- **Node role:**', '- **Node type:**')
       .replace('If the Node UI injects', 'If the Node UI supplies');
-    for (const token of REQUIRED_SKILL_TOKENS) {
-      expect(reworded).toContain(`{{${token}}}`);
-    }
+
+    const rendered = renderSkillTemplate(
+      {
+        nodeVersion: '10.0.14',
+        baseUrl: 'http://127.0.0.1:9200',
+        peerId: '12D3KooWRendered',
+        nodeRole: 'edge',
+        extractionPipelines: 'markitdown',
+      },
+      reworded,
+    );
+
+    expect(rendered).not.toMatch(/\{\{[a-zA-Z]+\}\}/);
+    expect(rendered).toContain('- **Node type:** edge');
+    expect(rendered).toContain('- **Node version:** 10.0.14');
+    expect(rendered).toContain('If the Node UI supplies');
   });
 });
 
@@ -144,9 +161,11 @@ describe('standalone skill delivery renders too (GH#1125 review)', () => {
     expect(delivered).toContain('- **Node role:** _(`core` or `edge` — run `dkg status`)_');
   });
 
-  it('the setup delivery path goes through the renderer, not the raw file', () => {
-    // Guards the actual regression: hermes-setup/mcp-setup previously
-    // readFileSync'd the bundled SKILL.md straight into the client directory.
+  it('the hermes setup path goes through the renderer, not the raw file', () => {
+    // NOTE: this covers hermes-setup ONLY. mcp-setup had its own private copy
+    // of this loader, so reverting just that file passed every assertion here
+    // (PR #2331 review). The duplicate is deleted and mcp-setup calls the
+    // shared renderer directly; `mcp-setup.test.ts` asserts the delivered file.
     const shipped = loadBundledDkgNodeSkill();
     expect(shipped).not.toMatch(/\{\{[a-zA-Z]+\}\}/);
     expect(shipped).toBe(renderStandaloneDkgNodeSkill());

--- a/packages/cli/test/skill-dynamic-substitution.test.ts
+++ b/packages/cli/test/skill-dynamic-substitution.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { buildSkillMd, loadSkillTemplate } from '../src/daemon/manifest.js';
+
+// GH#1125 — the served skill doc shipped literal "(dynamic)" placeholders.
+//
+// `buildSkillMd` substitutes with `String.replace(literalNeedle, …)`, which
+// fails SILENTLY when the needle does not match. The needle used to include a
+// trailing prose paragraph that had drifted out of sync with SKILL.md (the
+// `dkg_list_context_graphs` / `GET /api/context-graph/list` mentions are
+// order-swapped), so the whole Node Info block was never substituted and every
+// agent bootstrapping from /.well-known/skill.md read placeholders.
+const OPTS = {
+  version: '10.0.14',
+  baseUrl: 'http://127.0.0.1:9200',
+  peerId: '12D3KooWTestPeerIdForSubstitutionAssertions',
+  nodeRole: 'edge',
+  extractionPipelines: ['markitdown'],
+};
+
+describe('buildSkillMd — dynamic Node Info substitution (GH#1125)', () => {
+  it('serves no literal "(dynamic)" placeholder anywhere', () => {
+    expect(buildSkillMd(OPTS)).not.toContain('(dynamic)');
+  });
+
+  it('substitutes the real node values', () => {
+    const md = buildSkillMd(OPTS);
+    expect(md).toContain(`- **Node version:** ${OPTS.version}`);
+    expect(md).toContain(`- **Base URL:** ${OPTS.baseUrl}`);
+    expect(md).toContain(`- **Peer ID:** ${OPTS.peerId}`);
+    expect(md).toContain(`- **Node role:** ${OPTS.nodeRole}`);
+    expect(md).toContain('- **Available extraction pipelines:** markitdown');
+  });
+
+  it('reports no pipelines with actionable guidance rather than an empty value', () => {
+    const md = buildSkillMd({ ...OPTS, extractionPipelines: [] });
+    expect(md).not.toContain('(dynamic)');
+    expect(md).toContain('none (install markitdown to enable document conversion)');
+  });
+
+  it('substitution does not depend on the prose that follows the bullets', () => {
+    // The regression guard: the template paragraph after the pipelines line is
+    // free to be reworded without silently disabling substitution.
+    const template = loadSkillTemplate();
+    expect(template).toContain('- **Available extraction pipelines:** (dynamic)');
+    const md = buildSkillMd(OPTS);
+    expect(md).toContain('If the Node UI injects a target context graph');
+  });
+
+  it('is idempotent — building twice yields identical output', () => {
+    expect(buildSkillMd(OPTS)).toBe(buildSkillMd(OPTS));
+  });
+});

--- a/packages/cli/test/skill-dynamic-substitution.test.ts
+++ b/packages/cli/test/skill-dynamic-substitution.test.ts
@@ -1,14 +1,18 @@
 import { describe, expect, it } from 'vitest';
-import { buildSkillMd, loadSkillTemplate } from '../src/daemon/manifest.js';
+import {
+  REQUIRED_SKILL_TOKENS,
+  buildSkillMd,
+  loadSkillTemplate,
+  missingSkillTokens,
+} from '../src/daemon/manifest.js';
 
 // GH#1125 — the served skill doc shipped literal "(dynamic)" placeholders.
 //
-// `buildSkillMd` substitutes with `String.replace(literalNeedle, …)`, which
-// fails SILENTLY when the needle does not match. The needle used to include a
-// trailing prose paragraph that had drifted out of sync with SKILL.md (the
-// `dkg_list_context_graphs` / `GET /api/context-graph/list` mentions are
-// order-swapped), so the whole Node Info block was never substituted and every
-// agent bootstrapping from /.well-known/skill.md read placeholders.
+// `buildSkillMd` used to rebuild a copy of the template's Markdown and swap the
+// whole block with one literal `String.replace`, which fails SILENTLY on a
+// mismatch. The copy and SKILL.md had drifted by a single reordered sentence,
+// so the block was never substituted and every agent bootstrapping from
+// /.well-known/skill.md read placeholders.
 const OPTS = {
   version: '10.0.14',
   baseUrl: 'http://127.0.0.1:9200',
@@ -18,8 +22,10 @@ const OPTS = {
 };
 
 describe('buildSkillMd — dynamic Node Info substitution (GH#1125)', () => {
-  it('serves no literal "(dynamic)" placeholder anywhere', () => {
-    expect(buildSkillMd(OPTS)).not.toContain('(dynamic)');
+  it('leaves no unsubstituted token or legacy placeholder', () => {
+    const md = buildSkillMd(OPTS);
+    expect(md).not.toContain('(dynamic)');
+    expect(md).not.toMatch(/\{\{[a-zA-Z]+\}\}/);
   });
 
   it('substitutes the real node values', () => {
@@ -33,20 +39,85 @@ describe('buildSkillMd — dynamic Node Info substitution (GH#1125)', () => {
 
   it('reports no pipelines with actionable guidance rather than an empty value', () => {
     const md = buildSkillMd({ ...OPTS, extractionPipelines: [] });
-    expect(md).not.toContain('(dynamic)');
+    expect(md).not.toMatch(/\{\{[a-zA-Z]+\}\}/);
     expect(md).toContain('none (install markitdown to enable document conversion)');
   });
 
-  it('substitution does not depend on the prose that follows the bullets', () => {
-    // The regression guard: the template paragraph after the pipelines line is
-    // free to be reworded without silently disabling substitution.
-    const template = loadSkillTemplate();
-    expect(template).toContain('- **Available extraction pipelines:** (dynamic)');
-    const md = buildSkillMd(OPTS);
-    expect(md).toContain('If the Node UI injects a target context graph');
+  it('is idempotent', () => {
+    expect(buildSkillMd(OPTS)).toBe(buildSkillMd(OPTS));
+  });
+});
+
+// PR #2331 review, 🔴 — `String.replace(needle, replacementString)` interprets
+// `$&`, `$'`, "$`" and `$n` in the REPLACEMENT. `baseUrl` is derived from the
+// `X-Forwarded-Host` / `Host` headers (routes/status.ts:641) and
+// /.well-known/skill.md is public and unauthenticated, so those sequences were
+// attacker-controlled. Measured on the pre-fix build: `$&` put `(dynamic)`
+// back into the served doc, a single `$'` doubled the response (94 KB -> 187 KB)
+// and five of them reached 561 KB — unbounded amplification from one request.
+describe('buildSkillMd — replacement tokens in node metadata are literal (GH#1125 review)', () => {
+  const evil = ["$&", "$'", '$`', '$1', '$$'];
+
+  for (const seq of evil) {
+    it(`emits ${JSON.stringify(seq)} in baseUrl verbatim, exactly once`, () => {
+      const baseUrl = `http://host/${seq}`;
+      const md = buildSkillMd({ ...OPTS, baseUrl });
+
+      expect(md).toContain(`- **Base URL:** ${baseUrl}`);
+      expect(md.split(`- **Base URL:** ${baseUrl}`)).toHaveLength(2);
+      expect(md).not.toContain('(dynamic)');
+      expect(md).not.toMatch(/\{\{[a-zA-Z]+\}\}/);
+    });
+  }
+
+  it('does not amplify the response for any replacement sequence', () => {
+    const normal = buildSkillMd(OPTS).length;
+    for (const seq of evil) {
+      const md = buildSkillMd({ ...OPTS, baseUrl: `http://host/${seq.repeat(5)}` });
+      // Growth must be bounded by the length of the value itself, not by the
+      // template suffix. Allow a small slack for the longer URL.
+      expect(md.length).toBeLessThan(normal + 200);
+    }
   });
 
-  it('is idempotent — building twice yields identical output', () => {
-    expect(buildSkillMd(OPTS)).toBe(buildSkillMd(OPTS));
+  it('treats replacement sequences in every other field as literal too', () => {
+    const md = buildSkillMd({
+      ...OPTS,
+      version: "1.0.0-$'",
+      peerId: '12D3Koo$&',
+      nodeRole: "edge$`",
+      extractionPipelines: ["markitdown$'"],
+    });
+    expect(md).toContain("- **Node version:** 1.0.0-$'");
+    expect(md).toContain('- **Peer ID:** 12D3Koo$&');
+    expect(md).toContain('- **Node role:** edge$`');
+    expect(md).toContain("- **Available extraction pipelines:** markitdown$'");
+    expect(md).not.toContain('(dynamic)');
+  });
+});
+
+// PR #2331 review, 🔴 — the previous fix only shrank the literal needle; a
+// harmless prose or label edit could still silently disable every
+// substitution. Named tokens decouple substitution from the surrounding
+// Markdown, and the template is validated once at load rather than warning on
+// every render.
+describe('SKILL.md template token contract (GH#1125 review)', () => {
+  it('the shipped template carries every required token', () => {
+    expect(missingSkillTokens(loadSkillTemplate())).toEqual([]);
+  });
+
+  it('missingSkillTokens names what a drifted template dropped', () => {
+    const drifted = loadSkillTemplate().replace('{{nodeRole}}', '(dynamic)');
+    expect(missingSkillTokens(drifted)).toEqual(['nodeRole']);
+  });
+
+  it('substitution survives prose and label edits around the tokens', () => {
+    // The exact failure that caused #1125: reword the surrounding Markdown.
+    const reworded = loadSkillTemplate()
+      .replace('- **Node role:**', '- **Node type:**')
+      .replace('If the Node UI injects', 'If the Node UI supplies');
+    for (const token of REQUIRED_SKILL_TOKENS) {
+      expect(reworded).toContain(`{{${token}}}`);
+    }
   });
 });

--- a/packages/cli/test/skill-dynamic-substitution.test.ts
+++ b/packages/cli/test/skill-dynamic-substitution.test.ts
@@ -4,7 +4,10 @@ import {
   buildSkillMd,
   loadSkillTemplate,
   missingSkillTokens,
-} from '../src/daemon/manifest.js';
+  renderStandaloneDkgNodeSkill,
+  unknownSkillTokens,
+} from '../src/daemon/skill-template.js';
+import { loadBundledDkgNodeSkill } from '../src/hermes-setup.js';
 
 // GH#1125 — the served skill doc shipped literal "(dynamic)" placeholders.
 //
@@ -119,5 +122,65 @@ describe('SKILL.md template token contract (GH#1125 review)', () => {
     for (const token of REQUIRED_SKILL_TOKENS) {
       expect(reworded).toContain(`{{${token}}}`);
     }
+  });
+});
+
+// PR #2331 review — SKILL.md has TWO delivery modes and only one of them has a
+// node to describe. `dkg mcp setup` / `dkg hermes setup` copy the skill into a
+// client's skill directory (mcp-setup.ts deliverSkillToClient), and those paths
+// used to write the bundled file verbatim. Once the template carried
+// `{{token}}` syntax that meant shipping internal placeholders to end users —
+// a worse artifact than the `(dynamic)` prose it replaced.
+describe('standalone skill delivery renders too (GH#1125 review)', () => {
+  it('never delivers raw template syntax', () => {
+    const delivered = renderStandaloneDkgNodeSkill();
+    expect(delivered).not.toMatch(/\{\{[a-zA-Z]+\}\}/);
+    expect(delivered).not.toContain('(dynamic)');
+  });
+
+  it('delivers readable guidance in place of live values', () => {
+    const delivered = renderStandaloneDkgNodeSkill();
+    expect(delivered).toContain('- **Node version:** _(run `dkg --version` on your node)_');
+    expect(delivered).toContain('- **Node role:** _(`core` or `edge` — run `dkg status`)_');
+  });
+
+  it('the setup delivery path goes through the renderer, not the raw file', () => {
+    // Guards the actual regression: hermes-setup/mcp-setup previously
+    // readFileSync'd the bundled SKILL.md straight into the client directory.
+    const shipped = loadBundledDkgNodeSkill();
+    expect(shipped).not.toMatch(/\{\{[a-zA-Z]+\}\}/);
+    expect(shipped).toBe(renderStandaloneDkgNodeSkill());
+  });
+
+  it('served and delivered modes differ only in the substituted values', () => {
+    const served = buildSkillMd(OPTS);
+    const delivered = renderStandaloneDkgNodeSkill();
+    expect(served).not.toBe(delivered);
+    // Same document otherwise — compare a section far from the token block.
+    expect(served.includes('## 5. Memory Model')).toBe(delivered.includes('## 5. Memory Model'));
+  });
+});
+
+// PR #2331 review — the required-token array, the substitution map and the
+// template were three independent sources of truth, so adding `{{networkId}}`
+// to SKILL.md would render it verbatim while the validator still reported a
+// clean bill of health. Required names are now DERIVED from the value map, and
+// unknown tokens are detectable.
+describe('token contract has one source of truth (GH#1125 review)', () => {
+  it('the shipped template has no missing and no unknown tokens', () => {
+    expect(missingSkillTokens()).toEqual([]);
+    expect(unknownSkillTokens()).toEqual([]);
+  });
+
+  it('detects a token the template uses but nothing supplies', () => {
+    const drifted = loadSkillTemplate().replace('{{peerId}}', '{{networkId}}');
+    expect(unknownSkillTokens(drifted)).toEqual(['networkId']);
+    expect(missingSkillTokens(drifted)).toEqual(['peerId']);
+  });
+
+  it('REQUIRED_SKILL_TOKENS is derived, not a parallel list', () => {
+    expect([...REQUIRED_SKILL_TOKENS].sort()).toEqual(
+      ['baseUrl', 'extractionPipelines', 'nodeRole', 'nodeVersion', 'peerId'],
+    );
   });
 });

--- a/packages/cli/test/skill-dynamic-substitution.test.ts
+++ b/packages/cli/test/skill-dynamic-substitution.test.ts
@@ -203,3 +203,84 @@ describe('token contract has one source of truth (GH#1125 review)', () => {
     );
   });
 });
+
+// PR #2331 review — substituting one token at a time rescans the growing
+// OUTPUT, so a value could itself invoke the template language. `baseUrl` comes
+// from the `X-Forwarded-Host` / `Host` headers on a public unauthenticated
+// endpoint, so this was request-controlled: `http://{{peerId}}` rendered the
+// real peer ID into the advertised API URL. One pass over the ORIGINAL template
+// closes it.
+describe('buildSkillMd — values are never re-scanned as template syntax (GH#1125 review)', () => {
+  const base = {
+    version: '10.0.14',
+    peerId: '12D3KooWSensitivePeerIdentifier',
+    nodeRole: 'edge',
+    extractionPipelines: ['markitdown'],
+  };
+
+  it('does not resolve a token injected through baseUrl', () => {
+    const md = buildSkillMd({ ...base, baseUrl: 'http://{{peerId}}' });
+    expect(md).toContain('- **Base URL:** http://{{peerId}}');
+    expect(md).not.toContain(`http://${base.peerId}`);
+  });
+
+  it('does not depend on token processing order', () => {
+    // `nodeVersion` sorts before `baseUrl`; under the old loop this left raw
+    // syntax while `{{peerId}}` resolved. Both must now be verbatim.
+    for (const token of ['nodeVersion', 'baseUrl', 'peerId', 'nodeRole', 'extractionPipelines']) {
+      const md = buildSkillMd({ ...base, baseUrl: `http://{{${token}}}` });
+      expect(md).toContain(`- **Base URL:** http://{{${token}}}`);
+    }
+  });
+
+  it('treats injected tokens in every other field as literal too', () => {
+    const md = buildSkillMd({
+      ...base,
+      version: '{{peerId}}',
+      nodeRole: '{{baseUrl}}',
+      baseUrl: 'http://localhost:9200',
+      extractionPipelines: ['{{nodeVersion}}'],
+    });
+    expect(md).toContain('- **Node version:** {{peerId}}');
+    expect(md).toContain('- **Node role:** {{baseUrl}}');
+    expect(md).toContain('- **Available extraction pipelines:** {{nodeVersion}}');
+  });
+
+  it('still emits $-sequences literally and without amplification', () => {
+    const normal = buildSkillMd({ ...base, baseUrl: 'http://localhost:9200' }).length;
+    const md = buildSkillMd({ ...base, baseUrl: "http://h/" + "$'".repeat(5) });
+    expect(md).toContain("- **Base URL:** http://h/$'$'$'$'$'");
+    expect(md.length).toBeLessThan(normal + 200);
+  });
+});
+
+// PR #2331 review — the boundary must enforce its own contract, not leave it to
+// a test. Adding `{{networkId}}` to SKILL.md previously rendered it verbatim
+// into the served document.
+describe('renderSkillTemplate rejects an unsupplied token (GH#1125 review)', () => {
+  it('throws, naming the token, rather than serving it raw', () => {
+    const drifted = loadSkillTemplate().replace('{{peerId}}', '{{networkId}}');
+    expect(() => renderSkillTemplate(
+      {
+        nodeVersion: '1', baseUrl: '2', peerId: '3', nodeRole: '4', extractionPipelines: '5',
+      },
+      drifted,
+    )).toThrow(/networkId/);
+  });
+
+  it('the shipped template renders without throwing', () => {
+    expect(() => renderStandaloneDkgNodeSkill()).not.toThrow();
+  });
+});
+
+// PR #2331 review — the standalone copy told readers to run `dkg status` for
+// extraction pipelines, which does not report them. The served skill doc does.
+describe('standalone guidance points somewhere that answers (GH#1125 review)', () => {
+  it('does not send readers to dkg status for pipelines', () => {
+    const line = renderStandaloneDkgNodeSkill()
+      .split('\n')
+      .find((l) => l.startsWith('- **Available extraction pipelines:**'))!;
+    expect(line).not.toContain('dkg status');
+    expect(line).toContain('/.well-known/skill.md');
+  });
+});

--- a/packages/cli/test/skill-endpoint.test.ts
+++ b/packages/cli/test/skill-endpoint.test.ts
@@ -73,8 +73,17 @@ describe('SKILL.md file', () => {
     expect(skillContent).toContain('## 10. Common Workflows');
   });
 
-  it('contains dynamic placeholders for node info', () => {
-    expect(skillContent).toContain('(dynamic)');
+  it('contains substitution tokens for node info', () => {
+    // GH#1125 — the template used to carry literal `(dynamic)` text that
+    // `buildSkillMd` swapped out wholesale with one literal `String.replace`.
+    // That failed silently the moment the copy in manifest.ts drifted from the
+    // Markdown here, so the served doc shipped the placeholders verbatim. The
+    // template now carries named `{{token}}` values substituted individually;
+    // `skill-dynamic-substitution.test.ts` pins the rendered output.
+    expect(skillContent).not.toContain('(dynamic)');
+    expect(skillContent).toContain('{{nodeVersion}}');
+    expect(skillContent).toContain('{{baseUrl}}');
+    expect(skillContent).toContain('{{peerId}}');
     expect(skillContent).toContain('**Node version:**');
     expect(skillContent).toContain('**Base URL:**');
     expect(skillContent).toContain('**Peer ID:**');


### PR DESCRIPTION
## Summary

`/.well-known/skill.md` is the documented bootstrap entry point for MCP, OpenClaw and Hermes agents — and its §1 Node Info block was serving `- **Node version:** (dynamic)`, `- **Peer ID:** (dynamic)` and the rest to every agent that read it.

**Root cause.** `buildSkillMd` substitutes with `String.replace(literalNeedle, …)`, which fails **silently** when the needle does not match. The needle carried a trailing prose paragraph that had drifted out of sync with `SKILL.md` — the `dkg_list_context_graphs` and `GET /api/context-graph/list` mentions are **order-swapped** between the two files. That single divergence meant the *entire* block was never substituted.

## Changes

- Anchor the needle on just the five bullets, which are structural, so prose edits can no longer disable substitution.
- Warn when the anchor is missing instead of silently serving placeholders again.

## Test Plan

- [x] New `packages/cli/test/skill-dynamic-substitution.test.ts` — 5 cases, incl. “serves no literal `(dynamic)` anywhere”.
- [x] **Mutation-tested**: restoring the drifted prose into the needle reproduces the original bug and fails three cases.
- [x] cli: 241 files pass, 0 failed.

Closes #1125

🤖 Generated with [Claude Code](https://claude.com/claude-code)