### PR TITLE
fix(rfc64): authorize durable heads and verify gate contents

### DIFF
--- a/packages/agent/devnet/rfc64-private-catalog/agent-process.mjs
+++ b/packages/agent/devnet/rfc64-private-catalog/agent-process.mjs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { createInterface } from 'node:readline';
@@ -12,7 +13,11 @@ import {
   contextGraphLayerUri,
 } from '@origintrail-official/dkg-core';
 import { DKGAgent } from '@origintrail-official/dkg-agent';
-import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import {
+  OxigraphStore,
+  quadsToNQuads,
+  readExactGraphPagedWithDiscoveredCount,
+} from '@origintrail-official/dkg-storage';
 
 import {
   Rfc64PrivateDevnetChainAdapter,
@@ -306,8 +311,8 @@ async function inspect(expectedHeadDigest) {
     );
     graphCounts.push({
       kaNumber,
-      swm: await exactGraphCount(swmGraph),
-      vm: await exactGraphCount(vmGraph),
+      ...(await exactGraphEvidence(swmGraph, 'swm')),
+      ...(await exactGraphEvidence(vmGraph, 'vm')),
     });
   }
   const outsiderResult = ROLE === 'outsider'
@@ -365,13 +370,17 @@ async function proveDenied(command, requestId) {
   }
 }
 
-async function exactGraphCount(graph) {
-  const result = await agent.store.query(
-    `SELECT (COUNT(*) AS ?count) WHERE { GRAPH <${graph}> { ?s ?p ?o } }`,
-  );
-  const value = result?.bindings?.[0]?.count ?? '0';
-  const match = String(value).match(/-?[0-9]+/u);
-  return match === null ? 0 : Number(match[0]);
+async function exactGraphEvidence(graph, prefix) {
+  const quads = await readExactGraphPagedWithDiscoveredCount(agent.store, graph, {
+    maxQuadCount: 16,
+    maxNQuadsBytes: 64 * 1024,
+    outputGraph: '',
+  });
+  const canonical = quadsToNQuads(quads).split('\n').sort().join('\n');
+  return {
+    [prefix]: quads.length,
+    [`${prefix}Digest`]: createHash('sha256').update(canonical, 'utf8').digest('hex'),
+  };
 }
 
 function seededSubscriptionStore(contextGraphId) {

--- a/packages/agent/devnet/rfc64-private-catalog/fixture.mjs
+++ b/packages/agent/devnet/rfc64-private-catalog/fixture.mjs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { createHash } from 'node:crypto';
+
 import {
   CONTEXT_GRAPH_POLICY_OBJECT_TYPE_V1,
   CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
@@ -34,6 +36,14 @@ export const PROJECTION = new TextEncoder().encode(
   '<https://example.org/alice> <https://schema.org/age> "42"^^<http://www.w3.org/2001/XMLSchema#integer> .\n'
   + '<https://example.org/alice> <https://schema.org/name> "Alice" .\n',
 );
+export const PROJECTION_NQUADS = new TextDecoder().decode(PROJECTION)
+  .trim()
+  .split('\n')
+  .sort()
+  .join('\n');
+export const PROJECTION_DIGEST = createHash('sha256')
+  .update(PROJECTION_NQUADS, 'utf8')
+  .digest('hex');
 export const DEPLOYMENT = Object.freeze({
   networkId: NETWORK_ID,
   assertedAtChainId: CHAIN_ID,

--- a/packages/agent/devnet/rfc64-private-catalog/run.mjs
+++ b/packages/agent/devnet/rfc64-private-catalog/run.mjs
@@ -8,7 +8,7 @@ import { dirname, join, resolve } from 'node:path';
 import { createInterface } from 'node:readline';
 import { fileURLToPath } from 'node:url';
 
-import { roleAgentAddress } from './fixture.mjs';
+import { PROJECTION_DIGEST, roleAgentAddress } from './fixture.mjs';
 import {
   runRfc64PrivateGateArtifactLifecycleV1,
   sanitizeGateFailureV1,
@@ -225,7 +225,7 @@ async function main() {
     }, 'inspection');
     if (
       provider2StateAfterOwnerExit.exactExpectedHead !== true
-      || !exactMemoryCounts(provider2StateAfterOwnerExit)
+      || !hasExactMemoryContents(provider2StateAfterOwnerExit)
     ) {
       throw new Error('provider2: exact head, SWM, or VM changed after owner exit');
     }
@@ -287,7 +287,7 @@ async function main() {
         provider2Bootstrap.appliedHeadDigest === published.headObjectDigest
         && provider2State.exactExpectedHead === true
         && provider2State.inventoryRowCount === '2',
-      provider2HasExactSwmAndVm: exactMemoryCounts(provider2State),
+      provider2HasExactSwmAndVm: hasExactMemoryContents(provider2State),
       receiverUsedProvider2AfterOwnerStopped:
         receiverBootstrap.appliedHeadDigest === published.headObjectDigest
         && receiverBootstrap.providerPeerId === peerIds.provider2,
@@ -296,7 +296,7 @@ async function main() {
         && ownerListenerClosed
         && provider2ListenerDialable
         && owner.exitSequence < receiver.spawnSequence,
-      receiverHasExactSwmAndVm: exactMemoryCounts(receiverState),
+      receiverHasExactSwmAndVm: hasExactMemoryContents(receiverState),
       finalizedChainPathExecuted:
         provider2State.rpcCalls > 0 && receiverState.rpcCalls > 0,
       outsiderDeniedBeforeApplication:
@@ -309,7 +309,7 @@ async function main() {
         restartedReceiver.ready.peerId === peerIds.receiver
         && restartState.exactExpectedHead === true
         && restartState.inventoryRowCount === '2',
-      restartPreservedExactSwmAndVm: exactMemoryCounts(restartState),
+      restartPreservedExactSwmAndVm: hasExactMemoryContents(restartState),
     });
     const status = Object.values(checks).every(Boolean) ? 'PASS' : 'FAIL';
     artifact = {
@@ -385,9 +385,14 @@ async function dial(from, to) {
   }, 'dialed', 30_000);
 }
 
-function exactMemoryCounts(state) {
+export function hasExactMemoryContents(state) {
   return state.graphCounts.length === 2
-    && state.graphCounts.every(({ swm, vm }) => swm === 2 && vm === 2);
+    && state.graphCounts.every(({ swm, swmDigest, vm, vmDigest }) => (
+      swm === 2
+      && vm === 2
+      && swmDigest === PROJECTION_DIGEST
+      && vmDigest === PROJECTION_DIGEST
+    ));
 }
 
 function safeRole(ready) {

--- a/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
@@ -516,10 +516,6 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
     }
     const head = fetchedHead.envelope;
     assertFetchedHeadMatchesTrustedScope(head, trustedCatalogScope);
-    await this.stageVerifiedControlObjectV1(
-      fetchedHead,
-      'verified catalog head could not be staged for restart-safe recovery',
-    );
     if (expected === 'genesis' || (expected === 'any' && claimsGenesisHistory(head))) {
       return this.bootstrapEmptyBoundedPublicRootCatalogFetched(
         remotePeerId,
@@ -571,6 +567,12 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
       head,
       trustedCatalogScope,
       signal,
+    );
+    // A self-signed head is not catalog authority. Persist it only after the
+    // trusted author delegation above has bound this exact issuer and scope.
+    await this.stageVerifiedControlObjectV1(
+      fetchedHead,
+      'authorized catalog head could not be staged for restart-safe recovery',
     );
     const fetchedDirectory = await this.fetchCatalogObjectWithCacheV1(
       remotePeerId,
@@ -717,6 +719,11 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
       head,
       trustedCatalogScope,
       signal,
+    );
+    // Keep authorization-incomplete network heads out of the durable cache.
+    await this.stageVerifiedControlObjectV1(
+      fetchedHead,
+      'authorized catalog head could not be staged for restart-safe recovery',
     );
 
     const fetchedDirectory = await this.fetchCatalogObjectWithCacheV1(

--- a/packages/agent/test/rfc64-private-catalog-gate-artifact.test.ts
+++ b/packages/agent/test/rfc64-private-catalog-gate-artifact.test.ts
@@ -19,7 +19,11 @@ import {
   assertRfc64PrivateGatePassProvenanceV1,
   runRfc64PrivateGateArtifactLifecycleV1,
 } from '../devnet/rfc64-private-catalog/gate-artifact.mjs';
-import { AgentChild } from '../devnet/rfc64-private-catalog/run.mjs';
+import {
+  AgentChild,
+  hasExactMemoryContents,
+} from '../devnet/rfc64-private-catalog/run.mjs';
+import { PROJECTION_DIGEST } from '../devnet/rfc64-private-catalog/fixture.mjs';
 
 const temporaryRoots: string[] = [];
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -129,6 +133,22 @@ describe('RFC-64 private release gate artifact lifecycle', () => {
 });
 
 describe('RFC-64 private release gate process and denial evidence', () => {
+  it('rejects same-size SWM or VM semantic corruption', () => {
+    const exactGraphCounts = [41, 42].map((kaNumber) => ({
+      kaNumber,
+      swm: 2,
+      swmDigest: PROJECTION_DIGEST,
+      vm: 2,
+      vmDigest: PROJECTION_DIGEST,
+    }));
+    expect(hasExactMemoryContents({ graphCounts: exactGraphCounts })).toBe(true);
+    expect(hasExactMemoryContents({
+      graphCounts: exactGraphCounts.map((entry, index) => index === 0
+        ? { ...entry, vmDigest: '0'.repeat(64) }
+        : entry),
+    })).toBe(false);
+  });
+
   it('reaps a child that ignores the stop command and SIGTERM', async () => {
     const root = await mkdtemp(join(tmpdir(), 'rfc64-private-gate-stop-'));
     temporaryRoots.push(root);

--- a/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
@@ -1005,7 +1005,7 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
     )).rejects.toMatchObject({ code: 'catalog-native-receiver-slice' });
     expect(fixture.receiverObjectFetch).not.toHaveBeenCalled();
     expect(fixture.receiverBundleFetch).not.toHaveBeenCalled();
-    expect(observed.stageVerifiedObjects).toHaveBeenCalled();
+    expect(observed.stageVerifiedObjects).not.toHaveBeenCalled();
     expect(observed.compareAndSwapAppliedCatalogHeadV1).not.toHaveBeenCalled();
     expect(fixture.receiverPersistence.inventory.readAppliedCatalogHeadV1(
       fixture.scopeDigest,
@@ -1324,7 +1324,7 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
       observed.receiver,
     )).rejects.toMatchObject({ code: 'catalog-native-receiver-authorization' });
     expect(fixture.receiverBundleFetch).not.toHaveBeenCalled();
-    expect(observed.stageVerifiedObjects).toHaveBeenCalled();
+    expect(observed.stageVerifiedObjects).not.toHaveBeenCalled();
     expect(observed.compareAndSwapAppliedCatalogHeadV1).not.toHaveBeenCalled();
     expect(fixture.receiverPersistence.inventory.readAppliedCatalogHeadV1(
       fixture.scopeDigest,
@@ -1381,12 +1381,20 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
     fixture.authorBundleRead.mockClear();
     const observed = fixture.createCasObservedReceiver();
 
-    await expect(fixture.synchronize(
-      fixture.missingDelegationAnnouncement,
-      observed.receiver,
-    )).rejects.toMatchObject({
-      code: 'catalog-native-receiver-not-found',
-    });
+    for (let attempt = 0; attempt < 16; attempt += 1) {
+      await expect(fixture.synchronize(
+        fixture.missingDelegationAnnouncement,
+        observed.receiver,
+      )).rejects.toMatchObject({
+        code: 'catalog-native-receiver-not-found',
+      });
+    }
+    expect(observed.stageVerifiedObjects).not.toHaveBeenCalled();
+    await expect(fixture.receiverPersistence.controlObjects.getVerifiedObject({
+      objectDigest: fixture.missingDelegationAnnouncement.catalogHeadObjectDigest,
+      signatureVariantDigest: fixture.missingDelegationAnnouncement.signatureVariantDigest,
+      verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+    })).resolves.toBeNull();
     expect(observed.compareAndSwapAppliedCatalogHeadV1).not.toHaveBeenCalled();
     expect(fixture.receiverPersistence.inventory.readAppliedCatalogHeadV1(
       fixture.scopeDigest,


### PR DESCRIPTION
## Summary

- delay durable catalog-head staging until the exact direct-author delegation is verified
- keep repeated missing or invalid delegations from creating durable control-object entries
- make the four-process private RFC-64 gate compare deterministic SWM and VM content digests, not only triple counts
- prove that same-size semantic corruption fails the gate

This addresses the late red review findings from PR #2325:
- https://github.com/OriginTrail/dkg/pull/2325#discussion_r3862360040
- https://github.com/OriginTrail/dkg/pull/2325#discussion_r3862360043

## Validation

- focused native receiver tests: 3 passed
- private gate artifact tests: 7 passed
- full native receiver file: 44 passed and one obsolete assertion was corrected; its targeted rerun passed
- agent TypeScript check: passed
- Oxlint baseline: passed
- four-process private Releases 1-3 gate: PASS at commit a072857eb76e8d30b408b4cd77e8942eab6c37d4

The four-process gate proved exact head, SWM, and VM content before failover, after provider failover, and after receiver restart. The outsider remained denied.