### PR TITLE
fix(agent): give `dkg wallet` an actionable error for a bad key (#1432)

### DIFF
--- a/packages/agent/src/op-wallets.ts
+++ b/packages/agent/src/op-wallets.ts
@@ -191,8 +191,17 @@ function createWalletEntry(): WalletEntry {
   return { address: wallet.address, privateKey: wallet.privateKey };
 }
 
-/** Matches an ethers-acceptable secp256k1 key: 0x + 32 bytes of hex. */
-const PRIVATE_KEY_RE = /^0x[0-9a-fA-F]{64}$/;
+/**
+ * Matches an ethers-acceptable secp256k1 key: 32 bytes of hex, with the `0x`
+ * prefix OPTIONAL.
+ *
+ * The prefix really is optional to ethers — `new ethers.Wallet('11'.repeat(32))`
+ * derives the same address as the `0x`-prefixed form — so requiring it here
+ * would reject a wallets.json that works today. This guard exists to turn an
+ * unactionable ethers error into a diagnosable one, not to tighten what the
+ * loader accepts.
+ */
+const PRIVATE_KEY_RE = /^(?:0x)?[0-9a-fA-F]{64}$/;
 
 function validateWalletEntry(entry: WalletEntry, path: string): WalletEntry {
   // GH#1432 — `new ethers.Wallet(...)` throws INVALID_ARGUMENT with the value
@@ -204,7 +213,7 @@ function validateWalletEntry(entry: WalletEntry, path: string): WalletEntry {
       ? 'is missing'
       : typeof entry.privateKey !== 'string'
         ? `is a ${typeof entry.privateKey}, not a string`
-        : `is ${entry.privateKey.length} characters (expected 66: 0x + 64 hex)`;
+        : `is ${entry.privateKey.length} characters (expected 64 hex characters, optionally 0x-prefixed)`;
     throw new Error(
       `Invalid operational wallet key at ${path} in wallets.json: privateKey ${shape}. ` +
         `Entries must carry either an encrypted \`keystore\` or a plaintext \`privateKey\`; ` +

--- a/packages/agent/src/op-wallets.ts
+++ b/packages/agent/src/op-wallets.ts
@@ -96,8 +96,25 @@ export async function loadOpWallets(
         }
         // Legacy plaintext entry — accepted (back-compat), and flagged for
         // opportunistic migration to an encrypted keystore below.
+        // GH#1432 — an entry with NEITHER `keystore` nor `privateKey` lands
+        // here too (isEncryptedEntry only tests `keystore`), and the old
+        // `as string` cast handed `undefined` straight to ethers. Only count it
+        // as legacy plaintext once we know a key is actually present.
+        if (stored.privateKey === undefined || stored.privateKey === null || stored.privateKey === '') {
+          throw new Error(
+            `Operational wallet at ${path} in wallets.json has no key: it carries neither an ` +
+              `encrypted \`keystore\` nor a plaintext \`privateKey\`. Restore the entry from backup, ` +
+              `or remove it and let the node provision a replacement.`,
+          );
+        }
         sawLegacyPlaintext = true;
-        return validateWalletEntry({ address: stored.address, privateKey: stored.privateKey as string }, path);
+        // A present-but-malformed key falls through to validateWalletEntry, which
+        // reports the specific defect (wrong type / wrong length) rather than the
+        // generic "no key" above.
+        return validateWalletEntry(
+          { address: stored.address, privateKey: stored.privateKey as string },
+          path,
+        );
       };
 
       const wallets = existingWallets.map((w, index) => resolve(w, `wallets[${index}]`));
@@ -174,7 +191,26 @@ function createWalletEntry(): WalletEntry {
   return { address: wallet.address, privateKey: wallet.privateKey };
 }
 
+/** Matches an ethers-acceptable secp256k1 key: 0x + 32 bytes of hex. */
+const PRIVATE_KEY_RE = /^0x[0-9a-fA-F]{64}$/;
+
 function validateWalletEntry(entry: WalletEntry, path: string): WalletEntry {
+  // GH#1432 — `new ethers.Wallet(...)` throws INVALID_ARGUMENT with the value
+  // redacted, naming neither the file nor the offending entry, so `dkg wallet`
+  // died with a message an operator could not act on. Check the shape first and
+  // say exactly which entry in which file is wrong.
+  if (typeof entry.privateKey !== 'string' || !PRIVATE_KEY_RE.test(entry.privateKey)) {
+    const shape = entry.privateKey === undefined || entry.privateKey === null
+      ? 'is missing'
+      : typeof entry.privateKey !== 'string'
+        ? `is a ${typeof entry.privateKey}, not a string`
+        : `is ${entry.privateKey.length} characters (expected 66: 0x + 64 hex)`;
+    throw new Error(
+      `Invalid operational wallet key at ${path} in wallets.json: privateKey ${shape}. ` +
+        `Entries must carry either an encrypted \`keystore\` or a plaintext \`privateKey\`; ` +
+        `this one carries neither in usable form. Address on the entry: ${entry.address ?? '(none)'}.`,
+    );
+  }
   const derived = new ethers.Wallet(entry.privateKey);
   if (derived.address.toLowerCase() !== entry.address.toLowerCase()) {
     throw new Error(

--- a/packages/agent/src/op-wallets.ts
+++ b/packages/agent/src/op-wallets.ts
@@ -103,21 +103,17 @@ export async function loadOpWallets(
         // but malformed goes to validateWalletEntry, which lets ethers judge it
         // and reports the entry path.
         if (stored.privateKey === undefined || stored.privateKey === null || stored.privateKey === '') {
-          // PR #2332 review — do NOT promise provisioning. `loadOpWallets` never
-          // replenishes an entry in an existing file: deleting one just leaves
-          // fewer wallets, and deleting `adminWallet` leaves it undefined.
-          // Say what actually happens, and say it differently for the two cases.
-          const consequence =
-            path === 'adminWallet'
-              ? 'Removing it leaves the node with no admin wallet; it is NOT regenerated on load. ' +
-                'Restore the key from backup, or remove the entry deliberately and re-provision ' +
-                'the admin wallet with the documented procedure.'
-              : 'Removing it leaves the node with one fewer operational wallet; a replacement is ' +
-                'NOT provisioned on load. Restore the key from backup, or remove the entry ' +
-                'deliberately, accepting the reduced wallet count.';
+          // PR #2332 review — do NOT promise provisioning: `loadOpWallets`
+          // never replenishes an entry, so removing one just leaves fewer
+          // wallets (or no admin wallet). Keep it factual and role-neutral —
+          // an earlier version selected guidance by comparing the display path
+          // to the literal 'adminWallet', which would silently pick the wrong
+          // branch if that locator were ever reformatted.
           throw new Error(
-            `Operational wallet at ${path} in wallets.json has no key: it carries neither an ` +
-              `encrypted \`keystore\` nor a plaintext \`privateKey\`. ${consequence}`,
+            `Wallet entry at ${path} in wallets.json has no key: it carries neither an ` +
+              `encrypted \`keystore\` nor a plaintext \`privateKey\`. Restore the key from backup; ` +
+              `removing the entry is NOT repaired on load — the node simply starts with that ` +
+              `wallet absent.`,
           );
         }
         sawLegacyPlaintext = true;
@@ -202,33 +198,38 @@ function createWalletEntry(): WalletEntry {
 }
 
 /**
- * Describe a rejected key WITHOUT revealing it.
+ * Describe a rejected key WITHOUT revealing it, and WITHOUT reimplementing
+ * ethers' grammar.
  *
- * PR #2332 review — an earlier version kept a local regex copy of ethers'
- * private-key grammar. That duplicated a dependency-owned contract for the
- * sake of an error message: it already had to be widened once when ethers
- * turned out to accept bare hex, and it still admitted values ethers rejects
- * (all-zero, or a scalar at/above the secp256k1 order). `ethers.Wallet` stays
- * the canonical validator; this only supplies the context its error lacks.
+ * PR #2332 review — an earlier version classified prefix/hex/length locally to
+ * explain WHY a key was refused. That recreated a dependency-owned parser: it
+ * already had to be widened once when ethers turned out to accept bare hex, and
+ * it then misdiagnosed an uppercase `0X` prefix (which ethers rejects, but whose
+ * payload is perfectly in range) as an out-of-range scalar. `ethers.Wallet`
+ * owns validity; this reports only what is knowable locally and safe to print.
  */
 function describeRejectedKey(value: unknown): string {
   if (value === undefined || value === null) return 'is missing';
   if (typeof value !== 'string') return `is a ${typeof value}, not a string`;
   if (value.length === 0) return 'is empty';
-  const hex = value.startsWith('0x') || value.startsWith('0X') ? value.slice(2) : value;
-  if (!/^[0-9a-fA-F]*$/.test(hex)) return 'contains non-hexadecimal characters';
-  if (hex.length !== 64) {
-    return `is ${hex.length} hex characters (expected 64, optionally 0x-prefixed)`;
-  }
-  // Correct shape, still refused: out of range for secp256k1 (zero, or >= n).
-  return 'is not a valid secp256k1 key (out of range)';
+  return 'is not a key ethers accepts (expected 64 hex characters, optionally 0x-prefixed)';
+}
+
+/**
+ * `address` is UNTRUSTED until it parses. A malformed wallets.json can carry
+ * key material in that field, and this message goes to console and daemon logs
+ * — so print it only once it is a well-formed public address (PR #2332 review).
+ */
+function safeAddressForDiagnostic(address: unknown): string {
+  return typeof address === 'string' && /^0x[0-9a-fA-F]{40}$/.test(address)
+    ? address
+    : '(missing or malformed)';
 }
 
 /**
  * A wallets.json entry as PARSED, before validation. `privateKey` is `unknown`
- * because the file is untrusted input: the previous signature declared it a
- * `string`, which forced callers into an `as string` cast and split the
- * validation across two places (PR #2332 review).
+ * because the file is untrusted input: declaring it a `string` forced callers
+ * into an `as string` cast and split validation across two places.
  */
 interface CandidateWalletEntry {
   address: string;
@@ -239,8 +240,8 @@ function validateWalletEntry(entry: CandidateWalletEntry, path: string): WalletE
   // GH#1432 — `new ethers.Wallet(...)` throws INVALID_ARGUMENT with the value
   // redacted, naming neither the file nor the offending entry, so `dkg wallet`
   // died with a message an operator could not act on. Let ethers decide what is
-  // valid, and translate its refusal into something addressable. The key itself
-  // is never echoed.
+  // valid, and add the context its error lacks. Neither the key nor an
+  // unvalidated address is ever echoed.
   let derived: ethers.Wallet;
   try {
     derived = new ethers.Wallet(entry.privateKey as string);
@@ -248,7 +249,7 @@ function validateWalletEntry(entry: CandidateWalletEntry, path: string): WalletE
     throw new Error(
       `Invalid operational wallet key at ${path} in wallets.json: privateKey ` +
         `${describeRejectedKey(entry.privateKey)}. Address on the entry: ` +
-        `${entry.address ?? '(none)'}.`,
+        `${safeAddressForDiagnostic(entry.address)}.`,
     );
   }
   if (derived.address.toLowerCase() !== entry.address.toLowerCase()) {

--- a/packages/agent/src/op-wallets.ts
+++ b/packages/agent/src/op-wallets.ts
@@ -98,23 +98,33 @@ export async function loadOpWallets(
         // opportunistic migration to an encrypted keystore below.
         // GH#1432 — an entry with NEITHER `keystore` nor `privateKey` lands
         // here too (isEncryptedEntry only tests `keystore`), and the old
-        // `as string` cast handed `undefined` straight to ethers. Only count it
-        // as legacy plaintext once we know a key is actually present.
+        // cast handed `undefined` straight to ethers. Only count it as legacy
+        // plaintext once we know a key is actually present; anything present
+        // but malformed goes to validateWalletEntry, which lets ethers judge it
+        // and reports the entry path.
         if (stored.privateKey === undefined || stored.privateKey === null || stored.privateKey === '') {
+          // PR #2332 review — do NOT promise provisioning. `loadOpWallets` never
+          // replenishes an entry in an existing file: deleting one just leaves
+          // fewer wallets, and deleting `adminWallet` leaves it undefined.
+          // Say what actually happens, and say it differently for the two cases.
+          const consequence =
+            path === 'adminWallet'
+              ? 'Removing it leaves the node with no admin wallet; it is NOT regenerated on load. ' +
+                'Restore the key from backup, or remove the entry deliberately and re-provision ' +
+                'the admin wallet with the documented procedure.'
+              : 'Removing it leaves the node with one fewer operational wallet; a replacement is ' +
+                'NOT provisioned on load. Restore the key from backup, or remove the entry ' +
+                'deliberately, accepting the reduced wallet count.';
           throw new Error(
             `Operational wallet at ${path} in wallets.json has no key: it carries neither an ` +
-              `encrypted \`keystore\` nor a plaintext \`privateKey\`. Restore the entry from backup, ` +
-              `or remove it and let the node provision a replacement.`,
+              `encrypted \`keystore\` nor a plaintext \`privateKey\`. ${consequence}`,
           );
         }
         sawLegacyPlaintext = true;
         // A present-but-malformed key falls through to validateWalletEntry, which
         // reports the specific defect (wrong type / wrong length) rather than the
         // generic "no key" above.
-        return validateWalletEntry(
-          { address: stored.address, privateKey: stored.privateKey as string },
-          path,
-        );
+        return validateWalletEntry({ address: stored.address, privateKey: stored.privateKey }, path);
       };
 
       const wallets = existingWallets.map((w, index) => resolve(w, `wallets[${index}]`));
@@ -192,35 +202,55 @@ function createWalletEntry(): WalletEntry {
 }
 
 /**
- * Matches an ethers-acceptable secp256k1 key: 32 bytes of hex, with the `0x`
- * prefix OPTIONAL.
+ * Describe a rejected key WITHOUT revealing it.
  *
- * The prefix really is optional to ethers — `new ethers.Wallet('11'.repeat(32))`
- * derives the same address as the `0x`-prefixed form — so requiring it here
- * would reject a wallets.json that works today. This guard exists to turn an
- * unactionable ethers error into a diagnosable one, not to tighten what the
- * loader accepts.
+ * PR #2332 review — an earlier version kept a local regex copy of ethers'
+ * private-key grammar. That duplicated a dependency-owned contract for the
+ * sake of an error message: it already had to be widened once when ethers
+ * turned out to accept bare hex, and it still admitted values ethers rejects
+ * (all-zero, or a scalar at/above the secp256k1 order). `ethers.Wallet` stays
+ * the canonical validator; this only supplies the context its error lacks.
  */
-const PRIVATE_KEY_RE = /^(?:0x)?[0-9a-fA-F]{64}$/;
+function describeRejectedKey(value: unknown): string {
+  if (value === undefined || value === null) return 'is missing';
+  if (typeof value !== 'string') return `is a ${typeof value}, not a string`;
+  if (value.length === 0) return 'is empty';
+  const hex = value.startsWith('0x') || value.startsWith('0X') ? value.slice(2) : value;
+  if (!/^[0-9a-fA-F]*$/.test(hex)) return 'contains non-hexadecimal characters';
+  if (hex.length !== 64) {
+    return `is ${hex.length} hex characters (expected 64, optionally 0x-prefixed)`;
+  }
+  // Correct shape, still refused: out of range for secp256k1 (zero, or >= n).
+  return 'is not a valid secp256k1 key (out of range)';
+}
 
-function validateWalletEntry(entry: WalletEntry, path: string): WalletEntry {
+/**
+ * A wallets.json entry as PARSED, before validation. `privateKey` is `unknown`
+ * because the file is untrusted input: the previous signature declared it a
+ * `string`, which forced callers into an `as string` cast and split the
+ * validation across two places (PR #2332 review).
+ */
+interface CandidateWalletEntry {
+  address: string;
+  privateKey: unknown;
+}
+
+function validateWalletEntry(entry: CandidateWalletEntry, path: string): WalletEntry {
   // GH#1432 — `new ethers.Wallet(...)` throws INVALID_ARGUMENT with the value
   // redacted, naming neither the file nor the offending entry, so `dkg wallet`
-  // died with a message an operator could not act on. Check the shape first and
-  // say exactly which entry in which file is wrong.
-  if (typeof entry.privateKey !== 'string' || !PRIVATE_KEY_RE.test(entry.privateKey)) {
-    const shape = entry.privateKey === undefined || entry.privateKey === null
-      ? 'is missing'
-      : typeof entry.privateKey !== 'string'
-        ? `is a ${typeof entry.privateKey}, not a string`
-        : `is ${entry.privateKey.length} characters (expected 64 hex characters, optionally 0x-prefixed)`;
+  // died with a message an operator could not act on. Let ethers decide what is
+  // valid, and translate its refusal into something addressable. The key itself
+  // is never echoed.
+  let derived: ethers.Wallet;
+  try {
+    derived = new ethers.Wallet(entry.privateKey as string);
+  } catch {
     throw new Error(
-      `Invalid operational wallet key at ${path} in wallets.json: privateKey ${shape}. ` +
-        `Entries must carry either an encrypted \`keystore\` or a plaintext \`privateKey\`; ` +
-        `this one carries neither in usable form. Address on the entry: ${entry.address ?? '(none)'}.`,
+      `Invalid operational wallet key at ${path} in wallets.json: privateKey ` +
+        `${describeRejectedKey(entry.privateKey)}. Address on the entry: ` +
+        `${entry.address ?? '(none)'}.`,
     );
   }
-  const derived = new ethers.Wallet(entry.privateKey);
   if (derived.address.toLowerCase() !== entry.address.toLowerCase()) {
     throw new Error(
       `Address mismatch in wallets.json ${path}: expected ${derived.address} but got ${entry.address}`,

--- a/packages/agent/test/op-wallets-key-diagnostics.test.ts
+++ b/packages/agent/test/op-wallets-key-diagnostics.test.ts
@@ -40,9 +40,7 @@ describe('loadOpWallets — actionable key diagnostics (GH#1432)', () => {
     await writeWallets(dir, [{ address: '0x1111111111111111111111111111111111111111', privateKey: '0xdeadbeef' }]);
 
     await expect(loadOpWallets(dir)).rejects.toThrow(/wallets\[0\]/);
-    // Reported in HEX characters (the `0x` is not counted), so the number
-    // lines up with the "expected 64" it is compared against.
-    await expect(loadOpWallets(dir)).rejects.toThrow(/is 8 hex characters \(expected 64/);
+    await expect(loadOpWallets(dir)).rejects.toThrow(/not a key ethers accepts/);
   });
 
   it('names the entry for a non-string key', async () => {
@@ -105,7 +103,7 @@ describe('loadOpWallets — actionable key diagnostics (GH#1432)', () => {
     ]);
 
     await expect(loadOpWallets(dir)).rejects.toThrow(/wallets\[0\]/);
-    await expect(loadOpWallets(dir)).rejects.toThrow(/non-hexadecimal/);
+    await expect(loadOpWallets(dir)).rejects.toThrow(/not a key ethers accepts/);
     await expect(loadOpWallets(dir)).rejects.not.toThrow(/INVALID_ARGUMENT/);
   });
 
@@ -118,7 +116,7 @@ describe('loadOpWallets — actionable key diagnostics (GH#1432)', () => {
     ]);
 
     await expect(loadOpWallets(dir)).rejects.toThrow(/wallets\[0\]/);
-    await expect(loadOpWallets(dir)).rejects.toThrow(/out of range/);
+    await expect(loadOpWallets(dir)).rejects.toThrow(/not a key ethers accepts/);
   });
 
   it('names the entry for a key at the secp256k1 group order', async () => {
@@ -128,7 +126,7 @@ describe('loadOpWallets — actionable key diagnostics (GH#1432)', () => {
     await writeWallets(dir, [{ address: '0x1111111111111111111111111111111111111111', privateKey: n }]);
 
     await expect(loadOpWallets(dir)).rejects.toThrow(/wallets\[0\]/);
-    await expect(loadOpWallets(dir)).rejects.toThrow(/out of range/);
+    await expect(loadOpWallets(dir)).rejects.toThrow(/not a key ethers accepts/);
   });
 
   it('never echoes the rejected key material in the diagnostic', async () => {
@@ -153,7 +151,7 @@ describe('loadOpWallets — actionable key diagnostics (GH#1432)', () => {
     ]);
 
     await expect(loadOpWallets(dir)).rejects.toThrow(/wallets\[1\]/);
-    await expect(loadOpWallets(dir)).rejects.toThrow(/NOT provisioned on load/);
+    await expect(loadOpWallets(dir)).rejects.toThrow(/NOT repaired on load/);
 
     // And the promise holds: removing the entry yields one wallet, not two.
     await writeWallets(dir, [{ address: new Wallet(good).address, privateKey: good }]);
@@ -175,7 +173,34 @@ describe('loadOpWallets — actionable key diagnostics (GH#1432)', () => {
     );
 
     await expect(loadOpWallets(dir)).rejects.toThrow(/adminWallet/);
-    await expect(loadOpWallets(dir)).rejects.toThrow(/no admin wallet/);
-    await expect(loadOpWallets(dir)).rejects.toThrow(/NOT regenerated on load/);
+    await expect(loadOpWallets(dir)).rejects.toThrow(/NOT repaired on load/);
+  });
+
+  // PR #2332 review — the diagnostic must not become a secret-disclosure path.
+  // A malformed file can duplicate key material into `address`, and this
+  // message goes to console and daemon logs.
+  it('never echoes key material that was copied into the address field', async () => {
+    const dir = await tempDir();
+    const leaked = '0x' + 'ab'.repeat(32) + 'ff'; // 33 bytes -> rejected
+    await writeWallets(dir, [{ address: leaked, privateKey: leaked }]);
+
+    await expect(loadOpWallets(dir)).rejects.toThrow(/wallets\[0\]/);
+    // Neither copy may appear, in any casing.
+    await expect(loadOpWallets(dir)).rejects.not.toThrow(new RegExp('ab'.repeat(8), 'i'));
+    await expect(loadOpWallets(dir)).rejects.toThrow(/missing or malformed/);
+  });
+
+  // PR #2332 review — ethers REJECTS an uppercase `0X` prefix even though the
+  // payload is in range, so the diagnostic must not claim to know the reason.
+  it('does not misdiagnose an uppercase 0X prefix as a scalar problem', async () => {
+    const dir = await tempDir();
+    await writeWallets(dir, [
+      { address: '0x1111111111111111111111111111111111111111', privateKey: '0X' + '11'.repeat(32) },
+    ]);
+
+    await expect(loadOpWallets(dir)).rejects.toThrow(/wallets\[0\]/);
+    await expect(loadOpWallets(dir)).rejects.toThrow(/not a key ethers accepts/);
+    // The old classifier stripped `0X` and reported an out-of-range scalar.
+    await expect(loadOpWallets(dir)).rejects.not.toThrow(/out of range/);
   });
 });

--- a/packages/agent/test/op-wallets-key-diagnostics.test.ts
+++ b/packages/agent/test/op-wallets-key-diagnostics.test.ts
@@ -40,7 +40,9 @@ describe('loadOpWallets — actionable key diagnostics (GH#1432)', () => {
     await writeWallets(dir, [{ address: '0x1111111111111111111111111111111111111111', privateKey: '0xdeadbeef' }]);
 
     await expect(loadOpWallets(dir)).rejects.toThrow(/wallets\[0\]/);
-    await expect(loadOpWallets(dir)).rejects.toThrow(/10 characters/);
+    // Reported in HEX characters (the `0x` is not counted), so the number
+    // lines up with the "expected 64" it is compared against.
+    await expect(loadOpWallets(dir)).rejects.toThrow(/is 8 hex characters \(expected 64/);
   });
 
   it('names the entry for a non-string key', async () => {
@@ -91,5 +93,89 @@ describe('loadOpWallets — actionable key diagnostics (GH#1432)', () => {
     const cfg = await loadOpWallets(dir);
     expect(cfg.wallets).toHaveLength(1);
     expect(cfg.wallets[0]!.privateKey).toBe(key);
+  });
+
+  // PR #2332 review — length alone is not discriminating: a regression to a
+  // simple 66-character check would leave the earlier cases green while
+  // same-length malformed keys fell through to the opaque ethers error.
+  it('names the entry for a same-length key containing non-hex characters', async () => {
+    const dir = await tempDir();
+    await writeWallets(dir, [
+      { address: '0x1111111111111111111111111111111111111111', privateKey: '0x' + 'z'.repeat(64) },
+    ]);
+
+    await expect(loadOpWallets(dir)).rejects.toThrow(/wallets\[0\]/);
+    await expect(loadOpWallets(dir)).rejects.toThrow(/non-hexadecimal/);
+    await expect(loadOpWallets(dir)).rejects.not.toThrow(/INVALID_ARGUMENT/);
+  });
+
+  // Correct shape, still refused by secp256k1. The old regex admitted these,
+  // so ethers produced the unactionable error the issue is about.
+  it('names the entry for an all-zero key (valid shape, invalid scalar)', async () => {
+    const dir = await tempDir();
+    await writeWallets(dir, [
+      { address: '0x1111111111111111111111111111111111111111', privateKey: '0x' + '0'.repeat(64) },
+    ]);
+
+    await expect(loadOpWallets(dir)).rejects.toThrow(/wallets\[0\]/);
+    await expect(loadOpWallets(dir)).rejects.toThrow(/out of range/);
+  });
+
+  it('names the entry for a key at the secp256k1 group order', async () => {
+    const dir = await tempDir();
+    // n itself is out of range (valid keys are 1 <= k < n).
+    const n = '0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141';
+    await writeWallets(dir, [{ address: '0x1111111111111111111111111111111111111111', privateKey: n }]);
+
+    await expect(loadOpWallets(dir)).rejects.toThrow(/wallets\[0\]/);
+    await expect(loadOpWallets(dir)).rejects.toThrow(/out of range/);
+  });
+
+  it('never echoes the rejected key material in the diagnostic', async () => {
+    const dir = await tempDir();
+    const secretish = '0x' + 'ab'.repeat(32) + 'ff';
+    await writeWallets(dir, [
+      { address: '0x1111111111111111111111111111111111111111', privateKey: secretish },
+    ]);
+    await expect(loadOpWallets(dir)).rejects.not.toThrow(new RegExp('ab'.repeat(8)));
+  });
+
+  // PR #2332 review — the diagnostic must describe what a later load ACTUALLY
+  // does. The loader never replenishes an entry, so promising provisioning
+  // would send an operator down a path that silently reduces wallet count.
+  it('describes the real recovery outcome for an operational entry', async () => {
+    const dir = await tempDir();
+    const good = '0x' + '11'.repeat(32);
+    const { Wallet } = await import('ethers');
+    await writeWallets(dir, [
+      { address: new Wallet(good).address, privateKey: good },
+      { address: '0x2222222222222222222222222222222222222222' },
+    ]);
+
+    await expect(loadOpWallets(dir)).rejects.toThrow(/wallets\[1\]/);
+    await expect(loadOpWallets(dir)).rejects.toThrow(/NOT provisioned on load/);
+
+    // And the promise holds: removing the entry yields one wallet, not two.
+    await writeWallets(dir, [{ address: new Wallet(good).address, privateKey: good }]);
+    const cfg = await loadOpWallets(dir);
+    expect(cfg.wallets).toHaveLength(1);
+  });
+
+  it('describes the real recovery outcome for the admin entry', async () => {
+    const dir = await tempDir();
+    const good = '0x' + '11'.repeat(32);
+    const { Wallet } = await import('ethers');
+    await writeFile(
+      join(dir, 'wallets.json'),
+      JSON.stringify({
+        adminWallet: { address: '0x2222222222222222222222222222222222222222' },
+        wallets: [{ address: new Wallet(good).address, privateKey: good }],
+      }),
+      'utf-8',
+    );
+
+    await expect(loadOpWallets(dir)).rejects.toThrow(/adminWallet/);
+    await expect(loadOpWallets(dir)).rejects.toThrow(/no admin wallet/);
+    await expect(loadOpWallets(dir)).rejects.toThrow(/NOT regenerated on load/);
   });
 });

--- a/packages/agent/test/op-wallets-key-diagnostics.test.ts
+++ b/packages/agent/test/op-wallets-key-diagnostics.test.ts
@@ -1,0 +1,80 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+import { loadOpWallets } from '../src/op-wallets.js';
+
+// GH#1128 sibling / GH#1432 — `dkg wallet` died with ethers'
+// `invalid private key (argument="privateKey", value="[ REDACTED ]",
+// code=INVALID_ARGUMENT)`, which names neither the file nor the entry, so an
+// operator had no path from the message to the fix. `validateWalletEntry`
+// handed the value straight to `new ethers.Wallet(...)`, and the legacy branch
+// cast a possibly-absent `privateKey` with `as string`.
+const tempDirs: string[] = [];
+async function tempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'dkg-wallet-diag-'));
+  tempDirs.push(dir);
+  return dir;
+}
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((d) => rm(d, { recursive: true, force: true })));
+});
+
+async function writeWallets(dir: string, wallets: unknown[]): Promise<void> {
+  await writeFile(join(dir, 'wallets.json'), JSON.stringify({ wallets }, null, 2), 'utf-8');
+}
+
+describe('loadOpWallets — actionable key diagnostics (GH#1432)', () => {
+  it('names the entry when it carries neither keystore nor privateKey', async () => {
+    const dir = await tempDir();
+    await writeWallets(dir, [{ address: '0x1111111111111111111111111111111111111111' }]);
+
+    await expect(loadOpWallets(dir)).rejects.toThrow(/wallets\[0\]/);
+    await expect(loadOpWallets(dir)).rejects.toThrow(/wallets\.json/);
+    // The ethers message must not be what the operator sees.
+    await expect(loadOpWallets(dir)).rejects.not.toThrow(/INVALID_ARGUMENT/);
+  });
+
+  it('names the entry and the observed length for a truncated key', async () => {
+    const dir = await tempDir();
+    await writeWallets(dir, [{ address: '0x1111111111111111111111111111111111111111', privateKey: '0xdeadbeef' }]);
+
+    await expect(loadOpWallets(dir)).rejects.toThrow(/wallets\[0\]/);
+    await expect(loadOpWallets(dir)).rejects.toThrow(/10 characters/);
+  });
+
+  it('names the entry for a non-string key', async () => {
+    const dir = await tempDir();
+    await writeWallets(dir, [{ address: '0x1111111111111111111111111111111111111111', privateKey: 12345 }]);
+
+    await expect(loadOpWallets(dir)).rejects.toThrow(/is a number, not a string/);
+  });
+
+  it('reports adminWallet by name, not by index', async () => {
+    const dir = await tempDir();
+    const good = '0x' + '11'.repeat(32);
+    const { Wallet } = await import('ethers');
+    await writeFile(
+      join(dir, 'wallets.json'),
+      JSON.stringify({
+        // adminWallet carries no key; the operational entry is well-formed, so
+        // adminWallet must be what the error names.
+        adminWallet: { address: '0x2222222222222222222222222222222222222222' },
+        wallets: [{ address: new Wallet(good).address, privateKey: good }],
+      }),
+      'utf-8',
+    );
+    await expect(loadOpWallets(dir)).rejects.toThrow(/adminWallet/);
+  });
+
+  it('still loads a well-formed plaintext wallets.json', async () => {
+    const dir = await tempDir();
+    const key = '0x' + '11'.repeat(32);
+    const { Wallet } = await import('ethers');
+    await writeWallets(dir, [{ address: new Wallet(key).address, privateKey: key }]);
+
+    const cfg = await loadOpWallets(dir);
+    expect(cfg.wallets).toHaveLength(1);
+    expect(cfg.wallets[0]!.privateKey).toBe(key);
+  });
+});

--- a/packages/agent/test/op-wallets-key-diagnostics.test.ts
+++ b/packages/agent/test/op-wallets-key-diagnostics.test.ts
@@ -67,6 +67,21 @@ describe('loadOpWallets — actionable key diagnostics (GH#1432)', () => {
     await expect(loadOpWallets(dir)).rejects.toThrow(/adminWallet/);
   });
 
+  it('accepts a bare-hex key with no 0x prefix, as ethers does', async () => {
+    // Regression guard: ethers derives the same address from `'11'.repeat(32)`
+    // as from the 0x-prefixed form, so a wallets.json using the bare form works
+    // today. This guard must diagnose bad keys, not narrow what loads.
+    const dir = await tempDir();
+    const bare = '11'.repeat(32);
+    const { Wallet } = await import('ethers');
+    await writeWallets(dir, [{ address: new Wallet(bare).address, privateKey: bare }]);
+
+    const cfg = await loadOpWallets(dir);
+    expect(cfg.wallets).toHaveLength(1);
+    // Normalised to the 0x form on the way out, as before.
+    expect(cfg.wallets[0]!.privateKey).toBe('0x' + bare);
+  });
+
   it('still loads a well-formed plaintext wallets.json', async () => {
     const dir = await tempDir();
     const key = '0x' + '11'.repeat(32);


### PR DESCRIPTION
## Summary

`dkg wallet` died with ethers’ `invalid private key (argument="privateKey", value="[ REDACTED ]", code=INVALID_ARGUMENT)` — naming neither the file nor the offending entry. The daemon kept working with the same `wallets.json`, which made it look like a CLI-vs-daemon divergence.

It is one shared loader. The reporter’s theory was wrong, which is why the real cause went unfound:

- `validateWalletEntry` handed the value straight to `new ethers.Wallet(...)` with no shape check.
- `isEncryptedEntry` only tests for `keystore`, so an entry carrying **neither** a keystore **nor** a plaintext key falls into the legacy branch, where `stored.privateKey as string` passes `undefined` to ethers — exactly the reported crash on a keystore-shaped file.

## Changes

Check the shape first, and say which entry in which file is wrong and whether the key is missing, the wrong type, or the wrong length. A genuinely absent key gets its own message; a present-but-malformed one falls through to the type-specific diagnosis rather than being mislabelled “no key”.

## Test Plan

- [x] New `packages/agent/test/op-wallets-key-diagnostics.test.ts` — 5 cases, incl. `adminWallet` reported by name and a well-formed file still loading.
- [x] **Mutation-tested**: removing the guard fails all four diagnostic cases.
- [x] agent: all three op-wallets suites, 12/12.

Closes #1432

🤖 Generated with [Claude Code](https://claude.com/claude-code)