### PR TITLE
fix(adapter-hermes): stop silently lowercasing the on-chain author (#1086)

### DIFF
--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -2559,24 +2559,25 @@ def _normalize_wm_agent_address(agent_address: str) -> str:
         except Exception as exc:  # GH#1086
             # eth-utils ships no keccak backend by default and the Hermes setup
             # pip-installs nothing, so this path is reached routinely rather
-            # than exceptionally. Returning `value` unchanged silently emits a
-            # NON-CHECKSUMMED (usually all-lowercase) address as the on-chain
-            # author, which is a different string from the checksummed form
-            # every other surface writes — so attribution splits in two and the
-            # operator sees nothing explaining why.
+            # than exceptionally. Fail open: the value is still a usable
+            # identifier and refusing the call would be a worse regression.
             #
-            # Still fail open: a lowercase address is a valid EIP-55-agnostic
-            # identifier and refusing the write would be a worse regression
-            # than a mixed-case mismatch. But say so, once, loudly enough to be
-            # actionable.
+            # PR #2334 review — keep the wording OPERATION-NEUTRAL and
+            # CONDITIONAL. This helper is shared: it runs on the
+            # working-memory READ path (dkg_query, view="working-memory") as
+            # well as the finalize author path, and its input may ALREADY be
+            # checksummed, in which case returning it unchanged is correct.
+            # Asserting "this will split attribution" would be a definitive but
+            # often false diagnosis.
             global _CHECKSUM_FALLBACK_WARNED
             if not _CHECKSUM_FALLBACK_WARNED:
                 _CHECKSUM_FALLBACK_WARNED = True
                 logger.warning(
-                    "DKG: cannot checksum agent address %s (%s: %s). Emitting it "
-                    "unchanged, which will NOT match the checksummed form used "
-                    "elsewhere and will split author attribution. Install a keccak "
-                    "backend to fix: pip install 'eth-hash[pycryptodome]'",
+                    "DKG: could not canonicalize agent address %s to EIP-55 "
+                    "checksum form (%s: %s); using it as-is. If it is not "
+                    "already checksummed it may fail to match canonical "
+                    "identity records. Install a keccak backend to fix: "
+                    "pip install 'eth-hash[pycryptodome]'",
                     value,
                     type(exc).__name__,
                     exc,

--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -2543,6 +2543,11 @@ def _filter_context_graphs_for_scope(graphs: Any, scope: str) -> List[Any]:
 _ETH_ADDRESS_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
 
 
+# GH#1086 — one warning per process for a missing keccak backend; the
+# normalizer runs on every write and must not spam the operator log.
+_CHECKSUM_FALLBACK_WARNED = False
+
+
 def _normalize_wm_agent_address(agent_address: str) -> str:
     value = agent_address.strip()
     if value.startswith("did:dkg:agent:"):
@@ -2551,7 +2556,31 @@ def _normalize_wm_agent_address(agent_address: str) -> str:
         try:
             from eth_utils import to_checksum_address
             return to_checksum_address(value)
-        except Exception:
+        except Exception as exc:  # GH#1086
+            # eth-utils ships no keccak backend by default and the Hermes setup
+            # pip-installs nothing, so this path is reached routinely rather
+            # than exceptionally. Returning `value` unchanged silently emits a
+            # NON-CHECKSUMMED (usually all-lowercase) address as the on-chain
+            # author, which is a different string from the checksummed form
+            # every other surface writes — so attribution splits in two and the
+            # operator sees nothing explaining why.
+            #
+            # Still fail open: a lowercase address is a valid EIP-55-agnostic
+            # identifier and refusing the write would be a worse regression
+            # than a mixed-case mismatch. But say so, once, loudly enough to be
+            # actionable.
+            global _CHECKSUM_FALLBACK_WARNED
+            if not _CHECKSUM_FALLBACK_WARNED:
+                _CHECKSUM_FALLBACK_WARNED = True
+                logger.warning(
+                    "DKG: cannot checksum agent address %s (%s: %s). Emitting it "
+                    "unchanged, which will NOT match the checksummed form used "
+                    "elsewhere and will split author attribution. Install a keccak "
+                    "backend to fix: pip install 'eth-hash[pycryptodome]'",
+                    value,
+                    type(exc).__name__,
+                    exc,
+                )
             return value
     return value
 

--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -2543,8 +2543,9 @@ def _filter_context_graphs_for_scope(graphs: Any, scope: str) -> List[Any]:
 _ETH_ADDRESS_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
 
 
-# GH#1086 — one warning per process for a missing keccak backend; the
-# normalizer runs on every write and must not spam the operator log.
+# GH#1086 — the checksum fallback below warns at most once per process. The
+# normalizer runs on every call on both the read and the write path, so an
+# unconditional warning would flood the operator log.
 _CHECKSUM_FALLBACK_WARNED = False
 
 
@@ -2557,18 +2558,17 @@ def _normalize_wm_agent_address(agent_address: str) -> str:
             from eth_utils import to_checksum_address
             return to_checksum_address(value)
         except Exception as exc:  # GH#1086
-            # eth-utils ships no keccak backend by default and the Hermes setup
-            # pip-installs nothing, so this path is reached routinely rather
-            # than exceptionally. Fail open: the value is still a usable
-            # identifier and refusing the call would be a worse regression.
+            # eth-utils ships no keccak backend by default and the Hermes
+            # setup pip-installs nothing, so this is a routine condition rather
+            # than an exceptional one. Fail open: the value is still a usable
+            # identifier, and refusing the call would be the worse regression.
             #
-            # PR #2334 review — keep the wording OPERATION-NEUTRAL and
-            # CONDITIONAL. This helper is shared: it runs on the
-            # working-memory READ path (dkg_query, view="working-memory") as
-            # well as the finalize author path, and its input may ALREADY be
-            # checksummed, in which case returning it unchanged is correct.
-            # Asserting "this will split attribution" would be a definitive but
-            # often false diagnosis.
+            # INVARIANT: this helper is shared by the working-memory read path
+            # (dkg_query, view="working-memory") and the finalize author path,
+            # and its input may already be checksummed — in which case
+            # returning it unchanged is correct. Diagnostics here must
+            # therefore stay operation-neutral and conditional: never name a
+            # write-only consequence, and never assert the value is wrong.
             global _CHECKSUM_FALLBACK_WARNED
             if not _CHECKSUM_FALLBACK_WARNED:
                 _CHECKSUM_FALLBACK_WARNED = True

--- a/packages/adapter-hermes/pytests/test_agent_address_checksum_fallback.py
+++ b/packages/adapter-hermes/pytests/test_agent_address_checksum_fallback.py
@@ -25,12 +25,34 @@ LOWER = CHECKSUMMED.lower()
 
 @pytest.fixture
 def no_keccak(monkeypatch):
-    """Force the eth_utils import to fail, as it does on a stock Hermes install."""
+    """Reproduce the ACTUAL stock-Hermes failure: the import succeeds, and the
+    checksum raises lazily when it reaches for a keccak backend.
+
+    PR #2334 review — an earlier version of this fixture made the whole
+    `eth_utils` import fail. That is a different (and rarer) condition, and it
+    would have been satisfied by code that only handled a missing package,
+    giving false confidence about the documented failure path. eth-utils is
+    installed; what it lacks by default is a keccak backend, and
+    `to_checksum_address` raises at CALL time.
+    """
+    eth_utils = pytest.importorskip("eth_utils")
+
+    def raise_backend_unavailable(_value):
+        raise Exception(
+            "The backend `eth_hash.backends.pycryptodome` is not installed."
+        )
+
+    monkeypatch.setattr(eth_utils, "to_checksum_address", raise_backend_unavailable)
+
+
+@pytest.fixture
+def no_eth_utils(monkeypatch):
+    """The rarer variant: the package itself is absent. Still must fail open."""
     real_import = builtins.__import__
 
     def boom(name, *args, **kwargs):
         if name == "eth_utils":
-            raise ImportError("no keccak backend")
+            raise ImportError("No module named 'eth_utils'")
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", boom)
@@ -81,3 +103,14 @@ def test_fallback_warns_once_not_per_write(plugin_module, no_keccak, caplog):
 def test_non_address_values_pass_through_untouched(plugin_module):
     assert plugin_module._normalize_wm_agent_address("not-an-address") == "not-an-address"
     assert plugin_module._normalize_wm_agent_address("  ") == ""
+
+
+def test_missing_package_also_fails_open_with_a_warning(plugin_module, no_eth_utils, caplog):
+    """The import-error path is rarer but must behave identically."""
+    plugin_module._CHECKSUM_FALLBACK_WARNED = False
+
+    with caplog.at_level("WARNING"):
+        out = plugin_module._normalize_wm_agent_address(LOWER)
+
+    assert out == LOWER
+    assert "cannot checksum agent address" in caplog.text.lower()

--- a/packages/adapter-hermes/pytests/test_agent_address_checksum_fallback.py
+++ b/packages/adapter-hermes/pytests/test_agent_address_checksum_fallback.py
@@ -1,0 +1,83 @@
+"""GH#1086 — the finalize author-address normaliser lowercased in silence.
+
+``_normalize_wm_agent_address`` caught every exception from
+``to_checksum_address`` and returned the input verbatim. eth-utils ships no
+keccak backend by default and the Hermes setup pip-installs nothing, so this
+path is reached routinely rather than exceptionally — meaning a NON-checksummed
+address was written as the on-chain author, a different string from the
+checksummed form every other surface emits, splitting attribution with nothing
+in the log to explain it.
+
+The fallback must stay fail-open (a lowercase address is still a usable
+identifier; refusing the write would be the worse regression) but must warn,
+and must warn once rather than on every write.
+"""
+
+from __future__ import annotations
+
+import builtins
+
+import pytest
+
+CHECKSUMMED = "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"
+LOWER = CHECKSUMMED.lower()
+
+
+@pytest.fixture
+def no_keccak(monkeypatch):
+    """Force the eth_utils import to fail, as it does on a stock Hermes install."""
+    real_import = builtins.__import__
+
+    def boom(name, *args, **kwargs):
+        if name == "eth_utils":
+            raise ImportError("no keccak backend")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", boom)
+
+
+def test_strips_the_did_prefix(plugin_module):
+    out = plugin_module._normalize_wm_agent_address("did:dkg:agent:" + LOWER)
+    assert not out.startswith("did:dkg:agent:")
+    assert out.lower() == LOWER
+
+
+def test_checksums_when_a_backend_is_available(plugin_module):
+    try:
+        from eth_utils import to_checksum_address
+
+        to_checksum_address(LOWER)
+    except Exception:
+        pytest.skip("no keccak backend in this environment")
+    assert plugin_module._normalize_wm_agent_address(LOWER) == CHECKSUMMED
+
+
+def test_fallback_is_fail_open_but_not_silent(plugin_module, no_keccak, caplog):
+    plugin_module._CHECKSUM_FALLBACK_WARNED = False
+
+    with caplog.at_level("WARNING"):
+        out = plugin_module._normalize_wm_agent_address(LOWER)
+
+    # Fail open: the write still proceeds with a usable identifier.
+    assert out == LOWER
+    # But no longer silently, and the message says how to fix it.
+    text = caplog.text.lower()
+    assert "cannot checksum agent address" in text
+    assert "eth-hash" in caplog.text
+    assert "attribution" in text
+
+
+def test_fallback_warns_once_not_per_write(plugin_module, no_keccak, caplog):
+    plugin_module._CHECKSUM_FALLBACK_WARNED = False
+
+    with caplog.at_level("WARNING"):
+        for _ in range(25):
+            plugin_module._normalize_wm_agent_address(LOWER)
+
+    warnings = [r for r in caplog.records if "checksum agent address" in r.getMessage().lower()]
+    assert len(warnings) == 1, f"expected exactly one warning, got {len(warnings)}"
+
+
+def test_non_address_values_pass_through_untouched(plugin_module):
+    assert plugin_module._normalize_wm_agent_address("not-an-address") == "not-an-address"
+    assert plugin_module._normalize_wm_agent_address("  ") == ""

--- a/packages/adapter-hermes/pytests/test_agent_address_checksum_fallback.py
+++ b/packages/adapter-hermes/pytests/test_agent_address_checksum_fallback.py
@@ -84,9 +84,13 @@ def test_fallback_is_fail_open_but_not_silent(plugin_module, no_keccak, caplog):
     assert out == LOWER
     # But no longer silently, and the message says how to fix it.
     text = caplog.text.lower()
-    assert "cannot checksum agent address" in text
+    assert "could not canonicalize agent address" in text
     assert "eth-hash" in caplog.text
-    assert "attribution" in text
+    # PR #2334 review — the wording must stay CONDITIONAL. This helper also
+    # serves working-memory reads, and the input may already be checksummed, so
+    # a definitive "attribution will split" claim is often simply false.
+    assert "if it is not" in text
+    assert "may fail to match" in text
 
 
 def test_fallback_warns_once_not_per_write(plugin_module, no_keccak, caplog):
@@ -96,7 +100,7 @@ def test_fallback_warns_once_not_per_write(plugin_module, no_keccak, caplog):
         for _ in range(25):
             plugin_module._normalize_wm_agent_address(LOWER)
 
-    warnings = [r for r in caplog.records if "checksum agent address" in r.getMessage().lower()]
+    warnings = [r for r in caplog.records if "canonicalize agent address" in r.getMessage().lower()]
     assert len(warnings) == 1, f"expected exactly one warning, got {len(warnings)}"
 
 
@@ -113,4 +117,32 @@ def test_missing_package_also_fails_open_with_a_warning(plugin_module, no_eth_ut
         out = plugin_module._normalize_wm_agent_address(LOWER)
 
     assert out == LOWER
-    assert "cannot checksum agent address" in caplog.text.lower()
+    assert "could not canonicalize agent address" in caplog.text.lower()
+
+
+def test_already_checksummed_input_passes_through_correctly(plugin_module, no_keccak, caplog):
+    """PR #2334 review — the value returned is already correct here, so the
+    warning must not assert that it will fail to match anything."""
+    plugin_module._CHECKSUM_FALLBACK_WARNED = False
+
+    with caplog.at_level("WARNING"):
+        out = plugin_module._normalize_wm_agent_address(CHECKSUMMED)
+
+    # Unchanged and still canonical — no attribution split occurs at all.
+    assert out == CHECKSUMMED
+    text = caplog.text.lower()
+    assert "will not match" not in text
+    assert "may fail to match" in text
+
+
+def test_working_memory_read_path_gets_no_write_specific_claim(plugin_module, no_keccak, caplog):
+    """The helper runs on dkg_query(view="working-memory") too (line ~1495),
+    which performs no write, so the message must not describe an author write."""
+    plugin_module._CHECKSUM_FALLBACK_WARNED = False
+
+    with caplog.at_level("WARNING"):
+        plugin_module._normalize_wm_agent_address(LOWER)
+
+    text = caplog.text.lower()
+    for write_specific in ("author", "emitting", "on-chain", "split"):
+        assert write_specific not in text, f"message names a write-only consequence: {write_specific}"


### PR DESCRIPTION
## Summary

`_normalize_wm_agent_address` caught **every** exception from `to_checksum_address` and returned the input verbatim:

```python
except Exception:
    return value
```

eth-utils ships no keccak backend by default and the Hermes setup pip-installs nothing, so this path is reached **routinely**, not exceptionally. The result is a non-checksummed address written as the on-chain author — a different string from the checksummed form every other surface emits — so attribution silently splits in two, with nothing in the log to explain why.

## Changes

Keep the fallback **fail-open**: a lowercase address is still a usable identifier, and refusing the write would be a worse regression than a mixed-case mismatch. But:

- warn, naming the remedy (`pip install 'eth-hash[pycryptodome]'`) and the consequence;
- warn **once per process**, since the normaliser runs on every write and must not drown the operator log.

## Test Plan

- [x] New `packages/adapter-hermes/pytests/test_agent_address_checksum_fallback.py` — 5 cases, using the existing `plugin_module` fixture.
- [x] Asserts the fallback still returns a usable address (fail-open) *and* that the warning is emitted exactly once across 25 calls.
- [x] **Mutation-tested**: restoring the bare `except` fails both warning cases.
- [x] pytest: 5/5.

Closes #1086

🤖 Generated with [Claude Code](https://claude.com/claude-code)