### PR TITLE
test(rfc64): exercise private gate digests end to end

### DIFF
--- a/packages/agent/devnet/rfc64-private-catalog/agent-process.mjs
+++ b/packages/agent/devnet/rfc64-private-catalog/agent-process.mjs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { createInterface } from 'node:readline';
@@ -13,11 +12,7 @@ import {
   contextGraphLayerUri,
 } from '@origintrail-official/dkg-core';
 import { DKGAgent } from '@origintrail-official/dkg-agent';
-import {
-  OxigraphStore,
-  quadsToNQuads,
-  readExactGraphPagedWithDiscoveredCount,
-} from '@origintrail-official/dkg-storage';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
 
 import {
   Rfc64PrivateDevnetChainAdapter,
@@ -36,6 +31,7 @@ import {
   roleAgentAddress,
 } from './fixture.mjs';
 import { classifyExpectedPrivateCatalogDenialV1 } from './denial-evidence.mjs';
+import { readExactGraphMemoryEvidence } from './memory-evidence.mjs';
 
 const ROLE = requiredEnv('DKG_RFC64_PRIVATE_ROLE');
 const MODE = requiredEnv('DKG_RFC64_PRIVATE_MODE');
@@ -309,10 +305,16 @@ async function inspect(expectedHeadDigest) {
       authorAddress,
       kaNumber,
     );
+    const [swm, vm] = await Promise.all([
+      readExactGraphMemoryEvidence(agent.store, swmGraph),
+      readExactGraphMemoryEvidence(agent.store, vmGraph),
+    ]);
     graphCounts.push({
       kaNumber,
-      ...(await exactGraphEvidence(swmGraph, 'swm')),
-      ...(await exactGraphEvidence(vmGraph, 'vm')),
+      swm: swm.count,
+      swmDigest: swm.digest,
+      vm: vm.count,
+      vmDigest: vm.digest,
     });
   }
   const outsiderResult = ROLE === 'outsider'
@@ -368,19 +370,6 @@ async function proveDenied(command, requestId) {
       ...denial,
     });
   }
-}
-
-async function exactGraphEvidence(graph, prefix) {
-  const quads = await readExactGraphPagedWithDiscoveredCount(agent.store, graph, {
-    maxQuadCount: 16,
-    maxNQuadsBytes: 64 * 1024,
-    outputGraph: '',
-  });
-  const canonical = quadsToNQuads(quads).split('\n').sort().join('\n');
-  return {
-    [prefix]: quads.length,
-    [`${prefix}Digest`]: createHash('sha256').update(canonical, 'utf8').digest('hex'),
-  };
 }
 
 function seededSubscriptionStore(contextGraphId) {

--- a/packages/agent/devnet/rfc64-private-catalog/agent-process.mjs
+++ b/packages/agent/devnet/rfc64-private-catalog/agent-process.mjs
@@ -6,10 +6,8 @@ import { createInterface } from 'node:readline';
 
 import { multiaddr } from '@multiformats/multiaddr';
 import {
-  MemoryLayer,
   computeAuthorCatalogScopeDigestV1,
   computeNetworkId,
-  contextGraphLayerUri,
 } from '@origintrail-official/dkg-core';
 import { DKGAgent } from '@origintrail-official/dkg-agent';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
@@ -31,7 +29,7 @@ import {
   roleAgentAddress,
 } from './fixture.mjs';
 import { classifyExpectedPrivateCatalogDenialV1 } from './denial-evidence.mjs';
-import { readExactGraphMemoryEvidence } from './memory-evidence.mjs';
+import { readPrivateCatalogGraphCountEvidence } from './memory-evidence.mjs';
 
 const ROLE = requiredEnv('DKG_RFC64_PRIVATE_ROLE');
 const MODE = requiredEnv('DKG_RFC64_PRIVATE_MODE');
@@ -291,32 +289,11 @@ async function inspect(expectedHeadDigest) {
     catalogScopeDigest: scopeDigest,
     authorAddress,
   });
-  const graphCounts = [];
-  for (const kaNumber of ASSET_NUMBERS) {
-    const swmGraph = contextGraphLayerUri(
-      CONTEXT_GRAPH_ID,
-      MemoryLayer.SharedWorkingMemory,
-      authorAddress,
-      kaNumber,
-    );
-    const vmGraph = contextGraphLayerUri(
-      CONTEXT_GRAPH_ID,
-      MemoryLayer.VerifiableMemory,
-      authorAddress,
-      kaNumber,
-    );
-    const [swm, vm] = await Promise.all([
-      readExactGraphMemoryEvidence(agent.store, swmGraph),
-      readExactGraphMemoryEvidence(agent.store, vmGraph),
-    ]);
-    graphCounts.push({
-      kaNumber,
-      swm: swm.count,
-      swmDigest: swm.digest,
-      vm: vm.count,
-      vmDigest: vm.digest,
-    });
-  }
+  const graphCounts = await readPrivateCatalogGraphCountEvidence(agent.store, {
+    assetNumbers: ASSET_NUMBERS,
+    contextGraphId: CONTEXT_GRAPH_ID,
+    authorAddress,
+  });
   const outsiderResult = ROLE === 'outsider'
     ? null
     : await agent.query(

--- a/packages/agent/devnet/rfc64-private-catalog/fixture.mjs
+++ b/packages/agent/devnet/rfc64-private-catalog/fixture.mjs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { createHash } from 'node:crypto';
-
 import {
   CONTEXT_GRAPH_POLICY_OBJECT_TYPE_V1,
   CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
@@ -11,6 +9,10 @@ import {
   computeContextGraphPolicyObjectDigestV1,
 } from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
+import {
+  canonicalGraphlessProjectionNQuads,
+  computeGraphlessMemoryEvidence,
+} from './memory-evidence.mjs';
 
 const ROLE_KEYS = Object.freeze({
   owner: `0x${'64'.repeat(32)}`,
@@ -32,22 +34,22 @@ export const FINALIZED_POLICY_BLOCK_HASH = `0x${'76'.repeat(32)}`;
 export const ASSERTION_ROOT =
   '0x8d7a7be6029c98db1a7300bf47008c90084d5de4a3b97a68c043c0ea4773609f';
 export const ASSET_NUMBERS = Object.freeze([41, 42]);
-export const PROJECTION = new TextEncoder().encode(
-  '<https://example.org/alice> <https://schema.org/age> "42"^^<http://www.w3.org/2001/XMLSchema#integer> .\n'
-  + '<https://example.org/alice> <https://schema.org/name> "Alice" .\n',
-);
-export const PROJECTION_NQUADS = new TextDecoder().decode(PROJECTION)
-  .trim()
-  .split('\n')
-  .sort()
-  .join('\n');
-export const PROJECTION_DIGEST = createHash('sha256')
-  .update(PROJECTION_NQUADS, 'utf8')
-  .digest('hex');
-export const PROJECTION_EVIDENCE = Object.freeze({
-  count: PROJECTION_NQUADS.length === 0 ? 0 : PROJECTION_NQUADS.split('\n').length,
-  digest: PROJECTION_DIGEST,
-});
+export const PROJECTION_QUADS = Object.freeze([
+  Object.freeze({
+    subject: 'https://example.org/alice',
+    predicate: 'https://schema.org/age',
+    object: '"42"^^<http://www.w3.org/2001/XMLSchema#integer>',
+  }),
+  Object.freeze({
+    subject: 'https://example.org/alice',
+    predicate: 'https://schema.org/name',
+    object: '"Alice"',
+  }),
+]);
+export const PROJECTION_NQUADS = canonicalGraphlessProjectionNQuads(PROJECTION_QUADS);
+export const PROJECTION = new TextEncoder().encode(`${PROJECTION_NQUADS}\n`);
+export const PROJECTION_EVIDENCE = computeGraphlessMemoryEvidence(PROJECTION_QUADS);
+export const PROJECTION_DIGEST = PROJECTION_EVIDENCE.digest;
 export const DEPLOYMENT = Object.freeze({
   networkId: NETWORK_ID,
   assertedAtChainId: CHAIN_ID,

--- a/packages/agent/devnet/rfc64-private-catalog/fixture.mjs
+++ b/packages/agent/devnet/rfc64-private-catalog/fixture.mjs
@@ -44,6 +44,10 @@ export const PROJECTION_NQUADS = new TextDecoder().decode(PROJECTION)
 export const PROJECTION_DIGEST = createHash('sha256')
   .update(PROJECTION_NQUADS, 'utf8')
   .digest('hex');
+export const PROJECTION_EVIDENCE = Object.freeze({
+  count: PROJECTION_NQUADS.length === 0 ? 0 : PROJECTION_NQUADS.split('\n').length,
+  digest: PROJECTION_DIGEST,
+});
 export const DEPLOYMENT = Object.freeze({
   networkId: NETWORK_ID,
   assertedAtChainId: CHAIN_ID,

--- a/packages/agent/devnet/rfc64-private-catalog/memory-evidence.mjs
+++ b/packages/agent/devnet/rfc64-private-catalog/memory-evidence.mjs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from 'node:crypto';
+
+import {
+  quadsToNQuads,
+  readExactGraphPagedWithDiscoveredCount,
+} from '@origintrail-official/dkg-storage';
+
+const DEFAULT_MAX_QUAD_COUNT = 16;
+const DEFAULT_MAX_NQUADS_BYTES = 64 * 1024;
+
+/**
+ * Read one exact graph through the same bounded path used by the release gate
+ * and return its canonical, graph-name-independent fingerprint.
+ */
+export async function readExactGraphMemoryEvidence(store, graph, options = {}) {
+  const quads = await readExactGraphPagedWithDiscoveredCount(store, graph, {
+    maxQuadCount: options.maxQuadCount ?? DEFAULT_MAX_QUAD_COUNT,
+    maxNQuadsBytes: options.maxNQuadsBytes ?? DEFAULT_MAX_NQUADS_BYTES,
+    outputGraph: '',
+  });
+  const canonicalNQuads = quadsToNQuads(quads).split('\n').sort().join('\n');
+  return Object.freeze({
+    count: quads.length,
+    digest: createHash('sha256').update(canonicalNQuads, 'utf8').digest('hex'),
+  });
+}
+
+/**
+ * Validate the flattened process evidence against one explicit fixture model.
+ * Asset and statement cardinalities are supplied by the fixture rather than
+ * duplicated as magic numbers in the executable runner.
+ */
+export function hasExactPrivateCatalogMemoryContents(state, expected) {
+  if (!Array.isArray(state?.graphCounts) || !Array.isArray(expected?.assetNumbers)) {
+    return false;
+  }
+  const expectedAssets = new Set(expected.assetNumbers);
+  const actualAssets = new Set(state.graphCounts.map(({ kaNumber }) => kaNumber));
+  if (
+    state.graphCounts.length !== expectedAssets.size
+    || actualAssets.size !== expectedAssets.size
+    || [...expectedAssets].some((kaNumber) => !actualAssets.has(kaNumber))
+  ) {
+    return false;
+  }
+  const projection = expected.projection;
+  return state.graphCounts.every(({ swm, swmDigest, vm, vmDigest }) => (
+    swm === projection?.count
+    && vm === projection?.count
+    && swmDigest === projection?.digest
+    && vmDigest === projection?.digest
+  ));
+}

--- a/packages/agent/devnet/rfc64-private-catalog/memory-evidence.mjs
+++ b/packages/agent/devnet/rfc64-private-catalog/memory-evidence.mjs
@@ -3,6 +3,10 @@
 import { createHash } from 'node:crypto';
 
 import {
+  MemoryLayer,
+  contextGraphLayerUri,
+} from '@origintrail-official/dkg-core';
+import {
   quadsToNQuads,
   readExactGraphPagedWithDiscoveredCount,
 } from '@origintrail-official/dkg-storage';
@@ -25,6 +29,39 @@ export async function readExactGraphMemoryEvidence(store, graph, options = {}) {
     count: quads.length,
     digest: createHash('sha256').update(canonicalNQuads, 'utf8').digest('hex'),
   });
+}
+
+/**
+ * Construct the flattened per-asset evidence emitted by the release-gate
+ * child. Each asset and both of its memory projections are independent, so all
+ * bounded graph reads begin together while the returned order stays stable.
+ */
+export async function readPrivateCatalogGraphCountEvidence(store, input) {
+  return Promise.all(input.assetNumbers.map(async (kaNumber) => {
+    const swmGraph = contextGraphLayerUri(
+      input.contextGraphId,
+      MemoryLayer.SharedWorkingMemory,
+      input.authorAddress,
+      kaNumber,
+    );
+    const vmGraph = contextGraphLayerUri(
+      input.contextGraphId,
+      MemoryLayer.VerifiableMemory,
+      input.authorAddress,
+      kaNumber,
+    );
+    const [swm, vm] = await Promise.all([
+      readExactGraphMemoryEvidence(store, swmGraph),
+      readExactGraphMemoryEvidence(store, vmGraph),
+    ]);
+    return Object.freeze({
+      kaNumber,
+      swm: swm.count,
+      swmDigest: swm.digest,
+      vm: vm.count,
+      vmDigest: vm.digest,
+    });
+  }));
 }
 
 /**

--- a/packages/agent/devnet/rfc64-private-catalog/memory-evidence.mjs
+++ b/packages/agent/devnet/rfc64-private-catalog/memory-evidence.mjs
@@ -14,6 +14,35 @@ import {
 const DEFAULT_MAX_QUAD_COUNT = 16;
 const DEFAULT_MAX_NQUADS_BYTES = 64 * 1024;
 
+/** Canonical graph-name-independent serialization for one projection model. */
+export function canonicalGraphlessProjectionNQuads(quads) {
+  return quadsToNQuads(quads.map(({ subject, predicate, object }) => ({
+    subject,
+    predicate,
+    object,
+    graph: '',
+  }))).split('\n').sort().join('\n');
+}
+
+/** Pure projection evidence shared by fixture construction and store reads. */
+export function computeGraphlessMemoryEvidence(quads) {
+  const canonicalNQuads = canonicalGraphlessProjectionNQuads(quads);
+  return Object.freeze({
+    count: quads.length,
+    digest: createHash('sha256').update(canonicalNQuads, 'utf8').digest('hex'),
+  });
+}
+
+/** Bind the canonical graphless fixture projection to one concrete memory graph. */
+export function bindGraphlessProjectionToGraph(quads, graph) {
+  return quads.map(({ subject, predicate, object }) => ({
+    subject,
+    predicate,
+    object,
+    graph,
+  }));
+}
+
 /**
  * Read one exact graph through the same bounded path used by the release gate
  * and return its canonical, graph-name-independent fingerprint.
@@ -24,11 +53,7 @@ export async function readExactGraphMemoryEvidence(store, graph, options = {}) {
     maxNQuadsBytes: options.maxNQuadsBytes ?? DEFAULT_MAX_NQUADS_BYTES,
     outputGraph: '',
   });
-  const canonicalNQuads = quadsToNQuads(quads).split('\n').sort().join('\n');
-  return Object.freeze({
-    count: quads.length,
-    digest: createHash('sha256').update(canonicalNQuads, 'utf8').digest('hex'),
-  });
+  return computeGraphlessMemoryEvidence(quads);
 }
 
 /**

--- a/packages/agent/devnet/rfc64-private-catalog/run.mjs
+++ b/packages/agent/devnet/rfc64-private-catalog/run.mjs
@@ -26,7 +26,7 @@ const AGENT_PROCESS = join(HERE, 'agent-process.mjs');
 const ARTIFACT = join(HERE, 'artifacts', 'latest.json');
 const ROLES = Object.freeze(['owner', 'provider2', 'receiver', 'outsider']);
 const RUN_TIMEOUT_MS = 90_000;
-const EXPECTED_MEMORY_CONTENTS = Object.freeze({
+export const EXPECTED_MEMORY_CONTENTS = Object.freeze({
   assetNumbers: ASSET_NUMBERS,
   projection: PROJECTION_EVIDENCE,
 });
@@ -394,7 +394,7 @@ async function dial(from, to) {
   }, 'dialed', 30_000);
 }
 
-const hasExactMemoryContents = (state) =>
+export const hasExactMemoryContents = (state) =>
   hasExactPrivateCatalogMemoryContents(state, EXPECTED_MEMORY_CONTENTS);
 
 function safeRole(ready) {

--- a/packages/agent/devnet/rfc64-private-catalog/run.mjs
+++ b/packages/agent/devnet/rfc64-private-catalog/run.mjs
@@ -8,12 +8,17 @@ import { dirname, join, resolve } from 'node:path';
 import { createInterface } from 'node:readline';
 import { fileURLToPath } from 'node:url';
 
-import { PROJECTION_DIGEST, roleAgentAddress } from './fixture.mjs';
+import {
+  ASSET_NUMBERS,
+  PROJECTION_EVIDENCE,
+  roleAgentAddress,
+} from './fixture.mjs';
 import {
   runRfc64PrivateGateArtifactLifecycleV1,
   sanitizeGateFailureV1,
 } from './gate-artifact.mjs';
 import { isExpectedPrivateCatalogDenialResultV1 } from './denial-evidence.mjs';
+import { hasExactPrivateCatalogMemoryContents } from './memory-evidence.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const AGENT_ROOT = join(HERE, '..', '..');
@@ -21,6 +26,10 @@ const AGENT_PROCESS = join(HERE, 'agent-process.mjs');
 const ARTIFACT = join(HERE, 'artifacts', 'latest.json');
 const ROLES = Object.freeze(['owner', 'provider2', 'receiver', 'outsider']);
 const RUN_TIMEOUT_MS = 90_000;
+const EXPECTED_MEMORY_CONTENTS = Object.freeze({
+  assetNumbers: ASSET_NUMBERS,
+  projection: PROJECTION_EVIDENCE,
+});
 
 let requestSequence = 0;
 let lifecycleSequence = 0;
@@ -385,15 +394,8 @@ async function dial(from, to) {
   }, 'dialed', 30_000);
 }
 
-export function hasExactMemoryContents(state) {
-  return state.graphCounts.length === 2
-    && state.graphCounts.every(({ swm, swmDigest, vm, vmDigest }) => (
-      swm === 2
-      && vm === 2
-      && swmDigest === PROJECTION_DIGEST
-      && vmDigest === PROJECTION_DIGEST
-    ));
-}
+const hasExactMemoryContents = (state) =>
+  hasExactPrivateCatalogMemoryContents(state, EXPECTED_MEMORY_CONTENTS);
 
 function safeRole(ready) {
   return {

--- a/packages/agent/test/rfc64-private-catalog-gate-artifact.test.ts
+++ b/packages/agent/test/rfc64-private-catalog-gate-artifact.test.ts
@@ -32,9 +32,11 @@ import {
   ASSET_NUMBERS,
   CONTEXT_GRAPH_ID,
   PROJECTION_EVIDENCE,
+  PROJECTION_QUADS,
   roleAgentAddress,
 } from '../devnet/rfc64-private-catalog/fixture.mjs';
 import {
+  bindGraphlessProjectionToGraph,
   hasExactPrivateCatalogMemoryContents,
   readExactGraphMemoryEvidence,
   readPrivateCatalogGraphCountEvidence,
@@ -201,20 +203,12 @@ describe('RFC-64 private release gate process and denial evidence', () => {
   it('hashes real graph contents and rejects same-size semantic corruption', async () => {
     const graph = 'urn:rfc64:private-gate:test-memory';
     const store = new OxigraphStore();
-    const projection = (name: string) => [
-      {
-        graph,
-        subject: 'https://example.org/alice',
-        predicate: 'https://schema.org/age',
-        object: '"42"^^<http://www.w3.org/2001/XMLSchema#integer>',
-      },
-      {
-        graph,
-        subject: 'https://example.org/alice',
-        predicate: 'https://schema.org/name',
-        object: `"${name}"`,
-      },
-    ];
+    const projection = (name: string) => bindGraphlessProjectionToGraph(
+      PROJECTION_QUADS.map((quad) => quad.predicate === 'https://schema.org/name'
+        ? { ...quad, object: `"${name}"` }
+        : quad),
+      graph,
+    );
     try {
       // Reverse fixture order: canonicalization, not insertion order, defines
       // the digest used by the process gate.

--- a/packages/agent/test/rfc64-private-catalog-gate-artifact.test.ts
+++ b/packages/agent/test/rfc64-private-catalog-gate-artifact.test.ts
@@ -178,6 +178,8 @@ describe('RFC-64 private release gate process and denial evidence', () => {
         { graphCounts: exactGraphCounts },
         expected,
       )).toBe(true);
+      // Identity substitution, multiplicity, and omission are independent
+      // failures even when every surviving projection digest is authentic.
       expect(hasExactPrivateCatalogMemoryContents({
         graphCounts: exactGraphCounts.map((entry, index) => index === 1
           ? { ...entry, kaNumber: 43 }

--- a/packages/agent/test/rfc64-private-catalog-gate-artifact.test.ts
+++ b/packages/agent/test/rfc64-private-catalog-gate-artifact.test.ts
@@ -178,6 +178,17 @@ describe('RFC-64 private release gate process and denial evidence', () => {
         { graphCounts: exactGraphCounts },
         expected,
       )).toBe(true);
+      expect(hasExactPrivateCatalogMemoryContents({
+        graphCounts: exactGraphCounts.map((entry, index) => index === 1
+          ? { ...entry, kaNumber: 43 }
+          : entry),
+      }, expected)).toBe(false);
+      expect(hasExactPrivateCatalogMemoryContents({
+        graphCounts: exactGraphCounts.map((entry) => ({ ...entry, kaNumber: 41 })),
+      }, expected)).toBe(false);
+      expect(hasExactPrivateCatalogMemoryContents({
+        graphCounts: exactGraphCounts.slice(0, 1),
+      }, expected)).toBe(false);
 
       await store.delete(original);
       await store.insert(projection('Mallory'));

--- a/packages/agent/test/rfc64-private-catalog-gate-artifact.test.ts
+++ b/packages/agent/test/rfc64-private-catalog-gate-artifact.test.ts
@@ -6,6 +6,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { afterEach, describe, expect, it } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
 
 import {
   Rfc64PublicCatalogCurrentHeadDiscoveryErrorV1,
@@ -19,11 +20,15 @@ import {
   assertRfc64PrivateGatePassProvenanceV1,
   runRfc64PrivateGateArtifactLifecycleV1,
 } from '../devnet/rfc64-private-catalog/gate-artifact.mjs';
+import { AgentChild } from '../devnet/rfc64-private-catalog/run.mjs';
 import {
-  AgentChild,
-  hasExactMemoryContents,
-} from '../devnet/rfc64-private-catalog/run.mjs';
-import { PROJECTION_DIGEST } from '../devnet/rfc64-private-catalog/fixture.mjs';
+  ASSET_NUMBERS,
+  PROJECTION_EVIDENCE,
+} from '../devnet/rfc64-private-catalog/fixture.mjs';
+import {
+  hasExactPrivateCatalogMemoryContents,
+  readExactGraphMemoryEvidence,
+} from '../devnet/rfc64-private-catalog/memory-evidence.mjs';
 
 const temporaryRoots: string[] = [];
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -133,20 +138,64 @@ describe('RFC-64 private release gate artifact lifecycle', () => {
 });
 
 describe('RFC-64 private release gate process and denial evidence', () => {
-  it('rejects same-size SWM or VM semantic corruption', () => {
-    const exactGraphCounts = [41, 42].map((kaNumber) => ({
-      kaNumber,
-      swm: 2,
-      swmDigest: PROJECTION_DIGEST,
-      vm: 2,
-      vmDigest: PROJECTION_DIGEST,
-    }));
-    expect(hasExactMemoryContents({ graphCounts: exactGraphCounts })).toBe(true);
-    expect(hasExactMemoryContents({
-      graphCounts: exactGraphCounts.map((entry, index) => index === 0
-        ? { ...entry, vmDigest: '0'.repeat(64) }
-        : entry),
-    })).toBe(false);
+  it('hashes real graph contents and rejects same-size semantic corruption', async () => {
+    const graph = 'urn:rfc64:private-gate:test-memory';
+    const store = new OxigraphStore();
+    const projection = (name: string) => [
+      {
+        graph,
+        subject: 'https://example.org/alice',
+        predicate: 'https://schema.org/age',
+        object: '"42"^^<http://www.w3.org/2001/XMLSchema#integer>',
+      },
+      {
+        graph,
+        subject: 'https://example.org/alice',
+        predicate: 'https://schema.org/name',
+        object: `"${name}"`,
+      },
+    ];
+    try {
+      // Reverse fixture order: canonicalization, not insertion order, defines
+      // the digest used by the process gate.
+      const original = projection('Alice').reverse();
+      await store.insert(original);
+      const exact = await readExactGraphMemoryEvidence(store, graph);
+      expect(exact).toEqual(PROJECTION_EVIDENCE);
+
+      const exactGraphCounts = ASSET_NUMBERS.map((kaNumber) => ({
+        kaNumber,
+        swm: exact.count,
+        swmDigest: exact.digest,
+        vm: exact.count,
+        vmDigest: exact.digest,
+      }));
+      const expected = {
+        assetNumbers: ASSET_NUMBERS,
+        projection: PROJECTION_EVIDENCE,
+      };
+      expect(hasExactPrivateCatalogMemoryContents(
+        { graphCounts: exactGraphCounts },
+        expected,
+      )).toBe(true);
+
+      await store.delete(original);
+      await store.insert(projection('Mallory'));
+      const corrupted = await readExactGraphMemoryEvidence(store, graph);
+      expect(corrupted.count).toBe(PROJECTION_EVIDENCE.count);
+      expect(corrupted.digest).not.toBe(PROJECTION_EVIDENCE.digest);
+      expect(hasExactPrivateCatalogMemoryContents({
+        graphCounts: exactGraphCounts.map((entry, index) => index === 0
+          ? {
+              ...entry,
+              vm: corrupted.count,
+              vmDigest: corrupted.digest,
+            }
+          : entry),
+      }, expected)).toBe(false);
+    } finally {
+      await store.close();
+    }
   });
 
   it('reaps a child that ignores the stop command and SIGTERM', async () => {

--- a/packages/agent/test/rfc64-private-catalog-gate-artifact.test.ts
+++ b/packages/agent/test/rfc64-private-catalog-gate-artifact.test.ts
@@ -7,6 +7,10 @@ import { fileURLToPath } from 'node:url';
 
 import { afterEach, describe, expect, it } from 'vitest';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import {
+  MemoryLayer,
+  contextGraphLayerUri,
+} from '@origintrail-official/dkg-core';
 
 import {
   Rfc64PublicCatalogCurrentHeadDiscoveryErrorV1,
@@ -20,14 +24,20 @@ import {
   assertRfc64PrivateGatePassProvenanceV1,
   runRfc64PrivateGateArtifactLifecycleV1,
 } from '../devnet/rfc64-private-catalog/gate-artifact.mjs';
-import { AgentChild } from '../devnet/rfc64-private-catalog/run.mjs';
+import {
+  AgentChild,
+  hasExactMemoryContents,
+} from '../devnet/rfc64-private-catalog/run.mjs';
 import {
   ASSET_NUMBERS,
+  CONTEXT_GRAPH_ID,
   PROJECTION_EVIDENCE,
+  roleAgentAddress,
 } from '../devnet/rfc64-private-catalog/fixture.mjs';
 import {
   hasExactPrivateCatalogMemoryContents,
   readExactGraphMemoryEvidence,
+  readPrivateCatalogGraphCountEvidence,
 } from '../devnet/rfc64-private-catalog/memory-evidence.mjs';
 
 const temporaryRoots: string[] = [];
@@ -138,6 +148,56 @@ describe('RFC-64 private release gate artifact lifecycle', () => {
 });
 
 describe('RFC-64 private release gate process and denial evidence', () => {
+  it('feeds process-built SWM/VM evidence through the executable gate predicate', async () => {
+    const store = new OxigraphStore();
+    const authorAddress = roleAgentAddress('owner');
+    try {
+      for (const kaNumber of ASSET_NUMBERS) {
+        for (const layer of [MemoryLayer.SharedWorkingMemory, MemoryLayer.VerifiableMemory]) {
+          const graph = contextGraphLayerUri(
+            CONTEXT_GRAPH_ID,
+            layer,
+            authorAddress,
+            kaNumber,
+          );
+          await store.insert([
+            {
+              graph,
+              subject: 'https://example.org/alice',
+              predicate: 'https://schema.org/age',
+              object: '"42"^^<http://www.w3.org/2001/XMLSchema#integer>',
+            },
+            {
+              graph,
+              subject: 'https://example.org/alice',
+              predicate: 'https://schema.org/name',
+              object: '"Alice"',
+            },
+          ]);
+        }
+      }
+
+      const graphCounts = await readPrivateCatalogGraphCountEvidence(store, {
+        assetNumbers: ASSET_NUMBERS,
+        contextGraphId: CONTEXT_GRAPH_ID,
+        authorAddress,
+      });
+      expect(hasExactMemoryContents({ graphCounts })).toBe(true);
+      expect(hasExactMemoryContents({
+        graphCounts: graphCounts.map((entry, index) => index === 0
+          ? { ...entry, swmDigest: entry.vmDigest, vmDigest: '0'.repeat(64) }
+          : entry),
+      })).toBe(false);
+      expect(hasExactMemoryContents({
+        graphCounts: graphCounts.map((entry, index) => index === 1
+          ? { ...entry, kaNumber: 43 }
+          : entry),
+      })).toBe(false);
+    } finally {
+      await store.close();
+    }
+  });
+
   it('hashes real graph contents and rejects same-size semantic corruption', async () => {
     const graph = 'urn:rfc64:private-gate:test-memory';
     const store = new OxigraphStore();

--- a/packages/agent/test/rfc64-private-catalog-gate-artifact.test.ts
+++ b/packages/agent/test/rfc64-private-catalog-gate-artifact.test.ts
@@ -32,6 +32,7 @@ import {
   ASSET_NUMBERS,
   CONTEXT_GRAPH_ID,
   PROJECTION_EVIDENCE,
+  PROJECTION_NQUADS,
   PROJECTION_QUADS,
   roleAgentAddress,
 } from '../devnet/rfc64-private-catalog/fixture.mjs';
@@ -44,6 +45,17 @@ import {
 
 const temporaryRoots: string[] = [];
 const HERE = dirname(fileURLToPath(import.meta.url));
+// Independent oracle: these bytes and this digest are intentionally NOT
+// produced by memory-evidence.mjs. If canonicalization drops or rewrites any
+// term, the fixture/helper assertions below fail together against this pin.
+const EXPECTED_PROJECTION_NQUADS =
+  '<https://example.org/alice> <https://schema.org/age> ' +
+  '"42"^^<http://www.w3.org/2001/XMLSchema#integer> .\n' +
+  '<https://example.org/alice> <https://schema.org/name> "Alice" .';
+const EXPECTED_PROJECTION_EVIDENCE = Object.freeze({
+  count: 2,
+  digest: 'babf6f5fe8b4028a569792682dc3775c7410a853adfeb4e55ecea14d5ba0445f',
+});
 
 afterEach(async () => {
   await Promise.all(temporaryRoots.splice(0).map((root) => (
@@ -154,30 +166,18 @@ describe('RFC-64 private release gate process and denial evidence', () => {
     const store = new OxigraphStore();
     const authorAddress = roleAgentAddress('owner');
     try {
-      for (const kaNumber of ASSET_NUMBERS) {
-        for (const layer of [MemoryLayer.SharedWorkingMemory, MemoryLayer.VerifiableMemory]) {
+      const graphs = ASSET_NUMBERS.flatMap((kaNumber) => (
+        [MemoryLayer.SharedWorkingMemory, MemoryLayer.VerifiableMemory].flatMap((layer) => {
           const graph = contextGraphLayerUri(
             CONTEXT_GRAPH_ID,
             layer,
             authorAddress,
             kaNumber,
           );
-          await store.insert([
-            {
-              graph,
-              subject: 'https://example.org/alice',
-              predicate: 'https://schema.org/age',
-              object: '"42"^^<http://www.w3.org/2001/XMLSchema#integer>',
-            },
-            {
-              graph,
-              subject: 'https://example.org/alice',
-              predicate: 'https://schema.org/name',
-              object: '"Alice"',
-            },
-          ]);
-        }
-      }
+          return bindGraphlessProjectionToGraph(PROJECTION_QUADS, graph);
+        })
+      ));
+      await store.insert(graphs);
 
       const graphCounts = await readPrivateCatalogGraphCountEvidence(store, {
         assetNumbers: ASSET_NUMBERS,
@@ -215,7 +215,9 @@ describe('RFC-64 private release gate process and denial evidence', () => {
       const original = projection('Alice').reverse();
       await store.insert(original);
       const exact = await readExactGraphMemoryEvidence(store, graph);
-      expect(exact).toEqual(PROJECTION_EVIDENCE);
+      expect(PROJECTION_NQUADS).toBe(EXPECTED_PROJECTION_NQUADS);
+      expect(PROJECTION_EVIDENCE).toEqual(EXPECTED_PROJECTION_EVIDENCE);
+      expect(exact).toEqual(EXPECTED_PROJECTION_EVIDENCE);
 
       const exactGraphCounts = ASSET_NUMBERS.map((kaNumber) => ({
         kaNumber,
@@ -245,6 +247,29 @@ describe('RFC-64 private release gate process and denial evidence', () => {
       expect(hasExactPrivateCatalogMemoryContents({
         graphCounts: exactGraphCounts.slice(0, 1),
       }, expected)).toBe(false);
+
+      const semanticCorruptions = [
+        ['omitted age statement', PROJECTION_QUADS.slice(1)],
+        ['omitted name statement', PROJECTION_QUADS.slice(0, 1)],
+        ['changed subject', PROJECTION_QUADS.map((quad, index) => index === 0
+          ? { ...quad, subject: 'https://example.org/bob' }
+          : quad)],
+        ['changed predicate', PROJECTION_QUADS.map((quad, index) => index === 0
+          ? { ...quad, predicate: 'https://schema.org/birthDate' }
+          : quad)],
+        ['changed object', PROJECTION_QUADS.map((quad, index) => index === 0
+          ? { ...quad, object: '"43"^^<http://www.w3.org/2001/XMLSchema#integer>' }
+          : quad)],
+      ] as const;
+      for (const [label, quads] of semanticCorruptions) {
+        await store.delete(original);
+        const corruptedProjection = bindGraphlessProjectionToGraph(quads, graph);
+        await store.insert(corruptedProjection);
+        const evidence = await readExactGraphMemoryEvidence(store, graph);
+        expect(evidence, label).not.toEqual(EXPECTED_PROJECTION_EVIDENCE);
+        await store.delete(corruptedProjection);
+        await store.insert(original);
+      }
 
       await store.delete(original);
       await store.insert(projection('Mallory'));

--- a/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
@@ -2094,20 +2094,11 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
       issuerSignature: await verifyControlEnvelopeIssuerSignatureV1(envelope),
     })),
   );
-  const stagedObjects: Array<{
-    readonly objectDigest: Digest32V1;
-    readonly signatureVariantDigest: Digest32V1;
-  }> = [];
   for (let offset = 0; offset < verifiedObjects.length; offset += 16) {
-    const stagedBatch = await authorPersistence.controlObjects.stageVerifiedObjects(
+    await authorPersistence.controlObjects.stageVerifiedObjects(
       verifiedObjects.slice(offset, offset + 16),
     );
-    stagedObjects.push(...stagedBatch.objects);
   }
-  const staged = { objects: stagedObjects };
-  const stagedKeysByObjectDigest = new Map(
-    staged.objects.map((keys) => [keys.objectDigest, keys]),
-  );
   const receivedAnnouncements: Rfc64PublicCatalogHeadAnnouncementV1[] = [];
   const openPolicy = async () => Object.freeze({
     accessPolicy: 0 as const,
@@ -2228,42 +2219,32 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
   receiverNativeTransport.start();
   const announcementFor = (
     head: Readonly<SignedAuthorCatalogHeadEnvelopeV1>,
-    base?: Readonly<Rfc64PublicCatalogHeadAnnouncementV1>,
-  ): Readonly<Rfc64PublicCatalogHeadAnnouncementV1> => {
-    const keys = stagedKeysByObjectDigest.get(head.objectDigest);
-    if (keys === undefined) throw new Error(`catalog head ${head.objectDigest} was not staged`);
-    return Object.freeze({
-      ...(base ?? {
-        kind: RFC64_PUBLIC_CATALOG_HEAD_ANNOUNCEMENT_KIND_V1,
-        networkId: head.payload.networkId,
-        contextGraphId: head.payload.contextGraphId,
-        subGraphName: head.payload.subGraphName,
-        authorAddress: head.payload.authorAddress,
-        catalogEra: head.payload.era,
-        policyDigest: POLICY_DIGEST,
-      }),
-      catalogVersion: head.payload.version,
-      catalogHeadObjectDigest: keys.objectDigest,
-      signatureVariantDigest: keys.signatureVariantDigest,
-    });
-  };
+  ): Readonly<Rfc64PublicCatalogHeadAnnouncementV1> => Object.freeze({
+    kind: RFC64_PUBLIC_CATALOG_HEAD_ANNOUNCEMENT_KIND_V1,
+    networkId: head.payload.networkId,
+    contextGraphId: head.payload.contextGraphId,
+    subGraphName: head.payload.subGraphName,
+    authorAddress: head.payload.authorAddress,
+    catalogEra: head.payload.era,
+    policyDigest: POLICY_DIGEST,
+    catalogVersion: head.payload.version,
+    catalogHeadObjectDigest: head.objectDigest,
+    signatureVariantDigest: rfc64CatalogSignatureVariantDigestV1(head),
+  });
   const announcement = announcementFor(successor.head);
-  const genesisAnnouncement = announcementFor(genesis.head, announcement);
-  const multiAssetAnnouncement = announcementFor(multiAssetSuccessor.head, announcement);
-  const removalAnnouncement = announcementFor(removalSuccessor.head, announcement);
-  const replacementAnnouncement = announcementFor(replacementSuccessor.head, announcement);
-  const threeAssetAnnouncement = announcementFor(threeAssetSuccessor.head, announcement);
-  const competingAnnouncement = announcementFor(competingSuccessor.head, announcement);
-  const governedGenesisAnnouncement = announcementFor(governedGenesis.head, announcement);
-  const governedSuccessorAnnouncement = announcementFor(governedSuccessor.head, announcement);
-  const crossLaneAnnouncement = announcementFor(crossLaneHead, announcement);
-  const expiredAnnouncement = announcementFor(expiredHead, announcement);
-  const missingDelegationAnnouncement = announcementFor(missingDelegationHead, announcement);
-  const missingDelegationGenesisAnnouncement = announcementFor(
-    missingDelegationGenesisHead,
-    announcement,
-  );
-  const invalidGenesisAnnouncement = announcementFor(invalidGenesis.head, announcement);
+  const genesisAnnouncement = announcementFor(genesis.head);
+  const multiAssetAnnouncement = announcementFor(multiAssetSuccessor.head);
+  const removalAnnouncement = announcementFor(removalSuccessor.head);
+  const replacementAnnouncement = announcementFor(replacementSuccessor.head);
+  const threeAssetAnnouncement = announcementFor(threeAssetSuccessor.head);
+  const competingAnnouncement = announcementFor(competingSuccessor.head);
+  const governedGenesisAnnouncement = announcementFor(governedGenesis.head);
+  const governedSuccessorAnnouncement = announcementFor(governedSuccessor.head);
+  const crossLaneAnnouncement = announcementFor(crossLaneHead);
+  const expiredAnnouncement = announcementFor(expiredHead);
+  const missingDelegationAnnouncement = announcementFor(missingDelegationHead);
+  const missingDelegationGenesisAnnouncement = announcementFor(missingDelegationGenesisHead);
+  const invalidGenesisAnnouncement = announcementFor(invalidGenesis.head);
   await authorHeadTransport.announceCatalogHead(receiverNode.peerId, genesisAnnouncement);
   await authorHeadTransport.announceCatalogHead(receiverNode.peerId, announcement);
   expect(receivedAnnouncements).toEqual([genesisAnnouncement, announcement]);

--- a/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
@@ -2056,28 +2056,28 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
     genesis.head,
     successor.directoryPath[0]!,
   );
+  const authorEnvelopes: readonly SignedControlEnvelopeV1[] = Object.freeze([
+    catalogIssuerDelegation,
+    governedCatalogIssuerDelegation,
+    crossLaneDelegation,
+    expiredDelegation,
+    ...genesis.stagedObjects,
+    ...governedGenesis.stagedObjects,
+    ...invalidGenesis.stagedObjects,
+    ...successor.stagedObjects,
+    ...multiAssetSuccessor.stagedObjects,
+    ...removalSuccessor.stagedObjects,
+    ...threeAssetSuccessor.stagedObjects,
+    ...replacementSuccessor.stagedObjects,
+    ...governedSuccessor.stagedObjects,
+    ...competingSuccessor.stagedObjects,
+    crossLaneHead,
+    expiredHead,
+    missingDelegationHead,
+    missingDelegationGenesisHead,
+  ]);
   const authorObjects = new Map<string, SignedControlEnvelopeV1>(
-    [
-      catalogIssuerDelegation,
-      governedCatalogIssuerDelegation,
-      crossLaneDelegation,
-      expiredDelegation,
-      ...genesis.stagedObjects,
-      ...governedGenesis.stagedObjects,
-      ...invalidGenesis.stagedObjects,
-      ...successor.stagedObjects,
-      ...multiAssetSuccessor.stagedObjects,
-      ...removalSuccessor.stagedObjects,
-      ...threeAssetSuccessor.stagedObjects,
-      ...replacementSuccessor.stagedObjects,
-      ...governedSuccessor.stagedObjects,
-      ...competingSuccessor.stagedObjects,
-      crossLaneHead,
-      expiredHead,
-      missingDelegationHead,
-      missingDelegationGenesisHead,
-    ]
-      .map((envelope) => [envelope.objectDigest, envelope]),
+    authorEnvelopes.map((envelope) => [envelope.objectDigest, envelope]),
   );
   const authorObjectRead = vi.fn(async (digest: Digest32V1) =>
     authorObjects.get(digest) ?? null);
@@ -2089,30 +2089,10 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
   const authorBundleRead = vi.fn(async (digest: Digest32V1) =>
     bundleBytesByDigest.get(digest) ?? null);
   const verifiedObjects = await Promise.all(
-    [
-      catalogIssuerDelegation,
-      governedCatalogIssuerDelegation,
-      crossLaneDelegation,
-      expiredDelegation,
-      ...genesis.stagedObjects,
-      ...governedGenesis.stagedObjects,
-      ...invalidGenesis.stagedObjects,
-      ...successor.stagedObjects,
-      ...multiAssetSuccessor.stagedObjects,
-      ...removalSuccessor.stagedObjects,
-      ...threeAssetSuccessor.stagedObjects,
-      ...replacementSuccessor.stagedObjects,
-      ...governedSuccessor.stagedObjects,
-      ...competingSuccessor.stagedObjects,
-      crossLaneHead,
-      expiredHead,
-      missingDelegationHead,
-      missingDelegationGenesisHead,
-    ]
-      .map(async (envelope) => ({
+    authorEnvelopes.map(async (envelope) => ({
       envelope,
       issuerSignature: await verifyControlEnvelopeIssuerSignatureV1(envelope),
-      })),
+    })),
   );
   const stagedObjects: Array<{
     readonly objectDigest: Digest32V1;
@@ -2125,64 +2105,9 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
     stagedObjects.push(...stagedBatch.objects);
   }
   const staged = { objects: stagedObjects };
-  const headKeys = staged.objects.find(
-    (keys) => keys.objectDigest === successor.head.objectDigest,
+  const stagedKeysByObjectDigest = new Map(
+    staged.objects.map((keys) => [keys.objectDigest, keys]),
   );
-  const genesisHeadKeys = staged.objects.find(
-    (keys) => keys.objectDigest === genesis.head.objectDigest,
-  );
-  const multiAssetHeadKeys = staged.objects.find(
-    (keys) => keys.objectDigest === multiAssetSuccessor.head.objectDigest,
-  );
-  const removalHeadKeys = staged.objects.find(
-    (keys) => keys.objectDigest === removalSuccessor.head.objectDigest,
-  );
-  const replacementHeadKeys = staged.objects.find(
-    (keys) => keys.objectDigest === replacementSuccessor.head.objectDigest,
-  );
-  const threeAssetHeadKeys = staged.objects.find(
-    (keys) => keys.objectDigest === threeAssetSuccessor.head.objectDigest,
-  );
-  const governedGenesisHeadKeys = staged.objects.find(
-    (keys) => keys.objectDigest === governedGenesis.head.objectDigest,
-  );
-  const governedSuccessorHeadKeys = staged.objects.find(
-    (keys) => keys.objectDigest === governedSuccessor.head.objectDigest,
-  );
-  const invalidGenesisHeadKeys = staged.objects.find(
-    (keys) => keys.objectDigest === invalidGenesis.head.objectDigest,
-  );
-  const competingHeadKeys = staged.objects.find(
-    (keys) => keys.objectDigest === competingSuccessor.head.objectDigest,
-  );
-  const crossLaneHeadKeys = staged.objects.find(
-    (keys) => keys.objectDigest === crossLaneHead.objectDigest,
-  );
-  const expiredHeadKeys = staged.objects.find(
-    (keys) => keys.objectDigest === expiredHead.objectDigest,
-  );
-  const missingDelegationHeadKeys = staged.objects.find(
-    (keys) => keys.objectDigest === missingDelegationHead.objectDigest,
-  );
-  const missingDelegationGenesisHeadKeys = staged.objects.find(
-    (keys) => keys.objectDigest === missingDelegationGenesisHead.objectDigest,
-  );
-  if (headKeys === undefined) throw new Error('successor head was not staged');
-  if (genesisHeadKeys === undefined) throw new Error('genesis head was not staged');
-  if (multiAssetHeadKeys === undefined) throw new Error('multi-asset successor head was not staged');
-  if (removalHeadKeys === undefined) throw new Error('removal successor head was not staged');
-  if (replacementHeadKeys === undefined) throw new Error('replacement successor head was not staged');
-  if (threeAssetHeadKeys === undefined) throw new Error('three-asset successor head was not staged');
-  if (governedGenesisHeadKeys === undefined) throw new Error('governed genesis head was not staged');
-  if (governedSuccessorHeadKeys === undefined) throw new Error('governed successor head was not staged');
-  if (invalidGenesisHeadKeys === undefined) throw new Error('invalid genesis head was not staged');
-  if (competingHeadKeys === undefined) throw new Error('competing successor head was not staged');
-  if (crossLaneHeadKeys === undefined) throw new Error('cross-lane successor head was not staged');
-  if (expiredHeadKeys === undefined) throw new Error('expired-delegation head was not staged');
-  if (missingDelegationHeadKeys === undefined) throw new Error('missing-delegation head was not staged');
-  if (missingDelegationGenesisHeadKeys === undefined) {
-    throw new Error('missing-delegation genesis head was not staged');
-  }
   const receivedAnnouncements: Rfc64PublicCatalogHeadAnnouncementV1[] = [];
   const openPolicy = async () => Object.freeze({
     accessPolicy: 0 as const,
@@ -2301,88 +2226,44 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
   receiverHeadTransport.start();
   authorNativeTransport.start();
   receiverNativeTransport.start();
-  const announcement = Object.freeze({
-    kind: RFC64_PUBLIC_CATALOG_HEAD_ANNOUNCEMENT_KIND_V1,
-    networkId: successor.head.payload.networkId,
-    contextGraphId: successor.head.payload.contextGraphId,
-    subGraphName: successor.head.payload.subGraphName,
-    authorAddress: successor.head.payload.authorAddress,
-    catalogEra: successor.head.payload.era,
-    catalogVersion: successor.head.payload.version,
-    policyDigest: POLICY_DIGEST,
-    catalogHeadObjectDigest: headKeys.objectDigest,
-    signatureVariantDigest: headKeys.signatureVariantDigest,
-  }) satisfies Rfc64PublicCatalogHeadAnnouncementV1;
-  const genesisAnnouncement = Object.freeze({
-    ...announcement,
-    catalogVersion: genesis.head.payload.version,
-    catalogHeadObjectDigest: genesisHeadKeys.objectDigest,
-    signatureVariantDigest: genesisHeadKeys.signatureVariantDigest,
-  }) satisfies Rfc64PublicCatalogHeadAnnouncementV1;
-  const multiAssetAnnouncement = Object.freeze({
-    ...announcement,
-    catalogVersion: multiAssetSuccessor.head.payload.version,
-    catalogHeadObjectDigest: multiAssetHeadKeys.objectDigest,
-    signatureVariantDigest: multiAssetHeadKeys.signatureVariantDigest,
-  }) satisfies Rfc64PublicCatalogHeadAnnouncementV1;
-  const removalAnnouncement = Object.freeze({
-    ...announcement,
-    catalogVersion: removalSuccessor.head.payload.version,
-    catalogHeadObjectDigest: removalHeadKeys.objectDigest,
-    signatureVariantDigest: removalHeadKeys.signatureVariantDigest,
-  }) satisfies Rfc64PublicCatalogHeadAnnouncementV1;
-  const replacementAnnouncement = Object.freeze({
-    ...announcement,
-    catalogVersion: replacementSuccessor.head.payload.version,
-    catalogHeadObjectDigest: replacementHeadKeys.objectDigest,
-    signatureVariantDigest: replacementHeadKeys.signatureVariantDigest,
-  }) satisfies Rfc64PublicCatalogHeadAnnouncementV1;
-  const threeAssetAnnouncement = Object.freeze({
-    ...announcement,
-    catalogVersion: threeAssetSuccessor.head.payload.version,
-    catalogHeadObjectDigest: threeAssetHeadKeys.objectDigest,
-    signatureVariantDigest: threeAssetHeadKeys.signatureVariantDigest,
-  }) satisfies Rfc64PublicCatalogHeadAnnouncementV1;
-  const competingAnnouncement = Object.freeze({
-    ...announcement,
-    catalogHeadObjectDigest: competingHeadKeys.objectDigest,
-    signatureVariantDigest: competingHeadKeys.signatureVariantDigest,
-  }) satisfies Rfc64PublicCatalogHeadAnnouncementV1;
-  const governedGenesisAnnouncement = Object.freeze({
-    ...genesisAnnouncement,
-    catalogHeadObjectDigest: governedGenesisHeadKeys.objectDigest,
-    signatureVariantDigest: governedGenesisHeadKeys.signatureVariantDigest,
-  }) satisfies Rfc64PublicCatalogHeadAnnouncementV1;
-  const governedSuccessorAnnouncement = Object.freeze({
-    ...announcement,
-    catalogHeadObjectDigest: governedSuccessorHeadKeys.objectDigest,
-    signatureVariantDigest: governedSuccessorHeadKeys.signatureVariantDigest,
-  }) satisfies Rfc64PublicCatalogHeadAnnouncementV1;
-  const crossLaneAnnouncement = Object.freeze({
-    ...announcement,
-    catalogHeadObjectDigest: crossLaneHeadKeys.objectDigest,
-    signatureVariantDigest: crossLaneHeadKeys.signatureVariantDigest,
-  }) satisfies Rfc64PublicCatalogHeadAnnouncementV1;
-  const expiredAnnouncement = Object.freeze({
-    ...announcement,
-    catalogHeadObjectDigest: expiredHeadKeys.objectDigest,
-    signatureVariantDigest: expiredHeadKeys.signatureVariantDigest,
-  }) satisfies Rfc64PublicCatalogHeadAnnouncementV1;
-  const missingDelegationAnnouncement = Object.freeze({
-    ...announcement,
-    catalogHeadObjectDigest: missingDelegationHeadKeys.objectDigest,
-    signatureVariantDigest: missingDelegationHeadKeys.signatureVariantDigest,
-  }) satisfies Rfc64PublicCatalogHeadAnnouncementV1;
-  const missingDelegationGenesisAnnouncement = Object.freeze({
-    ...genesisAnnouncement,
-    catalogHeadObjectDigest: missingDelegationGenesisHeadKeys.objectDigest,
-    signatureVariantDigest: missingDelegationGenesisHeadKeys.signatureVariantDigest,
-  }) satisfies Rfc64PublicCatalogHeadAnnouncementV1;
-  const invalidGenesisAnnouncement = Object.freeze({
-    ...genesisAnnouncement,
-    catalogHeadObjectDigest: invalidGenesisHeadKeys.objectDigest,
-    signatureVariantDigest: invalidGenesisHeadKeys.signatureVariantDigest,
-  }) satisfies Rfc64PublicCatalogHeadAnnouncementV1;
+  const announcementFor = (
+    head: Readonly<SignedAuthorCatalogHeadEnvelopeV1>,
+    base?: Readonly<Rfc64PublicCatalogHeadAnnouncementV1>,
+  ): Readonly<Rfc64PublicCatalogHeadAnnouncementV1> => {
+    const keys = stagedKeysByObjectDigest.get(head.objectDigest);
+    if (keys === undefined) throw new Error(`catalog head ${head.objectDigest} was not staged`);
+    return Object.freeze({
+      ...(base ?? {
+        kind: RFC64_PUBLIC_CATALOG_HEAD_ANNOUNCEMENT_KIND_V1,
+        networkId: head.payload.networkId,
+        contextGraphId: head.payload.contextGraphId,
+        subGraphName: head.payload.subGraphName,
+        authorAddress: head.payload.authorAddress,
+        catalogEra: head.payload.era,
+        policyDigest: POLICY_DIGEST,
+      }),
+      catalogVersion: head.payload.version,
+      catalogHeadObjectDigest: keys.objectDigest,
+      signatureVariantDigest: keys.signatureVariantDigest,
+    });
+  };
+  const announcement = announcementFor(successor.head);
+  const genesisAnnouncement = announcementFor(genesis.head, announcement);
+  const multiAssetAnnouncement = announcementFor(multiAssetSuccessor.head, announcement);
+  const removalAnnouncement = announcementFor(removalSuccessor.head, announcement);
+  const replacementAnnouncement = announcementFor(replacementSuccessor.head, announcement);
+  const threeAssetAnnouncement = announcementFor(threeAssetSuccessor.head, announcement);
+  const competingAnnouncement = announcementFor(competingSuccessor.head, announcement);
+  const governedGenesisAnnouncement = announcementFor(governedGenesis.head, announcement);
+  const governedSuccessorAnnouncement = announcementFor(governedSuccessor.head, announcement);
+  const crossLaneAnnouncement = announcementFor(crossLaneHead, announcement);
+  const expiredAnnouncement = announcementFor(expiredHead, announcement);
+  const missingDelegationAnnouncement = announcementFor(missingDelegationHead, announcement);
+  const missingDelegationGenesisAnnouncement = announcementFor(
+    missingDelegationGenesisHead,
+    announcement,
+  );
+  const invalidGenesisAnnouncement = announcementFor(invalidGenesis.head, announcement);
   await authorHeadTransport.announceCatalogHead(receiverNode.peerId, genesisAnnouncement);
   await authorHeadTransport.announceCatalogHead(receiverNode.peerId, announcement);
   expect(receivedAnnouncements).toEqual([genesisAnnouncement, announcement]);

--- a/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
@@ -1156,6 +1156,30 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
     }
   }, 30_000);
 
+  it('rejects a genesis head with no delegation without staging it durably', async () => {
+    const fixture = await setupLiveReceiver();
+    const observed = fixture.createCasObservedReceiver();
+
+    await expect(fixture.bootstrap(
+      fixture.missingDelegationGenesisAnnouncement,
+      observed.receiver,
+    )).rejects.toMatchObject({ code: 'catalog-native-receiver-not-found' });
+
+    expect(observed.stageVerifiedObjects).not.toHaveBeenCalled();
+    await expect(fixture.receiverPersistence.controlObjects.getVerifiedObject({
+      objectDigest: fixture.missingDelegationGenesisAnnouncement.catalogHeadObjectDigest,
+      signatureVariantDigest:
+        fixture.missingDelegationGenesisAnnouncement.signatureVariantDigest,
+      verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+    })).resolves.toBeNull();
+    expect(observed.compareAndSwapAppliedCatalogHeadV1).not.toHaveBeenCalled();
+    expect(fixture.receiverPersistence.inventory.readAppliedCatalogHeadV1(
+      fixture.scopeDigest,
+      AUTHOR,
+    )).toBeNull();
+    await expect(fixture.receiverStore.countQuads()).resolves.toBe(0);
+  }, 30_000);
+
   it('retries genesis idempotently after verified staging wins but its CAS crashes', async () => {
     const fixture = await setupLiveReceiver();
     const rollback = vi.fn(async () => {});
@@ -2024,6 +2048,10 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
     successor.head,
     MISSING_DELEGATION_DIGEST,
   );
+  const missingDelegationGenesisHead = await rewriteCatalogHeadDelegation(
+    genesis.head,
+    MISSING_DELEGATION_DIGEST,
+  );
   const invalidGenesis = await buildInvalidEmptyGenesis(
     genesis.head,
     successor.directoryPath[0]!,
@@ -2047,6 +2075,7 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
       crossLaneHead,
       expiredHead,
       missingDelegationHead,
+      missingDelegationGenesisHead,
     ]
       .map((envelope) => [envelope.objectDigest, envelope]),
   );
@@ -2078,6 +2107,7 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
       crossLaneHead,
       expiredHead,
       missingDelegationHead,
+      missingDelegationGenesisHead,
     ]
       .map(async (envelope) => ({
       envelope,
@@ -2134,6 +2164,9 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
   const missingDelegationHeadKeys = staged.objects.find(
     (keys) => keys.objectDigest === missingDelegationHead.objectDigest,
   );
+  const missingDelegationGenesisHeadKeys = staged.objects.find(
+    (keys) => keys.objectDigest === missingDelegationGenesisHead.objectDigest,
+  );
   if (headKeys === undefined) throw new Error('successor head was not staged');
   if (genesisHeadKeys === undefined) throw new Error('genesis head was not staged');
   if (multiAssetHeadKeys === undefined) throw new Error('multi-asset successor head was not staged');
@@ -2147,6 +2180,9 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
   if (crossLaneHeadKeys === undefined) throw new Error('cross-lane successor head was not staged');
   if (expiredHeadKeys === undefined) throw new Error('expired-delegation head was not staged');
   if (missingDelegationHeadKeys === undefined) throw new Error('missing-delegation head was not staged');
+  if (missingDelegationGenesisHeadKeys === undefined) {
+    throw new Error('missing-delegation genesis head was not staged');
+  }
   const receivedAnnouncements: Rfc64PublicCatalogHeadAnnouncementV1[] = [];
   const openPolicy = async () => Object.freeze({
     accessPolicy: 0 as const,
@@ -2337,6 +2373,11 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
     catalogHeadObjectDigest: missingDelegationHeadKeys.objectDigest,
     signatureVariantDigest: missingDelegationHeadKeys.signatureVariantDigest,
   }) satisfies Rfc64PublicCatalogHeadAnnouncementV1;
+  const missingDelegationGenesisAnnouncement = Object.freeze({
+    ...genesisAnnouncement,
+    catalogHeadObjectDigest: missingDelegationGenesisHeadKeys.objectDigest,
+    signatureVariantDigest: missingDelegationGenesisHeadKeys.signatureVariantDigest,
+  }) satisfies Rfc64PublicCatalogHeadAnnouncementV1;
   const invalidGenesisAnnouncement = Object.freeze({
     ...genesisAnnouncement,
     catalogHeadObjectDigest: invalidGenesisHeadKeys.objectDigest,
@@ -2458,6 +2499,7 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
     receiver,
     receiverBundleFetch,
     missingDelegationAnnouncement,
+    missingDelegationGenesisAnnouncement,
     multiAssetAnnouncement,
     multiAssetSuccessor,
     removalAnnouncement,


### PR DESCRIPTION
## Summary

Follow-up to #2349.

- move the bounded graph read, canonical N-Quads fingerprint, and exact-memory validator into one shared gate evidence module
- derive expected asset and statement cardinalities from the private-gate fixture
- exercise the production store-to-digest path with a real OxigraphStore
- prove insertion-order independence and reject a same-cardinality semantic mutation
- add the missing genesis-path regression proving a head without its delegation is never staged durably

## Validation

- `pnpm --filter "@origintrail-official/dkg-agent..." build`
- focused RFC-64 suites: 46/46 passed
- post-rebase targeted regressions: 2/2 passed
- Oxlint diagnostic fingerprint baseline passed

Addresses the test gaps identified in #2349 review.