### PR TITLE
Fix prefixed graph-query classification in remote stores

### DIFF
--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -21,6 +21,7 @@ import { toBlazegraphAsciiSafeNQuads } from './blazegraph-nquads.js';
 import { SPARQL_QUERY_CONTENT_TYPE, SPARQL_UPDATE_CONTENT_TYPE } from './sparql-content-types.js';
 import {
   assertQuadLiteralsMutf8Safe,
+  classifySparqlOperation,
   getMetrics,
   JAVA_WRITE_UTF_MAX_BYTES,
 } from '@origintrail-official/dkg-core';
@@ -474,9 +475,13 @@ export class BlazegraphStore implements TripleStore {
     storeOperation?: StoreOperation,
   ): Promise<QueryResult> {
     const trimmed = sparql.trim();
-    const upper = trimmed.toUpperCase();
-    const isAsk = upper.startsWith('ASK');
-    const isConstruct = upper.startsWith('CONSTRUCT') || upper.startsWith('DESCRIBE');
+    // PREFIX / BASE prologues precede the query form. Classify through the
+    // shared scanner so graph-producing queries still negotiate N-Quads
+    // instead of being sent with the SELECT/ASK JSON Accept header.
+    const operation = classifySparqlOperation(trimmed);
+    const isAsk = operation.kind === 'read' && operation.form === 'ASK';
+    const isConstruct = operation.kind === 'read'
+      && (operation.form === 'CONSTRUCT' || operation.form === 'DESCRIBE');
     return this.runStoreWork(
       storeOperation ?? (isConstruct ? 'construct' : 'query'),
       options,

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -837,9 +837,12 @@ export class SparqlHttpStore implements TripleStore {
     storeOperation?: StoreOperation,
   ): Promise<QueryResult> {
     const trimmed = sparql.trim();
-    const upper = trimmed.toUpperCase();
-    const isAsk = upper.startsWith('ASK');
-    const isConstruct = upper.startsWith('CONSTRUCT') || upper.startsWith('DESCRIBE');
+    // PREFIX / BASE prologues precede the query form. Use the shared scanner
+    // so graph-producing queries negotiate N-Quads instead of SPARQL JSON.
+    const operation = classifySparqlOperation(trimmed);
+    const isAsk = operation.kind === 'read' && operation.form === 'ASK';
+    const isConstruct = operation.kind === 'read'
+      && (operation.form === 'CONSTRUCT' || operation.form === 'DESCRIBE');
     const canonicalOperation = storeOperation ?? (isConstruct ? 'construct' : 'query');
     return this.runStoreWork(canonicalOperation, options, async (lifecycleSignal) => {
       const effectiveOptions: SparqlHttpQueryOptions = {

--- a/packages/storage/test/blazegraph.unit.test.ts
+++ b/packages/storage/test/blazegraph.unit.test.ts
@@ -242,6 +242,30 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     expect(String(init?.body)).toMatch(/^CONSTRUCT /);
   });
 
+  it.each([
+    [
+      'CONSTRUCT',
+      'BASE <http://ex.org/>\nPREFIX schema: <http://schema.org/>\nCONSTRUCT { <s> schema:name ?name } WHERE { <s> schema:name ?name }',
+    ],
+    [
+      'DESCRIBE',
+      'BASE <http://ex.org/>\nPREFIX schema: <http://schema.org/>\nDESCRIBE <s>',
+    ],
+  ])('uses an N-Quads Accept header for a BASE/PREFIX-prefixed %s query', async (
+    _form,
+    sparql,
+  ) => {
+    setFetch(async () => new Response(
+      '<http://ex.org/s> <http://schema.org/name> "Alice" .\n',
+      { status: 200, headers: { 'Content-Type': 'text/x-nquads' } },
+    ));
+    const s = new BlazegraphStore(baseUrl);
+    const result = await s.query(sparql);
+    expect(result.type).toBe('quads');
+    const headers = fetchCalls[0][1]?.headers as Record<string, string>;
+    expect(headers.Accept).toBe('text/x-nquads, application/n-quads');
+  });
+
   it('sends a server-side query deadline on SELECT and CONSTRUCT, wider than the client deadline', async () => {
     // Without a server-side bound, a client abort leaves the query executing
     // on Blazegraph indefinitely (observed on mainnet: 10-32+ min past a 30s

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -170,6 +170,40 @@ describe('SparqlHttpStore (test server)', () => {
     expect(updateReq?.contentType).toBe('application/sparql-update; charset=utf-8');
   });
 
+  it.each([
+    [
+      'CONSTRUCT',
+      'PREFIX schema: <http://schema.org/>\nCONSTRUCT { ?s schema:name ?name } WHERE { ?s schema:name ?name }',
+    ],
+    [
+      'DESCRIBE',
+      'PREFIX schema: <http://schema.org/>\nDESCRIBE ?s WHERE { ?s schema:name ?name }',
+    ],
+  ])('uses an N-Quads Accept header for a PREFIX-prefixed %s query', async (
+    _form,
+    sparql,
+  ) => {
+    const originalFetch = globalThis.fetch;
+    let accept = '';
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+      accept = ((init?.headers ?? {}) as Record<string, string>).Accept ?? '';
+      return new Response(
+        '<http://ex.org/s> <http://schema.org/name> "Alice" .\n',
+        { status: 200, headers: { 'Content-Type': 'application/n-quads' } },
+      );
+    }) as typeof fetch;
+    try {
+      const prefixedStore = new SparqlHttpStore({
+        queryEndpoint: 'http://prefixed-construct.test/query',
+      });
+      const result = await prefixedStore.query(sparql);
+      expect(result.type).toBe('quads');
+      expect(accept).toBe('application/n-quads, text/n-quads');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('rejects RDF literals above the Java MUTF-8 hard limit before update POST', async () => {
     insertedQuads.length = 0;
     await expect(store.insert([{


### PR DESCRIPTION
## Summary

- Classify SPARQL query forms after optional `BASE` and `PREFIX` prologues in the Blazegraph and generic SPARQL HTTP adapters.
- Negotiate N-Quads for prefixed `CONSTRUCT` and `DESCRIBE` queries instead of incorrectly requesting SPARQL JSON results.
- Add focused wire-level regressions for both remote adapters.

## Separation from #2302

This storage fix was extracted from #2302 so query-catalog work does not carry generic triple-store changes.

This PR intentionally does **not** add `replaceSubjects`, multi-subject deletion, catalog upsert behavior, or query-catalog persistence changes.

## Validation

- `pnpm --filter @origintrail-official/dkg-storage... run build`
- `pnpm --filter @origintrail-official/dkg-storage exec vitest run test/blazegraph.unit.test.ts test/sparql-http.test.ts` — 110/110 passed
- Remote Query Catalog smoke against the pinned native Oxigraph 0.5.8 HTTP server — a prefixed `CONSTRUCT` returned the two expected catalog quads and a prefixed `DESCRIBE` was negotiated and decoded as an RDF quad result
- `git diff --check origin/testnet-canary..HEAD`
