### PR TITLE
fix(publisher): demand-driven transaction reconciliation for detached publishes

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -857,8 +857,19 @@ export interface DkgConfig {
     enabled?: boolean;
     pollIntervalMs?: number;
     errorBackoffMs?: number;
-    /** How often to check submitted transactions for chain confirmation. Default 60000ms. */
+    /**
+     * The IDLE sweep: how often to check submitted transactions for chain confirmation when the
+     * queue reports no transaction awaiting proof (crash recovery, missed wake-ups).
+     * Default 60000ms.
+     */
     recoveryIntervalMs?: number;
+    /**
+     * The ACTIVE reconcile cadence: how often to re-check while at least one submitted
+     * transaction is still awaiting chain proof. The publisher additionally wakes reconciliation
+     * immediately when a receipt task settles, so this bounds only the re-check loop for
+     * transactions whose proof was not yet available. Default 5000ms.
+     */
+    activeRecoveryIntervalMs?: number;
     /**
      * Retry budget per job — ONE counter shared by the publisher's automatic
      * retries and manual reaccepts, snapshot at admission. Default 10.

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -243,11 +243,18 @@ export async function startPublisherRuntimeIfEnabled(args: {
       pollIntervalMs: args.config.publisher.pollIntervalMs,
       errorBackoffMs: args.config.publisher.errorBackoffMs,
       recoveryIntervalMs: args.config.publisher.recoveryIntervalMs,
+      activeRecoveryIntervalMs: args.config.publisher.activeRecoveryIntervalMs,
       maxRetries: args.config.publisher.maxRetries,
       // GH#2270 — this is the ONE runtime whose retry scheduler and claim-time
       // sweep actually run, so the kill-switch and backoff knobs are dead
       // config unless they travel this hop (the #1836 bug class).
       retryTuning: resolvePublisherRetryTuning(args.config.publisher),
+      // Runner errors (wallet loop + reconciliation) were previously swallowed after their
+      // backoff; a chronically failing reconcile pass then looks exactly like a slow publisher.
+      onRunnerError: (error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        args.log(`[publisher] runner error: ${message}`);
+      },
       config: args.config,
       ackTransportFactory: args.ackTransportFactory,
       publishEncryptionFactory: args.publishEncryptionFactory,
@@ -355,9 +362,16 @@ interface PublisherRuntimeBaseArgs {
   pollIntervalMs?: number;
   errorBackoffMs?: number;
   recoveryIntervalMs?: number;
+  activeRecoveryIntervalMs?: number;
   maxRetries?: number;
   /** GH#2270 — validated `config.publisher` retry knobs; unset knobs keep the library defaults. */
   retryTuning?: PublisherRetryTuning;
+  /**
+   * Receives wallet-loop and reconciliation errors from the runner. Without it those errors are
+   * swallowed after their backoff, which turns a chronically failing reconcile pass into a silent
+   * publishing slowdown.
+   */
+  onRunnerError?: (error: unknown) => void;
   ackTransportFactory?: ACKTransportFactory;
   v10ACKProviderFactory?: () => PublishOptions['v10ACKProvider'];
   publishEncryptionFactory?: PublishEncryptionFactory;
@@ -376,6 +390,7 @@ export async function createPublisherRuntime(args: {
   pollIntervalMs?: number;
   errorBackoffMs?: number;
   recoveryIntervalMs?: number;
+  activeRecoveryIntervalMs?: number;
   maxRetries?: number;
 }): Promise<PublisherRuntime> {
   const publisherWallets = await loadPublisherWallets(args.dataDir);
@@ -402,6 +417,7 @@ export async function createPublisherRuntime(args: {
     pollIntervalMs: args.pollIntervalMs,
     errorBackoffMs: args.errorBackoffMs,
     recoveryIntervalMs: args.recoveryIntervalMs ?? args.config.publisher?.recoveryIntervalMs,
+    activeRecoveryIntervalMs: args.activeRecoveryIntervalMs ?? args.config.publisher?.activeRecoveryIntervalMs,
     maxRetries: args.maxRetries ?? args.config.publisher?.maxRetries,
     retryTuning: resolvePublisherRetryTuning(args.config.publisher),
     publicSnapshotStore,
@@ -515,8 +531,10 @@ export async function createPublisherRuntimeFromAgent(args: {
   pollIntervalMs?: number;
   errorBackoffMs?: number;
   recoveryIntervalMs?: number;
+  activeRecoveryIntervalMs?: number;
   maxRetries?: number;
   retryTuning?: PublisherRetryTuning;
+  onRunnerError?: (error: unknown) => void;
   config?: Pick<DkgConfig, 'sharedMemoryPublicSnapshotStorage'>;
   ackTransportFactory?: ACKTransportFactory;
   v10ACKProviderFactory?: () => PublishOptions['v10ACKProvider'];
@@ -533,8 +551,10 @@ export async function createPublisherRuntimeFromAgent(args: {
     pollIntervalMs: args.pollIntervalMs,
     errorBackoffMs: args.errorBackoffMs,
     recoveryIntervalMs: args.recoveryIntervalMs,
+    activeRecoveryIntervalMs: args.activeRecoveryIntervalMs,
     maxRetries: args.maxRetries,
     retryTuning: args.retryTuning,
+    onRunnerError: args.onRunnerError,
     ackTransportFactory: args.ackTransportFactory,
     v10ACKProviderFactory: args.v10ACKProviderFactory,
     publishEncryptionFactory: args.publishEncryptionFactory,
@@ -692,6 +712,8 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
     pollIntervalMs: args.pollIntervalMs,
     errorBackoffMs: args.errorBackoffMs,
     recoveryIntervalMs: args.recoveryIntervalMs,
+    activeRecoveryIntervalMs: args.activeRecoveryIntervalMs,
+    onError: args.onRunnerError,
     // Operator-only maintenance seam. Recovery still reconciles signed transactions, but wallet
     // loops cannot claim released jobs while a closed run is being removed from the queue.
     startPaused: args.startPaused ?? false,

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -19,6 +19,7 @@ import {
 import {
   ACKCollector,
   AsyncLiftRunner,
+  type AsyncLiftRunnerConfig,
   DKGPublisher,
   FileWorkspacePublicSnapshotStore,
   TripleStoreAsyncLiftPublisher,
@@ -218,6 +219,18 @@ export function resolvePublisherStartPaused(value: string | undefined): boolean 
   return value === '1';
 }
 
+/**
+ * r4 (🟡 3872361426) — the runner's scheduling knobs and error sink travel the construction
+ * chain as ONE value with the runner's own field names, resolved once at each production
+ * boundary (daemon config, standalone CLI args) and spread intact into `new AsyncLiftRunner`.
+ * A knob added to this Pick reaches the runner without touching any intermediate factory —
+ * the per-field relay this replaces is how configured knobs got dropped silently (#1836).
+ */
+export type PublisherRunnerSchedulingOptions = Pick<
+  AsyncLiftRunnerConfig,
+  'pollIntervalMs' | 'errorBackoffMs' | 'recoveryIntervalMs' | 'activeRecoveryIntervalMs' | 'onError'
+>;
+
 export async function startPublisherRuntimeIfEnabled(args: {
   dataDir: string;
   config: DkgConfig;
@@ -240,21 +253,24 @@ export async function startPublisherRuntimeIfEnabled(args: {
       store: args.store,
       keypair: args.keypair,
       chainBase: args.chainBase,
-      pollIntervalMs: args.config.publisher.pollIntervalMs,
-      errorBackoffMs: args.config.publisher.errorBackoffMs,
-      recoveryIntervalMs: args.config.publisher.recoveryIntervalMs,
-      activeRecoveryIntervalMs: args.config.publisher.activeRecoveryIntervalMs,
+      // The daemon boundary: config resolves into the runner's own option shape ONCE, here.
+      runnerOptions: {
+        pollIntervalMs: args.config.publisher.pollIntervalMs,
+        errorBackoffMs: args.config.publisher.errorBackoffMs,
+        recoveryIntervalMs: args.config.publisher.recoveryIntervalMs,
+        activeRecoveryIntervalMs: args.config.publisher.activeRecoveryIntervalMs,
+        // Runner errors (wallet loop + reconciliation) were previously swallowed after their
+        // backoff; a chronically failing reconcile pass then looks exactly like a slow publisher.
+        onError: (error: unknown) => {
+          const message = error instanceof Error ? error.message : String(error);
+          args.log(`[publisher] runner error: ${message}`);
+        },
+      },
       maxRetries: args.config.publisher.maxRetries,
       // GH#2270 — this is the ONE runtime whose retry scheduler and claim-time
       // sweep actually run, so the kill-switch and backoff knobs are dead
       // config unless they travel this hop (the #1836 bug class).
       retryTuning: resolvePublisherRetryTuning(args.config.publisher),
-      // Runner errors (wallet loop + reconciliation) were previously swallowed after their
-      // backoff; a chronically failing reconcile pass then looks exactly like a slow publisher.
-      onRunnerError: (error: unknown) => {
-        const message = error instanceof Error ? error.message : String(error);
-        args.log(`[publisher] runner error: ${message}`);
-      },
       config: args.config,
       ackTransportFactory: args.ackTransportFactory,
       publishEncryptionFactory: args.publishEncryptionFactory,
@@ -359,19 +375,11 @@ interface PublisherRuntimeBaseArgs {
   keypair: Ed25519Keypair;
   store: TripleStore;
   chainBase?: RuntimeEvmChainConfig;
-  pollIntervalMs?: number;
-  errorBackoffMs?: number;
-  recoveryIntervalMs?: number;
-  activeRecoveryIntervalMs?: number;
+  /** Already resolved at the calling boundary; passed through intact to `new AsyncLiftRunner`. */
+  runnerOptions?: PublisherRunnerSchedulingOptions;
   maxRetries?: number;
   /** GH#2270 — validated `config.publisher` retry knobs; unset knobs keep the library defaults. */
   retryTuning?: PublisherRetryTuning;
-  /**
-   * Receives wallet-loop and reconciliation errors from the runner. Without it those errors are
-   * swallowed after their backoff, which turns a chronically failing reconcile pass into a silent
-   * publishing slowdown.
-   */
-  onRunnerError?: (error: unknown) => void;
   ackTransportFactory?: ACKTransportFactory;
   v10ACKProviderFactory?: () => PublishOptions['v10ACKProvider'];
   publishEncryptionFactory?: PublishEncryptionFactory;
@@ -414,10 +422,13 @@ export async function createPublisherRuntime(args: {
     keypair: keypair.keypair,
     store,
     chainBase,
-    pollIntervalMs: args.pollIntervalMs,
-    errorBackoffMs: args.errorBackoffMs,
-    recoveryIntervalMs: args.recoveryIntervalMs ?? args.config.publisher?.recoveryIntervalMs,
-    activeRecoveryIntervalMs: args.activeRecoveryIntervalMs ?? args.config.publisher?.activeRecoveryIntervalMs,
+    // The standalone boundary: explicit CLI arguments win over config.json, resolved ONCE here.
+    runnerOptions: {
+      pollIntervalMs: args.pollIntervalMs,
+      errorBackoffMs: args.errorBackoffMs,
+      recoveryIntervalMs: args.recoveryIntervalMs ?? args.config.publisher?.recoveryIntervalMs,
+      activeRecoveryIntervalMs: args.activeRecoveryIntervalMs ?? args.config.publisher?.activeRecoveryIntervalMs,
+    },
     maxRetries: args.maxRetries ?? args.config.publisher?.maxRetries,
     retryTuning: resolvePublisherRetryTuning(args.config.publisher),
     publicSnapshotStore,
@@ -528,13 +539,10 @@ export async function createPublisherRuntimeFromAgent(args: {
   store: TripleStore;
   keypair: Ed25519Keypair;
   chainBase?: RuntimeEvmChainConfig;
-  pollIntervalMs?: number;
-  errorBackoffMs?: number;
-  recoveryIntervalMs?: number;
-  activeRecoveryIntervalMs?: number;
+  /** Resolved by the caller's boundary (daemon config or test); passed through intact. */
+  runnerOptions?: PublisherRunnerSchedulingOptions;
   maxRetries?: number;
   retryTuning?: PublisherRetryTuning;
-  onRunnerError?: (error: unknown) => void;
   config?: Pick<DkgConfig, 'sharedMemoryPublicSnapshotStorage'>;
   ackTransportFactory?: ACKTransportFactory;
   v10ACKProviderFactory?: () => PublishOptions['v10ACKProvider'];
@@ -548,13 +556,9 @@ export async function createPublisherRuntimeFromAgent(args: {
     keypair: args.keypair,
     store: args.store,
     chainBase: args.chainBase,
-    pollIntervalMs: args.pollIntervalMs,
-    errorBackoffMs: args.errorBackoffMs,
-    recoveryIntervalMs: args.recoveryIntervalMs,
-    activeRecoveryIntervalMs: args.activeRecoveryIntervalMs,
+    runnerOptions: args.runnerOptions,
     maxRetries: args.maxRetries,
     retryTuning: args.retryTuning,
-    onRunnerError: args.onRunnerError,
     ackTransportFactory: args.ackTransportFactory,
     v10ACKProviderFactory: args.v10ACKProviderFactory,
     publishEncryptionFactory: args.publishEncryptionFactory,
@@ -709,11 +713,8 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
   const runner = new AsyncLiftRunner({
     publisher: asyncPublisher,
     walletIds: validWalletIds,
-    pollIntervalMs: args.pollIntervalMs,
-    errorBackoffMs: args.errorBackoffMs,
-    recoveryIntervalMs: args.recoveryIntervalMs,
-    activeRecoveryIntervalMs: args.activeRecoveryIntervalMs,
-    onError: args.onRunnerError,
+    // The boundary-resolved scheduling options land here INTACT — no per-field relay to forget.
+    ...args.runnerOptions,
     // Operator-only maintenance seam. Recovery still reconciles signed transactions, but wallet
     // loops cannot claim released jobs while a closed run is being removed from the queue.
     startPaused: args.startPaused ?? false,

--- a/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
+++ b/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
@@ -1448,8 +1448,7 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
       store,
       keypair,
       chainBase: undefined,
-      pollIntervalMs: 10,
-      errorBackoffMs: 10,
+      runnerOptions: { pollIntervalMs: 10, errorBackoffMs: 10 },
       knowledgeAssetVmPublishHandler: {
         execute: async (input) => {
           executorCalls.push(input);
@@ -1583,8 +1582,7 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
       store,
       keypair,
       chainBase: undefined,
-      pollIntervalMs: 10,
-      errorBackoffMs: 10,
+      runnerOptions: { pollIntervalMs: 10, errorBackoffMs: 10 },
       knowledgeAssetVmPublishHandler: {
         execute: createKnowledgeAssetVmPublishHandler(fakeAgent as unknown as DKGAgent).execute,
       },
@@ -1695,8 +1693,7 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
       store,
       keypair,
       chainBase: undefined,
-      pollIntervalMs: 10,
-      errorBackoffMs: 10,
+      runnerOptions: { pollIntervalMs: 10, errorBackoffMs: 10 },
       knowledgeAssetVmPublishHandler: {
         execute: createKnowledgeAssetVmPublishHandler(fakeAgent as unknown as DKGAgent).execute,
       },

--- a/packages/cli/test/publisher-retry-tuning-wiring-2270.test.ts
+++ b/packages/cli/test/publisher-retry-tuning-wiring-2270.test.ts
@@ -15,6 +15,7 @@ import { createTripleStore, type TripleStore } from '@origintrail-official/dkg-s
 // spread (or the `retryTuning:` argument feeding it) fails them.
 const mocks = vi.hoisted(() => ({
   publisherConfigs: [] as any[],
+  runnerConfigs: [] as any[],
 }));
 
 vi.mock('@origintrail-official/dkg-publisher', async importOriginal => {
@@ -27,7 +28,20 @@ vi.mock('@origintrail-official/dkg-publisher', async importOriginal => {
       mocks.publisherConfigs.push(config);
     }
   }
-  return { ...actual, TripleStoreAsyncLiftPublisher: CapturingAsyncLiftPublisher };
+  // Same seam, second hop: the reconcile cadence knobs land on the RUNNER, not the
+  // publisher constructor, so a capture of only the publisher config would let a
+  // dropped runner projection pass every row.
+  class CapturingAsyncLiftRunner extends actual.AsyncLiftRunner {
+    constructor(config: any) {
+      super(config);
+      mocks.runnerConfigs.push(config);
+    }
+  }
+  return {
+    ...actual,
+    TripleStoreAsyncLiftPublisher: CapturingAsyncLiftPublisher,
+    AsyncLiftRunner: CapturingAsyncLiftRunner,
+  };
 });
 
 const { resolvePublisherRetryTuning } = await import('../src/config.js');
@@ -49,6 +63,7 @@ describe('publisher retry-knob config→construction wiring (#2270)', () => {
     if (dataDir) await rm(dataDir, { recursive: true, force: true });
     dataDir = undefined;
     mocks.publisherConfigs.length = 0;
+    mocks.runnerConfigs.length = 0;
   });
 
   /** Start the real daemon publisher runtime over a temp wallet + store. */
@@ -125,6 +140,25 @@ describe('publisher retry-knob config→construction wiring (#2270)', () => {
     expect(config.retryJitterRatio).toBe(0.4);
     expect(config.retryBackoffBaseMs).toBe(2_222);
     expect(config.retryBackoffMaxMs).toBe(3_333);
+  });
+
+  it('forwards the reconcile cadence knobs and the error sink into the runner (10.0.14 slowdown fix)', async () => {
+    await capturePublisherConfig({ recoveryIntervalMs: 111_222, activeRecoveryIntervalMs: 7_500 });
+
+    expect(mocks.runnerConfigs).toHaveLength(1);
+    const runnerConfig = mocks.runnerConfigs[0];
+    expect(runnerConfig.recoveryIntervalMs).toBe(111_222);
+    expect(runnerConfig.activeRecoveryIntervalMs).toBe(7_500);
+    // Runner errors used to be swallowed after their backoff; the daemon now sinks them to its log.
+    expect(typeof runnerConfig.onError).toBe('function');
+  });
+
+  it('leaves the runner cadence knobs undefined when unconfigured so the library defaults hold', async () => {
+    await capturePublisherConfig({});
+
+    expect(mocks.runnerConfigs).toHaveLength(1);
+    expect(mocks.runnerConfigs[0].recoveryIntervalMs).toBeUndefined();
+    expect(mocks.runnerConfigs[0].activeRecoveryIntervalMs).toBeUndefined();
   });
 
   it('forwards autoRetryEnabled: true as an explicit value, not only the falsy case', async () => {

--- a/packages/cli/test/publisher-retry-tuning-wiring-2270.test.ts
+++ b/packages/cli/test/publisher-retry-tuning-wiring-2270.test.ts
@@ -54,6 +54,7 @@ describe('publisher retry-knob config→construction wiring (#2270)', () => {
   let dataDir: string | undefined;
   let store: TripleStore | undefined;
   let runtime: PublisherRuntime | null = null;
+  const capturedLogLines: string[] = [];
 
   afterEach(async () => {
     await runtime?.stop().catch(() => {});
@@ -64,6 +65,7 @@ describe('publisher retry-knob config→construction wiring (#2270)', () => {
     dataDir = undefined;
     mocks.publisherConfigs.length = 0;
     mocks.runnerConfigs.length = 0;
+    capturedLogLines.length = 0;
   });
 
   /** Start the real daemon publisher runtime over a temp wallet + store. */
@@ -83,7 +85,7 @@ describe('publisher retry-knob config→construction wiring (#2270)', () => {
         // A long poll interval keeps the started runner idle for the assertion.
         publisher: { enabled: true, pollIntervalMs: 600_000, ...publisher },
       } as any,
-      log: () => {},
+      log: (line: string) => { capturedLogLines.push(line); },
     });
     expect(runtime).not.toBeNull();
     // Exactly one async-lift publisher is built for the runtime, so there is no
@@ -142,15 +144,18 @@ describe('publisher retry-knob config→construction wiring (#2270)', () => {
     expect(config.retryBackoffMaxMs).toBe(3_333);
   });
 
-  it('forwards the reconcile cadence knobs and the error sink into the runner (10.0.14 slowdown fix)', async () => {
+  it('forwards the reconcile cadence knobs and a log-reaching error sink into the runner (10.0.14 slowdown fix)', async () => {
     await capturePublisherConfig({ recoveryIntervalMs: 111_222, activeRecoveryIntervalMs: 7_500 });
 
     expect(mocks.runnerConfigs).toHaveLength(1);
     const runnerConfig = mocks.runnerConfigs[0];
     expect(runnerConfig.recoveryIntervalMs).toBe(111_222);
     expect(runnerConfig.activeRecoveryIntervalMs).toBe(7_500);
-    // Runner errors used to be swallowed after their backoff; the daemon now sinks them to its log.
-    expect(typeof runnerConfig.onError).toBe('function');
+    // r3 (🔴 3872361413) — exercise the sink, not its type: runner errors used to be swallowed
+    // after their backoff, and a no-op callback here would silently restore that. The captured
+    // callback must put the error's message into the daemon log.
+    runnerConfig.onError(new Error('reconcile failed'));
+    expect(capturedLogLines).toContain('[publisher] runner error: reconcile failed');
   });
 
   it('leaves the runner cadence knobs undefined when unconfigured so the library defaults hold', async () => {
@@ -159,6 +164,63 @@ describe('publisher retry-knob config→construction wiring (#2270)', () => {
     expect(mocks.runnerConfigs).toHaveLength(1);
     expect(mocks.runnerConfigs[0].recoveryIntervalMs).toBeUndefined();
     expect(mocks.runnerConfigs[0].activeRecoveryIntervalMs).toBeUndefined();
+  });
+
+  it('forwards the config-fallback cadence knobs through the STANDALONE runtime path', async () => {
+    // r5 (🟡 3872361432) — the standalone projection is its own boundary; deleting its config
+    // fallback would leave every daemon-path row green while `dkg publisher run` silently used
+    // the library default.
+    const { createPublisherRuntime } = await import('../src/publisher-runner.js');
+    dataDir = await mkdtemp(join(tmpdir(), 'dkg-cadence-standalone-'));
+    await addPublisherWallet(dataDir, ethers.Wallet.createRandom().privateKey);
+    runtime = await createPublisherRuntime({
+      dataDir,
+      config: {
+        name: 'cadence-standalone-test',
+        apiPort: 0,
+        listenPort: 0,
+        nodeRole: 'edge',
+        networkConfig: 'mainnet-gnosis',
+        store: { backend: 'oxigraph' },
+        publisher: {
+          enabled: true,
+          pollIntervalMs: 600_000,
+          recoveryIntervalMs: 111_222,
+          activeRecoveryIntervalMs: 7_500,
+        },
+      } as any,
+    });
+    expect(mocks.runnerConfigs).toHaveLength(1);
+    expect(mocks.runnerConfigs[0].recoveryIntervalMs).toBe(111_222);
+    expect(mocks.runnerConfigs[0].activeRecoveryIntervalMs).toBe(7_500);
+  });
+
+  it('lets an explicit standalone argument override the configured cadence', async () => {
+    const { createPublisherRuntime } = await import('../src/publisher-runner.js');
+    dataDir = await mkdtemp(join(tmpdir(), 'dkg-cadence-standalone-arg-'));
+    await addPublisherWallet(dataDir, ethers.Wallet.createRandom().privateKey);
+    runtime = await createPublisherRuntime({
+      dataDir,
+      recoveryIntervalMs: 222_333,
+      activeRecoveryIntervalMs: 3_333,
+      config: {
+        name: 'cadence-standalone-arg-test',
+        apiPort: 0,
+        listenPort: 0,
+        nodeRole: 'edge',
+        networkConfig: 'mainnet-gnosis',
+        store: { backend: 'oxigraph' },
+        publisher: {
+          enabled: true,
+          pollIntervalMs: 600_000,
+          recoveryIntervalMs: 111_222,
+          activeRecoveryIntervalMs: 7_500,
+        },
+      } as any,
+    });
+    expect(mocks.runnerConfigs).toHaveLength(1);
+    expect(mocks.runnerConfigs[0].recoveryIntervalMs).toBe(222_333);
+    expect(mocks.runnerConfigs[0].activeRecoveryIntervalMs).toBe(3_333);
   });
 
   it('forwards autoRetryEnabled: true as an explicit value, not only the falsy case', async () => {

--- a/packages/cli/test/publisher-runner-ack-transport.test.ts
+++ b/packages/cli/test/publisher-runner-ack-transport.test.ts
@@ -145,8 +145,7 @@ describe('publisher runner ACK transport handoff', () => {
         store,
         keypair,
         chainBase: undefined,
-        pollIntervalMs: 10,
-        errorBackoffMs: 10,
+        runnerOptions: { pollIntervalMs: 10, errorBackoffMs: 10 },
         ackTransportFactory,
       });
 

--- a/packages/cli/test/publisher-runner-lu11.test.ts
+++ b/packages/cli/test/publisher-runner-lu11.test.ts
@@ -48,8 +48,7 @@ describe('publisher runner LU-11 runtime wiring', () => {
       store,
       keypair,
       chainBase: undefined,
-      pollIntervalMs: 10,
-      errorBackoffMs: 10,
+      runnerOptions: { pollIntervalMs: 10, errorBackoffMs: 10 },
       publishEncryptionFactory: (publishOptions) => {
         factoryInput = publishOptions;
         return {

--- a/packages/cli/test/publisher-runner-private-encryption.test.ts
+++ b/packages/cli/test/publisher-runner-private-encryption.test.ts
@@ -83,8 +83,7 @@ describe('publisher runner — private (non-public) inline-encryption callback h
         store,
         keypair,
         chainBase: undefined,
-        pollIntervalMs: 10,
-        errorBackoffMs: 10,
+        runnerOptions: { pollIntervalMs: 10, errorBackoffMs: 10 },
         publishEncryptionFactory: () => ({
           encryptInlinePayload: realInline,
           encryptInlineChunked: realChunked,

--- a/packages/cli/test/publisher-wallets.test.ts
+++ b/packages/cli/test/publisher-wallets.test.ts
@@ -216,8 +216,7 @@ describe('publisher wallets', () => {
       store,
       keypair,
       chainBase: undefined,
-      pollIntervalMs: 10,
-      errorBackoffMs: 10,
+      runnerOptions: { pollIntervalMs: 10, errorBackoffMs: 10 },
     });
 
     expect(runtime.walletIds).toEqual([wallet.address]);
@@ -251,8 +250,7 @@ describe('publisher wallets', () => {
       store,
       keypair,
       chainBase: undefined,
-      pollIntervalMs: 10,
-      errorBackoffMs: 10,
+      runnerOptions: { pollIntervalMs: 10, errorBackoffMs: 10 },
       maxRetries: 10,
       v10ACKProviderFactory: () => {
         v10ACKProviderWasPassed = true;
@@ -298,8 +296,7 @@ describe('publisher wallets', () => {
         store,
         keypair,
         chainBase: { rpcUrl, hubAddress },
-        pollIntervalMs: 10,
-        errorBackoffMs: 10,
+        runnerOptions: { pollIntervalMs: 10, errorBackoffMs: 10 },
       });
 
       expect(runtime.walletIds).toEqual([wallet.address]);
@@ -358,8 +355,7 @@ describe('publisher wallets', () => {
         store,
         keypair,
         chainBase: { rpcUrl, hubAddress },
-        pollIntervalMs: 10,
-        errorBackoffMs: 10,
+        runnerOptions: { pollIntervalMs: 10, errorBackoffMs: 10 },
         knowledgeAssetVmPublishHandler: {
           execute: async (input: KnowledgeAssetVmPublishExecutorInput) => {
             const publisher = input.publisher;
@@ -454,8 +450,7 @@ describe('publisher wallets', () => {
         store,
         keypair,
         chainBase: { rpcUrl, hubAddress },
-        pollIntervalMs: 10,
-        errorBackoffMs: 10,
+        runnerOptions: { pollIntervalMs: 10, errorBackoffMs: 10 },
       });
 
       expect(new Set(runtime.walletIds)).toEqual(new Set([identityfulWallet.address, identitylessWallet.address]));

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -470,6 +470,15 @@ export class TripleStoreAsyncLiftPublisher
   private readonly activeProcessJobIds = new Set<string>();
   /** Receipt tasks that continue after the RPC-acceptance fast return. */
   private readonly detachedExecutions = new Map<string, Promise<void>>();
+  /** Poked when a tx-bearing job stops being executor-owned; see setReconciliationDemandListener. */
+  private reconciliationDemandListener?: () => void;
+  /**
+   * Rotates the live-lane iteration start across passes. The pass deadline may truncate the walk,
+   * and `list()` order is stable, so without rotation the same head jobs would be re-asked every
+   * pass while the tail starved behind a slow resolver. In-memory for the same reason as
+   * `chainProofNextDueAt`: a restart resetting the rotation is safe, skipping is a pure no-op.
+   */
+  private reconcilePassOffset = 0;
   private readonly knowledgeAssetVmPublishRecoveryResolver?: AsyncKnowledgeAssetVmPublishRecoveryResolver;
   private readonly detachReceiptReconciliation: boolean;
   /** 3825614002 — this instance's ROLE, resolved once from its wiring. */
@@ -1018,6 +1027,7 @@ export class TripleStoreAsyncLiftPublisher
         // interrupted-broadcast path reconciles it on chain, never resend. Receipt timeout is
         // UNKNOWN, not failed. The tx-bearing job retains the wallet until
         // chain proof finalizes, proves a revert, or proves create absence.
+        this.notifyReconciliationDemand();
         return await this.getRequiredJob(claimed.jobId);
       }
       // #1867 — either the tx never left ('not-reached' / 'rolled-back-pre-send'), or a
@@ -1107,6 +1117,10 @@ export class TripleStoreAsyncLiftPublisher
       if (this.detachedExecutions.get(jobId) === tracked) {
         this.detachedExecutions.delete(jobId);
       }
+      // The job just stopped being executor-owned (line-of-ownership: reconciliation skips jobs
+      // in this map). Whatever the execution's outcome, only chain proof can settle the record
+      // now, so invite the reconcile pass instead of leaving the job to the idle sweep.
+      this.notifyReconciliationDemand();
     });
     this.detachedExecutions.set(jobId, tracked);
   }
@@ -1114,6 +1128,34 @@ export class TripleStoreAsyncLiftPublisher
   async drainDetachedExecutions(): Promise<void> {
     while (this.detachedExecutions.size > 0) {
       await Promise.all([...this.detachedExecutions.values()]);
+    }
+  }
+
+  setReconciliationDemandListener(listener: () => void): void {
+    this.reconciliationDemandListener = listener;
+  }
+
+  async hasPendingTransactionReconciliation(): Promise<boolean> {
+    await this.ensureGraph();
+    const jobs = await this.list();
+    return jobs.some(
+      (job) =>
+        (job.status === 'broadcast' || job.status === 'included')
+        && !this.detachedExecutions.has(job.jobId)
+        && !this.activeProcessJobIds.has(job.jobId),
+    );
+  }
+
+  /**
+   * A scheduling poke, not a state transition: it must never throw into a job's own control flow,
+   * and it establishes nothing — the reconcile pass re-reads the queue and remains the only judge
+   * of what is actionable.
+   */
+  private notifyReconciliationDemand(): void {
+    try {
+      this.reconciliationDemandListener?.();
+    } catch {
+      // The listener belongs to the caller's scheduler; its failure must not touch job state.
     }
   }
 
@@ -1616,6 +1658,12 @@ export class TripleStoreAsyncLiftPublisher
     const txBearing = (await this.list()).filter(
       (job) => job.status === 'broadcast' || job.status === 'included',
     );
+    // The pass deadline below may truncate this walk, and `list()` order is stable — without
+    // rotation a head job behind a slow resolver would be re-asked every pass while the tail
+    // starved. Rotating the start bounds every job's wait to at most `txBearing.length` passes.
+    // (The failed-job lane needs no rotation: its per-job due times already rotate the batch.)
+    const offset = txBearing.length > 0 ? this.reconcilePassOffset++ % txBearing.length : 0;
+    const rotatedTxBearing = txBearing.slice(offset).concat(txBearing.slice(0, offset));
 
     const deadline = new AbortController();
     const deadlineTimer = setTimeout(
@@ -1623,7 +1671,7 @@ export class TripleStoreAsyncLiftPublisher
       Math.max(0, this.chainProofDispatchTimeBudgetMs),
     );
     try {
-      for (const snapshot of txBearing) {
+      for (const snapshot of rotatedTxBearing) {
         if (deadline.signal.aborted) break;
         await this.withJobTransitionLock(snapshot.jobId, async () => {
           const current = await this.getStatus(snapshot.jobId);

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -1720,6 +1720,11 @@ export class TripleStoreAsyncLiftPublisher
     // reached before the deadline. Held-failed jobs are deliberately NOT counted — the
     // failed-job dispatcher paces itself with per-job due times.
     let remainingLive = 0;
+    // Jobs the live lane settled THIS pass. A settle can be a transition INTO the held-failed
+    // state (inconclusive timeout, proven revert), and the dispatcher below must see those in
+    // the same pass — with only the shared start-of-pass snapshot they would wait out the idle
+    // sweep holding their wallets, which per-lane inventories never made them do.
+    const settledLive: string[] = [];
     const deadline = new AbortController();
     const deadlineTimer = setTimeout(
       () => deadline.abort(),
@@ -1739,6 +1744,7 @@ export class TripleStoreAsyncLiftPublisher
           if (this.activeProcessJobIds.has(current.jobId)) return;
           if (await this.jobHandlerFor(current.request).recoverInterrupted(current, { signal: deadline.signal })) {
             reconciled += 1;
+            settledLive.push(current.jobId);
           } else {
             remainingLive += 1;
           }
@@ -1749,7 +1755,19 @@ export class TripleStoreAsyncLiftPublisher
       deadline.abort();
     }
 
-    reconciled += await this.dispatchFailedJobsOnChainProof(inventory);
+    // The dispatcher's view: the shared snapshot with this pass's own settlements made current
+    // (a point read per settled job — zero on the common pass — not a second inventory).
+    let dispatcherInventory: readonly LiftJob[] = inventory;
+    if (settledLive.length > 0) {
+      const refreshed = new Map<string, LiftJob | null>();
+      for (const jobId of settledLive) {
+        refreshed.set(jobId, await this.getStatus(jobId));
+      }
+      dispatcherInventory = inventory
+        .map((job) => (refreshed.has(job.jobId) ? refreshed.get(job.jobId) ?? null : job))
+        .filter((job): job is LiftJob => job !== null);
+    }
+    reconciled += await this.dispatchFailedJobsOnChainProof(dispatcherInventory);
     return { reconciled, pendingWork: remainingLive > 0 };
   }
 

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -819,11 +819,24 @@ export class TripleStoreAsyncLiftPublisher
     if (!claimed) {
       return null;
     }
+    let processed: LiftJob;
     try {
-      return await this.jobHandlerFor(claimed.request).process(claimed, walletId);
+      processed = await this.jobHandlerFor(claimed.request).process(claimed, walletId);
     } finally {
       this.activeProcessJobIds.delete(claimed.jobId);
     }
+    // r1 (🔴 3872361393) — the demand poke belongs on the OWNERSHIP BOUNDARY, after the marker
+    // above is gone. Poking from inside a processing path (as the ambiguous-broadcast catch
+    // first did) let the invited pass run while the job still read as executor-owned: the pass
+    // skipped it, the outlook answered false, and the one-shot demand was spent — parking the
+    // job for the idle sweep. Here the job is provably past every ownership marker the pass
+    // checks, so an invited pass can always act. (A process() that THROWS never reaches this;
+    // a tx-bearing job left behind by an escaped throw is the idle sweep's to find, which is
+    // the pre-existing contract for that path.)
+    if (this.isReconciliationActionable(processed)) {
+      this.notifyReconciliationDemand();
+    }
+    return processed;
   }
 
   private async processRawLift(claimed: LiftJob, walletId: string): Promise<LiftJob> {
@@ -1026,8 +1039,9 @@ export class TripleStoreAsyncLiftPublisher
         // Ambiguous post-write-ahead failure — leave the job in 'broadcast' so recovery's
         // interrupted-broadcast path reconciles it on chain, never resend. Receipt timeout is
         // UNKNOWN, not failed. The tx-bearing job retains the wallet until
-        // chain proof finalizes, proves a revert, or proves create absence.
-        this.notifyReconciliationDemand();
+        // chain proof finalizes, proves a revert, or proves create absence. The reconciliation
+        // demand poke for this job fires at the processNext ownership boundary, not here —
+        // this frame still holds the job's activeProcessJobIds marker (r1 🔴 3872361393).
         return await this.getRequiredJob(claimed.jobId);
       }
       // #1867 — either the tx never left ('not-reached' / 'rolled-back-pre-send'), or a
@@ -1131,18 +1145,34 @@ export class TripleStoreAsyncLiftPublisher
     }
   }
 
-  setReconciliationDemandListener(listener: () => void): void {
-    this.reconciliationDemandListener = listener;
-  }
+  readonly reconciliationScheduling = {
+    subscribeDemand: (listener: () => void): (() => void) => {
+      this.reconciliationDemandListener = listener;
+      return () => {
+        // Unsubscribes only THIS listener: a replacement subscription must not be torn down by
+        // a stale disposer from the runner incarnation it replaced.
+        if (this.reconciliationDemandListener === listener) {
+          this.reconciliationDemandListener = undefined;
+        }
+      };
+    },
+    hasPendingWork: async (): Promise<boolean> => {
+      await this.ensureGraph();
+      return (await this.list()).some((job) => this.isReconciliationActionable(job));
+    },
+  };
 
-  async hasPendingTransactionReconciliation(): Promise<boolean> {
-    await this.ensureGraph();
-    const jobs = await this.list();
-    return jobs.some(
-      (job) =>
-        (job.status === 'broadcast' || job.status === 'included')
-        && !this.detachedExecutions.has(job.jobId)
-        && !this.activeProcessJobIds.has(job.jobId),
+  /**
+   * The ONE definition of "reconciliation can act on this job now": live tx-bearing state with
+   * no executor ownership marker. Shared by the outlook above, the reconcile pass pre-filter,
+   * and the ownership-boundary demand poke, so the three cannot drift. The deeper per-job
+   * re-checks under the transition lock remain authoritative; this is the coherent pre-answer.
+   */
+  private isReconciliationActionable(job: LiftJob): boolean {
+    return (
+      (job.status === 'broadcast' || job.status === 'included')
+      && !this.detachedExecutions.has(job.jobId)
+      && !this.activeProcessJobIds.has(job.jobId)
     );
   }
 
@@ -1655,9 +1685,9 @@ export class TripleStoreAsyncLiftPublisher
   async reconcileTransactions(): Promise<number> {
     await this.ensureGraph();
     let reconciled = await this.recoverInterruptedPreBroadcastJobs();
-    const txBearing = (await this.list()).filter(
-      (job) => job.status === 'broadcast' || job.status === 'included',
-    );
+    // Same actionability rule the scheduling outlook answers with: executor-owned jobs are
+    // skipped up front rather than each burning a transition-lock turn to be skipped deeper in.
+    const txBearing = (await this.list()).filter((job) => this.isReconciliationActionable(job));
     // The pass deadline below may truncate this walk, and `list()` order is stable — without
     // rotation a head job behind a slow resolver would be re-asked every pass while the tail
     // starved. Rotating the start bounds every job's wait to at most `txBearing.length` passes.

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -819,22 +819,27 @@ export class TripleStoreAsyncLiftPublisher
     if (!claimed) {
       return null;
     }
-    let processed: LiftJob;
+    let processed: LiftJob | undefined;
     try {
       processed = await this.jobHandlerFor(claimed.request).process(claimed, walletId);
     } finally {
       this.activeProcessJobIds.delete(claimed.jobId);
-    }
-    // r1 (🔴 3872361393) — the demand poke belongs on the OWNERSHIP BOUNDARY, after the marker
-    // above is gone. Poking from inside a processing path (as the ambiguous-broadcast catch
-    // first did) let the invited pass run while the job still read as executor-owned: the pass
-    // skipped it, the outlook answered false, and the one-shot demand was spent — parking the
-    // job for the idle sweep. Here the job is provably past every ownership marker the pass
-    // checks, so an invited pass can always act. (A process() that THROWS never reaches this;
-    // a tx-bearing job left behind by an escaped throw is the idle sweep's to find, which is
-    // the pre-existing contract for that path.)
-    if (this.isReconciliationActionable(processed)) {
-      this.notifyReconciliationDemand();
+      // r1 (🔴 3872361393) — the demand poke belongs on the OWNERSHIP BOUNDARY, after the
+      // marker above is gone. Poking from inside a processing path (as the ambiguous-broadcast
+      // catch first did) let the invited pass run while the job still read as executor-owned:
+      // the pass skipped it, the outlook answered false, and the one-shot demand was spent —
+      // parking the job for the idle sweep. Here the job is provably past every ownership
+      // marker the pass checks, so an invited pass can always act.
+      //
+      // r3 (🟡 3873024814, branarakic) — an ESCAPED processing fault pokes too. A durably
+      // recorded broadcast may already exist when a secondary read/write throws (store
+      // pressure), and asking the queue what state the job is in would use the same store that
+      // just failed. The poke is scheduling-only — the invited pass re-reads canonical job and
+      // chain state before acting — so over-inviting on the error path costs one empty pass,
+      // while under-inviting recreates the idle-sweep wallet hold this PR removes.
+      if (processed === undefined || this.isReconciliationActionable(processed)) {
+        this.notifyReconciliationDemand();
+      }
     }
     return processed;
   }
@@ -1704,10 +1709,17 @@ export class TripleStoreAsyncLiftPublisher
    */
   private async runReconciliationPass(): Promise<{ reconciled: number; pendingWork: boolean }> {
     await this.ensureGraph();
-    let reconciled = await this.recoverInterruptedPreBroadcastJobs();
+    // r3-1 follow-up (branarakic 3873026014, production evidence) — ONE queue inventory per
+    // pass, partitioned in memory across the three lanes. The lanes previously each ran their
+    // own all-job read (pre-broadcast, live, failed): at a 5s active cadence over a large queue
+    // that moved the bottleneck from wallet scheduling into store/control-plane work. Each lane
+    // still re-reads its jobs individually under the transition lock before acting, so the
+    // shared snapshot only selects candidates and staleness cannot change a disposition.
+    const inventory = await this.list();
+    let reconciled = await this.recoverInterruptedPreBroadcastJobs(inventory);
     // Same actionability rule the scheduling outlook answers with: executor-owned jobs are
     // skipped up front rather than each burning a transition-lock turn to be skipped deeper in.
-    const txBearing = (await this.list()).filter((job) => this.isReconciliationActionable(job));
+    const txBearing = inventory.filter((job) => this.isReconciliationActionable(job));
     // The pass deadline below may truncate this walk, and `list()` order is stable — without
     // rotation a head job behind a slow resolver would be re-asked every pass while the tail
     // starved. Rotating the start bounds every job's wait to at most `txBearing.length` passes.
@@ -1748,7 +1760,7 @@ export class TripleStoreAsyncLiftPublisher
       deadline.abort();
     }
 
-    reconciled += await this.dispatchFailedJobsOnChainProof();
+    reconciled += await this.dispatchFailedJobsOnChainProof(inventory);
     return { reconciled, pendingWork: remainingLive > 0 };
   }
 
@@ -1774,8 +1786,10 @@ export class TripleStoreAsyncLiftPublisher
     }
   }
 
-  private async recoverInterruptedPreBroadcastJobs(): Promise<number> {
-    const interrupted = (await this.list()).filter(
+  private async recoverInterruptedPreBroadcastJobs(inventory: readonly LiftJob[]): Promise<number> {
+    // Candidates come from the pass's shared inventory snapshot; each is re-read under its
+    // transition lock below before anything acts on it.
+    const interrupted = inventory.filter(
       (job) => job.status === 'claimed' || job.status === 'validated',
     );
     let recovered = 0;
@@ -1840,7 +1854,7 @@ export class TripleStoreAsyncLiftPublisher
     return this.heldJobSettlement(job, walletId, liftJobOperationKindMarker(job));
   }
 
-  private async dispatchFailedJobsOnChainProof(): Promise<number> {
+  private async dispatchFailedJobsOnChainProof(inventory: readonly LiftJob[]): Promise<number> {
     // The dispatcher RE-QUEUES work (a proven-absent job goes back to 'accepted') and spends a
     // chain read per held job per tick. `pause()` means this node is not driving publishes, so it
     // must not do either. The interrupted half above deliberately keeps running while paused: it
@@ -1855,7 +1869,10 @@ export class TripleStoreAsyncLiftPublisher
     // bounds apply, and none of them changes a job's DISPOSITION: a job that is not asked is left
     // exactly as held, so no bound can authorize a resend.
     const startedAt = this.now();
-    const heldJobs = (await this.list({ status: 'failed' }))
+    // Candidates from the pass's shared inventory snapshot (branarakic 3873026014 — one read
+    // per pass); dispositions still act only on state re-read via each job's own turn.
+    const heldJobs = inventory
+      .filter((job) => job.status === 'failed')
       .filter(isFailedJob)
       .filter((job) => this.jobHandlerFor(job.request).canRetryFailedRecovery(job));
 

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -824,19 +824,12 @@ export class TripleStoreAsyncLiftPublisher
       processed = await this.jobHandlerFor(claimed.request).process(claimed, walletId);
     } finally {
       this.activeProcessJobIds.delete(claimed.jobId);
-      // r1 (🔴 3872361393) — the demand poke belongs on the OWNERSHIP BOUNDARY, after the
-      // marker above is gone. Poking from inside a processing path (as the ambiguous-broadcast
-      // catch first did) let the invited pass run while the job still read as executor-owned:
-      // the pass skipped it, the outlook answered false, and the one-shot demand was spent —
-      // parking the job for the idle sweep. Here the job is provably past every ownership
-      // marker the pass checks, so an invited pass can always act.
-      //
-      // r3 (🟡 3873024814, branarakic) — an ESCAPED processing fault pokes too. A durably
-      // recorded broadcast may already exist when a secondary read/write throws (store
-      // pressure), and asking the queue what state the job is in would use the same store that
-      // just failed. The poke is scheduling-only — the invited pass re-reads canonical job and
-      // chain state before acting — so over-inviting on the error path costs one empty pass,
-      // while under-inviting recreates the idle-sweep wallet hold this PR removes.
+      // Invariant: the demand poke fires only at the OWNERSHIP BOUNDARY — after the marker
+      // above is deleted — so an invited pass can always act on the announced job. An ESCAPED
+      // processing fault pokes unconditionally: a durable broadcast may already exist, reading
+      // the job state back would use the store that just failed, and the poke is scheduling-only
+      // (the pass re-reads canonical state before acting) — an unneeded invite costs one empty
+      // pass, a missed one parks the wallet until the idle sweep.
       if (processed === undefined || this.isReconciliationActionable(processed)) {
         this.notifyReconciliationDemand();
       }
@@ -1046,7 +1039,7 @@ export class TripleStoreAsyncLiftPublisher
         // UNKNOWN, not failed. The tx-bearing job retains the wallet until
         // chain proof finalizes, proves a revert, or proves create absence. The reconciliation
         // demand poke for this job fires at the processNext ownership boundary, not here —
-        // this frame still holds the job's activeProcessJobIds marker (r1 🔴 3872361393).
+        // this frame still holds the job's activeProcessJobIds marker.
         return await this.getRequiredJob(claimed.jobId);
       }
       // #1867 — either the tx never left ('not-reached' / 'rolled-back-pre-send'), or a
@@ -1151,22 +1144,19 @@ export class TripleStoreAsyncLiftPublisher
   }
 
   readonly reconciliationScheduling = {
-    // r2-1 (🟡 3872744747) — an EXCLUSIVE attachment, named as one: reconciliation demand has
-    // exactly one owner (the scheduling runner), so attaching takes over from the previous
-    // owner rather than joining a subscriber set nothing in production would ever have two of.
-    // See the interface doc for the ownership/handover contract.
+    // Exclusive attachment: reconciliation demand has exactly one owner (the scheduling
+    // runner); attaching takes over. See the interface doc for the ownership/handover contract.
     attachDemandListener: (listener: () => void): (() => void) => {
       this.reconciliationDemandListener = listener;
       return () => {
-        // Detaches only THIS attachment: a superseding owner must not be torn down by a stale
-        // detach from the runner incarnation it replaced — that is the safe handover.
+        // Detaches only THIS attachment — a stale detach from a superseded owner is a no-op.
         if (this.reconciliationDemandListener === listener) {
           this.reconciliationDemandListener = undefined;
         }
       };
     },
-    // r3-1 (🟡 3872935134) — the scheduling caller's per-tick operation: one pass, one atomic
-    // answer. `hasPendingWork` below remains for the boot-time seed and diagnostics only.
+    // The scheduling caller's per-tick operation: one pass, one atomic answer.
+    // `hasPendingWork` below is the boot-time seed and diagnostic probe only.
     reconcile: (): Promise<{ reconciled: number; pendingWork: boolean }> => this.runReconciliationPass(),
     hasPendingWork: async (): Promise<boolean> => {
       await this.ensureGraph();
@@ -1699,22 +1689,19 @@ export class TripleStoreAsyncLiftPublisher
   }
 
   /**
-   * r3-1 (🟡 3872935134) — ONE canonical pass that reports both what it settled and whether
-   * actionable live work remains, computed DURING the walk (per-job, from the same under-lock
-   * re-reads the pass already pays for) rather than by a second queue inventory afterwards.
-   * The scheduling caller consumes this outcome atomically, so there is no separate outlook
-   * read that can fail after a successful pass and strand a served demand on the idle cadence
-   * (r3-red 3872934465). `reconcileTransactions`/`recover` remain the wire-stable numeric
-   * surface over the same pass.
+   * The ONE canonical pass: reports both what it settled and whether actionable live work
+   * remains, computed DURING the walk (per-job, from the under-lock re-reads the pass already
+   * pays for) — never by a second queue inventory afterwards. The scheduling caller consumes
+   * this outcome atomically, so no separate outlook read exists to fail after a successful
+   * pass and strand a served demand on the idle cadence. `reconcileTransactions`/`recover`
+   * remain the wire-stable numeric surface over the same pass.
    */
   private async runReconciliationPass(): Promise<{ reconciled: number; pendingWork: boolean }> {
     await this.ensureGraph();
-    // r3-1 follow-up (branarakic 3873026014, production evidence) — ONE queue inventory per
-    // pass, partitioned in memory across the three lanes. The lanes previously each ran their
-    // own all-job read (pre-broadcast, live, failed): at a 5s active cadence over a large queue
-    // that moved the bottleneck from wallet scheduling into store/control-plane work. Each lane
-    // still re-reads its jobs individually under the transition lock before acting, so the
-    // shared snapshot only selects candidates and staleness cannot change a disposition.
+    // ONE queue inventory per pass, partitioned in memory across the three lanes — per-lane
+    // full reads at an active cadence move the bottleneck into store/control-plane work. Each
+    // lane re-reads its candidates under the transition lock before acting, so the shared
+    // snapshot only selects candidates and staleness cannot change a disposition.
     const inventory = await this.list();
     let reconciled = await this.recoverInterruptedPreBroadcastJobs(inventory);
     // Same actionability rule the scheduling outlook answers with: executor-owned jobs are
@@ -1869,8 +1856,8 @@ export class TripleStoreAsyncLiftPublisher
     // bounds apply, and none of them changes a job's DISPOSITION: a job that is not asked is left
     // exactly as held, so no bound can authorize a resend.
     const startedAt = this.now();
-    // Candidates from the pass's shared inventory snapshot (branarakic 3873026014 — one read
-    // per pass); dispositions still act only on state re-read via each job's own turn.
+    // Candidates from the pass's shared inventory snapshot (one read per pass); dispositions
+    // still act only on state re-read in each job's own turn.
     const heldJobs = inventory
       .filter((job) => job.status === 'failed')
       .filter(isFailedJob)

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -1160,6 +1160,9 @@ export class TripleStoreAsyncLiftPublisher
         }
       };
     },
+    // r3-1 (🟡 3872935134) — the scheduling caller's per-tick operation: one pass, one atomic
+    // answer. `hasPendingWork` below remains for the boot-time seed and diagnostics only.
+    reconcile: (): Promise<{ reconciled: number; pendingWork: boolean }> => this.runReconciliationPass(),
     hasPendingWork: async (): Promise<boolean> => {
       await this.ensureGraph();
       return (await this.list()).some((job) => this.isReconciliationActionable(job));
@@ -1683,10 +1686,23 @@ export class TripleStoreAsyncLiftPublisher
   async recover(): Promise<number> {
     await this.ensureGraph();
     await this.sweepStaleWalletLocks();
-    return await this.reconcileTransactions();
+    return (await this.runReconciliationPass()).reconciled;
   }
 
   async reconcileTransactions(): Promise<number> {
+    return (await this.runReconciliationPass()).reconciled;
+  }
+
+  /**
+   * r3-1 (🟡 3872935134) — ONE canonical pass that reports both what it settled and whether
+   * actionable live work remains, computed DURING the walk (per-job, from the same under-lock
+   * re-reads the pass already pays for) rather than by a second queue inventory afterwards.
+   * The scheduling caller consumes this outcome atomically, so there is no separate outlook
+   * read that can fail after a successful pass and strand a served demand on the idle cadence
+   * (r3-red 3872934465). `reconcileTransactions`/`recover` remain the wire-stable numeric
+   * surface over the same pass.
+   */
+  private async runReconciliationPass(): Promise<{ reconciled: number; pendingWork: boolean }> {
     await this.ensureGraph();
     let reconciled = await this.recoverInterruptedPreBroadcastJobs();
     // Same actionability rule the scheduling outlook answers with: executor-owned jobs are
@@ -1699,20 +1715,31 @@ export class TripleStoreAsyncLiftPublisher
     const offset = txBearing.length > 0 ? this.reconcilePassOffset++ % txBearing.length : 0;
     const rotatedTxBearing = txBearing.slice(offset).concat(txBearing.slice(0, offset));
 
+    // Live jobs this pass could not settle: still awaiting proof after their turn, or not
+    // reached before the deadline. Held-failed jobs are deliberately NOT counted — the
+    // failed-job dispatcher paces itself with per-job due times.
+    let remainingLive = 0;
     const deadline = new AbortController();
     const deadlineTimer = setTimeout(
       () => deadline.abort(),
       Math.max(0, this.chainProofDispatchTimeBudgetMs),
     );
     try {
-      for (const snapshot of rotatedTxBearing) {
-        if (deadline.signal.aborted) break;
+      for (let i = 0; i < rotatedTxBearing.length; i += 1) {
+        if (deadline.signal.aborted) {
+          remainingLive += rotatedTxBearing.length - i;
+          break;
+        }
+        const snapshot = rotatedTxBearing[i];
         await this.withJobTransitionLock(snapshot.jobId, async () => {
           const current = await this.getStatus(snapshot.jobId);
+          // Settled or re-owned since the pre-filter: no longer this pass's remaining work.
           if (!current || (current.status !== 'broadcast' && current.status !== 'included')) return;
           if (this.activeProcessJobIds.has(current.jobId)) return;
           if (await this.jobHandlerFor(current.request).recoverInterrupted(current, { signal: deadline.signal })) {
             reconciled += 1;
+          } else {
+            remainingLive += 1;
           }
         });
       }
@@ -1722,7 +1749,7 @@ export class TripleStoreAsyncLiftPublisher
     }
 
     reconciled += await this.dispatchFailedJobsOnChainProof();
-    return reconciled;
+    return { reconciled, pendingWork: remainingLive > 0 };
   }
 
   private async resolveChainProofWithinSignal(

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -1146,11 +1146,15 @@ export class TripleStoreAsyncLiftPublisher
   }
 
   readonly reconciliationScheduling = {
-    subscribeDemand: (listener: () => void): (() => void) => {
+    // r2-1 (🟡 3872744747) — an EXCLUSIVE attachment, named as one: reconciliation demand has
+    // exactly one owner (the scheduling runner), so attaching takes over from the previous
+    // owner rather than joining a subscriber set nothing in production would ever have two of.
+    // See the interface doc for the ownership/handover contract.
+    attachDemandListener: (listener: () => void): (() => void) => {
       this.reconciliationDemandListener = listener;
       return () => {
-        // Unsubscribes only THIS listener: a replacement subscription must not be torn down by
-        // a stale disposer from the runner incarnation it replaced.
+        // Detaches only THIS attachment: a superseding owner must not be torn down by a stale
+        // detach from the runner incarnation it replaced — that is the safe handover.
         if (this.reconciliationDemandListener === listener) {
           this.reconciliationDemandListener = undefined;
         }

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -1156,12 +1156,10 @@ export class TripleStoreAsyncLiftPublisher
       };
     },
     // The scheduling caller's per-tick operation: one pass, one atomic answer.
-    // `hasPendingWork` below is the boot-time seed and diagnostic probe only.
     reconcile: (): Promise<{ reconciled: number; pendingWork: boolean }> => this.runReconciliationPass(),
-    hasPendingWork: async (): Promise<boolean> => {
-      await this.ensureGraph();
-      return (await this.list()).some((job) => this.isReconciliationActionable(job));
-    },
+    // Startup recovery with the outcome kept: the caller seeds its cadence from the pass it
+    // already ran instead of paying a second boot-time inventory.
+    recover: (): Promise<{ reconciled: number; pendingWork: boolean }> => this.runRecovery(),
   };
 
   /**
@@ -1679,9 +1677,13 @@ export class TripleStoreAsyncLiftPublisher
   }
 
   async recover(): Promise<number> {
+    return (await this.runRecovery()).reconciled;
+  }
+
+  private async runRecovery(): Promise<{ reconciled: number; pendingWork: boolean }> {
     await this.ensureGraph();
     await this.sweepStaleWalletLocks();
-    return (await this.runReconciliationPass()).reconciled;
+    return await this.runReconciliationPass();
   }
 
   async reconcileTransactions(): Promise<number> {

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -1163,17 +1163,37 @@ export class TripleStoreAsyncLiftPublisher
   };
 
   /**
-   * The ONE definition of "reconciliation can act on this job now": live tx-bearing state with
-   * no executor ownership marker. Shared by the outlook above, the reconcile pass pre-filter,
-   * and the ownership-boundary demand poke, so the three cannot drift. The deeper per-job
-   * re-checks under the transition lock remain authoritative; this is the coherent pre-answer.
+   * The ONE definition of "reconciliation can act on this job now": live tx-bearing state, no
+   * executor ownership marker, and a lane that can actually move the record as THIS publisher
+   * is wired. Shared by the outlook, the reconcile pass pre-filter, and the ownership-boundary
+   * demand poke, so the three cannot drift. The deeper per-job re-checks under the transition
+   * lock remain authoritative; this is the coherent pre-answer.
    */
   private isReconciliationActionable(job: LiftJob): boolean {
     return (
       (job.status === 'broadcast' || job.status === 'included')
       && !this.detachedExecutions.has(job.jobId)
       && !this.activeProcessJobIds.has(job.jobId)
+      && this.canReconciliationProgress(job)
     );
+  }
+
+  /**
+   * Whether any configured lane can ever TRANSITION this live record. A named-KA job with
+   * neither the chain-proof resolver nor the named recovery resolver has no path that changes
+   * it — it is deliberately held for safety — so advertising it as active work would pin the
+   * scheduling caller to the active cadence (a full inventory per tick) forever, in exactly the
+   * degraded configuration where recovery is unavailable. Such records stay eligible for the
+   * idle crash-recovery sweep and become actionable the moment a resolver is configured again.
+   * The raw lane always has a transition available (evidence-free reset, or the inconclusive
+   * timeout into the held-failed state), so its jobs always count.
+   */
+  private canReconciliationProgress(job: LiftJob): boolean {
+    if (isKnowledgeAssetVmPublishJobRequest(job.request)) {
+      return this.chainProofResolver !== undefined
+        || this.knowledgeAssetVmPublishRecoveryResolver !== undefined;
+    }
+    return true;
   }
 
   /**

--- a/packages/publisher/src/async-lift-publisher-types.ts
+++ b/packages/publisher/src/async-lift-publisher-types.ts
@@ -123,16 +123,21 @@ export interface AsyncLiftPublisher {
    */
   readonly reconciliationScheduling?: {
     /**
-     * Register the single listener poked when transaction reconciliation gains actionable
-     * work — a tx-bearing job stops being executor-owned (a detached receipt execution
-     * settles, or `processNext` hands back a live broadcast after an ambiguous send). The poke
-     * carries no payload and establishes nothing about the queue; it only invites the caller
-     * to run {@link reconcileTransactions} sooner than its idle cadence would, and it fires
-     * only once the work is actually visible to that pass. A later subscription replaces the
-     * earlier listener. Returns the unsubscribe for THIS listener; calling it after a
-     * replacement is a no-op.
+     * EXCLUSIVE attachment of the demand listener — deliberately not pub/sub. Reconciliation
+     * demand has exactly one owner (the scheduling runner driving this publisher), so attaching
+     * TAKES OVER: a later attachment supersedes the earlier one, which is the safe handover
+     * when a new runner incarnation starts while its predecessor is still stopping. The
+     * returned detach releases only the caller's OWN attachment (a stale detach from a
+     * superseded owner is a no-op), so the handover cannot be torn down by the incarnation it
+     * replaced.
+     *
+     * The poke itself carries no payload and establishes nothing about the queue; it fires
+     * when a tx-bearing job stops being executor-owned (a detached receipt execution settles,
+     * or `processNext` hands back a live broadcast after an ambiguous send) — i.e. only once
+     * the work is actually visible to a {@link reconcileTransactions} pass — and merely
+     * invites the owner to run that pass sooner than its idle cadence would.
      */
-    subscribeDemand(listener: () => void): () => void;
+    attachDemandListener(listener: () => void): () => void;
     /**
      * Whether any transaction-bearing job currently awaits chain-proof reconciliation — live
      * `broadcast`/`included` state with no executor (in-process or detached) still owning it,

--- a/packages/publisher/src/async-lift-publisher-types.ts
+++ b/packages/publisher/src/async-lift-publisher-types.ts
@@ -149,13 +149,12 @@ export interface AsyncLiftPublisher {
      */
     reconcile(): Promise<{ reconciled: number; pendingWork: boolean }>;
     /**
-     * Whether any transaction-bearing job currently awaits chain-proof reconciliation — live
-     * `broadcast`/`included` state with no executor (in-process or detached) still owning it,
-     * the same actionability rule the reconcile pass itself applies. A read-only probe for the
-     * caller's boot-time cadence seed and for diagnostics; the scheduling loop itself consumes
-     * {@link reconcile}'s outcome instead of pairing this query with the pass.
+     * Startup recovery with the same outcome shape: stale-wallet-lock sweep plus one reconcile
+     * pass, so a starting caller seeds its cadence from the pass it already ran instead of
+     * paying a second boot-time inventory. Identical recovery semantics to
+     * {@link AsyncLiftPublisher.recover}, the wire-stable numeric surface over the same pass.
      */
-    hasPendingWork(): Promise<boolean>;
+    recover(): Promise<{ reconciled: number; pendingWork: boolean }>;
   };
   getStats(): Promise<Record<LiftJobState, number>>;
   pause(): Promise<void>;

--- a/packages/publisher/src/async-lift-publisher-types.ts
+++ b/packages/publisher/src/async-lift-publisher-types.ts
@@ -139,11 +139,21 @@ export interface AsyncLiftPublisher {
      */
     attachDemandListener(listener: () => void): () => void;
     /**
+     * Run one reconcile pass and report BOTH what it settled and whether actionable live work
+     * remains — one operation, one atomic answer, computed during the pass's own walk rather
+     * than by a second queue inventory. This is what the scheduling caller consumes per tick
+     * to pick its next cadence: a separate post-pass outlook query could fail after the pass
+     * succeeded and strand an already-served demand on the idle cadence. Identical pass
+     * semantics to {@link reconcileTransactions}, which stays the wire-stable numeric surface
+     * over the same pass.
+     */
+    reconcile(): Promise<{ reconciled: number; pendingWork: boolean }>;
+    /**
      * Whether any transaction-bearing job currently awaits chain-proof reconciliation — live
      * `broadcast`/`included` state with no executor (in-process or detached) still owning it,
-     * the same actionability rule the reconcile pass itself applies. Lets the caller hold a
-     * short reconcile cadence exactly while an unresolved chain question exists and fall back
-     * to its idle sweep otherwise.
+     * the same actionability rule the reconcile pass itself applies. A read-only probe for the
+     * caller's boot-time cadence seed and for diagnostics; the scheduling loop itself consumes
+     * {@link reconcile}'s outcome instead of pairing this query with the pass.
      */
     hasPendingWork(): Promise<boolean>;
   };

--- a/packages/publisher/src/async-lift-publisher-types.ts
+++ b/packages/publisher/src/async-lift-publisher-types.ts
@@ -115,6 +115,22 @@ export interface AsyncLiftPublisher {
   reconcileTransactions?(): Promise<number>;
   /** Wait until every receipt task detached after RPC acceptance has stopped. Older implementations can omit it. */
   drainDetachedExecutions?(): Promise<void>;
+  /**
+   * Register the single listener poked when transaction reconciliation gains actionable work —
+   * a detached receipt execution settles, or an ambiguous broadcast is left behind for chain
+   * proof. A later registration replaces the earlier listener. The poke carries no payload and
+   * establishes nothing about the queue; it only invites the caller to run
+   * {@link reconcileTransactions} sooner than its idle cadence would. Older implementations can
+   * omit it, and a caller that never registers loses nothing but latency.
+   */
+  setReconciliationDemandListener?(listener: () => void): void;
+  /**
+   * Whether any transaction-bearing job currently awaits chain-proof reconciliation — live
+   * `broadcast`/`included` state with no executor (in-process or detached) still owning it.
+   * Lets the caller hold a short reconcile cadence exactly while an unresolved chain question
+   * exists and fall back to its idle sweep otherwise. Older implementations can omit it.
+   */
+  hasPendingTransactionReconciliation?(): Promise<boolean>;
   getStats(): Promise<Record<LiftJobState, number>>;
   pause(): Promise<void>;
   resume(): Promise<void>;

--- a/packages/publisher/src/async-lift-publisher-types.ts
+++ b/packages/publisher/src/async-lift-publisher-types.ts
@@ -116,21 +116,32 @@ export interface AsyncLiftPublisher {
   /** Wait until every receipt task detached after RPC acceptance has stopped. Older implementations can omit it. */
   drainDetachedExecutions?(): Promise<void>;
   /**
-   * Register the single listener poked when transaction reconciliation gains actionable work —
-   * a detached receipt execution settles, or an ambiguous broadcast is left behind for chain
-   * proof. A later registration replaces the earlier listener. The poke carries no payload and
-   * establishes nothing about the queue; it only invites the caller to run
-   * {@link reconcileTransactions} sooner than its idle cadence would. Older implementations can
-   * omit it, and a caller that never registers loses nothing but latency.
+   * Demand-driven reconciliation scheduling. ONE optional capability rather than independent
+   * optional methods, so a publisher cannot implement the wake-up without the outlook (or the
+   * reverse) — the incoherent halves are unrepresentable. Older implementations omit the whole
+   * capability and a caller that never subscribes loses nothing but latency.
    */
-  setReconciliationDemandListener?(listener: () => void): void;
-  /**
-   * Whether any transaction-bearing job currently awaits chain-proof reconciliation — live
-   * `broadcast`/`included` state with no executor (in-process or detached) still owning it.
-   * Lets the caller hold a short reconcile cadence exactly while an unresolved chain question
-   * exists and fall back to its idle sweep otherwise. Older implementations can omit it.
-   */
-  hasPendingTransactionReconciliation?(): Promise<boolean>;
+  readonly reconciliationScheduling?: {
+    /**
+     * Register the single listener poked when transaction reconciliation gains actionable
+     * work — a tx-bearing job stops being executor-owned (a detached receipt execution
+     * settles, or `processNext` hands back a live broadcast after an ambiguous send). The poke
+     * carries no payload and establishes nothing about the queue; it only invites the caller
+     * to run {@link reconcileTransactions} sooner than its idle cadence would, and it fires
+     * only once the work is actually visible to that pass. A later subscription replaces the
+     * earlier listener. Returns the unsubscribe for THIS listener; calling it after a
+     * replacement is a no-op.
+     */
+    subscribeDemand(listener: () => void): () => void;
+    /**
+     * Whether any transaction-bearing job currently awaits chain-proof reconciliation — live
+     * `broadcast`/`included` state with no executor (in-process or detached) still owning it,
+     * the same actionability rule the reconcile pass itself applies. Lets the caller hold a
+     * short reconcile cadence exactly while an unresolved chain question exists and fall back
+     * to its idle sweep otherwise.
+     */
+    hasPendingWork(): Promise<boolean>;
+  };
   getStats(): Promise<Record<LiftJobState, number>>;
   pause(): Promise<void>;
   resume(): Promise<void>;

--- a/packages/publisher/src/async-lift-runner.ts
+++ b/packages/publisher/src/async-lift-runner.ts
@@ -35,15 +35,19 @@ export class AsyncLiftRunner {
   private lastRecoveryAttemptAt = 0;
   private recoveryInFlight?: Promise<void>;
   private recoveryTimer?: ReturnType<typeof setTimeout>;
-  /** An unserved demand poke exists; the next pass is due now, not next cadence. */
-  private reconciliationDemanded = false;
   /**
-   * Bumped per poke. A pass records the generation it started under and clears the demand flag
-   * only when it SUCCEEDS with that generation still current — so a pass that throws leaves the
-   * demand standing (retried on the errorBackoffMs floor), and a poke that lands mid-pass
-   * survives the pass that may already be past its job.
+   * r2-2 (🟡 3872744751) — ONE invariant, two monotonic cursors: demand is pending exactly while
+   * `servedDemandGeneration < demandedGeneration`. A poke advances `demanded`; only a pass that
+   * SUCCEEDS advances `served`, and only to the generation it captured at start — so a failed
+   * pass leaves the demand standing (retried on the errorBackoffMs floor) and a poke landing
+   * mid-pass stays ahead of the pass that may already be past its job. No separate boolean can
+   * drift out of sync, because the pending state is derived, never stored.
    */
-  private demandGeneration = 0;
+  private demandedGeneration = 0;
+  private servedDemandGeneration = 0;
+  private get reconciliationDemanded(): boolean {
+    return this.servedDemandGeneration < this.demandedGeneration;
+  }
   /** Last answer from the publisher's `reconciliationScheduling.hasPendingWork`; selects active vs idle cadence. */
   private pendingReconciliation = false;
   private unsubscribeReconciliationDemand?: () => void;
@@ -89,7 +93,7 @@ export class AsyncLiftRunner {
     // A tx-bearing job leaves executor ownership (detached receipt settles, ambiguous broadcast)
     // between passes; the poke pulls the next pass forward instead of waiting out the cadence.
     this.unsubscribeReconciliationDemand = this.config.publisher.reconciliationScheduling
-      ?.subscribeDemand(() => this.demandTransactionReconciliation());
+      ?.attachDemandListener(() => this.demandTransactionReconciliation());
     // Startup recovery may have left unresolved tx-bearing jobs behind (chain proof still
     // pending); seed the cadence choice from the queue rather than assuming idle.
     await this.refreshPendingReconciliation();
@@ -143,8 +147,7 @@ export class AsyncLiftRunner {
    */
   private demandTransactionReconciliation(): void {
     if (this.stopped || !this.started) return;
-    this.reconciliationDemanded = true;
-    this.demandGeneration += 1;
+    this.demandedGeneration += 1;
     if (this.recoveryInFlight) return;
     if (this.recoveryTimer) {
       clearTimeout(this.recoveryTimer);
@@ -179,19 +182,17 @@ export class AsyncLiftRunner {
 
   private startTransactionReconciliation(): void {
     if (this.stopped || this.recoveryInFlight) return;
-    // r2 (🔴 3872361404) — the demand is consumed only by a pass that SUCCEEDS. Consuming it at
-    // pass start let one transient reconcile error spend the only wake-up and park the job for
-    // the idle interval; now a failed demanded pass stays due and retries on the errorBackoffMs
-    // floor. The generation check keeps the mid-pass-poke semantics: a poke that lands while
-    // this pass runs re-arms the demand, because the pass may already be past that job.
-    const generationAtStart = this.demandGeneration;
+    // r2 (🔴 3872361404) — the demand is served only by a pass that SUCCEEDS: `served` advances
+    // to the generation captured here, never past it. Consuming demand at pass start let one
+    // transient reconcile error spend the only wake-up and park the job for the idle interval;
+    // a failed pass now leaves `served` behind `demanded`, so the demand stays due on the
+    // errorBackoffMs floor, and a poke landing mid-pass keeps `demanded` ahead of this capture.
+    const generationAtStart = this.demandedGeneration;
     this.lastRecoveryAttemptAt = Date.now();
     const recovery = (this.config.publisher.reconcileTransactions?.() ?? this.config.publisher.recover())
       .then(async () => {
         this.lastRecoveryAt = Date.now();
-        if (this.demandGeneration === generationAtStart) {
-          this.reconciliationDemanded = false;
-        }
+        this.servedDemandGeneration = Math.max(this.servedDemandGeneration, generationAtStart);
         await this.refreshPendingReconciliation();
       })
       .catch(async (error) => {

--- a/packages/publisher/src/async-lift-runner.ts
+++ b/packages/publisher/src/async-lift-runner.ts
@@ -40,16 +40,12 @@ export class AsyncLiftRunner {
   private recoveryInFlight?: Promise<void>;
   private recoveryTimer?: ReturnType<typeof setTimeout>;
   /**
-   * Demand invariant: pending exactly while `served < demanded`. A poke advances `demanded`;
-   * only a SUCCESSFUL pass advances `served`, and only to the generation it captured at start —
-   * so a failed pass keeps the demand due (retried on the errorBackoffMs floor) and a mid-pass
-   * poke survives the pass that may already be past its job. Pending is derived, never stored.
+   * Demand latch: set by a poke, consumed at pass start, restored if that pass FAILS — so a
+   * transient error cannot spend the only wake-up. A mid-pass poke sets it after the consume
+   * and therefore survives a successful pass that may already be past its job; repeated pokes
+   * coalesce naturally. Only one pass runs at a time, so a boolean is the whole state.
    */
-  private demandedGeneration = 0;
-  private servedDemandGeneration = 0;
-  private get reconciliationDemanded(): boolean {
-    return this.servedDemandGeneration < this.demandedGeneration;
-  }
+  private reconciliationDemanded = false;
   /** Whether unresolved tx work remains, from the last pass outcome (boot-seeded); selects active vs idle cadence. */
   private pendingReconciliation = false;
   private unsubscribeReconciliationDemand?: () => void;
@@ -82,7 +78,15 @@ export class AsyncLiftRunner {
       if (this.config.startPaused === true) {
         await this.config.publisher.pause();
       }
-      await this.config.publisher.recover();
+      // Startup recovery IS the first pass: with the scheduling capability its outcome seeds
+      // the cadence choice directly — one inventory, no second boot-time outlook read. Without
+      // the capability the legacy numeric recover() runs and the idle cadence is the seed.
+      const scheduling = this.config.publisher.reconciliationScheduling;
+      if (scheduling) {
+        this.pendingReconciliation = (await scheduling.recover()).pendingWork;
+      } else {
+        await this.config.publisher.recover();
+      }
       this.lastRecoveryAt = Date.now();
       if (!this.config.hasIncludedRecoveryResolver) {
         const includedJobs = await this.config.publisher.list({ status: 'included' });
@@ -98,11 +102,10 @@ export class AsyncLiftRunner {
     this.started = true;
     // A tx-bearing job leaves executor ownership (detached receipt settles, ambiguous broadcast)
     // between passes; the poke pulls the next pass forward instead of waiting out the cadence.
+    // No in-process work can settle before this point — executors only run once the wallet
+    // loops below start — so attaching after startup recovery loses nothing.
     this.unsubscribeReconciliationDemand = this.config.publisher.reconciliationScheduling
       ?.attachDemandListener(() => this.demandTransactionReconciliation());
-    // Startup recovery may have left unresolved tx-bearing jobs behind (chain proof still
-    // pending); seed the cadence choice from the queue rather than assuming idle.
-    await this.seedPendingReconciliation();
     this.scheduleTransactionReconciliation();
     this.running = Promise.all(
       this.config.walletIds.map((walletId) => this.walletLoop(walletId)),
@@ -153,33 +156,13 @@ export class AsyncLiftRunner {
    */
   private demandTransactionReconciliation(): void {
     if (this.stopped || !this.started) return;
-    this.demandedGeneration += 1;
+    this.reconciliationDemanded = true;
     if (this.recoveryInFlight) return;
     if (this.recoveryTimer) {
       clearTimeout(this.recoveryTimer);
       this.recoveryTimer = undefined;
     }
     this.scheduleTransactionReconciliation();
-  }
-
-  /**
-   * BOOT-TIME cadence seed only — the per-tick outlook comes atomically out of the pass itself
-   * (see startTransactionReconciliation). Fail-open by design: a probe that cannot read the
-   * queue must neither abort startup nor stop scheduling; it reports through onError, keeps
-   * the previous (idle) cadence, and lets the idle sweep bound the staleness.
-   */
-  private async seedPendingReconciliation(): Promise<void> {
-    const scheduling = this.config.publisher.reconciliationScheduling;
-    if (!scheduling) return;
-    try {
-      this.pendingReconciliation = await scheduling.hasPendingWork();
-    } catch (error) {
-      try {
-        await this.onError?.(error);
-      } catch {
-        // Error reporting must not turn the fail-open probe into a startup failure.
-      }
-    }
   }
 
   private scheduleTransactionReconciliation(): void {
@@ -198,10 +181,10 @@ export class AsyncLiftRunner {
 
   private startTransactionReconciliation(): void {
     if (this.stopped || this.recoveryInFlight) return;
-    // Demand is served only by a pass that SUCCEEDS: `served` advances to the generation
-    // captured here, never past it. A failed pass keeps the demand due (errorBackoffMs floor);
-    // a poke landing mid-pass keeps `demanded` ahead of this capture.
-    const generationAtStart = this.demandedGeneration;
+    // Consume the latch; a failed pass restores what it consumed (errorBackoffMs floor paces
+    // the retry), and a mid-pass poke re-sets the latch independently of this capture.
+    const demandConsumed = this.reconciliationDemanded;
+    this.reconciliationDemanded = false;
     this.lastRecoveryAttemptAt = Date.now();
     const scheduling = this.config.publisher.reconciliationScheduling;
     // The outlook arrives IN the pass result: serving the demand and learning whether work
@@ -216,9 +199,9 @@ export class AsyncLiftRunner {
       .then((outcome) => {
         this.lastRecoveryAt = Date.now();
         this.pendingReconciliation = outcome.pendingWork;
-        this.servedDemandGeneration = Math.max(this.servedDemandGeneration, generationAtStart);
       })
       .catch(async (error) => {
+        this.reconciliationDemanded = this.reconciliationDemanded || demandConsumed;
         try {
           await this.onError?.(error);
         } catch {

--- a/packages/publisher/src/async-lift-runner.ts
+++ b/packages/publisher/src/async-lift-runner.ts
@@ -11,7 +11,7 @@ export interface AsyncLiftRunnerConfig {
    * Reconciliation cadence while the publisher reports transaction-bearing jobs awaiting chain
    * proof. `recoveryIntervalMs` stays the idle sweep for work no wake-up can announce (crash
    * recovery, jobs stranded by a listener that never fired). Only consulted when the publisher
-   * implements `hasPendingTransactionReconciliation`.
+   * implements the `reconciliationScheduling` capability.
    */
   readonly activeRecoveryIntervalMs?: number;
   /** Start recovery, but do not claim accepted jobs until an operator restarts unpaused. */
@@ -35,10 +35,18 @@ export class AsyncLiftRunner {
   private lastRecoveryAttemptAt = 0;
   private recoveryInFlight?: Promise<void>;
   private recoveryTimer?: ReturnType<typeof setTimeout>;
-  /** A demand poke arrived since the last pass started; the next pass is due now, not next cadence. */
+  /** An unserved demand poke exists; the next pass is due now, not next cadence. */
   private reconciliationDemanded = false;
-  /** Last answer from `hasPendingTransactionReconciliation`; selects active vs idle cadence. */
+  /**
+   * Bumped per poke. A pass records the generation it started under and clears the demand flag
+   * only when it SUCCEEDS with that generation still current — so a pass that throws leaves the
+   * demand standing (retried on the errorBackoffMs floor), and a poke that lands mid-pass
+   * survives the pass that may already be past its job.
+   */
+  private demandGeneration = 0;
+  /** Last answer from the publisher's `reconciliationScheduling.hasPendingWork`; selects active vs idle cadence. */
   private pendingReconciliation = false;
+  private unsubscribeReconciliationDemand?: () => void;
 
   constructor(private readonly config: AsyncLiftRunnerConfig) {
     this.pollIntervalMs = config.pollIntervalMs ?? 1000;
@@ -80,7 +88,8 @@ export class AsyncLiftRunner {
     this.started = true;
     // A tx-bearing job leaves executor ownership (detached receipt settles, ambiguous broadcast)
     // between passes; the poke pulls the next pass forward instead of waiting out the cadence.
-    this.config.publisher.setReconciliationDemandListener?.(() => this.demandTransactionReconciliation());
+    this.unsubscribeReconciliationDemand = this.config.publisher.reconciliationScheduling
+      ?.subscribeDemand(() => this.demandTransactionReconciliation());
     // Startup recovery may have left unresolved tx-bearing jobs behind (chain proof still
     // pending); seed the cadence choice from the queue rather than assuming idle.
     await this.refreshPendingReconciliation();
@@ -96,6 +105,11 @@ export class AsyncLiftRunner {
       clearTimeout(this.recoveryTimer);
       this.recoveryTimer = undefined;
     }
+    // Dispose the demand subscription so the publisher does not keep (or invoke) a callback
+    // into a stopped runner — the drain below settles detached executions, which would
+    // otherwise poke this corpse on every settle.
+    this.unsubscribeReconciliationDemand?.();
+    this.unsubscribeReconciliationDemand = undefined;
     await this.running;
     await this.recoveryInFlight;
     await this.config.publisher.drainDetachedExecutions?.();
@@ -130,6 +144,7 @@ export class AsyncLiftRunner {
   private demandTransactionReconciliation(): void {
     if (this.stopped || !this.started) return;
     this.reconciliationDemanded = true;
+    this.demandGeneration += 1;
     if (this.recoveryInFlight) return;
     if (this.recoveryTimer) {
       clearTimeout(this.recoveryTimer);
@@ -139,10 +154,10 @@ export class AsyncLiftRunner {
   }
 
   private async refreshPendingReconciliation(): Promise<void> {
-    const hasPending = this.config.publisher.hasPendingTransactionReconciliation;
-    if (!hasPending) return;
+    const scheduling = this.config.publisher.reconciliationScheduling;
+    if (!scheduling) return;
     try {
-      this.pendingReconciliation = await hasPending.call(this.config.publisher);
+      this.pendingReconciliation = await scheduling.hasPendingWork();
     } catch {
       // An unanswerable queue read keeps the previous cadence; the idle sweep bounds staleness.
     }
@@ -164,13 +179,19 @@ export class AsyncLiftRunner {
 
   private startTransactionReconciliation(): void {
     if (this.stopped || this.recoveryInFlight) return;
-    // Consumed at pass START: a poke that lands while this pass runs re-arms the flag, because
-    // this pass may already be past the job the poke announced.
-    this.reconciliationDemanded = false;
+    // r2 (🔴 3872361404) — the demand is consumed only by a pass that SUCCEEDS. Consuming it at
+    // pass start let one transient reconcile error spend the only wake-up and park the job for
+    // the idle interval; now a failed demanded pass stays due and retries on the errorBackoffMs
+    // floor. The generation check keeps the mid-pass-poke semantics: a poke that lands while
+    // this pass runs re-arms the demand, because the pass may already be past that job.
+    const generationAtStart = this.demandGeneration;
     this.lastRecoveryAttemptAt = Date.now();
     const recovery = (this.config.publisher.reconcileTransactions?.() ?? this.config.publisher.recover())
       .then(async () => {
         this.lastRecoveryAt = Date.now();
+        if (this.demandGeneration === generationAtStart) {
+          this.reconciliationDemanded = false;
+        }
         await this.refreshPendingReconciliation();
       })
       .catch(async (error) => {

--- a/packages/publisher/src/async-lift-runner.ts
+++ b/packages/publisher/src/async-lift-runner.ts
@@ -96,7 +96,7 @@ export class AsyncLiftRunner {
       ?.attachDemandListener(() => this.demandTransactionReconciliation());
     // Startup recovery may have left unresolved tx-bearing jobs behind (chain proof still
     // pending); seed the cadence choice from the queue rather than assuming idle.
-    await this.refreshPendingReconciliation();
+    await this.seedPendingReconciliation();
     this.scheduleTransactionReconciliation();
     this.running = Promise.all(
       this.config.walletIds.map((walletId) => this.walletLoop(walletId)),
@@ -156,13 +156,23 @@ export class AsyncLiftRunner {
     this.scheduleTransactionReconciliation();
   }
 
-  private async refreshPendingReconciliation(): Promise<void> {
+  /**
+   * BOOT-TIME cadence seed only — the per-tick outlook comes atomically out of the pass itself
+   * (see startTransactionReconciliation). Fail-open by design: a probe that cannot read the
+   * queue must neither abort startup nor stop scheduling; it reports through onError, keeps
+   * the previous (idle) cadence, and lets the idle sweep bound the staleness.
+   */
+  private async seedPendingReconciliation(): Promise<void> {
     const scheduling = this.config.publisher.reconciliationScheduling;
     if (!scheduling) return;
     try {
       this.pendingReconciliation = await scheduling.hasPendingWork();
-    } catch {
-      // An unanswerable queue read keeps the previous cadence; the idle sweep bounds staleness.
+    } catch (error) {
+      try {
+        await this.onError?.(error);
+      } catch {
+        // Error reporting must not turn the fail-open probe into a startup failure.
+      }
     }
   }
 
@@ -189,11 +199,21 @@ export class AsyncLiftRunner {
     // errorBackoffMs floor, and a poke landing mid-pass keeps `demanded` ahead of this capture.
     const generationAtStart = this.demandedGeneration;
     this.lastRecoveryAttemptAt = Date.now();
-    const recovery = (this.config.publisher.reconcileTransactions?.() ?? this.config.publisher.recover())
-      .then(async () => {
+    const scheduling = this.config.publisher.reconciliationScheduling;
+    // r3-red (🔴 3872934465) — the outlook arrives IN the pass result, so acknowledging the
+    // demand and learning whether work remains are one atomic step: there is no separate
+    // post-pass queue read that can fail after a successful pass, silently park an unresolved
+    // transaction on the idle cadence, and leave the demand already spent. A publisher without
+    // the capability has no outlook to report; its passes keep the seeded (idle) cadence.
+    const pass: Promise<{ reconciled: number; pendingWork: boolean }> = scheduling
+      ? scheduling.reconcile()
+      : (this.config.publisher.reconcileTransactions?.() ?? this.config.publisher.recover())
+        .then((reconciled) => ({ reconciled, pendingWork: this.pendingReconciliation }));
+    const recovery = pass
+      .then((outcome) => {
         this.lastRecoveryAt = Date.now();
+        this.pendingReconciliation = outcome.pendingWork;
         this.servedDemandGeneration = Math.max(this.servedDemandGeneration, generationAtStart);
-        await this.refreshPendingReconciliation();
       })
       .catch(async (error) => {
         try {

--- a/packages/publisher/src/async-lift-runner.ts
+++ b/packages/publisher/src/async-lift-runner.ts
@@ -7,6 +7,13 @@ export interface AsyncLiftRunnerConfig {
   readonly pollIntervalMs?: number;
   readonly errorBackoffMs?: number;
   readonly recoveryIntervalMs?: number;
+  /**
+   * Reconciliation cadence while the publisher reports transaction-bearing jobs awaiting chain
+   * proof. `recoveryIntervalMs` stays the idle sweep for work no wake-up can announce (crash
+   * recovery, jobs stranded by a listener that never fired). Only consulted when the publisher
+   * implements `hasPendingTransactionReconciliation`.
+   */
+  readonly activeRecoveryIntervalMs?: number;
   /** Start recovery, but do not claim accepted jobs until an operator restarts unpaused. */
   readonly startPaused?: boolean;
   readonly sleep?: (ms: number) => Promise<void>;
@@ -18,6 +25,7 @@ export class AsyncLiftRunner {
   private readonly pollIntervalMs: number;
   private readonly errorBackoffMs: number;
   private readonly recoveryIntervalMs: number;
+  private readonly activeRecoveryIntervalMs: number;
   private readonly sleep: (ms: number) => Promise<void>;
   private readonly onError?: (error: unknown) => void | Promise<void>;
   private started = false;
@@ -27,12 +35,18 @@ export class AsyncLiftRunner {
   private lastRecoveryAttemptAt = 0;
   private recoveryInFlight?: Promise<void>;
   private recoveryTimer?: ReturnType<typeof setTimeout>;
+  /** A demand poke arrived since the last pass started; the next pass is due now, not next cadence. */
+  private reconciliationDemanded = false;
+  /** Last answer from `hasPendingTransactionReconciliation`; selects active vs idle cadence. */
+  private pendingReconciliation = false;
 
   constructor(private readonly config: AsyncLiftRunnerConfig) {
     this.pollIntervalMs = config.pollIntervalMs ?? 1000;
     this.errorBackoffMs = config.errorBackoffMs ?? 1000;
     this.recoveryIntervalMs = config.recoveryIntervalMs ?? 60_000;
     assertNodeTimerDelayMs(this.recoveryIntervalMs, 'AsyncLiftRunner recoveryIntervalMs');
+    this.activeRecoveryIntervalMs = config.activeRecoveryIntervalMs ?? 5_000;
+    assertNodeTimerDelayMs(this.activeRecoveryIntervalMs, 'AsyncLiftRunner activeRecoveryIntervalMs');
     this.sleep = config.sleep ?? defaultSleep;
     this.onError = config.onError;
   }
@@ -64,6 +78,12 @@ export class AsyncLiftRunner {
     }
 
     this.started = true;
+    // A tx-bearing job leaves executor ownership (detached receipt settles, ambiguous broadcast)
+    // between passes; the poke pulls the next pass forward instead of waiting out the cadence.
+    this.config.publisher.setReconciliationDemandListener?.(() => this.demandTransactionReconciliation());
+    // Startup recovery may have left unresolved tx-bearing jobs behind (chain proof still
+    // pending); seed the cadence choice from the queue rather than assuming idle.
+    await this.refreshPendingReconciliation();
     this.scheduleTransactionReconciliation();
     this.running = Promise.all(
       this.config.walletIds.map((walletId) => this.walletLoop(walletId)),
@@ -101,11 +121,39 @@ export class AsyncLiftRunner {
     }
   }
 
+  /**
+   * The publisher's poke that reconciliation gained actionable work. Coalesced: during an
+   * in-flight pass it only marks the flag, and the pass's own rescheduling turns any number of
+   * pokes into one follow-up pass. `errorBackoffMs` since the last attempt stays the floor, so a
+   * reconciliation that keeps throwing cannot be poked into a hot loop.
+   */
+  private demandTransactionReconciliation(): void {
+    if (this.stopped || !this.started) return;
+    this.reconciliationDemanded = true;
+    if (this.recoveryInFlight) return;
+    if (this.recoveryTimer) {
+      clearTimeout(this.recoveryTimer);
+      this.recoveryTimer = undefined;
+    }
+    this.scheduleTransactionReconciliation();
+  }
+
+  private async refreshPendingReconciliation(): Promise<void> {
+    const hasPending = this.config.publisher.hasPendingTransactionReconciliation;
+    if (!hasPending) return;
+    try {
+      this.pendingReconciliation = await hasPending.call(this.config.publisher);
+    } catch {
+      // An unanswerable queue read keeps the previous cadence; the idle sweep bounds staleness.
+    }
+  }
+
   private scheduleTransactionReconciliation(): void {
     if (this.stopped || this.recoveryTimer || this.recoveryInFlight) return;
     const now = Date.now();
+    const cadenceMs = this.pendingReconciliation ? this.activeRecoveryIntervalMs : this.recoveryIntervalMs;
     const nextAt = Math.max(
-      this.lastRecoveryAt + this.recoveryIntervalMs,
+      this.reconciliationDemanded ? now : this.lastRecoveryAt + cadenceMs,
       this.lastRecoveryAttemptAt + this.errorBackoffMs,
     );
     this.recoveryTimer = setTimeout(() => {
@@ -116,10 +164,14 @@ export class AsyncLiftRunner {
 
   private startTransactionReconciliation(): void {
     if (this.stopped || this.recoveryInFlight) return;
+    // Consumed at pass START: a poke that lands while this pass runs re-arms the flag, because
+    // this pass may already be past the job the poke announced.
+    this.reconciliationDemanded = false;
     this.lastRecoveryAttemptAt = Date.now();
     const recovery = (this.config.publisher.reconcileTransactions?.() ?? this.config.publisher.recover())
-      .then(() => {
+      .then(async () => {
         this.lastRecoveryAt = Date.now();
+        await this.refreshPendingReconciliation();
       })
       .catch(async (error) => {
         try {

--- a/packages/publisher/src/async-lift-runner.ts
+++ b/packages/publisher/src/async-lift-runner.ts
@@ -12,6 +12,10 @@ export interface AsyncLiftRunnerConfig {
    * proof. `recoveryIntervalMs` stays the idle sweep for work no wake-up can announce (crash
    * recovery, jobs stranded by a listener that never fired). Only consulted when the publisher
    * implements the `reconciliationScheduling` capability.
+   *
+   * When omitted, the effective active cadence is `min(recoveryIntervalMs, 5000)`: never slower
+   * than the 5s default, and never slower than an explicitly configured `recoveryIntervalMs` —
+   * a consumer that already checks pending transactions faster than 5s keeps that rate.
    */
   readonly activeRecoveryIntervalMs?: number;
   /** Start recovery, but do not claim accepted jobs until an operator restarts unpaused. */
@@ -36,19 +40,17 @@ export class AsyncLiftRunner {
   private recoveryInFlight?: Promise<void>;
   private recoveryTimer?: ReturnType<typeof setTimeout>;
   /**
-   * r2-2 (🟡 3872744751) — ONE invariant, two monotonic cursors: demand is pending exactly while
-   * `servedDemandGeneration < demandedGeneration`. A poke advances `demanded`; only a pass that
-   * SUCCEEDS advances `served`, and only to the generation it captured at start — so a failed
-   * pass leaves the demand standing (retried on the errorBackoffMs floor) and a poke landing
-   * mid-pass stays ahead of the pass that may already be past its job. No separate boolean can
-   * drift out of sync, because the pending state is derived, never stored.
+   * Demand invariant: pending exactly while `served < demanded`. A poke advances `demanded`;
+   * only a SUCCESSFUL pass advances `served`, and only to the generation it captured at start —
+   * so a failed pass keeps the demand due (retried on the errorBackoffMs floor) and a mid-pass
+   * poke survives the pass that may already be past its job. Pending is derived, never stored.
    */
   private demandedGeneration = 0;
   private servedDemandGeneration = 0;
   private get reconciliationDemanded(): boolean {
     return this.servedDemandGeneration < this.demandedGeneration;
   }
-  /** Last answer from the publisher's `reconciliationScheduling.hasPendingWork`; selects active vs idle cadence. */
+  /** Whether unresolved tx work remains, from the last pass outcome (boot-seeded); selects active vs idle cadence. */
   private pendingReconciliation = false;
   private unsubscribeReconciliationDemand?: () => void;
 
@@ -57,7 +59,11 @@ export class AsyncLiftRunner {
     this.errorBackoffMs = config.errorBackoffMs ?? 1000;
     this.recoveryIntervalMs = config.recoveryIntervalMs ?? 60_000;
     assertNodeTimerDelayMs(this.recoveryIntervalMs, 'AsyncLiftRunner recoveryIntervalMs');
-    this.activeRecoveryIntervalMs = config.activeRecoveryIntervalMs ?? 5_000;
+    // The active cadence must never be SLOWER than an explicitly configured recoveryIntervalMs:
+    // that setting was a consumer's pending-transaction check rate before the active/idle split
+    // existed, and the new default must not override a faster explicit choice.
+    this.activeRecoveryIntervalMs = config.activeRecoveryIntervalMs
+      ?? Math.min(config.recoveryIntervalMs ?? 5_000, 5_000);
     assertNodeTimerDelayMs(this.activeRecoveryIntervalMs, 'AsyncLiftRunner activeRecoveryIntervalMs');
     this.sleep = config.sleep ?? defaultSleep;
     this.onError = config.onError;
@@ -192,19 +198,16 @@ export class AsyncLiftRunner {
 
   private startTransactionReconciliation(): void {
     if (this.stopped || this.recoveryInFlight) return;
-    // r2 (🔴 3872361404) — the demand is served only by a pass that SUCCEEDS: `served` advances
-    // to the generation captured here, never past it. Consuming demand at pass start let one
-    // transient reconcile error spend the only wake-up and park the job for the idle interval;
-    // a failed pass now leaves `served` behind `demanded`, so the demand stays due on the
-    // errorBackoffMs floor, and a poke landing mid-pass keeps `demanded` ahead of this capture.
+    // Demand is served only by a pass that SUCCEEDS: `served` advances to the generation
+    // captured here, never past it. A failed pass keeps the demand due (errorBackoffMs floor);
+    // a poke landing mid-pass keeps `demanded` ahead of this capture.
     const generationAtStart = this.demandedGeneration;
     this.lastRecoveryAttemptAt = Date.now();
     const scheduling = this.config.publisher.reconciliationScheduling;
-    // r3-red (🔴 3872934465) — the outlook arrives IN the pass result, so acknowledging the
-    // demand and learning whether work remains are one atomic step: there is no separate
-    // post-pass queue read that can fail after a successful pass, silently park an unresolved
-    // transaction on the idle cadence, and leave the demand already spent. A publisher without
-    // the capability has no outlook to report; its passes keep the seeded (idle) cadence.
+    // The outlook arrives IN the pass result: serving the demand and learning whether work
+    // remains are one atomic step, so no separate post-pass queue read exists to fail after a
+    // successful pass and park an unresolved transaction on the idle cadence. A publisher
+    // without the capability has no outlook to report; its passes keep the seeded cadence.
     const pass: Promise<{ reconciled: number; pendingWork: boolean }> = scheduling
       ? scheduling.reconcile()
       : (this.config.publisher.reconcileTransactions?.() ?? this.config.publisher.recover())

--- a/packages/publisher/test/async-lift-reconcile-demand.test.ts
+++ b/packages/publisher/test/async-lift-reconcile-demand.test.ts
@@ -61,7 +61,10 @@ describe('async-lift reconciliation demand channel', () => {
   }
 
   it('reports pass outcomes that track each job state: pendingWork only for unowned live transactions', async () => {
-    const publisher = createPublisher();
+    const publisher = createPublisher({
+      chainProofResolver: async () => ({ status: 'pending' }),
+      knowledgeAssetVmPublishRecoveryResolver: async () => null,
+    });
     await stageShareSnapshot();
     const reconcile = () => publisher.reconciliationScheduling.reconcile();
 
@@ -99,6 +102,32 @@ describe('async-lift reconciliation demand channel', () => {
       errorPayloadRef: `urn:dkg:test:error:${jobId}`,
     });
     expect(await reconcile()).toEqual({ reconciled: 0, pendingWork: false });
+  });
+
+  it('does not advertise a named-KA broadcast as active work when no recovery lane can move it', async () => {
+    // The degraded configuration: a persisted named-KA broadcast on a publisher with NEITHER
+    // the chain-proof resolver NOR the named recovery resolver. The record is deliberately held
+    // for safety and no pass can ever transition it — reporting it as pending would pin the
+    // scheduling caller to the active cadence (a full inventory per tick) forever. It stays
+    // eligible for the idle crash-recovery sweep and counts again once a resolver is configured.
+    const publisher = createPublisher();
+    await stageShareSnapshot();
+    const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    await publisher.claimNext('wallet-1');
+    await publisher.update(jobId, 'validated', { validation: KA_VM_VALIDATION });
+    await publisher.update(jobId, 'broadcast', {
+      broadcast: { txHash: KA_VM_EXECUTOR_TX_HASH, walletId: 'wallet-1', operationKind: 'create' },
+    });
+
+    expect(await publisher.reconciliationScheduling.reconcile()).toEqual({ reconciled: 0, pendingWork: false });
+    expect((await publisher.getStatus(jobId))?.status).toBe('broadcast');
+
+    // The same record on a resolver-equipped publisher over the same store IS active work.
+    const equipped = createPublisher({
+      chainProofResolver: async () => ({ status: 'pending' }),
+      knowledgeAssetVmPublishRecoveryResolver: async () => null,
+    });
+    expect(await equipped.reconciliationScheduling.reconcile()).toEqual({ reconciled: 0, pendingWork: true });
   });
 
   it('excludes an executor-owned detached job from pending work and pokes the listener when it settles', async () => {
@@ -145,6 +174,8 @@ describe('async-lift reconciliation demand channel', () => {
 
   it('pokes the listener for an ambiguous post-write-ahead failure only at the ownership boundary', async () => {
     const publisher = createPublisher({
+      chainProofResolver: async () => ({ status: 'pending' }),
+      knowledgeAssetVmPublishRecoveryResolver: async () => null,
       knowledgeAssetVmPublishHandler: {
         execute: async (input) => {
           await input.publishOptions.onBeforeBroadcast?.({ txHash: KA_VM_EXECUTOR_TX_HASH });
@@ -175,6 +206,8 @@ describe('async-lift reconciliation demand channel', () => {
 
   it('a stale detach from a superseded owner does not tear down the current attachment', async () => {
     const publisher = createPublisher({
+      chainProofResolver: async () => ({ status: 'pending' }),
+      knowledgeAssetVmPublishRecoveryResolver: async () => null,
       knowledgeAssetVmPublishHandler: {
         execute: async (input) => {
           await input.publishOptions.onBeforeBroadcast?.({ txHash: KA_VM_EXECUTOR_TX_HASH });
@@ -199,6 +232,8 @@ describe('async-lift reconciliation demand channel', () => {
 
   it('survives a listener that throws without touching job state', async () => {
     const publisher = createPublisher({
+      chainProofResolver: async () => ({ status: 'pending' }),
+      knowledgeAssetVmPublishRecoveryResolver: async () => null,
       knowledgeAssetVmPublishHandler: {
         execute: async (input) => {
           await input.publishOptions.onBeforeBroadcast?.({ txHash: KA_VM_EXECUTOR_TX_HASH });
@@ -281,6 +316,8 @@ describe('async-lift reconciliation demand channel', () => {
     const publisher = new TripleStoreAsyncLiftPublisher(saturatedStore, {
       now: () => ++now,
       idGenerator: () => `job-${++ids}`,
+      chainProofResolver: async () => ({ status: 'pending' }),
+      knowledgeAssetVmPublishRecoveryResolver: async () => null,
       knowledgeAssetVmPublishHandler: {
         execute: async (input) => {
           await input.publishOptions.onBeforeBroadcast?.({ txHash: KA_VM_EXECUTOR_TX_HASH });

--- a/packages/publisher/test/async-lift-reconcile-demand.test.ts
+++ b/packages/publisher/test/async-lift-reconcile-demand.test.ts
@@ -108,7 +108,7 @@ describe('async-lift reconciliation demand channel', () => {
       },
     });
     const outlookAtPoke: Promise<boolean>[] = [];
-    publisher.reconciliationScheduling.subscribeDemand(() => {
+    publisher.reconciliationScheduling.attachDemandListener(() => {
       outlookAtPoke.push(publisher.reconciliationScheduling.hasPendingWork());
     });
     await stageShareSnapshot();
@@ -145,7 +145,7 @@ describe('async-lift reconciliation demand channel', () => {
     // catch) reads false here, spends the one-shot demand on a pass that skips the job, and
     // parks it for the idle sweep.
     const outlookAtPoke: Promise<boolean>[] = [];
-    publisher.reconciliationScheduling.subscribeDemand(() => {
+    publisher.reconciliationScheduling.attachDemandListener(() => {
       outlookAtPoke.push(publisher.reconciliationScheduling.hasPendingWork());
     });
     await stageShareSnapshot();
@@ -158,7 +158,7 @@ describe('async-lift reconciliation demand channel', () => {
     expect(await publisher.reconciliationScheduling.hasPendingWork()).toBe(true);
   });
 
-  it('a stale unsubscribe from a replaced listener does not tear down the current subscription', async () => {
+  it('a stale detach from a superseded owner does not tear down the current attachment', async () => {
     const publisher = createPublisher({
       knowledgeAssetVmPublishHandler: {
         execute: async (input) => {
@@ -168,11 +168,12 @@ describe('async-lift reconciliation demand channel', () => {
       },
     });
     const pokes: string[] = [];
-    const disposeReplaced = publisher.reconciliationScheduling.subscribeDemand(() => pokes.push('replaced'));
-    publisher.reconciliationScheduling.subscribeDemand(() => pokes.push('current'));
-    // A restarted runner replaced the subscription; the old incarnation's disposer firing late
-    // (e.g. from a delayed stop()) must not silence the new one.
-    disposeReplaced();
+    const detachSuperseded = publisher.reconciliationScheduling.attachDemandListener(() => pokes.push('superseded'));
+    publisher.reconciliationScheduling.attachDemandListener(() => pokes.push('current'));
+    // A new runner incarnation took over the attachment; the superseded owner's detach firing
+    // late (e.g. from a delayed stop()) must not silence the takeover — that is the handover
+    // contract of the exclusive attachment.
+    detachSuperseded();
     await stageShareSnapshot();
     await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
 
@@ -190,7 +191,7 @@ describe('async-lift reconciliation demand channel', () => {
         },
       },
     });
-    publisher.reconciliationScheduling.subscribeDemand(() => {
+    publisher.reconciliationScheduling.attachDemandListener(() => {
       throw new Error('scheduler exploded');
     });
     await stageShareSnapshot();
@@ -236,6 +237,55 @@ describe('async-lift reconciliation demand channel', () => {
     expect(asked.length).toBe(3);
     expect(new Set(asked).size).toBe(3);
     expect(new Set(asked)).toEqual(new Set(txHashes));
+  });
+
+  it('suppresses pending work and reconciliation while processNext still owns a live broadcast', async () => {
+    let releaseExecutor!: () => void;
+    const executorGate = new Promise<void>((resolve) => { releaseExecutor = resolve; });
+    let broadcastPersisted!: () => void;
+    const broadcastReady = new Promise<void>((resolve) => { broadcastPersisted = resolve; });
+    const resolverAsks: string[] = [];
+    const publisher = createPublisher({
+      chainProofResolver: async (lookup) => {
+        resolverAsks.push((lookup as { txHash?: string }).txHash ?? 'unknown');
+        return { status: 'pending' };
+      },
+      knowledgeAssetVmPublishRecoveryResolver: async () => null,
+      knowledgeAssetVmPublishHandler: {
+        execute: async (input) => {
+          await input.publishOptions.onBeforeBroadcast?.({ txHash: KA_VM_EXECUTOR_TX_HASH });
+          broadcastPersisted();
+          await executorGate;
+          throw new Error('socket hang up mid-send');
+        },
+      },
+    });
+    const outlookAtPoke: Promise<boolean>[] = [];
+    publisher.reconciliationScheduling.attachDemandListener(() => {
+      outlookAtPoke.push(publisher.reconciliationScheduling.hasPendingWork());
+    });
+    await stageShareSnapshot();
+    await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+
+    const processing = publisher.processNext('wallet-1');
+    await broadcastReady;
+    // r2-3 (🟡 3872744759) — the third conjunct of the actionability rule: the job is durably
+    // 'broadcast' but processNext still owns it, so it is not pending, no demand has fired, and
+    // a reconcile pass running NOW must not spend a chain read on it.
+    expect(await publisher.reconciliationScheduling.hasPendingWork()).toBe(false);
+    expect(await publisher.reconcileTransactions()).toBe(0);
+    expect(resolverAsks).toHaveLength(0);
+    expect(outlookAtPoke).toHaveLength(0);
+
+    releaseExecutor();
+    const processed = await processing;
+    expect(processed?.status).toBe('broadcast');
+    // Ownership released at the boundary: the poke fired with the work already visible, and a
+    // pass now reaches the chain-proof resolver for this job.
+    expect(outlookAtPoke).toHaveLength(1);
+    await expect(outlookAtPoke[0]).resolves.toBe(true);
+    await publisher.reconcileTransactions();
+    expect(resolverAsks).toEqual([KA_VM_EXECUTOR_TX_HASH]);
   });
 
   it('finalizes a detached publish through the demand channel alone, one send, with the idle sweep parked', async () => {

--- a/packages/publisher/test/async-lift-reconcile-demand.test.ts
+++ b/packages/publisher/test/async-lift-reconcile-demand.test.ts
@@ -25,10 +25,13 @@ import {
 } from '../src/async-lift-control-plane.js';
 import {
   KA_VM_EXECUTOR_TX_HASH,
+  KA_VM_KA_UAL,
   KA_VM_VALIDATION,
   kaVmPublishRequest,
   stageKnowledgeAssetShareSnapshot,
 } from './_helpers/ka-vm-publish.js';
+import { seedLegacyRawLiftTestJob } from './_helpers/legacy-raw-lift.js';
+import { GRAPH_KA_CONTENT_SCOPE_VERSION } from '@origintrail-official/dkg-core';
 
 describe('async-lift reconciliation demand channel', () => {
   let now = 1_000;
@@ -343,6 +346,52 @@ describe('async-lift reconciliation demand channel', () => {
     expect(outcome).toEqual({ reconciled: 1, pendingWork: true });
     expect((await publisher.getStatus(jobA))?.status).toBe('finalized');
     expect((await publisher.getStatus(jobB))?.status).toBe('broadcast');
+  });
+
+  it('hands a job the pass itself just failed to the same pass dispatcher, not the idle sweep', async () => {
+    // A live job can transition INTO the held-failed state during the pass (here: the raw
+    // lane's inconclusive-recovery timeout). The failed-job dispatcher runs in the same pass
+    // and must see that transition — through the shared snapshot it would keep the wallet
+    // parked until the idle sweep, which the per-lane inventories it replaced never did.
+    const resolverAsks: string[] = [];
+    const publisher = createPublisher({
+      recoveryLookupTimeoutMs: 1_000,
+      chainProofResolver: async (lookup) => {
+        resolverAsks.push((lookup as { txHash?: string }).txHash ?? 'unknown');
+        return { status: 'pending' };
+      },
+      knowledgeAssetVmPublishRecoveryResolver: async () => null,
+    });
+    await stageShareSnapshot();
+    const jobId = await seedLegacyRawLiftTestJob(store, {
+      swmId: 'swm-1',
+      namespace: 'default',
+      contextGraphId: 'music-social',
+      shareOperationId: 'share-op-1',
+      roots: [],
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: KA_VM_KA_UAL,
+      assertionVersion: '1',
+      publicTripleCount: 2,
+      privateTripleCount: 0,
+      scope: 'full',
+      transitionType: 'CREATE',
+      authority: { type: 'owner', proofRef: 'proof:owner:1' },
+    }, { now: () => ++now, idGenerator: () => `raw-job-${++ids}` });
+    await publisher.claimNext('wallet-raw');
+    await publisher.update(jobId, 'validated', { validation: KA_VM_VALIDATION });
+    await publisher.update(jobId, 'broadcast', {
+      broadcast: { txHash: KA_VM_EXECUTOR_TX_HASH, walletId: 'wallet-raw', operationKind: 'create' },
+    });
+    // Sail past the inconclusive-recovery window so the live lane fails the job THIS pass.
+    now += 5_000;
+
+    const outcome = await publisher.reconciliationScheduling.reconcile();
+    expect((await publisher.getStatus(jobId))?.status).toBe('failed');
+    expect(outcome).toEqual({ reconciled: 1, pendingWork: false });
+    // Two chain reads in ONE pass: the live lane's probe that timed the job out, then the
+    // dispatcher's proof-first turn for the freshly held job.
+    expect(resolverAsks).toEqual([KA_VM_EXECUTOR_TX_HASH, KA_VM_EXECUTOR_TX_HASH]);
   });
 
   it('runs exactly one queue inventory per reconcile pass across all three lanes', async () => {

--- a/packages/publisher/test/async-lift-reconcile-demand.test.ts
+++ b/packages/publisher/test/async-lift-reconcile-demand.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Demand-driven transaction reconciliation (10.0.14 async-publisher slowdown fix).
+ *
+ * Detached receipt reconciliation (#2310) moved finalization and wallet release of an
+ * RPC-accepted publish onto `reconcileTransactions()`, which used to run only on the idle
+ * `recoveryIntervalMs` sweep — so a successful transaction waited out up to several 60s windows
+ * after its receipt task settled. These tests pin the demand channel that closes that gap:
+ * the publisher pokes a listener at the moments a tx-bearing job stops being executor-owned,
+ * reports whether unresolved chain questions remain, and rotates the live reconcile walk so a
+ * budget-truncated pass cannot starve the tail. The end-to-end rows run a real runner with the
+ * idle sweep effectively disabled (10-minute interval): finalization can then only happen
+ * through the demand channel, which is exactly the property the fix must hold.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { GraphManager, OxigraphStore } from '@origintrail-official/dkg-storage';
+import {
+  AsyncLiftRunner,
+  TripleStoreAsyncLiftPublisher,
+  type AsyncLiftPublisherConfig,
+} from '../src/index.js';
+import {
+  CONTROL_LOCKED_JOB,
+  DEFAULT_WALLET_LOCK_GRAPH_URI,
+  walletLockSubject,
+} from '../src/async-lift-control-plane.js';
+import {
+  KA_VM_EXECUTOR_TX_HASH,
+  KA_VM_VALIDATION,
+  kaVmPublishRequest,
+  stageKnowledgeAssetShareSnapshot,
+} from './_helpers/ka-vm-publish.js';
+
+async function waitFor(assertion: () => void, timeout = 5000): Promise<void> {
+  const start = Date.now();
+  while (true) {
+    try {
+      assertion();
+      return;
+    } catch (e) {
+      if (Date.now() - start > timeout) throw e;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+  }
+}
+
+describe('async-lift reconciliation demand channel', () => {
+  let now = 1_000;
+  let ids = 0;
+  let store: OxigraphStore;
+  let graphManager: GraphManager;
+
+  beforeEach(() => {
+    now = 1_000;
+    ids = 0;
+    store = new OxigraphStore();
+    graphManager = new GraphManager(store);
+  });
+
+  function createPublisher(
+    config: Omit<AsyncLiftPublisherConfig, 'now' | 'idGenerator'> = {},
+  ): TripleStoreAsyncLiftPublisher {
+    return new TripleStoreAsyncLiftPublisher(store, {
+      now: () => ++now,
+      idGenerator: () => `job-${++ids}`,
+      ...config,
+    });
+  }
+
+  async function stageShareSnapshot(): Promise<void> {
+    await stageKnowledgeAssetShareSnapshot({ store, graphManager });
+  }
+
+  it('reports pending transaction reconciliation exactly while an unowned tx-bearing job exists', async () => {
+    const publisher = createPublisher();
+    await stageShareSnapshot();
+
+    expect(await publisher.hasPendingTransactionReconciliation()).toBe(false);
+
+    const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    expect(await publisher.hasPendingTransactionReconciliation()).toBe(false);
+
+    await publisher.claimNext('wallet-1');
+    await publisher.update(jobId, 'validated', { validation: KA_VM_VALIDATION });
+    expect(await publisher.hasPendingTransactionReconciliation()).toBe(false);
+
+    await publisher.update(jobId, 'broadcast', {
+      broadcast: { txHash: KA_VM_EXECUTOR_TX_HASH, walletId: 'wallet-1', operationKind: 'create' },
+    });
+    expect(await publisher.hasPendingTransactionReconciliation()).toBe(true);
+
+    await publisher.update(jobId, 'included', {
+      broadcast: { txHash: KA_VM_EXECUTOR_TX_HASH, walletId: 'wallet-1' },
+      inclusion: { txHash: KA_VM_EXECUTOR_TX_HASH, blockNumber: 42 },
+    });
+    expect(await publisher.hasPendingTransactionReconciliation()).toBe(true);
+
+    // A held failure hands the job to the failed-job dispatcher, whose per-job due times pace
+    // themselves — it must not keep the caller on the active cadence.
+    await publisher.recordPublishFailure(jobId, {
+      error: new Error('on-chain confirmation mismatch'),
+      failedFromState: 'included',
+      errorPayloadRef: `urn:dkg:test:error:${jobId}`,
+    });
+    expect(await publisher.hasPendingTransactionReconciliation()).toBe(false);
+  });
+
+  it('excludes an executor-owned detached job from pending work and pokes the listener when it settles', async () => {
+    let releaseExecution!: () => void;
+    const executionGate = new Promise<void>((resolve) => { releaseExecution = resolve; });
+    const publisher = createPublisher({
+      detachReceiptReconciliation: true,
+      chainProofResolver: async () => ({ status: 'pending' }),
+      knowledgeAssetVmPublishRecoveryResolver: async () => null,
+      knowledgeAssetVmPublishHandler: {
+        execute: async (input) => {
+          await input.publishOptions.onBeforeBroadcast?.({ txHash: KA_VM_EXECUTOR_TX_HASH });
+          input.publishOptions.onBroadcastAccepted?.({ txHash: KA_VM_EXECUTOR_TX_HASH });
+          await executionGate;
+          throw new Error('receipt polling timed out after accepted broadcast');
+        },
+      },
+    });
+    let demandPokes = 0;
+    publisher.setReconciliationDemandListener(() => { demandPokes += 1; });
+    await stageShareSnapshot();
+    await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+
+    const processed = await publisher.processNext('wallet-1');
+    expect(processed?.status).toBe('broadcast');
+    expect(processed?.timestamps.rpcAcceptedAt).toBeDefined();
+    // The receipt task still owns the job: reconciliation would skip it, so it must not count as
+    // pending work, and RPC acceptance alone must not have poked the listener.
+    expect(await publisher.hasPendingTransactionReconciliation()).toBe(false);
+    expect(demandPokes).toBe(0);
+
+    releaseExecution();
+    await publisher.drainDetachedExecutions();
+    expect(demandPokes).toBe(1);
+    expect(await publisher.hasPendingTransactionReconciliation()).toBe(true);
+  });
+
+  it('pokes the listener when an ambiguous post-write-ahead failure leaves a live broadcast behind', async () => {
+    const publisher = createPublisher({
+      knowledgeAssetVmPublishHandler: {
+        execute: async (input) => {
+          await input.publishOptions.onBeforeBroadcast?.({ txHash: KA_VM_EXECUTOR_TX_HASH });
+          throw new Error('socket hang up mid-send');
+        },
+      },
+    });
+    let demandPokes = 0;
+    publisher.setReconciliationDemandListener(() => { demandPokes += 1; });
+    await stageShareSnapshot();
+    await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+
+    const processed = await publisher.processNext('wallet-1');
+    expect(processed?.status).toBe('broadcast');
+    expect(demandPokes).toBe(1);
+    expect(await publisher.hasPendingTransactionReconciliation()).toBe(true);
+  });
+
+  it('survives a listener that throws without touching job state', async () => {
+    const publisher = createPublisher({
+      knowledgeAssetVmPublishHandler: {
+        execute: async (input) => {
+          await input.publishOptions.onBeforeBroadcast?.({ txHash: KA_VM_EXECUTOR_TX_HASH });
+          throw new Error('socket hang up mid-send');
+        },
+      },
+    });
+    publisher.setReconciliationDemandListener(() => {
+      throw new Error('scheduler exploded');
+    });
+    await stageShareSnapshot();
+    await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+
+    const processed = await publisher.processNext('wallet-1');
+    expect(processed?.status).toBe('broadcast');
+    expect(await publisher.hasPendingTransactionReconciliation()).toBe(true);
+  });
+
+  it('rotates the live reconcile walk so a budget-truncated pass cannot starve the tail', async () => {
+    const asked: string[] = [];
+    const publisher = createPublisher({
+      chainProofDispatchTimeBudgetMs: 5,
+      // Never settles: every pass spends its whole budget on the first job it asks, which is
+      // exactly the starvation shape — only the rotation lets the other jobs be reached.
+      chainProofResolver: (lookup) => {
+        asked.push((lookup as { txHash?: string }).txHash ?? 'unknown');
+        return new Promise(() => {});
+      },
+      knowledgeAssetVmPublishRecoveryResolver: async () => null,
+    });
+    await stageShareSnapshot();
+
+    const txHashes: string[] = [];
+    for (const wallet of ['wallet-1', 'wallet-2', 'wallet-3'] as const) {
+      const jobId = await publisher.enqueueKnowledgeAssetVmPublish(
+        kaVmPublishRequest({ name: `album-${wallet}` }),
+      );
+      const txHash = `0x${wallet.slice(-1).repeat(64)}`;
+      txHashes.push(txHash);
+      await publisher.claimNext(wallet);
+      await publisher.update(jobId, 'validated', { validation: KA_VM_VALIDATION });
+      await publisher.update(jobId, 'broadcast', {
+        broadcast: { txHash: txHash as `0x${string}`, walletId: wallet, operationKind: 'create' },
+      });
+    }
+
+    await publisher.reconcileTransactions();
+    await publisher.reconcileTransactions();
+    await publisher.reconcileTransactions();
+
+    expect(asked.length).toBe(3);
+    expect(new Set(asked).size).toBe(3);
+    expect(new Set(asked)).toEqual(new Set(txHashes));
+  });
+
+  it('finalizes a detached publish through the demand channel alone, one send, with the idle sweep parked', async () => {
+    const executions: string[] = [];
+    let proofAsks = 0;
+    const publisher = createPublisher({
+      detachReceiptReconciliation: true,
+      // The first ask answers 'pending' (receipt not yet provable), later asks answer
+      // 'recovered' — so finalization needs BOTH the settle poke and the active re-check
+      // cadence, never the parked idle sweep.
+      chainProofResolver: async () => {
+        proofAsks += 1;
+        if (proofAsks < 2) return { status: 'pending' };
+        return { status: 'recovered', recovery: { txHash: KA_VM_EXECUTOR_TX_HASH } } as never;
+      },
+      knowledgeAssetVmPublishRecoveryResolver: async () => ({
+        inclusion: { blockNumber: 1, txHash: KA_VM_EXECUTOR_TX_HASH },
+        finalization: { merkleRoot: `0x${'12'.repeat(32)}` },
+      } as never),
+      knowledgeAssetVmPublishHandler: {
+        execute: async (input) => {
+          executions.push(input.walletId);
+          await input.publishOptions.onBeforeBroadcast?.({ txHash: KA_VM_EXECUTOR_TX_HASH });
+          input.publishOptions.onBroadcastAccepted?.({ txHash: KA_VM_EXECUTOR_TX_HASH });
+          // Simulated receipt wait: settle shortly after acceptance, like a mined tx.
+          await new Promise((resolve) => setTimeout(resolve, 20));
+          throw new Error('detached executor result must not be needed for finalization');
+        },
+        finalizeRecovered: async () => {},
+      },
+    });
+    await stageShareSnapshot();
+
+    const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+
+    const runner = new AsyncLiftRunner({
+      publisher,
+      walletIds: ['wallet-1'],
+      pollIntervalMs: 5,
+      // The idle sweep is parked ten minutes out: any finalization inside this test can only
+      // have come through the demand poke plus the active re-check cadence.
+      recoveryIntervalMs: 600_000,
+      activeRecoveryIntervalMs: 10,
+      // Keep the attempt floor below the active cadence; production keeps its 1s default.
+      errorBackoffMs: 10,
+      hasIncludedRecoveryResolver: true,
+    });
+    await runner.start();
+    try {
+      const deadline = Date.now() + 15_000;
+      while ((await publisher.getStatus(jobId))?.status !== 'finalized') {
+        if (Date.now() > deadline) {
+          throw new Error(
+            `job never finalized through the demand channel (status: ${(await publisher.getStatus(jobId))?.status})`,
+          );
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+    } finally {
+      await runner.stop();
+    }
+
+    // One send, at least two proof asks (the pending answer forced the active re-check), and the
+    // wallet lock gone — chain proof released it, so the next job could claim this wallet.
+    expect(executions).toEqual(['wallet-1']);
+    expect(proofAsks).toBeGreaterThanOrEqual(2);
+    const lock = await store.query(`SELECT ?job WHERE {
+      GRAPH <${DEFAULT_WALLET_LOCK_GRAPH_URI}> {
+        <${walletLockSubject('wallet-1')}> <${CONTROL_LOCKED_JOB}> ?job .
+      }
+    }`);
+    expect(lock.type).toBe('bindings');
+    if (lock.type === 'bindings') expect(lock.bindings).toEqual([]);
+  });
+});

--- a/packages/publisher/test/async-lift-reconcile-demand.test.ts
+++ b/packages/publisher/test/async-lift-reconcile-demand.test.ts
@@ -11,7 +11,7 @@
  * idle sweep effectively disabled (10-minute interval): finalization can then only happen
  * through the demand channel, which is exactly the property the fix must hold.
  */
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { GraphManager, OxigraphStore } from '@origintrail-official/dkg-storage';
 import {
   AsyncLiftRunner,
@@ -240,6 +240,75 @@ describe('async-lift reconciliation demand channel', () => {
     expect(asked.length).toBe(3);
     expect(new Set(asked).size).toBe(3);
     expect(new Set(asked)).toEqual(new Set(txHashes));
+  });
+
+  it('demands reconciliation when an escaped fault interrupts processNext after a durable broadcast', async () => {
+    // r3 (🟡 3873024814, branarakic) — the write-ahead has durably recorded 'broadcast', then a
+    // secondary store read fails (observed production shape: transient store-scheduler
+    // saturation). processNext must still poke on its way out: ownership is released, only
+    // reconciliation can settle the job, and without the poke it waits out the idle sweep.
+    let failNextQuery = false;
+    const saturatedStore = new Proxy(store, {
+      get(target, prop, receiver) {
+        const value = Reflect.get(target, prop, receiver);
+        if (prop === 'query' && typeof value === 'function') {
+          return async (...args: unknown[]) => {
+            if (failNextQuery) {
+              failNextQuery = false;
+              throw new Error('store scheduler saturated');
+            }
+            return (value as (...a: unknown[]) => unknown).apply(target, args);
+          };
+        }
+        return typeof value === 'function' ? (value as (...a: unknown[]) => unknown).bind(target) : value;
+      },
+    }) as typeof store;
+    const publisher = new TripleStoreAsyncLiftPublisher(saturatedStore, {
+      now: () => ++now,
+      idGenerator: () => `job-${++ids}`,
+      knowledgeAssetVmPublishHandler: {
+        execute: async (input) => {
+          await input.publishOptions.onBeforeBroadcast?.({ txHash: KA_VM_EXECUTOR_TX_HASH });
+          // Arm the failure for the next store read — the ambiguous path's own job re-read —
+          // so the fault escapes process() AFTER the durable broadcast exists.
+          failNextQuery = true;
+          throw new Error('socket hang up mid-send');
+        },
+      },
+    });
+    const outlookAtPoke: Promise<boolean>[] = [];
+    publisher.reconciliationScheduling.attachDemandListener(() => {
+      outlookAtPoke.push(publisher.reconciliationScheduling.hasPendingWork());
+    });
+    await stageShareSnapshot();
+    await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+
+    await expect(publisher.processNext('wallet-1')).rejects.toThrow('store scheduler saturated');
+    expect(outlookAtPoke).toHaveLength(1);
+    // The poke fired after ownership release, with the durable broadcast visible to the pass.
+    await expect(outlookAtPoke[0]).resolves.toBe(true);
+  });
+
+  it('runs exactly one queue inventory per reconcile pass across all three lanes', async () => {
+    // r3-1 follow-up (branarakic 3873026014) — the lanes share one list() snapshot; per-tick
+    // inventory cost must not scale with the number of lanes.
+    const publisher = createPublisher({
+      chainProofResolver: async () => ({ status: 'pending' }),
+      knowledgeAssetVmPublishRecoveryResolver: async () => null,
+    });
+    await stageShareSnapshot();
+    const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    await publisher.claimNext('wallet-1');
+    await publisher.update(jobId, 'validated', { validation: KA_VM_VALIDATION });
+    await publisher.update(jobId, 'broadcast', {
+      broadcast: { txHash: KA_VM_EXECUTOR_TX_HASH, walletId: 'wallet-1', operationKind: 'create' },
+    });
+
+    const listSpy = vi.spyOn(publisher, 'list');
+    const outcome = await publisher.reconciliationScheduling.reconcile();
+    expect(outcome).toEqual({ reconciled: 0, pendingWork: true });
+    expect(listSpy).toHaveBeenCalledTimes(1);
+    listSpy.mockRestore();
   });
 
   it('suppresses pending work and reconciliation while processNext still owns a live broadcast', async () => {

--- a/packages/publisher/test/async-lift-reconcile-demand.test.ts
+++ b/packages/publisher/test/async-lift-reconcile-demand.test.ts
@@ -61,25 +61,25 @@ describe('async-lift reconciliation demand channel', () => {
     const publisher = createPublisher();
     await stageShareSnapshot();
 
-    expect(await publisher.hasPendingTransactionReconciliation()).toBe(false);
+    expect(await publisher.reconciliationScheduling.hasPendingWork()).toBe(false);
 
     const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
-    expect(await publisher.hasPendingTransactionReconciliation()).toBe(false);
+    expect(await publisher.reconciliationScheduling.hasPendingWork()).toBe(false);
 
     await publisher.claimNext('wallet-1');
     await publisher.update(jobId, 'validated', { validation: KA_VM_VALIDATION });
-    expect(await publisher.hasPendingTransactionReconciliation()).toBe(false);
+    expect(await publisher.reconciliationScheduling.hasPendingWork()).toBe(false);
 
     await publisher.update(jobId, 'broadcast', {
       broadcast: { txHash: KA_VM_EXECUTOR_TX_HASH, walletId: 'wallet-1', operationKind: 'create' },
     });
-    expect(await publisher.hasPendingTransactionReconciliation()).toBe(true);
+    expect(await publisher.reconciliationScheduling.hasPendingWork()).toBe(true);
 
     await publisher.update(jobId, 'included', {
       broadcast: { txHash: KA_VM_EXECUTOR_TX_HASH, walletId: 'wallet-1' },
       inclusion: { txHash: KA_VM_EXECUTOR_TX_HASH, blockNumber: 42 },
     });
-    expect(await publisher.hasPendingTransactionReconciliation()).toBe(true);
+    expect(await publisher.reconciliationScheduling.hasPendingWork()).toBe(true);
 
     // A held failure hands the job to the failed-job dispatcher, whose per-job due times pace
     // themselves — it must not keep the caller on the active cadence.
@@ -88,7 +88,7 @@ describe('async-lift reconciliation demand channel', () => {
       failedFromState: 'included',
       errorPayloadRef: `urn:dkg:test:error:${jobId}`,
     });
-    expect(await publisher.hasPendingTransactionReconciliation()).toBe(false);
+    expect(await publisher.reconciliationScheduling.hasPendingWork()).toBe(false);
   });
 
   it('excludes an executor-owned detached job from pending work and pokes the listener when it settles', async () => {
@@ -107,8 +107,10 @@ describe('async-lift reconciliation demand channel', () => {
         },
       },
     });
-    let demandPokes = 0;
-    publisher.setReconciliationDemandListener(() => { demandPokes += 1; });
+    const outlookAtPoke: Promise<boolean>[] = [];
+    publisher.reconciliationScheduling.subscribeDemand(() => {
+      outlookAtPoke.push(publisher.reconciliationScheduling.hasPendingWork());
+    });
     await stageShareSnapshot();
     await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
 
@@ -117,16 +119,18 @@ describe('async-lift reconciliation demand channel', () => {
     expect(processed?.timestamps.rpcAcceptedAt).toBeDefined();
     // The receipt task still owns the job: reconciliation would skip it, so it must not count as
     // pending work, and RPC acceptance alone must not have poked the listener.
-    expect(await publisher.hasPendingTransactionReconciliation()).toBe(false);
-    expect(demandPokes).toBe(0);
+    expect(await publisher.reconciliationScheduling.hasPendingWork()).toBe(false);
+    expect(outlookAtPoke).toHaveLength(0);
 
     releaseExecution();
     await publisher.drainDetachedExecutions();
-    expect(demandPokes).toBe(1);
-    expect(await publisher.hasPendingTransactionReconciliation()).toBe(true);
+    expect(outlookAtPoke).toHaveLength(1);
+    // The settle poke fires after the detached-ownership marker is cleared, so the invited pass
+    // can already act.
+    await expect(outlookAtPoke[0]).resolves.toBe(true);
   });
 
-  it('pokes the listener when an ambiguous post-write-ahead failure leaves a live broadcast behind', async () => {
+  it('pokes the listener for an ambiguous post-write-ahead failure only at the ownership boundary', async () => {
     const publisher = createPublisher({
       knowledgeAssetVmPublishHandler: {
         execute: async (input) => {
@@ -135,15 +139,46 @@ describe('async-lift reconciliation demand channel', () => {
         },
       },
     });
-    let demandPokes = 0;
-    publisher.setReconciliationDemandListener(() => { demandPokes += 1; });
+    // r1 (🔴 3872361393) — the poke must fire only once the invited pass can already act on the
+    // job. Reading the outlook FROM the listener pins that: a poke emitted while the job still
+    // held its activeProcessJobIds marker (the pre-fix placement, inside the ambiguous-broadcast
+    // catch) reads false here, spends the one-shot demand on a pass that skips the job, and
+    // parks it for the idle sweep.
+    const outlookAtPoke: Promise<boolean>[] = [];
+    publisher.reconciliationScheduling.subscribeDemand(() => {
+      outlookAtPoke.push(publisher.reconciliationScheduling.hasPendingWork());
+    });
     await stageShareSnapshot();
     await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
 
     const processed = await publisher.processNext('wallet-1');
     expect(processed?.status).toBe('broadcast');
-    expect(demandPokes).toBe(1);
-    expect(await publisher.hasPendingTransactionReconciliation()).toBe(true);
+    expect(outlookAtPoke).toHaveLength(1);
+    await expect(outlookAtPoke[0]).resolves.toBe(true);
+    expect(await publisher.reconciliationScheduling.hasPendingWork()).toBe(true);
+  });
+
+  it('a stale unsubscribe from a replaced listener does not tear down the current subscription', async () => {
+    const publisher = createPublisher({
+      knowledgeAssetVmPublishHandler: {
+        execute: async (input) => {
+          await input.publishOptions.onBeforeBroadcast?.({ txHash: KA_VM_EXECUTOR_TX_HASH });
+          throw new Error('socket hang up mid-send');
+        },
+      },
+    });
+    const pokes: string[] = [];
+    const disposeReplaced = publisher.reconciliationScheduling.subscribeDemand(() => pokes.push('replaced'));
+    publisher.reconciliationScheduling.subscribeDemand(() => pokes.push('current'));
+    // A restarted runner replaced the subscription; the old incarnation's disposer firing late
+    // (e.g. from a delayed stop()) must not silence the new one.
+    disposeReplaced();
+    await stageShareSnapshot();
+    await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+
+    const processed = await publisher.processNext('wallet-1');
+    expect(processed?.status).toBe('broadcast');
+    expect(pokes).toEqual(['current']);
   });
 
   it('survives a listener that throws without touching job state', async () => {
@@ -155,7 +190,7 @@ describe('async-lift reconciliation demand channel', () => {
         },
       },
     });
-    publisher.setReconciliationDemandListener(() => {
+    publisher.reconciliationScheduling.subscribeDemand(() => {
       throw new Error('scheduler exploded');
     });
     await stageShareSnapshot();
@@ -163,7 +198,7 @@ describe('async-lift reconciliation demand channel', () => {
 
     const processed = await publisher.processNext('wallet-1');
     expect(processed?.status).toBe('broadcast');
-    expect(await publisher.hasPendingTransactionReconciliation()).toBe(true);
+    expect(await publisher.reconciliationScheduling.hasPendingWork()).toBe(true);
   });
 
   it('rotates the live reconcile walk so a budget-truncated pass cannot starve the tail', async () => {

--- a/packages/publisher/test/async-lift-reconcile-demand.test.ts
+++ b/packages/publisher/test/async-lift-reconcile-demand.test.ts
@@ -57,29 +57,36 @@ describe('async-lift reconciliation demand channel', () => {
     await stageKnowledgeAssetShareSnapshot({ store, graphManager });
   }
 
-  it('reports pending transaction reconciliation exactly while an unowned tx-bearing job exists', async () => {
+  it('reports pass outcomes that track each job state: pendingWork only for unowned live transactions', async () => {
     const publisher = createPublisher();
     await stageShareSnapshot();
+    const reconcile = () => publisher.reconciliationScheduling.reconcile();
 
-    expect(await publisher.reconciliationScheduling.hasPendingWork()).toBe(false);
+    expect(await reconcile()).toEqual({ reconciled: 0, pendingWork: false });
 
     const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
-    expect(await publisher.reconciliationScheduling.hasPendingWork()).toBe(false);
+    expect(await reconcile()).toEqual({ reconciled: 0, pendingWork: false });
 
+    // A stranded pre-broadcast job is RESET by the pass (recover-reset lane), never pending:
+    // nothing was sent, so there is no chain question to hold a cadence for.
     await publisher.claimNext('wallet-1');
     await publisher.update(jobId, 'validated', { validation: KA_VM_VALIDATION });
-    expect(await publisher.reconciliationScheduling.hasPendingWork()).toBe(false);
+    expect(await reconcile()).toEqual({ reconciled: 1, pendingWork: false });
+    expect((await publisher.getStatus(jobId))?.status).toBe('accepted');
 
+    // Re-drive the same job to a live broadcast: now a chain question exists.
+    await publisher.claimNext('wallet-1');
+    await publisher.update(jobId, 'validated', { validation: KA_VM_VALIDATION });
     await publisher.update(jobId, 'broadcast', {
       broadcast: { txHash: KA_VM_EXECUTOR_TX_HASH, walletId: 'wallet-1', operationKind: 'create' },
     });
-    expect(await publisher.reconciliationScheduling.hasPendingWork()).toBe(true);
+    expect(await reconcile()).toEqual({ reconciled: 0, pendingWork: true });
 
     await publisher.update(jobId, 'included', {
       broadcast: { txHash: KA_VM_EXECUTOR_TX_HASH, walletId: 'wallet-1' },
       inclusion: { txHash: KA_VM_EXECUTOR_TX_HASH, blockNumber: 42 },
     });
-    expect(await publisher.reconciliationScheduling.hasPendingWork()).toBe(true);
+    expect(await reconcile()).toEqual({ reconciled: 0, pendingWork: true });
 
     // A held failure hands the job to the failed-job dispatcher, whose per-job due times pace
     // themselves — it must not keep the caller on the active cadence.
@@ -88,7 +95,7 @@ describe('async-lift reconciliation demand channel', () => {
       failedFromState: 'included',
       errorPayloadRef: `urn:dkg:test:error:${jobId}`,
     });
-    expect(await publisher.reconciliationScheduling.hasPendingWork()).toBe(false);
+    expect(await reconcile()).toEqual({ reconciled: 0, pendingWork: false });
   });
 
   it('excludes an executor-owned detached job from pending work and pokes the listener when it settles', async () => {
@@ -109,7 +116,10 @@ describe('async-lift reconciliation demand channel', () => {
     });
     const outlookAtPoke: Promise<boolean>[] = [];
     publisher.reconciliationScheduling.attachDemandListener(() => {
-      outlookAtPoke.push(publisher.reconciliationScheduling.hasPendingWork());
+      // Ground truth at poke time: an invited pass must already be able to act — it reports
+      // remaining work (or settles something) only if the announced job is visible to it.
+      outlookAtPoke.push(publisher.reconciliationScheduling.reconcile()
+        .then((outcome) => outcome.pendingWork || outcome.reconciled > 0));
     });
     await stageShareSnapshot();
     await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
@@ -117,9 +127,9 @@ describe('async-lift reconciliation demand channel', () => {
     const processed = await publisher.processNext('wallet-1');
     expect(processed?.status).toBe('broadcast');
     expect(processed?.timestamps.rpcAcceptedAt).toBeDefined();
-    // The receipt task still owns the job: reconciliation would skip it, so it must not count as
+    // The receipt task still owns the job: a pass running now must skip it and report no
     // pending work, and RPC acceptance alone must not have poked the listener.
-    expect(await publisher.reconciliationScheduling.hasPendingWork()).toBe(false);
+    expect(await publisher.reconciliationScheduling.reconcile()).toEqual({ reconciled: 0, pendingWork: false });
     expect(outlookAtPoke).toHaveLength(0);
 
     releaseExecution();
@@ -146,7 +156,10 @@ describe('async-lift reconciliation demand channel', () => {
     // parks it for the idle sweep.
     const outlookAtPoke: Promise<boolean>[] = [];
     publisher.reconciliationScheduling.attachDemandListener(() => {
-      outlookAtPoke.push(publisher.reconciliationScheduling.hasPendingWork());
+      // Ground truth at poke time: an invited pass must already be able to act — it reports
+      // remaining work (or settles something) only if the announced job is visible to it.
+      outlookAtPoke.push(publisher.reconciliationScheduling.reconcile()
+        .then((outcome) => outcome.pendingWork || outcome.reconciled > 0));
     });
     await stageShareSnapshot();
     await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
@@ -155,7 +168,6 @@ describe('async-lift reconciliation demand channel', () => {
     expect(processed?.status).toBe('broadcast');
     expect(outlookAtPoke).toHaveLength(1);
     await expect(outlookAtPoke[0]).resolves.toBe(true);
-    expect(await publisher.reconciliationScheduling.hasPendingWork()).toBe(true);
   });
 
   it('a stale detach from a superseded owner does not tear down the current attachment', async () => {
@@ -199,7 +211,7 @@ describe('async-lift reconciliation demand channel', () => {
 
     const processed = await publisher.processNext('wallet-1');
     expect(processed?.status).toBe('broadcast');
-    expect(await publisher.reconciliationScheduling.hasPendingWork()).toBe(true);
+    expect(await publisher.reconciliationScheduling.reconcile()).toEqual({ reconciled: 0, pendingWork: true });
   });
 
   it('rotates the live reconcile walk so a budget-truncated pass cannot starve the tail', async () => {
@@ -278,7 +290,10 @@ describe('async-lift reconciliation demand channel', () => {
     });
     const outlookAtPoke: Promise<boolean>[] = [];
     publisher.reconciliationScheduling.attachDemandListener(() => {
-      outlookAtPoke.push(publisher.reconciliationScheduling.hasPendingWork());
+      // Ground truth at poke time: an invited pass must already be able to act — it reports
+      // remaining work (or settles something) only if the announced job is visible to it.
+      outlookAtPoke.push(publisher.reconciliationScheduling.reconcile()
+        .then((outcome) => outcome.pendingWork || outcome.reconciled > 0));
     });
     await stageShareSnapshot();
     await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
@@ -375,7 +390,10 @@ describe('async-lift reconciliation demand channel', () => {
     });
     const outlookAtPoke: Promise<boolean>[] = [];
     publisher.reconciliationScheduling.attachDemandListener(() => {
-      outlookAtPoke.push(publisher.reconciliationScheduling.hasPendingWork());
+      // Ground truth at poke time: an invited pass must already be able to act — it reports
+      // remaining work (or settles something) only if the announced job is visible to it.
+      outlookAtPoke.push(publisher.reconciliationScheduling.reconcile()
+        .then((outcome) => outcome.pendingWork || outcome.reconciled > 0));
     });
     await stageShareSnapshot();
     await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
@@ -385,8 +403,7 @@ describe('async-lift reconciliation demand channel', () => {
     // r2-3 (🟡 3872744759) — the third conjunct of the actionability rule: the job is durably
     // 'broadcast' but processNext still owns it, so it is not pending, no demand has fired, and
     // a reconcile pass running NOW must not spend a chain read on it.
-    expect(await publisher.reconciliationScheduling.hasPendingWork()).toBe(false);
-    expect(await publisher.reconcileTransactions()).toBe(0);
+    expect(await publisher.reconciliationScheduling.reconcile()).toEqual({ reconciled: 0, pendingWork: false });
     expect(resolverAsks).toHaveLength(0);
     expect(outlookAtPoke).toHaveLength(0);
 
@@ -399,7 +416,8 @@ describe('async-lift reconciliation demand channel', () => {
     await expect(outlookAtPoke[0]).resolves.toBe(true);
     const outcome = await publisher.reconciliationScheduling.reconcile();
     expect(outcome).toEqual({ reconciled: 0, pendingWork: true });
-    expect(resolverAsks).toEqual([KA_VM_EXECUTOR_TX_HASH]);
+    // The poke-time ground-truth pass and the explicit pass above each reached the resolver.
+    expect(resolverAsks).toEqual([KA_VM_EXECUTOR_TX_HASH, KA_VM_EXECUTOR_TX_HASH]);
   });
 
   it('finalizes a detached publish through the demand channel alone, one send, with the idle sweep parked', async () => {

--- a/packages/publisher/test/async-lift-reconcile-demand.test.ts
+++ b/packages/publisher/test/async-lift-reconcile-demand.test.ts
@@ -289,6 +289,47 @@ describe('async-lift reconciliation demand channel', () => {
     await expect(outlookAtPoke[0]).resolves.toBe(true);
   });
 
+  it('reports pendingWork for the unresolved job even when the same pass settles another', async () => {
+    // A pass may both settle and leave work: settling one job must not report the queue quiet
+    // while another transaction still awaits proof.
+    const txA = `0x${'aa'.repeat(32)}` as `0x${string}`;
+    const txB = `0x${'bb'.repeat(32)}` as `0x${string}`;
+    const publisher = createPublisher({
+      chainProofResolver: async (lookup) => {
+        const txHash = (lookup as { txHash?: string }).txHash;
+        if (txHash === txA) return { status: 'recovered', recovery: { txHash: txA } } as never;
+        return { status: 'pending' };
+      },
+      knowledgeAssetVmPublishRecoveryResolver: async () => ({
+        inclusion: { blockNumber: 1, txHash: txA },
+        finalization: { merkleRoot: `0x${'12'.repeat(32)}` },
+      } as never),
+      knowledgeAssetVmPublishHandler: {
+        execute: async () => { throw new Error('executor must not run in this test'); },
+        finalizeRecovered: async () => {},
+      },
+    });
+    await stageShareSnapshot();
+
+    const jobA = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    await publisher.claimNext('wallet-a');
+    await publisher.update(jobA, 'validated', { validation: KA_VM_VALIDATION });
+    await publisher.update(jobA, 'broadcast', {
+      broadcast: { txHash: txA, walletId: 'wallet-a', operationKind: 'create' },
+    });
+    const jobB = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest({ name: 'albums-pending' }));
+    await publisher.claimNext('wallet-b');
+    await publisher.update(jobB, 'validated', { validation: KA_VM_VALIDATION });
+    await publisher.update(jobB, 'broadcast', {
+      broadcast: { txHash: txB, walletId: 'wallet-b', operationKind: 'create' },
+    });
+
+    const outcome = await publisher.reconciliationScheduling.reconcile();
+    expect(outcome).toEqual({ reconciled: 1, pendingWork: true });
+    expect((await publisher.getStatus(jobA))?.status).toBe('finalized');
+    expect((await publisher.getStatus(jobB))?.status).toBe('broadcast');
+  });
+
   it('runs exactly one queue inventory per reconcile pass across all three lanes', async () => {
     // r3-1 follow-up (branarakic 3873026014) — the lanes share one list() snapshot; per-tick
     // inventory cost must not scale with the number of lanes.

--- a/packages/publisher/test/async-lift-reconcile-demand.test.ts
+++ b/packages/publisher/test/async-lift-reconcile-demand.test.ts
@@ -348,6 +348,44 @@ describe('async-lift reconciliation demand channel', () => {
     expect((await publisher.getStatus(jobB))?.status).toBe('broadcast');
   });
 
+  it('capability startup recovery performs the real crash-recovery effects, not just the outcome shape', async () => {
+    // The runner's capability path replaced `publisher.recover()` as the production startup
+    // entry point. This row drives the REAL publisher through a REAL runner start: a crashed
+    // process left a claimed job behind an expired wallet lease, and startup must requeue the
+    // job and release the lock before wallet processing begins — a `recover()` that merely
+    // returned the outcome shape would leave the post-crash wallet locked forever.
+    const publisher = createPublisher();
+    await stageShareSnapshot();
+    const jobId = await publisher.enqueueKnowledgeAssetVmPublish(kaVmPublishRequest());
+    await publisher.claimNext('wallet-1');
+    expect((await publisher.getStatus(jobId))?.status).toBe('claimed');
+    // The "crash": nothing progresses the claim, and its 5-minute lease expires.
+    now += 6 * 60_000;
+
+    const runner = new AsyncLiftRunner({
+      publisher,
+      walletIds: ['wallet-1'],
+      pollIntervalMs: 600_000,
+      recoveryIntervalMs: 600_000,
+      // Paused start: recovery must still run in maintenance mode, before any claiming.
+      startPaused: true,
+      hasIncludedRecoveryResolver: true,
+    });
+    await runner.start();
+    try {
+      expect((await publisher.getStatus(jobId))?.status).toBe('accepted');
+      const lock = await store.query(`SELECT ?job WHERE {
+        GRAPH <${DEFAULT_WALLET_LOCK_GRAPH_URI}> {
+          <${walletLockSubject('wallet-1')}> <${CONTROL_LOCKED_JOB}> ?job .
+        }
+      }`);
+      expect(lock.type).toBe('bindings');
+      if (lock.type === 'bindings') expect(lock.bindings).toEqual([]);
+    } finally {
+      await runner.stop();
+    }
+  });
+
   it('hands a job the pass itself just failed to the same pass dispatcher, not the idle sweep', async () => {
     // A live job can transition INTO the held-failed state during the pass (here: the raw
     // lane's inconclusive-recovery timeout). The failed-job dispatcher runs in the same pass

--- a/packages/publisher/test/async-lift-reconcile-demand.test.ts
+++ b/packages/publisher/test/async-lift-reconcile-demand.test.ts
@@ -230,9 +230,12 @@ describe('async-lift reconciliation demand channel', () => {
       });
     }
 
-    await publisher.reconcileTransactions();
-    await publisher.reconcileTransactions();
-    await publisher.reconcileTransactions();
+    // Each budget-truncated pass reports its remaining work atomically in its own outcome —
+    // the probed job stays pending and the deadline-skipped tail counts as remaining too.
+    for (let pass = 0; pass < 3; pass += 1) {
+      const outcome = await publisher.reconciliationScheduling.reconcile();
+      expect(outcome).toEqual({ reconciled: 0, pendingWork: true });
+    }
 
     expect(asked.length).toBe(3);
     expect(new Set(asked).size).toBe(3);
@@ -284,7 +287,8 @@ describe('async-lift reconciliation demand channel', () => {
     // pass now reaches the chain-proof resolver for this job.
     expect(outlookAtPoke).toHaveLength(1);
     await expect(outlookAtPoke[0]).resolves.toBe(true);
-    await publisher.reconcileTransactions();
+    const outcome = await publisher.reconciliationScheduling.reconcile();
+    expect(outcome).toEqual({ reconciled: 0, pendingWork: true });
     expect(resolverAsks).toEqual([KA_VM_EXECUTOR_TX_HASH]);
   });
 
@@ -352,6 +356,8 @@ describe('async-lift reconciliation demand channel', () => {
     // wallet lock gone — chain proof released it, so the next job could claim this wallet.
     expect(executions).toEqual(['wallet-1']);
     expect(proofAsks).toBeGreaterThanOrEqual(2);
+    // The settled queue reports no remaining live work — the false polarity of the atomic outcome.
+    expect(await publisher.reconciliationScheduling.reconcile()).toEqual({ reconciled: 0, pendingWork: false });
     const lock = await store.query(`SELECT ?job WHERE {
       GRAPH <${DEFAULT_WALLET_LOCK_GRAPH_URI}> {
         <${walletLockSubject('wallet-1')}> <${CONTROL_LOCKED_JOB}> ?job .

--- a/packages/publisher/test/async-lift-reconcile-demand.test.ts
+++ b/packages/publisher/test/async-lift-reconcile-demand.test.ts
@@ -30,19 +30,6 @@ import {
   stageKnowledgeAssetShareSnapshot,
 } from './_helpers/ka-vm-publish.js';
 
-async function waitFor(assertion: () => void, timeout = 5000): Promise<void> {
-  const start = Date.now();
-  while (true) {
-    try {
-      assertion();
-      return;
-    } catch (e) {
-      if (Date.now() - start > timeout) throw e;
-      await new Promise((r) => setTimeout(r, 10));
-    }
-  }
-}
-
 describe('async-lift reconciliation demand channel', () => {
   let now = 1_000;
   let ids = 0;

--- a/packages/publisher/test/async-lift-runner.test.ts
+++ b/packages/publisher/test/async-lift-runner.test.ts
@@ -474,8 +474,12 @@ describe('AsyncLiftRunner', () => {
         reconciliationCalls += 1;
         return 0;
       },
-      setReconciliationDemandListener: (listener: () => void) => {
-        demand = listener;
+      reconciliationScheduling: {
+        subscribeDemand: (listener: () => void) => {
+          demand = listener;
+          return () => { demand = undefined; };
+        },
+        hasPendingWork: async () => false,
       },
     } as any);
     const runner = new AsyncLiftRunner({
@@ -505,8 +509,12 @@ describe('AsyncLiftRunner', () => {
         if (reconciliationCalls === 1) await firstPassGate;
         return 0;
       },
-      setReconciliationDemandListener: (listener: () => void) => {
-        demand = listener;
+      reconciliationScheduling: {
+        subscribeDemand: (listener: () => void) => {
+          demand = listener;
+          return () => {};
+        },
+        hasPendingWork: async () => false,
       },
     } as any);
     const runner = new AsyncLiftRunner({
@@ -539,7 +547,10 @@ describe('AsyncLiftRunner', () => {
         reconciliationCalls += 1;
         return 0;
       },
-      hasPendingTransactionReconciliation: async () => pending,
+      reconciliationScheduling: {
+        subscribeDemand: () => () => {},
+        hasPendingWork: async () => pending,
+      },
     } as any);
     const runner = new AsyncLiftRunner({
       publisher,
@@ -572,8 +583,12 @@ describe('AsyncLiftRunner', () => {
         reconciliationCalls += 1;
         throw new Error('reconciliation keeps failing');
       },
-      setReconciliationDemandListener: (listener: () => void) => {
-        demand = listener;
+      reconciliationScheduling: {
+        subscribeDemand: (listener: () => void) => {
+          demand = listener;
+          return () => {};
+        },
+        hasPendingWork: async () => false,
       },
     } as any);
     const runner = new AsyncLiftRunner({
@@ -599,16 +614,20 @@ describe('AsyncLiftRunner', () => {
     await runner.stop();
   });
 
-  it('ignores demand pokes after stop', async () => {
-    let demand!: () => void;
+  it('disposes the demand subscription on stop and ignores pokes from a kept listener reference', async () => {
+    let demand: (() => void) | undefined;
     let reconciliationCalls = 0;
     const publisher = createPublisher({
       reconcileTransactions: async () => {
         reconciliationCalls += 1;
         return 0;
       },
-      setReconciliationDemandListener: (listener: () => void) => {
-        demand = listener;
+      reconciliationScheduling: {
+        subscribeDemand: (listener: () => void) => {
+          demand = listener;
+          return () => { demand = undefined; };
+        },
+        hasPendingWork: async () => false,
       },
     } as any);
     const runner = new AsyncLiftRunner({
@@ -619,11 +638,52 @@ describe('AsyncLiftRunner', () => {
     });
 
     await runner.start();
+    expect(demand).toBeDefined();
+    const keptListener = demand!;
     await runner.stop();
+    // stop() disposed the subscription, so the publisher no longer holds the callback...
+    expect(demand).toBeUndefined();
     const callsAfterStop = reconciliationCalls;
-    demand();
+    // ...and even a reference someone kept anyway cannot poke the stopped runner into a pass.
+    keptListener();
     await new Promise((resolve) => setTimeout(resolve, 100));
     expect(reconciliationCalls).toBe(callsAfterStop);
+  });
+
+  it('retries a demanded pass on the error backoff after a transient failure instead of dropping the demand', async () => {
+    let demand!: () => void;
+    let reconciliationCalls = 0;
+    const errors: unknown[] = [];
+    const publisher = createPublisher({
+      reconcileTransactions: async () => {
+        reconciliationCalls += 1;
+        if (reconciliationCalls === 1) throw new Error('transient reconcile failure');
+        return 0;
+      },
+      reconciliationScheduling: {
+        subscribeDemand: (listener: () => void) => {
+          demand = listener;
+          return () => {};
+        },
+        hasPendingWork: async () => false,
+      },
+    } as any);
+    const runner = new AsyncLiftRunner({
+      publisher,
+      walletIds: ['wallet-1'],
+      pollIntervalMs: 1,
+      // Ten minutes out with a short backoff: the ONE poke below must survive the failed first
+      // pass and produce the successful second pass on the backoff floor, not at the idle sweep.
+      recoveryIntervalMs: 600_000,
+      errorBackoffMs: 10,
+      onError: (error) => { errors.push(error); },
+    });
+
+    await runner.start();
+    demand();
+    await waitFor(() => expect(reconciliationCalls).toBeGreaterThanOrEqual(2));
+    expect(errors).toHaveLength(1);
+    await runner.stop();
   });
 
   it('rejects an active recovery interval above the Node.js timer limit', () => {

--- a/packages/publisher/test/async-lift-runner.test.ts
+++ b/packages/publisher/test/async-lift-runner.test.ts
@@ -475,7 +475,7 @@ describe('AsyncLiftRunner', () => {
         return 0;
       },
       reconciliationScheduling: {
-        subscribeDemand: (listener: () => void) => {
+        attachDemandListener: (listener: () => void) => {
           demand = listener;
           return () => { demand = undefined; };
         },
@@ -510,7 +510,7 @@ describe('AsyncLiftRunner', () => {
         return 0;
       },
       reconciliationScheduling: {
-        subscribeDemand: (listener: () => void) => {
+        attachDemandListener: (listener: () => void) => {
           demand = listener;
           return () => {};
         },
@@ -548,7 +548,7 @@ describe('AsyncLiftRunner', () => {
         return 0;
       },
       reconciliationScheduling: {
-        subscribeDemand: () => () => {},
+        attachDemandListener: () => () => {},
         hasPendingWork: async () => pending,
       },
     } as any);
@@ -584,7 +584,7 @@ describe('AsyncLiftRunner', () => {
         throw new Error('reconciliation keeps failing');
       },
       reconciliationScheduling: {
-        subscribeDemand: (listener: () => void) => {
+        attachDemandListener: (listener: () => void) => {
           demand = listener;
           return () => {};
         },
@@ -623,7 +623,7 @@ describe('AsyncLiftRunner', () => {
         return 0;
       },
       reconciliationScheduling: {
-        subscribeDemand: (listener: () => void) => {
+        attachDemandListener: (listener: () => void) => {
           demand = listener;
           return () => { demand = undefined; };
         },
@@ -661,7 +661,7 @@ describe('AsyncLiftRunner', () => {
         return 0;
       },
       reconciliationScheduling: {
-        subscribeDemand: (listener: () => void) => {
+        attachDemandListener: (listener: () => void) => {
           demand = listener;
           return () => {};
         },

--- a/packages/publisher/test/async-lift-runner.test.ts
+++ b/packages/publisher/test/async-lift-runner.test.ts
@@ -479,7 +479,7 @@ describe('AsyncLiftRunner', () => {
           reconciliationCalls += 1;
           return { reconciled: 0, pendingWork: false };
         },
-        hasPendingWork: async () => false,
+        recover: async () => ({ reconciled: 0, pendingWork: false }),
       },
     } as any);
     const runner = new AsyncLiftRunner({
@@ -514,7 +514,7 @@ describe('AsyncLiftRunner', () => {
           if (reconciliationCalls === 1) await firstPassGate;
           return { reconciled: 0, pendingWork: false };
         },
-        hasPendingWork: async () => false,
+        recover: async () => ({ reconciled: 0, pendingWork: false }),
       },
     } as any);
     const runner = new AsyncLiftRunner({
@@ -549,7 +549,7 @@ describe('AsyncLiftRunner', () => {
           reconciliationCalls += 1;
           return { reconciled: 0, pendingWork: pending };
         },
-        hasPendingWork: async () => pending,
+        recover: async () => ({ reconciled: 0, pendingWork: pending }),
       },
     } as any);
     const runner = new AsyncLiftRunner({
@@ -588,7 +588,7 @@ describe('AsyncLiftRunner', () => {
           reconciliationCalls += 1;
           throw new Error('reconciliation keeps failing');
         },
-        hasPendingWork: async () => false,
+        recover: async () => ({ reconciled: 0, pendingWork: false }),
       },
     } as any);
     const runner = new AsyncLiftRunner({
@@ -627,7 +627,7 @@ describe('AsyncLiftRunner', () => {
           reconciliationCalls += 1;
           return { reconciled: 0, pendingWork: false };
         },
-        hasPendingWork: async () => false,
+        recover: async () => ({ reconciled: 0, pendingWork: false }),
       },
     } as any);
     const runner = new AsyncLiftRunner({
@@ -665,7 +665,7 @@ describe('AsyncLiftRunner', () => {
           if (reconciliationCalls === 1) throw new Error('transient reconcile failure');
           return { reconciled: 0, pendingWork: false };
         },
-        hasPendingWork: async () => false,
+        recover: async () => ({ reconciled: 0, pendingWork: false }),
       },
     } as any);
     const runner = new AsyncLiftRunner({
@@ -697,7 +697,7 @@ describe('AsyncLiftRunner', () => {
           reconciliationCalls += 1;
           return { reconciled: 0, pendingWork: true };
         },
-        hasPendingWork: async () => true,
+        recover: async () => ({ reconciled: 0, pendingWork: true }),
       },
     } as any);
     const runner = new AsyncLiftRunner({
@@ -742,7 +742,7 @@ describe('AsyncLiftRunner', () => {
           reconciliationCalls += 1;
           return { reconciled: 0, pendingWork: true };
         },
-        hasPendingWork: async () => true,
+        recover: async () => ({ reconciled: 0, pendingWork: true }),
       },
     } as any);
     const runner = new AsyncLiftRunner({
@@ -769,22 +769,63 @@ describe('AsyncLiftRunner', () => {
     }
   });
 
-  it('continues startup and scheduling when the boot-time pending probe rejects', async () => {
-    let demand!: () => void;
+
+  it('holds an explicitly configured active cadence exactly, not merely a fast one', async () => {
+    // The knob must CONTROL the delay: a runner that ignored it for any hard-coded fast
+    // cadence would pass every loose "reconciles quickly" assertion while hammering the
+    // store and chain at a rate the operator never chose.
+    vi.useFakeTimers();
+    const blockedSleeps: Array<() => void> = [];
     let reconciliationCalls = 0;
-    const errors: unknown[] = [];
     const publisher = createPublisher({
       reconciliationScheduling: {
-        attachDemandListener: (listener: () => void) => {
-          demand = listener;
-          return () => {};
+        attachDemandListener: () => () => {},
+        reconcile: async () => {
+          reconciliationCalls += 1;
+          return { reconciled: 0, pendingWork: true };
         },
+        recover: async () => ({ reconciled: 0, pendingWork: true }),
+      },
+    } as any);
+    const runner = new AsyncLiftRunner({
+      publisher,
+      walletIds: ['wallet-1'],
+      recoveryIntervalMs: 600_000,
+      activeRecoveryIntervalMs: 1_234,
+      errorBackoffMs: 1,
+      sleep: () => new Promise<void>((resolve) => { blockedSleeps.push(resolve); }),
+    });
+    try {
+      await runner.start();
+      expect(reconciliationCalls).toBe(0);
+      await vi.advanceTimersByTimeAsync(1_233);
+      expect(reconciliationCalls).toBe(0);
+      await vi.advanceTimersByTimeAsync(2);
+      expect(reconciliationCalls).toBe(1);
+      await vi.advanceTimersByTimeAsync(1_235);
+      expect(reconciliationCalls).toBe(2);
+    } finally {
+      const stopping = runner.stop();
+      blockedSleeps.forEach((resolve) => resolve());
+      await stopping;
+      vi.useRealTimers();
+    }
+  });
+
+  it('can retry start after the capability recovery pass fails once', async () => {
+    let recoverCalls = 0;
+    let reconciliationCalls = 0;
+    const publisher = createPublisher({
+      reconciliationScheduling: {
+        attachDemandListener: () => () => {},
         reconcile: async () => {
           reconciliationCalls += 1;
           return { reconciled: 0, pendingWork: false };
         },
-        hasPendingWork: async () => {
-          throw new Error('store read failed during boot probe');
+        recover: async () => {
+          recoverCalls += 1;
+          if (recoverCalls === 1) throw new Error('startup recovery failed');
+          return { reconciled: 0, pendingWork: false };
         },
       },
     } as any);
@@ -793,17 +834,13 @@ describe('AsyncLiftRunner', () => {
       walletIds: ['wallet-1'],
       pollIntervalMs: 1,
       recoveryIntervalMs: 600_000,
-      onError: (error) => { errors.push(error); },
     });
 
-    // Fail-open: the rejecting probe must neither abort startup...
-    await runner.start();
-    expect(errors).toHaveLength(1);
-    expect(reconciliationCalls).toBe(0);
-    // ...nor stop the scheduling loop that follows it.
-    demand();
-    await waitFor(() => expect(reconciliationCalls).toBeGreaterThanOrEqual(1));
+    await expect(runner.start()).rejects.toThrow('startup recovery failed');
+    await expect(runner.start()).resolves.toBeUndefined();
+    expect(recoverCalls).toBe(2);
     await runner.stop();
+    expect(reconciliationCalls).toBe(0);
   });
 
   it('rejects an active recovery interval above the Node.js timer limit', () => {

--- a/packages/publisher/test/async-lift-runner.test.ts
+++ b/packages/publisher/test/async-lift-runner.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { AsyncLiftPublisher, LiftJob } from '../src/index.js';
 import { AsyncLiftRunner } from '../src/index.js';
 
@@ -470,14 +470,14 @@ describe('AsyncLiftRunner', () => {
     let demand: (() => void) | undefined;
     let reconciliationCalls = 0;
     const publisher = createPublisher({
-      reconcileTransactions: async () => {
-        reconciliationCalls += 1;
-        return 0;
-      },
       reconciliationScheduling: {
         attachDemandListener: (listener: () => void) => {
           demand = listener;
           return () => { demand = undefined; };
+        },
+        reconcile: async () => {
+          reconciliationCalls += 1;
+          return { reconciled: 0, pendingWork: false };
         },
         hasPendingWork: async () => false,
       },
@@ -504,15 +504,15 @@ describe('AsyncLiftRunner', () => {
     const firstPassGate = new Promise<void>((resolve) => { releaseFirstPass = resolve; });
     let reconciliationCalls = 0;
     const publisher = createPublisher({
-      reconcileTransactions: async () => {
-        reconciliationCalls += 1;
-        if (reconciliationCalls === 1) await firstPassGate;
-        return 0;
-      },
       reconciliationScheduling: {
         attachDemandListener: (listener: () => void) => {
           demand = listener;
           return () => {};
+        },
+        reconcile: async () => {
+          reconciliationCalls += 1;
+          if (reconciliationCalls === 1) await firstPassGate;
+          return { reconciled: 0, pendingWork: false };
         },
         hasPendingWork: async () => false,
       },
@@ -543,12 +543,12 @@ describe('AsyncLiftRunner', () => {
     let pending = true;
     let reconciliationCalls = 0;
     const publisher = createPublisher({
-      reconcileTransactions: async () => {
-        reconciliationCalls += 1;
-        return 0;
-      },
       reconciliationScheduling: {
         attachDemandListener: () => () => {},
+        reconcile: async () => {
+          reconciliationCalls += 1;
+          return { reconciled: 0, pendingWork: pending };
+        },
         hasPendingWork: async () => pending,
       },
     } as any);
@@ -579,14 +579,14 @@ describe('AsyncLiftRunner', () => {
     let reconciliationCalls = 0;
     const errors: unknown[] = [];
     const publisher = createPublisher({
-      reconcileTransactions: async () => {
-        reconciliationCalls += 1;
-        throw new Error('reconciliation keeps failing');
-      },
       reconciliationScheduling: {
         attachDemandListener: (listener: () => void) => {
           demand = listener;
           return () => {};
+        },
+        reconcile: async () => {
+          reconciliationCalls += 1;
+          throw new Error('reconciliation keeps failing');
         },
         hasPendingWork: async () => false,
       },
@@ -618,14 +618,14 @@ describe('AsyncLiftRunner', () => {
     let demand: (() => void) | undefined;
     let reconciliationCalls = 0;
     const publisher = createPublisher({
-      reconcileTransactions: async () => {
-        reconciliationCalls += 1;
-        return 0;
-      },
       reconciliationScheduling: {
         attachDemandListener: (listener: () => void) => {
           demand = listener;
           return () => { demand = undefined; };
+        },
+        reconcile: async () => {
+          reconciliationCalls += 1;
+          return { reconciled: 0, pendingWork: false };
         },
         hasPendingWork: async () => false,
       },
@@ -655,15 +655,15 @@ describe('AsyncLiftRunner', () => {
     let reconciliationCalls = 0;
     const errors: unknown[] = [];
     const publisher = createPublisher({
-      reconcileTransactions: async () => {
-        reconciliationCalls += 1;
-        if (reconciliationCalls === 1) throw new Error('transient reconcile failure');
-        return 0;
-      },
       reconciliationScheduling: {
         attachDemandListener: (listener: () => void) => {
           demand = listener;
           return () => {};
+        },
+        reconcile: async () => {
+          reconciliationCalls += 1;
+          if (reconciliationCalls === 1) throw new Error('transient reconcile failure');
+          return { reconciled: 0, pendingWork: false };
         },
         hasPendingWork: async () => false,
       },
@@ -683,6 +683,86 @@ describe('AsyncLiftRunner', () => {
     demand();
     await waitFor(() => expect(reconciliationCalls).toBeGreaterThanOrEqual(2));
     expect(errors).toHaveLength(1);
+    await runner.stop();
+  });
+
+  it('holds the documented 5000ms default active cadence when activeRecoveryIntervalMs is unset', async () => {
+    vi.useFakeTimers();
+    const blockedSleeps: Array<() => void> = [];
+    let reconciliationCalls = 0;
+    const publisher = createPublisher({
+      reconciliationScheduling: {
+        attachDemandListener: () => () => {},
+        reconcile: async () => {
+          reconciliationCalls += 1;
+          return { reconciled: 0, pendingWork: true };
+        },
+        hasPendingWork: async () => true,
+      },
+    } as any);
+    const runner = new AsyncLiftRunner({
+      publisher,
+      walletIds: ['wallet-1'],
+      // No activeRecoveryIntervalMs: the row pins the library DEFAULT the slowdown fix relies
+      // on — a regression to a longer default would leave every override-based row green.
+      recoveryIntervalMs: 600_000,
+      errorBackoffMs: 1,
+      // Park the wallet loop without real timers: each idle turn blocks until stop.
+      sleep: () => new Promise<void>((resolve) => { blockedSleeps.push(resolve); }),
+    });
+    try {
+      await runner.start();
+      expect(reconciliationCalls).toBe(0);
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(reconciliationCalls).toBe(0);
+      await vi.advanceTimersByTimeAsync(2);
+      expect(reconciliationCalls).toBe(1);
+      // Repeats on the same default while pending work remains — the ACTIVE cadence, not the
+      // parked 600s idle sweep.
+      await vi.advanceTimersByTimeAsync(5_001);
+      expect(reconciliationCalls).toBe(2);
+    } finally {
+      const stopping = runner.stop();
+      blockedSleeps.forEach((resolve) => resolve());
+      await stopping;
+      vi.useRealTimers();
+    }
+  });
+
+  it('continues startup and scheduling when the boot-time pending probe rejects', async () => {
+    let demand!: () => void;
+    let reconciliationCalls = 0;
+    const errors: unknown[] = [];
+    const publisher = createPublisher({
+      reconciliationScheduling: {
+        attachDemandListener: (listener: () => void) => {
+          demand = listener;
+          return () => {};
+        },
+        reconcile: async () => {
+          reconciliationCalls += 1;
+          return { reconciled: 0, pendingWork: false };
+        },
+        hasPendingWork: async () => {
+          throw new Error('store read failed during boot probe');
+        },
+      },
+    } as any);
+    const runner = new AsyncLiftRunner({
+      publisher,
+      walletIds: ['wallet-1'],
+      pollIntervalMs: 1,
+      recoveryIntervalMs: 600_000,
+      onError: (error) => { errors.push(error); },
+    });
+
+    // Fail-open: the rejecting probe must neither abort startup...
+    await runner.start();
+    expect(errors).toHaveLength(1);
+    expect(reconciliationCalls).toBe(0);
+    // ...nor stop the scheduling loop that follows it.
+    demand();
+    await waitFor(() => expect(reconciliationCalls).toBeGreaterThanOrEqual(1));
     await runner.stop();
   });
 

--- a/packages/publisher/test/async-lift-runner.test.ts
+++ b/packages/publisher/test/async-lift-runner.test.ts
@@ -466,6 +466,174 @@ describe('AsyncLiftRunner', () => {
     );
   });
 
+  it('runs reconciliation promptly on a demand poke instead of waiting out the idle cadence', async () => {
+    let demand: (() => void) | undefined;
+    let reconciliationCalls = 0;
+    const publisher = createPublisher({
+      reconcileTransactions: async () => {
+        reconciliationCalls += 1;
+        return 0;
+      },
+      setReconciliationDemandListener: (listener: () => void) => {
+        demand = listener;
+      },
+    } as any);
+    const runner = new AsyncLiftRunner({
+      publisher,
+      walletIds: ['wallet-1'],
+      pollIntervalMs: 1,
+      // Ten minutes out: any pass inside this test can only have come from the poke.
+      recoveryIntervalMs: 600_000,
+    });
+
+    await runner.start();
+    expect(demand).toBeDefined();
+    expect(reconciliationCalls).toBe(0);
+    demand!();
+    await waitFor(() => expect(reconciliationCalls).toBeGreaterThanOrEqual(1));
+    await runner.stop();
+  });
+
+  it('coalesces demand pokes that arrive during an in-flight pass into one follow-up pass', async () => {
+    let demand!: () => void;
+    let releaseFirstPass!: () => void;
+    const firstPassGate = new Promise<void>((resolve) => { releaseFirstPass = resolve; });
+    let reconciliationCalls = 0;
+    const publisher = createPublisher({
+      reconcileTransactions: async () => {
+        reconciliationCalls += 1;
+        if (reconciliationCalls === 1) await firstPassGate;
+        return 0;
+      },
+      setReconciliationDemandListener: (listener: () => void) => {
+        demand = listener;
+      },
+    } as any);
+    const runner = new AsyncLiftRunner({
+      publisher,
+      walletIds: ['wallet-1'],
+      pollIntervalMs: 1,
+      recoveryIntervalMs: 600_000,
+      // Keep the attempt floor out of the way so the assertion measures coalescing, not backoff.
+      errorBackoffMs: 5,
+    });
+
+    await runner.start();
+    demand();
+    await waitFor(() => expect(reconciliationCalls).toBe(1));
+    demand();
+    demand();
+    demand();
+    releaseFirstPass();
+    await waitFor(() => expect(reconciliationCalls).toBe(2));
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(reconciliationCalls).toBe(2);
+    await runner.stop();
+  });
+
+  it('holds the active cadence while pending work remains and returns to the idle sweep when none does', async () => {
+    let pending = true;
+    let reconciliationCalls = 0;
+    const publisher = createPublisher({
+      reconcileTransactions: async () => {
+        reconciliationCalls += 1;
+        return 0;
+      },
+      hasPendingTransactionReconciliation: async () => pending,
+    } as any);
+    const runner = new AsyncLiftRunner({
+      publisher,
+      walletIds: ['wallet-1'],
+      pollIntervalMs: 1,
+      recoveryIntervalMs: 600_000,
+      activeRecoveryIntervalMs: 5,
+      // Keep the attempt floor below the active cadence so the assertion measures the cadence.
+      errorBackoffMs: 1,
+    });
+
+    await runner.start();
+    // Pending was seeded before the first schedule, so passes run on the active cadence.
+    await waitFor(() => expect(reconciliationCalls).toBeGreaterThanOrEqual(3));
+    pending = false;
+    // Let the already-due pass observe the flip, then require the cadence to go quiet.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const settledCalls = reconciliationCalls;
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(reconciliationCalls).toBe(settledCalls);
+    await runner.stop();
+  });
+
+  it('keeps the error backoff as the floor for demanded reconciliation', async () => {
+    let demand!: () => void;
+    let reconciliationCalls = 0;
+    const errors: unknown[] = [];
+    const publisher = createPublisher({
+      reconcileTransactions: async () => {
+        reconciliationCalls += 1;
+        throw new Error('reconciliation keeps failing');
+      },
+      setReconciliationDemandListener: (listener: () => void) => {
+        demand = listener;
+      },
+    } as any);
+    const runner = new AsyncLiftRunner({
+      publisher,
+      walletIds: ['wallet-1'],
+      pollIntervalMs: 1,
+      recoveryIntervalMs: 600_000,
+      errorBackoffMs: 100,
+      onError: (error) => { errors.push(error); },
+    });
+
+    await runner.start();
+    const pokeUntil = Date.now() + 250;
+    while (Date.now() < pokeUntil) {
+      demand();
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    // 250ms of continuous pokes over a 100ms floor allows the initial pass plus at most a few
+    // backed-off retries — a hot loop would have produced dozens.
+    expect(reconciliationCalls).toBeGreaterThanOrEqual(1);
+    expect(reconciliationCalls).toBeLessThanOrEqual(5);
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    await runner.stop();
+  });
+
+  it('ignores demand pokes after stop', async () => {
+    let demand!: () => void;
+    let reconciliationCalls = 0;
+    const publisher = createPublisher({
+      reconcileTransactions: async () => {
+        reconciliationCalls += 1;
+        return 0;
+      },
+      setReconciliationDemandListener: (listener: () => void) => {
+        demand = listener;
+      },
+    } as any);
+    const runner = new AsyncLiftRunner({
+      publisher,
+      walletIds: ['wallet-1'],
+      pollIntervalMs: 1,
+      recoveryIntervalMs: 600_000,
+    });
+
+    await runner.start();
+    await runner.stop();
+    const callsAfterStop = reconciliationCalls;
+    demand();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(reconciliationCalls).toBe(callsAfterStop);
+  });
+
+  it('rejects an active recovery interval above the Node.js timer limit', () => {
+    expect(() => new AsyncLiftRunner({
+      publisher: createPublisher(),
+      walletIds: ['wallet-1'],
+      activeRecoveryIntervalMs: 2_147_483_648,
+    })).toThrow(/1 through 2147483647 ms/);
+  });
+
   it('stops cleanly while idle without scheduling extra work', async () => {
     const processNextCalls: unknown[][] = [];
     const sleepCalls: unknown[][] = [];

--- a/packages/publisher/test/async-lift-runner.test.ts
+++ b/packages/publisher/test/async-lift-runner.test.ts
@@ -729,6 +729,46 @@ describe('AsyncLiftRunner', () => {
     }
   });
 
+  it('inherits an explicitly faster recoveryIntervalMs as the active cadence when the new knob is unset', async () => {
+    // A consumer that configured recoveryIntervalMs below 5s already had that pending-check
+    // rate; the new active default must not slow them down on upgrade.
+    vi.useFakeTimers();
+    const blockedSleeps: Array<() => void> = [];
+    let reconciliationCalls = 0;
+    const publisher = createPublisher({
+      reconciliationScheduling: {
+        attachDemandListener: () => () => {},
+        reconcile: async () => {
+          reconciliationCalls += 1;
+          return { reconciled: 0, pendingWork: true };
+        },
+        hasPendingWork: async () => true,
+      },
+    } as any);
+    const runner = new AsyncLiftRunner({
+      publisher,
+      walletIds: ['wallet-1'],
+      recoveryIntervalMs: 1_000,
+      errorBackoffMs: 1,
+      sleep: () => new Promise<void>((resolve) => { blockedSleeps.push(resolve); }),
+    });
+    try {
+      await runner.start();
+      expect(reconciliationCalls).toBe(0);
+      await vi.advanceTimersByTimeAsync(999);
+      expect(reconciliationCalls).toBe(0);
+      await vi.advanceTimersByTimeAsync(2);
+      expect(reconciliationCalls).toBe(1);
+      await vi.advanceTimersByTimeAsync(1_001);
+      expect(reconciliationCalls).toBe(2);
+    } finally {
+      const stopping = runner.stop();
+      blockedSleeps.forEach((resolve) => resolve());
+      await stopping;
+      vi.useRealTimers();
+    }
+  });
+
   it('continues startup and scheduling when the boot-time pending probe rejects', async () => {
     let demand!: () => void;
     let reconciliationCalls = 0;

--- a/packages/publisher/vitest.unit.config.ts
+++ b/packages/publisher/vitest.unit.config.ts
@@ -25,6 +25,8 @@ export default defineConfig({
       'test/async-lift-auto-retry-2270.test.ts',
       'test/async-lift-retry-disposition-2270.test.ts',
       'test/async-lift-chain-proof-dispatch-2270.test.ts',
+      'test/async-lift-reconcile-demand.test.ts',
+      'test/async-lift-runner.test.ts',
       'test/pre-broadcast-signal-await.test.ts',
       'test/async-lift-admission-clear-2270.test.ts',
       'test/lift-job-failure.test.ts',


### PR DESCRIPTION
## Summary

- Fixes the 10.0.14 async-publisher throughput regression: detached receipt reconciliation (#2310) made `reconcileTransactions()` the sole owner of finalization and wallet release for RPC-accepted publishes, but that pass only ran on the 60-second end-to-start recovery sweep, walking jobs sequentially under one shared 15-second budget. A successful transaction waited out one or more sweep windows **after** its receipt task settled before its wallet was released.
- Measured on an identical six-wallet SCAN campaign (480 distinct-asset publications, all finalized, 1 retry): median chain-inclusion→finalized 6.1s → 144.8s (p90 10.2s → 282.6s, max 502.4s); median same-wallet spacing 42s → 156s. Independently reproduced from the published npm artifacts (10.0.13 `9151aee8` vs 10.0.14 `780f14aa`, 50 KAs each, same three wallets, same config, back-to-back): **6.1× slower campaign wall time** (195.9s → 1192.5s), 50/50 finalized and zero retries in both, with the delay quantised to the 60s sweep — 36 of 47 same-wallet broadcast gaps inside a 63.8–68.7s band (vs ~11.5s ≈ pollIntervalMs on 10.0.13), and 70% of jobs waiting one full sweep window between broadcast and the node's observation of inclusion. The delay is pure scheduling — the wallet is already released the moment a pass obtains canonical proof. (Instrumentation note: in the node's own job timestamps the wait lands in `broadcastAt → includedAt`, because the sweep writes inclusion and finalization in one pass — `includedAt` is the node's observation, not the block time.)
- The fix adds a demand channel without changing what a pass does: a new optional `reconciliationScheduling` capability on `AsyncLiftPublisher` (`attachDemandListener` + `hasPendingWork`, one grouped capability so incoherent halves are unrepresentable; the listener attachment is explicitly EXCLUSIVE — one owner, takeover-on-attach, identity-guarded detach as the runner-incarnation handover) pokes the runner at the **ownership boundary** — the moment a tx-bearing job stops being executor-owned (detached receipt settles, or `processNext` hands back a live broadcast after an ambiguous send). The poke fires only once the invited pass can already act; reading the outlook from inside the listener pins that in tests.
- `AsyncLiftRunner` runs a poked pass immediately (coalesced; `errorBackoffMs` floor; a failed demanded pass **retains** its demand and retries on the floor), holds a new `activeRecoveryIntervalMs` cadence (default 5s, config key `publisher.activeRecoveryIntervalMs`) while the publisher reports unresolved transactions, keeps the 60s `recoveryIntervalMs` sweep for crash recovery, and disposes the demand subscription on `stop()`.
- The live reconcile walk rotates its start across passes so a budget-truncated pass cannot starve the tail; the failed-job lane (own budget, batch bound, due-time rotation) is untouched. The daemon now sinks runner errors to its log — previously they were swallowed after their backoff, making a chronically failing pass look like a slow publisher.
- Safety unchanged: wallet release still requires canonical chain proof, nothing resends on ambiguity, pass internals / transition locks / deadline semantics untouched, and reconciliation still never touches executor-owned jobs.
- Deploys with library defaults — no config or Ansible change needed. Stopgap before upgrade: lower the existing `publisher.recoveryIntervalMs` to 5–10s at the cost of idle churn.

## Related

- Follow-up to #2310 (`detachReceiptReconciliation` + configurable finality/recovery), which shipped in v10.0.14.
- Review round 1 (otReviewAgent, 3 red / 3 yellow) addressed in 48e8b501b: ownership-boundary poke, demand retained across a failed pass, behavioral error-sink test, grouped capability with `stop()` disposal, `PublisherRunnerSchedulingOptions` grouped through the CLI construction chain, standalone-path coverage.
- Review round 2 (3 yellow) addressed in d8c18387c: the attachment made explicitly exclusive (`attachDemandListener`), the runner demand state collapsed to one derived invariant (`servedDemandGeneration < demandedGeneration`), and the active-`processNext` ownership conjunct given its own discriminating coverage.
- Review round 5 (1 red + 2 yellow) addressed in 99e8b0506: explicit active cadence boundary-pinned under fake timers (1234ms), demand state collapsed to one capture-and-restore latch (closes #2358 item 2), and the capability gained `recover()` with the pass outcome so startup runs ONE inventory and `hasPendingWork` plus the boot probe are gone.
- Review round 4 (1 red + 2 yellow) addressed in 7519dd43c: active cadence never slower than an explicitly configured `recoveryIntervalMs` (min-inherit, so upgrades cannot slow an existing fast confirmation cadence), mixed-outcome pass coverage, and the PR's added comments rewritten as durable invariant documentation. @branarakic's targeted-reconciliation roadmap filed as #2359.
- Review round 3 (1 red follow-up + 5 yellow, incl. two from @branarakic with production evidence) addressed in 4f91ab615 + 83e3d80f8: the pass now returns `{ reconciled, pendingWork }` atomically (the failed-outlook-after-served-demand red has no code path left), ONE partitioned queue inventory per pass across all three lanes, a demand poke on escaped `processNext` faults, the 5000ms default cadence pinned under fake timers, and the boot probe's reported fail-open pinned. Two oscillating API-shape preferences deferred to #2358 with rationale in-thread.

## Diagrams

### Detached publish finalization and wallet release

Before:

```mermaid
sequenceDiagram
    participant Executor as Detached receipt task
    participant Publisher as Async-lift publisher
    participant Runner as AsyncLiftRunner
    participant Chain as Chain RPC
    Executor->>Publisher: RPC accepted (job parked in 'broadcast')
    Executor->>Publisher: receipt task settles (executor ownership ends)
    Note over Runner: nothing announces the work — next sweep is up to 60s away (end-to-start)
    Runner->>Publisher: reconcileTransactions() (60s idle sweep)
    Publisher->>Chain: chain-proof lookup (sequential, shared 15s budget)
    Chain-->>Publisher: canonical proof
    Publisher->>Publisher: release wallet, finalize job
    Note over Publisher: inclusion → finalized: median 144.8s, max 502s
```

After:

```mermaid
sequenceDiagram
    participant Executor as Detached receipt task
    participant Publisher as Async-lift publisher
    participant Runner as AsyncLiftRunner
    participant Chain as Chain RPC
    Executor->>Publisher: RPC accepted (job parked in 'broadcast')
    Executor->>Publisher: receipt task settles (executor ownership ends)
    Publisher->>Runner: demand poke (reconciliationScheduling.attachDemandListener)
    Runner->>Publisher: reconcileTransactions() (immediate, coalesced, errorBackoffMs floor)
    Publisher->>Chain: chain-proof lookup (rotated walk)
    alt proof still pending
        Runner->>Publisher: re-check on activeRecoveryIntervalMs (5s) while hasPendingWork()
        Publisher->>Chain: chain-proof lookup
    end
    Chain-->>Publisher: canonical proof
    Publisher->>Publisher: release wallet, finalize job
    Note over Runner: 60s recoveryIntervalMs sweep remains, for crash recovery only
```

## Files changed

| File | What |
|------|------|
| `packages/publisher/src/async-lift-publisher-types.ts` | New grouped optional `reconciliationScheduling` capability (`attachDemandListener` — exclusive attachment returning a detach, `hasPendingWork`) on `AsyncLiftPublisher` |
| `packages/publisher/src/async-lift-publisher-impl.ts` | Capability implementation; one shared `isReconciliationActionable` predicate (outlook + pass pre-filter + poke gate); demand poke at the `processNext` ownership boundary and at detached-execution settle; rotated live-lane walk |
| `packages/publisher/src/async-lift-runner.ts` | Demand subscription (disposed in `stop()`), immediate coalesced demanded passes with generation-tracked retention across failures, `activeRecoveryIntervalMs` active cadence vs `recoveryIntervalMs` idle sweep |
| `packages/publisher/test/async-lift-reconcile-demand.test.ts` | New spec: outlook polarity, ownership-boundary poke ordering (outlook read from the listener), stale-disposer no-op, throwing listener, rotation under budget truncation, end-to-end demand-channel finalization with the idle sweep parked at 600s |
| `packages/publisher/test/async-lift-runner.test.ts` | Runner rows: poke beats idle cadence, coalescing, active/idle cadence in both polarities, error-backoff floor under continuous pokes, failed-demanded-pass retention, `stop()` disposal, timer-limit validation |
| `packages/publisher/vitest.unit.config.ts` | New spec + runner spec added to the unit lane |
| `packages/cli/src/config.ts` | `publisher.activeRecoveryIntervalMs` config key + sharpened `recoveryIntervalMs` doc |
| `packages/cli/src/publisher-runner.ts` | `PublisherRunnerSchedulingOptions` (Pick of `AsyncLiftRunnerConfig`) resolved once per boundary (daemon config / standalone args) and spread intact into the runner; daemon log sink for runner errors |
| `packages/cli/test/publisher-retry-tuning-wiring-2270.test.ts` | Runner-hop seam rows: cadence knobs + behavioral log-reaching error sink, unconfigured polarity, standalone config fallback and explicit-arg precedence |
| `packages/cli/test/publisher-wallets.test.ts` + 4 more CLI specs | Call sites updated to the grouped `runnerOptions` shape |

## Test plan

- [x] `packages/publisher` unit lane (`vitest.unit.config.ts`): 30 rows across the runner + demand specs green, including the end-to-end row — with `recoveryIntervalMs` parked at 600s, a detached publish finalizes in ~0.4s purely through the demand channel, exactly one send, wallet lock gone
- [x] `packages/publisher` hardhat-backed reconciliation specs (`async-lift-publisher.test.ts`, `e2e-publisher-queue.test.ts`): 67/67 green
- [x] `packages/cli` unit lane: wiring seam spec 19/19; touched call-site specs (`knowledge-assets-1116`, `lu11`, `ack-transport`) 69/69 green
- [x] Serial solo mutants, each killed on its exact target assertion and reverted: settle-poke removed; `hasPendingWork` always-false and always-true; rotation removed; subscription registration dropped; cadence selection ignoring pending; pre-boundary poke placement; pass-start demand consumption; `stop()` without disposal; unconditional unsubscribe; no-op error sink; dropped `runnerOptions` spread
- [x] `turbo build` for publisher + cli dependency closure green
- [x] CI fully green on the pre-review head (50 checks); re-running on 48e8b501b
- [ ] Post-merge: live canary re-running the A/B driver method (50 distinct KAs over the daemon HTTP API, `run-reports/10014-publisher-perf` methodology) against a build containing this fix. Gate metrics (per @branarakic): user-visible wall-clock KA/sec, chain inclusion → wallet release p50 < 15s / p95 < 30s, same-wallet spacing back to ~pollIntervalMs (no 60s quantisation), control-plane/Oxigraph query count and latency, store queue pressure, zero duplicate nonces/publications

🤖 Generated with [Claude Code](https://claude.com/claude-code)
