### PR TITLE
fix(agent): register local graphs with colliding names

### DIFF
--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -418,15 +418,6 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
   ): Promise<string | null> {
     const registrationStatus = knownRegistrationStatus
       ?? await this.getContextGraphRegistrationStatus(contextGraphId);
-    const subscription = this.subscribedContextGraphs.get(contextGraphId);
-    const currentBinding = this.contextGraphBindingState.currentBindingFor(
-      contextGraphId,
-      subscription,
-    );
-    if (currentBinding?.bindingKind === 'authoritative') {
-      return currentBinding.onChainId;
-    }
-
     const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
     const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
     const receipt = await this.store.query(
@@ -468,6 +459,20 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
         'without a durable receipt binding. Refusing to submit another transaction; recover or ' +
         'clear the original attempt after verifying its chain outcome.',
       );
+    }
+
+    // An exact receipt persisted by this registration attempt and the local
+    // registration state both outrank a subscription learned from chain
+    // discovery. Reused deployment labels can leave that subscription pointing
+    // at an older numeric slot. It remains authoritative for established or
+    // legacy graphs that do not carry an explicit local attempt state.
+    const subscription = this.subscribedContextGraphs.get(contextGraphId);
+    const currentBinding = this.contextGraphBindingState.currentBindingFor(
+      contextGraphId,
+      subscription,
+    );
+    if (currentBinding?.bindingKind === 'authoritative') {
+      return currentBinding.onChainId;
     }
     return this.getContextGraphOnChainId(contextGraphId);
   }

--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -378,6 +378,294 @@ import type { DKGAgent } from './dkg-agent.js';
 import { isCanonicalPositiveContextGraphId } from './context-graph-binding-state.js';
 
 export class ContextGraphRegistryMethods extends DKGAgentBase {
+  /** Read the local registration-state marker without choosing a binding. */
+  async getContextGraphRegistrationStatus(
+    this: DKGAgent,
+    contextGraphId: string,
+  ): Promise<string | undefined> {
+    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
+    const result = await this.store.query(
+      `SELECT DISTINCT ?status WHERE { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> ?status } }`,
+      { source: 'agent.contextGraph.registrationStatus' },
+    );
+    if (result.type !== 'bindings' || result.bindings.length === 0) return undefined;
+    const statuses = [...new Set(result.bindings
+      .map((binding) => binding['status']?.replace(/^"|"$/g, ''))
+      .filter((status): status is string => typeof status === 'string'))];
+    if (statuses.length !== 1) {
+      throw new Error(
+        `Context graph "${contextGraphId}" has conflicting registration states: ${statuses.join(', ')}`,
+      );
+    }
+    return statuses[0];
+  }
+
+  /**
+   * Registration-specific binding boundary.
+   *
+   * An explicit `unregistered` marker means this local graph is distinct even
+   * when another deployment used the same label, so historical name-hash
+   * discovery is forbidden. A durable subscription id or a receipt-stamped
+   * `_meta` id is authoritative. An interrupted attempt without either exact
+   * binding fails closed because submitting another transaction could mint an
+   * irreversible duplicate.
+   */
+  async resolveContextGraphRegistrationOnChainId(
+    this: DKGAgent,
+    contextGraphId: string,
+    knownRegistrationStatus?: string,
+  ): Promise<string | null> {
+    const registrationStatus = knownRegistrationStatus
+      ?? await this.getContextGraphRegistrationStatus(contextGraphId);
+    const subscription = this.subscribedContextGraphs.get(contextGraphId);
+    const currentBinding = this.contextGraphBindingState.currentBindingFor(
+      contextGraphId,
+      subscription,
+    );
+    if (currentBinding?.bindingKind === 'authoritative') {
+      return currentBinding.onChainId;
+    }
+
+    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
+    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
+    const receipt = await this.store.query(
+      `SELECT DISTINCT ?id ?txHash WHERE {
+        GRAPH <${cgMetaGraph}> {
+          <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId> ?id .
+          OPTIONAL { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_TX_HASH}> ?txHash }
+        }
+      }`,
+      { source: 'agent.contextGraph.registrationReceipt' },
+    );
+    if (receipt.type === 'bindings' && receipt.bindings.length > 0) {
+      const ids = [...new Set(receipt.bindings
+        .map((binding) => binding['id']?.replace(/^"|"$/g, ''))
+        .filter((id): id is string => isCanonicalPositiveContextGraphId(id)))];
+      if (ids.length > 1) {
+        throw new Error(
+          `Context graph "${contextGraphId}" has conflicting durable registration ids: ${ids.join(', ')}`,
+        );
+      }
+      const hasReceiptProvenance = receipt.bindings.some((binding) => (
+        typeof binding['txHash'] === 'string'
+        && /^"?0x[0-9a-fA-F]+"?$/.test(binding['txHash'])
+      ));
+      if (
+        ids.length === 1
+        && (registrationStatus === 'registered'
+          || registrationStatus?.startsWith('registering:') === true
+          || hasReceiptProvenance)
+      ) {
+        return ids[0];
+      }
+    }
+
+    if (registrationStatus === 'unregistered') return null;
+    if (registrationStatus?.startsWith('registering:')) {
+      throw new Error(
+        `Context graph "${contextGraphId}" has an interrupted on-chain registration attempt ` +
+        'without a durable receipt binding. Refusing to submit another transaction; recover or ' +
+        'clear the original attempt after verifying its chain outcome.',
+      );
+    }
+    return this.getContextGraphOnChainId(contextGraphId);
+  }
+
+  /** Atomically claim the single transaction-submission slot for this graph. */
+  async beginContextGraphRegistrationAttempt(
+    this: DKGAgent,
+    contextGraphId: string,
+    expectedStatus: string | undefined,
+  ): Promise<string> {
+    if (expectedStatus !== undefined && expectedStatus !== 'unregistered') {
+      throw new Error(
+        `Context graph "${contextGraphId}" cannot begin registration from state ${expectedStatus}`,
+      );
+    }
+    const cgMetaGraph = assertSafeIri(contextGraphMetaGraphUri(contextGraphId));
+    const contextGraphUri = assertSafeIri(`did:dkg:context-graph:${contextGraphId}`);
+    const attemptStatus = `registering:${randomUUID()}`;
+    const expectedPattern = expectedStatus === undefined
+      ? `FILTER NOT EXISTS { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> ?existingStatus } }`
+      : `GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> "unregistered" }`;
+    const deletePattern = expectedStatus === undefined
+      ? ''
+      : `DELETE { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> "unregistered" } }`;
+    const updated = await tryUpdateWithTouchedGraphs(
+      this.store,
+      `${deletePattern}
+       INSERT { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> ${sparqlString(attemptStatus)} } }
+       WHERE { ${expectedPattern} }`,
+      [cgMetaGraph],
+      { source: 'agent.contextGraph.registrationAttempt.begin' },
+    );
+    if (!updated) {
+      throw new Error('Context Graph registration requires atomic SPARQL UPDATE support.');
+    }
+    await this.store.flush?.({ source: 'agent.contextGraph.registrationAttempt.begin.flush' });
+    const currentStatus = await this.getContextGraphRegistrationStatus(contextGraphId);
+    if (currentStatus !== attemptStatus) {
+      throw new Error(
+        `Context graph "${contextGraphId}" registration was claimed concurrently; refusing a second transaction`,
+      );
+    }
+    return attemptStatus;
+  }
+
+  /** Persist exact post-receipt provenance before any other local projection. */
+  async persistContextGraphRegistrationReceipt(
+    this: DKGAgent,
+    contextGraphId: string,
+    attemptStatus: string,
+    onChainId: string,
+    txHash: string,
+  ): Promise<void> {
+    if (!attemptStatus.startsWith('registering:')) {
+      throw new Error(`Invalid Context Graph registration attempt state: ${attemptStatus}`);
+    }
+    if (!isCanonicalPositiveContextGraphId(onChainId)) {
+      throw new Error(`Invalid Context Graph registration receipt id: ${onChainId}`);
+    }
+    // Production EVM receipts are bytes32; the in-memory adapter intentionally
+    // appends a deterministic suffix so parallel tests can retain uniqueness.
+    if (!/^0x[0-9a-fA-F]+$/.test(txHash)) {
+      throw new Error(`Invalid Context Graph registration transaction hash: ${txHash}`);
+    }
+    const cgMetaGraph = assertSafeIri(contextGraphMetaGraphUri(contextGraphId));
+    const contextGraphUri = assertSafeIri(`did:dkg:context-graph:${contextGraphId}`);
+    const onChainIdPredicate = `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`;
+    const updated = await tryUpdateWithTouchedGraphs(
+      this.store,
+      `DELETE { GRAPH <${cgMetaGraph}> {
+         <${contextGraphUri}> <${onChainIdPredicate}> ?oldId .
+         <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_TX_HASH}> ?oldTxHash .
+       } }
+       INSERT { GRAPH <${cgMetaGraph}> {
+         <${contextGraphUri}> <${onChainIdPredicate}> ${sparqlString(onChainId)} .
+         <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_TX_HASH}> ${sparqlString(txHash.toLowerCase())} .
+       } }
+       WHERE {
+         GRAPH <${cgMetaGraph}> {
+           <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> ${sparqlString(attemptStatus)} .
+           OPTIONAL { <${contextGraphUri}> <${onChainIdPredicate}> ?oldId }
+           OPTIONAL { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_TX_HASH}> ?oldTxHash }
+         }
+       }`,
+      [cgMetaGraph],
+      { source: 'agent.contextGraph.registrationAttempt.receipt' },
+    );
+    if (!updated) {
+      throw new Error('Context Graph registration receipt persistence requires atomic SPARQL UPDATE support.');
+    }
+    await this.store.flush?.({ source: 'agent.contextGraph.registrationAttempt.receipt.flush' });
+    const recovered = await this.resolveContextGraphRegistrationOnChainId(
+      contextGraphId,
+      attemptStatus,
+    );
+    if (recovered !== onChainId) {
+      throw new Error(
+        `Context graph "${contextGraphId}" registration receipt was not durably persisted`,
+      );
+    }
+  }
+
+  /** Atomically publish the complete local binding after receipt persistence. */
+  async completeContextGraphRegistrationProjection(
+    this: DKGAgent,
+    contextGraphId: string,
+    onChainId: string,
+    nameHash: string,
+  ): Promise<void> {
+    if (!isCanonicalPositiveContextGraphId(onChainId)) {
+      throw new Error(`Invalid Context Graph registration projection id: ${onChainId}`);
+    }
+    if (!/^0x[0-9a-fA-F]{64}$/.test(nameHash)) {
+      throw new Error(`Invalid Context Graph registration name hash: ${nameHash}`);
+    }
+    const cgMetaGraph = assertSafeIri(contextGraphMetaGraphUri(contextGraphId));
+    const ontologyGraph = assertSafeIri(contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY));
+    const contextGraphUri = assertSafeIri(`did:dkg:context-graph:${contextGraphId}`);
+    const onChainIdPredicate = `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`;
+    const onChainHashPredicate = `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainHash`;
+    const updated = await tryUpdateWithTouchedGraphs(
+      this.store,
+      `DELETE {
+         GRAPH <${cgMetaGraph}> {
+           <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> ?oldStatus .
+           <${contextGraphUri}> <${onChainIdPredicate}> ?oldMetaId .
+           <${contextGraphUri}> <${onChainHashPredicate}> ?oldNameHash .
+         }
+         GRAPH <${ontologyGraph}> { <${contextGraphUri}> <${onChainIdPredicate}> ?oldOntologyId }
+       }
+       INSERT {
+         GRAPH <${cgMetaGraph}> {
+           <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> "registered" .
+           <${contextGraphUri}> <${onChainIdPredicate}> ${sparqlString(onChainId)} .
+           <${contextGraphUri}> <${onChainHashPredicate}> ${sparqlString(nameHash.toLowerCase())} .
+         }
+         GRAPH <${ontologyGraph}> { <${contextGraphUri}> <${onChainIdPredicate}> ${sparqlString(onChainId)} }
+       }
+       WHERE {
+         OPTIONAL { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> ?oldStatus } }
+         OPTIONAL { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${onChainIdPredicate}> ?oldMetaId } }
+         OPTIONAL { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${onChainHashPredicate}> ?oldNameHash } }
+         OPTIONAL { GRAPH <${ontologyGraph}> { <${contextGraphUri}> <${onChainIdPredicate}> ?oldOntologyId } }
+       }`,
+      [cgMetaGraph, ontologyGraph],
+      { source: 'agent.contextGraph.registrationAttempt.complete' },
+    );
+    if (!updated) {
+      throw new Error('Context Graph registration completion requires atomic SPARQL UPDATE support.');
+    }
+    await this.store.flush?.({ source: 'agent.contextGraph.registrationAttempt.complete.flush' });
+    const status = await this.getContextGraphRegistrationStatus(contextGraphId);
+    const resolved = await this.resolveContextGraphRegistrationOnChainId(contextGraphId, status);
+    if (status !== 'registered' || resolved !== onChainId) {
+      throw new Error(`Context graph "${contextGraphId}" registration projection did not commit`);
+    }
+  }
+
+  /** Clear a receipt only after chain truth proves that numeric slot inactive. */
+  async resetInactiveContextGraphRegistration(
+    this: DKGAgent,
+    contextGraphId: string,
+  ): Promise<void> {
+    const cgMetaGraph = assertSafeIri(contextGraphMetaGraphUri(contextGraphId));
+    const ontologyGraph = assertSafeIri(contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY));
+    const contextGraphUri = assertSafeIri(`did:dkg:context-graph:${contextGraphId}`);
+    const onChainIdPredicate = `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`;
+    const onChainHashPredicate = `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainHash`;
+    const updated = await tryUpdateWithTouchedGraphs(
+      this.store,
+      `DELETE {
+         GRAPH <${cgMetaGraph}> {
+           <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> ?oldStatus .
+           <${contextGraphUri}> <${onChainIdPredicate}> ?oldMetaId .
+           <${contextGraphUri}> <${onChainHashPredicate}> ?oldNameHash .
+           <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_TX_HASH}> ?oldTxHash .
+         }
+         GRAPH <${ontologyGraph}> { <${contextGraphUri}> <${onChainIdPredicate}> ?oldOntologyId }
+       }
+       INSERT { GRAPH <${cgMetaGraph}> {
+         <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> "unregistered"
+       } }
+       WHERE {
+         OPTIONAL { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> ?oldStatus } }
+         OPTIONAL { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${onChainIdPredicate}> ?oldMetaId } }
+         OPTIONAL { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${onChainHashPredicate}> ?oldNameHash } }
+         OPTIONAL { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_TX_HASH}> ?oldTxHash } }
+         OPTIONAL { GRAPH <${ontologyGraph}> { <${contextGraphUri}> <${onChainIdPredicate}> ?oldOntologyId } }
+       }`,
+      [cgMetaGraph, ontologyGraph],
+      { source: 'agent.contextGraph.registrationAttempt.resetInactive' },
+    );
+    if (!updated) {
+      throw new Error('Context Graph registration reset requires atomic SPARQL UPDATE support.');
+    }
+    await this.store.flush?.({ source: 'agent.contextGraph.registrationAttempt.resetInactive.flush' });
+  }
+
   /**
    * Check whether a context graph has been registered on-chain.
    */

--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -489,17 +489,26 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     const cgMetaGraph = assertSafeIri(contextGraphMetaGraphUri(contextGraphId));
     const contextGraphUri = assertSafeIri(`did:dkg:context-graph:${contextGraphId}`);
     const attemptStatus = `registering:${randomUUID()}`;
+    const onChainIdPredicate = `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`;
+    const onChainHashPredicate = `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainHash`;
     const expectedPattern = expectedStatus === undefined
       ? `FILTER NOT EXISTS { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> ?existingStatus } }`
       : `GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> "unregistered" }`;
-    const deletePattern = expectedStatus === undefined
-      ? ''
-      : `DELETE { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> "unregistered" } }`;
     const updated = await tryUpdateWithTouchedGraphs(
       this.store,
-      `${deletePattern}
+      `DELETE { GRAPH <${cgMetaGraph}> {
+         <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> "unregistered" .
+         <${contextGraphUri}> <${onChainIdPredicate}> ?oldId .
+         <${contextGraphUri}> <${onChainHashPredicate}> ?oldNameHash .
+         <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_TX_HASH}> ?oldTxHash .
+       } }
        INSERT { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> ${sparqlString(attemptStatus)} } }
-       WHERE { ${expectedPattern} }`,
+       WHERE {
+         ${expectedPattern}
+         OPTIONAL { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${onChainIdPredicate}> ?oldId } }
+         OPTIONAL { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${onChainHashPredicate}> ?oldNameHash } }
+         OPTIONAL { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_TX_HASH}> ?oldTxHash } }
+       }`,
       [cgMetaGraph],
       { source: 'agent.contextGraph.registrationAttempt.begin' },
     );
@@ -514,6 +523,104 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
       );
     }
     return attemptStatus;
+  }
+
+  /** Persist the exact signed transaction hash before registration broadcast. */
+  async persistContextGraphRegistrationBroadcast(
+    this: DKGAgent,
+    contextGraphId: string,
+    attemptStatus: string,
+    txHash: string,
+  ): Promise<void> {
+    if (!attemptStatus.startsWith('registering:')) {
+      throw new Error(`Invalid Context Graph registration attempt state: ${attemptStatus}`);
+    }
+    if (!/^0x[0-9a-fA-F]+$/.test(txHash)) {
+      throw new Error(`Invalid Context Graph registration transaction hash: ${txHash}`);
+    }
+    const cgMetaGraph = assertSafeIri(contextGraphMetaGraphUri(contextGraphId));
+    const contextGraphUri = assertSafeIri(`did:dkg:context-graph:${contextGraphId}`);
+    const updated = await tryUpdateWithTouchedGraphs(
+      this.store,
+      `DELETE { GRAPH <${cgMetaGraph}> {
+         <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_TX_HASH}> ?oldTxHash .
+       } }
+       INSERT { GRAPH <${cgMetaGraph}> {
+         <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_TX_HASH}> ${sparqlString(txHash.toLowerCase())} .
+       } }
+       WHERE {
+         GRAPH <${cgMetaGraph}> {
+           <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> ${sparqlString(attemptStatus)} .
+           OPTIONAL { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_TX_HASH}> ?oldTxHash }
+         }
+       }`,
+      [cgMetaGraph],
+      { source: 'agent.contextGraph.registrationAttempt.broadcast' },
+    );
+    if (!updated) {
+      throw new Error('Context Graph registration broadcast persistence requires atomic SPARQL UPDATE support.');
+    }
+    await this.store.flush?.({ source: 'agent.contextGraph.registrationAttempt.broadcast.flush' });
+    const checkpoint = await this.store.query(
+      `SELECT DISTINCT ?txHash WHERE {
+        GRAPH <${cgMetaGraph}> {
+          <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> ${sparqlString(attemptStatus)} ;
+            <${DKG_ONTOLOGY.DKG_REGISTRATION_TX_HASH}> ?txHash .
+        }
+      }`,
+      { source: 'agent.contextGraph.registrationAttempt.broadcast.verify' },
+    );
+    const hashes = checkpoint.type === 'bindings'
+      ? [...new Set(checkpoint.bindings
+        .map((binding) => binding['txHash']?.replace(/^"|"$/g, '').toLowerCase())
+        .filter((hash): hash is string => typeof hash === 'string'))]
+      : [];
+    if (hashes.length !== 1 || hashes[0] !== txHash.toLowerCase()) {
+      throw new Error(
+        `Context graph "${contextGraphId}" registration broadcast was not durably checkpointed`,
+      );
+    }
+  }
+
+  /** Roll back only this exact attempt when the adapter proves no broadcast occurred. */
+  async resetUnbroadcastContextGraphRegistrationAttempt(
+    this: DKGAgent,
+    contextGraphId: string,
+    attemptStatus: string,
+  ): Promise<void> {
+    if (!attemptStatus.startsWith('registering:')) {
+      throw new Error(`Invalid Context Graph registration attempt state: ${attemptStatus}`);
+    }
+    const cgMetaGraph = assertSafeIri(contextGraphMetaGraphUri(contextGraphId));
+    const contextGraphUri = assertSafeIri(`did:dkg:context-graph:${contextGraphId}`);
+    const updated = await tryUpdateWithTouchedGraphs(
+      this.store,
+      `DELETE { GRAPH <${cgMetaGraph}> {
+         <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> ${sparqlString(attemptStatus)} .
+         <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_TX_HASH}> ?oldTxHash .
+       } }
+       INSERT { GRAPH <${cgMetaGraph}> {
+         <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> "unregistered" .
+       } }
+       WHERE {
+         GRAPH <${cgMetaGraph}> {
+           <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> ${sparqlString(attemptStatus)} .
+           OPTIONAL { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_TX_HASH}> ?oldTxHash }
+         }
+       }`,
+      [cgMetaGraph],
+      { source: 'agent.contextGraph.registrationAttempt.resetUnbroadcast' },
+    );
+    if (!updated) {
+      throw new Error('Context Graph registration pre-broadcast reset requires atomic SPARQL UPDATE support.');
+    }
+    await this.store.flush?.({ source: 'agent.contextGraph.registrationAttempt.resetUnbroadcast.flush' });
+    const status = await this.getContextGraphRegistrationStatus(contextGraphId);
+    if (status !== 'unregistered') {
+      throw new Error(
+        `Context graph "${contextGraphId}" pre-broadcast registration reset did not commit`,
+      );
+    }
   }
 
   /** Persist exact post-receipt provenance before any other local projection. */

--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -451,20 +451,10 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
       }
     }
 
-    if (registrationStatus === 'unregistered') return null;
-    if (registrationStatus?.startsWith('registering:')) {
-      throw new Error(
-        `Context graph "${contextGraphId}" has an interrupted on-chain registration attempt ` +
-        'without a durable receipt binding. Refusing to submit another transaction; recover or ' +
-        'clear the original attempt after verifying its chain outcome.',
-      );
-    }
-
-    // An exact receipt persisted by this registration attempt and the local
-    // registration state both outrank a subscription learned from chain
-    // discovery. Reused deployment labels can leave that subscription pointing
-    // at an older numeric slot. It remains authoritative for established or
-    // legacy graphs that do not carry an explicit local attempt state.
+    // An exact receipt persisted by this registration attempt outranks the
+    // durable subscription binding. The latter remains authoritative when no
+    // receipt exists: it is the canonical owner for an already admitted local
+    // graph and must be liveness-checked instead of silently re-minted.
     const subscription = this.subscribedContextGraphs.get(contextGraphId);
     const currentBinding = this.contextGraphBindingState.currentBindingFor(
       contextGraphId,
@@ -472,6 +462,15 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     );
     if (currentBinding?.bindingKind === 'authoritative') {
       return currentBinding.onChainId;
+    }
+
+    if (registrationStatus === 'unregistered') return null;
+    if (registrationStatus?.startsWith('registering:')) {
+      throw new Error(
+        `Context graph "${contextGraphId}" has an interrupted on-chain registration attempt ` +
+        'without a durable receipt binding. Refusing to submit another transaction; recover or ' +
+        'clear the original attempt after verifying its chain outcome.',
+      );
     }
     return this.getContextGraphOnChainId(contextGraphId);
   }

--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -377,6 +377,57 @@ import { DKGAgentBase } from './dkg-agent-base.js';
 import type { DKGAgent } from './dkg-agent.js';
 import { isCanonicalPositiveContextGraphId } from './context-graph-binding-state.js';
 
+const registrationFallbackQueues = new WeakMap<TripleStore, Map<string, Promise<void>>>();
+
+/** Serialize compatibility mutations for stores without server-side UPDATE. */
+async function withRegistrationFallbackLock<T>(
+  store: TripleStore,
+  contextGraphId: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  let queues = registrationFallbackQueues.get(store);
+  if (!queues) {
+    queues = new Map();
+    registrationFallbackQueues.set(store, queues);
+  }
+  const previous = queues.get(contextGraphId) ?? Promise.resolve();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  const current = previous.catch(() => {}).then(() => gate);
+  queues.set(contextGraphId, current);
+  await previous.catch(() => {});
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (queues.get(contextGraphId) === current) queues.delete(contextGraphId);
+  }
+}
+
+async function applyRegistrationFallbackMutation(
+  store: TripleStore,
+  contextGraphId: string,
+  options: {
+    before?: () => Promise<void>;
+    deletions: Array<Partial<Quad>>;
+    insertions: Quad[];
+    finalInsertions?: Quad[];
+  },
+): Promise<void> {
+  await withRegistrationFallbackLock(store, contextGraphId, async () => {
+    await options.before?.();
+    for (const pattern of options.deletions) {
+      await store.deleteByPattern(pattern);
+    }
+    if (options.insertions.length > 0) {
+      await store.insert(options.insertions);
+    }
+    if (options.finalInsertions && options.finalInsertions.length > 0) {
+      await store.insert(options.finalInsertions);
+    }
+  });
+}
+
 export class ContextGraphRegistryMethods extends DKGAgentBase {
   /** Read the local registration-state marker without choosing a binding. */
   async getContextGraphRegistrationStatus(
@@ -513,7 +564,31 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
       { source: 'agent.contextGraph.registrationAttempt.begin' },
     );
     if (!updated) {
-      throw new Error('Context Graph registration requires atomic SPARQL UPDATE support.');
+      await applyRegistrationFallbackMutation(this.store, contextGraphId, {
+        before: async () => {
+          const currentStatus = await this.getContextGraphRegistrationStatus(contextGraphId);
+          if (currentStatus !== expectedStatus) {
+            throw new Error(
+              `Context graph "${contextGraphId}" registration was claimed concurrently; refusing a second transaction`,
+            );
+          }
+        },
+        // Clear transaction provenance first. If a compatibility write fails
+        // partway through, an old ID can never be mistaken for this attempt's
+        // receipt on the next call.
+        deletions: [
+          DKG_ONTOLOGY.DKG_REGISTRATION_TX_HASH,
+          onChainIdPredicate,
+          onChainHashPredicate,
+          DKG_ONTOLOGY.DKG_REGISTRATION_STATUS,
+        ].map((predicate) => ({ graph: cgMetaGraph, subject: contextGraphUri, predicate })),
+        insertions: [{
+          graph: cgMetaGraph,
+          subject: contextGraphUri,
+          predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS,
+          object: sparqlString(attemptStatus),
+        }],
+      });
     }
     await this.store.flush?.({ source: 'agent.contextGraph.registrationAttempt.begin.flush' });
     const currentStatus = await this.getContextGraphRegistrationStatus(contextGraphId);
@@ -558,7 +633,27 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
       { source: 'agent.contextGraph.registrationAttempt.broadcast' },
     );
     if (!updated) {
-      throw new Error('Context Graph registration broadcast persistence requires atomic SPARQL UPDATE support.');
+      await applyRegistrationFallbackMutation(this.store, contextGraphId, {
+        before: async () => {
+          const currentStatus = await this.getContextGraphRegistrationStatus(contextGraphId);
+          if (currentStatus !== attemptStatus) {
+            throw new Error(
+              `Context graph "${contextGraphId}" registration attempt is no longer owned by ${attemptStatus}`,
+            );
+          }
+        },
+        deletions: [{
+          graph: cgMetaGraph,
+          subject: contextGraphUri,
+          predicate: DKG_ONTOLOGY.DKG_REGISTRATION_TX_HASH,
+        }],
+        insertions: [{
+          graph: cgMetaGraph,
+          subject: contextGraphUri,
+          predicate: DKG_ONTOLOGY.DKG_REGISTRATION_TX_HASH,
+          object: sparqlString(txHash.toLowerCase()),
+        }],
+      });
     }
     await this.store.flush?.({ source: 'agent.contextGraph.registrationAttempt.broadcast.flush' });
     const checkpoint = await this.store.query(
@@ -612,7 +707,26 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
       { source: 'agent.contextGraph.registrationAttempt.resetUnbroadcast' },
     );
     if (!updated) {
-      throw new Error('Context Graph registration pre-broadcast reset requires atomic SPARQL UPDATE support.');
+      await applyRegistrationFallbackMutation(this.store, contextGraphId, {
+        before: async () => {
+          const currentStatus = await this.getContextGraphRegistrationStatus(contextGraphId);
+          if (currentStatus !== attemptStatus) {
+            throw new Error(
+              `Context graph "${contextGraphId}" registration attempt is no longer owned by ${attemptStatus}`,
+            );
+          }
+        },
+        deletions: [
+          DKG_ONTOLOGY.DKG_REGISTRATION_TX_HASH,
+          DKG_ONTOLOGY.DKG_REGISTRATION_STATUS,
+        ].map((predicate) => ({ graph: cgMetaGraph, subject: contextGraphUri, predicate })),
+        insertions: [{
+          graph: cgMetaGraph,
+          subject: contextGraphUri,
+          predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS,
+          object: '"unregistered"',
+        }],
+      });
     }
     await this.store.flush?.({ source: 'agent.contextGraph.registrationAttempt.resetUnbroadcast.flush' });
     const status = await this.getContextGraphRegistrationStatus(contextGraphId);
@@ -666,7 +780,31 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
       { source: 'agent.contextGraph.registrationAttempt.receipt' },
     );
     if (!updated) {
-      throw new Error('Context Graph registration receipt persistence requires atomic SPARQL UPDATE support.');
+      await applyRegistrationFallbackMutation(this.store, contextGraphId, {
+        before: async () => {
+          const currentStatus = await this.getContextGraphRegistrationStatus(contextGraphId);
+          if (currentStatus !== attemptStatus) {
+            throw new Error(
+              `Context graph "${contextGraphId}" registration attempt is no longer owned by ${attemptStatus}`,
+            );
+          }
+        },
+        deletions: [
+          DKG_ONTOLOGY.DKG_REGISTRATION_TX_HASH,
+          onChainIdPredicate,
+        ].map((predicate) => ({ graph: cgMetaGraph, subject: contextGraphUri, predicate })),
+        insertions: [{
+          graph: cgMetaGraph,
+          subject: contextGraphUri,
+          predicate: DKG_ONTOLOGY.DKG_REGISTRATION_TX_HASH,
+          object: sparqlString(txHash.toLowerCase()),
+        }, {
+          graph: cgMetaGraph,
+          subject: contextGraphUri,
+          predicate: onChainIdPredicate,
+          object: sparqlString(onChainId),
+        }],
+      });
     }
     await this.store.flush?.({ source: 'agent.contextGraph.registrationAttempt.receipt.flush' });
     const recovered = await this.resolveContextGraphRegistrationOnChainId(
@@ -726,7 +864,39 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
       { source: 'agent.contextGraph.registrationAttempt.complete' },
     );
     if (!updated) {
-      throw new Error('Context Graph registration completion requires atomic SPARQL UPDATE support.');
+      await applyRegistrationFallbackMutation(this.store, contextGraphId, {
+        // The exact receipt remains present throughout this compatibility
+        // sequence. `registered` is written last, so interruption before the
+        // complete projection is retryable without another chain transaction.
+        deletions: [
+          { graph: cgMetaGraph, subject: contextGraphUri, predicate: onChainIdPredicate },
+          { graph: cgMetaGraph, subject: contextGraphUri, predicate: onChainHashPredicate },
+          { graph: ontologyGraph, subject: contextGraphUri, predicate: onChainIdPredicate },
+          { graph: cgMetaGraph, subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS },
+        ],
+        insertions: [{
+          graph: cgMetaGraph,
+          subject: contextGraphUri,
+          predicate: onChainIdPredicate,
+          object: sparqlString(onChainId),
+        }, {
+          graph: cgMetaGraph,
+          subject: contextGraphUri,
+          predicate: onChainHashPredicate,
+          object: sparqlString(nameHash.toLowerCase()),
+        }, {
+          graph: ontologyGraph,
+          subject: contextGraphUri,
+          predicate: onChainIdPredicate,
+          object: sparqlString(onChainId),
+        }],
+        finalInsertions: [{
+          graph: cgMetaGraph,
+          subject: contextGraphUri,
+          predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS,
+          object: '"registered"',
+        }],
+      });
     }
     await this.store.flush?.({ source: 'agent.contextGraph.registrationAttempt.complete.flush' });
     const status = await this.getContextGraphRegistrationStatus(contextGraphId);
@@ -771,7 +941,21 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
       { source: 'agent.contextGraph.registrationAttempt.resetInactive' },
     );
     if (!updated) {
-      throw new Error('Context Graph registration reset requires atomic SPARQL UPDATE support.');
+      await applyRegistrationFallbackMutation(this.store, contextGraphId, {
+        deletions: [
+          { graph: cgMetaGraph, subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_REGISTRATION_TX_HASH },
+          { graph: cgMetaGraph, subject: contextGraphUri, predicate: onChainIdPredicate },
+          { graph: cgMetaGraph, subject: contextGraphUri, predicate: onChainHashPredicate },
+          { graph: cgMetaGraph, subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS },
+          { graph: ontologyGraph, subject: contextGraphUri, predicate: onChainIdPredicate },
+        ],
+        insertions: [{
+          graph: cgMetaGraph,
+          subject: contextGraphUri,
+          predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS,
+          object: '"unregistered"',
+        }],
+      });
     }
     await this.store.flush?.({ source: 'agent.contextGraph.registrationAttempt.resetInactive.flush' });
   }

--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -445,7 +445,6 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
       if (
         ids.length === 1
         && (registrationStatus === 'registered'
-          || registrationStatus?.startsWith('registering:') === true
           || hasReceiptProvenance)
       ) {
         return ids[0];

--- a/packages/agent/src/dkg-agent-context-graph.ts
+++ b/packages/agent/src/dkg-agent-context-graph.ts
@@ -130,6 +130,7 @@ import {
   type QueryRequest, type QueryResponse, type QueryAccessConfig, type LookupType,
 } from '@origintrail-official/dkg-query';
 import { DKGAgentWallet, type AgentWallet } from './agent-wallet.js';
+import { isCanonicalPositiveContextGraphId } from './context-graph-binding-state.js';
 import { buildAuthoritativePublicMetaQuads } from './context-graph-public-meta-proof.js';
 
 import { ProfileManager } from './profile-manager.js';
@@ -994,7 +995,10 @@ export class ContextGraphMethods extends DKGAgentBase {
       `SELECT ?status WHERE { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> ?status } } LIMIT 1`,
       { source: 'agent.contextGraph.register.status' },
     );
-    if (statusResult.type === 'bindings' && statusResult.bindings[0]?.['status']?.replace(/^"|"$/g, '') === 'registered') {
+    const registrationStatus = statusResult.type === 'bindings'
+      ? statusResult.bindings[0]?.['status']?.replace(/^"|"$/g, '')
+      : undefined;
+    if (registrationStatus === 'registered') {
       const existingOnChainId = this.subscribedContextGraphs.get(id)?.onChainId;
       throw new Error(`Context graph "${id}" is already registered on-chain${existingOnChainId ? ` (${existingOnChainId})` : ''}`);
     }
@@ -1144,7 +1148,22 @@ export class ContextGraphMethods extends DKGAgentBase {
     // A local OnChainId triple alone is not enough — devnet restarts and
     // partial failures can leave ontology id "1" while the chain slot is
     // inactive, which would skip registration and strand publishes.
-    const existingOnChainId = await this.getContextGraphOnChainId(id);
+    // An explicit local `unregistered` marker is authoritative for this
+    // registration attempt. Do not run the historical name-hash resolver in
+    // that state: Context Graph names are not globally unique, so another
+    // deployment can legitimately have one or more on-chain graphs with the
+    // same hash. Reverse-resolving here would either adopt somebody else's
+    // numeric id or fail on an ambiguous set before this graph can register.
+    //
+    // Preserve a durable numeric subscription binding when present. That
+    // covers a process interruption after the chain receipt was persisted but
+    // before the registration-status projection was flipped.
+    const localOnChainId = this.subscribedContextGraphs.get(id)?.onChainId;
+    const existingOnChainId = registrationStatus === 'unregistered'
+      ? (localOnChainId && isCanonicalPositiveContextGraphId(localOnChainId)
+          ? localOnChainId
+          : null)
+      : await this.getContextGraphOnChainId(id);
     if (existingOnChainId) {
       let onChainLive = false;
       if (typeof this.chain.isContextGraphActiveOnChain === 'function') {

--- a/packages/agent/src/dkg-agent-context-graph.ts
+++ b/packages/agent/src/dkg-agent-context-graph.ts
@@ -854,6 +854,66 @@ export class ContextGraphMethods extends DKGAgentBase {
   }
 
   /**
+   * Complete every local and peer-visible consequence of a confirmed Context
+   * Graph registration. Fresh receipts and interrupted-receipt recovery share
+   * this path so publish preflight never treats a half-projected binding as
+   * fully registered.
+   */
+  async finalizeContextGraphRegistration(
+    this: DKGAgent,
+    id: string,
+    onChainId: string,
+    nameHash: string,
+  ): Promise<void> {
+    const ctx = createOperationContext('system');
+    const contextGraphUri = `did:dkg:context-graph:${id}`;
+    const ontologyGraph = contextGraphDataUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+
+    await this.completeContextGraphRegistrationProjection(id, onChainId, nameHash);
+    this.invalidateListContextGraphsCache();
+    this.contextGraphMetaProjection.markDirty(id);
+
+    const sub = this.subscribedContextGraphs.get(id);
+    if (sub) {
+      const next = { ...sub, onChainHash: nameHash };
+      this.bindSubscriptionOnChainId(id, next, onChainId);
+      this.setContextGraphSubscription(id, next, { persist: false });
+      this.subscribeToContextGraph(id, {
+        trackSyncScope: true,
+        syncMode: 'always-on',
+      });
+      if (!next.subscribed) {
+        this.log.info(ctx, `Subscribed to newly registered context graph "${id}"`);
+      }
+      this.persistContextGraphSubscription(id);
+    }
+
+    // Registration status is in _meta and propagates through authenticated
+    // sync. The ontology binding is also broadcast so already-subscribed peers
+    // can discover the immutable numeric slot immediately.
+    try {
+      const onChainNquad = `<${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId> "${onChainId}" <${ontologyGraph}> .`;
+      const ontologyTopic = contextGraphPublishTopic(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+      const regMsg = encodePublishRequest({
+        ual: `did:dkg:context-graph:${id}`,
+        nquads: new TextEncoder().encode(onChainNquad),
+        contextGraphId: SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
+        kas: [],
+        publisherIdentity: this.wallet.keypair.publicKey,
+        publisherAddress: '',
+        startKAId: 0,
+        endKAId: 0,
+        chainId: '',
+        publisherSignatureR: new Uint8Array(0),
+        publisherSignatureVs: new Uint8Array(0),
+      });
+      await this.gossip.publish(ontologyTopic, regMsg);
+    } catch (err) {
+      this.log.debug(ctx, `Registration gossip broadcast failed (peers may not be subscribed yet): ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  /**
    * Register an existing context graph on-chain. This is the explicit upgrade
    * step that unlocks Verifiable Memory, chain-based discovery, and economic
    * participation. Requires native gas. Direct registration also requires the
@@ -1169,7 +1229,7 @@ export class ContextGraphMethods extends DKGAgentBase {
       if (onChainLive) {
         this.log.info(ctx, `Context graph "${id}" already has on-chain ID ${existingOnChainId} — skipping chain call`);
         const recoveredNameHash = ethers.keccak256(ethers.toUtf8Bytes(id)).toLowerCase();
-        await this.completeContextGraphRegistrationProjection(
+        await this.finalizeContextGraphRegistration(
           id,
           existingOnChainId,
           recoveredNameHash,
@@ -1181,18 +1241,12 @@ export class ContextGraphMethods extends DKGAgentBase {
         ctx,
         `Context graph "${id}" has local on-chain id ${existingOnChainId} but it is not active on-chain — re-registering`,
       );
-      const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
-      await this.store.deleteByPattern({
-        graph: ontologyGraph,
-        subject: contextGraphUri,
-        predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
-      });
+      await this.resetInactiveContextGraphRegistration(id);
       const sub = this.subscribedContextGraphs.get(id);
       if (sub) {
         this.forceClearVmReconcileStateForContextGraph(id);
         this.setContextGraphSubscription(id, { ...sub, onChainId: undefined, lastReconciledOrdinal: 0 });
       }
-      await this.resetInactiveContextGraphRegistration(id);
       registrationStatus = 'unregistered';
     }
 
@@ -1432,14 +1486,37 @@ export class ContextGraphMethods extends DKGAgentBase {
       id,
       registrationStatus,
     );
-    const result = await this.registerContextGraphOnChain({
-      accessPolicy: resolvedLocalAccessPolicy,
-      publishPolicy,
-      ...(publishAuthority ? { publishAuthority } : {}),
-      ...(isPcaCurated ? { publishAuthorityAccountId } : {}),
-      participantAgents,
-      nameHash,
-    });
+    let broadcastCheckpointed = false;
+    let result: CreateOnChainContextGraphResult;
+    try {
+      result = await this.registerContextGraphOnChain({
+        accessPolicy: resolvedLocalAccessPolicy,
+        publishPolicy,
+        ...(publishAuthority ? { publishAuthority } : {}),
+        ...(isPcaCurated ? { publishAuthorityAccountId } : {}),
+        participantAgents,
+        nameHash,
+        onBroadcast: async ({ txHash }) => {
+          await this.persistContextGraphRegistrationBroadcast(
+            id,
+            registrationAttemptStatus,
+            txHash,
+          );
+          broadcastCheckpointed = true;
+        },
+      });
+    } catch (err) {
+      if (
+        !broadcastCheckpointed
+        && this.chain.contextGraphRegistrationWriteAhead === true
+      ) {
+        await this.resetUnbroadcastContextGraphRegistrationAttempt(
+          id,
+          registrationAttemptStatus,
+        );
+      }
+      throw err;
+    }
     const onChainId = result.contextGraphId.toString();
 
     // Persist the exact receipt provenance before any fallible projection
@@ -1454,60 +1531,12 @@ export class ContextGraphMethods extends DKGAgentBase {
 
     this.log.info(ctx, `Context graph "${id}" registered on-chain: ${onChainId} (nameHash=${nameHash.slice(0, 18)}…)`);
 
-    // Update _meta with registered status and the member-syncable on-chain
-    // binding.  The ontology copy remains for system-graph discovery, while
-    // the authenticated CG-local copy lets a late member learn the immutable
-    // slot from the curator's private `_meta` snapshot.  A private joiner may
-    // have missed the one-shot ontology gossip emitted below and must not be
-    // left unable to start chain-driven VM reconciliation as a result.
-    await this.completeContextGraphRegistrationProjection(id, onChainId, nameHash);
-    this.invalidateListContextGraphsCache();
-    this.contextGraphMetaProjection.markDirty(id);
+    await this.finalizeContextGraphRegistration(id, onChainId, nameHash);
     // We no longer persist `publishAuthorityAccountId` locally even on
     // success (Codex PR #502 round-6 follow-through): with the
     // stored-value fallback gone, nothing reads it. A CG can only
     // register on-chain once anyway — re-reads of the stored id
     // wouldn't be useful.
-
-    // Update in-memory subscription record and ensure we're subscribed
-    const sub = this.subscribedContextGraphs.get(id);
-    if (sub) {
-      const next = { ...sub, onChainHash: nameHash };
-      this.bindSubscriptionOnChainId(id, next, onChainId);
-      this.setContextGraphSubscription(id, next, { persist: false });
-      this.subscribeToContextGraph(id, {
-        trackSyncScope: true,
-        syncMode: 'always-on',
-      });
-      if (!next.subscribed) {
-        this.log.info(ctx, `Subscribed to newly registered context graph "${id}"`);
-      }
-      this.persistContextGraphSubscription(id);
-    }
-
-    // Registration status is in _meta — it propagates to peers via sync, not
-    // gossip, so that only the authenticated sync path can update it.
-    // Broadcast the ontology-graph OnChainId quad so peers see the link.
-    try {
-      const onChainNquad = `<${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId> "${onChainId}" <${ontologyGraph}> .`;
-      const ontologyTopic = contextGraphPublishTopic(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
-      const regMsg = encodePublishRequest({
-        ual: `did:dkg:context-graph:${id}`,
-        nquads: new TextEncoder().encode(onChainNquad),
-        contextGraphId: SYSTEM_CONTEXT_GRAPHS.ONTOLOGY,
-        kas: [],
-        publisherIdentity: this.wallet.keypair.publicKey,
-        publisherAddress: '',
-        startKAId: 0,
-        endKAId: 0,
-        chainId: '',
-        publisherSignatureR: new Uint8Array(0),
-        publisherSignatureVs: new Uint8Array(0),
-      });
-      await this.gossip.publish(ontologyTopic, regMsg);
-    } catch (err) {
-      this.log.debug(ctx, `Registration gossip broadcast failed (peers may not be subscribed yet): ${err instanceof Error ? err.message : String(err)}`);
-    }
 
     return { onChainId };
   }

--- a/packages/agent/src/dkg-agent-context-graph.ts
+++ b/packages/agent/src/dkg-agent-context-graph.ts
@@ -130,7 +130,6 @@ import {
   type QueryRequest, type QueryResponse, type QueryAccessConfig, type LookupType,
 } from '@origintrail-official/dkg-query';
 import { DKGAgentWallet, type AgentWallet } from './agent-wallet.js';
-import { isCanonicalPositiveContextGraphId } from './context-graph-binding-state.js';
 import { buildAuthoritativePublicMetaQuads } from './context-graph-public-meta-proof.js';
 
 import { ProfileManager } from './profile-manager.js';
@@ -991,13 +990,7 @@ export class ContextGraphMethods extends DKGAgentBase {
     // Check if already registered
     const cgMetaGraph = contextGraphMetaUri(id);
     const contextGraphUri = `did:dkg:context-graph:${id}`;
-    const statusResult = await this.store.query(
-      `SELECT ?status WHERE { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REGISTRATION_STATUS}> ?status } } LIMIT 1`,
-      { source: 'agent.contextGraph.register.status' },
-    );
-    const registrationStatus = statusResult.type === 'bindings'
-      ? statusResult.bindings[0]?.['status']?.replace(/^"|"$/g, '')
-      : undefined;
+    let registrationStatus = await this.getContextGraphRegistrationStatus(id);
     if (registrationStatus === 'registered') {
       const existingOnChainId = this.subscribedContextGraphs.get(id)?.onChainId;
       throw new Error(`Context graph "${id}" is already registered on-chain${existingOnChainId ? ` (${existingOnChainId})` : ''}`);
@@ -1148,22 +1141,14 @@ export class ContextGraphMethods extends DKGAgentBase {
     // A local OnChainId triple alone is not enough — devnet restarts and
     // partial failures can leave ontology id "1" while the chain slot is
     // inactive, which would skip registration and strand publishes.
-    // An explicit local `unregistered` marker is authoritative for this
-    // registration attempt. Do not run the historical name-hash resolver in
-    // that state: Context Graph names are not globally unique, so another
-    // deployment can legitimately have one or more on-chain graphs with the
-    // same hash. Reverse-resolving here would either adopt somebody else's
-    // numeric id or fail on an ambiguous set before this graph can register.
-    //
-    // Preserve a durable numeric subscription binding when present. That
-    // covers a process interruption after the chain receipt was persisted but
-    // before the registration-status projection was flipped.
-    const localOnChainId = this.subscribedContextGraphs.get(id)?.onChainId;
-    const existingOnChainId = registrationStatus === 'unregistered'
-      ? (localOnChainId && isCanonicalPositiveContextGraphId(localOnChainId)
-          ? localOnChainId
-          : null)
-      : await this.getContextGraphOnChainId(id);
+    // The registry/binding layer owns registration-time provenance. In
+    // particular, an explicit local `unregistered` marker must not reverse-
+    // resolve a non-unique name hash, while an interrupted attempt may trust
+    // only its durable numeric receipt binding.
+    const existingOnChainId = await this.resolveContextGraphRegistrationOnChainId(
+      id,
+      registrationStatus,
+    );
     if (existingOnChainId) {
       let onChainLive = false;
       if (typeof this.chain.isContextGraphActiveOnChain === 'function') {
@@ -1183,14 +1168,12 @@ export class ContextGraphMethods extends DKGAgentBase {
       }
       if (onChainLive) {
         this.log.info(ctx, `Context graph "${id}" already has on-chain ID ${existingOnChainId} — skipping chain call`);
-        await this.store.deleteByPattern({
-          graph: cgMetaGraph,
-          subject: contextGraphUri,
-          predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS,
-        });
-        await this.store.insert([
-          { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS, object: `"registered"`, graph: cgMetaGraph },
-        ]);
+        const recoveredNameHash = ethers.keccak256(ethers.toUtf8Bytes(id)).toLowerCase();
+        await this.completeContextGraphRegistrationProjection(
+          id,
+          existingOnChainId,
+          recoveredNameHash,
+        );
         this.contextGraphMetaProjection.markDirty(id);
         return { onChainId: existingOnChainId, txHash: undefined };
       }
@@ -1209,6 +1192,8 @@ export class ContextGraphMethods extends DKGAgentBase {
         this.forceClearVmReconcileStateForContextGraph(id);
         this.setContextGraphSubscription(id, { ...sub, onChainId: undefined, lastReconciledOrdinal: 0 });
       }
+      await this.resetInactiveContextGraphRegistration(id);
+      registrationStatus = 'unregistered';
     }
 
     // LU-2: edge-owned CG pattern — no `participantIdentityIds`/
@@ -1443,6 +1428,10 @@ export class ContextGraphMethods extends DKGAgentBase {
     // subscribe will key on the wrong topic.
     const nameHash = ethers.keccak256(ethers.toUtf8Bytes(id)).toLowerCase();
 
+    const registrationAttemptStatus = await this.beginContextGraphRegistrationAttempt(
+      id,
+      registrationStatus,
+    );
     const result = await this.registerContextGraphOnChain({
       accessPolicy: resolvedLocalAccessPolicy,
       publishPolicy,
@@ -1453,6 +1442,16 @@ export class ContextGraphMethods extends DKGAgentBase {
     });
     const onChainId = result.contextGraphId.toString();
 
+    // Persist the exact receipt provenance before any fallible projection
+    // updates. If this write itself fails, the durable attempt marker remains
+    // and all retries fail closed instead of minting a second graph.
+    await this.persistContextGraphRegistrationReceipt(
+      id,
+      registrationAttemptStatus,
+      onChainId,
+      result.hash,
+    );
+
     this.log.info(ctx, `Context graph "${id}" registered on-chain: ${onChainId} (nameHash=${nameHash.slice(0, 18)}…)`);
 
     // Update _meta with registered status and the member-syncable on-chain
@@ -1461,33 +1460,7 @@ export class ContextGraphMethods extends DKGAgentBase {
     // slot from the curator's private `_meta` snapshot.  A private joiner may
     // have missed the one-shot ontology gossip emitted below and must not be
     // left unable to start chain-driven VM reconciliation as a result.
-    await this.store.deleteByPattern({
-      graph: cgMetaGraph,
-      subject: contextGraphUri,
-      predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS,
-    });
-    // Single-valued binding guard (RS heal): the on-chain id is immutable, so
-    // clear any prior value before insert — the cgId resolver / heal read this
-    // and must never see a multi-valued (LIMIT-1-nondeterministic) binding.
-    await this.store.deleteByPattern({
-      graph: ontologyGraph,
-      subject: contextGraphUri,
-      predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
-    });
-    await this.store.deleteByPattern({
-      graph: cgMetaGraph,
-      subject: contextGraphUri,
-      predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
-    });
-    await this.store.insert([
-      { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS, object: `"registered"`, graph: cgMetaGraph },
-      { subject: contextGraphUri, predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`, object: `"${onChainId}"`, graph: ontologyGraph },
-      { subject: contextGraphUri, predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`, object: `"${onChainId}"`, graph: cgMetaGraph },
-      // Persist the wire-id commitment in the cg's _meta graph so a
-      // restart can resume host-mode subscription on the correct
-      // topic without re-reading the chain event.
-      { subject: contextGraphUri, predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainHash`, object: `"${nameHash}"`, graph: cgMetaGraph },
-    ]);
+    await this.completeContextGraphRegistrationProjection(id, onChainId, nameHash);
     this.invalidateListContextGraphsCache();
     this.contextGraphMetaProjection.markDirty(id);
     // We no longer persist `publishAuthorityAccountId` locally even on

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -4220,8 +4220,12 @@ export class PublishMethods extends DKGAgentBase {
     contextGraphId: string,
     opts?: { callerAgentAddress?: string },
   ): Promise<void> {
-    const existingOnChainId = await this.resolveContextGraphRegistrationOnChainId(contextGraphId);
-    if (existingOnChainId) return;
+    const registrationStatus = await this.getContextGraphRegistrationStatus(contextGraphId);
+    const existingOnChainId = await this.resolveContextGraphRegistrationOnChainId(
+      contextGraphId,
+      registrationStatus,
+    );
+    if (existingOnChainId && registrationStatus === 'registered') return;
     // #1085 — the publish path has no request-body policy, so it reads the
     // stored create-time policy + PCA directly from the canonical store reader
     // and forwards BOTH. Deliberately NOT wrapped in a catch: a stored-read
@@ -4250,7 +4254,8 @@ export class PublishMethods extends DKGAgentBase {
       // id; this only swallows the benign concurrent-winner rejection.
       if (
         /already registered on-chain/i.test(err?.message ?? String(err)) &&
-        (await this.resolveContextGraphRegistrationOnChainId(contextGraphId))
+        (await this.getContextGraphRegistrationStatus(contextGraphId)) === 'registered' &&
+        (await this.resolveContextGraphRegistrationOnChainId(contextGraphId, 'registered'))
       ) {
         return;
       }

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -4220,7 +4220,7 @@ export class PublishMethods extends DKGAgentBase {
     contextGraphId: string,
     opts?: { callerAgentAddress?: string },
   ): Promise<void> {
-    const existingOnChainId = await this.getContextGraphOnChainId(contextGraphId);
+    const existingOnChainId = await this.resolveContextGraphRegistrationOnChainId(contextGraphId);
     if (existingOnChainId) return;
     // #1085 — the publish path has no request-body policy, so it reads the
     // stored create-time policy + PCA directly from the canonical store reader
@@ -4250,7 +4250,7 @@ export class PublishMethods extends DKGAgentBase {
       // id; this only swallows the benign concurrent-winner rejection.
       if (
         /already registered on-chain/i.test(err?.message ?? String(err)) &&
-        (await this.getContextGraphOnChainId(contextGraphId))
+        (await this.resolveContextGraphRegistrationOnChainId(contextGraphId))
       ) {
         return;
       }

--- a/packages/agent/test/agent.part-13.test.ts
+++ b/packages/agent/test/agent.part-13.test.ts
@@ -85,6 +85,44 @@ describe('Genesis Knowledge', () => {
     });
 
 
+    it('rejects an interrupted attempt with a stale unproven meta id before chain submission', async () => {
+      const store = new OxigraphStore();
+      const chain = new CapturingContextGraphChainAdapter();
+      const agent = await DKGAgent.create({
+        name: 'RegistrationStaleMetaFailClosedBot',
+        store,
+        chainAdapter: chain,
+        nodeRole: 'core',
+      });
+      await agent.start();
+      const contextGraphId = 'stale-meta-fail-closed';
+      const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
+      const metaGraph = contextGraphMetaUri(contextGraphId);
+
+      await agent.createContextGraph({
+        id: contextGraphId,
+        name: 'Stale meta fail closed',
+        callerAgentAddress: ethers.getAddress(chain.signerAddress),
+      });
+      await store.insert([{
+        subject: contextGraphUri,
+        predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
+        object: '"7"',
+        graph: metaGraph,
+      }]);
+      await (agent as any).beginContextGraphRegistrationAttempt(
+        contextGraphId,
+        'unregistered',
+      );
+
+      await expect(agent.registerContextGraph(contextGraphId, {
+        callerAgentAddress: ethers.getAddress(chain.signerAddress),
+      })).rejects.toThrow(/interrupted on-chain registration attempt/);
+      expect(chain.createOnChainContextGraphCalls).toHaveLength(0);
+      await agent.stop().catch(() => {});
+    });
+
+
     it('recovers a durable receipt binding after later projection failure', async () => {
       const store = new OxigraphStore();
       const chain = new CapturingContextGraphChainAdapter();

--- a/packages/agent/test/agent.part-13.test.ts
+++ b/packages/agent/test/agent.part-13.test.ts
@@ -17,6 +17,42 @@ afterAll(async () => {
 describe('Genesis Knowledge', () => {
 
 
+    it('registers an explicitly unregistered local graph without reverse-binding a colliding name hash', async () => {
+      const store = new OxigraphStore();
+      const chain = new CapturingContextGraphChainAdapter();
+      const ambiguousLookup = vi.spyOn(chain, 'resolveContextGraphIdByNameHash')
+        .mockRejectedValue(new Error(
+          'resolveContextGraphIdByNameHash: ambiguous name hash; getNameHash commits it to 2 numeric ids',
+        ));
+      const agent = await DKGAgent.create({
+        name: 'RegistrationNameCollisionBot',
+        store,
+        chainAdapter: chain,
+        nodeRole: 'core',
+      });
+      await agent.start();
+
+      const curatorAddress = ethers.getAddress(chain.signerAddress);
+      await agent.createContextGraph({
+        id: 'shared-deployment-label',
+        name: 'Shared deployment label',
+        accessPolicy: 1,
+        publishPolicy: 1,
+        callerAgentAddress: curatorAddress,
+      });
+
+      await expect(agent.registerContextGraph('shared-deployment-label', {
+        accessPolicy: 1,
+        publishPolicy: 1,
+        callerAgentAddress: curatorAddress,
+      })).resolves.toMatchObject({ onChainId: expect.any(String) });
+
+      expect(ambiguousLookup).not.toHaveBeenCalled();
+      expect(chain.createOnChainContextGraphCalls).toHaveLength(1);
+      await agent.stop().catch(() => {});
+    });
+
+
   	  it('requires address-scoped curator authority for on-chain registration', async () => {
       const store = new OxigraphStore();
       const chain = new CapturingContextGraphChainAdapter();

--- a/packages/agent/test/agent.part-13.test.ts
+++ b/packages/agent/test/agent.part-13.test.ts
@@ -85,6 +85,51 @@ describe('Genesis Knowledge', () => {
     });
 
 
+    it('clears a proven pre-broadcast failure so a corrected retry can submit once', async () => {
+      class FailBeforeBroadcastOnceChain extends CapturingContextGraphChainAdapter {
+        private failNext = true;
+
+        override async createOnChainContextGraph(
+          params: CreateOnChainContextGraphParams,
+        ): Promise<CreateOnChainContextGraphResult> {
+          if (this.failNext) {
+            this.failNext = false;
+            throw new Error('injected gas-estimation failure before broadcast');
+          }
+          return super.createOnChainContextGraph(params);
+        }
+      }
+
+      const store = new OxigraphStore();
+      const chain = new FailBeforeBroadcastOnceChain();
+      const agent = await DKGAgent.create({
+        name: 'RegistrationPreBroadcastRetryBot',
+        store,
+        chainAdapter: chain,
+        nodeRole: 'core',
+      });
+      await agent.start();
+      const curatorAddress = ethers.getAddress(chain.signerAddress);
+
+      await agent.createContextGraph({
+        id: 'pre-broadcast-retry',
+        name: 'Pre-broadcast retry',
+        callerAgentAddress: curatorAddress,
+      });
+      await expect(agent.registerContextGraph('pre-broadcast-retry', {
+        callerAgentAddress: curatorAddress,
+      })).rejects.toThrow(/before broadcast/);
+      await expect((agent as any).getContextGraphRegistrationStatus('pre-broadcast-retry'))
+        .resolves.toBe('unregistered');
+
+      await expect(agent.registerContextGraph('pre-broadcast-retry', {
+        callerAgentAddress: curatorAddress,
+      })).resolves.toMatchObject({ onChainId: '1' });
+      expect(chain.createOnChainContextGraphCalls).toHaveLength(1);
+      await agent.stop().catch(() => {});
+    });
+
+
     it('rejects an interrupted attempt with a stale unproven meta id before chain submission', async () => {
       const store = new OxigraphStore();
       const chain = new CapturingContextGraphChainAdapter();
@@ -110,9 +155,14 @@ describe('Genesis Knowledge', () => {
         object: '"7"',
         graph: metaGraph,
       }]);
-      await (agent as any).beginContextGraphRegistrationAttempt(
+      const attemptStatus = await (agent as any).beginContextGraphRegistrationAttempt(
         contextGraphId,
         'unregistered',
+      );
+      await (agent as any).persistContextGraphRegistrationBroadcast(
+        contextGraphId,
+        attemptStatus,
+        `0x${'ab'.repeat(32)}`,
       );
 
       await expect(agent.registerContextGraph(contextGraphId, {
@@ -123,10 +173,12 @@ describe('Genesis Knowledge', () => {
     });
 
 
-    it('recovers a durable receipt binding after later projection failure', async () => {
-      const store = new OxigraphStore();
+    it('recovers a durable receipt binding after reopening storage', async () => {
+      const persistentDir = await mkdtemp(join(tmpdir(), 'dkg-registration-recovery-'));
+      const persistentPath = join(persistentDir, 'store.nq');
+      const store = new OxigraphStore(persistentPath);
       const chain = new CapturingContextGraphChainAdapter();
-      const agent = await DKGAgent.create({
+      let agent = await DKGAgent.create({
         name: 'RegistrationReceiptRecoveryBot',
         store,
         chainAdapter: chain,
@@ -148,8 +200,61 @@ describe('Genesis Knowledge', () => {
       await expect(agent.registerContextGraph('receipt-binding-recovery', { callerAgentAddress: curatorAddress }))
         .rejects.toThrow(/injected post-receipt projection failure/);
       completeProjection.mockRestore();
+
+      await agent.stop().catch(() => {});
+      agent = await DKGAgent.create({
+        name: 'RegistrationReceiptRecoveryRestartedBot',
+        store: new OxigraphStore(persistentPath),
+        chainAdapter: chain,
+        nodeRole: 'core',
+      });
+      await agent.start();
       await expect(agent.registerContextGraph('receipt-binding-recovery', { callerAgentAddress: curatorAddress }))
         .resolves.toMatchObject({ onChainId: '1' });
+      expect(chain.createOnChainContextGraphCalls).toHaveLength(1);
+      await agent.stop().catch(() => {});
+      await rm(persistentDir, { recursive: true, force: true });
+    });
+
+
+    it('auto-publish preflight completes a receipt-backed interrupted projection', async () => {
+      const store = new OxigraphStore();
+      const chain = new CapturingContextGraphChainAdapter();
+      const agent = await DKGAgent.create({
+        name: 'RegistrationPublishRecoveryBot',
+        store,
+        chainAdapter: chain,
+        nodeRole: 'core',
+      });
+      await agent.start();
+      const contextGraphId = 'receipt-publish-recovery';
+      const curatorAddress = ethers.getAddress(chain.signerAddress);
+
+      await agent.createContextGraph({
+        id: contextGraphId,
+        name: 'Receipt publish recovery',
+        callerAgentAddress: curatorAddress,
+      });
+      const completeProjection = vi.spyOn(
+        agent as any,
+        'completeContextGraphRegistrationProjection',
+      ).mockRejectedValueOnce(new Error('injected post-receipt projection failure'));
+
+      await expect(agent.registerContextGraph(contextGraphId, {
+        callerAgentAddress: curatorAddress,
+      })).rejects.toThrow(/injected post-receipt projection failure/);
+      completeProjection.mockRestore();
+
+      await expect((agent as any).ensureRegisteredForPublish(contextGraphId, {
+        callerAgentAddress: curatorAddress,
+      })).resolves.toBeUndefined();
+      await expect((agent as any).getContextGraphRegistrationStatus(contextGraphId))
+        .resolves.toBe('registered');
+      const subscription = (agent as any).subscribedContextGraphs.get(contextGraphId);
+      expect(subscription?.onChainId).toBe('1');
+      expect(subscription?.onChainHash).toBe(
+        ethers.keccak256(ethers.toUtf8Bytes(contextGraphId)).toLowerCase(),
+      );
       expect(chain.createOnChainContextGraphCalls).toHaveLength(1);
       await agent.stop().catch(() => {});
     });

--- a/packages/agent/test/agent.part-13.test.ts
+++ b/packages/agent/test/agent.part-13.test.ts
@@ -53,6 +53,76 @@ describe('Genesis Knowledge', () => {
     });
 
 
+    it('liveness-checks an authoritative subscription before an unregistered marker', async () => {
+      const store = new OxigraphStore();
+      const chain = new CapturingContextGraphChainAdapter();
+      const activeCheck = vi.spyOn(chain, 'isContextGraphActiveOnChain')
+        .mockResolvedValue(true);
+      const agent = await DKGAgent.create({
+        name: 'RegistrationAuthoritativeBindingBot',
+        store,
+        chainAdapter: chain,
+        nodeRole: 'core',
+      });
+      await agent.start();
+      const contextGraphId = 'authoritative-binding-precedence';
+      const curatorAddress = ethers.getAddress(chain.signerAddress);
+
+      await agent.createContextGraph({
+        id: contextGraphId,
+        name: 'Authoritative binding precedence',
+        callerAgentAddress: curatorAddress,
+      });
+      const subscription = (agent as any).subscribedContextGraphs.get(contextGraphId);
+      (agent as any).setContextGraphSubscription(contextGraphId, {
+        ...subscription,
+        onChainId: '42',
+      });
+
+      await expect(agent.registerContextGraph(contextGraphId, {
+        callerAgentAddress: curatorAddress,
+      })).resolves.toMatchObject({ onChainId: '42' });
+      expect(activeCheck).toHaveBeenCalledWith(42n);
+      expect(chain.createOnChainContextGraphCalls).toHaveLength(0);
+      await agent.stop().catch(() => {});
+    });
+
+
+    it('registers with a conforming custom store that omits optional update()', async () => {
+      const backingStore = new OxigraphStore();
+      const storeWithoutUpdate = new Proxy(backingStore as any, {
+        get(target, property) {
+          if (property === 'update') return undefined;
+          const value = Reflect.get(target, property, target);
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+      });
+      const chain = new CapturingContextGraphChainAdapter();
+      const agent = await DKGAgent.create({
+        name: 'RegistrationOptionalUpdateStoreBot',
+        store: storeWithoutUpdate,
+        chainAdapter: chain,
+        nodeRole: 'core',
+      });
+      await agent.start();
+      const contextGraphId = 'optional-update-store';
+      const curatorAddress = ethers.getAddress(chain.signerAddress);
+
+      await agent.createContextGraph({
+        id: contextGraphId,
+        name: 'Optional update store',
+        callerAgentAddress: curatorAddress,
+      });
+      await expect(agent.registerContextGraph(contextGraphId, {
+        callerAgentAddress: curatorAddress,
+      })).resolves.toMatchObject({ onChainId: '1' });
+      await expect((agent as any).getContextGraphRegistrationStatus(contextGraphId))
+        .resolves.toBe('registered');
+      expect(chain.createOnChainContextGraphCalls).toHaveLength(1);
+      await agent.stop().catch(() => {});
+    });
+
+
     it('fails closed when registration is interrupted before receipt persistence', async () => {
       const store = new OxigraphStore();
       const chain = new CapturingContextGraphChainAdapter();

--- a/packages/agent/test/agent.part-13.test.ts
+++ b/packages/agent/test/agent.part-13.test.ts
@@ -53,7 +53,71 @@ describe('Genesis Knowledge', () => {
     });
 
 
-  	  it('requires address-scoped curator authority for on-chain registration', async () => {
+    it('fails closed when registration is interrupted before receipt persistence', async () => {
+      const store = new OxigraphStore();
+      const chain = new CapturingContextGraphChainAdapter();
+      const agent = await DKGAgent.create({
+        name: 'RegistrationReceiptFailClosedBot',
+        store,
+        chainAdapter: chain,
+        nodeRole: 'core',
+      });
+      await agent.start();
+      const curatorAddress = ethers.getAddress(chain.signerAddress);
+
+      await agent.createContextGraph({
+        id: 'receipt-fail-closed',
+        name: 'Receipt fail closed',
+        callerAgentAddress: curatorAddress,
+      });
+      const persistReceipt = vi.spyOn(
+        agent as any,
+        'persistContextGraphRegistrationReceipt',
+      ).mockRejectedValueOnce(new Error('injected post-receipt persistence failure'));
+
+      await expect(agent.registerContextGraph('receipt-fail-closed', { callerAgentAddress: curatorAddress }))
+        .rejects.toThrow(/injected post-receipt persistence failure/);
+      persistReceipt.mockRestore();
+      await expect(agent.registerContextGraph('receipt-fail-closed', { callerAgentAddress: curatorAddress }))
+        .rejects.toThrow(/interrupted on-chain registration attempt/);
+      expect(chain.createOnChainContextGraphCalls).toHaveLength(1);
+      await agent.stop().catch(() => {});
+    });
+
+
+    it('recovers a durable receipt binding after later projection failure', async () => {
+      const store = new OxigraphStore();
+      const chain = new CapturingContextGraphChainAdapter();
+      const agent = await DKGAgent.create({
+        name: 'RegistrationReceiptRecoveryBot',
+        store,
+        chainAdapter: chain,
+        nodeRole: 'core',
+      });
+      await agent.start();
+      const curatorAddress = ethers.getAddress(chain.signerAddress);
+
+      await agent.createContextGraph({
+        id: 'receipt-binding-recovery',
+        name: 'Receipt binding recovery',
+        callerAgentAddress: curatorAddress,
+      });
+      const completeProjection = vi.spyOn(
+        agent as any,
+        'completeContextGraphRegistrationProjection',
+      ).mockRejectedValueOnce(new Error('injected post-receipt projection failure'));
+
+      await expect(agent.registerContextGraph('receipt-binding-recovery', { callerAgentAddress: curatorAddress }))
+        .rejects.toThrow(/injected post-receipt projection failure/);
+      completeProjection.mockRestore();
+      await expect(agent.registerContextGraph('receipt-binding-recovery', { callerAgentAddress: curatorAddress }))
+        .resolves.toMatchObject({ onChainId: '1' });
+      expect(chain.createOnChainContextGraphCalls).toHaveLength(1);
+      await agent.stop().catch(() => {});
+    });
+
+
+    it('requires address-scoped curator authority for on-chain registration', async () => {
       const store = new OxigraphStore();
       const chain = new CapturingContextGraphChainAdapter();
       const agent = await DKGAgent.create({

--- a/packages/agent/test/e2e-memory-layers.test.ts
+++ b/packages/agent/test/e2e-memory-layers.test.ts
@@ -2626,22 +2626,28 @@ describe('WM → SWM gossip → VM (2 nodes)', () => {
 describe('Query views', () => {
   it('includeSharedMemory merges SWM data into query results', async () => {
     const agent = await createAgent('ViewBot');
-    await agent.createContextGraph({ id: CG_ID, name: 'View E2E' });
+    // This file intentionally reuses CG_ID across many independent agents.
+    // Registration now treats an explicit local `unregistered` marker as a
+    // fresh graph instead of reverse-binding a historical name hash, so those
+    // independent tests legitimately leave multiple chain slots for CG_ID.
+    // Keep this query-view test isolated from that registration fixture noise.
+    const queryViewCgId = `${CG_ID}-query-views`;
+    await agent.createContextGraph({ id: queryViewCgId, name: 'View E2E' });
 
     // Put data in canonical graph via publish
-    await agent.publish(CG_ID, [
+    await agent.publish(queryViewCgId, [
       { subject: `${ENTITY_BASE}:canonical`, predicate: 'http://schema.org/name', object: '"Canonical"', graph: '' },
     ]);
 
     // Put data in SWM
-    await agent.share(CG_ID, [
+    await agent.share(queryViewCgId, [
       { subject: `${ENTITY_BASE}:shared`, predicate: 'http://schema.org/name', object: '"Shared"', graph: '' },
     ], { localOnly: true });
 
     // Default query (data graph only) — should see canonical
     const defaultResult = await agent.query(
       `SELECT ?s ?name WHERE { ?s <http://schema.org/name> ?name }`,
-      CG_ID,
+      queryViewCgId,
     );
     const defaultSubjects = defaultResult.bindings.map((b: any) => b['s']);
     expect(defaultSubjects.some((s: string) => s.includes('canonical'))).toBe(true);
@@ -2649,7 +2655,7 @@ describe('Query views', () => {
     // includeSharedMemory — should see both
     const mergedResult = await agent.query(
       `SELECT ?s ?name WHERE { ?s <http://schema.org/name> ?name }`,
-      { contextGraphId: CG_ID, includeSharedMemory: true },
+      { contextGraphId: queryViewCgId, includeSharedMemory: true },
     );
     const mergedSubjects = mergedResult.bindings.map((b: any) => b['s']);
     expect(mergedSubjects.some((s: string) => s.includes('canonical'))).toBe(true);

--- a/packages/agent/test/ensure-registered-for-publish.test.ts
+++ b/packages/agent/test/ensure-registered-for-publish.test.ts
@@ -21,6 +21,9 @@ type Stub = Record<string, any>;
 function makeStub(overrides: Stub = {}): Stub {
   return {
     getContextGraphOnChainId: async () => null,
+    resolveContextGraphRegistrationOnChainId: async function (contextGraphId: string) {
+      return this.getContextGraphOnChainId(contextGraphId);
+    },
     getStoredContextGraphRegistrationOptions: async () => ({}),
     registerContextGraph: async () => undefined,
     ...overrides,

--- a/packages/agent/test/ensure-registered-for-publish.test.ts
+++ b/packages/agent/test/ensure-registered-for-publish.test.ts
@@ -20,10 +20,9 @@ type Stub = Record<string, any>;
  * tests stub. It forwards BOTH stored fields and stays fail-loud. */
 function makeStub(overrides: Stub = {}): Stub {
   return {
+    getContextGraphRegistrationStatus: async () => 'unregistered',
     getContextGraphOnChainId: async () => null,
-    resolveContextGraphRegistrationOnChainId: async function (contextGraphId: string) {
-      return this.getContextGraphOnChainId(contextGraphId);
-    },
+    resolveContextGraphRegistrationOnChainId: async () => null,
     getStoredContextGraphRegistrationOptions: async () => ({}),
     registerContextGraph: async () => undefined,
     ...overrides,
@@ -38,11 +37,38 @@ describe('DKGAgent.ensureRegisteredForPublish', () => {
   it('short-circuits (no register) when an on-chain id already exists', async () => {
     const registerCalls: any[] = [];
     const stub = makeStub({
-      getContextGraphOnChainId: async () => 42n,
+      getContextGraphRegistrationStatus: async () => 'registered',
+      resolveContextGraphRegistrationOnChainId: async () => 42n,
       registerContextGraph: async (...a: any[]) => { registerCalls.push(a); },
     });
     await callEnsure(stub, 'cg-already');
     expect(registerCalls.length).toBe(0); // idempotent — no second mint
+  });
+
+  it('finalizes a receipt-backed interrupted registration instead of treating its id as complete', async () => {
+    const registerCalls: any[][] = [];
+    const stub = makeStub({
+      getContextGraphRegistrationStatus: async () => 'registering:attempt-1',
+      resolveContextGraphRegistrationOnChainId: async () => 42n,
+      registerContextGraph: async (...args: any[]) => { registerCalls.push(args); },
+    });
+
+    await callEnsure(stub, 'cg-receipt-backed');
+
+    expect(registerCalls).toEqual([['cg-receipt-backed', {}]]);
+  });
+
+  it('registers an explicit-unregistered graph even when the legacy lookup sees a colliding id', async () => {
+    const registerCalls: any[][] = [];
+    const stub = makeStub({
+      getContextGraphOnChainId: async () => 99n,
+      resolveContextGraphRegistrationOnChainId: async () => null,
+      registerContextGraph: async (...args: any[]) => { registerCalls.push(args); },
+    });
+
+    await callEnsure(stub, 'cg-colliding-label');
+
+    expect(registerCalls).toEqual([['cg-colliding-label', {}]]);
   });
 
   it('(a) reads stored options for the EXACT publish cg id, then forwards its publishPolicy / publishAuthorityAccountId + callerAgentAddress into registerContextGraph', async () => {
@@ -103,12 +129,17 @@ describe('DKGAgent.ensureRegisteredForPublish', () => {
   });
 
   it('(b) race-confirm: registerContextGraph throws "already registered on-chain" AND an id now exists ⇒ RETURNS (swallows)', async () => {
-    let onChainIdCalls = 0;
+    let statusCalls = 0;
+    let resolverCalls = 0;
     const stub = makeStub({
       // First call (the pre-check) → null; second call (the race confirm) → truthy.
-      getContextGraphOnChainId: async () => {
-        onChainIdCalls += 1;
-        return onChainIdCalls >= 2 ? 7n : null;
+      getContextGraphRegistrationStatus: async () => {
+        statusCalls += 1;
+        return statusCalls >= 2 ? 'registered' : 'unregistered';
+      },
+      resolveContextGraphRegistrationOnChainId: async () => {
+        resolverCalls += 1;
+        return resolverCalls >= 2 ? 7n : null;
       },
       registerContextGraph: async () => {
         throw new Error('Context graph "cg-race" is already registered on-chain.');
@@ -117,12 +148,12 @@ describe('DKGAgent.ensureRegisteredForPublish', () => {
 
     // Must NOT throw — the concurrent publisher won the race; the CG IS registered.
     await expect(callEnsure(stub, 'cg-race')).resolves.toBeUndefined();
-    expect(onChainIdCalls).toBeGreaterThanOrEqual(2); // it re-checked after the throw
+    expect(resolverCalls).toBeGreaterThanOrEqual(2); // it re-checked after the throw
   });
 
   it('(b) race-confirm: "already registered" but the id is STILL falsy ⇒ RETHROWS', async () => {
     const stub = makeStub({
-      getContextGraphOnChainId: async () => null, // never resolves to a truthy id
+      resolveContextGraphRegistrationOnChainId: async () => null,
       registerContextGraph: async () => {
         throw new Error('Context graph "cg-noid" is already registered on-chain.');
       },
@@ -132,7 +163,7 @@ describe('DKGAgent.ensureRegisteredForPublish', () => {
 
   it('(b) a genuine registration failure (NOT "already registered") always RETHROWS', async () => {
     const stub = makeStub({
-      getContextGraphOnChainId: async () => null,
+      resolveContextGraphRegistrationOnChainId: async () => null,
       registerContextGraph: async () => {
         throw new Error('insufficient TRAC to register context graph');
       },

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -583,6 +583,11 @@ export interface CreateOnChainContextGraphParams {
    * surface forward-compatible.
    */
   nameHash?: string;
+  /**
+   * Write-ahead hook invoked after the registration transaction is signed and
+   * immediately before it is broadcast. A thrown error aborts the broadcast.
+   */
+  onBroadcast?: (signal: PreBroadcastSignal) => Promise<void> | void;
 }
 
 export interface CreateOnChainContextGraphResult extends Omit<TxResult, 'contextGraphId'> {
@@ -1114,6 +1119,14 @@ export interface ChainAdapter {
    * `chainId` (single in-memory deployment per process).
    */
   deploymentId: string;
+
+  /**
+   * Proves that `createOnChainContextGraph` invokes its `onBroadcast` hook
+   * immediately before every possible broadcast. Callers may roll back a
+   * write-ahead attempt after an error only when this capability is present
+   * and the hook was never reached.
+   */
+  readonly contextGraphRegistrationWriteAhead?: true;
 
   /**
    * OPTIONAL RPC-usage capability: drain the raw JSON-RPC request counts

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -56,7 +56,10 @@ type ContractWriteSender = (
   args: readonly unknown[],
   signer: Wallet,
   label: string,
-  opts?: { gasLimitBufferBps?: number },
+  opts?: {
+    gasLimitBufferBps?: number;
+    onBroadcast?: (signal: PreBroadcastSignal) => Promise<void> | void;
+  },
 ) => Promise<ethers.TransactionReceipt>;
 
 type SerializedSignerWriteContext = {
@@ -609,6 +612,8 @@ export class EVMChainAdapterBase {
   }
 
   readonly chainType = 'evm' as const;
+
+  readonly contextGraphRegistrationWriteAhead = true as const;
 
   readonly chainId: string;
 
@@ -1866,7 +1871,10 @@ export class EVMChainAdapterBase {
     args: readonly unknown[],
     signer: Wallet,
     label: string,
-    opts?: { gasLimitBufferBps?: number },
+    opts?: {
+      gasLimitBufferBps?: number;
+      onBroadcast?: (signal: PreBroadcastSignal) => Promise<void> | void;
+    },
   ): Promise<ethers.TransactionReceipt> {
     return this.withSerializedSignerWrite(signer, (ctx) =>
       ctx.sendContractTransaction(contract, method, args, signer, label, opts),
@@ -1912,7 +1920,10 @@ export class EVMChainAdapterBase {
     // observed estimate-vs-execution spread is small here but unbounded in
     // production with many CGs/KCs. When set, we estimate once and inflate
     // the limit by `gasLimitBufferBps` basis points so the drift can't OOG.
-    opts?: { gasLimitBufferBps?: number },
+    opts?: {
+      gasLimitBufferBps?: number;
+      onBroadcast?: (signal: PreBroadcastSignal) => Promise<void> | void;
+    },
   ): Promise<ethers.TransactionReceipt> {
     // Parent span for the whole send. Broadcast + receipt-wait open their own
     // nested spans/metrics (chain.tx_submit / chain.tx_wait) inside
@@ -1924,10 +1935,18 @@ export class EVMChainAdapterBase {
         // Populate+sign with per-endpoint failover (shared with the V10 path),
         // then broadcast+confirm the single signed tx. Split so `onBroadcast`
         // (the WAL checkpoint) can sit between sign and broadcast for V10 callers.
-        const { signedTx, txHash } = await this.populateAndSignAcrossProviders(
+        const { signedTx, txHash, nonce } = await this.populateAndSignAcrossProviders(
           contract, method, args, signer, label, opts,
         );
         span.setAttribute('dkg.tx_hash', txHash);
+        try {
+          await opts?.onBroadcast?.({ txHash, ...(nonce === undefined ? {} : { nonce }) });
+        } catch (hookErr) {
+          throw new Error(
+            `chain:writeahead hook failed before ${label} broadcast: ` +
+            `${hookErr instanceof Error ? hookErr.message : String(hookErr)}`,
+          );
+        }
         return this.sendSignedTransactionAndWait(signedTx, txHash, label);
       },
       { attributes: { 'rpc.method': 'eth_sendRawTransaction', 'dkg.chain_id': this.chainId } },

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -467,6 +467,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         createArgs,
         this.signer,
         'create on-chain context graph',
+        { onBroadcast: params.onBroadcast },
       );
 
     // OT-RFC-53: when the registration deposit is active, createContextGraph

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -170,6 +170,7 @@ function applyV10UpdateContext(
  */
 export class MockChainAdapter implements ChainAdapter {
   readonly chainType = 'evm' as const;
+  readonly contextGraphRegistrationWriteAhead = true as const;
   readonly chainId: string;
   readonly signerAddress: string;
 
@@ -1278,6 +1279,16 @@ export class MockChainAdapter implements ChainAdapter {
         throw new Error(`Mock: invalid nameHash ${params.nameHash}`);
       }
       nameHash = params.nameHash.toLowerCase();
+    }
+
+    const preBroadcastTxHash = this.peekTxHash();
+    try {
+      await params.onBroadcast?.({ txHash: preBroadcastTxHash });
+    } catch (hookErr) {
+      throw new Error(
+        'chain:writeahead hook failed before mock context-graph registration broadcast: ' +
+        `${hookErr instanceof Error ? hookErr.message : String(hookErr)}`,
+      );
     }
 
     const contextGraphId = this.nextContextGraphId++;

--- a/packages/chain/test/evm-adapter-cg-deposit.test.ts
+++ b/packages/chain/test/evm-adapter-cg-deposit.test.ts
@@ -126,4 +126,38 @@ describe('EVMChainAdapter — OT-RFC-53 CG registration deposit approval', () =>
     // but leave a stray CORE_OP→ContextGraphs approval, which this catches.
     expect(await approvalCount(coreOpAddress, fromBlock + 1)).toBe(0);
   });
+
+  it('checkpoints the exact signed registration hash before broadcast', async () => {
+    await setDeposit(0n);
+    const adapter = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    let checkpointedHash: string | undefined;
+
+    const result = await adapter.createOnChainContextGraph({
+      accessPolicy: 0,
+      publishPolicy: 1,
+      onBroadcast: ({ txHash }) => {
+        checkpointedHash = txHash;
+      },
+    });
+
+    expect(checkpointedHash).toBe(result.hash);
+  });
+
+  it('does not broadcast when the registration write-ahead hook fails', async () => {
+    await setDeposit(0n);
+    const adapter = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    let checkpointedHash: string | undefined;
+
+    await expect(adapter.createOnChainContextGraph({
+      accessPolicy: 0,
+      publishPolicy: 1,
+      onBroadcast: ({ txHash }) => {
+        checkpointedHash = txHash;
+        throw new Error('injected registration checkpoint failure');
+      },
+    })).rejects.toThrow(/checkpoint failure/);
+
+    expect(checkpointedHash).toMatch(/^0x[0-9a-fA-F]{64}$/);
+    expect(await provider.getTransaction(checkpointedHash!)).toBeNull();
+  });
 });

--- a/packages/core/src/genesis.ts
+++ b/packages/core/src/genesis.ts
@@ -360,6 +360,7 @@ export const DKG_ONTOLOGY = {
   SKILL_OFFERS: 'https://dkg.origintrail.io/skill#offersSkill',
   SKILL_FRAMEWORK: 'https://dkg.origintrail.io/skill#framework',
   DKG_REGISTRATION_STATUS: `${DKG}registrationStatus`,
+  DKG_REGISTRATION_TX_HASH: `${DKG}registrationTransactionHash`,
   DKG_CURATOR: `${DKG}curator`,
   DKG_ALLOWED_PEER: `${DKG}allowedPeer`,
   DKG_ALLOWED_AGENT: `${DKG}allowedAgent`,


### PR DESCRIPTION
## Summary

- allow an explicitly unregistered local Context Graph to register when unrelated on-chain graphs share its name hash
- claim a durable, single-writer registration attempt before submitting the transaction
- persist the exact transaction hash and numeric graph ID before later projection work, recovering that binding on retry or failing closed when no receipt was persisted
- checkpoint the signed transaction hash immediately before broadcast so proven pre-broadcast failures can retry while ambiguous outcomes remain fail-closed
- resume the complete local subscription/binding finalization from both explicit registration and automatic publish preflight
- preserve compatibility with conforming custom triple stores that omit optional `update()`, while production stores retain atomic SPARQL updates
- keep registration provenance rules in the canonical registry/binding layer and preserve historical reverse-name ambiguity checks elsewhere

## Why

Context Graph names are local labels, not globally unique identities. SCAN deployments intentionally use the local graph ID `argus-vault`. On Base Sepolia, two unrelated existing graphs already commit to that name hash, so DKG 10.0.14 invokes historical reverse resolution during registration and fails as ambiguous before it can submit the deployment's own graph.

Simply skipping that reverse lookup is not enough: a process interruption after a successful receipt but before local projection could otherwise cause a retry to mint a second irreversible graph. This change therefore introduces a receipt-safe registration state machine. An explicit `unregistered` graph does not inspect unrelated historical slots; a unique attempt marker serializes submission; the exact receipt is durably recorded before projection; a retry recovers the same ID when possible and otherwise refuses a second transaction.

## Related work

- SCAN staging deployment acceptance on DKG 10.0.14
- Follow-up deployment qualification will register the staging `argus-vault` graph and resume the existing same-job publish retry proof

## Files changed

| File | Change |
| --- | --- |
| `packages/agent/src/dkg-agent-cg-registry.ts` | Own registration-state resolution, atomic attempt claiming, exact-receipt precedence, recovery, completion, verified-inactive reset, and a serialized compatibility path for stores without optional `update()` |
| `packages/agent/src/dkg-agent-context-graph.ts` | Delegate binding decisions to the registry and place durable attempt/receipt boundaries around the chain call |
| `packages/agent/src/dkg-agent-publish.ts` | Use registration-aware resolution in automatic publish preflight and concurrent-winner recovery |
| `packages/agent/test/agent.part-13.test.ts` | Cover name collision, authoritative subscription precedence, optional-store compatibility, fail-closed interruptions, stale unproven IDs, and same-ID recovery without a second chain call |
| `packages/agent/test/ensure-registered-for-publish.test.ts` | Keep focused publish-registration stubs aligned with the new resolver seam |
| `packages/agent/test/e2e-memory-layers.test.ts` | Isolate the query-view fixture from deliberate historical-label reuse in the full chain-backed file |
| `packages/core/src/genesis.ts` | Define the durable registration transaction-hash predicate |
| `packages/chain/src/chain-adapter.ts` | Expose the fail-closed Context Graph registration write-ahead hook and capability |
| `packages/chain/src/evm-adapter-base.ts`, `packages/chain/src/evm-adapter-context-graph.ts` | Invoke the durable hook after signing and immediately before the concrete registration broadcast |
| `packages/chain/src/mock-adapter.ts` | Mirror the same pre-broadcast contract in agent tests |
| `packages/chain/test/evm-adapter-cg-deposit.test.ts` | Prove exact-hash checkpointing and that a hook failure sends no transaction |

## Test plan

- [x] `pnpm run build` (23/23 package tasks; 5/5 UI tasks)
- [x] `pnpm --filter @origintrail-official/dkg-agent build`
- [x] registration/binding/reconciliation selection (4 files, 70/70 tests)
- [x] focused registration and publish seam (23/23 tests)
- [x] prior CI failure plus full chain-backed memory-layer selection (2 files, 174/174 tests)
- [x] real EVM registration deposit/write-ahead suite (4/4 tests)
- [x] failure injection before receipt persistence proves retry fails closed with one chain call
- [x] proven pre-broadcast failure rolls back the exact attempt and succeeds on retry with one submission
- [x] stale unproven `_meta` ID plus interrupted attempt proves retry fails closed with zero chain calls
- [x] receipt recovery crosses an actual persistent-store close/reopen boundary and recovers the same numeric ID with one chain call
- [x] automatic publish preflight completes receipt-backed projection/subscription state without a second chain call
- [x] authoritative subscription binding is liveness-checked before an `unregistered` marker and performs no create call
- [x] a conforming custom store without optional `update()` registers once and reaches `registered`
- [ ] Register the staging SCAN `argus-vault` graph on Base Sepolia
- [ ] Re-arm the two existing pre-broadcast jobs under their original job IDs and confirm receipts

## Deployment impact

This affects any DKG deployment that registers a local graph whose label is already used on-chain. It does not couple an edge node to a PCA or to whichever core node owns a PCA. Already registered graphs and historical/reconciliation ambiguity checks remain fail-closed. SCAN staging will use the reviewed patch only for the one-time registration step, then restore its byte-exact sealed 10.0.14 runtime before acceptance continues.
