### PR TITLE
fix(chain): harden strict finalized RPC failover config

### DIFF
--- a/packages/chain/src/strict-current-finalized-evm-config.ts
+++ b/packages/chain/src/strict-current-finalized-evm-config.ts
@@ -249,6 +249,11 @@ function normalizeEndpoint(input: unknown): StrictFinalizedEndpointV1 {
   if ((url.protocol !== 'http:' && url.protocol !== 'https:') || url.hash !== '') {
     throw new TypeError('Strict current-finalized RPC endpoint must use HTTP(S) without a fragment');
   }
+  if (url.username !== '' || url.password !== '') {
+    throw new TypeError(
+      'Strict current-finalized RPC endpoint must not contain username or password credentials',
+    );
+  }
   let origin: string;
   try {
     origin = normalizeEndpointOrigin(url.origin, 'strict current-finalized RPC endpoint origin');

--- a/packages/chain/src/strict-current-finalized-evm-rpc-client.ts
+++ b/packages/chain/src/strict-current-finalized-evm-rpc-client.ts
@@ -52,13 +52,18 @@ export async function postStrictFinalizedJsonRpcV1(
     throw unavailable(`JSON-RPC ${method} transport failed`, cause);
   }
 
-  const body = await readResponseBodyBounded(response, maxResponseBytes);
   if (!response.ok) {
     // An HTTP intermediary/provider failure is transport availability, even if
     // its untrusted body happens to mimic a deterministic JSON-RPC revert. Only
     // a successful JSON-RPC transport response may select an invalidity code.
+    // Do not run the successful-response byte cap over an error page first:
+    // oversized proxy/provider bodies must remain failover-eligible transport
+    // failures, not become terminal resource-limit evidence.
+    await response.body?.cancel().catch(() => undefined);
     throw unavailable(`JSON-RPC ${method} returned HTTP ${response.status}`);
   }
+
+  const body = await readResponseBodyBounded(response, maxResponseBytes);
 
   let parsed: unknown;
   try {

--- a/packages/chain/test/strict-current-finalized-evm-rpc.unit.test.ts
+++ b/packages/chain/test/strict-current-finalized-evm-rpc.unit.test.ts
@@ -538,6 +538,30 @@ describe('RFC-64 strict current-finalized raw JSON-RPC transport', () => {
     expect(server.calls).toHaveLength(1);
   });
 
+  it('fails over after an oversized non-2xx body instead of treating it as a resource limit', async () => {
+    const unavailable = await startRpcServer((_call, response) => {
+      response.writeHead(503, { 'content-type': 'text/plain' });
+      response.end('x'.repeat(CONTROL_EIP1271_MAX_RPC_RESPONSE_BYTES_V1 + 1));
+    });
+    const backup = await startRpcServer(successfulHandler());
+    const adapter = createStrictCurrentFinalizedEvmChainAdapterV1({
+      chainId: CHAIN_ID,
+      endpoints: [unavailable.url, backup.url],
+    });
+
+    await expect(adapter(fixedRequest())).resolves.toMatchObject({
+      chainId: CHAIN_ID,
+      blockHash: BLOCK_HASH,
+    });
+    expect(unavailable.calls.map(({ method }) => method)).toEqual(['eth_chainId']);
+    expect(backup.calls.map(({ method }) => method)).toEqual([
+      'eth_chainId',
+      'eth_getBlockByNumber',
+      'eth_getCode',
+      'eth_call',
+    ]);
+  });
+
   it('applies the two-endpoint ceiling after normalized endpoint deduplication', async () => {
     const primary = await startRpcServer((call, response) => {
       sendResult(response, call, '0x1');
@@ -882,6 +906,7 @@ describe('RFC-64 strict current-finalized raw JSON-RPC transport', () => {
       { chainId: CHAIN_ID, endpoints: [] },
       { chainId: CHAIN_ID, endpoints: ['ftp://127.0.0.1/a'] },
       { chainId: CHAIN_ID, endpoints: ['http://127.0.0.1/a#fragment'] },
+      { chainId: CHAIN_ID, endpoints: ['https://user:pass@rpc.example.com'] },
       { chainId: CHAIN_ID, endpoints: ['http://127.0.0.1:1'], peerEndpoint: third },
     ]) {
       expect(() => createStrictCurrentFinalizedEvmChainAdapterV1(

--- a/packages/chain/test/strict-finalized-endpoint-session.unit.test.ts
+++ b/packages/chain/test/strict-finalized-endpoint-session.unit.test.ts
@@ -151,8 +151,12 @@ describe('origin identity, proven end-to-end through the config boundary', () =>
     ])).toEqual(['https://a.example.com/rpc', 'https://b.example.com/']);
   });
 
-  it('rejects credentialed URLs before they reach native fetch', () => {
-    expect(() => sel(['https://user:pass@a.example.com/rpc']))
+  it.each([
+    'https://user@a.example.com/rpc',
+    'https://:pass@a.example.com/rpc',
+    'https://user:pass@a.example.com/rpc',
+  ])('rejects credentialed URL %s before it reaches native fetch', (endpoint) => {
+    expect(() => sel([endpoint]))
       .toThrow(/must not contain username or password credentials/);
   });
 

--- a/packages/chain/test/strict-finalized-endpoint-session.unit.test.ts
+++ b/packages/chain/test/strict-finalized-endpoint-session.unit.test.ts
@@ -140,19 +140,20 @@ describe('origin identity, proven end-to-end through the config boundary', () =>
   const sel = (endpoints: readonly string[]) =>
     snapshotStrictCurrentFinalizedEvmConfigV1({ chainId: CHAIN, endpoints } as never).endpoints;
 
-  it('treats path/query/credential/case variants of one host as ONE provider', () => {
+  it('treats path/query/case variants of one host as ONE provider', () => {
     // Three elements so `endpoints` DISCRIMINATES: if these were three providers
     // the second slot would be the second variant, not `b`.
     //
-    // The CREDENTIAL variant is load-bearing and was missing at one point while
-    // this test's name still claimed it: `url.origin` excludes userinfo, so two
-    // tokens on one host are one provider. Without a credential-bearing URL here,
-    // an identity rule that folded userinfo in would pass green.
     expect(sel([
-      'https://token-a@a.example.com/rpc',
-      'https://token-b@A.EXAMPLE.COM/other?k=1',
+      'https://a.example.com/rpc',
+      'https://A.EXAMPLE.COM/other?k=1',
       'https://b.example.com',
-    ])).toEqual(['https://token-a@a.example.com/rpc', 'https://b.example.com/']);
+    ])).toEqual(['https://a.example.com/rpc', 'https://b.example.com/']);
+  });
+
+  it('rejects credentialed URLs before they reach native fetch', () => {
+    expect(() => sel(['https://user:pass@a.example.com/rpc']))
+      .toThrow(/must not contain username or password credentials/);
   });
 
   it('collapses an explicit default port with the portless form', () => {


### PR DESCRIPTION
Focused canary replacement for the still-valuable hardening left in #1810 after its original monolithic implementation was superseded by the modular strict finalized-RPC stack.

What changes:
- classify every non-2xx HTTP response as failover-eligible `rpc-unavailable` before reading an untrusted provider/proxy error body;
- cancel that response body so an oversized 503 cannot become terminal `resource-limit` evidence;
- reject credential-bearing endpoint URLs at config time because native Node fetch rejects URL userinfo;
- retain origin-level endpoint deduplication for supported HTTP(S) URLs.

Regression coverage:
- oversized chunked 503 from endpoint A fails over successfully to endpoint B;
- username-only, password-only, and combined URL credentials each fail construction with the credential-specific `TypeError`;
- endpoint origin selection remains pinned without credentialed URLs.

Validation on exact head `b167de26b`:
- chain build: passed;
- focused strict RPC and endpoint-session tests: 60/60 passed;
- full chain unit suite: 56 files, 1,059 passed, 1 skipped;
- diff check against `testnet-canary`: passed.

Supersedes #1810. No merge is requested by this PR creation.
