### PR TITLE
fix(agent): settle recovery inbox after exact asset sync

### DIFF
--- a/packages/agent/src/confirmed-graph-scoped-vm-resolver.ts
+++ b/packages/agent/src/confirmed-graph-scoped-vm-resolver.ts
@@ -1,0 +1,103 @@
+import {
+  assertSafeIri,
+  createGraphKnowledgeAssetScope,
+} from '@origintrail-official/dkg-core';
+import {
+  computeFlatKCRootV10,
+  readConfirmedGraphKnowledgeAssetMetadataEnvelope,
+  workspacePublicQuadsDigest,
+  type ConfirmedGraphKnowledgeAssetMetadataEnvelope,
+} from '@origintrail-official/dkg-publisher';
+import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
+
+export interface ConfirmedGraphScopedVmResolutionInput {
+  contextGraphId: string;
+  ual: string;
+  merkleRoot: Uint8Array;
+  kaId: bigint;
+  subGraphName?: string;
+}
+
+export type ConfirmedGraphScopedVmInvalidReason =
+  | 'metadata'
+  | 'identity'
+  | 'content-count'
+  | 'content-merkle';
+
+export type ConfirmedGraphScopedVmResolution =
+  | { status: 'absent' }
+  | { status: 'invalid'; reason: ConfirmedGraphScopedVmInvalidReason }
+  | {
+      status: 'verified';
+      envelope: ConfirmedGraphKnowledgeAssetMetadataEnvelope;
+      scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
+      quads: Quad[];
+      publicQuadsDigest: string;
+    };
+
+function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
+  return left.length === right.length
+    && left.every((byte, index) => byte === right[index]);
+}
+
+/**
+ * Resolve one exact confirmed graph-scoped VM assertion from its immutable
+ * metadata and stored content. Both chain reconciliation and inbox replay use
+ * this resolver so they cannot apply different recognition rules.
+ */
+export async function resolveConfirmedGraphScopedVm(
+  store: TripleStore,
+  input: ConfirmedGraphScopedVmResolutionInput,
+): Promise<ConfirmedGraphScopedVmResolution> {
+  const stored = await readConfirmedGraphKnowledgeAssetMetadataEnvelope(store, {
+    contextGraphId: input.contextGraphId,
+    ual: input.ual,
+  });
+  if (stored.state === 'absent') return { status: 'absent' };
+  if (stored.state === 'invalid') {
+    return { status: 'invalid', reason: 'metadata' };
+  }
+
+  const { envelope } = stored;
+  let scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
+  try {
+    scope = createGraphKnowledgeAssetScope(input.ual, envelope.assertionVersion);
+  } catch {
+    return { status: 'invalid', reason: 'identity' };
+  }
+  const packedKaId = (BigInt(scope.agentAddress) << 96n) | BigInt(scope.kaNumber);
+  if (
+    scope.ual !== input.ual
+    || packedKaId !== input.kaId
+    || envelope.batchId !== input.kaId
+    || !equalBytes(envelope.merkleRoot, input.merkleRoot)
+    || input.subGraphName !== envelope.subGraphName
+  ) {
+    return { status: 'invalid', reason: 'identity' };
+  }
+
+  const result = await store.query(
+    `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${assertSafeIri(envelope.assertionGraph)}> { ?s ?p ?o } }`,
+    { source: 'agent.finalization.resolveConfirmedGraphScopedVm' },
+  );
+  const quads = result.type === 'quads'
+    ? result.quads.map((quad) => ({ ...quad, graph: '' }))
+    : [];
+  if (quads.length !== envelope.publicTripleCount) {
+    return { status: 'invalid', reason: 'content-count' };
+  }
+  const merkleRoot = computeFlatKCRootV10(
+    quads,
+    envelope.privateMerkleRoot ? [envelope.privateMerkleRoot] : [],
+  );
+  if (!equalBytes(merkleRoot, input.merkleRoot)) {
+    return { status: 'invalid', reason: 'content-merkle' };
+  }
+  return {
+    status: 'verified',
+    envelope,
+    scope,
+    quads,
+    publicQuadsDigest: workspacePublicQuadsDigest(quads),
+  };
+}

--- a/packages/agent/src/confirmed-graph-scoped-vm-resolver.ts
+++ b/packages/agent/src/confirmed-graph-scoped-vm-resolver.ts
@@ -1,14 +1,10 @@
+import { createGraphKnowledgeAssetScope } from '@origintrail-official/dkg-core';
 import {
-  assertSafeIri,
-  createGraphKnowledgeAssetScope,
-} from '@origintrail-official/dkg-core';
-import {
-  computeFlatKCRootV10,
   readConfirmedGraphKnowledgeAssetMetadataEnvelope,
-  workspacePublicQuadsDigest,
   type ConfirmedGraphKnowledgeAssetMetadataEnvelope,
 } from '@origintrail-official/dkg-publisher';
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
+import { verifyExactGraphContent } from './exact-graph-content-verifier.js';
 
 export interface ConfirmedGraphScopedVmResolutionInput {
   contextGraphId: string;
@@ -76,28 +72,27 @@ export async function resolveConfirmedGraphScopedVm(
     return { status: 'invalid', reason: 'identity' };
   }
 
-  const result = await store.query(
-    `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${assertSafeIri(envelope.assertionGraph)}> { ?s ?p ?o } }`,
-    { source: 'agent.finalization.resolveConfirmedGraphScopedVm' },
-  );
-  const quads = result.type === 'quads'
-    ? result.quads.map((quad) => ({ ...quad, graph: '' }))
-    : [];
-  if (quads.length !== envelope.publicTripleCount) {
+  const content = await verifyExactGraphContent(store, {
+    graphUri: envelope.assertionGraph,
+    publicTripleCount: envelope.publicTripleCount,
+    ...(envelope.privateMerkleRoot
+      ? { privateMerkleRoot: envelope.privateMerkleRoot }
+      : {}),
+    expectedMerkleRoot: input.merkleRoot,
+    includePublicQuadsDigest: true,
+    source: 'agent.finalization.resolveConfirmedGraphScopedVm',
+  });
+  if (content.status === 'count-mismatch') {
     return { status: 'invalid', reason: 'content-count' };
   }
-  const merkleRoot = computeFlatKCRootV10(
-    quads,
-    envelope.privateMerkleRoot ? [envelope.privateMerkleRoot] : [],
-  );
-  if (!equalBytes(merkleRoot, input.merkleRoot)) {
+  if (content.status !== 'verified' || !content.publicQuadsDigest) {
     return { status: 'invalid', reason: 'content-merkle' };
   }
   return {
     status: 'verified',
     envelope,
     scope,
-    quads,
-    publicQuadsDigest: workspacePublicQuadsDigest(quads),
+    quads: content.quads,
+    publicQuadsDigest: content.publicQuadsDigest,
   };
 }

--- a/packages/agent/src/confirmed-graph-scoped-vm-resolver.ts
+++ b/packages/agent/src/confirmed-graph-scoped-vm-resolver.ts
@@ -12,7 +12,7 @@ export interface ConfirmedGraphScopedVmResolutionInput {
   ual: string;
   merkleRoot: Uint8Array;
   kaId: bigint;
-  batchId?: bigint;
+  batchId: bigint;
   subGraphName?: string;
 }
 
@@ -67,7 +67,7 @@ export async function resolveConfirmedGraphScopedVm(
   if (
     scope.ual !== input.ual
     || packedKaId !== input.kaId
-    || (input.batchId !== undefined && envelope.batchId !== input.batchId)
+    || envelope.batchId !== input.batchId
     || !equalBytes(envelope.merkleRoot, input.merkleRoot)
     || input.subGraphName !== envelope.subGraphName
   ) {

--- a/packages/agent/src/confirmed-graph-scoped-vm-resolver.ts
+++ b/packages/agent/src/confirmed-graph-scoped-vm-resolver.ts
@@ -1,6 +1,7 @@
 import { createGraphKnowledgeAssetScope } from '@origintrail-official/dkg-core';
 import {
   readConfirmedGraphKnowledgeAssetMetadataEnvelope,
+  workspacePublicQuadsDigest,
   type ConfirmedGraphKnowledgeAssetMetadataEnvelope,
 } from '@origintrail-official/dkg-publisher';
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
@@ -11,6 +12,7 @@ export interface ConfirmedGraphScopedVmResolutionInput {
   ual: string;
   merkleRoot: Uint8Array;
   kaId: bigint;
+  batchId?: bigint;
   subGraphName?: string;
 }
 
@@ -65,7 +67,7 @@ export async function resolveConfirmedGraphScopedVm(
   if (
     scope.ual !== input.ual
     || packedKaId !== input.kaId
-    || envelope.batchId !== input.kaId
+    || (input.batchId !== undefined && envelope.batchId !== input.batchId)
     || !equalBytes(envelope.merkleRoot, input.merkleRoot)
     || input.subGraphName !== envelope.subGraphName
   ) {
@@ -79,13 +81,12 @@ export async function resolveConfirmedGraphScopedVm(
       ? { privateMerkleRoot: envelope.privateMerkleRoot }
       : {}),
     expectedMerkleRoot: input.merkleRoot,
-    includePublicQuadsDigest: true,
     source: 'agent.finalization.resolveConfirmedGraphScopedVm',
   });
   if (content.status === 'count-mismatch') {
     return { status: 'invalid', reason: 'content-count' };
   }
-  if (content.status !== 'verified' || !content.publicQuadsDigest) {
+  if (content.status !== 'verified') {
     return { status: 'invalid', reason: 'content-merkle' };
   }
   return {
@@ -93,6 +94,6 @@ export async function resolveConfirmedGraphScopedVm(
     envelope,
     scope,
     quads: content.quads,
-    publicQuadsDigest: content.publicQuadsDigest,
+    publicQuadsDigest: workspacePublicQuadsDigest(content.quads),
   };
 }

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -5113,6 +5113,9 @@ export class PublishMethods extends DKGAgentBase {
       merkleRoot: ethers.getBytes(recovered.materialization.merkleRoot),
       publisherAddress: recovered.materialization.publisherAddress,
       kaId: recovered.reservedKaId,
+      // Named-KA recovery rejects any receipt whose batch differs from this
+      // reserved packed KA id before it reaches materialization.
+      batchId: recovered.reservedKaId,
       versionBlock: recovered.materialization.versionBlock,
       authorAddress: recovered.materialization.authorAddress,
       subGraphName: request.subGraphName,

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -3243,6 +3243,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
           merkleRoot: item.merkleRoot,
           publisherAddress: item.publisherAddress,
           kaId: item.kaId,
+          batchId: item.batchId,
           versionBlock: item.versionBlock,
           authorAddress: item.authorAddress,
         }, ctx);
@@ -6214,6 +6215,8 @@ export class SwmHostModeMethods extends DKGAgentBase {
       merkleRoot,
       publisherAddress,
       kaId,
+      // V10 context-graph inventory stores one packed KA per batch.
+      batchId: kaId,
       versionBlock,
     };
 

--- a/packages/agent/src/exact-graph-content-verifier.ts
+++ b/packages/agent/src/exact-graph-content-verifier.ts
@@ -1,0 +1,91 @@
+import { assertSafeIri } from '@origintrail-official/dkg-core';
+import {
+  computeFlatKCRootV10,
+  workspacePublicQuadsDigest,
+} from '@origintrail-official/dkg-publisher';
+import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
+
+export type ExactGraphContentVerification =
+  | {
+      status: 'verified';
+      graphUri: string;
+      quads: Quad[];
+      merkleRoot: Uint8Array;
+      publicQuadsDigest?: string;
+    }
+  | {
+      status: 'count-mismatch';
+      graphUri: string;
+      actualCount: number;
+    }
+  | {
+      status: 'merkle-mismatch';
+      graphUri: string;
+    }
+  | {
+      status: 'head-mismatch';
+      graphUri: string;
+    };
+
+export type VerifiedExactGraphContent = Extract<
+  ExactGraphContentVerification,
+  { status: 'verified' }
+>;
+
+/** Verify the exact public content stored in one named graph. */
+export async function verifyExactGraphContent(
+  store: TripleStore,
+  input: {
+    graphUri: string;
+    publicTripleCount: number;
+    privateMerkleRoot?: Uint8Array;
+    expectedMerkleRoot: Uint8Array;
+    expectedPublicQuadsDigest?: string;
+    includePublicQuadsDigest?: boolean;
+    source: string;
+  },
+): Promise<ExactGraphContentVerification> {
+  const result = await store.query(
+    `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${assertSafeIri(input.graphUri)}> { ?s ?p ?o } }`,
+    { source: input.source },
+  );
+  const quads = result.type === 'quads'
+    ? result.quads.map((quad) => ({ ...quad, graph: '' }))
+    : [];
+  if (quads.length !== input.publicTripleCount) {
+    return {
+      status: 'count-mismatch',
+      graphUri: input.graphUri,
+      actualCount: quads.length,
+    };
+  }
+  const merkleRoot = computeFlatKCRootV10(
+    quads,
+    input.privateMerkleRoot ? [input.privateMerkleRoot] : [],
+  );
+  if (!equalBytes(merkleRoot, input.expectedMerkleRoot)) {
+    return { status: 'merkle-mismatch', graphUri: input.graphUri };
+  }
+  const publicQuadsDigest = input.includePublicQuadsDigest
+    || input.expectedPublicQuadsDigest !== undefined
+    ? workspacePublicQuadsDigest(quads)
+    : undefined;
+  if (
+    input.expectedPublicQuadsDigest !== undefined
+    && publicQuadsDigest !== input.expectedPublicQuadsDigest
+  ) {
+    return { status: 'head-mismatch', graphUri: input.graphUri };
+  }
+  return {
+    status: 'verified',
+    graphUri: input.graphUri,
+    quads,
+    merkleRoot,
+    ...(publicQuadsDigest ? { publicQuadsDigest } : {}),
+  };
+}
+
+function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
+  return left.length === right.length
+    && left.every((byte, index) => byte === right[index]);
+}

--- a/packages/agent/src/exact-graph-content-verifier.ts
+++ b/packages/agent/src/exact-graph-content-verifier.ts
@@ -1,9 +1,13 @@
-import { assertSafeIri } from '@origintrail-official/dkg-core';
 import {
   computeFlatKCRootV10,
   workspacePublicQuadsDigest,
 } from '@origintrail-official/dkg-publisher';
-import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
+import {
+  ExactGraphReadError,
+  readExactGraphPaged,
+  type Quad,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
 
 export type ExactGraphContentVerification =
   | {
@@ -43,19 +47,26 @@ export async function verifyExactGraphContent(
     source: string;
   },
 ): Promise<ExactGraphContentVerification> {
-  const result = await store.query(
-    `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${assertSafeIri(input.graphUri)}> { ?s ?p ?o } }`,
-    { source: input.source },
-  );
-  const quads = result.type === 'quads'
-    ? result.quads.map((quad) => ({ ...quad, graph: '' }))
-    : [];
-  if (quads.length !== input.publicTripleCount) {
-    return {
-      status: 'count-mismatch',
-      graphUri: input.graphUri,
-      actualCount: quads.length,
-    };
+  let quads: Quad[];
+  try {
+    quads = await readExactGraphPaged(store, input.graphUri, {
+      expectedQuadCount: input.publicTripleCount,
+      outputGraph: '',
+      queryOptions: { source: input.source },
+    });
+  } catch (error) {
+    if (
+      error instanceof ExactGraphReadError
+      && error.code === 'QUAD_COUNT_MISMATCH'
+      && typeof error.actual === 'number'
+    ) {
+      return {
+        status: 'count-mismatch',
+        graphUri: input.graphUri,
+        actualCount: error.actual,
+      };
+    }
+    throw error;
   }
   const merkleRoot = computeFlatKCRootV10(
     quads,

--- a/packages/agent/src/exact-graph-content-verifier.ts
+++ b/packages/agent/src/exact-graph-content-verifier.ts
@@ -11,7 +11,6 @@ export type ExactGraphContentVerification =
       graphUri: string;
       quads: Quad[];
       merkleRoot: Uint8Array;
-      publicQuadsDigest?: string;
     }
   | {
       status: 'count-mismatch';
@@ -41,7 +40,6 @@ export async function verifyExactGraphContent(
     privateMerkleRoot?: Uint8Array;
     expectedMerkleRoot: Uint8Array;
     expectedPublicQuadsDigest?: string;
-    includePublicQuadsDigest?: boolean;
     source: string;
   },
 ): Promise<ExactGraphContentVerification> {
@@ -66,13 +64,9 @@ export async function verifyExactGraphContent(
   if (!equalBytes(merkleRoot, input.expectedMerkleRoot)) {
     return { status: 'merkle-mismatch', graphUri: input.graphUri };
   }
-  const publicQuadsDigest = input.includePublicQuadsDigest
-    || input.expectedPublicQuadsDigest !== undefined
-    ? workspacePublicQuadsDigest(quads)
-    : undefined;
   if (
     input.expectedPublicQuadsDigest !== undefined
-    && publicQuadsDigest !== input.expectedPublicQuadsDigest
+    && workspacePublicQuadsDigest(quads) !== input.expectedPublicQuadsDigest
   ) {
     return { status: 'head-mismatch', graphUri: input.graphUri };
   }
@@ -81,7 +75,6 @@ export async function verifyExactGraphContent(
     graphUri: input.graphUri,
     quads,
     merkleRoot,
-    ...(publicQuadsDigest ? { publicQuadsDigest } : {}),
   };
 }
 

--- a/packages/agent/src/finalization-graph-envelope.ts
+++ b/packages/agent/src/finalization-graph-envelope.ts
@@ -78,6 +78,11 @@ export interface VerifiedGraphScopedFinalizationIdentity {
   targetContextGraphId?: string;
 }
 
+export type VerifiedGraphScopedFinalizationEvidencePlacement =
+  | 'original'
+  | 'canonical-moved'
+  | 'mismatch';
+
 export interface BuildVerifiedGraphScopedFinalizationEvidenceInput {
   candidate: ParsedGraphScopedFinalization;
   publicQuadsDigest?: string;
@@ -251,8 +256,18 @@ export class VerifiedGraphScopedFinalizationEvidenceCodec {
     candidate: ParsedGraphScopedFinalization,
     identity: VerifiedGraphScopedFinalizationIdentity,
   ): boolean {
-    return this.matchesImmutableEnvelope(evidence, candidate, identity)
-      && candidate.blockNumber === evidence.blockNumber;
+    return this.classifyPlacement(evidence, candidate, identity) === 'original';
+  }
+
+  static classifyPlacement(
+    evidence: VerifiedGraphScopedFinalizationEvidence,
+    candidate: ParsedGraphScopedFinalization,
+    identity: VerifiedGraphScopedFinalizationIdentity,
+  ): VerifiedGraphScopedFinalizationEvidencePlacement {
+    if (!this.matchesImmutableEnvelope(evidence, candidate, identity)) return 'mismatch';
+    return candidate.blockNumber === evidence.blockNumber
+      ? 'original'
+      : 'canonical-moved';
   }
 
   static matchesImmutableEnvelope(

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -43,7 +43,6 @@ import {
   generatedPrivateCatalogFloorQuads,
   generatedPrivateCatalogTripleKeys,
   generateConfirmedFullMetadata, generateGraphKnowledgeAssetMetadata,
-  readConfirmedGraphKnowledgeAssetMetadataEnvelope,
   buildDeterministicTokenRows, compareRootIris, getTentativeStatusQuad,
   insertBoundedAgentRegistryMeta,
   generateSubGraphRegistration,
@@ -102,6 +101,7 @@ import {
   type VerifiedGraphScopedFinalizationEvidence,
 } from './finalization-graph-envelope.js';
 import { recoverReceiptBackedGraphScopedEvidence } from './receipt-backed-graph-scoped-evidence.js';
+import { resolveConfirmedGraphScopedVm } from './confirmed-graph-scoped-vm-resolver.js';
 import { protobufScalarToBigInt, protobufScalarToNumber } from './protobuf-scalars.js';
 
 /**
@@ -1445,60 +1445,26 @@ export class FinalizationHandler {
     versionBlock: number;
     subGraphName?: string;
   }, ctx: OperationContext): Promise<'already-confirmed' | 'no-swm' | undefined> {
-    const stored = await readConfirmedGraphKnowledgeAssetMetadataEnvelope(this.store, {
+    const resolution = await resolveConfirmedGraphScopedVm(this.store, {
       contextGraphId: input.contextGraphId,
       ual: input.ual,
+      merkleRoot: input.merkleRoot,
+      kaId: input.kaId,
+      ...(input.subGraphName ? { subGraphName: input.subGraphName } : {}),
     });
-    if (stored.state === 'absent') return undefined;
-    if (stored.state === 'invalid') {
-      this.log.warn(ctx, `Chain-reconcile: invalid confirmed graph-scoped metadata for ${input.ual}`);
-      return 'no-swm';
-    }
-
-    const { envelope } = stored;
-    let scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
-    try {
-      scope = createGraphKnowledgeAssetScope(input.ual, envelope.assertionVersion);
-    } catch {
-      return 'no-swm';
-    }
-    const packedKaId = (BigInt(scope.agentAddress) << 96n) | BigInt(scope.kaNumber);
-    if (
-      scope.ual !== input.ual
-      || packedKaId !== input.kaId
-      || envelope.batchId !== input.kaId
-      || !equalBytes(envelope.merkleRoot, input.merkleRoot)
-      || (input.subGraphName !== undefined && input.subGraphName !== envelope.subGraphName)
-    ) {
+    if (resolution.status === 'absent') return undefined;
+    if (resolution.status === 'invalid') {
       this.log.warn(
         ctx,
-        `Chain-reconcile: confirmed graph-scoped metadata does not match chain identity for ${input.ual}`,
-      );
-      return 'no-swm';
-    }
-
-    const verification = await this.verifyExactGraphScopedLayer({
-      contextGraphId: input.contextGraphId,
-      scope,
-      layer: MemoryLayer.VerifiableMemory,
-      publicTripleCount: envelope.publicTripleCount,
-      ...(envelope.privateMerkleRoot
-        ? { privateMerkleRoot: envelope.privateMerkleRoot }
-        : {}),
-      expectedMerkleRoot: input.merkleRoot,
-      ...(envelope.subGraphName ? { subGraphName: envelope.subGraphName } : {}),
-    });
-    if (verification.status !== 'verified') {
-      this.log.warn(
-        ctx,
-        `Chain-reconcile: confirmed metadata exists but exact VM content is invalid for ${input.ual}`,
+        `Chain-reconcile: confirmed graph-scoped VM is invalid for ${input.ual} `
+          + `(${resolution.reason})`,
       );
       return 'no-swm';
     }
 
     await this.advanceExactGraphScopedVersion({
       contextGraphId: input.contextGraphId,
-      scope,
+      scope: resolution.scope,
       materializedVersion: { blockNumber: input.versionBlock, txIndex: 0 },
     });
     this.log.info(
@@ -1520,14 +1486,28 @@ export class FinalizationHandler {
     candidate: ParsedGraphScopedFinalization;
   }): Promise<VerifiedGraphScopedFinalizationEvidence | undefined> {
     const { replay, candidate } = input;
-    const stored = await readConfirmedGraphKnowledgeAssetMetadataEnvelope(this.store, {
+    let kaId: bigint;
+    let onChainContextGraphId: bigint;
+    try {
+      kaId = BigInt(replay.kaId);
+      onChainContextGraphId = BigInt(replay.onChainCgId);
+      if (kaId !== candidate.kaId || onChainContextGraphId <= 0n) return undefined;
+    } catch {
+      return undefined;
+    }
+
+    const resolution = await resolveConfirmedGraphScopedVm(this.store, {
       contextGraphId: replay.contextGraphId,
       ual: replay.ual,
+      merkleRoot: ethers.getBytes(replay.merkleRoot),
+      kaId,
+      ...(candidate.msg.subGraphName
+        ? { subGraphName: candidate.msg.subGraphName }
+        : {}),
     });
-    if (stored.state !== 'confirmed') return undefined;
+    if (resolution.status !== 'verified') return undefined;
 
-    const { envelope } = stored;
-    const messageSubGraphName = candidate.msg.subGraphName || undefined;
+    const { envelope } = resolution;
     if (
       envelope.transactionHash?.toLowerCase() !== candidate.msg.txHash.toLowerCase()
       || envelope.assertionVersion !== candidate.assertionVersion
@@ -1539,44 +1519,17 @@ export class FinalizationHandler {
         ? ethers.hexlify(candidate.privateMerkleRoot).toLowerCase()
         : undefined)
       || envelope.batchId !== candidate.batchId
-      || !equalBytes(envelope.merkleRoot, candidate.msg.kcMerkleRoot)
-      || messageSubGraphName !== envelope.subGraphName
     ) return undefined;
-
-    let scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
-    let kaId: bigint;
-    let onChainContextGraphId: bigint;
-    try {
-      scope = createGraphKnowledgeAssetScope(replay.ual, envelope.assertionVersion);
-      kaId = BigInt(replay.kaId);
-      onChainContextGraphId = BigInt(replay.onChainCgId);
-      if (kaId !== candidate.kaId || onChainContextGraphId <= 0n) return undefined;
-    } catch {
-      return undefined;
-    }
-
-    const verification = await this.verifyExactGraphScopedLayer({
-      contextGraphId: replay.contextGraphId,
-      scope,
-      layer: MemoryLayer.VerifiableMemory,
-      publicTripleCount: envelope.publicTripleCount,
-      ...(envelope.privateMerkleRoot
-        ? { privateMerkleRoot: envelope.privateMerkleRoot }
-        : {}),
-      expectedMerkleRoot: ethers.getBytes(replay.merkleRoot),
-      ...(envelope.subGraphName ? { subGraphName: envelope.subGraphName } : {}),
-    });
-    if (verification.status !== 'verified') return undefined;
 
     const recovery = await recoverReceiptBackedGraphScopedEvidence({
       store: this.store,
       chain: this.chain,
       contextGraphId: replay.contextGraphId,
-      scope,
+      scope: resolution.scope,
       head: {
         kaUal: replay.ual,
         assertionVersion: envelope.assertionVersion,
-        publicQuadsDigest: workspacePublicQuadsDigest(verification.quads),
+        publicQuadsDigest: resolution.publicQuadsDigest,
         publicTripleCount: envelope.publicTripleCount,
         ...(envelope.privateMerkleRoot
           ? { privateMerkleRoot: ethers.hexlify(envelope.privateMerkleRoot) }

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -1413,6 +1413,7 @@ export class FinalizationHandler {
     ual: string;
     merkleRoot: Uint8Array;
     kaId: bigint;
+    batchId: bigint;
     versionBlock: number;
     subGraphName?: string;
   }, ctx: OperationContext): Promise<'already-confirmed' | 'no-swm' | undefined> {
@@ -1421,6 +1422,7 @@ export class FinalizationHandler {
       ual: input.ual,
       merkleRoot: input.merkleRoot,
       kaId: input.kaId,
+      batchId: input.batchId,
       ...(input.subGraphName ? { subGraphName: input.subGraphName } : {}),
     });
     if (resolution.status === 'absent') return undefined;
@@ -1530,7 +1532,7 @@ export class FinalizationHandler {
     merkleRoot: Uint8Array;
     publisherAddress: string;
     kaId: bigint;
-    batchId?: bigint;
+    batchId: bigint;
     versionBlock: number;
     authorAddress?: string;
     subGraphName?: string;
@@ -1594,6 +1596,7 @@ export class FinalizationHandler {
           ual,
           merkleRoot,
           kaId,
+          batchId,
           versionBlock,
           ...(subGraphName ? { subGraphName } : {}),
         }, ctx)) ?? 'no-swm';
@@ -1607,6 +1610,7 @@ export class FinalizationHandler {
         ual,
         merkleRoot,
         kaId,
+        batchId,
         versionBlock,
         ...(subGraphName ? { subGraphName } : {}),
       }, ctx);
@@ -1655,7 +1659,7 @@ export class FinalizationHandler {
       );
       return 'no-swm';
     }
-    const reconciliationBatchId = batchId ?? kaId;
+    const reconciliationBatchId = batchId;
     if (head.publicTripleCount === 0 && head.privateTripleCount === 0) {
       this.log.warn(ctx, `Chain-reconcile: empty graph-scoped content envelope for ${ual}`);
       return 'no-swm';
@@ -3141,6 +3145,7 @@ export class FinalizationHandler {
       merkleRoot,
       publisherAddress,
       kaId,
+      batchId: kaId,
       versionBlock,
       authorAddress,
       subGraphName,

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -356,6 +356,7 @@ export interface ChainReconciledKCInput {
   merkleRoot: Uint8Array;
   publisherAddress: string;
   kaId: bigint;
+  batchId: bigint;
   versionBlock: number;
   authorAddress?: string;
   subGraphName?: string;
@@ -3108,7 +3109,7 @@ export class FinalizationHandler {
     const input = resolvedInput;
     const {
       contextGraphId, onChainCgId, ual, merkleRoot, publisherAddress,
-      kaId, versionBlock, authorAddress, subGraphName, trustedAssertionEvidence,
+      kaId, batchId, versionBlock, authorAddress, subGraphName, trustedAssertionEvidence,
     } = input;
     const ctxGraphId = onChainCgId.length > 0 ? onChainCgId : undefined;
     const targetMetaGraph = ctxGraphId
@@ -3145,7 +3146,7 @@ export class FinalizationHandler {
       merkleRoot,
       publisherAddress,
       kaId,
-      batchId: kaId,
+      batchId,
       versionBlock,
       authorAddress,
       subGraphName,
@@ -3200,7 +3201,7 @@ export class FinalizationHandler {
     if (!exact.legacyEligible) return exact.outcome;
     const {
       contextGraphId, onChainCgId, ual, merkleRoot, publisherAddress,
-      kaId, versionBlock, authorAddress, subGraphName,
+      kaId, batchId, versionBlock, authorAddress, subGraphName,
     } = exact.input;
     const ctxGraphId = onChainCgId.length > 0 ? onChainCgId : undefined;
 
@@ -3243,7 +3244,7 @@ export class FinalizationHandler {
       blockNumber: versionBlock,
       startKAId: kaId,
       endKAId: kaId,
-      batchId: 0n,
+      batchId,
       ctxGraphId,
       subGraphName: resolvedSubGraphName,
       authorAddress,

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -483,6 +483,7 @@ export class FinalizationHandler {
         merkleRoot: ethers.getBytes(replay.merkleRoot),
         publisherAddress: evidence.publisherAddress,
         kaId: BigInt(replay.kaId),
+        batchId: candidate.batchId,
         versionBlock: evidence.blockNumber,
         ...(evidence.authorAddress ? { authorAddress: evidence.authorAddress } : {}),
         ...(evidence.subGraphName ? { subGraphName: evidence.subGraphName } : {}),
@@ -1471,6 +1472,7 @@ export class FinalizationHandler {
       ual: replay.ual,
       merkleRoot: ethers.getBytes(replay.merkleRoot),
       kaId,
+      batchId: candidate.batchId,
       ...(candidate.msg.subGraphName
         ? { subGraphName: candidate.msg.subGraphName }
         : {}),
@@ -1509,6 +1511,7 @@ export class FinalizationHandler {
       merkleRoot: envelope.merkleRoot,
       publisherAddress: candidate.msg.publisherAddress,
       kaId,
+      batchId: candidate.batchId,
       onChainContextGraphId,
       ...(envelope.subGraphName ? { subGraphName: envelope.subGraphName } : {}),
     });
@@ -1527,6 +1530,7 @@ export class FinalizationHandler {
     merkleRoot: Uint8Array;
     publisherAddress: string;
     kaId: bigint;
+    batchId?: bigint;
     versionBlock: number;
     authorAddress?: string;
     subGraphName?: string;
@@ -1546,6 +1550,7 @@ export class FinalizationHandler {
       merkleRoot,
       publisherAddress,
       kaId,
+      batchId,
       versionBlock,
       authorAddress,
       subGraphName,
@@ -1650,6 +1655,7 @@ export class FinalizationHandler {
       );
       return 'no-swm';
     }
+    const reconciliationBatchId = batchId ?? kaId;
     if (head.publicTripleCount === 0 && head.privateTripleCount === 0) {
       this.log.warn(ctx, `Chain-reconcile: empty graph-scoped content envelope for ${ual}`);
       return 'no-swm';
@@ -1687,7 +1693,7 @@ export class FinalizationHandler {
         scope,
         head,
         merkleRoot,
-        batchId: kaId,
+        batchId: reconciliationBatchId,
         expectedTxHash: trustedAssertionEvidence?.transactionHash,
         accessPolicy: access.accessPolicy,
         allowedPeers: access.allowedPeers,
@@ -1710,7 +1716,7 @@ export class FinalizationHandler {
           scope,
           head,
           merkleRoot,
-          batchId: kaId,
+          batchId: reconciliationBatchId,
           accessPolicy: 'ownerOnly',
           allowedPeers: [],
           confirmationKind: 'transaction',
@@ -1753,6 +1759,7 @@ export class FinalizationHandler {
           merkleRoot,
           publisherAddress,
           kaId,
+          batchId: reconciliationBatchId,
           onChainContextGraphId,
           subGraphName,
         });
@@ -1769,7 +1776,7 @@ export class FinalizationHandler {
             computedMerkleRoot: vmVerification.merkleRoot,
             evidence: recovery.evidence,
             privateMerkleRoot,
-            batchId: kaId,
+            batchId: reconciliationBatchId,
             preserveNewerWorkspaceLifecycle: false,
             ctx,
           });
@@ -1781,7 +1788,7 @@ export class FinalizationHandler {
           head,
           privateMerkleRoot,
           merkleRoot,
-          batchId: kaId,
+          batchId: reconciliationBatchId,
           versionBlock,
           subGraphName,
           verifiedLayer: {
@@ -1803,7 +1810,7 @@ export class FinalizationHandler {
         computedMerkleRoot: vmVerification.merkleRoot,
         evidence: trustedAssertionEvidence,
         privateMerkleRoot,
-        batchId: kaId,
+        batchId: reconciliationBatchId,
         preserveNewerWorkspaceLifecycle,
         ctx,
       });
@@ -1858,7 +1865,7 @@ export class FinalizationHandler {
         head,
         privateMerkleRoot,
         merkleRoot,
-        batchId: kaId,
+        batchId: reconciliationBatchId,
         versionBlock,
         subGraphName,
         verifiedLayer: {
@@ -1876,7 +1883,7 @@ export class FinalizationHandler {
       head,
       privateMerkleRoot,
       computedMerkleRoot: swmVerification.merkleRoot,
-      batchId: kaId,
+      batchId: reconciliationBatchId,
       authorAddress: evidenceAuthorAddress,
       confirmation: {
         kind: 'transaction',

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -492,6 +492,9 @@ export class FinalizationHandler {
     const materializer: FinalizationRecoveryMaterializer<PreparedGraphScopedMaterialization> = {
       prepare: (input) => this.prepareGraphScopedMaterialization(input),
       apply: (input) => this.applyPreparedGraphScopedMaterialization(input),
+      recoverVerifiedEvidence: (input) => (
+        this.recoverVerifiedGraphScopedEvidenceFromConfirmedVm(input)
+      ),
       replayVerified: ({ replay, candidate, evidence }) => this.reconcileGraphScopedKC({
         contextGraphId: replay.contextGraphId,
         ual: replay.ual,
@@ -1503,6 +1506,90 @@ export class FinalizationHandler {
       `Chain-reconcile: exact confirmed VM state survives without a workspace head for ${input.ual}`,
     );
     return 'already-confirmed';
+  }
+
+  /** Recover canonical receipt evidence from an exact, receipt-backed VM assertion. */
+  private async recoverVerifiedGraphScopedEvidenceFromConfirmedVm(input: {
+    replay: {
+      contextGraphId: string;
+      onChainCgId: string;
+      ual: string;
+      merkleRoot: string;
+      kaId: string;
+    };
+    candidate: ParsedGraphScopedFinalization;
+  }): Promise<VerifiedGraphScopedFinalizationEvidence | undefined> {
+    const { replay, candidate } = input;
+    const stored = await readConfirmedGraphKnowledgeAssetMetadataEnvelope(this.store, {
+      contextGraphId: replay.contextGraphId,
+      ual: replay.ual,
+    });
+    if (stored.state !== 'confirmed') return undefined;
+
+    const { envelope } = stored;
+    const messageSubGraphName = candidate.msg.subGraphName || undefined;
+    if (
+      envelope.transactionHash?.toLowerCase() !== candidate.msg.txHash.toLowerCase()
+      || envelope.assertionVersion !== candidate.assertionVersion
+      || envelope.publicTripleCount !== candidate.publicTripleCount
+      || envelope.privateTripleCount !== candidate.privateTripleCount
+      || (envelope.privateMerkleRoot
+        ? ethers.hexlify(envelope.privateMerkleRoot).toLowerCase()
+        : undefined) !== (candidate.privateMerkleRoot
+        ? ethers.hexlify(candidate.privateMerkleRoot).toLowerCase()
+        : undefined)
+      || envelope.batchId !== candidate.batchId
+      || !equalBytes(envelope.merkleRoot, candidate.msg.kcMerkleRoot)
+      || messageSubGraphName !== envelope.subGraphName
+    ) return undefined;
+
+    let scope: ReturnType<typeof createGraphKnowledgeAssetScope>;
+    let kaId: bigint;
+    let onChainContextGraphId: bigint;
+    try {
+      scope = createGraphKnowledgeAssetScope(replay.ual, envelope.assertionVersion);
+      kaId = BigInt(replay.kaId);
+      onChainContextGraphId = BigInt(replay.onChainCgId);
+      if (kaId !== candidate.kaId || onChainContextGraphId <= 0n) return undefined;
+    } catch {
+      return undefined;
+    }
+
+    const verification = await this.verifyExactGraphScopedLayer({
+      contextGraphId: replay.contextGraphId,
+      scope,
+      layer: MemoryLayer.VerifiableMemory,
+      publicTripleCount: envelope.publicTripleCount,
+      ...(envelope.privateMerkleRoot
+        ? { privateMerkleRoot: envelope.privateMerkleRoot }
+        : {}),
+      expectedMerkleRoot: ethers.getBytes(replay.merkleRoot),
+      ...(envelope.subGraphName ? { subGraphName: envelope.subGraphName } : {}),
+    });
+    if (verification.status !== 'verified') return undefined;
+
+    const recovery = await recoverReceiptBackedGraphScopedEvidence({
+      store: this.store,
+      chain: this.chain,
+      contextGraphId: replay.contextGraphId,
+      scope,
+      head: {
+        kaUal: replay.ual,
+        assertionVersion: envelope.assertionVersion,
+        publicQuadsDigest: workspacePublicQuadsDigest(verification.quads),
+        publicTripleCount: envelope.publicTripleCount,
+        ...(envelope.privateMerkleRoot
+          ? { privateMerkleRoot: ethers.hexlify(envelope.privateMerkleRoot) }
+          : {}),
+        privateTripleCount: envelope.privateTripleCount,
+      },
+      merkleRoot: envelope.merkleRoot,
+      publisherAddress: candidate.msg.publisherAddress,
+      kaId,
+      onChainContextGraphId,
+      ...(envelope.subGraphName ? { subGraphName: envelope.subGraphName } : {}),
+    });
+    return recovery.status === 'recovered' ? recovery.evidence : undefined;
   }
 
   /**

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -102,6 +102,11 @@ import {
 } from './finalization-graph-envelope.js';
 import { recoverReceiptBackedGraphScopedEvidence } from './receipt-backed-graph-scoped-evidence.js';
 import { resolveConfirmedGraphScopedVm } from './confirmed-graph-scoped-vm-resolver.js';
+import {
+  verifyExactGraphContent,
+  type ExactGraphContentVerification,
+  type VerifiedExactGraphContent,
+} from './exact-graph-content-verifier.js';
 import { protobufScalarToBigInt, protobufScalarToNumber } from './protobuf-scalars.js';
 
 /**
@@ -187,31 +192,8 @@ function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
     && left.every((byte, index) => byte === right[index]);
 }
 
-type ExactGraphScopedLayerVerification =
-  | {
-      status: 'verified';
-      graphUri: string;
-      quads: Quad[];
-      merkleRoot: Uint8Array;
-    }
-  | {
-      status: 'count-mismatch';
-      graphUri: string;
-      actualCount: number;
-    }
-  | {
-      status: 'merkle-mismatch';
-      graphUri: string;
-    }
-  | {
-      status: 'head-mismatch';
-      graphUri: string;
-    };
-
-type VerifiedGraphScopedLayer = Extract<
-  ExactGraphScopedLayerVerification,
-  { status: 'verified' }
->;
+type ExactGraphScopedLayerVerification = ExactGraphContentVerification;
+type VerifiedGraphScopedLayer = VerifiedExactGraphContent;
 
 /**
  * Exact local content accepted by the receiptless public-finalization policy.
@@ -1410,30 +1392,18 @@ export class FinalizationHandler {
       input.scope,
       input.subGraphName,
     );
-    const result = await this.store.query(
-      `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${assertSafeIri(graphUri)}> { ?s ?p ?o } }`,
-      { source: 'agent.finalization.verifyExactLayer' },
-    );
-    const quads = result.type === 'quads'
-      ? result.quads.map((quad) => ({ ...quad, graph: '' }))
-      : [];
-    if (quads.length !== input.publicTripleCount) {
-      return { status: 'count-mismatch', graphUri, actualCount: quads.length };
-    }
-    const merkleRoot = computeFlatKCRoot(
-      quads,
-      input.privateMerkleRoot ? [input.privateMerkleRoot] : [],
-    );
-    if (!equalBytes(merkleRoot, input.expectedMerkleRoot)) {
-      return { status: 'merkle-mismatch', graphUri };
-    }
-    if (
-      input.expectedPublicQuadsDigest !== undefined
-      && workspacePublicQuadsDigest(quads) !== input.expectedPublicQuadsDigest
-    ) {
-      return { status: 'head-mismatch', graphUri };
-    }
-    return { status: 'verified', graphUri, quads, merkleRoot };
+    return verifyExactGraphContent(this.store, {
+      graphUri,
+      publicTripleCount: input.publicTripleCount,
+      ...(input.privateMerkleRoot
+        ? { privateMerkleRoot: input.privateMerkleRoot }
+        : {}),
+      expectedMerkleRoot: input.expectedMerkleRoot,
+      ...(input.expectedPublicQuadsDigest
+        ? { expectedPublicQuadsDigest: input.expectedPublicQuadsDigest }
+        : {}),
+      source: 'agent.finalization.verifyExactLayer',
+    });
   }
 
   /** Recognize exact confirmed VM state from surviving immutable metadata. */

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -52,7 +52,6 @@ import {
   withMaterializationLock,
   KnowledgeAssetWorkspaceHeadCorruptError,
   resolveKnowledgeAssetWorkspaceHead,
-  workspacePublicQuadsDigest,
   type MaterializedVersion,
   type KnowledgeAssetWorkspaceHead,
   type KCMetadata, type KAMetadata, type OnChainProvenance,
@@ -185,11 +184,6 @@ function sameBigIntLiteral(left: string | bigint | null | undefined, right: stri
   } catch {
     return false;
   }
-}
-
-function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
-  return left.length === right.length
-    && left.every((byte, index) => byte === right[index]);
 }
 
 type ExactGraphScopedLayerVerification = ExactGraphContentVerification;

--- a/packages/agent/src/finalization-recovery-sqlite-codec.ts
+++ b/packages/agent/src/finalization-recovery-sqlite-codec.ts
@@ -1,7 +1,6 @@
 import { createHash } from 'node:crypto';
 import {
   VerifiedGraphScopedFinalizationEvidenceCodec,
-  type VerifiedGraphScopedFinalizationEvidence,
 } from './finalization-graph-envelope.js';
 import type {
   FinalizationRecoveryEntry,
@@ -146,11 +145,4 @@ export function finalizationRecoveryRowToEntry(
     createdAt: asSafeInteger(row.created_at, 'created_at'),
     updatedAt: asSafeInteger(row.updated_at, 'updated_at'),
   };
-}
-
-export function sameFinalizationRecoveryEvidence(
-  left: VerifiedGraphScopedFinalizationEvidence,
-  right: VerifiedGraphScopedFinalizationEvidence,
-): boolean {
-  return VerifiedGraphScopedFinalizationEvidenceCodec.same(left, right);
 }

--- a/packages/agent/src/finalization-recovery-sqlite-store.ts
+++ b/packages/agent/src/finalization-recovery-sqlite-store.ts
@@ -5,6 +5,7 @@ import {
 import {
   type FinalizationRecoveryEntry,
   type FinalizationRecoveryHealth,
+  type FinalizationRecoveryRecoveredEvidenceCommit,
   type FinalizationRecoveryReceiveInput,
   type FinalizationRecoveryReceiveResult,
   type FinalizationRecoverySettledPublisherUpgradeResult,
@@ -512,60 +513,131 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
     if (this.#closed || this.#closing) return Promise.resolve({ status: 'closed' });
     return this.mutate(() => {
       if (this.#closed) return { status: 'closed' };
+      return this.commitVerifiedEvidenceWithinTransaction(
+        key,
+        generation,
+        evidence,
+      );
+    });
+  }
+
+  commitRecoveredEvidence(
+    key: string,
+    generation: number,
+    commit: FinalizationRecoveryRecoveredEvidenceCommit,
+  ): Promise<FinalizationRecoveryVerifyResult> {
+    if (this.#closed || this.#closing) return Promise.resolve({ status: 'closed' });
+    return this.mutate(() => {
+      if (this.#closed) return { status: 'closed' };
+      return this.commitVerifiedEvidenceWithinTransaction(
+        key,
+        generation,
+        commit.evidence,
+        commit.receiptMoved ? commit.reason : undefined,
+      );
+    });
+  }
+
+  private commitVerifiedEvidenceWithinTransaction(
+    key: string,
+    generation: number,
+    evidence: VerifiedGraphScopedFinalizationEvidence,
+    movedReceiptReason?: string,
+  ): FinalizationRecoveryVerifyResult {
+    let outcome: FinalizationRecoveryVerifyResult = { status: 'conflict' };
+    this.transaction(() => {
       const row = this.database.prepare(
         'SELECT * FROM finalization_inbox_v1 WHERE key = ?',
       ).get(key);
-      if (!row) return { status: 'missing' };
+      if (!row) {
+        outcome = { status: 'missing' };
+        return;
+      }
       const current = finalizationRecoveryRowToEntry(row);
-      if (current.generation !== generation) return { status: 'conflict' };
+      if (current.generation !== generation) return;
       if (current.verifiedEvidence) {
-        return sameFinalizationRecoveryEvidence(current.verifiedEvidence, evidence)
+        outcome = sameFinalizationRecoveryEvidence(current.verifiedEvidence, evidence)
           ? { status: 'existing', entry: current }
           : { status: 'conflict' };
+        return;
       }
-      if (current.state !== 'RECEIVED' && current.state !== 'REORGED') {
-        return { status: 'conflict' };
-      }
+      const receiptMoved = movedReceiptReason !== undefined;
       if (
-        current.txHash.toLowerCase() !== evidence.transactionHash.toLowerCase()
+        (current.state !== 'RECEIVED' && current.state !== 'REORGED')
+        || (receiptMoved && (current.state !== 'RECEIVED' || generation !== 0))
+        || current.txHash.toLowerCase() !== evidence.transactionHash.toLowerCase()
         || current.assertionVersion !== evidence.assertionVersion
-      ) return { status: 'conflict' };
-      this.transaction(() => {
-        this.database.prepare(`
-          UPDATE finalization_inbox_v1
-          SET state = 'VERIFIED',
-              block_number = ?,
-              block_hash = ?,
-              tx_index = ?,
-              publisher_address = ?,
-              author_address = ?,
-              verified_evidence_json = ?,
-              updated_at = ?
-          WHERE key = ? AND generation = ?
-            AND state IN ('RECEIVED','REORGED')
-            AND verified_evidence_json IS NULL
-        `).run(
-          evidence.blockNumber,
-          evidence.blockHash,
-          evidence.txIndex,
-          evidence.publisherAddress,
-          evidence.authorAddress ?? null,
-          JSON.stringify(evidence),
-          this.#policy.now(),
-          key,
-          generation,
-        );
-      });
+      ) return;
+
+      const update = receiptMoved
+        ? this.database.prepare(`
+            UPDATE finalization_inbox_v1
+            SET state = 'VERIFIED',
+                block_number = ?,
+                block_hash = ?,
+                tx_index = ?,
+                publisher_address = ?,
+                author_address = ?,
+                verified_evidence_json = ?,
+                generation = generation + 1,
+                attempt_count = 0,
+                next_attempt_at = NULL,
+                last_error = ?,
+                updated_at = ?
+            WHERE key = ? AND generation = ? AND state = 'RECEIVED'
+              AND verified_evidence_json IS NULL
+          `).run(
+            evidence.blockNumber,
+            evidence.blockHash,
+            evidence.txIndex,
+            evidence.publisherAddress,
+            evidence.authorAddress ?? null,
+            JSON.stringify(evidence),
+            movedReceiptReason,
+            this.#policy.now(),
+            key,
+            generation,
+          )
+        : this.database.prepare(`
+            UPDATE finalization_inbox_v1
+            SET state = 'VERIFIED',
+                block_number = ?,
+                block_hash = ?,
+                tx_index = ?,
+                publisher_address = ?,
+                author_address = ?,
+                verified_evidence_json = ?,
+                updated_at = ?
+            WHERE key = ? AND generation = ?
+              AND state IN ('RECEIVED','REORGED')
+              AND verified_evidence_json IS NULL
+          `).run(
+            evidence.blockNumber,
+            evidence.blockHash,
+            evidence.txIndex,
+            evidence.publisherAddress,
+            evidence.authorAddress ?? null,
+            JSON.stringify(evidence),
+            this.#policy.now(),
+            key,
+            generation,
+          );
+      if (update.changes === 0) return;
       const updated = this.database.prepare(
         'SELECT * FROM finalization_inbox_v1 WHERE key = ?',
       ).get(key);
-      if (!updated) return { status: 'missing' };
+      if (!updated) {
+        outcome = { status: 'missing' };
+        return;
+      }
       const entry = finalizationRecoveryRowToEntry(updated);
-      return entry.verifiedEvidence
+      if (
+        entry.generation === generation + (receiptMoved ? 1 : 0)
+        && entry.verifiedEvidence
         && sameFinalizationRecoveryEvidence(entry.verifiedEvidence, evidence)
-        ? { status: 'verified', entry }
-        : { status: 'conflict' };
+      ) outcome = { status: 'verified', entry };
     });
+    return outcome;
   }
 
   markReorged(key: string, generation: number, lastError: string): Promise<boolean> {

--- a/packages/agent/src/finalization-recovery-sqlite-store.ts
+++ b/packages/agent/src/finalization-recovery-sqlite-store.ts
@@ -1,11 +1,8 @@
 import type { DatabaseSync } from 'node:sqlite';
 import {
-  type VerifiedGraphScopedFinalizationEvidence,
-} from './finalization-graph-envelope.js';
-import {
   type FinalizationRecoveryEntry,
   type FinalizationRecoveryHealth,
-  type FinalizationRecoveryRecoveredEvidenceCommit,
+  type FinalizationRecoveryVerifiedEvidenceCommit,
   type FinalizationRecoveryReceiveInput,
   type FinalizationRecoveryReceiveResult,
   type FinalizationRecoverySettledPublisherUpgradeResult,
@@ -505,26 +502,10 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
     });
   }
 
-  markVerified(
+  commitVerifiedEvidence(
     key: string,
     generation: number,
-    evidence: VerifiedGraphScopedFinalizationEvidence,
-  ): Promise<FinalizationRecoveryVerifyResult> {
-    if (this.#closed || this.#closing) return Promise.resolve({ status: 'closed' });
-    return this.mutate(() => {
-      if (this.#closed) return { status: 'closed' };
-      return this.commitVerifiedEvidenceWithinTransaction(
-        key,
-        generation,
-        { evidence, placement: 'original' },
-      );
-    });
-  }
-
-  commitRecoveredEvidence(
-    key: string,
-    generation: number,
-    commit: FinalizationRecoveryRecoveredEvidenceCommit,
+    commit: FinalizationRecoveryVerifiedEvidenceCommit,
   ): Promise<FinalizationRecoveryVerifyResult> {
     if (this.#closed || this.#closing) return Promise.resolve({ status: 'closed' });
     return this.mutate(() => {
@@ -540,7 +521,7 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
   private commitVerifiedEvidenceWithinTransaction(
     key: string,
     generation: number,
-    commit: FinalizationRecoveryRecoveredEvidenceCommit,
+    commit: FinalizationRecoveryVerifiedEvidenceCommit,
   ): FinalizationRecoveryVerifyResult {
     const { evidence } = commit;
     let outcome: FinalizationRecoveryVerifyResult = { status: 'conflict' };

--- a/packages/agent/src/finalization-recovery-sqlite-store.ts
+++ b/packages/agent/src/finalization-recovery-sqlite-store.ts
@@ -516,7 +516,7 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
       return this.commitVerifiedEvidenceWithinTransaction(
         key,
         generation,
-        evidence,
+        { evidence, placement: 'original' },
       );
     });
   }
@@ -532,8 +532,7 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
       return this.commitVerifiedEvidenceWithinTransaction(
         key,
         generation,
-        commit.evidence,
-        commit.receiptMoved ? commit.reason : undefined,
+        commit,
       );
     });
   }
@@ -541,9 +540,9 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
   private commitVerifiedEvidenceWithinTransaction(
     key: string,
     generation: number,
-    evidence: VerifiedGraphScopedFinalizationEvidence,
-    movedReceiptReason?: string,
+    commit: FinalizationRecoveryRecoveredEvidenceCommit,
   ): FinalizationRecoveryVerifyResult {
+    const { evidence } = commit;
     let outcome: FinalizationRecoveryVerifyResult = { status: 'conflict' };
     this.transaction(() => {
       const row = this.database.prepare(
@@ -561,67 +560,61 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
           : { status: 'conflict' };
         return;
       }
-      const receiptMoved = movedReceiptReason !== undefined;
       if (
         (current.state !== 'RECEIVED' && current.state !== 'REORGED')
-        || (receiptMoved && (current.state !== 'RECEIVED' || generation !== 0))
+        || (
+          commit.placement === 'canonical-moved'
+          && (current.state !== 'RECEIVED' || generation !== 0)
+        )
         || current.txHash.toLowerCase() !== evidence.transactionHash.toLowerCase()
         || current.assertionVersion !== evidence.assertionVersion
       ) return;
 
-      const update = receiptMoved
-        ? this.database.prepare(`
-            UPDATE finalization_inbox_v1
-            SET state = 'VERIFIED',
-                block_number = ?,
-                block_hash = ?,
-                tx_index = ?,
-                publisher_address = ?,
-                author_address = ?,
-                verified_evidence_json = ?,
-                generation = generation + 1,
-                attempt_count = 0,
-                next_attempt_at = NULL,
-                last_error = ?,
-                updated_at = ?
-            WHERE key = ? AND generation = ? AND state = 'RECEIVED'
-              AND verified_evidence_json IS NULL
-          `).run(
-            evidence.blockNumber,
-            evidence.blockHash,
-            evidence.txIndex,
-            evidence.publisherAddress,
-            evidence.authorAddress ?? null,
-            JSON.stringify(evidence),
-            movedReceiptReason,
-            this.#policy.now(),
-            key,
+      const updatePlan = commit.placement === 'canonical-moved'
+        ? {
+            generation: generation + 1,
+            attemptCount: 0,
+            nextAttemptAt: null,
+            lastError: commit.reason,
+          }
+        : {
             generation,
-          )
-        : this.database.prepare(`
-            UPDATE finalization_inbox_v1
-            SET state = 'VERIFIED',
-                block_number = ?,
-                block_hash = ?,
-                tx_index = ?,
-                publisher_address = ?,
-                author_address = ?,
-                verified_evidence_json = ?,
-                updated_at = ?
-            WHERE key = ? AND generation = ?
-              AND state IN ('RECEIVED','REORGED')
-              AND verified_evidence_json IS NULL
-          `).run(
-            evidence.blockNumber,
-            evidence.blockHash,
-            evidence.txIndex,
-            evidence.publisherAddress,
-            evidence.authorAddress ?? null,
-            JSON.stringify(evidence),
-            this.#policy.now(),
-            key,
-            generation,
-          );
+            attemptCount: current.attemptCount,
+            nextAttemptAt: current.nextAttemptAt ?? null,
+            lastError: current.lastError ?? null,
+          };
+      const update = this.database.prepare(`
+        UPDATE finalization_inbox_v1
+        SET state = 'VERIFIED',
+            block_number = ?,
+            block_hash = ?,
+            tx_index = ?,
+            publisher_address = ?,
+            author_address = ?,
+            verified_evidence_json = ?,
+            generation = ?,
+            attempt_count = ?,
+            next_attempt_at = ?,
+            last_error = ?,
+            updated_at = ?
+        WHERE key = ? AND generation = ? AND state = ?
+          AND verified_evidence_json IS NULL
+      `).run(
+        evidence.blockNumber,
+        evidence.blockHash,
+        evidence.txIndex,
+        evidence.publisherAddress,
+        evidence.authorAddress ?? null,
+        JSON.stringify(evidence),
+        updatePlan.generation,
+        updatePlan.attemptCount,
+        updatePlan.nextAttemptAt,
+        updatePlan.lastError,
+        this.#policy.now(),
+        key,
+        generation,
+        current.state,
+      );
       if (update.changes === 0) return;
       const updated = this.database.prepare(
         'SELECT * FROM finalization_inbox_v1 WHERE key = ?',
@@ -632,7 +625,7 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
       }
       const entry = finalizationRecoveryRowToEntry(updated);
       if (
-        entry.generation === generation + (receiptMoved ? 1 : 0)
+        entry.generation === updatePlan.generation
         && entry.verifiedEvidence
         && sameFinalizationRecoveryEvidence(entry.verifiedEvidence, evidence)
       ) outcome = { status: 'verified', entry };

--- a/packages/agent/src/finalization-recovery-sqlite-store.ts
+++ b/packages/agent/src/finalization-recovery-sqlite-store.ts
@@ -1,4 +1,5 @@
 import type { DatabaseSync } from 'node:sqlite';
+import { VerifiedGraphScopedFinalizationEvidenceCodec } from './finalization-graph-envelope.js';
 import {
   type FinalizationRecoveryEntry,
   type FinalizationRecoveryHealth,
@@ -9,12 +10,12 @@ import {
   type FinalizationRecoveryState,
   type FinalizationRecoveryStore,
   type FinalizationRecoveryVerifyResult,
+  planFinalizationRecoveryVerifiedEvidenceTransition,
 } from './finalization-recovery-store.js';
 import {
   finalizationEnvelopeFromRow,
   finalizationEnvelopeSha256,
   finalizationRecoveryRowToEntry,
-  sameFinalizationRecoveryEvidence,
 } from './finalization-recovery-sqlite-codec.js';
 import {
   fsyncFinalizationRecoveryDatabase,
@@ -523,7 +524,6 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
     generation: number,
     commit: FinalizationRecoveryVerifiedEvidenceCommit,
   ): FinalizationRecoveryVerifyResult {
-    const { evidence } = commit;
     let outcome: FinalizationRecoveryVerifyResult = { status: 'conflict' };
     this.transaction(() => {
       const row = this.database.prepare(
@@ -534,39 +534,20 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
         return;
       }
       const current = finalizationRecoveryRowToEntry(row);
-      if (current.generation !== generation) return;
-      if (current.verifiedEvidence) {
-        outcome = sameFinalizationRecoveryEvidence(current.verifiedEvidence, evidence)
-          ? { status: 'existing', entry: current }
-          : { status: 'conflict' };
+      const plan = planFinalizationRecoveryVerifiedEvidenceTransition(
+        current,
+        generation,
+        commit,
+      );
+      if (plan.status === 'existing') {
+        outcome = plan;
         return;
       }
-      if (
-        (current.state !== 'RECEIVED' && current.state !== 'REORGED')
-        || (
-          commit.placement === 'canonical-moved'
-          && (current.state !== 'RECEIVED' || generation !== 0)
-        )
-        || current.txHash.toLowerCase() !== evidence.transactionHash.toLowerCase()
-        || current.assertionVersion !== evidence.assertionVersion
-      ) return;
-
-      const updatePlan = commit.placement === 'canonical-moved'
-        ? {
-            generation: generation + 1,
-            attemptCount: 0,
-            nextAttemptAt: null,
-            lastError: commit.reason,
-          }
-        : {
-            generation,
-            attemptCount: current.attemptCount,
-            nextAttemptAt: current.nextAttemptAt ?? null,
-            lastError: current.lastError ?? null,
-          };
+      if (plan.status === 'conflict') return;
+      const { fields } = plan;
       const update = this.database.prepare(`
         UPDATE finalization_inbox_v1
-        SET state = 'VERIFIED',
+        SET state = ?,
             block_number = ?,
             block_hash = ?,
             tx_index = ?,
@@ -581,16 +562,17 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
         WHERE key = ? AND generation = ? AND state = ?
           AND verified_evidence_json IS NULL
       `).run(
-        evidence.blockNumber,
-        evidence.blockHash,
-        evidence.txIndex,
-        evidence.publisherAddress,
-        evidence.authorAddress ?? null,
-        JSON.stringify(evidence),
-        updatePlan.generation,
-        updatePlan.attemptCount,
-        updatePlan.nextAttemptAt,
-        updatePlan.lastError,
+        fields.state,
+        fields.verifiedEvidence.blockNumber,
+        fields.verifiedEvidence.blockHash,
+        fields.verifiedEvidence.txIndex,
+        fields.verifiedEvidence.publisherAddress,
+        fields.verifiedEvidence.authorAddress ?? null,
+        JSON.stringify(fields.verifiedEvidence),
+        fields.generation,
+        fields.attemptCount,
+        fields.nextAttemptAt,
+        fields.lastError,
         this.#policy.now(),
         key,
         generation,
@@ -606,9 +588,12 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
       }
       const entry = finalizationRecoveryRowToEntry(updated);
       if (
-        entry.generation === updatePlan.generation
+        entry.generation === fields.generation
         && entry.verifiedEvidence
-        && sameFinalizationRecoveryEvidence(entry.verifiedEvidence, evidence)
+        && VerifiedGraphScopedFinalizationEvidenceCodec.same(
+          entry.verifiedEvidence,
+          fields.verifiedEvidence,
+        )
       ) outcome = { status: 'verified', entry };
     });
     return outcome;

--- a/packages/agent/src/finalization-recovery-store.ts
+++ b/packages/agent/src/finalization-recovery-store.ts
@@ -69,7 +69,7 @@ export type FinalizationRecoveryVerifyResult =
   | { status: 'missing' }
   | { status: 'closed' };
 
-export type FinalizationRecoveryRecoveredEvidenceCommit =
+export type FinalizationRecoveryVerifiedEvidenceCommit =
   | {
       evidence: VerifiedGraphScopedFinalizationEvidence;
       placement: 'original';
@@ -130,16 +130,11 @@ export interface FinalizationRecoveryStore {
     publisherPeerId: string,
     lastError: string,
   ): Promise<boolean>;
-  markVerified(
+  /** Atomically records verified evidence and any canonical receipt move. */
+  commitVerifiedEvidence(
     key: string,
     generation: number,
-    evidence: VerifiedGraphScopedFinalizationEvidence,
-  ): Promise<FinalizationRecoveryVerifyResult>;
-  /** Atomically records independently recovered evidence and any receipt move. */
-  commitRecoveredEvidence(
-    key: string,
-    generation: number,
-    commit: FinalizationRecoveryRecoveredEvidenceCommit,
+    commit: FinalizationRecoveryVerifiedEvidenceCommit,
   ): Promise<FinalizationRecoveryVerifyResult>;
   markReorged(key: string, generation: number, lastError: string): Promise<boolean>;
   clearSettledRetry(key: string, generation: number): Promise<void>;

--- a/packages/agent/src/finalization-recovery-store.ts
+++ b/packages/agent/src/finalization-recovery-store.ts
@@ -72,11 +72,11 @@ export type FinalizationRecoveryVerifyResult =
 export type FinalizationRecoveryRecoveredEvidenceCommit =
   | {
       evidence: VerifiedGraphScopedFinalizationEvidence;
-      receiptMoved: false;
+      placement: 'original';
     }
   | {
       evidence: VerifiedGraphScopedFinalizationEvidence;
-      receiptMoved: true;
+      placement: 'canonical-moved';
       reason: string;
     };
 

--- a/packages/agent/src/finalization-recovery-store.ts
+++ b/packages/agent/src/finalization-recovery-store.ts
@@ -1,5 +1,6 @@
-import type {
-  VerifiedGraphScopedFinalizationEvidence,
+import {
+  VerifiedGraphScopedFinalizationEvidenceCodec,
+  type VerifiedGraphScopedFinalizationEvidence,
 } from './finalization-graph-envelope.js';
 
 export const FINALIZATION_INBOX_DATABASE_FILENAME = 'finalization-inbox-v1.sqlite3';
@@ -79,6 +80,71 @@ export type FinalizationRecoveryVerifiedEvidenceCommit =
       placement: 'canonical-moved';
       reason: string;
     };
+
+export interface FinalizationRecoveryVerifiedEvidenceUpdate {
+  state: 'VERIFIED';
+  verifiedEvidence: VerifiedGraphScopedFinalizationEvidence;
+  generation: number;
+  attemptCount: number;
+  nextAttemptAt: number | null;
+  lastError: string | null;
+}
+
+export type FinalizationRecoveryVerifiedEvidenceTransitionPlan =
+  | { status: 'update'; fields: FinalizationRecoveryVerifiedEvidenceUpdate }
+  | { status: 'existing'; entry: FinalizationRecoveryEntry }
+  | { status: 'conflict' };
+
+/**
+ * Plans the domain transition before a store applies it atomically. Generation
+ * remains the compare-and-swap token; placement decides whether this commit
+ * preserves or advances it.
+ */
+export function planFinalizationRecoveryVerifiedEvidenceTransition(
+  current: FinalizationRecoveryEntry,
+  generation: number,
+  commit: FinalizationRecoveryVerifiedEvidenceCommit,
+): FinalizationRecoveryVerifiedEvidenceTransitionPlan {
+  const { evidence } = commit;
+  if (current.generation !== generation) return { status: 'conflict' };
+  if (current.verifiedEvidence) {
+    return VerifiedGraphScopedFinalizationEvidenceCodec.same(
+      current.verifiedEvidence,
+      evidence,
+    )
+      ? { status: 'existing', entry: current }
+      : { status: 'conflict' };
+  }
+  if (
+    (current.state !== 'RECEIVED' && current.state !== 'REORGED')
+    || (
+      commit.placement === 'canonical-moved'
+      && (current.state !== 'RECEIVED' || generation !== 0)
+    )
+    || current.txHash.toLowerCase() !== evidence.transactionHash.toLowerCase()
+    || current.assertionVersion !== evidence.assertionVersion
+  ) return { status: 'conflict' };
+
+  return {
+    status: 'update',
+    fields: {
+      state: 'VERIFIED',
+      verifiedEvidence: evidence,
+      generation: commit.placement === 'canonical-moved'
+        ? generation + 1
+        : generation,
+      attemptCount: commit.placement === 'canonical-moved'
+        ? 0
+        : current.attemptCount,
+      nextAttemptAt: commit.placement === 'canonical-moved'
+        ? null
+        : current.nextAttemptAt ?? null,
+      lastError: commit.placement === 'canonical-moved'
+        ? commit.reason
+        : current.lastError ?? null,
+    },
+  };
+}
 
 export type FinalizationRecoverySettledPublisherUpgradeResult =
   | { status: 'recorded' | 'existing'; entry: FinalizationRecoveryEntry }

--- a/packages/agent/src/finalization-recovery-store.ts
+++ b/packages/agent/src/finalization-recovery-store.ts
@@ -69,6 +69,17 @@ export type FinalizationRecoveryVerifyResult =
   | { status: 'missing' }
   | { status: 'closed' };
 
+export type FinalizationRecoveryRecoveredEvidenceCommit =
+  | {
+      evidence: VerifiedGraphScopedFinalizationEvidence;
+      receiptMoved: false;
+    }
+  | {
+      evidence: VerifiedGraphScopedFinalizationEvidence;
+      receiptMoved: true;
+      reason: string;
+    };
+
 export type FinalizationRecoverySettledPublisherUpgradeResult =
   | { status: 'recorded' | 'existing'; entry: FinalizationRecoveryEntry }
   | { status: 'conflict' | 'missing' | 'closed' };
@@ -123,6 +134,12 @@ export interface FinalizationRecoveryStore {
     key: string,
     generation: number,
     evidence: VerifiedGraphScopedFinalizationEvidence,
+  ): Promise<FinalizationRecoveryVerifyResult>;
+  /** Atomically records independently recovered evidence and any receipt move. */
+  commitRecoveredEvidence(
+    key: string,
+    generation: number,
+    commit: FinalizationRecoveryRecoveredEvidenceCommit,
   ): Promise<FinalizationRecoveryVerifyResult>;
   markReorged(key: string, generation: number, lastError: string): Promise<boolean>;
   clearSettledRetry(key: string, generation: number): Promise<void>;

--- a/packages/agent/src/finalization-recovery.ts
+++ b/packages/agent/src/finalization-recovery.ts
@@ -16,6 +16,7 @@ import {
   type GraphScopedAccessPolicy,
   type ParsedGraphScopedFinalization,
   type VerifiedGraphScopedFinalizationEvidence,
+  type VerifiedGraphScopedFinalizationEvidencePlacement,
 } from './finalization-graph-envelope.js';
 import type {
   FinalizationRecoveryEntry,
@@ -62,6 +63,7 @@ type EnsuredVerifiedReplayEntry =
       status: 'verified';
       entry: FinalizationRecoveryEntry;
       evidence: VerifiedGraphScopedFinalizationEvidence;
+      placement: Exclude<VerifiedGraphScopedFinalizationEvidencePlacement, 'mismatch'>;
     }
   | { status: 'unverified'; entry: FinalizationRecoveryEntry }
   | { status: 'invalid' };
@@ -181,10 +183,6 @@ type FinalizationVerificationContext =
 export type FinalizationCanonicalReceiptOutcome =
   | { status: 'confirmed'; receipt: CanonicalFinalizationReceipt }
   | { status: 'pending' | 'reorged' | 'rejected' | 'not-found' | 'unsupported' };
-
-interface ResolveCanonicalReceiptOptions {
-  acceptCanonicalPlacement?: boolean;
-}
 
 const SETTLED_RECEIPT_RETRY_BASE_MS = 1_000;
 const SETTLED_RECEIPT_RETRY_MAX_MS = 60_000;
@@ -762,8 +760,8 @@ export class FinalizationRecovery<
 
   async resolveCanonicalReceipt(
     candidate: ParsedGraphScopedFinalization,
-    persisted?: VerifiedGraphScopedFinalizationEvidence,
-    options: ResolveCanonicalReceiptOptions = {},
+    persisted: VerifiedGraphScopedFinalizationEvidence | undefined,
+    evidencePlacement: Exclude<VerifiedGraphScopedFinalizationEvidencePlacement, 'mismatch'>,
   ): Promise<FinalizationCanonicalReceiptOutcome> {
     const resolver = this.chain?.resolveCanonicalFinalizationReceipt;
     if (!this.chain || this.chain.chainId === 'none' || !resolver) {
@@ -807,7 +805,7 @@ export class FinalizationRecovery<
       return { status: 'rejected' };
     }
     if (
-      !options.acceptCanonicalPlacement
+      evidencePlacement === 'original'
       && receipt.blockNumber !== candidate.blockNumber
     ) return { status: 'reorged' };
     return { status: 'confirmed', receipt };
@@ -840,7 +838,7 @@ export class FinalizationRecovery<
     const canonical = await this.resolveCanonicalReceipt(
       candidate,
       entry.verifiedEvidence,
-      { acceptCanonicalPlacement: entry.state === 'REORGED' },
+      entry.state === 'REORGED' ? 'canonical-moved' : 'original',
     );
     if (canonical.status === 'unsupported') {
       await this.markUnsupported(entry);
@@ -999,7 +997,7 @@ export class FinalizationRecovery<
   private async commitRecoveredEvidence(
     entry: FinalizationRecoveryEntry,
     evidence: VerifiedGraphScopedFinalizationEvidence,
-    receiptMoved: boolean,
+    placement: Exclude<VerifiedGraphScopedFinalizationEvidencePlacement, 'mismatch'>,
   ): Promise<FinalizationRecoveryEntry | undefined> {
     const store = this.getStore();
     if (!store) return undefined;
@@ -1007,13 +1005,13 @@ export class FinalizationRecovery<
       const result = await store.commitRecoveredEvidence(
         entry.key,
         entry.generation,
-        receiptMoved
+        placement === 'canonical-moved'
           ? {
               evidence,
-              receiptMoved: true,
+              placement,
               reason: 'independently recovered canonical receipt moved',
             }
-          : { evidence, receiptMoved: false },
+          : { evidence, placement },
       );
       if (result.status === 'verified' || result.status === 'existing') {
         return result.entry;
@@ -1084,14 +1082,14 @@ export class FinalizationRecovery<
     entry: FinalizationRecoveryEntry,
   ): Promise<FinalizationRecoveryEntry | undefined> {
     const evidence = entry.verifiedEvidence;
-    if (
-      !evidence
-      || !VerifiedGraphScopedFinalizationEvidenceCodec.matchesImmutableEnvelope(
-        evidence,
-        input.candidate,
-        entry,
-      )
-    ) {
+    const placement = evidence
+      ? VerifiedGraphScopedFinalizationEvidenceCodec.classifyPlacement(
+          evidence,
+          input.candidate,
+          entry,
+        )
+      : 'mismatch';
+    if (!evidence || placement === 'mismatch') {
       this.log.warn(
         `Finalization recovery settled evidence does not match replacement envelope for `
           + `${entry.ual}`,
@@ -1131,7 +1129,7 @@ export class FinalizationRecovery<
     const canonical = await this.resolveCanonicalReceipt(
       input.candidate,
       evidence,
-      { acceptCanonicalPlacement: entry.generation > 0 },
+      placement,
     );
     if (canonical.status === 'rejected') {
       await this.invalidateSettled(
@@ -1589,14 +1587,14 @@ export class FinalizationRecovery<
     deferredRetryDelay?: number,
   ): Promise<FinalizationRecoveryReplayOutcome> {
     const evidence = entry.verifiedEvidence;
-    if (
-      !evidence
-      || !VerifiedGraphScopedFinalizationEvidenceCodec.matchesImmutableEnvelope(
-        evidence,
-        candidate,
-        entry,
-      )
-    ) {
+    const placement = evidence
+      ? VerifiedGraphScopedFinalizationEvidenceCodec.classifyPlacement(
+          evidence,
+          candidate,
+          entry,
+        )
+      : 'mismatch';
+    if (!evidence || placement === 'mismatch') {
       this.log.warn(
         `Finalization recovery settled evidence does not match its envelope for ${entry.ual}`,
       );
@@ -1610,7 +1608,7 @@ export class FinalizationRecovery<
     const canonical = await this.resolveCanonicalReceipt(
       candidate,
       evidence,
-      { acceptCanonicalPlacement: entry.generation > 0 },
+      placement,
     );
     if (canonical.status === 'confirmed') {
       if (entry.publisherUpgradePending) {
@@ -1816,6 +1814,7 @@ export class FinalizationRecovery<
     if (!entry || (!this.isLiveEntry(entry) && entry.state !== 'SETTLED')) {
       return 'none';
     }
+    let activeEntry = entry;
     try {
       // Only autonomous replay observes its persisted deadline. Chain
       // reconciliation remains an immediate, authoritative recovery trigger.
@@ -1838,14 +1837,15 @@ export class FinalizationRecovery<
       const ensured = await this.ensureVerifiedReplayEntry(entry, candidate, input);
       if (ensured.status === 'invalid') return 'none' as const;
       const replayEntry = ensured.entry;
+      activeEntry = replayEntry;
 
       let outcome: FinalizationRecoveryApplyOutcome;
       if (ensured.status === 'verified') {
-        const { evidence } = ensured;
+        const { evidence, placement } = ensured;
         const receiptStatus = await this.verifyPersistedReceipt(
           candidate,
           evidence,
-          replayEntry.generation > 0,
+          placement,
         );
         if (receiptStatus !== 'confirmed') {
           if (receiptStatus === 'reorged') {
@@ -1915,11 +1915,11 @@ export class FinalizationRecovery<
     } catch (error) {
       if (!this.materializer.isRetryableError(error)) throw error;
       this.log.info(
-        `Finalization recovery materialization remains busy for ${entry.ual}; `
+        `Finalization recovery materialization remains busy for ${activeEntry.ual}; `
           + 'keeping inbox entry',
       );
       await this.recordDeferred(
-        entry,
+        activeEntry,
         'replay store scheduler remained busy',
         deferredRetryDelay,
       );
@@ -1959,20 +1959,12 @@ export class FinalizationRecovery<
       return { status: 'unverified', entry };
     }
 
-    const matchesImmutableEnvelope =
-      VerifiedGraphScopedFinalizationEvidenceCodec.matchesImmutableEnvelope(
-        evidence,
-        candidate,
-        entry,
-      );
-    const matchesEnvelope = persistedEvidence && entry.generation === 0
-      ? VerifiedGraphScopedFinalizationEvidenceCodec.matchesEnvelope(
-          evidence,
-          candidate,
-          entry,
-        )
-      : matchesImmutableEnvelope;
-    if (!matchesEnvelope) {
+    const placement = VerifiedGraphScopedFinalizationEvidenceCodec.classifyPlacement(
+      evidence,
+      candidate,
+      entry,
+    );
+    if (placement === 'mismatch') {
       if (persistedEvidence) {
         this.log.warn(
           `Finalization recovery evidence does not match its envelope for ${entry.ual}`,
@@ -1991,24 +1983,16 @@ export class FinalizationRecovery<
     }
 
     if (persistedEvidence) {
-      return { status: 'verified', entry, evidence };
+      return { status: 'verified', entry, evidence, placement };
     }
-
-    const receiptMoved =
-      entry.generation === 0
-      && !VerifiedGraphScopedFinalizationEvidenceCodec.matchesEnvelope(
-        evidence,
-        candidate,
-        entry,
-      );
 
     const committed = await this.commitRecoveredEvidence(
       entry,
       evidence,
-      receiptMoved,
+      placement,
     );
     return committed
-      ? { status: 'verified', entry: committed, evidence }
+      ? { status: 'verified', entry: committed, evidence, placement }
       : { status: 'unverified', entry };
   }
 
@@ -2176,12 +2160,12 @@ export class FinalizationRecovery<
   private async verifyPersistedReceipt(
     candidate: ParsedGraphScopedFinalization,
     evidence: VerifiedGraphScopedFinalizationEvidence,
-    acceptCanonicalPlacement: boolean,
+    placement: Exclude<VerifiedGraphScopedFinalizationEvidencePlacement, 'mismatch'>,
   ): Promise<FinalizationCanonicalReceiptOutcome['status']> {
     const outcome = await this.resolveCanonicalReceipt(
       candidate,
       evidence,
-      { acceptCanonicalPlacement },
+      placement,
     );
     if (outcome.status !== 'confirmed') return outcome.status;
     const receipt = outcome.receipt;

--- a/packages/agent/src/finalization-recovery.ts
+++ b/packages/agent/src/finalization-recovery.ts
@@ -1905,7 +1905,8 @@ export class FinalizationRecovery<
     candidate: ParsedGraphScopedFinalization,
     replay: FinalizationRecoveryReplayInput,
   ): Promise<EnsuredVerifiedReplayEntry> {
-    const evidence = entry.state === 'VERIFIED'
+    const persistedEvidence = entry.state === 'VERIFIED';
+    const evidence = persistedEvidence
       ? entry.verifiedEvidence
       : await this.materializer.recoverVerifiedEvidence({
           replay,
@@ -1913,7 +1914,7 @@ export class FinalizationRecovery<
           candidate,
         });
     if (!evidence) {
-      if (entry.state === 'VERIFIED') {
+      if (persistedEvidence) {
         this.log.warn(
           `Finalization recovery VERIFIED entry has no evidence for ${entry.ual}`,
         );
@@ -1923,19 +1924,21 @@ export class FinalizationRecovery<
       return { status: 'unverified', entry };
     }
 
-    const matchesEnvelope = entry.generation > 0
-      ? VerifiedGraphScopedFinalizationEvidenceCodec.matchesImmutableEnvelope(
+    const matchesImmutableEnvelope =
+      VerifiedGraphScopedFinalizationEvidenceCodec.matchesImmutableEnvelope(
+        evidence,
+        candidate,
+        entry,
+      );
+    const matchesEnvelope = persistedEvidence && entry.generation === 0
+      ? VerifiedGraphScopedFinalizationEvidenceCodec.matchesEnvelope(
           evidence,
           candidate,
           entry,
         )
-      : VerifiedGraphScopedFinalizationEvidenceCodec.matchesEnvelope(
-          evidence,
-          candidate,
-          entry,
-        );
+      : matchesImmutableEnvelope;
     if (!matchesEnvelope) {
-      if (entry.state === 'VERIFIED') {
+      if (persistedEvidence) {
         this.log.warn(
           `Finalization recovery evidence does not match its envelope for ${entry.ual}`,
         );
@@ -1952,13 +1955,39 @@ export class FinalizationRecovery<
       return { status: 'unverified', entry };
     }
 
-    if (entry.state === 'VERIFIED') {
+    if (persistedEvidence) {
       return { status: 'verified', entry, evidence };
     }
-    const committed = await this.recordVerified(entry, evidence);
+
+    let commitEntry = entry;
+    if (
+      entry.generation === 0
+      && !VerifiedGraphScopedFinalizationEvidenceCodec.matchesEnvelope(
+        evidence,
+        candidate,
+        entry,
+      )
+    ) {
+      const reorged = await this.markReorged(
+        entry,
+        'independently recovered canonical receipt moved',
+      );
+      if (!reorged) return { status: 'unverified', entry };
+      const current = await this.getStore()?.get(entry.key);
+      if (
+        !current
+        || current.state !== 'REORGED'
+        || current.generation !== entry.generation + 1
+      ) {
+        return { status: 'invalid' };
+      }
+      commitEntry = current;
+    }
+
+    const committed = await this.recordVerified(commitEntry, evidence);
     return committed
       ? { status: 'verified', entry: committed, evidence }
-      : { status: 'unverified', entry };
+      : { status: 'unverified', entry: commitEntry };
   }
 
   private decodeEntry(

--- a/packages/agent/src/finalization-recovery.ts
+++ b/packages/agent/src/finalization-recovery.ts
@@ -996,6 +996,41 @@ export class FinalizationRecovery<
     return undefined;
   }
 
+  private async commitRecoveredEvidence(
+    entry: FinalizationRecoveryEntry,
+    evidence: VerifiedGraphScopedFinalizationEvidence,
+    receiptMoved: boolean,
+  ): Promise<FinalizationRecoveryEntry | undefined> {
+    const store = this.getStore();
+    if (!store) return undefined;
+    try {
+      const result = await store.commitRecoveredEvidence(
+        entry.key,
+        entry.generation,
+        receiptMoved
+          ? {
+              evidence,
+              receiptMoved: true,
+              reason: 'independently recovered canonical receipt moved',
+            }
+          : { evidence, receiptMoved: false },
+      );
+      if (result.status === 'verified' || result.status === 'existing') {
+        return result.entry;
+      }
+      this.log.warn(
+        `Finalization recovery inbox refused recovered evidence for ${entry.ual}: `
+          + result.status,
+      );
+    } catch (error) {
+      this.log.warn(
+        `Finalization recovery evidence commit failed for ${entry.ual}: `
+          + `${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    return undefined;
+  }
+
   async settleEntry(
     entry: FinalizationRecoveryEntry,
     outcome: FinalizationRecoveryApplyOutcome,
@@ -1959,35 +1994,22 @@ export class FinalizationRecovery<
       return { status: 'verified', entry, evidence };
     }
 
-    let commitEntry = entry;
-    if (
+    const receiptMoved =
       entry.generation === 0
       && !VerifiedGraphScopedFinalizationEvidenceCodec.matchesEnvelope(
         evidence,
         candidate,
         entry,
-      )
-    ) {
-      const reorged = await this.markReorged(
-        entry,
-        'independently recovered canonical receipt moved',
       );
-      if (!reorged) return { status: 'unverified', entry };
-      const current = await this.getStore()?.get(entry.key);
-      if (
-        !current
-        || current.state !== 'REORGED'
-        || current.generation !== entry.generation + 1
-      ) {
-        return { status: 'invalid' };
-      }
-      commitEntry = current;
-    }
 
-    const committed = await this.recordVerified(commitEntry, evidence);
+    const committed = await this.commitRecoveredEvidence(
+      entry,
+      evidence,
+      receiptMoved,
+    );
     return committed
       ? { status: 'verified', entry: committed, evidence }
-      : { status: 'unverified', entry: commitEntry };
+      : { status: 'unverified', entry };
   }
 
   private decodeEntry(

--- a/packages/agent/src/finalization-recovery.ts
+++ b/packages/agent/src/finalization-recovery.ts
@@ -128,6 +128,15 @@ export type FinalizationRecoveryReplayOutcome =
   | 'retry-pending'
   | 'none';
 
+export type FinalizationCanonicalReceiptExpectation =
+  | { kind: 'candidate-placement' }
+  | { kind: 'reorg-recovery' }
+  | {
+      kind: 'persisted';
+      evidence: VerifiedGraphScopedFinalizationEvidence;
+      placement: Exclude<VerifiedGraphScopedFinalizationEvidencePlacement, 'mismatch'>;
+    };
+
 export type FinalizationRecoveryReplayMaterializationOutcome =
   | 'promoted'
   | 'already-confirmed'
@@ -760,13 +769,26 @@ export class FinalizationRecovery<
 
   async resolveCanonicalReceipt(
     candidate: ParsedGraphScopedFinalization,
-    persisted: VerifiedGraphScopedFinalizationEvidence | undefined,
-    evidencePlacement: Exclude<VerifiedGraphScopedFinalizationEvidencePlacement, 'mismatch'>,
+    expectation: FinalizationCanonicalReceiptExpectation = {
+      kind: 'candidate-placement',
+    },
   ): Promise<FinalizationCanonicalReceiptOutcome> {
     const resolver = this.chain?.resolveCanonicalFinalizationReceipt;
     if (!this.chain || this.chain.chainId === 'none' || !resolver) {
       return { status: 'unsupported' };
     }
+    const persisted = expectation?.kind === 'persisted'
+      ? expectation.evidence
+      : undefined;
+    // Treat omitted or invalid placement data as the original candidate
+    // placement. This preserves fail-closed reorg detection for JavaScript callers.
+    const evidencePlacement = expectation?.kind === 'reorg-recovery'
+      || (
+        expectation?.kind === 'persisted'
+        && expectation.placement === 'canonical-moved'
+      )
+      ? 'canonical-moved'
+      : 'original';
     let resolution: CanonicalFinalizationReceiptResolution;
     try {
       resolution = await resolver.call(
@@ -837,8 +859,15 @@ export class FinalizationRecovery<
     const { entry } = context;
     const canonical = await this.resolveCanonicalReceipt(
       candidate,
-      entry.verifiedEvidence,
-      entry.state === 'REORGED' ? 'canonical-moved' : 'original',
+      entry.verifiedEvidence
+        ? {
+            kind: 'persisted',
+            evidence: entry.verifiedEvidence,
+            placement: entry.state === 'REORGED' ? 'canonical-moved' : 'original',
+          }
+        : entry.state === 'REORGED'
+          ? { kind: 'reorg-recovery' }
+          : { kind: 'candidate-placement' },
     );
     if (canonical.status === 'unsupported') {
       await this.markUnsupported(entry);
@@ -980,7 +1009,11 @@ export class FinalizationRecovery<
     const store = this.getStore();
     if (!store) return undefined;
     try {
-      const result = await store.markVerified(entry.key, entry.generation, evidence);
+      const result = await store.commitVerifiedEvidence(
+        entry.key,
+        entry.generation,
+        { evidence, placement: 'original' },
+      );
       if (result.status === 'verified' || result.status === 'existing') return result.entry;
       this.log.warn(
         `Finalization recovery inbox refused VERIFIED for ${entry.ual}: ${result.status}`,
@@ -1002,7 +1035,7 @@ export class FinalizationRecovery<
     const store = this.getStore();
     if (!store) return undefined;
     try {
-      const result = await store.commitRecoveredEvidence(
+      const result = await store.commitVerifiedEvidence(
         entry.key,
         entry.generation,
         placement === 'canonical-moved'
@@ -1128,8 +1161,7 @@ export class FinalizationRecovery<
     if (!publisherUpgradeNewlyRecorded && !attemptDue) return undefined;
     const canonical = await this.resolveCanonicalReceipt(
       input.candidate,
-      evidence,
-      placement,
+      { kind: 'persisted', evidence, placement },
     );
     if (canonical.status === 'rejected') {
       await this.invalidateSettled(
@@ -1607,8 +1639,7 @@ export class FinalizationRecovery<
     }
     const canonical = await this.resolveCanonicalReceipt(
       candidate,
-      evidence,
-      placement,
+      { kind: 'persisted', evidence, placement },
     );
     if (canonical.status === 'confirmed') {
       if (entry.publisherUpgradePending) {
@@ -2164,8 +2195,7 @@ export class FinalizationRecovery<
   ): Promise<FinalizationCanonicalReceiptOutcome['status']> {
     const outcome = await this.resolveCanonicalReceipt(
       candidate,
-      evidence,
-      placement,
+      { kind: 'persisted', evidence, placement },
     );
     if (outcome.status !== 'confirmed') return outcome.status;
     const receipt = outcome.receipt;

--- a/packages/agent/src/finalization-recovery.ts
+++ b/packages/agent/src/finalization-recovery.ts
@@ -147,6 +147,11 @@ export interface FinalizationRecoveryMaterializer<
     candidate: ParsedGraphScopedFinalization;
     evidence: VerifiedGraphScopedFinalizationEvidence;
   }): Promise<FinalizationRecoveryReplayMaterializationOutcome>;
+  recoverVerifiedEvidence?(input: {
+    replay: FinalizationRecoveryReplayInput;
+    entry: FinalizationRecoveryEntry;
+    candidate: ParsedGraphScopedFinalization;
+  }): Promise<VerifiedGraphScopedFinalizationEvidence | undefined>;
   invalidateVerified(input: {
     entry: FinalizationRecoveryEntry;
     candidate: ParsedGraphScopedFinalization;
@@ -1786,54 +1791,91 @@ export class FinalizationRecovery<
         );
       }
 
+      let replayEntry = entry;
+      if (
+        replayEntry.state !== 'VERIFIED'
+        && this.materializer.recoverVerifiedEvidence
+      ) {
+        const recoveredEvidence = await this.materializer.recoverVerifiedEvidence({
+          replay: input,
+          entry: replayEntry,
+          candidate,
+        });
+        if (recoveredEvidence) {
+          const recoveredEvidenceMatchesEnvelope = replayEntry.generation > 0
+            ? VerifiedGraphScopedFinalizationEvidenceCodec.matchesImmutableEnvelope(
+                recoveredEvidence,
+                candidate,
+                replayEntry,
+              )
+            : VerifiedGraphScopedFinalizationEvidenceCodec.matchesEnvelope(
+                recoveredEvidence,
+                candidate,
+                replayEntry,
+              );
+          if (!recoveredEvidenceMatchesEnvelope) {
+            this.log.warn(
+              `Finalization recovery ignored recovered evidence that does not match `
+                + `its envelope for ${replayEntry.ual}`,
+            );
+          } else {
+            replayEntry = await this.recordVerified(replayEntry, recoveredEvidence)
+              ?? replayEntry;
+          }
+        }
+      }
+
       let outcome: FinalizationRecoveryApplyOutcome;
-      if (entry.state === 'VERIFIED' && entry.verifiedEvidence) {
-        const evidence = entry.verifiedEvidence;
-        const evidenceMatchesEnvelope = entry.generation > 0
+      if (replayEntry.state === 'VERIFIED' && replayEntry.verifiedEvidence) {
+        const evidence = replayEntry.verifiedEvidence;
+        const evidenceMatchesEnvelope = replayEntry.generation > 0
           ? VerifiedGraphScopedFinalizationEvidenceCodec.matchesImmutableEnvelope(
               evidence,
               candidate,
-              entry,
+              replayEntry,
             )
           : VerifiedGraphScopedFinalizationEvidenceCodec.matchesEnvelope(
               evidence,
               candidate,
-              entry,
+              replayEntry,
             );
         if (!evidenceMatchesEnvelope) {
           this.log.warn(
-            `Finalization recovery evidence does not match its envelope for ${entry.ual}`,
+            `Finalization recovery evidence does not match its envelope for ${replayEntry.ual}`,
           );
-          await this.rejectEntry(entry, 'verified evidence does not match immutable envelope');
+          await this.rejectEntry(
+            replayEntry,
+            'verified evidence does not match immutable envelope',
+          );
           return 'none' as const;
         }
         const receiptStatus = await this.verifyPersistedReceipt(
           candidate,
           evidence,
-          entry.generation > 0,
+          replayEntry.generation > 0,
         );
         if (receiptStatus !== 'confirmed') {
           if (receiptStatus === 'reorged') {
             await this.markReorged(
-              entry,
+              replayEntry,
               'persisted receipt disagrees with canonical chain truth',
             );
           } else if (receiptStatus === 'rejected') {
             await this.rejectEntry(
-              entry,
+              replayEntry,
               'persisted transaction failed or contains no finalization event',
             );
           } else if (receiptStatus === 'unsupported') {
-            await this.markUnsupported(entry);
+            await this.markUnsupported(replayEntry);
           } else {
             await this.recordDeferred(
-              entry,
+              replayEntry,
               `persisted receipt is ${receiptStatus}`,
               deferredRetryDelay,
             );
           }
           this.log.info(
-            `Finalization recovery receipt is ${receiptStatus} for ${entry.ual}`,
+            `Finalization recovery receipt is ${receiptStatus} for ${replayEntry.ual}`,
           );
           return deferredRetryDelay !== undefined
             && (receiptStatus === 'pending' || receiptStatus === 'not-found')
@@ -1842,7 +1884,7 @@ export class FinalizationRecovery<
         }
         const replayOutcome = await this.materializer.replayVerified({
           replay: input,
-          entry,
+          entry: replayEntry,
           candidate,
           evidence,
         });
@@ -1866,7 +1908,7 @@ export class FinalizationRecovery<
 
       if (outcome === 'deferred') {
         await this.recordDeferred(
-          entry,
+          replayEntry,
           'replay processing deferred',
           deferredRetryDelay,
         );
@@ -1874,7 +1916,7 @@ export class FinalizationRecovery<
           ? 'none' as const
           : 'retry-pending' as const;
       }
-      const settled = await this.settleEntry(entry, outcome);
+      const settled = await this.settleEntry(replayEntry, outcome);
       return settled ? 'recovered' as const : 'none' as const;
     } catch (error) {
       if (!this.materializer.isRetryableError(error)) throw error;

--- a/packages/agent/src/finalization-recovery.ts
+++ b/packages/agent/src/finalization-recovery.ts
@@ -57,6 +57,15 @@ type FinalizationRecoveryReceiveOutcome =
   | { status: 'capacity' }
   | { status: 'rejected' };
 
+type EnsuredVerifiedReplayEntry =
+  | {
+      status: 'verified';
+      entry: FinalizationRecoveryEntry;
+      evidence: VerifiedGraphScopedFinalizationEvidence;
+    }
+  | { status: 'unverified'; entry: FinalizationRecoveryEntry }
+  | { status: 'invalid' };
+
 export type FinalizationRecoveryLiveAdmission =
   | {
     status: 'admitted';
@@ -147,7 +156,7 @@ export interface FinalizationRecoveryMaterializer<
     candidate: ParsedGraphScopedFinalization;
     evidence: VerifiedGraphScopedFinalizationEvidence;
   }): Promise<FinalizationRecoveryReplayMaterializationOutcome>;
-  recoverVerifiedEvidence?(input: {
+  recoverVerifiedEvidence(input: {
     replay: FinalizationRecoveryReplayInput;
     entry: FinalizationRecoveryEntry;
     candidate: ParsedGraphScopedFinalization;
@@ -1791,64 +1800,13 @@ export class FinalizationRecovery<
         );
       }
 
-      let replayEntry = entry;
-      if (
-        replayEntry.state !== 'VERIFIED'
-        && this.materializer.recoverVerifiedEvidence
-      ) {
-        const recoveredEvidence = await this.materializer.recoverVerifiedEvidence({
-          replay: input,
-          entry: replayEntry,
-          candidate,
-        });
-        if (recoveredEvidence) {
-          const recoveredEvidenceMatchesEnvelope = replayEntry.generation > 0
-            ? VerifiedGraphScopedFinalizationEvidenceCodec.matchesImmutableEnvelope(
-                recoveredEvidence,
-                candidate,
-                replayEntry,
-              )
-            : VerifiedGraphScopedFinalizationEvidenceCodec.matchesEnvelope(
-                recoveredEvidence,
-                candidate,
-                replayEntry,
-              );
-          if (!recoveredEvidenceMatchesEnvelope) {
-            this.log.warn(
-              `Finalization recovery ignored recovered evidence that does not match `
-                + `its envelope for ${replayEntry.ual}`,
-            );
-          } else {
-            replayEntry = await this.recordVerified(replayEntry, recoveredEvidence)
-              ?? replayEntry;
-          }
-        }
-      }
+      const ensured = await this.ensureVerifiedReplayEntry(entry, candidate, input);
+      if (ensured.status === 'invalid') return 'none' as const;
+      const replayEntry = ensured.entry;
 
       let outcome: FinalizationRecoveryApplyOutcome;
-      if (replayEntry.state === 'VERIFIED' && replayEntry.verifiedEvidence) {
-        const evidence = replayEntry.verifiedEvidence;
-        const evidenceMatchesEnvelope = replayEntry.generation > 0
-          ? VerifiedGraphScopedFinalizationEvidenceCodec.matchesImmutableEnvelope(
-              evidence,
-              candidate,
-              replayEntry,
-            )
-          : VerifiedGraphScopedFinalizationEvidenceCodec.matchesEnvelope(
-              evidence,
-              candidate,
-              replayEntry,
-            );
-        if (!evidenceMatchesEnvelope) {
-          this.log.warn(
-            `Finalization recovery evidence does not match its envelope for ${replayEntry.ual}`,
-          );
-          await this.rejectEntry(
-            replayEntry,
-            'verified evidence does not match immutable envelope',
-          );
-          return 'none' as const;
-        }
+      if (ensured.status === 'verified') {
+        const { evidence } = ensured;
         const receiptStatus = await this.verifyPersistedReceipt(
           candidate,
           evidence,
@@ -1894,15 +1852,16 @@ export class FinalizationRecovery<
             ? 'already-confirmed'
             : 'deferred';
       } else {
-        const recoverySourcePeerId = entry.trustedPublisherPeerId ?? entry.sourcePeerId;
+        const recoverySourcePeerId = replayEntry.trustedPublisherPeerId
+          ?? replayEntry.sourcePeerId;
         outcome = await this.materialize(
           {
-            rawMessage: entry.rawMessage,
-            contextGraphId: entry.contextGraphId,
+            rawMessage: replayEntry.rawMessage,
+            contextGraphId: replayEntry.contextGraphId,
             ...(recoverySourcePeerId ? { sourcePeerId: recoverySourcePeerId } : {}),
             candidate,
           },
-          { kind: 'recovery', entry },
+          { kind: 'recovery', entry: replayEntry },
         );
       }
 
@@ -1933,6 +1892,73 @@ export class FinalizationRecovery<
         ? 'none' as const
         : 'retry-pending' as const;
     }
+  }
+
+  /**
+   * Make evidence recovery one explicit replay transition. Persisted evidence
+   * is rejected on an envelope mismatch. Independently recovered evidence
+   * falls back to normal materialization when it is absent, mismatched, or
+   * cannot be committed.
+   */
+  private async ensureVerifiedReplayEntry(
+    entry: FinalizationRecoveryEntry,
+    candidate: ParsedGraphScopedFinalization,
+    replay: FinalizationRecoveryReplayInput,
+  ): Promise<EnsuredVerifiedReplayEntry> {
+    const evidence = entry.state === 'VERIFIED'
+      ? entry.verifiedEvidence
+      : await this.materializer.recoverVerifiedEvidence({
+          replay,
+          entry,
+          candidate,
+        });
+    if (!evidence) {
+      if (entry.state === 'VERIFIED') {
+        this.log.warn(
+          `Finalization recovery VERIFIED entry has no evidence for ${entry.ual}`,
+        );
+        await this.rejectEntry(entry, 'verified entry has no evidence');
+        return { status: 'invalid' };
+      }
+      return { status: 'unverified', entry };
+    }
+
+    const matchesEnvelope = entry.generation > 0
+      ? VerifiedGraphScopedFinalizationEvidenceCodec.matchesImmutableEnvelope(
+          evidence,
+          candidate,
+          entry,
+        )
+      : VerifiedGraphScopedFinalizationEvidenceCodec.matchesEnvelope(
+          evidence,
+          candidate,
+          entry,
+        );
+    if (!matchesEnvelope) {
+      if (entry.state === 'VERIFIED') {
+        this.log.warn(
+          `Finalization recovery evidence does not match its envelope for ${entry.ual}`,
+        );
+        await this.rejectEntry(
+          entry,
+          'verified evidence does not match immutable envelope',
+        );
+        return { status: 'invalid' };
+      }
+      this.log.warn(
+        `Finalization recovery ignored recovered evidence that does not match `
+          + `its envelope for ${entry.ual}`,
+      );
+      return { status: 'unverified', entry };
+    }
+
+    if (entry.state === 'VERIFIED') {
+      return { status: 'verified', entry, evidence };
+    }
+    const committed = await this.recordVerified(entry, evidence);
+    return committed
+      ? { status: 'verified', entry: committed, evidence }
+      : { status: 'unverified', entry };
   }
 
   private decodeEntry(

--- a/packages/agent/src/receipt-backed-graph-scoped-evidence.ts
+++ b/packages/agent/src/receipt-backed-graph-scoped-evidence.ts
@@ -37,6 +37,7 @@ export interface RecoverReceiptBackedGraphScopedEvidenceInput {
   merkleRoot: Uint8Array;
   publisherAddress: string;
   kaId: bigint;
+  batchId: bigint;
   onChainContextGraphId: bigint;
   subGraphName?: string;
 }
@@ -205,7 +206,7 @@ export async function recoverReceiptBackedGraphScopedEvidence(
       if (
         canonical.txHash.toLowerCase() !== transactionHash.toLowerCase()
         || canonical.kaId !== input.kaId
-        || canonical.batchId !== input.kaId
+        || canonical.batchId !== input.batchId
         || canonical.startKAId !== input.kaId
         || canonical.endKAId !== input.kaId
       ) return { status: 'unavailable', reason: 'canonical publish receipt does not match the target KA' };

--- a/packages/agent/src/receipt-backed-graph-scoped-evidence.ts
+++ b/packages/agent/src/receipt-backed-graph-scoped-evidence.ts
@@ -18,12 +18,22 @@ export type ReceiptBackedGraphScopedEvidenceRecovery =
   | { status: 'recovered'; evidence: VerifiedGraphScopedFinalizationEvidence }
   | { status: 'unavailable'; reason: string };
 
+export type ReceiptBackedGraphScopedAssertion = Pick<
+  KnowledgeAssetWorkspaceHead,
+  | 'kaUal'
+  | 'assertionVersion'
+  | 'publicQuadsDigest'
+  | 'publicTripleCount'
+  | 'privateMerkleRoot'
+  | 'privateTripleCount'
+>;
+
 export interface RecoverReceiptBackedGraphScopedEvidenceInput {
   store: TripleStore;
   chain?: ChainAdapter;
   contextGraphId: string;
   scope: { ual: string; assertionVersion: string };
-  head: KnowledgeAssetWorkspaceHead;
+  head: ReceiptBackedGraphScopedAssertion;
   merkleRoot: Uint8Array;
   publisherAddress: string;
   kaId: bigint;

--- a/packages/agent/src/sync/exact-asset-fetch.ts
+++ b/packages/agent/src/sync/exact-asset-fetch.ts
@@ -69,6 +69,7 @@ export interface ExactAssetChainSnapshot {
 export interface ExactAssetFetchEvidence {
   ual: string;
   kaId: bigint;
+  batchId: bigint;
   onChainCgId: string;
   merkleRoot: Uint8Array;
   authorAddress: string;
@@ -236,6 +237,9 @@ async function resolveEvidence(
   return {
     ual,
     kaId,
+    // The V10 exact-fetch chain inventory uses one packed KA per batch.
+    // Keep this identity explicit so reconciliation never invents it later.
+    batchId: kaId,
     onChainCgId,
     merkleRoot: bytes32FromHex(snapshot.latestRoot, ual),
     authorAddress: snapshot.latestAuthor,

--- a/packages/agent/test/finalization-recovery-sqlite-deferred.test.ts
+++ b/packages/agent/test/finalization-recovery-sqlite-deferred.test.ts
@@ -11,6 +11,19 @@ import {
   temporaryDirectory,
 } from './finalization-recovery-sqlite-test-helpers.js';
 
+function commitOriginalEvidence(
+  store: Awaited<ReturnType<typeof openSqliteFinalizationRecoveryStore>>,
+  key: string,
+  generation: number,
+  verifiedEvidence: ReturnType<typeof evidence>,
+) {
+  return store.commitVerifiedEvidence(
+    key,
+    generation,
+    { evidence: verifiedEvidence, placement: 'original' },
+  );
+}
+
 describe('SQLite finalization recovery deferred spool', () => {
   it('preserves a deferred envelope across reopen and promotes it later', async () => {
     const directory = await temporaryDirectory();
@@ -77,7 +90,7 @@ describe('SQLite finalization recovery deferred spool', () => {
     try {
       const store = await openSqliteFinalizationRecoveryStore(directory, { maxEntries: 1 });
       await store.receive(received());
-      await store.markVerified('entry-1', 0, evidence());
+      await commitOriginalEvidence(store, 'entry-1', 0, evidence());
       await expect(store.receive(received({
         key: 'entry-2',
         txHash: `0x${'ef'.repeat(32)}`,
@@ -332,7 +345,7 @@ describe('SQLite finalization recovery deferred spool', () => {
         now: () => now,
       });
       await store.receive(received());
-      await store.markVerified('entry-1', 0, evidence());
+      await commitOriginalEvidence(store, 'entry-1', 0, evidence());
       await expect(store.receive(received({
         key: 'stale-pending',
         txHash: `0x${'ef'.repeat(32)}`,

--- a/packages/agent/test/finalization-recovery-sqlite-store.test.ts
+++ b/packages/agent/test/finalization-recovery-sqlite-store.test.ts
@@ -151,7 +151,7 @@ describe('SQLite finalization recovery store', () => {
 
       await expect(store.commitRecoveredEvidence('entry-1', 0, {
         evidence: movedEvidence,
-        receiptMoved: true,
+        placement: 'canonical-moved',
         reason: 'independently recovered canonical receipt moved',
       })).resolves.toMatchObject({
         status: 'verified',
@@ -169,13 +169,40 @@ describe('SQLite finalization recovery store', () => {
       });
       await expect(store.commitRecoveredEvidence('entry-1', 0, {
         evidence: movedEvidence,
-        receiptMoved: true,
+        placement: 'canonical-moved',
         reason: 'stale retry',
       })).resolves.toEqual({ status: 'conflict' });
       await expect(store.get('entry-1')).resolves.toMatchObject({
         state: 'VERIFIED',
         generation: 1,
         lastError: 'independently recovered canonical receipt moved',
+      });
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('commits recovered evidence at its original placement without advancing generation', async () => {
+    const directory = await temporaryDirectory();
+    try {
+      const store = await openSqliteFinalizationRecoveryStore(directory);
+      await store.receive(received());
+
+      await expect(store.commitRecoveredEvidence('entry-1', 0, {
+        evidence: evidence(),
+        placement: 'original',
+      })).resolves.toMatchObject({
+        status: 'verified',
+        entry: {
+          state: 'VERIFIED',
+          generation: 0,
+          verifiedEvidence: {
+            blockNumber: 123,
+            blockHash: BLOCK_HASH,
+            txIndex: 4,
+          },
+        },
       });
       await store.close();
     } finally {

--- a/packages/agent/test/finalization-recovery-sqlite-store.test.ts
+++ b/packages/agent/test/finalization-recovery-sqlite-store.test.ts
@@ -138,6 +138,51 @@ describe('SQLite finalization recovery store', () => {
     }
   });
 
+  it('atomically commits recovered evidence after a canonical receipt moves', async () => {
+    const directory = await temporaryDirectory();
+    try {
+      const store = await openSqliteFinalizationRecoveryStore(directory);
+      await store.receive(received());
+      const movedEvidence = evidence({
+        blockNumber: 124,
+        blockHash: `0x${'ef'.repeat(32)}`,
+        txIndex: 7,
+      });
+
+      await expect(store.commitRecoveredEvidence('entry-1', 0, {
+        evidence: movedEvidence,
+        receiptMoved: true,
+        reason: 'independently recovered canonical receipt moved',
+      })).resolves.toMatchObject({
+        status: 'verified',
+        entry: {
+          state: 'VERIFIED',
+          generation: 1,
+          attemptCount: 0,
+          lastError: 'independently recovered canonical receipt moved',
+          verifiedEvidence: {
+            blockNumber: 124,
+            blockHash: `0x${'ef'.repeat(32)}`,
+            txIndex: 7,
+          },
+        },
+      });
+      await expect(store.commitRecoveredEvidence('entry-1', 0, {
+        evidence: movedEvidence,
+        receiptMoved: true,
+        reason: 'stale retry',
+      })).resolves.toEqual({ status: 'conflict' });
+      await expect(store.get('entry-1')).resolves.toMatchObject({
+        state: 'VERIFIED',
+        generation: 1,
+        lastError: 'independently recovered canonical receipt moved',
+      });
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it('starts SETTLED receipt retries with a fresh attempt budget', async () => {
     const directory = await temporaryDirectory();
     try {

--- a/packages/agent/test/finalization-recovery-sqlite-store.test.ts
+++ b/packages/agent/test/finalization-recovery-sqlite-store.test.ts
@@ -16,6 +16,19 @@ import {
   temporaryDirectory,
 } from './finalization-recovery-sqlite-test-helpers.js';
 
+function commitOriginalEvidence(
+  store: Awaited<ReturnType<typeof openSqliteFinalizationRecoveryStore>>,
+  key: string,
+  generation: number,
+  verifiedEvidence: ReturnType<typeof evidence>,
+) {
+  return store.commitVerifiedEvidence(
+    key,
+    generation,
+    { evidence: verifiedEvidence, placement: 'original' },
+  );
+}
+
 describe('SQLite finalization recovery store', () => {
   it('lists only due live work in bounded oldest-first batches', async () => {
     const directory = await temporaryDirectory();
@@ -28,7 +41,7 @@ describe('SQLite finalization recovery store', () => {
       await store.receive(received({ key: 'entry-2' }));
       await store.receive(received({ key: 'entry-3' }));
       await store.recordAttempt('entry-1', 0, 'busy', 1_000);
-      await store.markVerified('entry-3', 0, evidence());
+      await commitOriginalEvidence(store, 'entry-3', 0, evidence());
       await store.transition('entry-3', 0, 'SETTLED');
 
       await expect(store.listDue(16)).resolves.toMatchObject([
@@ -55,7 +68,7 @@ describe('SQLite finalization recovery store', () => {
         now: () => now,
       });
       await store.receive(received());
-      await store.markVerified('entry-1', 0, evidence());
+      await commitOriginalEvidence(store, 'entry-1', 0, evidence());
       await store.transition('entry-1', 0, 'SETTLED');
       await store.recordAttempt('entry-1', 0, 'receipt pending', 1_000);
 
@@ -116,7 +129,7 @@ describe('SQLite finalization recovery store', () => {
     try {
       const store = await openSqliteFinalizationRecoveryStore(directory);
       expect((await store.receive(received())).status).toBe('inserted');
-      expect((await store.markVerified('entry-1', 0, evidence())).status).toBe('verified');
+      expect((await commitOriginalEvidence(store, 'entry-1', 0, evidence())).status).toBe('verified');
       expect(await store.transition('entry-1', 0, 'SETTLED')).toBe(true);
       await store.close();
 
@@ -149,7 +162,7 @@ describe('SQLite finalization recovery store', () => {
         txIndex: 7,
       });
 
-      await expect(store.commitRecoveredEvidence('entry-1', 0, {
+      await expect(store.commitVerifiedEvidence('entry-1', 0, {
         evidence: movedEvidence,
         placement: 'canonical-moved',
         reason: 'independently recovered canonical receipt moved',
@@ -167,7 +180,7 @@ describe('SQLite finalization recovery store', () => {
           },
         },
       });
-      await expect(store.commitRecoveredEvidence('entry-1', 0, {
+      await expect(store.commitVerifiedEvidence('entry-1', 0, {
         evidence: movedEvidence,
         placement: 'canonical-moved',
         reason: 'stale retry',
@@ -183,13 +196,50 @@ describe('SQLite finalization recovery store', () => {
     }
   });
 
+  it('does not advance an already reorged generation twice for moved evidence', async () => {
+    const directory = await temporaryDirectory();
+    try {
+      const store = await openSqliteFinalizationRecoveryStore(directory);
+      await store.receive(received());
+      await expect(commitOriginalEvidence(store, 'entry-1', 0, evidence()))
+        .resolves.toMatchObject({ status: 'verified' });
+      await expect(store.markReorged(
+        'entry-1',
+        0,
+        'persisted receipt moved',
+      )).resolves.toBe(true);
+      const before = await store.get('entry-1');
+      expect(before).toMatchObject({
+        state: 'REORGED',
+        generation: 1,
+        attemptCount: 0,
+        lastError: 'persisted receipt moved',
+      });
+      expect(before).not.toHaveProperty('verifiedEvidence');
+
+      await expect(store.commitVerifiedEvidence('entry-1', 1, {
+        evidence: evidence({
+          blockNumber: 124,
+          blockHash: `0x${'ef'.repeat(32)}`,
+          txIndex: 7,
+        }),
+        placement: 'canonical-moved',
+        reason: 'independently recovered canonical receipt moved',
+      })).resolves.toEqual({ status: 'conflict' });
+      await expect(store.get('entry-1')).resolves.toEqual(before);
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it('commits recovered evidence at its original placement without advancing generation', async () => {
     const directory = await temporaryDirectory();
     try {
       const store = await openSqliteFinalizationRecoveryStore(directory);
       await store.receive(received());
 
-      await expect(store.commitRecoveredEvidence('entry-1', 0, {
+      await expect(store.commitVerifiedEvidence('entry-1', 0, {
         evidence: evidence(),
         placement: 'original',
       })).resolves.toMatchObject({
@@ -215,7 +265,7 @@ describe('SQLite finalization recovery store', () => {
     try {
       const store = await openSqliteFinalizationRecoveryStore(directory);
       expect((await store.receive(received())).status).toBe('inserted');
-      expect((await store.markVerified('entry-1', 0, evidence())).status).toBe('verified');
+      expect((await commitOriginalEvidence(store, 'entry-1', 0, evidence())).status).toBe('verified');
       for (let attempt = 0; attempt < 4; attempt += 1) {
         await store.recordAttempt('entry-1', 0, 'store scheduler remained busy', 1_000);
       }
@@ -338,7 +388,7 @@ describe('SQLite finalization recovery store', () => {
       expect((await store.receive(received({
         sourcePeerId: '12D3KooWUntrustedRelay',
       }))).status).toBe('inserted');
-      expect((await store.markVerified('entry-1', 0, evidence())).status).toBe('verified');
+      expect((await commitOriginalEvidence(store, 'entry-1', 0, evidence())).status).toBe('verified');
       expect(await store.transition('entry-1', 0, 'SETTLED')).toBe(true);
       await store.recordAttempt('entry-1', 0, 'old settled retry', 1_000);
 
@@ -408,7 +458,7 @@ describe('SQLite finalization recovery store', () => {
       expect(rearmed).not.toHaveProperty('verifiedEvidence');
       expect(rearmed).not.toHaveProperty('nextAttemptAt');
 
-      expect((await store.markVerified('entry-1', 1, evidence({
+      expect((await commitOriginalEvidence(store, 'entry-1', 1, evidence({
         accessPolicy: 'allowList',
         allowedPeers: ['12D3KooWReader'],
       }))).status).toBe('verified');
@@ -434,7 +484,7 @@ describe('SQLite finalization recovery store', () => {
     try {
       const store = await openSqliteFinalizationRecoveryStore(directory);
       expect((await store.receive(received())).status).toBe('inserted');
-      expect((await store.markVerified('entry-1', 0, evidence())).status).toBe('verified');
+      expect((await commitOriginalEvidence(store, 'entry-1', 0, evidence())).status).toBe('verified');
       await expect(store.markReorged(
         'entry-1',
         0,
@@ -463,14 +513,14 @@ describe('SQLite finalization recovery store', () => {
         status: 'existing',
         entry: { state: 'REORGED', generation: 1, rawMessage: RAW },
       });
-      await expect(reopened.markVerified('entry-1', 0, evidence()))
+      await expect(commitOriginalEvidence(reopened, 'entry-1', 0, evidence()))
         .resolves.toEqual({ status: 'conflict' });
 
       const replacementEvidence = evidence({
         blockNumber: 124,
         blockHash: `0x${'ef'.repeat(32)}`,
       });
-      expect((await reopened.markVerified('entry-1', 1, replacementEvidence)).status)
+      expect((await commitOriginalEvidence(reopened, 'entry-1', 1, replacementEvidence)).status)
         .toBe('verified');
       expect(await reopened.list()).toMatchObject([{
         state: 'VERIFIED',
@@ -491,7 +541,7 @@ describe('SQLite finalization recovery store', () => {
     try {
       const store = await openSqliteFinalizationRecoveryStore(directory);
       await store.receive(received());
-      await store.markVerified('entry-1', 0, evidence());
+      await commitOriginalEvidence(store, 'entry-1', 0, evidence());
       await store.transition('entry-1', 0, 'SETTLED');
 
       await expect(store.receive(received())).resolves.toMatchObject({
@@ -528,7 +578,7 @@ describe('SQLite finalization recovery store', () => {
     try {
       const store = await openSqliteFinalizationRecoveryStore(directory);
       await store.receive(received());
-      await store.markVerified('entry-1', 0, evidence());
+      await commitOriginalEvidence(store, 'entry-1', 0, evidence());
       await store.markReorged('entry-1', 0, 'canonical reorg');
 
       await expect(store.receive(received({
@@ -550,10 +600,10 @@ describe('SQLite finalization recovery store', () => {
     try {
       const store = await openSqliteFinalizationRecoveryStore(directory);
       await store.receive(received());
-      await expect(store.markVerified('entry-1', 0, evidence({
+      await expect(commitOriginalEvidence(store, 'entry-1', 0, evidence({
         transactionHash: `0x${'ef'.repeat(32)}`,
       }))).resolves.toEqual({ status: 'conflict' });
-      await expect(store.markVerified('entry-1', 0, evidence({
+      await expect(commitOriginalEvidence(store, 'entry-1', 0, evidence({
         assertionVersion: '2',
       }))).resolves.toEqual({ status: 'conflict' });
       expect(await store.list()).toMatchObject([{ state: 'RECEIVED' }]);
@@ -630,7 +680,7 @@ describe('SQLite finalization recovery store', () => {
         key: 'verified',
         txHash: `0x${'ef'.repeat(32)}`,
       }));
-      await store.markVerified('verified', 0, evidence({
+      await commitOriginalEvidence(store, 'verified', 0, evidence({
         transactionHash: `0x${'ef'.repeat(32)}`,
       }));
       now += 101;
@@ -680,7 +730,7 @@ describe('SQLite finalization recovery store', () => {
         now: () => now,
       });
       await store.receive(received());
-      await store.markVerified('entry-1', 0, evidence());
+      await commitOriginalEvidence(store, 'entry-1', 0, evidence());
       await store.transition('entry-1', 0, 'SETTLED');
       await store.recordSettledPublisherUpgrade(
         'entry-1',
@@ -748,7 +798,7 @@ describe('SQLite finalization recovery store', () => {
       const store = await openSqliteFinalizationRecoveryStore(directory);
       const path = store.databasePath;
       await store.receive(received());
-      await store.markVerified('entry-1', 0, evidence());
+      await commitOriginalEvidence(store, 'entry-1', 0, evidence());
       await store.close();
 
       const database = new DatabaseSync(path);

--- a/packages/agent/test/finalization-recovery-store.test.ts
+++ b/packages/agent/test/finalization-recovery-store.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+import {
+  planFinalizationRecoveryVerifiedEvidenceTransition,
+  type FinalizationRecoveryEntry,
+  type FinalizationRecoveryVerifiedEvidenceCommit,
+} from '../src/finalization-recovery-store.js';
+import {
+  RAW,
+  TX_HASH,
+  evidence,
+} from './finalization-recovery-sqlite-test-helpers.js';
+
+function entry(
+  overrides: Partial<FinalizationRecoveryEntry> = {},
+): FinalizationRecoveryEntry {
+  return {
+    key: 'entry-1',
+    state: 'RECEIVED',
+    chainId: 'base:84532',
+    contextGraphId: 'graph',
+    sourcePeerId: '12D3KooWPublisher',
+    publisherUpgradePending: false,
+    ual: 'did:dkg:base:84532/0x1111111111111111111111111111111111111111/7',
+    txHash: TX_HASH,
+    assertionVersion: '1',
+    merkleRoot: `0x${'01'.repeat(32)}`,
+    kaId: '7',
+    batchId: '7',
+    targetContextGraphId: '42',
+    envelopeSha256: '00'.repeat(32),
+    rawMessage: RAW,
+    generation: 0,
+    attemptCount: 0,
+    createdAt: 1_000,
+    updatedAt: 1_000,
+    ...overrides,
+  };
+}
+
+describe('finalization recovery verified-evidence transition planner', () => {
+  it('preserves generation and retry state for original-placement evidence', () => {
+    const verifiedEvidence = evidence();
+    expect(planFinalizationRecoveryVerifiedEvidenceTransition(
+      entry({
+        state: 'REORGED',
+        generation: 2,
+        attemptCount: 3,
+        nextAttemptAt: 5_000,
+        lastError: 'receipt lookup pending',
+      }),
+      2,
+      { evidence: verifiedEvidence, placement: 'original' },
+    )).toEqual({
+      status: 'update',
+      fields: {
+        state: 'VERIFIED',
+        verifiedEvidence,
+        generation: 2,
+        attemptCount: 3,
+        nextAttemptAt: 5_000,
+        lastError: 'receipt lookup pending',
+      },
+    });
+  });
+
+  it('advances generation and resets retry state for a moved generation-0 receipt', () => {
+    const verifiedEvidence = evidence({
+      blockNumber: 124,
+      blockHash: `0x${'ef'.repeat(32)}`,
+      txIndex: 7,
+    });
+    expect(planFinalizationRecoveryVerifiedEvidenceTransition(
+      entry({
+        attemptCount: 3,
+        nextAttemptAt: 5_000,
+        lastError: 'receipt lookup pending',
+      }),
+      0,
+      {
+        evidence: verifiedEvidence,
+        placement: 'canonical-moved',
+        reason: 'independently recovered canonical receipt moved',
+      },
+    )).toEqual({
+      status: 'update',
+      fields: {
+        state: 'VERIFIED',
+        verifiedEvidence,
+        generation: 1,
+        attemptCount: 0,
+        nextAttemptAt: null,
+        lastError: 'independently recovered canonical receipt moved',
+      },
+    });
+  });
+
+  it('returns existing only for the same committed evidence', () => {
+    const verifiedEvidence = evidence();
+    const current = entry({
+      state: 'VERIFIED',
+      verifiedEvidence,
+    });
+    expect(planFinalizationRecoveryVerifiedEvidenceTransition(
+      current,
+      0,
+      { evidence: verifiedEvidence, placement: 'original' },
+    )).toEqual({ status: 'existing', entry: current });
+    expect(planFinalizationRecoveryVerifiedEvidenceTransition(
+      current,
+      0,
+      {
+        evidence: evidence({ blockHash: `0x${'ef'.repeat(32)}` }),
+        placement: 'original',
+      },
+    )).toEqual({ status: 'conflict' });
+  });
+
+  it.each([
+    [
+      'stale generation',
+      entry({ generation: 1 }),
+      0,
+      { evidence: evidence(), placement: 'original' },
+    ],
+    [
+      'moved evidence after a prior reorg',
+      entry({ state: 'REORGED', generation: 1 }),
+      1,
+      {
+        evidence: evidence({ blockNumber: 124 }),
+        placement: 'canonical-moved',
+        reason: 'second generation advance',
+      },
+    ],
+    [
+      'terminal source state',
+      entry({ state: 'SETTLED' }),
+      0,
+      { evidence: evidence(), placement: 'original' },
+    ],
+    [
+      'transaction mismatch',
+      entry(),
+      0,
+      {
+        evidence: evidence({ transactionHash: `0x${'ef'.repeat(32)}` }),
+        placement: 'original',
+      },
+    ],
+    [
+      'assertion mismatch',
+      entry(),
+      0,
+      { evidence: evidence({ assertionVersion: '2' }), placement: 'original' },
+    ],
+  ] satisfies Array<[
+    string,
+    FinalizationRecoveryEntry,
+    number,
+    FinalizationRecoveryVerifiedEvidenceCommit,
+  ]>)('rejects %s', (_case, current, generation, commit) => {
+    expect(planFinalizationRecoveryVerifiedEvidenceTransition(
+      current,
+      generation,
+      commit,
+    )).toEqual({ status: 'conflict' });
+  });
+
+  it('does not depend on block hash equality for immutable identity checks', () => {
+    expect(planFinalizationRecoveryVerifiedEvidenceTransition(
+      entry(),
+      0,
+      {
+        evidence: evidence({ blockHash: `0x${'ef'.repeat(32)}` }),
+        placement: 'original',
+      },
+    ).status).toBe('update');
+  });
+});

--- a/packages/agent/test/finalization-recovery.test.ts
+++ b/packages/agent/test/finalization-recovery.test.ts
@@ -25,6 +25,7 @@ import {
 import { StoreSchedulerBusyError } from '@origintrail-official/dkg-storage';
 import { DKGAgent } from '../src/index.js';
 import {
+  VerifiedGraphScopedFinalizationEvidenceCodec,
   parseGraphScopedFinalization,
   type VerifiedGraphScopedFinalizationEvidence,
 } from '../src/finalization-graph-envelope.js';
@@ -143,6 +144,45 @@ function verifiedEvidence(
 }
 
 describe('graph-scoped finalization recovery admission', () => {
+  it('classifies receipt placement independently of the recovery generation', () => {
+    const candidate = parsedMessage();
+    const identity = (generation: number) => ({
+      ual: UAL,
+      kaId: PACKED_KA_ID.toString(),
+      batchId: PACKED_KA_ID.toString(),
+      merkleRoot: `0x${'00'.repeat(32)}`,
+      targetContextGraphId: '42',
+      generation,
+    });
+    const original = verifiedEvidence();
+    const moved = verifiedEvidence({
+      blockNumber: 124,
+      blockHash: `0x${'ef'.repeat(32)}`,
+      txIndex: 7,
+    });
+
+    expect(VerifiedGraphScopedFinalizationEvidenceCodec.classifyPlacement(
+      original,
+      candidate,
+      identity(0),
+    )).toBe('original');
+    expect(VerifiedGraphScopedFinalizationEvidenceCodec.classifyPlacement(
+      original,
+      candidate,
+      identity(9),
+    )).toBe('original');
+    expect(VerifiedGraphScopedFinalizationEvidenceCodec.classifyPlacement(
+      moved,
+      candidate,
+      identity(0),
+    )).toBe('canonical-moved');
+    expect(VerifiedGraphScopedFinalizationEvidenceCodec.classifyPlacement(
+      moved,
+      candidate,
+      identity(9),
+    )).toBe('canonical-moved');
+  });
+
   it('preserves boolean fallback behavior for callers using the original API', async () => {
     const recovery = new FinalizationRecovery(
       undefined,
@@ -882,6 +922,89 @@ describe('graph-scoped finalization recovery admission', () => {
     }
   });
 
+  it('records moved-receipt retry backoff on the committed generation', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-recover-moved-retry-'));
+    try {
+      const now = 1_000;
+      const store = await openSqliteFinalizationRecoveryStore(directory, { now: () => now });
+      const movedEvidence = verifiedEvidence({
+        blockNumber: 124,
+        blockHash: `0x${'ef'.repeat(32)}`,
+        txIndex: 7,
+      });
+      const recoverVerifiedEvidence = vi.fn(async () => movedEvidence);
+      const replayVerified = vi.fn(async () => {
+        throw new StoreSchedulerBusyError(
+          'queue_wait_timeout',
+          'normal',
+          'finalization-recovery-worker',
+        );
+      });
+      const chain = recoveryChain({
+        resolveCanonicalFinalizationReceipt: async () => ({
+          status: 'confirmed',
+          receipt: confirmedReceipt({
+            blockNumber: movedEvidence.blockNumber,
+            blockHash: movedEvidence.blockHash,
+            txIndex: movedEvidence.txIndex,
+          }),
+        }),
+      });
+      const recovery = new FinalizationRecovery(
+        store,
+        chain,
+        { info: () => {}, warn: () => {} },
+        {
+          ...recoveryMaterializer(),
+          recoverVerifiedEvidence,
+          replayVerified,
+        },
+      );
+      await recovery.receive({
+        rawMessage: encodeFinalizationMessage(message()),
+        contextGraphId: CONTEXT_GRAPH,
+        sourcePeerId: '12D3KooWPublisher',
+        candidate: parsedMessage(),
+      });
+      const replay = {
+        chainId: chain.chainId,
+        contextGraphId: CONTEXT_GRAPH,
+        onChainCgId: '42',
+        ual: UAL,
+        merkleRoot: `0x${'00'.repeat(32)}`,
+        kaId: PACKED_KA_ID.toString(),
+      };
+
+      await expect(recovery.replayMatching(
+        replay,
+        { persistDeferredBackoff: true },
+      )).resolves.toBe('retry-pending');
+      expect(await store.list()).toMatchObject([{
+        state: 'VERIFIED',
+        generation: 1,
+        attemptCount: 1,
+        nextAttemptAt: expect.any(Number),
+        verifiedEvidence: {
+          blockNumber: 124,
+          blockHash: `0x${'ef'.repeat(32)}`,
+          txIndex: 7,
+        },
+      }]);
+      const [deferred] = await store.list();
+      expect(deferred!.nextAttemptAt).toBeGreaterThan(now);
+
+      await expect(recovery.replayMatching(
+        replay,
+        { persistDeferredBackoff: true },
+      )).resolves.toBe('retry-pending');
+      expect(recoverVerifiedEvidence).toHaveBeenCalledOnce();
+      expect(replayVerified).toHaveBeenCalledOnce();
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it('leaves no intermediate REORGED state when a moved receipt cannot be committed', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-recover-commit-failed-'));
     try {
@@ -940,7 +1063,7 @@ describe('graph-scoped finalization recovery admission', () => {
       expect(commitRecoveredEvidence).toHaveBeenCalledWith(
         expect.any(String),
         0,
-        expect.objectContaining({ receiptMoved: true }),
+        expect.objectContaining({ placement: 'canonical-moved' }),
       );
       expect(markVerified).toHaveBeenCalledOnce();
       expect(markReorged).not.toHaveBeenCalled();
@@ -1339,7 +1462,7 @@ describe('graph-scoped finalization recovery admission', () => {
         { info: () => {}, warn: () => {} },
         recoveryMaterializer(),
       );
-      return recovery.resolveCanonicalReceipt(parsedMessage());
+      return recovery.resolveCanonicalReceipt(parsedMessage(), undefined, 'original');
     };
 
     await expect(resolve(confirmedReceipt({ blockNumber: 124 })))
@@ -1932,7 +2055,11 @@ describe('graph-scoped finalization recovery admission', () => {
         contextGraphId: CONTEXT_GRAPH,
         candidate: parsedMessage(),
       });
-      expect(await recovery.resolveCanonicalReceipt(parsedMessage())).toEqual({
+      expect(await recovery.resolveCanonicalReceipt(
+        parsedMessage(),
+        undefined,
+        'original',
+      )).toEqual({
         status: 'unsupported',
       });
       if (!entry) throw new Error('expected durable RECEIVED entry');

--- a/packages/agent/test/finalization-recovery.test.ts
+++ b/packages/agent/test/finalization-recovery.test.ts
@@ -34,6 +34,7 @@ import {
 import {
   openSqliteFinalizationRecoveryStore,
 } from '../src/finalization-recovery-sqlite-store.js';
+import type { FinalizationRecoveryStore } from '../src/finalization-recovery-store.js';
 
 const CONTEXT_GRAPH = 'finalization-recovery-admission';
 const AUTHOR = '0x1111111111111111111111111111111111111111';
@@ -875,6 +876,68 @@ describe('graph-scoped finalization recovery admission', () => {
           publisherAddress: PUBLISHER,
         },
       }]);
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back without side effects when recovered evidence cannot be committed', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-recover-commit-failed-'));
+    try {
+      const store = await openSqliteFinalizationRecoveryStore(directory);
+      const markVerified = vi.fn(async () => ({ status: 'closed' as const }));
+      const refusingStore = new Proxy(store, {
+        get(target, property) {
+          if (property === 'markVerified') return markVerified;
+          const value = Reflect.get(target, property, target);
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+      }) as FinalizationRecoveryStore;
+      const prepare = vi.fn(recoveryMaterializer().prepare);
+      const apply = vi.fn(async () => 'applied' as const);
+      const recoverVerifiedEvidence = vi.fn(async () => verifiedEvidence());
+      const replayVerified = vi.fn(async () => 'already-confirmed' as const);
+      const chain = recoveryChain();
+      const recovery = new FinalizationRecovery(
+        refusingStore,
+        chain,
+        { info: () => {}, warn: () => {} },
+        {
+          ...recoveryMaterializer(),
+          prepare,
+          apply,
+          recoverVerifiedEvidence,
+          replayVerified,
+        },
+      );
+      await recovery.receive({
+        rawMessage: encodeFinalizationMessage(message()),
+        contextGraphId: CONTEXT_GRAPH,
+        sourcePeerId: '12D3KooWPublisher',
+        candidate: parsedMessage(),
+      });
+
+      await expect(recovery.replayMatching({
+        chainId: chain.chainId,
+        contextGraphId: CONTEXT_GRAPH,
+        onChainCgId: '42',
+        ual: UAL,
+        merkleRoot: `0x${'00'.repeat(32)}`,
+        kaId: PACKED_KA_ID.toString(),
+      })).resolves.toBe('none');
+
+      expect(recoverVerifiedEvidence).toHaveBeenCalledOnce();
+      expect(markVerified).toHaveBeenCalledTimes(2);
+      expect(prepare).toHaveBeenCalledOnce();
+      expect(apply).not.toHaveBeenCalled();
+      expect(replayVerified).not.toHaveBeenCalled();
+      const [entry] = await store.list();
+      expect(entry).toMatchObject({
+        state: 'RECEIVED',
+        attemptCount: 1,
+      });
+      expect(entry?.verifiedEvidence).toBeUndefined();
       await store.close();
     } finally {
       await rm(directory, { recursive: true, force: true });

--- a/packages/agent/test/finalization-recovery.test.ts
+++ b/packages/agent/test/finalization-recovery.test.ts
@@ -1009,13 +1009,11 @@ describe('graph-scoped finalization recovery admission', () => {
     const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-recover-commit-failed-'));
     try {
       const store = await openSqliteFinalizationRecoveryStore(directory);
-      const markVerified = vi.fn(async () => ({ status: 'closed' as const }));
-      const commitRecoveredEvidence = vi.fn(async () => ({ status: 'closed' as const }));
+      const commitVerifiedEvidence = vi.fn(async () => ({ status: 'closed' as const }));
       const markReorged = vi.fn(store.markReorged.bind(store));
       const refusingStore = new Proxy(store, {
         get(target, property) {
-          if (property === 'markVerified') return markVerified;
-          if (property === 'commitRecoveredEvidence') return commitRecoveredEvidence;
+          if (property === 'commitVerifiedEvidence') return commitVerifiedEvidence;
           if (property === 'markReorged') return markReorged;
           const value = Reflect.get(target, property, target);
           return typeof value === 'function' ? value.bind(target) : value;
@@ -1059,13 +1057,17 @@ describe('graph-scoped finalization recovery admission', () => {
       })).resolves.toBe('none');
 
       expect(recoverVerifiedEvidence).toHaveBeenCalledOnce();
-      expect(commitRecoveredEvidence).toHaveBeenCalledOnce();
-      expect(commitRecoveredEvidence).toHaveBeenCalledWith(
+      expect(commitVerifiedEvidence).toHaveBeenCalledTimes(2);
+      expect(commitVerifiedEvidence).toHaveBeenCalledWith(
         expect.any(String),
         0,
         expect.objectContaining({ placement: 'canonical-moved' }),
       );
-      expect(markVerified).toHaveBeenCalledOnce();
+      expect(commitVerifiedEvidence).toHaveBeenCalledWith(
+        expect.any(String),
+        0,
+        expect.objectContaining({ placement: 'original' }),
+      );
       expect(markReorged).not.toHaveBeenCalled();
       expect(prepare).toHaveBeenCalledOnce();
       expect(apply).not.toHaveBeenCalled();
@@ -1450,7 +1452,10 @@ describe('graph-scoped finalization recovery admission', () => {
   });
 
   it('distinguishes reorged block placement from permanent receipt content mismatch', async () => {
-    const resolve = async (receipt: CanonicalFinalizationReceipt) => {
+    const resolve = async (
+      receipt: CanonicalFinalizationReceipt,
+      expectation?: unknown,
+    ) => {
       const recovery = new FinalizationRecovery(
         undefined,
         recoveryChain({
@@ -1462,11 +1467,21 @@ describe('graph-scoped finalization recovery admission', () => {
         { info: () => {}, warn: () => {} },
         recoveryMaterializer(),
       );
-      return recovery.resolveCanonicalReceipt(parsedMessage(), undefined, 'original');
+      return expectation === undefined
+        ? recovery.resolveCanonicalReceipt(parsedMessage())
+        : recovery.resolveCanonicalReceipt(parsedMessage(), expectation as never);
     };
 
     await expect(resolve(confirmedReceipt({ blockNumber: 124 })))
       .resolves.toEqual({ status: 'reorged' });
+    await expect(resolve(
+      confirmedReceipt({ blockNumber: 124 }),
+      {
+        kind: 'persisted',
+        evidence: verifiedEvidence(),
+        placement: 'invalid-at-runtime',
+      },
+    )).resolves.toEqual({ status: 'reorged' });
     await expect(resolve(confirmedReceipt({
       merkleRoot: Uint8Array.from({ length: 32 }, () => 1),
     }))).resolves.toEqual({ status: 'rejected' });
@@ -2055,11 +2070,7 @@ describe('graph-scoped finalization recovery admission', () => {
         contextGraphId: CONTEXT_GRAPH,
         candidate: parsedMessage(),
       });
-      expect(await recovery.resolveCanonicalReceipt(
-        parsedMessage(),
-        undefined,
-        'original',
-      )).toEqual({
+      expect(await recovery.resolveCanonicalReceipt(parsedMessage())).toEqual({
         status: 'unsupported',
       });
       if (!entry) throw new Error('expected durable RECEIVED entry');

--- a/packages/agent/test/finalization-recovery.test.ts
+++ b/packages/agent/test/finalization-recovery.test.ts
@@ -114,6 +114,7 @@ function recoveryMaterializer() {
       allowedPeers: [],
     }),
     apply: async () => 'applied' as const,
+    recoverVerifiedEvidence: async () => undefined,
     replayVerified: async () => 'promoted' as const,
     invalidateVerified: async () => 'invalidated' as const,
     isRetryableError: (error: unknown) => error instanceof StoreSchedulerBusyError,
@@ -874,6 +875,54 @@ describe('graph-scoped finalization recovery admission', () => {
           publisherAddress: PUBLISHER,
         },
       }]);
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves normal replay when evidence recovery is unavailable', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-recover-noop-'));
+    try {
+      const store = await openSqliteFinalizationRecoveryStore(directory);
+      const recoverVerifiedEvidence = vi.fn(async () => undefined);
+      const prepare = vi.fn(recoveryMaterializer().prepare);
+      const apply = vi.fn(async () => 'applied' as const);
+      const replayVerified = vi.fn(async () => 'already-confirmed' as const);
+      const chain = recoveryChain();
+      const recovery = new FinalizationRecovery(
+        store,
+        chain,
+        { info: () => {}, warn: () => {} },
+        {
+          ...recoveryMaterializer(),
+          prepare,
+          apply,
+          recoverVerifiedEvidence,
+          replayVerified,
+        },
+      );
+      await recovery.receive({
+        rawMessage: encodeFinalizationMessage(message()),
+        contextGraphId: CONTEXT_GRAPH,
+        sourcePeerId: '12D3KooWPublisher',
+        candidate: parsedMessage(),
+      });
+
+      await expect(recovery.replayMatching({
+        chainId: chain.chainId,
+        contextGraphId: CONTEXT_GRAPH,
+        onChainCgId: '42',
+        ual: UAL,
+        merkleRoot: `0x${'00'.repeat(32)}`,
+        kaId: PACKED_KA_ID.toString(),
+      })).resolves.toBe('recovered');
+
+      expect(recoverVerifiedEvidence).toHaveBeenCalledOnce();
+      expect(prepare).toHaveBeenCalledOnce();
+      expect(apply).toHaveBeenCalledOnce();
+      expect(replayVerified).not.toHaveBeenCalled();
+      expect(await store.list()).toMatchObject([{ state: 'SETTLED' }]);
       await store.close();
     } finally {
       await rm(directory, { recursive: true, force: true });

--- a/packages/agent/test/finalization-recovery.test.ts
+++ b/packages/agent/test/finalization-recovery.test.ts
@@ -882,21 +882,29 @@ describe('graph-scoped finalization recovery admission', () => {
     }
   });
 
-  it('falls back without side effects when recovered evidence cannot be committed', async () => {
+  it('leaves no intermediate REORGED state when a moved receipt cannot be committed', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-recover-commit-failed-'));
     try {
       const store = await openSqliteFinalizationRecoveryStore(directory);
       const markVerified = vi.fn(async () => ({ status: 'closed' as const }));
+      const commitRecoveredEvidence = vi.fn(async () => ({ status: 'closed' as const }));
+      const markReorged = vi.fn(store.markReorged.bind(store));
       const refusingStore = new Proxy(store, {
         get(target, property) {
           if (property === 'markVerified') return markVerified;
+          if (property === 'commitRecoveredEvidence') return commitRecoveredEvidence;
+          if (property === 'markReorged') return markReorged;
           const value = Reflect.get(target, property, target);
           return typeof value === 'function' ? value.bind(target) : value;
         },
       }) as FinalizationRecoveryStore;
       const prepare = vi.fn(recoveryMaterializer().prepare);
       const apply = vi.fn(async () => 'applied' as const);
-      const recoverVerifiedEvidence = vi.fn(async () => verifiedEvidence());
+      const recoverVerifiedEvidence = vi.fn(async () => verifiedEvidence({
+        blockNumber: 124,
+        blockHash: `0x${'ef'.repeat(32)}`,
+        txIndex: 7,
+      }));
       const replayVerified = vi.fn(async () => 'already-confirmed' as const);
       const chain = recoveryChain();
       const recovery = new FinalizationRecovery(
@@ -928,13 +936,21 @@ describe('graph-scoped finalization recovery admission', () => {
       })).resolves.toBe('none');
 
       expect(recoverVerifiedEvidence).toHaveBeenCalledOnce();
-      expect(markVerified).toHaveBeenCalledTimes(2);
+      expect(commitRecoveredEvidence).toHaveBeenCalledOnce();
+      expect(commitRecoveredEvidence).toHaveBeenCalledWith(
+        expect.any(String),
+        0,
+        expect.objectContaining({ receiptMoved: true }),
+      );
+      expect(markVerified).toHaveBeenCalledOnce();
+      expect(markReorged).not.toHaveBeenCalled();
       expect(prepare).toHaveBeenCalledOnce();
       expect(apply).not.toHaveBeenCalled();
       expect(replayVerified).not.toHaveBeenCalled();
       const [entry] = await store.list();
       expect(entry).toMatchObject({
         state: 'RECEIVED',
+        generation: 0,
         attemptCount: 1,
       });
       expect(entry?.verifiedEvidence).toBeUndefined();

--- a/packages/agent/test/finalization-recovery.test.ts
+++ b/packages/agent/test/finalization-recovery.test.ts
@@ -26,6 +26,7 @@ import { StoreSchedulerBusyError } from '@origintrail-official/dkg-storage';
 import { DKGAgent } from '../src/index.js';
 import {
   parseGraphScopedFinalization,
+  type VerifiedGraphScopedFinalizationEvidence,
 } from '../src/finalization-graph-envelope.js';
 import {
   FinalizationRecovery,
@@ -116,6 +117,26 @@ function recoveryMaterializer() {
     replayVerified: async () => 'promoted' as const,
     invalidateVerified: async () => 'invalidated' as const,
     isRetryableError: (error: unknown) => error instanceof StoreSchedulerBusyError,
+  };
+}
+
+function verifiedEvidence(
+  overrides: Partial<VerifiedGraphScopedFinalizationEvidence> = {},
+): VerifiedGraphScopedFinalizationEvidence {
+  return {
+    assertionVersion: '1',
+    publicTripleCount: 1,
+    privateTripleCount: 0,
+    publisherPeerId: '12D3KooWPublisher',
+    publisherAddress: PUBLISHER,
+    transactionHash: message().txHash,
+    blockNumber: 123,
+    blockHash: BLOCK_HASH,
+    txIndex: 4,
+    authorAddress: AUTHOR,
+    accessPolicy: 'public',
+    allowedPeers: [],
+    ...overrides,
   };
 }
 
@@ -802,6 +823,106 @@ describe('graph-scoped finalization recovery admission', () => {
         kaId: PACKED_KA_ID.toString(),
       })).resolves.toBe('recovered');
       expect(await store.list()).toMatchObject([{ state: 'SETTLED' }]);
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('settles a RECEIVED entry from independently verified materialized evidence', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-recover-vm-evidence-'));
+    try {
+      const store = await openSqliteFinalizationRecoveryStore(directory);
+      const prepare = vi.fn(async () => undefined);
+      const recoverVerifiedEvidence = vi.fn(async () => verifiedEvidence());
+      const replayVerified = vi.fn(async () => 'already-confirmed' as const);
+      const chain = recoveryChain();
+      const recovery = new FinalizationRecovery(
+        store,
+        chain,
+        { info: () => {}, warn: () => {} },
+        {
+          ...recoveryMaterializer(),
+          prepare,
+          recoverVerifiedEvidence,
+          replayVerified,
+        },
+      );
+      await recovery.receive({
+        rawMessage: encodeFinalizationMessage(message()),
+        contextGraphId: CONTEXT_GRAPH,
+        sourcePeerId: '12D3KooWPublisher',
+        candidate: parsedMessage(),
+      });
+
+      await expect(recovery.replayMatching({
+        chainId: chain.chainId,
+        contextGraphId: CONTEXT_GRAPH,
+        onChainCgId: '42',
+        ual: UAL,
+        merkleRoot: `0x${'00'.repeat(32)}`,
+        kaId: PACKED_KA_ID.toString(),
+      })).resolves.toBe('recovered');
+
+      expect(recoverVerifiedEvidence).toHaveBeenCalledOnce();
+      expect(replayVerified).toHaveBeenCalledOnce();
+      expect(prepare).not.toHaveBeenCalled();
+      expect(await store.list()).toMatchObject([{
+        state: 'SETTLED',
+        verifiedEvidence: {
+          transactionHash: message().txHash,
+          publisherAddress: PUBLISHER,
+        },
+      }]);
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps a RECEIVED entry when recovered evidence does not match its envelope', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-reject-vm-evidence-'));
+    try {
+      const store = await openSqliteFinalizationRecoveryStore(directory);
+      const prepare = vi.fn(async () => undefined);
+      const replayVerified = vi.fn(async () => 'already-confirmed' as const);
+      const warn = vi.fn();
+      const chain = recoveryChain();
+      const recovery = new FinalizationRecovery(
+        store,
+        chain,
+        { info: () => {}, warn },
+        {
+          ...recoveryMaterializer(),
+          prepare,
+          recoverVerifiedEvidence: async () => verifiedEvidence({
+            transactionHash: `0x${'ff'.repeat(32)}`,
+          }),
+          replayVerified,
+        },
+      );
+      await recovery.receive({
+        rawMessage: encodeFinalizationMessage(message()),
+        contextGraphId: CONTEXT_GRAPH,
+        sourcePeerId: '12D3KooWPublisher',
+        candidate: parsedMessage(),
+      });
+
+      await expect(recovery.replayMatching({
+        chainId: chain.chainId,
+        contextGraphId: CONTEXT_GRAPH,
+        onChainCgId: '42',
+        ual: UAL,
+        merkleRoot: `0x${'00'.repeat(32)}`,
+        kaId: PACKED_KA_ID.toString(),
+      })).resolves.toBe('none');
+
+      expect(prepare).toHaveBeenCalledOnce();
+      expect(replayVerified).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining(
+        'ignored recovered evidence that does not match its envelope',
+      ));
+      expect(await store.list()).toMatchObject([{ state: 'RECEIVED' }]);
       await store.close();
     } finally {
       await rm(directory, { recursive: true, force: true });

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -29,6 +29,7 @@ import {
   storeKnowledgeAssetWorkspaceHead,
 } from '@origintrail-official/dkg-publisher';
 import { FinalizationHandler } from '../src/finalization-handler.js';
+import { resolveConfirmedGraphScopedVm } from '../src/confirmed-graph-scoped-vm-resolver.js';
 import {
   openSqliteFinalizationRecoveryStore,
   type SqliteFinalizationRecoveryStore,
@@ -3130,6 +3131,41 @@ describe('graph-scoped finalization handler', () => {
       versionBlock: 126,
       authorAddress: AUTHOR,
     }, createOperationContext('system'))).resolves.toBe('no-swm');
+  });
+
+  it('uses one confirmed VM resolver for absent, matching, and invalid metadata', async () => {
+    await expect(resolveConfirmedGraphScopedVm(store, {
+      contextGraphId: CG,
+      ual: UAL,
+      merkleRoot: new Uint8Array(32),
+      kaId: PACKED_KA_ID,
+    })).resolves.toEqual({ status: 'absent' });
+
+    const { message } = await stageGraph();
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(message), CG);
+    await expect(resolveConfirmedGraphScopedVm(store, {
+      contextGraphId: CG,
+      ual: UAL,
+      merkleRoot: message.kcMerkleRoot,
+      kaId: PACKED_KA_ID,
+    })).resolves.toMatchObject({
+      status: 'verified',
+      envelope: { assertionVersion: VERSION, batchId: PACKED_KA_ID },
+      scope: { ual: UAL },
+    });
+
+    await store.insert([{
+      graph: `did:dkg:context-graph:${CG}/_meta`,
+      subject: UAL,
+      predicate: 'http://dkg.io/ontology/contentScopeVersion',
+      object: '"999"',
+    }]);
+    await expect(resolveConfirmedGraphScopedVm(store, {
+      contextGraphId: CG,
+      ual: UAL,
+      merkleRoot: message.kcMerkleRoot,
+      kaId: PACKED_KA_ID,
+    })).resolves.toEqual({ status: 'invalid', reason: 'metadata' });
   });
 
   it('settles a RECEIVED inbox row from exact receipt-backed VM after the workspace head is lost', async () => {

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -3145,6 +3145,7 @@ describe('graph-scoped finalization handler', () => {
       ual: UAL,
       merkleRoot: new Uint8Array(32),
       kaId: PACKED_KA_ID,
+      batchId: PACKED_KA_ID,
     })).resolves.toEqual({ status: 'absent' });
 
     const { message } = await stageGraph();
@@ -3154,6 +3155,7 @@ describe('graph-scoped finalization handler', () => {
       ual: UAL,
       merkleRoot: message.kcMerkleRoot,
       kaId: PACKED_KA_ID,
+      batchId: PACKED_KA_ID,
     })).resolves.toMatchObject({
       status: 'verified',
       envelope: { assertionVersion: VERSION, batchId: PACKED_KA_ID },
@@ -3171,6 +3173,7 @@ describe('graph-scoped finalization handler', () => {
       ual: UAL,
       merkleRoot: message.kcMerkleRoot,
       kaId: PACKED_KA_ID,
+      batchId: PACKED_KA_ID,
     })).resolves.toEqual({ status: 'invalid', reason: 'metadata' });
   });
 

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -3132,6 +3132,70 @@ describe('graph-scoped finalization handler', () => {
     }, createOperationContext('system'))).resolves.toBe('no-swm');
   });
 
+  it('settles a RECEIVED inbox row from exact receipt-backed VM after the workspace head is lost', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-received-vm-settle-'));
+    let inbox: SqliteFinalizationRecoveryStore | undefined;
+    try {
+      const { message, vmGraph } = await stageGraph({ accessPolicy: 'ownerOnly' });
+      await seedAuthenticatedLocalControls(message);
+      await handler.handleFinalizationMessage(
+        encodeFinalizationMessage(message),
+        CG,
+        '12D3KooWPublisher',
+      );
+      expect(await store.countQuads(vmGraph)).toBe(2);
+
+      await store.deleteByPattern({
+        graph: graphManager.sharedMemoryMetaUri(CG),
+        subject: `${UAL}#dkg-swm-head`,
+      });
+      await expect(resolveKnowledgeAssetWorkspaceHead({
+        store,
+        graphManager,
+        contextGraphId: CG,
+        kaUal: UAL,
+      })).resolves.toBeUndefined();
+
+      const chain = {
+        chainId: 'base:84532',
+        getLatestMerkleRoot: async () => message.kcMerkleRoot,
+        getMerkleRootCount: async () => 1n,
+        getKAContextGraphId: async () => 42n,
+        resolveCanonicalFinalizationReceipt: async () => canonicalReceipt(message),
+      } as ChainAdapter;
+      inbox = await openSqliteFinalizationRecoveryStore(directory);
+      const recoveryHandler = new FinalizationHandler(
+        store,
+        chain,
+        recoveryOptions(inbox),
+      );
+      await recoveryHandler.handleFinalizationMessage(
+        encodeFinalizationMessage(message),
+        CG,
+        '12D3KooWPublisher',
+      );
+      expect(await inbox.list()).toMatchObject([{ state: 'RECEIVED' }]);
+
+      await expect(recoveryHandler.handleExactChainReconciledKC(
+        graphReconcileInput(message),
+        createOperationContext('system'),
+      )).resolves.toBe('already-confirmed');
+
+      expect(await store.countQuads(vmGraph)).toBe(2);
+      expect(await inbox.list()).toMatchObject([{
+        state: 'SETTLED',
+        verifiedEvidence: {
+          transactionHash: message.txHash,
+          publisherAddress: PUBLISHER,
+          accessPolicy: 'ownerOnly',
+        },
+      }]);
+    } finally {
+      await closeInbox(inbox);
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it('recognizes an exact confirmed VM copy when the mutable workspace head is corrupt', async () => {
     const { message, vmGraph } = await stageGraph();
     await handler.handleFinalizationMessage(encodeFinalizationMessage(message), CG);

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -30,6 +30,7 @@ import {
 } from '@origintrail-official/dkg-publisher';
 import { FinalizationHandler } from '../src/finalization-handler.js';
 import { resolveConfirmedGraphScopedVm } from '../src/confirmed-graph-scoped-vm-resolver.js';
+import { verifyExactGraphContent } from '../src/exact-graph-content-verifier.js';
 import {
   openSqliteFinalizationRecoveryStore,
   type SqliteFinalizationRecoveryStore,
@@ -3168,7 +3169,43 @@ describe('graph-scoped finalization handler', () => {
     })).resolves.toEqual({ status: 'invalid', reason: 'metadata' });
   });
 
-  it('settles a RECEIVED inbox row from exact receipt-backed VM after the workspace head is lost', async () => {
+  it('uses one verifier for exact graph content, count, root, and digest checks', async () => {
+    const { message, vmGraph } = await stageGraph();
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(message), CG);
+    const base = {
+      graphUri: vmGraph,
+      publicTripleCount: Number(message.publicTripleCount),
+      ...(message.privateMerkleRoot?.length
+        ? { privateMerkleRoot: message.privateMerkleRoot }
+        : {}),
+      expectedMerkleRoot: message.kcMerkleRoot,
+      includePublicQuadsDigest: true,
+      source: 'agent.test.verifyExactGraphContent',
+    };
+
+    const matching = await verifyExactGraphContent(store, base);
+    expect(matching).toMatchObject({ status: 'verified', graphUri: vmGraph });
+    if (matching.status !== 'verified') throw new Error('expected matching graph content');
+
+    await expect(verifyExactGraphContent(store, {
+      ...base,
+      publicTripleCount: base.publicTripleCount + 1,
+    })).resolves.toMatchObject({ status: 'count-mismatch', actualCount: 2 });
+    await expect(verifyExactGraphContent(store, {
+      ...base,
+      expectedMerkleRoot: new Uint8Array(32),
+    })).resolves.toMatchObject({ status: 'merkle-mismatch' });
+    await expect(verifyExactGraphContent(store, {
+      ...base,
+      expectedPublicQuadsDigest: `sha256:${'00'.repeat(32)}`,
+    })).resolves.toMatchObject({ status: 'head-mismatch' });
+    await expect(verifyExactGraphContent(store, {
+      ...base,
+      expectedPublicQuadsDigest: matching.publicQuadsDigest,
+    })).resolves.toMatchObject({ status: 'verified' });
+  });
+
+  it('settles a RECEIVED inbox row after the workspace head is lost and its receipt moves', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-received-vm-settle-'));
     let inbox: SqliteFinalizationRecoveryStore | undefined;
     try {
@@ -3192,12 +3229,19 @@ describe('graph-scoped finalization handler', () => {
         kaUal: UAL,
       })).resolves.toBeUndefined();
 
+      const movedReceipt = canonicalReceipt(message);
+      movedReceipt.receipt = {
+        ...movedReceipt.receipt,
+        blockNumber: 124,
+        blockHash: `0x${'ef'.repeat(32)}`,
+        txIndex: 7,
+      };
       const chain = {
         chainId: 'base:84532',
         getLatestMerkleRoot: async () => message.kcMerkleRoot,
         getMerkleRootCount: async () => 1n,
         getKAContextGraphId: async () => 42n,
-        resolveCanonicalFinalizationReceipt: async () => canonicalReceipt(message),
+        resolveCanonicalFinalizationReceipt: async () => movedReceipt,
       } as ChainAdapter;
       inbox = await openSqliteFinalizationRecoveryStore(directory);
       const recoveryHandler = new FinalizationHandler(
@@ -3220,8 +3264,12 @@ describe('graph-scoped finalization handler', () => {
       expect(await store.countQuads(vmGraph)).toBe(2);
       expect(await inbox.list()).toMatchObject([{
         state: 'SETTLED',
+        generation: 1,
         verifiedEvidence: {
           transactionHash: message.txHash,
+          blockNumber: 124,
+          blockHash: `0x${'ef'.repeat(32)}`,
+          txIndex: 7,
           publisherAddress: PUBLISHER,
           accessPolicy: 'ownerOnly',
         },
@@ -3230,6 +3278,51 @@ describe('graph-scoped finalization handler', () => {
       await closeInbox(inbox);
       await rm(directory, { recursive: true, force: true });
     }
+  });
+
+  it('uses the confirmed VM namespace when a named workspace head is lost', async () => {
+    const { message, vmGraph } = await stageGraph(undefined, 'named-scope');
+    await store.insert(generateAssertionCreatedMetadata({
+      contextGraphId: CG,
+      agentAddress: AUTHOR,
+      assertionName: 'named-asset',
+      subGraphName: 'named-scope',
+      timestamp: new Date(),
+      kaNumber: 7,
+      reservedUal: UAL,
+    }, { provenanceEvents: false }));
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(message), CG);
+    await store.deleteByPattern({
+      graph: graphManager.sharedMemoryMetaUri(CG, 'named-scope'),
+      subject: `${UAL}#dkg-swm-head`,
+    });
+    await expect(resolveKnowledgeAssetWorkspaceHead({
+      store,
+      graphManager,
+      contextGraphId: CG,
+      kaUal: UAL,
+      subGraphName: 'named-scope',
+    })).resolves.toBeUndefined();
+
+    const internals = handler as unknown as {
+      verifyChainCgBinding: () => Promise<boolean>;
+    };
+    internals.verifyChainCgBinding = async () => true;
+
+    const input = graphReconcileInput(message);
+    await expect(handler.handleExactChainReconciledKC(
+      input,
+      createOperationContext('system'),
+    )).resolves.toBe('already-confirmed');
+    await expect(handler.handleExactChainReconciledKC(
+      { ...input, subGraphName: 'named-scope' },
+      createOperationContext('system'),
+    )).resolves.toBe('already-confirmed');
+    await expect(handler.handleExactChainReconciledKC(
+      { ...input, subGraphName: 'different-scope' },
+      createOperationContext('system'),
+    )).resolves.toBe('no-swm');
+    expect(await store.countQuads(vmGraph)).toBe(2);
   });
 
   it('recognizes an exact confirmed VM copy when the mutable workspace head is corrupt', async () => {

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -27,6 +27,7 @@ import {
   resolveKnowledgeAssetWorkspaceHead,
   storeKnowledgeAssetOperationPublicQuads,
   storeKnowledgeAssetWorkspaceHead,
+  workspacePublicQuadsDigest,
 } from '@origintrail-official/dkg-publisher';
 import { FinalizationHandler } from '../src/finalization-handler.js';
 import { resolveConfirmedGraphScopedVm } from '../src/confirmed-graph-scoped-vm-resolver.js';
@@ -1505,6 +1506,7 @@ describe('graph-scoped finalization handler', () => {
         rearmSettledWithTrustedPublisher:
           inbox.rearmSettledWithTrustedPublisher.bind(inbox),
         markVerified: async () => ({ status: 'closed' }),
+        commitRecoveredEvidence: async () => ({ status: 'closed' }),
         markReorged: inbox.markReorged.bind(inbox),
         clearSettledRetry: inbox.clearSettledRetry.bind(inbox),
         rejectSettled: inbox.rejectSettled.bind(inbox),
@@ -1591,6 +1593,9 @@ describe('graph-scoped finalization handler', () => {
         },
         markVerified: async () => {
           throw new Error('markVerified must not run after failed admission');
+        },
+        commitRecoveredEvidence: async () => {
+          throw new Error('commitRecoveredEvidence must not run after failed admission');
         },
         markReorged: async () => false,
         clearSettledRetry: async () => {},
@@ -3179,7 +3184,6 @@ describe('graph-scoped finalization handler', () => {
         ? { privateMerkleRoot: message.privateMerkleRoot }
         : {}),
       expectedMerkleRoot: message.kcMerkleRoot,
-      includePublicQuadsDigest: true,
       source: 'agent.test.verifyExactGraphContent',
     };
 
@@ -3201,7 +3205,7 @@ describe('graph-scoped finalization handler', () => {
     })).resolves.toMatchObject({ status: 'head-mismatch' });
     await expect(verifyExactGraphContent(store, {
       ...base,
-      expectedPublicQuadsDigest: matching.publicQuadsDigest,
+      expectedPublicQuadsDigest: workspacePublicQuadsDigest(matching.quads),
     })).resolves.toMatchObject({ status: 'verified' });
   });
 
@@ -3209,7 +3213,9 @@ describe('graph-scoped finalization handler', () => {
     const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-received-vm-settle-'));
     let inbox: SqliteFinalizationRecoveryStore | undefined;
     try {
-      const { message, vmGraph } = await stageGraph({ accessPolicy: 'ownerOnly' });
+      const staged = await stageGraph({ accessPolicy: 'ownerOnly' });
+      const message = { ...staged.message, batchId: 42n };
+      const { vmGraph } = staged;
       await seedAuthenticatedLocalControls(message);
       await handler.handleFinalizationMessage(
         encodeFinalizationMessage(message),
@@ -3264,6 +3270,7 @@ describe('graph-scoped finalization handler', () => {
       expect(await store.countQuads(vmGraph)).toBe(2);
       expect(await inbox.list()).toMatchObject([{
         state: 'SETTLED',
+        batchId: '42',
         generation: 1,
         verifiedEvidence: {
           transactionHash: message.txHash,

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -1505,8 +1505,7 @@ describe('graph-scoped finalization handler', () => {
           inbox.recordSettledPublisherUpgrade.bind(inbox),
         rearmSettledWithTrustedPublisher:
           inbox.rearmSettledWithTrustedPublisher.bind(inbox),
-        markVerified: async () => ({ status: 'closed' }),
-        commitRecoveredEvidence: async () => ({ status: 'closed' }),
+        commitVerifiedEvidence: async () => ({ status: 'closed' }),
         markReorged: inbox.markReorged.bind(inbox),
         clearSettledRetry: inbox.clearSettledRetry.bind(inbox),
         rejectSettled: inbox.rejectSettled.bind(inbox),
@@ -1591,11 +1590,8 @@ describe('graph-scoped finalization handler', () => {
         rearmSettledWithTrustedPublisher: async () => {
           throw new Error('rearmSettledWithTrustedPublisher must not run after failed admission');
         },
-        markVerified: async () => {
-          throw new Error('markVerified must not run after failed admission');
-        },
-        commitRecoveredEvidence: async () => {
-          throw new Error('commitRecoveredEvidence must not run after failed admission');
+        commitVerifiedEvidence: async () => {
+          throw new Error('commitVerifiedEvidence must not run after failed admission');
         },
         markReorged: async () => false,
         clearSettledRetry: async () => {},

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -13,9 +13,12 @@ import {
 } from '@origintrail-official/dkg-core';
 import {
   GraphManager,
+  ExactGraphReadError,
   OxigraphStore,
   StoreSchedulerBusyError,
   type Quad,
+  type QueryResult,
+  type TripleStore,
 } from '@origintrail-official/dkg-storage';
 import type { ChainAdapter } from '@origintrail-official/dkg-chain';
 import {
@@ -396,6 +399,7 @@ describe('graph-scoped finalization handler', () => {
       merkleRoot: message.kcMerkleRoot,
       publisherAddress: PUBLISHER,
       kaId: PACKED_KA_ID,
+      batchId: message.batchId,
       versionBlock: 123,
       authorAddress: AUTHOR,
       ...overrides,
@@ -3054,6 +3058,7 @@ describe('graph-scoped finalization handler', () => {
       merkleRoot: message.kcMerkleRoot,
       publisherAddress: PUBLISHER,
       kaId: PACKED_KA_ID,
+      batchId: PACKED_KA_ID,
       versionBlock: 123,
       authorAddress: AUTHOR,
     }, createOperationContext('system'))).resolves.toBe('already-confirmed');
@@ -3063,7 +3068,9 @@ describe('graph-scoped finalization handler', () => {
   });
 
   it('recognizes only exact confirmed Verifiable Memory metadata after the workspace head is lost', async () => {
-    const { message, vmGraph } = await stageGraph();
+    const staged = await stageGraph();
+    const message = { ...staged.message, batchId: 42n };
+    const { vmGraph } = staged;
     await handler.handleFinalizationMessage(encodeFinalizationMessage(message), CG);
 
     await store.deleteByPattern({
@@ -3089,6 +3096,7 @@ describe('graph-scoped finalization handler', () => {
       merkleRoot: message.kcMerkleRoot,
       publisherAddress: PUBLISHER,
       kaId: PACKED_KA_ID,
+      batchId: 42n,
       versionBlock: 124,
       authorAddress: AUTHOR,
     }, createOperationContext('system'))).resolves.toBe('already-confirmed');
@@ -3109,6 +3117,7 @@ describe('graph-scoped finalization handler', () => {
       merkleRoot: message.kcMerkleRoot,
       publisherAddress: PUBLISHER,
       kaId: PACKED_KA_ID,
+      batchId: 42n,
       versionBlock: 125,
       authorAddress: AUTHOR,
     }, createOperationContext('system'))).rejects.toThrow('injected confirmed metadata outage');
@@ -3130,6 +3139,7 @@ describe('graph-scoped finalization handler', () => {
       merkleRoot: message.kcMerkleRoot,
       publisherAddress: PUBLISHER,
       kaId: PACKED_KA_ID,
+      batchId: 42n,
       versionBlock: 126,
       authorAddress: AUTHOR,
     }, createOperationContext('system'))).resolves.toBe('no-swm');
@@ -3206,6 +3216,45 @@ describe('graph-scoped finalization handler', () => {
       ...base,
       expectedPublicQuadsDigest: workspacePublicQuadsDigest(matching.quads),
     })).resolves.toMatchObject({ status: 'verified' });
+  });
+
+  it('preserves typed invalid-result failures from the bounded exact graph reader', async () => {
+    const invalidStore = {
+      query: async (sparql: string): Promise<QueryResult> => sparql.includes('COUNT(*)')
+        ? { type: 'bindings', bindings: [{ count: '"1"' }] }
+        : { type: 'boolean', value: false },
+    } as Pick<TripleStore, 'query'> as TripleStore;
+
+    const error = await verifyExactGraphContent(invalidStore, {
+      graphUri: 'urn:test:invalid-exact-graph-result',
+      publicTripleCount: 1,
+      expectedMerkleRoot: new Uint8Array(32),
+      source: 'agent.test.verifyExactGraphContent.invalid-result',
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(ExactGraphReadError);
+    expect(error).toMatchObject({ code: 'INVALID_QUERY_RESULT' });
+  });
+
+  it('keeps exact graph verification reads page-bounded', async () => {
+    let pageQuery = '';
+    const boundedStore = {
+      query: async (sparql: string): Promise<QueryResult> => {
+        if (sparql.includes('COUNT(*)')) {
+          return { type: 'bindings', bindings: [{ count: '"5000"' }] };
+        }
+        pageQuery = sparql;
+        return { type: 'bindings', bindings: [] };
+      },
+    } as Pick<TripleStore, 'query'> as TripleStore;
+
+    await expect(verifyExactGraphContent(boundedStore, {
+      graphUri: 'urn:test:bounded-exact-graph-read',
+      publicTripleCount: 5000,
+      expectedMerkleRoot: new Uint8Array(32),
+      source: 'agent.test.verifyExactGraphContent.bounded',
+    })).resolves.toMatchObject({ status: 'count-mismatch', actualCount: 0 });
+    expect(pageQuery).toMatch(/LIMIT 256\s+OFFSET 0/);
   });
 
   it('settles a RECEIVED inbox row after the workspace head is lost and its receipt moves', async () => {
@@ -3360,6 +3409,7 @@ describe('graph-scoped finalization handler', () => {
       merkleRoot: message.kcMerkleRoot,
       publisherAddress: PUBLISHER,
       kaId: PACKED_KA_ID,
+      batchId: PACKED_KA_ID,
       versionBlock: 124,
       authorAddress: AUTHOR,
     }, createOperationContext('system')))
@@ -3416,6 +3466,7 @@ describe('graph-scoped finalization handler', () => {
         merkleRoot: message.kcMerkleRoot,
         publisherAddress: PUBLISHER,
         kaId: PACKED_KA_ID,
+        batchId: PACKED_KA_ID,
         versionBlock,
         authorAddress: AUTHOR,
       }, createOperationContext('system'))).resolves.toBe('already-confirmed');


### PR DESCRIPTION
## Summary

RFC64 exact asset sync can restore a missing asset after its mutable workspace data is gone. The old finalization inbox item then remains in `RECEIVED` and keeps retrying.

This change lets exact reconciliation close that item when the confirmed VM asset and its canonical transaction receipt both match. The item moves through `VERIFIED` to `SETTLED`.

## Safety

- Verifies the exact VM content, Merkle root, triple counts, graph, transaction hash, publisher, and canonical chain receipt.
- Keeps the inbox item when any value does not match or proof is unavailable.
- Does not settle receipt-free materializations.
- Keeps the existing SWM recovery path as the fallback.

Follow-up to #2326.

## Validation

- `pnpm --filter @origintrail-official/dkg-agent build`
- 106 focused recovery and graph-finalization tests passed.
- The integration test recreates a correct VM asset with no workspace head and a `RECEIVED` row, then confirms exact reconciliation changes the row to `SETTLED` without rewriting the asset.