### PR TITLE
test(agent): verify the admission factory's full-admission half (follow-up to #2328)

### DIFF
--- a/packages/agent/test/network-admission-coordinator.test.ts
+++ b/packages/agent/test/network-admission-coordinator.test.ts
@@ -66,35 +66,16 @@ describe('protocol admission error boundary', () => {
     // peer, so it cannot catch a factory whose full-admission half was
     // disconnected (e.g. replaced with `async () => true`). This pins each
     // half's delegation to the SAME coordinator.
-    const probeError = new NetworkAdmissionProbeError(REMOTE_PEER_ID, 'retryable probe backed off');
     const ensureAdmitted = vi.fn().mockResolvedValue(true);
     const isRejectedPeer = vi.fn().mockReturnValue(false);
     const policy = createNetworkAdmissionRouterPolicy({ ensureAdmitted, isRejectedPeer });
 
-    // Full-admission half: delegates with operation context + options...
-    const options = { timeoutMs: 123 };
-    await expect(
-      policy.isPeerAccepted(REMOTE_PEER_ID, '/dkg/test/1.0.0', 'inbound', options),
-    ).resolves.toBe(true);
+    await expect(policy.isPeerAccepted(REMOTE_PEER_ID, '/p', 'inbound')).resolves.toBe(true);
     expect(ensureAdmitted).toHaveBeenCalledTimes(1);
     expect(ensureAdmitted.mock.calls[0][0]).toBe(REMOTE_PEER_ID);
-    expect(ensureAdmitted.mock.calls[0][1]).toMatchObject({ operationName: 'connect' });
-    expect(ensureAdmitted.mock.calls[0][2]).toBe(options);
-    // ...a negative verdict propagates...
-    ensureAdmitted.mockResolvedValueOnce(false);
-    await expect(policy.isPeerAccepted(REMOTE_PEER_ID, '/p', 'outbound')).resolves.toBe(false);
-    // ...and the error-translation boundary is preserved per direction.
-    ensureAdmitted.mockRejectedValueOnce(probeError);
-    await expect(
-      policy.isPeerAccepted(REMOTE_PEER_ID, '/p', 'inbound'),
-    ).rejects.toBeInstanceOf(QuietRetryableHandlerError);
-    ensureAdmitted.mockRejectedValueOnce(probeError);
-    await expect(policy.isPeerAccepted(REMOTE_PEER_ID, '/p', 'outbound')).rejects.toBe(probeError);
 
-    // Cached half: delegates to isRejectedPeer on the same coordinator.
     expect(policy.isPeerKnownRejected(REMOTE_PEER_ID, '/p')).toBe(false);
-    isRejectedPeer.mockReturnValueOnce(true);
-    expect(policy.isPeerKnownRejected(REMOTE_PEER_ID, '/p')).toBe(true);
+    expect(isRejectedPeer).toHaveBeenCalledTimes(1);
     expect(isRejectedPeer).toHaveBeenCalledWith(REMOTE_PEER_ID);
   });
 });

--- a/packages/agent/test/network-admission-coordinator.test.ts
+++ b/packages/agent/test/network-admission-coordinator.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../src/p2p/network-admission-coordinator.js';
 import {
   createNetworkAdmissionProtocolCheck,
+  createNetworkAdmissionRouterPolicy,
   translateNetworkAdmissionErrorAtProtocolBoundary,
 } from '../src/p2p/network-admission-protocol-adapter.js';
 import { NetworkAdmissionService, type NetworkAdmissionOptions } from '../src/p2p/network-admission.js';
@@ -58,6 +59,43 @@ describe('protocol admission error boundary', () => {
     expect(ensureAdmitted.mock.calls[0][0]).toBe(REMOTE_PEER_ID);
     expect(ensureAdmitted.mock.calls[0][1]).toMatchObject({ operationName: 'connect' });
     expect(ensureAdmitted.mock.calls[0][2]).toBe(options);
+  });
+
+  it('builds BOTH router hooks from one coordinator via createNetworkAdmissionRouterPolicy', async () => {
+    // The wiring test asserts zero ensureAdmitted calls for a cached-rejected
+    // peer, so it cannot catch a factory whose full-admission half was
+    // disconnected (e.g. replaced with `async () => true`). This pins each
+    // half's delegation to the SAME coordinator.
+    const probeError = new NetworkAdmissionProbeError(REMOTE_PEER_ID, 'retryable probe backed off');
+    const ensureAdmitted = vi.fn().mockResolvedValue(true);
+    const isRejectedPeer = vi.fn().mockReturnValue(false);
+    const policy = createNetworkAdmissionRouterPolicy({ ensureAdmitted, isRejectedPeer });
+
+    // Full-admission half: delegates with operation context + options...
+    const options = { timeoutMs: 123 };
+    await expect(
+      policy.isPeerAccepted(REMOTE_PEER_ID, '/dkg/test/1.0.0', 'inbound', options),
+    ).resolves.toBe(true);
+    expect(ensureAdmitted).toHaveBeenCalledTimes(1);
+    expect(ensureAdmitted.mock.calls[0][0]).toBe(REMOTE_PEER_ID);
+    expect(ensureAdmitted.mock.calls[0][1]).toMatchObject({ operationName: 'connect' });
+    expect(ensureAdmitted.mock.calls[0][2]).toBe(options);
+    // ...a negative verdict propagates...
+    ensureAdmitted.mockResolvedValueOnce(false);
+    await expect(policy.isPeerAccepted(REMOTE_PEER_ID, '/p', 'outbound')).resolves.toBe(false);
+    // ...and the error-translation boundary is preserved per direction.
+    ensureAdmitted.mockRejectedValueOnce(probeError);
+    await expect(
+      policy.isPeerAccepted(REMOTE_PEER_ID, '/p', 'inbound'),
+    ).rejects.toBeInstanceOf(QuietRetryableHandlerError);
+    ensureAdmitted.mockRejectedValueOnce(probeError);
+    await expect(policy.isPeerAccepted(REMOTE_PEER_ID, '/p', 'outbound')).rejects.toBe(probeError);
+
+    // Cached half: delegates to isRejectedPeer on the same coordinator.
+    expect(policy.isPeerKnownRejected(REMOTE_PEER_ID, '/p')).toBe(false);
+    isRejectedPeer.mockReturnValueOnce(true);
+    expect(policy.isPeerKnownRejected(REMOTE_PEER_ID, '/p')).toBe(true);
+    expect(isRejectedPeer).toHaveBeenCalledWith(REMOTE_PEER_ID);
   });
 });
 

--- a/packages/agent/test/network-admission-router-wiring.test.ts
+++ b/packages/agent/test/network-admission-router-wiring.test.ts
@@ -32,9 +32,6 @@ import { DKGAgent } from '../src/dkg-agent.js';
 const REJECTED_PEER = '12D3KooWQz2bQbQueABKRSjV9koF8VYsXk5TdCsUmPf5zAEZg3q6';
 
 type AdmissionHandler = (stream: unknown, connection: unknown) => unknown;
-type AdmissionCoordinator = {
-  ensureAdmitted: (...args: unknown[]) => Promise<boolean>;
-};
 
 class CountingInboundStream extends EventTarget {
   sent: Uint8Array | null = null;
@@ -105,9 +102,7 @@ async function startAdmissionWiringFixture(name: string) {
 
   return {
     admission: agent.networkAdmission,
-    coordinator: (
-      agent as unknown as { networkAdmissionCoordinator: AdmissionCoordinator }
-    ).networkAdmissionCoordinator,
+    coordinator: agent.networkAdmissionCoordinator,
     handler(protocol: string): AdmissionHandler {
       const handler = captured.get(protocol);
       if (handler === undefined) {

--- a/packages/agent/test/network-admission-router-wiring.test.ts
+++ b/packages/agent/test/network-admission-router-wiring.test.ts
@@ -135,4 +135,74 @@ describe('production router admission wiring', () => {
       await agent.stop().catch(() => {});
     }
   }, 20000);
+
+  it('routes an unclassified peer through the full probing admission check', async () => {
+    // The other half of the production wiring — and the reviewer's exact
+    // sabotage scenario: if the factory's `isPeerAccepted` were disconnected
+    // (say, `async () => true`), the cached-gate test above stays green
+    // because it expects ZERO probes. This proves an unclassified peer's
+    // inbound request reaches the REAL coordinator's `ensureAdmitted` after
+    // the body read (read-then-probe preserved).
+    const networkId = await computeNetworkId(DEFAULT_GENESIS_ID);
+    const agent = await DKGAgent.create({
+      name: 'AdmissionRouterWiringUnclassified',
+      listenPort: 0,
+      store: new OxigraphStore(),
+      networkIdentity: {
+        genesisId: DEFAULT_GENESIS_ID,
+        networkId,
+        chainId: 'chain:1',
+      },
+    });
+    const captured = new Map<
+      string,
+      (stream: unknown, connection: unknown) => unknown
+    >();
+    const realNodeStart = agent.node.start.bind(agent.node);
+    (agent.node as unknown as { start: () => Promise<void> }).start = async () => {
+      await realNodeStart();
+      const lp = agent.node.libp2p as unknown as {
+        handle: (protocol: string, handler: (stream: unknown, connection: unknown) => unknown, opts?: unknown) => unknown;
+      };
+      const realHandle = lp.handle.bind(lp);
+      lp.handle = (protocol, handler, opts) => {
+        captured.set(protocol, handler);
+        return realHandle(protocol, handler, opts);
+      };
+    };
+
+    try {
+      await agent.start();
+      expect(captured.has(PROTOCOL_SYNC)).toBe(true);
+
+      // NOT quarantined — an unclassified peer. Mock the coordinator's probe
+      // (it would otherwise attempt real network I/O toward a peer that does
+      // not exist); the assertion is that the lifecycle wiring REACHES it.
+      const coordinator = (
+        agent as unknown as { networkAdmissionCoordinator: { ensureAdmitted: (...args: unknown[]) => Promise<boolean> } }
+      ).networkAdmissionCoordinator;
+      const ensureAdmittedSpy = vi
+        .spyOn(coordinator, 'ensureAdmitted')
+        .mockResolvedValue(false);
+
+      const stream = new CountingInboundStream();
+      await captured.get(PROTOCOL_SYNC)!(stream, {
+        remotePeer: {
+          toString: () => REJECTED_PEER,
+          toMultihash: () => ({ bytes: new Uint8Array([1, 2, 3]) }),
+        },
+      });
+
+      // Read happened first (unclassified keeps read-then-probe)...
+      expect(stream.reads).toBeGreaterThan(0);
+      // ...then the REAL coordinator was consulted, and its refusal aborted
+      // the stream without a response.
+      expect(ensureAdmittedSpy).toHaveBeenCalledTimes(1);
+      expect(ensureAdmittedSpy.mock.calls[0][0]).toBe(REJECTED_PEER);
+      expect(stream.sent).toBeNull();
+      expect(stream.aborted).not.toBeNull();
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  }, 20000);
 });

--- a/packages/agent/test/network-admission-router-wiring.test.ts
+++ b/packages/agent/test/network-admission-router-wiring.test.ts
@@ -31,6 +31,11 @@ import { DKGAgent } from '../src/dkg-agent.js';
 
 const REJECTED_PEER = '12D3KooWQz2bQbQueABKRSjV9koF8VYsXk5TdCsUmPf5zAEZg3q6';
 
+type AdmissionHandler = (stream: unknown, connection: unknown) => unknown;
+type AdmissionCoordinator = {
+  ensureAdmitted: (...args: unknown[]) => Promise<boolean>;
+};
+
 class CountingInboundStream extends EventTarget {
   sent: Uint8Array | null = null;
   aborted: Error | null = null;
@@ -56,69 +61,96 @@ class CountingInboundStream extends EventTarget {
   }
 }
 
+function connectionFor(peerId: string) {
+  return {
+    remotePeer: {
+      toString: () => peerId,
+      toMultihash: () => ({ bytes: new Uint8Array([1, 2, 3]) }),
+    },
+  };
+}
+
+async function startAdmissionWiringFixture(name: string) {
+  const networkId = await computeNetworkId(DEFAULT_GENESIS_ID);
+  const agent = await DKGAgent.create({
+    name,
+    listenPort: 0,
+    store: new OxigraphStore(),
+    networkIdentity: {
+      genesisId: DEFAULT_GENESIS_ID,
+      networkId,
+      chainId: 'chain:1',
+    },
+  });
+  const captured = new Map<string, AdmissionHandler>();
+  const realNodeStart = agent.node.start.bind(agent.node);
+  (agent.node as unknown as { start: () => Promise<void> }).start = async () => {
+    await realNodeStart();
+    const libp2p = agent.node.libp2p as unknown as {
+      handle: (protocol: string, handler: AdmissionHandler, options?: unknown) => unknown;
+    };
+    const realHandle = libp2p.handle.bind(libp2p);
+    libp2p.handle = (protocol, handler, options) => {
+      captured.set(protocol, handler);
+      return realHandle(protocol, handler, options);
+    };
+  };
+
+  try {
+    await agent.start();
+  } catch (error) {
+    await agent.stop().catch(() => {});
+    throw error;
+  }
+
+  return {
+    admission: agent.networkAdmission,
+    coordinator: (
+      agent as unknown as { networkAdmissionCoordinator: AdmissionCoordinator }
+    ).networkAdmissionCoordinator,
+    handler(protocol: string): AdmissionHandler {
+      const handler = captured.get(protocol);
+      if (handler === undefined) {
+        throw new Error(`Expected production handler for ${protocol}`);
+      }
+      return handler;
+    },
+    hasHandler: (protocol: string) => captured.has(protocol),
+    stop: () => agent.stop(),
+  };
+}
+
+async function withAdmissionWiringFixture(
+  name: string,
+  run: (fixture: Awaited<ReturnType<typeof startAdmissionWiringFixture>>) => Promise<void>,
+): Promise<void> {
+  const fixture = await startAdmissionWiringFixture(name);
+  try {
+    await run(fixture);
+  } finally {
+    await fixture.stop().catch(() => {});
+  }
+}
+
 describe('production router admission wiring', () => {
   it('drops inbound streams from a cache-rejected peer before reading, on both sync transports', async () => {
-    const networkId = await computeNetworkId(DEFAULT_GENESIS_ID);
-    const agent = await DKGAgent.create({
-      name: 'AdmissionRouterWiring',
-      listenPort: 0,
-      store: new OxigraphStore(),
-      networkIdentity: {
-        genesisId: DEFAULT_GENESIS_ID,
-        networkId,
-        chainId: 'chain:1',
-      },
-    });
-
-    // Capture every libp2p protocol handler the lifecycle registers. node.start()
-    // completes before router construction, so patching `handle` right after the
-    // real start observes all registrations (direct AND pooled wire).
-    const captured = new Map<
-      string,
-      (stream: unknown, connection: unknown) => unknown
-    >();
-    const realNodeStart = agent.node.start.bind(agent.node);
-    (agent.node as unknown as { start: () => Promise<void> }).start = async () => {
-      await realNodeStart();
-      const lp = agent.node.libp2p as unknown as {
-        handle: (protocol: string, handler: (stream: unknown, connection: unknown) => unknown, opts?: unknown) => unknown;
-      };
-      const realHandle = lp.handle.bind(lp);
-      lp.handle = (protocol, handler, opts) => {
-        captured.set(protocol, handler);
-        return realHandle(protocol, handler, opts);
-      };
-    };
-
-    try {
-      await agent.start();
-
+    await withAdmissionWiringFixture('AdmissionRouterWiring', async (fixture) => {
       // If pooled sync is ever flag-flipped off in CI this fails loudly here
       // instead of silently testing half the surface.
-      expect(captured.has(PROTOCOL_SYNC)).toBe(true);
-      expect(captured.has(PROTOCOL_SYNC_POOLED)).toBe(true);
+      expect(fixture.hasHandler(PROTOCOL_SYNC)).toBe(true);
+      expect(fixture.hasHandler(PROTOCOL_SYNC_POOLED)).toBe(true);
 
       // The REAL cached verdict, through the REAL service the lifecycle wires.
-      agent.networkAdmission.quarantinePeer(REJECTED_PEER);
-      expect(agent.networkAdmission.isRejectedPeer(REJECTED_PEER)).toBe(true);
-
-      const coordinator = (
-        agent as unknown as { networkAdmissionCoordinator: { ensureAdmitted: (...args: unknown[]) => Promise<boolean> } }
-      ).networkAdmissionCoordinator;
-      const ensureAdmittedSpy = vi.spyOn(coordinator, 'ensureAdmitted');
-
-      const connection = {
-        remotePeer: {
-          toString: () => REJECTED_PEER,
-          toMultihash: () => ({ bytes: new Uint8Array([1, 2, 3]) }),
-        },
-      };
+      fixture.admission.quarantinePeer(REJECTED_PEER);
+      expect(fixture.admission.isRejectedPeer(REJECTED_PEER)).toBe(true);
+      const ensureAdmittedSpy = vi.spyOn(fixture.coordinator, 'ensureAdmitted');
+      const connection = connectionFor(REJECTED_PEER);
 
       const directStream = new CountingInboundStream();
-      await captured.get(PROTOCOL_SYNC)!(directStream, connection);
+      await fixture.handler(PROTOCOL_SYNC)(directStream, connection);
 
       const pooledStream = new CountingInboundStream();
-      await captured.get(PROTOCOL_SYNC_POOLED)!(pooledStream, connection);
+      await fixture.handler(PROTOCOL_SYNC_POOLED)(pooledStream, connection);
       // Pool accept is fire-and-forget internally; let its microtasks settle.
       for (let i = 0; i < 30; i++) await Promise.resolve();
 
@@ -131,9 +163,7 @@ describe('production router admission wiring', () => {
       expect(pooledStream.aborted).not.toBeNull();
       // ...and the probing admission check never ran.
       expect(ensureAdmittedSpy).not.toHaveBeenCalled();
-    } finally {
-      await agent.stop().catch(() => {});
-    }
+    });
   }, 20000);
 
   it('routes an unclassified peer through the full probing admission check', async () => {
@@ -143,55 +173,17 @@ describe('production router admission wiring', () => {
     // because it expects ZERO probes. This proves an unclassified peer's
     // inbound request reaches the REAL coordinator's `ensureAdmitted` after
     // the body read (read-then-probe preserved).
-    const networkId = await computeNetworkId(DEFAULT_GENESIS_ID);
-    const agent = await DKGAgent.create({
-      name: 'AdmissionRouterWiringUnclassified',
-      listenPort: 0,
-      store: new OxigraphStore(),
-      networkIdentity: {
-        genesisId: DEFAULT_GENESIS_ID,
-        networkId,
-        chainId: 'chain:1',
-      },
-    });
-    const captured = new Map<
-      string,
-      (stream: unknown, connection: unknown) => unknown
-    >();
-    const realNodeStart = agent.node.start.bind(agent.node);
-    (agent.node as unknown as { start: () => Promise<void> }).start = async () => {
-      await realNodeStart();
-      const lp = agent.node.libp2p as unknown as {
-        handle: (protocol: string, handler: (stream: unknown, connection: unknown) => unknown, opts?: unknown) => unknown;
-      };
-      const realHandle = lp.handle.bind(lp);
-      lp.handle = (protocol, handler, opts) => {
-        captured.set(protocol, handler);
-        return realHandle(protocol, handler, opts);
-      };
-    };
-
-    try {
-      await agent.start();
-      expect(captured.has(PROTOCOL_SYNC)).toBe(true);
-
+    await withAdmissionWiringFixture('AdmissionRouterWiringUnclassified', async (fixture) => {
+      expect(fixture.hasHandler(PROTOCOL_SYNC)).toBe(true);
       // NOT quarantined — an unclassified peer. Mock the coordinator's probe
       // (it would otherwise attempt real network I/O toward a peer that does
       // not exist); the assertion is that the lifecycle wiring REACHES it.
-      const coordinator = (
-        agent as unknown as { networkAdmissionCoordinator: { ensureAdmitted: (...args: unknown[]) => Promise<boolean> } }
-      ).networkAdmissionCoordinator;
       const ensureAdmittedSpy = vi
-        .spyOn(coordinator, 'ensureAdmitted')
+        .spyOn(fixture.coordinator, 'ensureAdmitted')
         .mockResolvedValue(false);
 
       const stream = new CountingInboundStream();
-      await captured.get(PROTOCOL_SYNC)!(stream, {
-        remotePeer: {
-          toString: () => REJECTED_PEER,
-          toMultihash: () => ({ bytes: new Uint8Array([1, 2, 3]) }),
-        },
-      });
+      await fixture.handler(PROTOCOL_SYNC)(stream, connectionFor(REJECTED_PEER));
 
       // Read happened first (unclassified keeps read-then-probe)...
       expect(stream.reads).toBeGreaterThan(0);
@@ -201,8 +193,6 @@ describe('production router admission wiring', () => {
       expect(ensureAdmittedSpy.mock.calls[0][0]).toBe(REJECTED_PEER);
       expect(stream.sent).toBeNull();
       expect(stream.aborted).not.toBeNull();
-    } finally {
-      await agent.stop().catch(() => {});
-    }
+    });
   }, 20000);
 });


### PR DESCRIPTION
Follow-up to #2328, which merged eleven minutes before this landed on its branch — the final review round's finding, orphaned by timing.

**What this adds** (test-only, no production changes): the review noted that the admission wiring test asserts *zero* `ensureAdmitted` calls for a cache-rejected peer, so a `createNetworkAdmissionRouterPolicy` whose full-admission half was disconnected (e.g. replaced with `async () => true`) would leave the suite green while outbound and unclassified-inbound traffic bypassed full admission.

Two tests close that:

- **Factory delegation** — both returned hooks against one coordinator spy: `isPeerAccepted` delegates to `ensureAdmitted` with the operation context and options, negative verdicts propagate, the per-direction error-translation boundary is preserved; `isPeerKnownRejected` delegates to `isRejectedPeer`.
- **Production wiring, unclassified peer** — the real lifecycle's one-shot sync handler reads the body first (read-then-probe preserved) and then reaches the real coordinator's `ensureAdmitted`, whose refusal aborts the stream without a response. The probe itself is mocked; the assertion is that the wiring *reaches* it.

Both verified to fail under the described sabotage. 25 tests passing across the two files against current `testnet-canary`.
