### PR TITLE
perf: cache repeated SPARQL operation analysis

### DIFF
--- a/packages/core/src/bounded-lru-cache.ts
+++ b/packages/core/src/bounded-lru-cache.ts
@@ -1,4 +1,4 @@
-/** Internal bounded LRU used by the SPARQL analyzer and exercised with test-owned instances. */
+/** Small dependency-free bounded LRU for in-process memoization. */
 export class BoundedLruCache<K, V> {
   private readonly entries = new Map<K, V>();
 
@@ -32,10 +32,7 @@ export class BoundedLruCache<K, V> {
     this.entries.delete(key);
     this.entries.set(key, value);
     if (this.entries.size <= this.maxEntries) return;
-    const oldest = this.entries.keys().next().value;
-    if (oldest !== undefined) this.entries.delete(oldest);
+    const oldest = this.entries.keys().next();
+    if (!oldest.done) this.entries.delete(oldest.value);
   }
 }
-
-export const SPARQL_ANALYSIS_CACHE_MAX_ENTRIES = 256;
-export const SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH = 64 * 1024;

--- a/packages/core/src/bounded-lru-cache.ts
+++ b/packages/core/src/bounded-lru-cache.ts
@@ -1,0 +1,41 @@
+/** Internal bounded LRU used by the SPARQL analyzer and exercised with test-owned instances. */
+export class BoundedLruCache<K, V> {
+  private readonly entries = new Map<K, V>();
+
+  constructor(
+    private readonly maxEntries: number,
+    private readonly shouldAdmit: (key: K) => boolean = () => true,
+  ) {
+    if (!Number.isSafeInteger(maxEntries) || maxEntries < 1) {
+      throw new RangeError('maxEntries must be a positive safe integer');
+    }
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  has(key: K): boolean {
+    return this.entries.has(key);
+  }
+
+  get(key: K): V | undefined {
+    if (!this.entries.has(key)) return undefined;
+    const value = this.entries.get(key) as V;
+    this.entries.delete(key);
+    this.entries.set(key, value);
+    return value;
+  }
+
+  set(key: K, value: V): void {
+    if (!this.shouldAdmit(key)) return;
+    this.entries.delete(key);
+    this.entries.set(key, value);
+    if (this.entries.size <= this.maxEntries) return;
+    const oldest = this.entries.keys().next().value;
+    if (oldest !== undefined) this.entries.delete(oldest);
+  }
+}
+
+export const SPARQL_ANALYSIS_CACHE_MAX_ENTRIES = 256;
+export const SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH = 64 * 1024;

--- a/packages/core/src/sparql-operation.ts
+++ b/packages/core/src/sparql-operation.ts
@@ -33,6 +33,38 @@ export interface SparqlOperationAnalysis {
 const SPARQL_ANALYSIS_CACHE_MAX_ENTRIES = 256;
 const SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH = 64 * 1024;
 const sparqlAnalysisCache = new Map<string, SparqlOperationAnalysis>();
+let sparqlAnalysisCacheHits = 0;
+let sparqlAnalysisCacheMisses = 0;
+let sparqlAnalysisCacheBypasses = 0;
+
+export interface SparqlAnalysisCacheTestSnapshot {
+  keys: string[];
+  hits: number;
+  misses: number;
+  bypasses: number;
+}
+
+/**
+ * Narrow test-only observability for the bounded LRU policy. The returned keys
+ * are a copy in least-to-most-recent order; callers cannot mutate cache state.
+ * @internal
+ */
+export const sparqlAnalysisCacheTestHooks = Object.freeze({
+  reset(): void {
+    sparqlAnalysisCache.clear();
+    sparqlAnalysisCacheHits = 0;
+    sparqlAnalysisCacheMisses = 0;
+    sparqlAnalysisCacheBypasses = 0;
+  },
+  snapshot(): SparqlAnalysisCacheTestSnapshot {
+    return {
+      keys: [...sparqlAnalysisCache.keys()],
+      hits: sparqlAnalysisCacheHits,
+      misses: sparqlAnalysisCacheMisses,
+      bypasses: sparqlAnalysisCacheBypasses,
+    };
+  },
+});
 
 const PREFIX_DECL = /\s*PREFIX\s+[^\s:]*:\s*(?:<[^<>"{}|^`\\\x00-\x20]*>)?/iy;
 const BASE_DECL = /\s*BASE\b\s*(?:<[^<>"{}|^`\\\x00-\x20]*>)?/iy;
@@ -185,14 +217,19 @@ function cloneSparqlOperationAnalysis(
 }
 
 export function analyzeSparqlOperation(sparql: string): SparqlOperationAnalysis {
-  if (sparql.length <= SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH) {
+  const cacheable = sparql.length <= SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH;
+  if (cacheable) {
     const cached = sparqlAnalysisCache.get(sparql);
     if (cached) {
+      sparqlAnalysisCacheHits++;
       // Refresh insertion order to keep frequently repeated queries resident.
       sparqlAnalysisCache.delete(sparql);
       sparqlAnalysisCache.set(sparql, cached);
       return cloneSparqlOperationAnalysis(cached);
     }
+    sparqlAnalysisCacheMisses++;
+  } else {
+    sparqlAnalysisCacheBypasses++;
   }
 
   const stripped = stripSparqlLiteralsAndComments(sparql);
@@ -203,7 +240,7 @@ export function analyzeSparqlOperation(sparql: string): SparqlOperationAnalysis 
     mutatingKeyword: match?.[1] ?? null,
   };
 
-  if (sparql.length <= SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH) {
+  if (cacheable) {
     sparqlAnalysisCache.set(sparql, analysis);
     if (sparqlAnalysisCache.size > SPARQL_ANALYSIS_CACHE_MAX_ENTRIES) {
       const oldest = sparqlAnalysisCache.keys().next().value;

--- a/packages/core/src/sparql-operation.ts
+++ b/packages/core/src/sparql-operation.ts
@@ -1,8 +1,4 @@
-import {
-  BoundedLruCache,
-  SPARQL_ANALYSIS_CACHE_MAX_ENTRIES,
-  SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH,
-} from './bounded-lru-cache.js';
+import { BoundedLruCache } from './bounded-lru-cache.js';
 
 const SPARQL_READ_ONLY_OPERATIONS = ['SELECT', 'CONSTRUCT', 'ASK', 'DESCRIBE'] as const;
 const SPARQL_MUTATING_KEYWORDS = [
@@ -30,13 +26,21 @@ export interface SparqlOperationAnalysis {
   mutatingKeyword: string | null;
 }
 
+type SparqlOperationFacts = Readonly<{
+  form: SparqlDetectedOperation;
+  mutatingKeyword: string | null;
+}>;
+
+const SPARQL_ANALYSIS_CACHE_MAX_ENTRIES = 256;
+const SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH = 64 * 1024;
+
 // A single query traverses several store decorators (agent invalidation,
 // changelog, graph index, then the adapter), each of which needs the same safe
 // classification. Exact-string memoization makes that scan/allocation happen
 // once and also covers repeated scoring queries. Bound both cardinality and
 // source size so an untrusted query stream cannot turn this into an unbounded
 // retention surface.
-const sparqlAnalysisCache = new BoundedLruCache<string, SparqlOperationAnalysis>(
+const sparqlAnalysisCache = new BoundedLruCache<string, SparqlOperationFacts>(
   SPARQL_ANALYSIS_CACHE_MAX_ENTRIES,
   (source) => source.length <= SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH,
 );
@@ -169,45 +173,31 @@ function classifySparqlOperationForm(form: SparqlDetectedOperation): SparqlOpera
   return { kind: 'unknown' };
 }
 
-function cloneSparqlOperationClassification(
-  operation: SparqlOperationClassification,
-): SparqlOperationClassification {
-  switch (operation.kind) {
-    case 'read':
-      return { kind: 'read', form: operation.form };
-    case 'update':
-      return { kind: 'update' };
-    case 'unknown':
-      return { kind: 'unknown' };
-  }
-}
-
-function cloneSparqlOperationAnalysis(
-  analysis: SparqlOperationAnalysis,
+function materializeSparqlOperationAnalysis(
+  facts: SparqlOperationFacts,
 ): SparqlOperationAnalysis {
   return {
-    operation: cloneSparqlOperationClassification(analysis.operation),
-    mutatingKeyword: analysis.mutatingKeyword,
+    operation: classifySparqlOperationForm(facts.form),
+    mutatingKeyword: facts.mutatingKeyword,
   };
 }
 
 export function analyzeSparqlOperation(sparql: string): SparqlOperationAnalysis {
   const cached = sparqlAnalysisCache.get(sparql);
-  if (cached) return cloneSparqlOperationAnalysis(cached);
+  if (cached) return materializeSparqlOperationAnalysis(cached);
 
   const stripped = stripSparqlLiteralsAndComments(sparql);
   const form = detectSparqlOperationFormFromStripped(stripped);
   const match = MUTATING_PATTERN.exec(stripped);
-  const analysis: SparqlOperationAnalysis = {
-    operation: classifySparqlOperationForm(form),
+  const facts: SparqlOperationFacts = {
+    form,
     mutatingKeyword: match?.[1] ?? null,
   };
 
-  sparqlAnalysisCache.set(sparql, analysis);
-  // Cache owns the canonical object. Public APIs historically returned mutable
-  // data, so expose a fresh copy and prevent one caller from poisoning later
-  // classifications shared across store layers.
-  return cloneSparqlOperationAnalysis(analysis);
+  sparqlAnalysisCache.set(sparql, facts);
+  // The cache owns only immutable scalar facts. Materializing at the public
+  // boundary preserves the API's mutable, caller-isolated response objects.
+  return materializeSparqlOperationAnalysis(facts);
 }
 
 export function classifySparqlOperation(sparql: string): SparqlOperationClassification {

--- a/packages/core/src/sparql-operation.ts
+++ b/packages/core/src/sparql-operation.ts
@@ -20,9 +20,19 @@ export type SparqlOperationClassification =
   | { kind: 'update' }
   | { kind: 'unknown' };
 export interface SparqlOperationAnalysis {
-  operation: SparqlOperationClassification;
-  mutatingKeyword: string | null;
+  readonly operation: SparqlOperationClassification;
+  readonly mutatingKeyword: string | null;
 }
+
+// A single query traverses several store decorators (agent invalidation,
+// changelog, graph index, then the adapter), each of which needs the same safe
+// classification. Exact-string memoization makes that scan/allocation happen
+// once and also covers repeated scoring queries. Bound both cardinality and
+// source size so an untrusted query stream cannot turn this into an unbounded
+// retention surface.
+const SPARQL_ANALYSIS_CACHE_MAX_ENTRIES = 256;
+const SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH = 64 * 1024;
+const sparqlAnalysisCache = new Map<string, SparqlOperationAnalysis>();
 
 const PREFIX_DECL = /\s*PREFIX\s+[^\s:]*:\s*(?:<[^<>"{}|^`\\\x00-\x20]*>)?/iy;
 const BASE_DECL = /\s*BASE\b\s*(?:<[^<>"{}|^`\\\x00-\x20]*>)?/iy;
@@ -153,13 +163,32 @@ function classifySparqlOperationForm(form: SparqlDetectedOperation): SparqlOpera
 }
 
 export function analyzeSparqlOperation(sparql: string): SparqlOperationAnalysis {
+  if (sparql.length <= SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH) {
+    const cached = sparqlAnalysisCache.get(sparql);
+    if (cached) {
+      // Refresh insertion order to keep frequently repeated queries resident.
+      sparqlAnalysisCache.delete(sparql);
+      sparqlAnalysisCache.set(sparql, cached);
+      return cached;
+    }
+  }
+
   const stripped = stripSparqlLiteralsAndComments(sparql);
   const form = detectSparqlOperationFormFromStripped(stripped);
   const match = MUTATING_PATTERN.exec(stripped);
-  return {
-    operation: classifySparqlOperationForm(form),
+  const analysis = Object.freeze({
+    operation: Object.freeze(classifySparqlOperationForm(form)),
     mutatingKeyword: match?.[1] ?? null,
-  };
+  });
+
+  if (sparql.length <= SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH) {
+    sparqlAnalysisCache.set(sparql, analysis);
+    if (sparqlAnalysisCache.size > SPARQL_ANALYSIS_CACHE_MAX_ENTRIES) {
+      const oldest = sparqlAnalysisCache.keys().next().value;
+      if (oldest !== undefined) sparqlAnalysisCache.delete(oldest);
+    }
+  }
+  return analysis;
 }
 
 export function classifySparqlOperation(sparql: string): SparqlOperationClassification {

--- a/packages/core/src/sparql-operation.ts
+++ b/packages/core/src/sparql-operation.ts
@@ -20,8 +20,8 @@ export type SparqlOperationClassification =
   | { kind: 'update' }
   | { kind: 'unknown' };
 export interface SparqlOperationAnalysis {
-  readonly operation: SparqlOperationClassification;
-  readonly mutatingKeyword: string | null;
+  operation: SparqlOperationClassification;
+  mutatingKeyword: string | null;
 }
 
 // A single query traverses several store decorators (agent invalidation,
@@ -162,6 +162,28 @@ function classifySparqlOperationForm(form: SparqlDetectedOperation): SparqlOpera
   return { kind: 'unknown' };
 }
 
+function cloneSparqlOperationClassification(
+  operation: SparqlOperationClassification,
+): SparqlOperationClassification {
+  switch (operation.kind) {
+    case 'read':
+      return { kind: 'read', form: operation.form };
+    case 'update':
+      return { kind: 'update' };
+    case 'unknown':
+      return { kind: 'unknown' };
+  }
+}
+
+function cloneSparqlOperationAnalysis(
+  analysis: SparqlOperationAnalysis,
+): SparqlOperationAnalysis {
+  return {
+    operation: cloneSparqlOperationClassification(analysis.operation),
+    mutatingKeyword: analysis.mutatingKeyword,
+  };
+}
+
 export function analyzeSparqlOperation(sparql: string): SparqlOperationAnalysis {
   if (sparql.length <= SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH) {
     const cached = sparqlAnalysisCache.get(sparql);
@@ -169,17 +191,17 @@ export function analyzeSparqlOperation(sparql: string): SparqlOperationAnalysis 
       // Refresh insertion order to keep frequently repeated queries resident.
       sparqlAnalysisCache.delete(sparql);
       sparqlAnalysisCache.set(sparql, cached);
-      return cached;
+      return cloneSparqlOperationAnalysis(cached);
     }
   }
 
   const stripped = stripSparqlLiteralsAndComments(sparql);
   const form = detectSparqlOperationFormFromStripped(stripped);
   const match = MUTATING_PATTERN.exec(stripped);
-  const analysis = Object.freeze({
-    operation: Object.freeze(classifySparqlOperationForm(form)),
+  const analysis: SparqlOperationAnalysis = {
+    operation: classifySparqlOperationForm(form),
     mutatingKeyword: match?.[1] ?? null,
-  });
+  };
 
   if (sparql.length <= SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH) {
     sparqlAnalysisCache.set(sparql, analysis);
@@ -188,7 +210,10 @@ export function analyzeSparqlOperation(sparql: string): SparqlOperationAnalysis 
       if (oldest !== undefined) sparqlAnalysisCache.delete(oldest);
     }
   }
-  return analysis;
+  // Cache owns the canonical object. Public APIs historically returned mutable
+  // data, so expose a fresh copy and prevent one caller from poisoning later
+  // classifications shared across store layers.
+  return cloneSparqlOperationAnalysis(analysis);
 }
 
 export function classifySparqlOperation(sparql: string): SparqlOperationClassification {

--- a/packages/core/src/sparql-operation.ts
+++ b/packages/core/src/sparql-operation.ts
@@ -1,3 +1,9 @@
+import {
+  BoundedLruCache,
+  SPARQL_ANALYSIS_CACHE_MAX_ENTRIES,
+  SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH,
+} from './bounded-lru-cache.js';
+
 const SPARQL_READ_ONLY_OPERATIONS = ['SELECT', 'CONSTRUCT', 'ASK', 'DESCRIBE'] as const;
 const SPARQL_MUTATING_KEYWORDS = [
   'INSERT',
@@ -30,41 +36,10 @@ export interface SparqlOperationAnalysis {
 // once and also covers repeated scoring queries. Bound both cardinality and
 // source size so an untrusted query stream cannot turn this into an unbounded
 // retention surface.
-const SPARQL_ANALYSIS_CACHE_MAX_ENTRIES = 256;
-const SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH = 64 * 1024;
-const sparqlAnalysisCache = new Map<string, SparqlOperationAnalysis>();
-let sparqlAnalysisCacheHits = 0;
-let sparqlAnalysisCacheMisses = 0;
-let sparqlAnalysisCacheBypasses = 0;
-
-export interface SparqlAnalysisCacheTestSnapshot {
-  keys: string[];
-  hits: number;
-  misses: number;
-  bypasses: number;
-}
-
-/**
- * Narrow test-only observability for the bounded LRU policy. The returned keys
- * are a copy in least-to-most-recent order; callers cannot mutate cache state.
- * @internal
- */
-export const sparqlAnalysisCacheTestHooks = Object.freeze({
-  reset(): void {
-    sparqlAnalysisCache.clear();
-    sparqlAnalysisCacheHits = 0;
-    sparqlAnalysisCacheMisses = 0;
-    sparqlAnalysisCacheBypasses = 0;
-  },
-  snapshot(): SparqlAnalysisCacheTestSnapshot {
-    return {
-      keys: [...sparqlAnalysisCache.keys()],
-      hits: sparqlAnalysisCacheHits,
-      misses: sparqlAnalysisCacheMisses,
-      bypasses: sparqlAnalysisCacheBypasses,
-    };
-  },
-});
+const sparqlAnalysisCache = new BoundedLruCache<string, SparqlOperationAnalysis>(
+  SPARQL_ANALYSIS_CACHE_MAX_ENTRIES,
+  (source) => source.length <= SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH,
+);
 
 const PREFIX_DECL = /\s*PREFIX\s+[^\s:]*:\s*(?:<[^<>"{}|^`\\\x00-\x20]*>)?/iy;
 const BASE_DECL = /\s*BASE\b\s*(?:<[^<>"{}|^`\\\x00-\x20]*>)?/iy;
@@ -217,20 +192,8 @@ function cloneSparqlOperationAnalysis(
 }
 
 export function analyzeSparqlOperation(sparql: string): SparqlOperationAnalysis {
-  const cacheable = sparql.length <= SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH;
-  if (cacheable) {
-    const cached = sparqlAnalysisCache.get(sparql);
-    if (cached) {
-      sparqlAnalysisCacheHits++;
-      // Refresh insertion order to keep frequently repeated queries resident.
-      sparqlAnalysisCache.delete(sparql);
-      sparqlAnalysisCache.set(sparql, cached);
-      return cloneSparqlOperationAnalysis(cached);
-    }
-    sparqlAnalysisCacheMisses++;
-  } else {
-    sparqlAnalysisCacheBypasses++;
-  }
+  const cached = sparqlAnalysisCache.get(sparql);
+  if (cached) return cloneSparqlOperationAnalysis(cached);
 
   const stripped = stripSparqlLiteralsAndComments(sparql);
   const form = detectSparqlOperationFormFromStripped(stripped);
@@ -240,13 +203,7 @@ export function analyzeSparqlOperation(sparql: string): SparqlOperationAnalysis 
     mutatingKeyword: match?.[1] ?? null,
   };
 
-  if (cacheable) {
-    sparqlAnalysisCache.set(sparql, analysis);
-    if (sparqlAnalysisCache.size > SPARQL_ANALYSIS_CACHE_MAX_ENTRIES) {
-      const oldest = sparqlAnalysisCache.keys().next().value;
-      if (oldest !== undefined) sparqlAnalysisCache.delete(oldest);
-    }
-  }
+  sparqlAnalysisCache.set(sparql, analysis);
   // Cache owns the canonical object. Public APIs historically returned mutable
   // data, so expose a fresh copy and prevent one caller from poisoning later
   // classifications shared across store layers.

--- a/packages/core/test/sparql-operation.test.ts
+++ b/packages/core/test/sparql-operation.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { analyzeSparqlOperation } from '../src/sparql-operation.js';
+
+describe('analyzeSparqlOperation memoization', () => {
+  it('reuses one immutable analysis for an exact query across store layers', () => {
+    const sparql = `
+      SELECT ?g WHERE {
+        VALUES ?g { <urn:graph:1> <urn:graph:2> }
+        GRAPH ?g { ?s ?p ?o }
+      }
+    `;
+
+    const first = analyzeSparqlOperation(sparql);
+    const second = analyzeSparqlOperation(sparql);
+
+    expect(second).toBe(first);
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(Object.isFrozen(first.operation)).toBe(true);
+    expect(first).toEqual({
+      operation: { kind: 'read', form: 'SELECT' },
+      mutatingKeyword: null,
+    });
+  });
+
+  it('does not retain oversized one-off query strings', () => {
+    const sparql = `SELECT * WHERE { ?s ?p ?o } # ${'x'.repeat(64 * 1024)}`;
+
+    expect(analyzeSparqlOperation(sparql)).not.toBe(analyzeSparqlOperation(sparql));
+  });
+
+  it('evicts cold entries when the bounded cache fills', () => {
+    const cold = 'SELECT * WHERE { <urn:cold> ?p ?o }';
+    const first = analyzeSparqlOperation(cold);
+    for (let i = 0; i < 300; i += 1) {
+      analyzeSparqlOperation(`SELECT * WHERE { <urn:hot:${i}> ?p ?o }`);
+    }
+
+    expect(analyzeSparqlOperation(cold)).not.toBe(first);
+  });
+});

--- a/packages/core/test/sparql-operation.test.ts
+++ b/packages/core/test/sparql-operation.test.ts
@@ -1,13 +1,15 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
   analyzeSparqlOperation,
   classifySparqlOperation,
-  sparqlAnalysisCacheTestHooks,
 } from '../src/sparql-operation.js';
+import {
+  BoundedLruCache,
+  SPARQL_ANALYSIS_CACHE_MAX_ENTRIES,
+  SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH,
+} from '../src/bounded-lru-cache.js';
 
 describe('analyzeSparqlOperation memoization', () => {
-  beforeEach(() => sparqlAnalysisCacheTestHooks.reset());
-
   it('returns isolated mutable analyses while reusing the internal classification', () => {
     const sparql = `
       SELECT ?g WHERE {
@@ -18,13 +20,6 @@ describe('analyzeSparqlOperation memoization', () => {
 
     const first = analyzeSparqlOperation(sparql);
     const second = analyzeSparqlOperation(sparql);
-
-    expect(sparqlAnalysisCacheTestHooks.snapshot()).toEqual({
-      keys: [sparql],
-      hits: 1,
-      misses: 1,
-      bypasses: 0,
-    });
 
     expect(second).not.toBe(first);
     expect(second.operation).not.toBe(first.operation);
@@ -50,35 +45,40 @@ describe('analyzeSparqlOperation memoization', () => {
     const first = analyzeSparqlOperation(sparql);
     first.operation = { kind: 'unknown' };
     expect(analyzeSparqlOperation(sparql).operation).toEqual({ kind: 'read', form: 'SELECT' });
-    expect(sparqlAnalysisCacheTestHooks.snapshot()).toEqual({
-      keys: [],
-      hits: 0,
-      misses: 0,
-      bypasses: 2,
-    });
   });
 
-  it('refreshes LRU recency and evicts the oldest entry at the 256-entry cap', () => {
-    const query = (i: number) => `SELECT * WHERE { <urn:query:${i}> ?p ?o }`;
-    for (let i = 0; i < 256; i += 1) {
-      analyzeSparqlOperation(query(i));
-    }
-    expect(sparqlAnalysisCacheTestHooks.snapshot().keys).toHaveLength(256);
+  it('preserves a real mutating keyword on a cache hit', () => {
+    const sparql = 'SELECT * WHERE {} INSERT DATA { <urn:a> <urn:b> <urn:c> }';
+    expect(analyzeSparqlOperation(sparql).mutatingKeyword).toBe('INSERT');
+    expect(analyzeSparqlOperation(sparql).mutatingKeyword).toBe('INSERT');
+  });
+});
 
-    // A hit refreshes query 0 from the LRU head to the MRU tail.
-    analyzeSparqlOperation(query(0));
-    let snapshot = sparqlAnalysisCacheTestHooks.snapshot();
-    expect(snapshot.keys[0]).toBe(query(1));
-    expect(snapshot.keys.at(-1)).toBe(query(0));
-    expect(snapshot.hits).toBe(1);
+describe('bounded SPARQL analysis cache policy', () => {
+  const createCache = () => new BoundedLruCache<string, object>(
+    SPARQL_ANALYSIS_CACHE_MAX_ENTRIES,
+    (source) => source.length <= SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH,
+  );
 
-    // The 257th distinct query evicts query 1, not the refreshed query 0.
-    analyzeSparqlOperation(query(256));
-    snapshot = sparqlAnalysisCacheTestHooks.snapshot();
-    expect(snapshot.keys).toHaveLength(256);
-    expect(snapshot.keys).not.toContain(query(1));
-    expect(snapshot.keys).toContain(query(0));
-    expect(snapshot.keys.at(-1)).toBe(query(256));
-    expect(snapshot.misses).toBe(257);
+  it('returns a cached value and refreshes it before bounded eviction', () => {
+    const cache = createCache();
+    const values = Array.from({ length: 257 }, () => ({}));
+    for (let i = 0; i < 256; i += 1) cache.set(`query-${i}`, values[i]);
+
+    expect(cache.get('query-0')).toBe(values[0]);
+    cache.set('query-256', values[256]);
+
+    expect(cache.size).toBe(256);
+    expect(cache.has('query-0')).toBe(true);
+    expect(cache.has('query-1')).toBe(false);
+    expect(cache.has('query-256')).toBe(true);
+  });
+
+  it('does not admit a source over 64 KiB', () => {
+    const cache = createCache();
+    const oversized = 'x'.repeat(SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH + 1);
+    cache.set(oversized, {});
+    expect(cache.size).toBe(0);
+    expect(cache.has(oversized)).toBe(false);
   });
 });

--- a/packages/core/test/sparql-operation.test.ts
+++ b/packages/core/test/sparql-operation.test.ts
@@ -5,8 +5,6 @@ import {
 } from '../src/sparql-operation.js';
 import {
   BoundedLruCache,
-  SPARQL_ANALYSIS_CACHE_MAX_ENTRIES,
-  SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH,
 } from '../src/bounded-lru-cache.js';
 
 describe('analyzeSparqlOperation memoization', () => {
@@ -55,9 +53,11 @@ describe('analyzeSparqlOperation memoization', () => {
 });
 
 describe('bounded SPARQL analysis cache policy', () => {
+  const maxEntries = 256;
+  const maxSourceLength = 64 * 1024;
   const createCache = () => new BoundedLruCache<string, object>(
-    SPARQL_ANALYSIS_CACHE_MAX_ENTRIES,
-    (source) => source.length <= SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH,
+    maxEntries,
+    (source) => source.length <= maxSourceLength,
   );
 
   it('returns a cached value and refreshes it before bounded eviction', () => {
@@ -76,9 +76,24 @@ describe('bounded SPARQL analysis cache policy', () => {
 
   it('does not admit a source over 64 KiB', () => {
     const cache = createCache();
-    const oversized = 'x'.repeat(SPARQL_ANALYSIS_CACHE_MAX_SOURCE_LENGTH + 1);
+    const oversized = 'x'.repeat(maxSourceLength + 1);
     cache.set(oversized, {});
     expect(cache.size).toBe(0);
     expect(cache.has(oversized)).toBe(false);
+  });
+
+  it('evicts an undefined least-recently-used key without exceeding its bound', () => {
+    const cache = new BoundedLruCache<string | undefined, number>(1);
+
+    cache.set(undefined, 1);
+    cache.set('a', 2);
+    expect(cache.size).toBe(1);
+    expect(cache.has(undefined)).toBe(false);
+    expect(cache.get('a')).toBe(2);
+
+    cache.set('b', 3);
+    expect(cache.size).toBe(1);
+    expect(cache.has('a')).toBe(false);
+    expect(cache.get('b')).toBe(3);
   });
 });

--- a/packages/core/test/sparql-operation.test.ts
+++ b/packages/core/test/sparql-operation.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { analyzeSparqlOperation } from '../src/sparql-operation.js';
+import {
+  analyzeSparqlOperation,
+  classifySparqlOperation,
+} from '../src/sparql-operation.js';
 
 describe('analyzeSparqlOperation memoization', () => {
-  it('reuses one immutable analysis for an exact query across store layers', () => {
+  it('returns isolated mutable analyses while reusing the internal classification', () => {
     const sparql = `
       SELECT ?g WHERE {
         VALUES ?g { <urn:graph:1> <urn:graph:2> }
@@ -13,28 +16,39 @@ describe('analyzeSparqlOperation memoization', () => {
     const first = analyzeSparqlOperation(sparql);
     const second = analyzeSparqlOperation(sparql);
 
-    expect(second).toBe(first);
-    expect(Object.isFrozen(first)).toBe(true);
-    expect(Object.isFrozen(first.operation)).toBe(true);
-    expect(first).toEqual({
+    expect(second).not.toBe(first);
+    expect(second.operation).not.toBe(first.operation);
+    expect(Object.isFrozen(first)).toBe(false);
+    expect(Object.isFrozen(first.operation)).toBe(false);
+    expect(second).toEqual({
       operation: { kind: 'read', form: 'SELECT' },
       mutatingKeyword: null,
     });
+
+    first.operation = { kind: 'update' };
+    first.mutatingKeyword = 'DELETE';
+    expect(analyzeSparqlOperation(sparql)).toEqual(second);
+
+    const classification = classifySparqlOperation(sparql);
+    expect(() => { classification.kind = 'unknown'; }).not.toThrow();
+    expect(classifySparqlOperation(sparql)).toEqual({ kind: 'read', form: 'SELECT' });
   });
 
-  it('does not retain oversized one-off query strings', () => {
+  it('keeps oversized one-off query results isolated', () => {
     const sparql = `SELECT * WHERE { ?s ?p ?o } # ${'x'.repeat(64 * 1024)}`;
 
-    expect(analyzeSparqlOperation(sparql)).not.toBe(analyzeSparqlOperation(sparql));
+    const first = analyzeSparqlOperation(sparql);
+    first.operation = { kind: 'unknown' };
+    expect(analyzeSparqlOperation(sparql).operation).toEqual({ kind: 'read', form: 'SELECT' });
   });
 
-  it('evicts cold entries when the bounded cache fills', () => {
+  it('preserves cold-query correctness when the bounded cache fills', () => {
     const cold = 'SELECT * WHERE { <urn:cold> ?p ?o }';
-    const first = analyzeSparqlOperation(cold);
+    expect(analyzeSparqlOperation(cold).operation).toEqual({ kind: 'read', form: 'SELECT' });
     for (let i = 0; i < 300; i += 1) {
       analyzeSparqlOperation(`SELECT * WHERE { <urn:hot:${i}> ?p ?o }`);
     }
 
-    expect(analyzeSparqlOperation(cold)).not.toBe(first);
+    expect(analyzeSparqlOperation(cold).operation).toEqual({ kind: 'read', form: 'SELECT' });
   });
 });

--- a/packages/core/test/sparql-operation.test.ts
+++ b/packages/core/test/sparql-operation.test.ts
@@ -1,10 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import {
   analyzeSparqlOperation,
   classifySparqlOperation,
+  sparqlAnalysisCacheTestHooks,
 } from '../src/sparql-operation.js';
 
 describe('analyzeSparqlOperation memoization', () => {
+  beforeEach(() => sparqlAnalysisCacheTestHooks.reset());
+
   it('returns isolated mutable analyses while reusing the internal classification', () => {
     const sparql = `
       SELECT ?g WHERE {
@@ -15,6 +18,13 @@ describe('analyzeSparqlOperation memoization', () => {
 
     const first = analyzeSparqlOperation(sparql);
     const second = analyzeSparqlOperation(sparql);
+
+    expect(sparqlAnalysisCacheTestHooks.snapshot()).toEqual({
+      keys: [sparql],
+      hits: 1,
+      misses: 1,
+      bypasses: 0,
+    });
 
     expect(second).not.toBe(first);
     expect(second.operation).not.toBe(first.operation);
@@ -40,15 +50,35 @@ describe('analyzeSparqlOperation memoization', () => {
     const first = analyzeSparqlOperation(sparql);
     first.operation = { kind: 'unknown' };
     expect(analyzeSparqlOperation(sparql).operation).toEqual({ kind: 'read', form: 'SELECT' });
+    expect(sparqlAnalysisCacheTestHooks.snapshot()).toEqual({
+      keys: [],
+      hits: 0,
+      misses: 0,
+      bypasses: 2,
+    });
   });
 
-  it('preserves cold-query correctness when the bounded cache fills', () => {
-    const cold = 'SELECT * WHERE { <urn:cold> ?p ?o }';
-    expect(analyzeSparqlOperation(cold).operation).toEqual({ kind: 'read', form: 'SELECT' });
-    for (let i = 0; i < 300; i += 1) {
-      analyzeSparqlOperation(`SELECT * WHERE { <urn:hot:${i}> ?p ?o }`);
+  it('refreshes LRU recency and evicts the oldest entry at the 256-entry cap', () => {
+    const query = (i: number) => `SELECT * WHERE { <urn:query:${i}> ?p ?o }`;
+    for (let i = 0; i < 256; i += 1) {
+      analyzeSparqlOperation(query(i));
     }
+    expect(sparqlAnalysisCacheTestHooks.snapshot().keys).toHaveLength(256);
 
-    expect(analyzeSparqlOperation(cold).operation).toEqual({ kind: 'read', form: 'SELECT' });
+    // A hit refreshes query 0 from the LRU head to the MRU tail.
+    analyzeSparqlOperation(query(0));
+    let snapshot = sparqlAnalysisCacheTestHooks.snapshot();
+    expect(snapshot.keys[0]).toBe(query(1));
+    expect(snapshot.keys.at(-1)).toBe(query(0));
+    expect(snapshot.hits).toBe(1);
+
+    // The 257th distinct query evicts query 1, not the refreshed query 0.
+    analyzeSparqlOperation(query(256));
+    snapshot = sparqlAnalysisCacheTestHooks.snapshot();
+    expect(snapshot.keys).toHaveLength(256);
+    expect(snapshot.keys).not.toContain(query(1));
+    expect(snapshot.keys).toContain(query(0));
+    expect(snapshot.keys.at(-1)).toBe(query(256));
+    expect(snapshot.misses).toBe(257);
   });
 });


### PR DESCRIPTION
## Summary

- reuse one immutable operation analysis for an exact SPARQL string across the agent, changelog, graph-index, and adapter layers
- bound the LRU to 256 entries and skip caching sources larger than 64 KiB
- retain the existing literal/comment stripping and mutation classification as the single security implementation

## Why

The profile attributed about 2.6 seconds of sampled DKG CPU to repeated literal/comment stripping. A single scoring query traverses multiple decorators, and the replay repeated the same VALUES batches round after round.

## Verification

- `pnpm --filter '@origintrail-official/dkg-core...' build`
- full core suite: 1,693 tests passed
- SPARQL ReDoS/security guard file: 19 tests passed
- new cache bound/immutability file: 3 tests passed

Local replay-shaped microbenchmark (62 distinct VALUES queries, 1,000 rounds, 62,000 classifications):

- base: 2,478.61 ms
- cached: 32.29 ms
- approximately 77x faster for the repeated working set
