### PR TITLE
feat(agent): reconcile signed SWM inventory into RFC-64 catalogs (R1.1)

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -30,6 +30,7 @@
     "./dist/rfc64/inventory-v1/statements.js": "./dist/rfc64/inventory-v1/statements.js",
     "./dist/rfc64/public-catalog-activation-config-v1.js": "./dist/rfc64/public-catalog-activation-config-v1.js",
     "./dist/rfc64/swm-author-inventory-producer-v1.js": "./dist/rfc64/swm-author-inventory-producer-v1.js",
+    "./dist/rfc64/swm-inventory-catalog-reconciler-v1.js": null,
     "./dist/rfc64/control-envelope-signer-v1.js": null,
     "./dist/rfc64/swm-inventory-shadow-runtime-v1.js": null,
     "./dist/rfc64/control-object-store-v1-internal.js": null,

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -77,6 +77,7 @@
     "./dist/rfc64/public-catalog-service-v1.js": null,
     "./dist/rfc64/public-catalog-issuer-delegation-v1.js": null,
     "./dist/rfc64/public-catalog-successor-producer-v1.js": null,
+    "./dist/rfc64/public-catalog-successor-asset-v1.js": null,
     "./dist/rfc64/public-catalog-transport-v1.js": null,
     "./dist/rfc64/recoverable-author-attestation-v1.js": null,
     "./dist/rfc64/secure-filesystem-policy-v1.js": null,

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -226,6 +226,7 @@ const blockedRfc64Modules = [
   'secure-filesystem-policy-v1.js',
   'swm-recovery-coordinator-v1.js',
   'swm-recovery-plan-v1.js',
+  'swm-inventory-catalog-reconciler-v1.js',
   'swm-inventory-shadow-runtime-v1.js',
 ];
 const packageExports = packageManifest.exports;

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -220,6 +220,7 @@ const blockedRfc64Modules = [
   'public-catalog-receiver-v1.js',
   'public-catalog-service-v1.js',
   'public-catalog-issuer-delegation-v1.js',
+  'public-catalog-successor-asset-v1.js',
   'public-catalog-successor-producer-v1.js',
   'public-catalog-transport-v1.js',
   'recoverable-author-attestation-v1.js',

--- a/packages/agent/src/dkg-agent-rfc64-catalog-auto-publish.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog-auto-publish.ts
@@ -7,6 +7,7 @@
 
 import {
   assertAssertionCoordinateV1,
+  assertCanonicalEvmAddress,
   assertContextGraphIdV1,
   assertSafeIri,
   assertSubGraphNameV1,
@@ -14,6 +15,7 @@ import {
   canonicalGraphScopedAuthorSealFromAssertionSealV1,
   computeCanonicalGraphScopedAuthorSealDigestV1,
   computeKaProjectionDigestV1,
+  computeSwmAuthorInventoryScopeDigestV1,
   contextGraphAssertionUri,
   contextGraphMetaUri,
   createOperationContext,
@@ -32,6 +34,7 @@ import {
   type OperationContext,
   type SubGraphNameV1,
   type SwmAuthorInventoryScopeV1,
+  type SwmAuthorInventoryRowV1,
   type SwmAuthorInventorySnapshotV1,
   type TimestampMsV1,
 } from '@origintrail-official/dkg-core';
@@ -48,6 +51,8 @@ import type {
   Rfc64CatalogAuthorSignerV1,
   Rfc64CatalogSuccessorAssetInputV1,
 } from './dkg-agent-rfc64-catalog.js';
+import type { ReconcileRfc64PublicRootCatalogExactSetResultV1 } from
+  './dkg-agent-rfc64-catalog-upsert.js';
 import type { Rfc64PublicCatalogAutoPublishConfigV1 } from './dkg-agent-types.js';
 import { snapshotRfc64CatalogDeploymentProfileV1 } from './rfc64/catalog-authority-config-v1.js';
 import type { AppliedCatalogHeadSnapshotV1 } from './rfc64/inventory-v1/index.js';
@@ -56,6 +61,9 @@ import {
   maintainRfc64SwmAuthorInventoryV1,
   removeRfc64SwmAuthorInventoryRowV1,
 } from './rfc64/swm-author-inventory-producer-v1.js';
+import {
+  prepareRfc64SwmInventoryCatalogTargetV1,
+} from './rfc64/swm-inventory-catalog-reconciler-v1.js';
 import {
   Rfc64SwmInventoryShadowRuntimeV1,
   type Rfc64SwmAuthorInventoryShadowMutationResultV1,
@@ -154,6 +162,17 @@ export interface ObserveRfc64ConfirmedVmParamsV1 {
   readonly assertionUri: string;
   readonly ctx: OperationContext;
   readonly publicationLabel: 'publish' | 'queued publish';
+}
+
+/** Explicit dormant R1.1 bridge; ordinary SHARE does not call this method. */
+export interface ReconcileRfc64PublicCatalogFromSwmInventoryParamsV1 {
+  readonly contextGraphId: ContextGraphIdV1;
+  readonly authorAddress: EvmAddressV1;
+}
+
+export interface ReconcileRfc64PublicCatalogFromSwmInventoryResultV1
+  extends ReconcileRfc64PublicRootCatalogExactSetResultV1 {
+  readonly inventoryHeadObjectDigest: Digest32V1;
 }
 
 interface ResolvedRfc64AcceptedPublicRootLaneV1 {
@@ -296,6 +315,59 @@ export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
       params.inventoryScopeDigest,
       params.authorAddress,
     ) ?? null;
+  }
+
+  /**
+   * Authenticate the author's complete signed SWM inventory, resolve every
+   * named durable public projection, and advance the matching catalog through
+   * deterministic one-KA successors. This stays explicit/dormant in R1.1;
+   * the later activation slice owns scheduling it after an atomic inventory
+   * commit.
+   */
+  async reconcileRfc64PublicCatalogFromSwmInventoryV1(
+    this: DKGAgent,
+    params: ReconcileRfc64PublicCatalogFromSwmInventoryParamsV1,
+  ): Promise<ReconcileRfc64PublicCatalogFromSwmInventoryResultV1 | null> {
+    assertContextGraphIdV1(params.contextGraphId, 'SWM catalog reconcile contextGraphId');
+    assertCanonicalEvmAddress(params.authorAddress, 'SWM catalog reconcile authorAddress');
+    const lane = this.resolveRfc64AcceptedPublicRootLaneV1(params.contextGraphId, null);
+    if (lane === null) return null;
+    const inventoryScope = Object.freeze({
+      ...lane.scopeBase,
+      authorAddress: params.authorAddress,
+    }) as SwmAuthorInventoryScopeV1;
+    const persistence = this.rfc64PersistenceV1;
+    if (persistence === undefined) throw new Error('RFC-64 persistence is unavailable');
+    const snapshot = persistence.swmAuthorInventory.readSwmAuthorInventorySnapshotV1(
+      computeSwmAuthorInventoryScopeDigestV1(inventoryScope),
+      params.authorAddress,
+    );
+    if (snapshot === null) return null;
+    const prepared = await prepareRfc64SwmInventoryCatalogTargetV1({
+      snapshot,
+      resolveAsset: (row) => this.resolveRfc64SwmInventoryCatalogAssetV1(
+        params.contextGraphId,
+        params.authorAddress,
+        row,
+      ),
+    });
+    lane.service.acceptedPolicySnapshotForCatalogScope(prepared.catalogScope);
+    const reconciled = await this.reconcileRfc64PublicRootCatalogExactSetV1({
+      scope: prepared.catalogScope,
+      author: this.createRfc64CatalogAuthorSignerV1(params.authorAddress),
+      assets: prepared.assets,
+      deployment: await this.resolveRfc64AutoPublishDeploymentProfileV1(lane.networkId),
+      peers: lane.autoPublishConfig.peers,
+      catalogIssuerDelegationEffectiveAt:
+        lane.autoPublishConfig.catalogIssuerDelegationEffectiveAt
+        ?? ('0' as TimestampMsV1),
+      catalogIssuerDelegationExpiresAt:
+        lane.autoPublishConfig.catalogIssuerDelegationExpiresAt,
+    });
+    return Object.freeze({
+      ...reconciled,
+      inventoryHeadObjectDigest: prepared.inventoryHeadObjectDigest as Digest32V1,
+    });
   }
 
   /** Read-only process-local evidence; authoritative state remains the signed SQLite snapshot. */
@@ -649,6 +721,70 @@ export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
       `RFC-64 SWM inventory shadow ${action} failed after the user operation committed: ${error}`,
     );
     return shadowResult('failed', action, 0, null, error);
+  }
+
+  private async resolveRfc64SwmInventoryCatalogAssetV1(
+    this: DKGAgent,
+    contextGraphId: ContextGraphIdV1,
+    authorAddress: EvmAddressV1,
+    row: Readonly<SwmAuthorInventoryRowV1>,
+  ): Promise<Rfc64CatalogSuccessorAssetInputV1> {
+    const assertionUri = contextGraphAssertionUri(
+      contextGraphId,
+      authorAddress,
+      row.assertionCoordinate,
+    );
+    const metaGraph = contextGraphMetaUri(contextGraphId);
+    const sealResult = await this.store.query(
+      `CONSTRUCT { <${assertSafeIri(assertionUri)}> ?p ?o } WHERE { GRAPH <${assertSafeIri(metaGraph)}> { <${assertSafeIri(assertionUri)}> ?p ?o } }`,
+      { source: 'agent.rfc64.swmInventory.catalogReconcile.seal' },
+    );
+    const candidate = parseGraphScopedAssertionSealCandidate(
+      sealResult.type === 'quads' ? sealResult.quads : [],
+      assertionUri,
+    );
+    if (candidate === undefined) {
+      throw new Error(`durable SWM inventory asset ${row.kaUal} has no strict author seal`);
+    }
+    if (
+      candidate.coordinate.scope !== contextGraphId
+      || candidate.coordinate.agentAddress.toLowerCase() !== authorAddress
+      || candidate.coordinate.name !== row.assertionCoordinate
+    ) {
+      throw new Error(`durable SWM inventory asset ${row.kaUal} has a different seal coordinate`);
+    }
+    const seal = canonicalGraphScopedAuthorSealFromAssertionSealV1(candidate.seal);
+    const graphManager = new GraphManager(this.store);
+    const head = await resolvePublishedKnowledgeAssetWorkspaceHead({
+      store: this.store,
+      graphManager,
+      contextGraphId,
+      kaUal: row.kaUal,
+    });
+    if (
+      head === undefined
+      || head.shareOperationId !== row.shareOperationId
+      || head.assertionVersion !== row.assertionVersion
+      || head.publicTripleCount !== Number(row.publicTripleCount)
+      || head.privateTripleCount !== Number(row.privateTripleCount)
+      || head.accessPolicy !== 'public'
+    ) {
+      throw new Error(`durable SWM head differs from signed inventory row ${row.kaUal}`);
+    }
+    const snapshot = await resolveKnowledgeAssetOperationPublicQuads({
+      store: this.store,
+      graphManager,
+      contextGraphId,
+      shareOperationId: row.shareOperationId,
+      kaUal: row.kaUal,
+      assertionVersion: row.assertionVersion,
+      publicSnapshotStore: this.publicSnapshotStore,
+    });
+    return Object.freeze({
+      assertionCoordinate: row.assertionCoordinate,
+      projectionBytes: encodeCanonicalCgSharedPublicRootProjectionV1(snapshot.quads),
+      seal,
+    });
   }
 
   private recordRfc64SwmAuthorInventoryShadowStatsV1(

--- a/packages/agent/src/dkg-agent-rfc64-catalog-auto-publish.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog-auto-publish.ts
@@ -338,36 +338,42 @@ export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
     }) as SwmAuthorInventoryScopeV1;
     const persistence = this.rfc64PersistenceV1;
     if (persistence === undefined) throw new Error('RFC-64 persistence is unavailable');
-    const snapshot = persistence.swmAuthorInventory.readSwmAuthorInventorySnapshotV1(
-      computeSwmAuthorInventoryScopeDigestV1(inventoryScope),
-      params.authorAddress,
+    const inventoryScopeDigest = computeSwmAuthorInventoryScopeDigestV1(inventoryScope);
+    return rfc64SwmInventoryShadowRuntimeV1(this).runScopeExclusive(
+      `${inventoryScopeDigest}\n${params.authorAddress}`,
+      async () => {
+        const snapshot = persistence.swmAuthorInventory.readSwmAuthorInventorySnapshotV1(
+          inventoryScopeDigest,
+          params.authorAddress,
+        );
+        if (snapshot === null) return null;
+        const prepared = await prepareRfc64SwmInventoryCatalogTargetV1({
+          snapshot,
+          resolveAsset: (row) => this.resolveRfc64SwmInventoryCatalogAssetV1(
+            params.contextGraphId,
+            params.authorAddress,
+            row,
+          ),
+        });
+        lane.service.acceptedPolicySnapshotForCatalogScope(prepared.catalogScope);
+        const reconciled = await this.reconcileRfc64PublicRootCatalogExactSetV1({
+          scope: prepared.catalogScope,
+          author: this.createRfc64CatalogAuthorSignerV1(params.authorAddress),
+          assets: prepared.assets,
+          deployment: await this.resolveRfc64AutoPublishDeploymentProfileV1(lane.networkId),
+          peers: lane.autoPublishConfig.peers,
+          catalogIssuerDelegationEffectiveAt:
+            lane.autoPublishConfig.catalogIssuerDelegationEffectiveAt
+            ?? ('0' as TimestampMsV1),
+          catalogIssuerDelegationExpiresAt:
+            lane.autoPublishConfig.catalogIssuerDelegationExpiresAt,
+        });
+        return Object.freeze({
+          ...reconciled,
+          inventoryHeadObjectDigest: prepared.inventoryHeadObjectDigest as Digest32V1,
+        });
+      },
     );
-    if (snapshot === null) return null;
-    const prepared = await prepareRfc64SwmInventoryCatalogTargetV1({
-      snapshot,
-      resolveAsset: (row) => this.resolveRfc64SwmInventoryCatalogAssetV1(
-        params.contextGraphId,
-        params.authorAddress,
-        row,
-      ),
-    });
-    lane.service.acceptedPolicySnapshotForCatalogScope(prepared.catalogScope);
-    const reconciled = await this.reconcileRfc64PublicRootCatalogExactSetV1({
-      scope: prepared.catalogScope,
-      author: this.createRfc64CatalogAuthorSignerV1(params.authorAddress),
-      assets: prepared.assets,
-      deployment: await this.resolveRfc64AutoPublishDeploymentProfileV1(lane.networkId),
-      peers: lane.autoPublishConfig.peers,
-      catalogIssuerDelegationEffectiveAt:
-        lane.autoPublishConfig.catalogIssuerDelegationEffectiveAt
-        ?? ('0' as TimestampMsV1),
-      catalogIssuerDelegationExpiresAt:
-        lane.autoPublishConfig.catalogIssuerDelegationExpiresAt,
-    });
-    return Object.freeze({
-      ...reconciled,
-      inventoryHeadObjectDigest: prepared.inventoryHeadObjectDigest as Digest32V1,
-    });
   }
 
   /** Read-only process-local evidence; authoritative state remains the signed SQLite snapshot. */
@@ -494,28 +500,32 @@ export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
       if (persistence === undefined) throw new Error('RFC-64 persistence is unavailable');
       const signer = this.createRfc64CatalogAuthorSignerV1(canonicalSeal.authorAddress);
       const issuedAt = Math.max(Date.now(), Number(sharedAt)).toString() as TimestampMsV1;
-      const maintained = await maintainRfc64SwmAuthorInventoryV1(
-        persistence.swmAuthorInventory,
-        {
-          scope,
-          row: Object.freeze({
-            assertionCoordinate: params.assertionCoordinate,
-            assertionVersion: canonicalSeal.assertionVersion,
-            kaUal: canonicalSeal.kaUal,
-            shareOperationId,
-            projectionDigest: computeKaProjectionDigestV1(projectionBytes),
-            publicTripleCount: canonicalSeal.publicTripleCount,
-            privateTripleCount: canonicalSeal.privateTripleCount,
-            sealDigest: computeCanonicalGraphScopedAuthorSealDigestV1(canonicalSeal),
-            sharedAt,
-            expiresAt: null,
-          }),
-          issuedAt,
-          signer: Object.freeze({
-            issuer: signer.address as EvmAddressV1,
-            signDigest: signer.signMessage,
-          }),
-        },
+      const inventoryScopeDigest = computeSwmAuthorInventoryScopeDigestV1(scope);
+      const maintained = await rfc64SwmInventoryShadowRuntimeV1(this).runScopeExclusive(
+        `${inventoryScopeDigest}\n${canonicalSeal.authorAddress}`,
+        () => maintainRfc64SwmAuthorInventoryV1(
+          persistence.swmAuthorInventory,
+          {
+            scope,
+            row: Object.freeze({
+              assertionCoordinate: params.assertionCoordinate as AssertionCoordinateV1,
+              assertionVersion: canonicalSeal.assertionVersion,
+              kaUal: canonicalSeal.kaUal,
+              shareOperationId,
+              projectionDigest: computeKaProjectionDigestV1(projectionBytes),
+              publicTripleCount: canonicalSeal.publicTripleCount,
+              privateTripleCount: canonicalSeal.privateTripleCount,
+              sealDigest: computeCanonicalGraphScopedAuthorSealDigestV1(canonicalSeal),
+              sharedAt,
+              expiresAt: null,
+            }),
+            issuedAt,
+            signer: Object.freeze({
+              issuer: signer.address as EvmAddressV1,
+              signDigest: signer.signMessage,
+            }),
+          },
+        ),
       );
       return this.recordRfc64SwmAuthorInventoryShadowStatsV1(
         shadowResult(
@@ -565,21 +575,25 @@ export class Rfc64CatalogAutoPublishMethods extends DKGAgentBase {
       const persistence = this.rfc64PersistenceV1;
       if (persistence === undefined) throw new Error('RFC-64 persistence is unavailable');
       const signer = this.createRfc64CatalogAuthorSignerV1(seal.authorAddress);
-      const removed = await removeRfc64SwmAuthorInventoryRowV1(
-        persistence.swmAuthorInventory,
-        {
-        scope,
-        expectedRow: Object.freeze({
-          kaUal: seal.kaUal,
-          assertionVersion: seal.assertionVersion,
-          sealDigest: computeCanonicalGraphScopedAuthorSealDigestV1(seal),
-        }),
-        issuedAt: Date.now().toString() as TimestampMsV1,
-        signer: Object.freeze({
-          issuer: signer.address as EvmAddressV1,
-          signDigest: signer.signMessage,
-        }),
-        },
+      const inventoryScopeDigest = computeSwmAuthorInventoryScopeDigestV1(scope);
+      const removed = await rfc64SwmInventoryShadowRuntimeV1(this).runScopeExclusive(
+        `${inventoryScopeDigest}\n${seal.authorAddress}`,
+        () => removeRfc64SwmAuthorInventoryRowV1(
+          persistence.swmAuthorInventory,
+          {
+            scope,
+            expectedRow: Object.freeze({
+              kaUal: seal.kaUal,
+              assertionVersion: seal.assertionVersion,
+              sealDigest: computeCanonicalGraphScopedAuthorSealDigestV1(seal),
+            }),
+            issuedAt: Date.now().toString() as TimestampMsV1,
+            signer: Object.freeze({
+              issuer: signer.address as EvmAddressV1,
+              signDigest: signer.signMessage,
+            }),
+          },
+        ),
       );
       return this.recordRfc64SwmAuthorInventoryShadowStatsV1(
         shadowResult(

--- a/packages/agent/src/dkg-agent-rfc64-catalog-upsert.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog-upsert.ts
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-/** Catalog-owned, serialized exact-set mutation for one confirmed public asset. */
+/** Catalog-owned, serialized exact-set mutations for confirmed public SWM assets. */
 
 import {
+  MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1,
   assertSignedAuthorCatalogHeadEnvelopeV1,
   assertSignedAuthorCatalogIssuerDelegationEnvelopeV1,
   canonicalizeCanonicalGraphScopedAuthorSealV1,
@@ -27,6 +28,10 @@ import {
   type Rfc64StagedAuthorCatalogHeadRefV1,
 } from './dkg-agent-rfc64-catalog.js';
 import type { AppliedCatalogHeadSnapshotV1 } from './rfc64/inventory-v1/index.js';
+import {
+  assertExactFieldSetV1,
+  snapshotPlainDataRecordV1,
+} from './rfc64/inventory-v1/exact-record.js';
 import { snapshotRfc64PublicCatalogAnnouncementPeersV1 } from './rfc64/catalog-peers-v1.js';
 import { computeRfc64AppliedInventoryDigestV1 } from './rfc64/public-catalog-inventory-completeness-v1.js';
 import type { Rfc64PublicCatalogIssuerAuthorizationV1 } from './rfc64/public-catalog-successor-producer-v1.js';
@@ -40,6 +45,32 @@ export interface UpsertConfirmedRfc64PublicRootCatalogAssetParamsV1 {
   readonly peers: readonly string[];
   readonly catalogIssuerDelegationEffectiveAt: TimestampMsV1;
   readonly catalogIssuerDelegationExpiresAt: TimestampMsV1;
+}
+
+export interface ReconcileRfc64PublicRootCatalogExactSetParamsV1 {
+  readonly scope: AuthorCatalogScopeV1;
+  readonly author: Rfc64CatalogAuthorSignerV1;
+  /** Complete bounded target. Input order is ignored after immutable snapshotting. */
+  readonly assets: readonly Rfc64CatalogSuccessorAssetInputV1[];
+  readonly deployment: CatalogSealDeploymentProfileV1;
+  readonly peers: readonly string[];
+  readonly catalogIssuerDelegationEffectiveAt: TimestampMsV1;
+  readonly catalogIssuerDelegationExpiresAt: TimestampMsV1;
+}
+
+export interface ReconcileRfc64PublicRootCatalogExactSetResultV1 {
+  readonly status: 'advanced' | 'existing' | 'empty';
+  readonly appliedHead: AppliedCatalogHeadSnapshotV1 | null;
+  readonly successorsApplied: number;
+  readonly targetAssetCount: number;
+}
+
+interface Rfc64CatalogMutationStateV1 {
+  readonly current: AppliedCatalogHeadSnapshotV1 | null;
+  readonly previousHead: Rfc64StagedAuthorCatalogHeadRefV1;
+  readonly catalogIssuerAuthorization: Rfc64PublicCatalogIssuerAuthorizationV1;
+  readonly assets: Rfc64CatalogSuccessorAssetInputV1[];
+  readonly expectedCurrentCatalogHeadDigest: Digest32V1 | null;
 }
 
 export class Rfc64CatalogUpsertMethods extends DKGAgentBase {
@@ -72,64 +103,12 @@ export class Rfc64CatalogUpsertMethods extends DKGAgentBase {
     const queueKey = `${catalogScopeDigest}\n${params.scope.authorAddress}`;
 
     return this.runSerializedRfc64AuthorCatalogMutationV1(queueKey, async () => {
-      const current = persistence.inventory.readAppliedCatalogHeadV1(
+      const state = await this.loadRfc64CatalogMutationStateV1(
+        persistence,
         catalogScopeDigest,
-        params.scope.authorAddress,
+        params,
       );
-      let previousHead: Rfc64StagedAuthorCatalogHeadRefV1;
-      let catalogIssuerAuthorization: Rfc64PublicCatalogIssuerAuthorizationV1;
-      let assets: Rfc64CatalogSuccessorAssetInputV1[];
-      let expectedCurrentCatalogHeadDigest: Digest32V1 | null;
-      if (current === null) {
-        const genesis = await this.publishAuthorCatalogGenesisV1({
-          scope: params.scope,
-          author: params.author,
-          peers: [],
-          issuedAt: Date.now().toString() as TimestampMsV1,
-          catalogIssuerDelegationEffectiveAt:
-            params.catalogIssuerDelegationEffectiveAt,
-          catalogIssuerDelegationExpiresAt:
-            params.catalogIssuerDelegationExpiresAt,
-        });
-        previousHead = Object.freeze({
-          objectDigest: genesis.headObjectDigest,
-          signatureVariantDigest: genesis.signatureVariantDigest,
-        });
-        catalogIssuerAuthorization = genesis.catalogIssuerAuthorization;
-        assets = [];
-        expectedCurrentCatalogHeadDigest = null;
-      } else {
-        const storedHead = await persistence.controlObjects.getVerifiedObjectByDigest({
-          objectDigest: current.currentCatalogHeadDigest,
-          verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
-        });
-        if (storedHead === null) {
-          throw new Error('RFC-64 applied author head is not durably staged');
-        }
-        assertSignedAuthorCatalogHeadEnvelopeV1(storedHead.envelope);
-        previousHead = Object.freeze({
-          objectDigest: storedHead.envelope.objectDigest as Digest32V1,
-          signatureVariantDigest: computeControlSignatureVariantDigestHex(
-            storedHead.envelope.objectDigest,
-            storedHead.envelope.signature,
-          ) as Digest32V1,
-        });
-        const history = await loadBoundedAuthorCatalogHistoryV1(persistence, previousHead);
-        assets = await loadRfc64CatalogSuccessorAssetsV1(persistence, history);
-        const storedDelegation = await persistence.controlObjects.getVerifiedObjectByDigest({
-          objectDigest: history.previousHead.payload.catalogIssuerDelegationDigest,
-          verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
-        });
-        if (storedDelegation === null) {
-          throw new Error('RFC-64 applied author head delegation is not durably staged');
-        }
-        assertSignedAuthorCatalogIssuerDelegationEnvelopeV1(storedDelegation.envelope);
-        catalogIssuerAuthorization = Object.freeze({
-          catalogIssuerDelegation: storedDelegation.envelope,
-          parentAuthorAgentEvidence: null,
-        });
-        expectedCurrentCatalogHeadDigest = current.currentCatalogHeadDigest;
-      }
+      const assets = state.assets;
       const existingIndex = assets.findIndex(
         (asset) => asset.seal.reservedKaId === params.asset.seal.reservedKaId,
       );
@@ -137,42 +116,228 @@ export class Rfc64CatalogUpsertMethods extends DKGAgentBase {
         existingIndex >= 0
         && sameRfc64SuccessorAssetV1(assets[existingIndex]!, params.asset)
       ) {
-        if (current === null) {
+        if (state.current === null) {
           throw new Error('RFC-64 staged genesis unexpectedly contains an ordinary asset');
         }
-        return current;
+        return state.current;
       }
       if (existingIndex >= 0) assets[existingIndex] = params.asset;
       else assets.push(params.asset);
-
-      const successor = await this.publishAuthorCatalogExactSetSuccessorV1({
-        previousHead,
-        author: params.author,
-        catalogIssuerAuthorization,
+      const committed = await this.applyRfc64CatalogSuccessorV1(
+        persistence,
+        state,
+        params,
         assets,
-        deployment: params.deployment,
-        issuedAt: Date.now().toString() as TimestampMsV1,
-        peers: [],
-      });
-      const appliedInventoryDigest = computeRfc64AppliedInventoryDigestV1({
-        catalogScopeDigest: successor.catalogScopeDigest,
-        rows: successor.assets,
-      });
-      const applied = persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
-        catalogScopeDigest: successor.catalogScopeDigest,
-        authorAddress: params.scope.authorAddress,
-        currentCatalogHeadDigest: successor.headObjectDigest,
-        appliedInventoryDigest,
-        catalogVersion: successor.announcement.catalogVersion,
-        inventoryRowCount: successor.signedBucketRowCount,
-        expectedCurrentCatalogHeadDigest,
-      }).snapshot;
-      await this.announceRfc64PublicCatalogHeadV1({
-        announcement: successor.announcement,
         peers,
-      });
-      return applied;
+      );
+      return committed.applied;
     });
+  }
+
+  /**
+   * Explicit dormant R1.1 entrypoint. Reconcile one complete, already-verified
+   * target through deterministic one-KA successors. Ordinary SHARE does not
+   * call this method until the later runtime activation slice.
+   */
+  async reconcileRfc64PublicRootCatalogExactSetV1(
+    this: DKGAgent,
+    params: ReconcileRfc64PublicRootCatalogExactSetParamsV1,
+  ): Promise<ReconcileRfc64PublicRootCatalogExactSetResultV1> {
+    if (params.scope.subGraphName !== null) {
+      throw new Error('RFC-64 exact-set reconciliation requires the root catalog lane');
+    }
+    const targetAssets = snapshotAndSortRfc64CatalogAssetsV1(params.assets);
+    for (const asset of targetAssets) {
+      if (asset.seal.authorAddress !== params.scope.authorAddress) {
+        throw new Error('RFC-64 exact-set target author differs from the catalog scope');
+      }
+    }
+    const peers = snapshotRfc64PublicCatalogAnnouncementPeersV1(params.peers);
+    const persistence = this.rfc64PersistenceV1;
+    if (persistence === undefined) {
+      throw new Error('RFC-64 exact-set reconciliation requires durable persistence');
+    }
+    const service = this.rfc64PublicCatalogServiceV1;
+    if (service === undefined) {
+      throw new Error('RFC-64 exact-set reconciliation requires the public catalog service');
+    }
+    service.acceptedPolicySnapshotForCatalogScope(params.scope);
+    const catalogScopeDigest = computeAuthorCatalogScopeDigestV1(params.scope);
+    const queueKey = `${catalogScopeDigest}\n${params.scope.authorAddress}`;
+
+    return this.runSerializedRfc64AuthorCatalogMutationV1(queueKey, async () => {
+      const currentBeforeGenesis = persistence.inventory.readAppliedCatalogHeadV1(
+        catalogScopeDigest,
+        params.scope.authorAddress,
+      );
+      if (currentBeforeGenesis === null && targetAssets.length === 0) {
+        return Object.freeze({
+          status: 'empty' as const,
+          appliedHead: null,
+          successorsApplied: 0,
+          targetAssetCount: 0,
+        });
+      }
+      let state = await this.loadRfc64CatalogMutationStateV1(
+        persistence,
+        catalogScopeDigest,
+        params,
+      );
+      assertReplacementHistoryIsContiguousV1(state.assets, targetAssets);
+      if (sameRfc64SuccessorAssetSetsV1(state.assets, targetAssets)) {
+        return Object.freeze({
+          status: state.current === null ? 'empty' as const : 'existing' as const,
+          appliedHead: state.current,
+          successorsApplied: 0,
+          targetAssetCount: targetAssets.length,
+        });
+      }
+
+      let successorsApplied = 0;
+      const hardLimit = MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1 * 2;
+      while (!sameRfc64SuccessorAssetSetsV1(state.assets, targetAssets)) {
+        if (successorsApplied >= hardLimit) {
+          throw new Error('RFC-64 exact-set reconciliation exceeded its bounded successor limit');
+        }
+        const nextAssets = nextRfc64CatalogExactSetV1(state.assets, targetAssets);
+        const committed = await this.applyRfc64CatalogSuccessorV1(
+          persistence,
+          state,
+          params,
+          nextAssets,
+          peers,
+        );
+        successorsApplied += 1;
+        state = Object.freeze({
+          current: committed.applied,
+          previousHead: Object.freeze({
+            objectDigest: committed.successor.headObjectDigest,
+            signatureVariantDigest: committed.successor.signatureVariantDigest,
+          }),
+          catalogIssuerAuthorization: state.catalogIssuerAuthorization,
+          assets: nextAssets,
+          expectedCurrentCatalogHeadDigest: committed.applied.currentCatalogHeadDigest,
+        });
+      }
+      return Object.freeze({
+        status: 'advanced' as const,
+        appliedHead: state.current,
+        successorsApplied,
+        targetAssetCount: targetAssets.length,
+      });
+    });
+  }
+
+  private async loadRfc64CatalogMutationStateV1(
+    this: DKGAgent,
+    persistence: Rfc64PersistenceV1,
+    catalogScopeDigest: Digest32V1,
+    params: Readonly<{
+      scope: AuthorCatalogScopeV1;
+      author: Rfc64CatalogAuthorSignerV1;
+      catalogIssuerDelegationEffectiveAt: TimestampMsV1;
+      catalogIssuerDelegationExpiresAt: TimestampMsV1;
+    }>,
+  ): Promise<Rfc64CatalogMutationStateV1> {
+    const current = persistence.inventory.readAppliedCatalogHeadV1(
+      catalogScopeDigest,
+      params.scope.authorAddress,
+    );
+    if (current === null) {
+      const genesis = await this.publishAuthorCatalogGenesisV1({
+        scope: params.scope,
+        author: params.author,
+        peers: [],
+        issuedAt: Date.now().toString() as TimestampMsV1,
+        catalogIssuerDelegationEffectiveAt: params.catalogIssuerDelegationEffectiveAt,
+        catalogIssuerDelegationExpiresAt: params.catalogIssuerDelegationExpiresAt,
+      });
+      return Object.freeze({
+        current,
+        previousHead: Object.freeze({
+          objectDigest: genesis.headObjectDigest,
+          signatureVariantDigest: genesis.signatureVariantDigest,
+        }),
+        catalogIssuerAuthorization: genesis.catalogIssuerAuthorization,
+        assets: [],
+        expectedCurrentCatalogHeadDigest: null,
+      });
+    }
+
+    const storedHead = await persistence.controlObjects.getVerifiedObjectByDigest({
+      objectDigest: current.currentCatalogHeadDigest,
+      verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+    });
+    if (storedHead === null) throw new Error('RFC-64 applied author head is not durably staged');
+    assertSignedAuthorCatalogHeadEnvelopeV1(storedHead.envelope);
+    const previousHead = Object.freeze({
+      objectDigest: storedHead.envelope.objectDigest as Digest32V1,
+      signatureVariantDigest: computeControlSignatureVariantDigestHex(
+        storedHead.envelope.objectDigest,
+        storedHead.envelope.signature,
+      ) as Digest32V1,
+    });
+    const history = await loadBoundedAuthorCatalogHistoryV1(persistence, previousHead);
+    const assets = await loadRfc64CatalogSuccessorAssetsV1(persistence, history);
+    const storedDelegation = await persistence.controlObjects.getVerifiedObjectByDigest({
+      objectDigest: history.previousHead.payload.catalogIssuerDelegationDigest,
+      verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+    });
+    if (storedDelegation === null) {
+      throw new Error('RFC-64 applied author head delegation is not durably staged');
+    }
+    assertSignedAuthorCatalogIssuerDelegationEnvelopeV1(storedDelegation.envelope);
+    return Object.freeze({
+      current,
+      previousHead,
+      catalogIssuerAuthorization: Object.freeze({
+        catalogIssuerDelegation: storedDelegation.envelope,
+        parentAuthorAgentEvidence: null,
+      }),
+      assets,
+      expectedCurrentCatalogHeadDigest: current.currentCatalogHeadDigest,
+    });
+  }
+
+  private async applyRfc64CatalogSuccessorV1(
+    this: DKGAgent,
+    persistence: Rfc64PersistenceV1,
+    state: Rfc64CatalogMutationStateV1,
+    params: Readonly<{
+      scope: AuthorCatalogScopeV1;
+      author: Rfc64CatalogAuthorSignerV1;
+      deployment: CatalogSealDeploymentProfileV1;
+    }>,
+    assets: readonly Rfc64CatalogSuccessorAssetInputV1[],
+    peers: readonly string[],
+  ) {
+    const successor = await this.publishAuthorCatalogExactSetSuccessorV1({
+      previousHead: state.previousHead,
+      author: params.author,
+      catalogIssuerAuthorization: state.catalogIssuerAuthorization,
+      assets,
+      deployment: params.deployment,
+      issuedAt: Date.now().toString() as TimestampMsV1,
+      peers: [],
+    });
+    const appliedInventoryDigest = computeRfc64AppliedInventoryDigestV1({
+      catalogScopeDigest: successor.catalogScopeDigest,
+      rows: successor.assets,
+    });
+    const applied = persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
+      catalogScopeDigest: successor.catalogScopeDigest,
+      authorAddress: params.scope.authorAddress,
+      currentCatalogHeadDigest: successor.headObjectDigest,
+      appliedInventoryDigest,
+      catalogVersion: successor.announcement.catalogVersion,
+      inventoryRowCount: successor.signedBucketRowCount,
+      expectedCurrentCatalogHeadDigest: state.expectedCurrentCatalogHeadDigest,
+    }).snapshot;
+    await this.announceRfc64PublicCatalogHeadV1({
+      announcement: successor.announcement,
+      peers,
+    });
+    return Object.freeze({ applied, successor });
   }
 
   private async runSerializedRfc64AuthorCatalogMutationV1<T>(
@@ -195,6 +360,141 @@ export class Rfc64CatalogUpsertMethods extends DKGAgentBase {
       }
     }
   }
+}
+
+function snapshotAndSortRfc64CatalogAssetsV1(
+  input: readonly Rfc64CatalogSuccessorAssetInputV1[],
+): Rfc64CatalogSuccessorAssetInputV1[] {
+  if (!Array.isArray(input) || Object.getPrototypeOf(input) !== Array.prototype) {
+    throw new TypeError('RFC-64 exact-set target assets must be an ordinary Array');
+  }
+  if (input.length > MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1) {
+    throw new RangeError(
+      `RFC-64 exact-set target exceeds ${MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1} assets`,
+    );
+  }
+  const ownKeys = Reflect.ownKeys(input);
+  const expectedOwnKeys = new Set<string>([
+    'length',
+    ...Array.from({ length: input.length }, (_value, index) => String(index)),
+  ]);
+  if (
+    ownKeys.some((key) => typeof key !== 'string')
+    || ownKeys.length !== expectedOwnKeys.size
+    || ownKeys.some((key) => typeof key === 'string' && !expectedOwnKeys.has(key))
+  ) {
+    throw new TypeError('RFC-64 exact-set target assets must be a dense data array');
+  }
+  const result: Rfc64CatalogSuccessorAssetInputV1[] = [];
+  for (let index = 0; index < input.length; index += 1) {
+    const descriptor = Object.getOwnPropertyDescriptor(input, String(index));
+    if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+      throw new TypeError('RFC-64 exact-set target assets must contain only data elements');
+    }
+    const record = snapshotPlainDataRecordV1(
+      descriptor.value,
+      `RFC-64 exact-set target asset ${index}`,
+    );
+    assertExactFieldSetV1(
+      record,
+      ['assertionCoordinate', 'projectionBytes', 'seal'],
+      `RFC-64 exact-set target asset ${index}`,
+    );
+    if (!(record.projectionBytes instanceof Uint8Array)) {
+      throw new TypeError(`RFC-64 exact-set target asset ${index} projectionBytes must be Uint8Array`);
+    }
+    result.push(Object.freeze({
+      assertionCoordinate: record.assertionCoordinate as Rfc64CatalogSuccessorAssetInputV1['assertionCoordinate'],
+      projectionBytes: new Uint8Array(record.projectionBytes),
+      seal: parseCanonicalGraphScopedAuthorSealV1(
+        canonicalizeCanonicalGraphScopedAuthorSealV1(
+          record.seal as Rfc64CatalogSuccessorAssetInputV1['seal'],
+        ),
+      ),
+    }));
+  }
+  result.sort((left, right) => compareRfc64CatalogAssetsByKaIdV1(left, right));
+  for (let index = 1; index < result.length; index += 1) {
+    if (result[index - 1]!.seal.reservedKaId === result[index]!.seal.reservedKaId) {
+      throw new Error(`RFC-64 exact-set target contains duplicate KA ${result[index]!.seal.reservedKaId}`);
+    }
+  }
+  return result;
+}
+
+function assertReplacementHistoryIsContiguousV1(
+  current: readonly Rfc64CatalogSuccessorAssetInputV1[],
+  target: readonly Rfc64CatalogSuccessorAssetInputV1[],
+): void {
+  const currentByKaId = new Map(current.map((asset) => [asset.seal.reservedKaId, asset]));
+  for (const targetAsset of target) {
+    const currentAsset = currentByKaId.get(targetAsset.seal.reservedKaId);
+    if (currentAsset === undefined || sameRfc64SuccessorAssetV1(currentAsset, targetAsset)) continue;
+    if (
+      currentAsset.assertionCoordinate !== targetAsset.assertionCoordinate
+      || BigInt(targetAsset.seal.assertionVersion)
+        !== BigInt(currentAsset.seal.assertionVersion) + 1n
+    ) {
+      throw new Error(
+        `RFC-64 exact-set replacement for KA ${targetAsset.seal.reservedKaId} is not the next assertion version`,
+      );
+    }
+  }
+}
+
+function nextRfc64CatalogExactSetV1(
+  current: readonly Rfc64CatalogSuccessorAssetInputV1[],
+  target: readonly Rfc64CatalogSuccessorAssetInputV1[],
+): Rfc64CatalogSuccessorAssetInputV1[] {
+  let currentIndex = 0;
+  let targetIndex = 0;
+  while (currentIndex < current.length || targetIndex < target.length) {
+    const currentAsset = current[currentIndex];
+    const targetAsset = target[targetIndex];
+    if (currentAsset === undefined) {
+      return insertRfc64CatalogAssetV1(current, targetAsset!);
+    }
+    if (targetAsset === undefined) {
+      return current.filter((_, index) => index !== currentIndex);
+    }
+    const comparison = compareRfc64CatalogAssetsByKaIdV1(currentAsset, targetAsset);
+    if (comparison < 0) return current.filter((_, index) => index !== currentIndex);
+    if (comparison > 0) return insertRfc64CatalogAssetV1(current, targetAsset);
+    if (!sameRfc64SuccessorAssetV1(currentAsset, targetAsset)) {
+      const next = [...current];
+      next[currentIndex] = targetAsset;
+      return next;
+    }
+    currentIndex += 1;
+    targetIndex += 1;
+  }
+  throw new Error('RFC-64 exact-set planner was called for an already-converged target');
+}
+
+function insertRfc64CatalogAssetV1(
+  current: readonly Rfc64CatalogSuccessorAssetInputV1[],
+  asset: Rfc64CatalogSuccessorAssetInputV1,
+): Rfc64CatalogSuccessorAssetInputV1[] {
+  const next = [...current, asset];
+  next.sort((left, right) => compareRfc64CatalogAssetsByKaIdV1(left, right));
+  return next;
+}
+
+function compareRfc64CatalogAssetsByKaIdV1(
+  left: Rfc64CatalogSuccessorAssetInputV1,
+  right: Rfc64CatalogSuccessorAssetInputV1,
+): number {
+  const leftId = BigInt(left.seal.reservedKaId);
+  const rightId = BigInt(right.seal.reservedKaId);
+  return leftId < rightId ? -1 : leftId > rightId ? 1 : 0;
+}
+
+function sameRfc64SuccessorAssetSetsV1(
+  left: readonly Rfc64CatalogSuccessorAssetInputV1[],
+  right: readonly Rfc64CatalogSuccessorAssetInputV1[],
+): boolean {
+  return left.length === right.length
+    && left.every((asset, index) => sameRfc64SuccessorAssetV1(asset, right[index]!));
 }
 
 async function loadRfc64CatalogSuccessorAssetsV1(

--- a/packages/agent/src/dkg-agent-rfc64-catalog-upsert.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog-upsert.ts
@@ -29,9 +29,9 @@ import {
 } from './dkg-agent-rfc64-catalog.js';
 import type { AppliedCatalogHeadSnapshotV1 } from './rfc64/inventory-v1/index.js';
 import {
-  assertExactFieldSetV1,
-  snapshotPlainDataRecordV1,
-} from './rfc64/inventory-v1/exact-record.js';
+  compareRfc64PublicCatalogSuccessorAssetsByKaIdV1,
+  snapshotAndSortRfc64PublicCatalogSuccessorAssetsV1,
+} from './rfc64/public-catalog-successor-asset-v1.js';
 import { snapshotRfc64PublicCatalogAnnouncementPeersV1 } from './rfc64/catalog-peers-v1.js';
 import { computeRfc64AppliedInventoryDigestV1 } from './rfc64/public-catalog-inventory-completeness-v1.js';
 import type { Rfc64PublicCatalogIssuerAuthorizationV1 } from './rfc64/public-catalog-successor-producer-v1.js';
@@ -103,11 +103,12 @@ export class Rfc64CatalogUpsertMethods extends DKGAgentBase {
     const queueKey = `${catalogScopeDigest}\n${params.scope.authorAddress}`;
 
     return this.runSerializedRfc64AuthorCatalogMutationV1(queueKey, async () => {
-      const state = await this.loadRfc64CatalogMutationStateV1(
+      let state = await this.readRfc64CatalogMutationStateV1(
         persistence,
         catalogScopeDigest,
-        params,
+        params.scope.authorAddress,
       );
+      state ??= await this.createRfc64CatalogGenesisStateV1(params);
       const assets = state.assets;
       const existingIndex = assets.findIndex(
         (asset) => asset.seal.reservedKaId === params.asset.seal.reservedKaId,
@@ -146,7 +147,10 @@ export class Rfc64CatalogUpsertMethods extends DKGAgentBase {
     if (params.scope.subGraphName !== null) {
       throw new Error('RFC-64 exact-set reconciliation requires the root catalog lane');
     }
-    const targetAssets = snapshotAndSortRfc64CatalogAssetsV1(params.assets);
+    const targetAssets = snapshotAndSortRfc64PublicCatalogSuccessorAssetsV1(
+      params.assets,
+      'RFC-64 exact-set target assets',
+    );
     for (const asset of targetAssets) {
       if (asset.seal.authorAddress !== params.scope.authorAddress) {
         throw new Error('RFC-64 exact-set target author differs from the catalog scope');
@@ -166,11 +170,12 @@ export class Rfc64CatalogUpsertMethods extends DKGAgentBase {
     const queueKey = `${catalogScopeDigest}\n${params.scope.authorAddress}`;
 
     return this.runSerializedRfc64AuthorCatalogMutationV1(queueKey, async () => {
-      const currentBeforeGenesis = persistence.inventory.readAppliedCatalogHeadV1(
+      let state = await this.readRfc64CatalogMutationStateV1(
+        persistence,
         catalogScopeDigest,
         params.scope.authorAddress,
       );
-      if (currentBeforeGenesis === null && targetAssets.length === 0) {
+      if (state === null && targetAssets.length === 0) {
         return Object.freeze({
           status: 'empty' as const,
           appliedHead: null,
@@ -178,11 +183,7 @@ export class Rfc64CatalogUpsertMethods extends DKGAgentBase {
           targetAssetCount: 0,
         });
       }
-      let state = await this.loadRfc64CatalogMutationStateV1(
-        persistence,
-        catalogScopeDigest,
-        params,
-      );
+      state ??= await this.createRfc64CatalogGenesisStateV1(params);
       assertReplacementHistoryIsContiguousV1(state.assets, targetAssets);
       if (sameRfc64SuccessorAssetSetsV1(state.assets, targetAssets)) {
         return Object.freeze({
@@ -199,7 +200,7 @@ export class Rfc64CatalogUpsertMethods extends DKGAgentBase {
         if (successorsApplied >= hardLimit) {
           throw new Error('RFC-64 exact-set reconciliation exceeded its bounded successor limit');
         }
-        const nextAssets = nextRfc64CatalogExactSetV1(state.assets, targetAssets);
+        const nextAssets = planNextRfc64CatalogExactSetV1(state.assets, targetAssets);
         const committed = await this.applyRfc64CatalogSuccessorV1(
           persistence,
           state,
@@ -228,41 +229,17 @@ export class Rfc64CatalogUpsertMethods extends DKGAgentBase {
     });
   }
 
-  private async loadRfc64CatalogMutationStateV1(
+  private async readRfc64CatalogMutationStateV1(
     this: DKGAgent,
     persistence: Rfc64PersistenceV1,
     catalogScopeDigest: Digest32V1,
-    params: Readonly<{
-      scope: AuthorCatalogScopeV1;
-      author: Rfc64CatalogAuthorSignerV1;
-      catalogIssuerDelegationEffectiveAt: TimestampMsV1;
-      catalogIssuerDelegationExpiresAt: TimestampMsV1;
-    }>,
-  ): Promise<Rfc64CatalogMutationStateV1> {
+    authorAddress: AuthorCatalogScopeV1['authorAddress'],
+  ): Promise<Rfc64CatalogMutationStateV1 | null> {
     const current = persistence.inventory.readAppliedCatalogHeadV1(
       catalogScopeDigest,
-      params.scope.authorAddress,
+      authorAddress,
     );
-    if (current === null) {
-      const genesis = await this.publishAuthorCatalogGenesisV1({
-        scope: params.scope,
-        author: params.author,
-        peers: [],
-        issuedAt: Date.now().toString() as TimestampMsV1,
-        catalogIssuerDelegationEffectiveAt: params.catalogIssuerDelegationEffectiveAt,
-        catalogIssuerDelegationExpiresAt: params.catalogIssuerDelegationExpiresAt,
-      });
-      return Object.freeze({
-        current,
-        previousHead: Object.freeze({
-          objectDigest: genesis.headObjectDigest,
-          signatureVariantDigest: genesis.signatureVariantDigest,
-        }),
-        catalogIssuerAuthorization: genesis.catalogIssuerAuthorization,
-        assets: [],
-        expectedCurrentCatalogHeadDigest: null,
-      });
-    }
+    if (current === null) return null;
 
     const storedHead = await persistence.controlObjects.getVerifiedObjectByDigest({
       objectDigest: current.currentCatalogHeadDigest,
@@ -296,6 +273,35 @@ export class Rfc64CatalogUpsertMethods extends DKGAgentBase {
       }),
       assets,
       expectedCurrentCatalogHeadDigest: current.currentCatalogHeadDigest,
+    });
+  }
+
+  private async createRfc64CatalogGenesisStateV1(
+    this: DKGAgent,
+    params: Readonly<{
+      scope: AuthorCatalogScopeV1;
+      author: Rfc64CatalogAuthorSignerV1;
+      catalogIssuerDelegationEffectiveAt: TimestampMsV1;
+      catalogIssuerDelegationExpiresAt: TimestampMsV1;
+    }>,
+  ): Promise<Rfc64CatalogMutationStateV1> {
+    const genesis = await this.publishAuthorCatalogGenesisV1({
+      scope: params.scope,
+      author: params.author,
+      peers: [],
+      issuedAt: Date.now().toString() as TimestampMsV1,
+      catalogIssuerDelegationEffectiveAt: params.catalogIssuerDelegationEffectiveAt,
+      catalogIssuerDelegationExpiresAt: params.catalogIssuerDelegationExpiresAt,
+    });
+    return Object.freeze({
+      current: null,
+      previousHead: Object.freeze({
+        objectDigest: genesis.headObjectDigest,
+        signatureVariantDigest: genesis.signatureVariantDigest,
+      }),
+      catalogIssuerAuthorization: genesis.catalogIssuerAuthorization,
+      assets: [],
+      expectedCurrentCatalogHeadDigest: null,
     });
   }
 
@@ -362,66 +368,6 @@ export class Rfc64CatalogUpsertMethods extends DKGAgentBase {
   }
 }
 
-function snapshotAndSortRfc64CatalogAssetsV1(
-  input: readonly Rfc64CatalogSuccessorAssetInputV1[],
-): Rfc64CatalogSuccessorAssetInputV1[] {
-  if (!Array.isArray(input) || Object.getPrototypeOf(input) !== Array.prototype) {
-    throw new TypeError('RFC-64 exact-set target assets must be an ordinary Array');
-  }
-  if (input.length > MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1) {
-    throw new RangeError(
-      `RFC-64 exact-set target exceeds ${MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1} assets`,
-    );
-  }
-  const ownKeys = Reflect.ownKeys(input);
-  const expectedOwnKeys = new Set<string>([
-    'length',
-    ...Array.from({ length: input.length }, (_value, index) => String(index)),
-  ]);
-  if (
-    ownKeys.some((key) => typeof key !== 'string')
-    || ownKeys.length !== expectedOwnKeys.size
-    || ownKeys.some((key) => typeof key === 'string' && !expectedOwnKeys.has(key))
-  ) {
-    throw new TypeError('RFC-64 exact-set target assets must be a dense data array');
-  }
-  const result: Rfc64CatalogSuccessorAssetInputV1[] = [];
-  for (let index = 0; index < input.length; index += 1) {
-    const descriptor = Object.getOwnPropertyDescriptor(input, String(index));
-    if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
-      throw new TypeError('RFC-64 exact-set target assets must contain only data elements');
-    }
-    const record = snapshotPlainDataRecordV1(
-      descriptor.value,
-      `RFC-64 exact-set target asset ${index}`,
-    );
-    assertExactFieldSetV1(
-      record,
-      ['assertionCoordinate', 'projectionBytes', 'seal'],
-      `RFC-64 exact-set target asset ${index}`,
-    );
-    if (!(record.projectionBytes instanceof Uint8Array)) {
-      throw new TypeError(`RFC-64 exact-set target asset ${index} projectionBytes must be Uint8Array`);
-    }
-    result.push(Object.freeze({
-      assertionCoordinate: record.assertionCoordinate as Rfc64CatalogSuccessorAssetInputV1['assertionCoordinate'],
-      projectionBytes: new Uint8Array(record.projectionBytes),
-      seal: parseCanonicalGraphScopedAuthorSealV1(
-        canonicalizeCanonicalGraphScopedAuthorSealV1(
-          record.seal as Rfc64CatalogSuccessorAssetInputV1['seal'],
-        ),
-      ),
-    }));
-  }
-  result.sort((left, right) => compareRfc64CatalogAssetsByKaIdV1(left, right));
-  for (let index = 1; index < result.length; index += 1) {
-    if (result[index - 1]!.seal.reservedKaId === result[index]!.seal.reservedKaId) {
-      throw new Error(`RFC-64 exact-set target contains duplicate KA ${result[index]!.seal.reservedKaId}`);
-    }
-  }
-  return result;
-}
-
 function assertReplacementHistoryIsContiguousV1(
   current: readonly Rfc64CatalogSuccessorAssetInputV1[],
   target: readonly Rfc64CatalogSuccessorAssetInputV1[],
@@ -442,7 +388,7 @@ function assertReplacementHistoryIsContiguousV1(
   }
 }
 
-function nextRfc64CatalogExactSetV1(
+export function planNextRfc64CatalogExactSetV1(
   current: readonly Rfc64CatalogSuccessorAssetInputV1[],
   target: readonly Rfc64CatalogSuccessorAssetInputV1[],
 ): Rfc64CatalogSuccessorAssetInputV1[] {
@@ -452,14 +398,16 @@ function nextRfc64CatalogExactSetV1(
     const currentAsset = current[currentIndex];
     const targetAsset = target[targetIndex];
     if (currentAsset === undefined) {
-      return insertRfc64CatalogAssetV1(current, targetAsset!);
+      return insertOrFreeRfc64CatalogCapacityV1(current, target, targetAsset!);
     }
     if (targetAsset === undefined) {
       return current.filter((_, index) => index !== currentIndex);
     }
     const comparison = compareRfc64CatalogAssetsByKaIdV1(currentAsset, targetAsset);
     if (comparison < 0) return current.filter((_, index) => index !== currentIndex);
-    if (comparison > 0) return insertRfc64CatalogAssetV1(current, targetAsset);
+    if (comparison > 0) {
+      return insertOrFreeRfc64CatalogCapacityV1(current, target, targetAsset);
+    }
     if (!sameRfc64SuccessorAssetV1(currentAsset, targetAsset)) {
       const next = [...current];
       next[currentIndex] = targetAsset;
@@ -469,6 +417,23 @@ function nextRfc64CatalogExactSetV1(
     targetIndex += 1;
   }
   throw new Error('RFC-64 exact-set planner was called for an already-converged target');
+}
+
+function insertOrFreeRfc64CatalogCapacityV1(
+  current: readonly Rfc64CatalogSuccessorAssetInputV1[],
+  target: readonly Rfc64CatalogSuccessorAssetInputV1[],
+  asset: Rfc64CatalogSuccessorAssetInputV1,
+): Rfc64CatalogSuccessorAssetInputV1[] {
+  if (current.length < MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1) {
+    return insertRfc64CatalogAssetV1(current, asset);
+  }
+  const targetKaIds = new Set(target.map((targetAsset) => targetAsset.seal.reservedKaId));
+  for (let index = current.length - 1; index >= 0; index -= 1) {
+    if (!targetKaIds.has(current[index]!.seal.reservedKaId)) {
+      return current.filter((_currentAsset, currentIndex) => currentIndex !== index);
+    }
+  }
+  throw new Error('RFC-64 exact-set planner cannot free capacity for a target-only asset');
 }
 
 function insertRfc64CatalogAssetV1(
@@ -483,10 +448,8 @@ function insertRfc64CatalogAssetV1(
 function compareRfc64CatalogAssetsByKaIdV1(
   left: Rfc64CatalogSuccessorAssetInputV1,
   right: Rfc64CatalogSuccessorAssetInputV1,
-): number {
-  const leftId = BigInt(left.seal.reservedKaId);
-  const rightId = BigInt(right.seal.reservedKaId);
-  return leftId < rightId ? -1 : leftId > rightId ? 1 : 0;
+): -1 | 0 | 1 {
+  return compareRfc64PublicCatalogSuccessorAssetsByKaIdV1(left, right);
 }
 
 function sameRfc64SuccessorAssetSetsV1(

--- a/packages/agent/src/dkg-agent-rfc64-catalog.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog.ts
@@ -217,7 +217,7 @@ export interface PublishAuthorCatalogExactSetSuccessorParamsV1 {
   readonly previousHead: Rfc64StagedAuthorCatalogHeadRefV1;
   readonly author: Rfc64CatalogAuthorSignerV1;
   readonly catalogIssuerAuthorization: Rfc64PublicCatalogIssuerAuthorizationV1;
-  /** Complete 1..1024-row live set; input order does not affect the signed head. */
+  /** Complete 0..1024-row live set; input order does not affect the signed head. */
   readonly assets: readonly Rfc64CatalogSuccessorAssetInputV1[];
   readonly deployment: CatalogSealDeploymentProfileV1;
   readonly issuedAt?: TimestampMsV1;
@@ -592,10 +592,11 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
     }) as Readonly<AuthorCatalogScopeV1>;
     const catalogScopeDigest = computeAuthorCatalogScopeDigestV1(catalogScope);
     const predecessorScopeDigest = computeAuthorCatalogScopeDigestV1(scope);
-    const signedBucketRowCount = produced.publication.bucket?.payload.rows.length.toString();
+    const signedBucketRowCount = produced.publication.bucket?.payload.rows.length.toString() ?? '0';
     if (
-      signedBucketRowCount === undefined
-      || signedBucketRowCount !== head.payload.totalRows
+      signedBucketRowCount !== head.payload.totalRows
+      || (head.payload.totalRows === '0' && produced.publication.bucket !== null)
+      || (head.payload.totalRows !== '0' && produced.publication.bucket === null)
       || catalogScopeDigest !== predecessorScopeDigest
       || produced.assets.some(
         (asset) => asset.projection.catalogScopeDigest !== catalogScopeDigest,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -41,6 +41,7 @@ export {
 } from './rfc64/recoverable-author-attestation-v1.js';
 export * from './rfc64/author-catalog-producer.js';
 export * from './rfc64/swm-author-inventory-producer-v1.js';
+export * from './rfc64/swm-inventory-catalog-reconciler-v1.js';
 export * from './rfc64/public-catalog-transport-v1.js';
 export * from './rfc64/public-catalog-current-head-discovery-v1.js';
 export * from './rfc64/open-catalog-policy-v1.js';
@@ -160,6 +161,14 @@ export type {
   PublishAuthorCatalogGenesisParamsV1,
   Rfc64CatalogAuthorSignerV1,
 } from './dkg-agent-rfc64-catalog.js';
+export type {
+  ReconcileRfc64PublicRootCatalogExactSetParamsV1,
+  ReconcileRfc64PublicRootCatalogExactSetResultV1,
+} from './dkg-agent-rfc64-catalog-upsert.js';
+export type {
+  ReconcileRfc64PublicCatalogFromSwmInventoryParamsV1,
+  ReconcileRfc64PublicCatalogFromSwmInventoryResultV1,
+} from './dkg-agent-rfc64-catalog-auto-publish.js';
 export type {
   AcceptedRfc64CatalogAccessSnapshotV1,
 } from './rfc64/catalog-access-policy-v1.js';

--- a/packages/agent/src/rfc64/public-catalog-inventory-completeness-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-inventory-completeness-v1.ts
@@ -8,8 +8,8 @@
  * module is the join between those two facts: it rejects missing, duplicate,
  * extra, or mismatched rows before minting deterministic inventory evidence.
  *
- * Gate 2 deliberately stays inside one canonical v1 bucket (at most 1,024
- * rows). Directory-tree expansion is a later, orthogonal capacity slice.
+ * Gate 2 deliberately stays inside one canonical v1 bucket descriptor (zero
+ * to 1,024 rows). Directory-tree expansion is a later, orthogonal capacity slice.
  */
 
 import {
@@ -181,12 +181,12 @@ export function verifyRfc64PublicCatalogInventoryCompletenessV1(
     );
   }
   if (
-    expectedCount < 1n
+    expectedCount < 0n
     || expectedCount > BigInt(MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1)
   ) {
     fail(
       'catalog-inventory-completeness-count',
-      `bounded catalog completion supports 1..${MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1} rows`,
+      `bounded catalog completion supports 0..${MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1} rows`,
     );
   }
 

--- a/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
@@ -801,55 +801,64 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
     } catch (cause) {
       fail('catalog-native-receiver-catalog', 'successor directory path is invalid', cause);
     }
+    const isEmptyTarget = expectedRowCount === 0;
     if (
       descriptor.rowCount !== head.payload.totalRows
-      || descriptor.bucketDigest === ZERO_DIGEST32_V1
+      || (isEmptyTarget && (
+        descriptor.bucketDigest !== ZERO_DIGEST32_V1
+        || descriptor.byteLength !== '0'
+      ))
+      || (!isEmptyTarget && descriptor.bucketDigest === ZERO_DIGEST32_V1)
     ) {
       fail(
         'catalog-native-receiver-slice',
-        'bounded receiver requires one non-empty bucket containing the exact head row count',
+        'bounded receiver requires the canonical empty descriptor or one bucket containing the exact head row count',
       );
     }
 
-    const fetchedBucket = await this.fetchCatalogObjectWithCacheV1(
-      remotePeerId,
-      scope,
-      AUTHOR_CATALOG_BUCKET_OBJECT_TYPE_V1,
-      descriptor.bucketDigest,
-      signal,
-    );
-    if (fetchedBucket === null) {
-      fail('catalog-native-receiver-not-found', 'successor catalog bucket was not found');
-    }
-    let bucket: SignedAuthorCatalogBucketEnvelopeV1;
-    try {
-      assertSignedAuthorCatalogBucketEnvelopeV1(fetchedBucket.envelope);
-      bucket = fetchedBucket.envelope;
-      assertAuthorCatalogBucketScopeBindingV1(
-        bucket.payload,
-        deriveAuthorCatalogScopeFromHeadV1(head.payload),
+    let fetchedBucket: FetchedRfc64PublicCatalogObjectV1 | null = null;
+    let bucket: SignedAuthorCatalogBucketEnvelopeV1 | null = null;
+    if (!isEmptyTarget) {
+      fetchedBucket = await this.fetchCatalogObjectWithCacheV1(
+        remotePeerId,
+        scope,
+        AUTHOR_CATALOG_BUCKET_OBJECT_TYPE_V1,
+        descriptor.bucketDigest,
+        signal,
       );
-      if (
-        bucket.issuer !== head.issuer
-        || bucket.objectDigest !== descriptor.bucketDigest
-        || bucket.payload.bucketId !== descriptor.bucketId
-        || bucket.payload.rows.length !== expectedRowCount
-        || bucket.payload.rows.length.toString() !== descriptor.rowCount
-        || canonicalizeAuthorCatalogBucketPayloadBytesV1(bucket.payload).byteLength.toString()
-          !== descriptor.byteLength
-      ) {
-        throw new Error('bucket differs from its verified directory descriptor');
+      if (fetchedBucket === null) {
+        fail('catalog-native-receiver-not-found', 'successor catalog bucket was not found');
       }
-    } catch (cause) {
-      fail('catalog-native-receiver-catalog', 'catalog bucket is not bound to its directory', cause);
+      try {
+        assertSignedAuthorCatalogBucketEnvelopeV1(fetchedBucket.envelope);
+        bucket = fetchedBucket.envelope;
+        assertAuthorCatalogBucketScopeBindingV1(
+          bucket.payload,
+          deriveAuthorCatalogScopeFromHeadV1(head.payload),
+        );
+        if (
+          bucket.issuer !== head.issuer
+          || bucket.objectDigest !== descriptor.bucketDigest
+          || bucket.payload.bucketId !== descriptor.bucketId
+          || bucket.payload.rows.length !== expectedRowCount
+          || bucket.payload.rows.length.toString() !== descriptor.rowCount
+          || canonicalizeAuthorCatalogBucketPayloadBytesV1(bucket.payload).byteLength.toString()
+            !== descriptor.byteLength
+        ) {
+          throw new Error('bucket differs from its verified directory descriptor');
+        }
+      } catch (cause) {
+        fail('catalog-native-receiver-catalog', 'catalog bucket is not bound to its directory', cause);
+      }
+      await this.stageVerifiedControlObjectV1(
+        fetchedBucket,
+        'verified successor bucket could not be staged for restart-safe recovery',
+      );
     }
-    await this.stageVerifiedControlObjectV1(
-      fetchedBucket,
-      'verified successor bucket could not be staged for restart-safe recovery',
-    );
+    const targetRows = bucket?.payload.rows ?? Object.freeze([]);
     try {
       assertRfc64PublicCatalogExactSetBundleBytesV1(
-        bucket.payload.rows.map((row) => row.transfer.byteLength),
+        targetRows.map((row) => row.transfer.byteLength),
       );
     } catch (cause) {
       fail(
@@ -868,8 +877,11 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
       readonly projectionBytes: Uint8Array;
       readonly expectedEvidence: Rfc64PublicCatalogInventoryEvidenceRowV1;
     }> = [];
-    for (const row of bucket.payload.rows) {
+    for (const row of targetRows) {
       throwIfAborted(signal);
+      if (bucket === null || fetchedBucket === null) {
+        fail('catalog-native-receiver-catalog', 'non-empty catalog target lost its bucket proof');
+      }
       let authorship: VerifiedAuthorCatalogRowAuthorshipSnapshotV1;
       let authorshipCapability: VerifiedAuthorCatalogRowAuthorshipV1;
       try {
@@ -1027,7 +1039,7 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
         // decision. Requiring target.previousHeadDigest here made the first
         // retry after a successful cold bootstrap fail despite exact durable
         // target state.
-        ? Object.freeze(bucket.payload.rows.map((row) => Object.freeze({ ...row })))
+        ? Object.freeze(targetRows.map((row) => Object.freeze({ ...row })))
         : await loadExactAppliedPredecessorRows(
           this.options.controlObjects,
           head,
@@ -1054,12 +1066,13 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
       // Every exact bundle crossed its immutable durability barrier directly
       // after verification above. This preserves restart/failover progress
       // without making a staged-only head authoritative.
-      await this.options.controlObjects.stageVerifiedObjects([
+      const verifiedObjects = [
         fetchedDelegation,
         fetchedHead,
         fetchedDirectory,
-        fetchedBucket,
-      ]);
+      ];
+      if (fetchedBucket !== null) verifiedObjects.push(fetchedBucket);
+      await this.options.controlObjects.stageVerifiedObjects(verifiedObjects);
     } catch (cause) {
       fail(
         'catalog-native-receiver-catalog',
@@ -1714,14 +1727,14 @@ function assertBoundedSuccessorHead(head: SignedAuthorCatalogHeadEnvelopeV1): nu
     || head.payload.bucketCount !== '1'
     || head.payload.directoryHeight !== '0'
     || !Number.isSafeInteger(totalRows)
-    || totalRows < 1
+    || totalRows < 0
     || totalRows > MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1
     || head.payload.version === '0'
     || head.payload.previousHeadDigest === null
   ) {
     fail(
       'catalog-native-receiver-slice',
-      `bounded receiver requires 1..${MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1} root-lane rows in one non-genesis successor bucket`,
+      `bounded receiver requires 0..${MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1} root-lane rows in one non-genesis successor`,
     );
   }
   return totalRows;

--- a/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-receiver-v1.ts
@@ -6,8 +6,8 @@
  * stable synchronization invariant.
  *
  * The supported vertical slice is intentionally narrow: one successor head,
- * one bucket with 1..1,024 rows, the root context-graph lane, and complete
- * bundles for every signed row.
+ * zero or one bucket with 0..1,024 rows, the root context-graph lane, and
+ * complete bundles for every signed row.
  * Every network hop is RFC-64 catalog-native. Activation happens only after
  * signed head/path/bucket verification, transfer verification, canonical
  * projection verification, one atomic projection-plus-seal replace, exact
@@ -36,6 +36,7 @@ import {
   canonicalizeAuthorSealStoreRoundTripRowV1,
   computeAuthorCatalogScopeDigestV1,
   computeControlSignatureVariantDigestHex,
+  contextGraphMetaUri,
   contextGraphWorkspaceGraphUri,
   deriveCanonicalGraphScopedAuthorSealPlacementV1,
   deriveAuthorCatalogScopeFromHeadV1,
@@ -121,6 +122,18 @@ const MAX_TRANSITION_GRAPH_QUADS_V1 =
 // wider than the verified projection-byte ceiling while remaining finite.
 const MAX_TRANSITION_GRAPH_NQUADS_BYTES_V1 = 256 * 1024 * 1024;
 const MAX_TRANSITION_SEAL_SUBJECT_ROWS_V1 = 15;
+
+type Rfc64BoundedSuccessorTargetV1 =
+  | Readonly<{
+    kind: 'empty';
+    rows: readonly [];
+  }>
+  | Readonly<{
+    kind: 'bucket';
+    rows: readonly AuthorCatalogRowV1[];
+    bucket: SignedAuthorCatalogBucketEnvelopeV1;
+    fetchedBucket: FetchedRfc64PublicCatalogObjectV1;
+  }>;
 
 export interface Rfc64PublicCatalogNativeReceiverOptionsV1 {
   /** Fetch-only capability; lifecycle ownership remains with the catalog service. */
@@ -816,10 +829,11 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
       );
     }
 
-    let fetchedBucket: FetchedRfc64PublicCatalogObjectV1 | null = null;
-    let bucket: SignedAuthorCatalogBucketEnvelopeV1 | null = null;
-    if (!isEmptyTarget) {
-      fetchedBucket = await this.fetchCatalogObjectWithCacheV1(
+    let target: Rfc64BoundedSuccessorTargetV1;
+    if (isEmptyTarget) {
+      target = Object.freeze({ kind: 'empty' as const, rows: Object.freeze([] as []) });
+    } else {
+      const fetchedBucket = await this.fetchCatalogObjectWithCacheV1(
         remotePeerId,
         scope,
         AUTHOR_CATALOG_BUCKET_OBJECT_TYPE_V1,
@@ -829,6 +843,7 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
       if (fetchedBucket === null) {
         fail('catalog-native-receiver-not-found', 'successor catalog bucket was not found');
       }
+      let bucket: SignedAuthorCatalogBucketEnvelopeV1;
       try {
         assertSignedAuthorCatalogBucketEnvelopeV1(fetchedBucket.envelope);
         bucket = fetchedBucket.envelope;
@@ -854,8 +869,14 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
         fetchedBucket,
         'verified successor bucket could not be staged for restart-safe recovery',
       );
+      target = Object.freeze({
+        kind: 'bucket' as const,
+        rows: bucket.payload.rows,
+        bucket,
+        fetchedBucket,
+      });
     }
-    const targetRows = bucket?.payload.rows ?? Object.freeze([]);
+    const targetRows = target.rows;
     try {
       assertRfc64PublicCatalogExactSetBundleBytesV1(
         targetRows.map((row) => row.transfer.byteLength),
@@ -879,7 +900,7 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
     }> = [];
     for (const row of targetRows) {
       throwIfAborted(signal);
-      if (bucket === null || fetchedBucket === null) {
+      if (target.kind !== 'bucket') {
         fail('catalog-native-receiver-catalog', 'non-empty catalog target lost its bucket proof');
       }
       let authorship: VerifiedAuthorCatalogRowAuthorshipSnapshotV1;
@@ -894,8 +915,8 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
           directoryPathEnvelopes: [directory],
           directoryPathSignatures: [fetchedDirectory.issuerSignature],
           directoryPathProof,
-          catalogBucket: bucket,
-          catalogBucketSignature: fetchedBucket.issuerSignature,
+          catalogBucket: target.bucket,
+          catalogBucketSignature: target.fetchedBucket.issuerSignature,
           targetKaId: row.kaId,
         });
         authorship = readVerifiedAuthorCatalogRowAuthorshipV1(authorshipCapability);
@@ -1071,7 +1092,7 @@ export class Rfc64PublicCatalogNativeReceiverV1 {
         fetchedHead,
         fetchedDirectory,
       ];
-      if (fetchedBucket !== null) verifiedObjects.push(fetchedBucket);
+      if (target.kind === 'bucket') verifiedObjects.push(target.fetchedBucket);
       await this.options.controlObjects.stageVerifiedObjects(verifiedObjects);
     } catch (cause) {
       fail(
@@ -2032,10 +2053,7 @@ async function assertColdBootstrapHasNoOmittedSemanticStateV1(
     );
   }
 
-  const metaGraph = targets[0]?.sealMetaGraph;
-  if (metaGraph === undefined) {
-    fail('catalog-native-receiver-history', 'cold successor has no semantic target scope');
-  }
+  const metaGraph = contextGraphMetaUri(scope.contextGraphId);
   let sealSubjects;
   try {
     sealSubjects = await store.query(

--- a/packages/agent/src/rfc64/public-catalog-native-reconciler-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-native-reconciler-v1.ts
@@ -138,7 +138,9 @@ export class Rfc64BoundedPublicRootCatalogNativeReconcilerV1
       // Preserve the already-qualified Gate-1 behavior. Refuse to bless a
       // multi-row snapshot without the exact staged head that commits its count.
       if (announcement.catalogVersion === '0') return '0' as CountV1;
-      return durableInventoryRowCount === '1' ? '1' as CountV1 : null;
+      return durableInventoryRowCount === '0' || durableInventoryRowCount === '1'
+        ? durableInventoryRowCount
+        : null;
     }
     const staged = await this.options.readStagedCatalogHead(announcement);
     if (staged === null) return null;
@@ -157,7 +159,6 @@ export class Rfc64BoundedPublicRootCatalogNativeReconcilerV1
         totalRows < 0n
         || totalRows > BigInt(MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1)
         || (announcement.catalogVersion === '0' && totalRows !== 0n)
-        || (announcement.catalogVersion !== '0' && totalRows < 1n)
       ) {
         throw new Error('staged head totalRows is outside the bounded lane');
       }

--- a/packages/agent/src/rfc64/public-catalog-successor-asset-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-successor-asset-v1.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1,
+  canonicalizeCanonicalGraphScopedAuthorSealV1,
+  compareAuthorCatalogKaIdsV1,
+  parseCanonicalGraphScopedAuthorSealV1,
+  type AssertionCoordinateV1,
+  type CanonicalGraphScopedAuthorSealV1,
+} from '@origintrail-official/dkg-core';
+
+import {
+  assertExactFieldSetV1,
+  snapshotPlainDataRecordV1,
+} from './inventory-v1/exact-record.js';
+
+/** One canonical immutable asset at the shared catalog producer boundary. */
+export interface Rfc64PublicCatalogSuccessorAssetInputV1 {
+  readonly assertionCoordinate: AssertionCoordinateV1;
+  readonly projectionBytes: Uint8Array;
+  readonly seal: CanonicalGraphScopedAuthorSealV1;
+}
+
+export function snapshotRfc64PublicCatalogSuccessorAssetV1(
+  input: unknown,
+  label = 'RFC-64 catalog successor asset',
+): Readonly<Rfc64PublicCatalogSuccessorAssetInputV1> {
+  const record = snapshotPlainDataRecordV1(input, label);
+  assertExactFieldSetV1(record, ['assertionCoordinate', 'projectionBytes', 'seal'], label);
+  if (!(record.projectionBytes instanceof Uint8Array)) {
+    throw new TypeError(`${label}.projectionBytes must be a Uint8Array`);
+  }
+  return Object.freeze({
+    assertionCoordinate:
+      record.assertionCoordinate as Rfc64PublicCatalogSuccessorAssetInputV1['assertionCoordinate'],
+    projectionBytes: new Uint8Array(record.projectionBytes),
+    seal: parseCanonicalGraphScopedAuthorSealV1(
+      canonicalizeCanonicalGraphScopedAuthorSealV1(
+        record.seal as Rfc64PublicCatalogSuccessorAssetInputV1['seal'],
+      ),
+    ),
+  });
+}
+
+export function snapshotAndSortRfc64PublicCatalogSuccessorAssetsV1(
+  input: unknown,
+  label = 'RFC-64 catalog successor assets',
+): readonly Readonly<Rfc64PublicCatalogSuccessorAssetInputV1>[] {
+  if (!Array.isArray(input) || Object.getPrototypeOf(input) !== Array.prototype) {
+    throw new TypeError(`${label} must be an ordinary Array`);
+  }
+  if (input.length > MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1) {
+    throw new RangeError(
+      `${label} exceeds ${MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1} assets`,
+    );
+  }
+  const ownKeys = Reflect.ownKeys(input);
+  const expectedOwnKeys = new Set<string>([
+    'length',
+    ...Array.from({ length: input.length }, (_value, index) => String(index)),
+  ]);
+  if (
+    ownKeys.some((key) => typeof key !== 'string')
+    || ownKeys.length !== expectedOwnKeys.size
+    || ownKeys.some((key) => typeof key === 'string' && !expectedOwnKeys.has(key))
+  ) {
+    throw new TypeError(`${label} must be a dense data array`);
+  }
+  const result: Readonly<Rfc64PublicCatalogSuccessorAssetInputV1>[] = [];
+  for (let index = 0; index < input.length; index += 1) {
+    const descriptor = Object.getOwnPropertyDescriptor(input, String(index));
+    if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+      throw new TypeError(`${label} must contain only enumerable data elements`);
+    }
+    result.push(snapshotRfc64PublicCatalogSuccessorAssetV1(
+      descriptor.value,
+      `${label}[${index}]`,
+    ));
+  }
+  result.sort((left, right) => compareAuthorCatalogKaIdsV1(
+    left.seal.reservedKaId,
+    right.seal.reservedKaId,
+  ));
+  for (let index = 1; index < result.length; index += 1) {
+    const previous = result[index - 1]!;
+    const current = result[index]!;
+    if (previous.seal.reservedKaId === current.seal.reservedKaId) {
+      throw new Error(`${label} contains duplicate KA ${current.seal.reservedKaId}`);
+    }
+  }
+  return Object.freeze(result);
+}
+
+export function compareRfc64PublicCatalogSuccessorAssetsByKaIdV1(
+  left: Readonly<Rfc64PublicCatalogSuccessorAssetInputV1>,
+  right: Readonly<Rfc64PublicCatalogSuccessorAssetInputV1>,
+): -1 | 0 | 1 {
+  return compareAuthorCatalogKaIdsV1(left.seal.reservedKaId, right.seal.reservedKaId);
+}

--- a/packages/agent/src/rfc64/public-catalog-successor-producer-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-successor-producer-v1.ts
@@ -149,6 +149,7 @@ export interface ProduceAndStagePublicOpenExactSetSuccessorInputV1 {
   readonly previousHead: SignedAuthorCatalogHeadEnvelopeV1;
   readonly previousDirectoryPath: readonly SignedAuthorCatalogDirectoryNodeEnvelopeV1[];
   readonly previousBucket: SignedAuthorCatalogBucketEnvelopeV1 | null;
+  /** Complete 0..1024-row live set; zero rows is the canonical final removal. */
   readonly assets: readonly Rfc64PublicCatalogSuccessorAssetInputV1[];
   readonly deployment: CatalogSealDeploymentProfileV1;
   readonly issuedAt: TimestampMsV1;
@@ -246,7 +247,7 @@ export class Rfc64PublicCatalogSuccessorProducerV1 {
     });
   }
 
-  /** Build and durably stage one complete, canonical 1..1024-row live set. */
+  /** Build and durably stage one complete, canonical 0..1024-row live set. */
   async produceAndStageExactSet(
     input: ProduceAndStagePublicOpenExactSetSuccessorInputV1,
   ): Promise<ProducedAndStagedPublicOpenExactSetSuccessorV1> {
@@ -296,14 +297,16 @@ export class Rfc64PublicCatalogSuccessorProducerV1 {
     }
 
     const producedBucket = publication.bucket;
+    const producedRows = producedBucket?.payload.rows ?? [];
     if (
       publication.head.payload.bucketCount !== '1'
       || publication.head.payload.directoryHeight !== '0'
       || publication.head.payload.totalRows !== String(preparedAssets.length)
       || publication.head.payload.version === '0'
       || publication.head.payload.previousHeadDigest === null
-      || producedBucket === null
-      || producedBucket.payload.rows.length !== preparedAssets.length
+      || (preparedAssets.length === 0 && producedBucket !== null)
+      || (preparedAssets.length > 0 && producedBucket === null)
+      || producedRows.length !== preparedAssets.length
     ) {
       fail(
         'catalog-successor-producer-verification',
@@ -311,7 +314,7 @@ export class Rfc64PublicCatalogSuccessorProducerV1 {
       );
     }
 
-    const verifiedAssets = producedBucket.payload.rows.map((producedRow, index) => {
+    const verifiedAssets = producedRows.map((producedRow, index) => {
       const prepared = preparedAssets[index];
       if (prepared === undefined || producedRow.kaId !== prepared.row.kaId) {
         fail(
@@ -392,26 +395,30 @@ export class Rfc64PublicCatalogSuccessorProducerV1 {
           envelope.objectDigest,
           `directory path node ${index}`,
         ));
-      const bucketSignature = requiredSignature(
-        signaturesByDigest,
-        producedBucket.objectDigest,
-        'catalog bucket',
-      );
-      authorship = producedBucket.payload.rows.map((row) =>
-        readVerifiedAuthorCatalogRowAuthorshipV1(verifyAuthorCatalogRowAuthorshipV1({
-          catalogIssuerDelegation: authorization.catalogIssuerDelegation,
-          catalogIssuerDelegationSignature,
-          parentAuthorAgentEvidence: authorization.parentAuthorAgentEvidence,
-          catalogHead: publication.head,
-          catalogHeadSignature: headSignature,
-          directoryPathEnvelopes: publication.directoryPath,
-          directoryPathSignatures,
-          directoryPathProof,
-          catalogBucket: producedBucket,
-          catalogBucketSignature: bucketSignature,
-          targetKaId: row.kaId,
-        })),
-      );
+      if (producedBucket === null) {
+        authorship = Object.freeze([]);
+      } else {
+        const bucketSignature = requiredSignature(
+          signaturesByDigest,
+          producedBucket.objectDigest,
+          'catalog bucket',
+        );
+        authorship = producedBucket.payload.rows.map((row) =>
+          readVerifiedAuthorCatalogRowAuthorshipV1(verifyAuthorCatalogRowAuthorshipV1({
+            catalogIssuerDelegation: authorization.catalogIssuerDelegation,
+            catalogIssuerDelegationSignature,
+            parentAuthorAgentEvidence: authorization.parentAuthorAgentEvidence,
+            catalogHead: publication.head,
+            catalogHeadSignature: headSignature,
+            directoryPathEnvelopes: publication.directoryPath,
+            directoryPathSignatures,
+            directoryPathProof,
+            catalogBucket: producedBucket,
+            catalogBucketSignature: bucketSignature,
+            targetKaId: row.kaId,
+          })),
+        );
+      }
     } catch (cause) {
       fail(
         'catalog-successor-producer-verification',
@@ -490,10 +497,10 @@ function prepareExactSet(input: ProduceAndStagePublicOpenExactSetSuccessorInputV
   ) {
     fail('catalog-successor-producer-input', 'assets must be a dense Array without properties');
   }
-  if (assets.length < 1 || assets.length > MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1) {
+  if (assets.length > MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1) {
     fail(
       'catalog-successor-producer-input',
-      `assets must contain 1..${MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1} entries`,
+      `assets must contain 0..${MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1} entries`,
     );
   }
   const snapshots: PreparedRfc64PublicCatalogSuccessorAssetSnapshotV1[] = [];

--- a/packages/agent/src/rfc64/public-catalog-successor-producer-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-successor-producer-v1.ts
@@ -20,12 +20,10 @@ import {
   calculateOpaqueKaBundleByteLengthV1,
   canonicalizeAuthorCatalogRowV1,
   canonicalizeCanonicalGraphScopedAuthorSealBytesV1,
-  compareAuthorCatalogKaIdsV1,
   computeCanonicalGraphScopedAuthorSealDigestV1,
   computeKaChunkTreeRootV1,
   encodeOpaqueKaBundleV1,
   parseCanonicalAuthorCatalogRowV1,
-  parseCanonicalGraphScopedAuthorSealV1,
   readVerifiedCatalogSealBindingV1,
   readVerifiedCgSharedProjectionMetadataV1,
   readVerifiedTransferredCatalogBundleMetadataV1,
@@ -72,6 +70,13 @@ import {
   RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_RESPONSE_MAX_BYTES_V1,
   addRfc64PublicCatalogExactSetBundleBytesV1,
 } from './public-catalog-native-transport-v1.js';
+import {
+  snapshotAndSortRfc64PublicCatalogSuccessorAssetsV1,
+  type Rfc64PublicCatalogSuccessorAssetInputV1,
+} from './public-catalog-successor-asset-v1.js';
+
+export type { Rfc64PublicCatalogSuccessorAssetInputV1 } from
+  './public-catalog-successor-asset-v1.js';
 
 export type Rfc64PublicCatalogSuccessorProducerErrorCodeV1 =
   | 'catalog-successor-producer-input'
@@ -130,13 +135,6 @@ export interface ProduceAndStagePublicOpenOneRowSuccessorInputV1 {
   readonly catalogSigner: Rfc64AuthorCatalogEip191SignerV1;
   /** Exact author/delegation closure authorizing the catalog signer for this lane. */
   readonly catalogIssuerAuthorization: Rfc64PublicCatalogIssuerAuthorizationV1;
-}
-
-/** One member of the complete bounded live set committed by a successor. */
-export interface Rfc64PublicCatalogSuccessorAssetInputV1 {
-  readonly assertionCoordinate: AssertionCoordinateV1;
-  readonly projectionBytes: Uint8Array;
-  readonly seal: CanonicalGraphScopedAuthorSealV1;
 }
 
 /**
@@ -485,58 +483,31 @@ export class Rfc64PublicCatalogSuccessorProducerV1 {
 }
 
 function prepareExactSet(input: ProduceAndStagePublicOpenExactSetSuccessorInputV1) {
-  const assets = input?.assets;
-  if (!Array.isArray(assets) || Object.getPrototypeOf(assets) !== Array.prototype) {
-    fail('catalog-successor-producer-input', 'assets must be an ordinary dense Array');
-  }
-  const ownKeys = Reflect.ownKeys(assets);
-  if (
-    ownKeys.some((key) => typeof key !== 'string')
-    || ownKeys.length !== assets.length + 1
-    || !ownKeys.includes('length')
-  ) {
-    fail('catalog-successor-producer-input', 'assets must be a dense Array without properties');
-  }
-  if (assets.length > MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1) {
-    fail(
-      'catalog-successor-producer-input',
-      `assets must contain 0..${MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1} entries`,
+  let assets: readonly Readonly<Rfc64PublicCatalogSuccessorAssetInputV1>[];
+  try {
+    assets = snapshotAndSortRfc64PublicCatalogSuccessorAssetsV1(
+      input?.assets,
+      'RFC-64 successor assets',
     );
+  } catch (cause) {
+    fail('catalog-successor-producer-input', 'assets are not one canonical exact set', cause);
   }
   const snapshots: PreparedRfc64PublicCatalogSuccessorAssetSnapshotV1[] = [];
   let aggregateBundleBytes = 0n;
-  for (let index = 0; index < assets.length; index += 1) {
-    const descriptor = Object.getOwnPropertyDescriptor(assets, String(index));
-    if (!descriptor?.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
-      fail(
-        'catalog-successor-producer-input',
-        'assets must contain only enumerable data elements',
-      );
-    }
-    const asset = descriptor.value as Rfc64PublicCatalogSuccessorAssetInputV1;
+  for (const asset of assets) {
     try {
-      // Snapshot each caller-owned field exactly once. In particular, no
-      // stateful projectionBytes getter can change validation vs encoding.
-      const assertionCoordinate = asset?.assertionCoordinate;
-      const projectionInput = asset?.projectionBytes;
-      const sealInput = asset?.seal;
-      if (!(projectionInput instanceof Uint8Array)) {
-        throw new TypeError('projectionBytes must be a Uint8Array');
-      }
       // Reject a projection that cannot possibly fit the Gate-1 transport
       // before allocating its detached snapshot.
       if (
-        BigInt(projectionInput.byteLength)
+        BigInt(asset.projectionBytes.byteLength)
         > BigInt(RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_RESPONSE_MAX_BYTES_V1)
           - MIN_KA_BUNDLE_BYTES_V1
       ) {
         throw new RangeError('projection exceeds the Gate-1 complete-bundle ceiling');
       }
-      const projectionBytes = new Uint8Array(projectionInput);
-      const sealBytes = canonicalizeCanonicalGraphScopedAuthorSealBytesV1(sealInput);
-      const seal = parseCanonicalGraphScopedAuthorSealV1(sealBytes);
+      const sealBytes = canonicalizeCanonicalGraphScopedAuthorSealBytesV1(asset.seal);
       const bundleByteLength = calculateOpaqueKaBundleByteLengthV1(
-        BigInt(projectionBytes.byteLength),
+        BigInt(asset.projectionBytes.byteLength),
         BigInt(sealBytes.byteLength),
       );
       if (bundleByteLength > BigInt(RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_RESPONSE_MAX_BYTES_V1)) {
@@ -548,9 +519,9 @@ function prepareExactSet(input: ProduceAndStagePublicOpenExactSetSuccessorInputV
         canonicalBundleByteLength,
       );
       snapshots.push(Object.freeze({
-        assertionCoordinate,
-        projectionBytes,
-        seal,
+        assertionCoordinate: asset.assertionCoordinate,
+        projectionBytes: new Uint8Array(asset.projectionBytes),
+        seal: asset.seal,
         sealBytes,
         bundleByteLength,
       }));
@@ -567,20 +538,6 @@ function prepareExactSet(input: ProduceAndStagePublicOpenExactSetSuccessorInputV
     input.previousHead,
     input.deployment,
   ));
-  prepared.sort((left, right) => compareAuthorCatalogKaIdsV1(left.row.kaId, right.row.kaId));
-  for (let index = 1; index < prepared.length; index += 1) {
-    const previous = prepared[index - 1];
-    const current = prepared[index];
-    if (previous === undefined || current === undefined) {
-      fail('catalog-successor-producer-input', 'assets are not a dense exact set');
-    }
-    if (previous.row.kaId === current.row.kaId) {
-      fail(
-        'catalog-successor-producer-input',
-        `assets contain duplicate kaId ${current.row.kaId}`,
-      );
-    }
-  }
   return Object.freeze(prepared);
 }
 

--- a/packages/agent/src/rfc64/swm-inventory-catalog-reconciler-v1.ts
+++ b/packages/agent/src/rfc64/swm-inventory-catalog-reconciler-v1.ts
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Dormant R1.1 boundary between the signed SWM author inventory and catalog
+ * production. It authenticates one exact inventory snapshot, resolves every
+ * row to immutable projection/seal input, and refuses any cross-layer drift
+ * before a catalog successor can be staged.
+ *
+ * This module does not schedule ordinary SHARE work, switch a semantic head,
+ * announce availability, or claim receiver convergence.
+ */
+
+import {
+  MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1,
+  assertSwmAuthorInventorySnapshotBindingV1,
+  canonicalizeCanonicalGraphScopedAuthorSealV1,
+  canonicalizeSignedSwmAuthorInventoryHeadEnvelopeBytesV1,
+  canonicalizeSwmAuthorInventoryRowsBytesV1,
+  computeCanonicalGraphScopedAuthorSealDigestV1,
+  computeKaProjectionDigestV1,
+  deriveSwmAuthorInventoryScopeFromHeadV1,
+  parseCanonicalGraphScopedAuthorSealV1,
+  parseCanonicalSignedSwmAuthorInventoryHeadEnvelopeV1,
+  parseCanonicalSwmAuthorInventoryRowsV1,
+  type AuthorCatalogScopeV1,
+  type SwmAuthorInventoryRowV1,
+  type SwmAuthorInventoryScopeV1,
+  type SwmAuthorInventorySnapshotV1,
+} from '@origintrail-official/dkg-core';
+import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dkg-chain';
+
+import type { Rfc64PublicCatalogSuccessorAssetInputV1 } from
+  './public-catalog-successor-producer-v1.js';
+import {
+  assertExactFieldSetV1,
+  snapshotPlainDataRecordV1,
+} from './inventory-v1/exact-record.js';
+
+export const RFC64_SWM_INVENTORY_CATALOG_TARGET_MAX_ROWS_V1 =
+  MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1;
+
+export type Rfc64SwmInventoryCatalogReconcilerErrorCodeV1 =
+  | 'swm-catalog-reconcile-input'
+  | 'swm-catalog-reconcile-signature'
+  | 'swm-catalog-reconcile-capacity'
+  | 'swm-catalog-reconcile-resolution'
+  | 'swm-catalog-reconcile-binding';
+
+export class Rfc64SwmInventoryCatalogReconcilerErrorV1 extends Error {
+  constructor(
+    readonly code: Rfc64SwmInventoryCatalogReconcilerErrorCodeV1,
+    message: string,
+    options: ErrorOptions = {},
+  ) {
+    super(`[${code}] ${message}`, options);
+    this.name = 'Rfc64SwmInventoryCatalogReconcilerErrorV1';
+  }
+}
+
+export interface PrepareRfc64SwmInventoryCatalogTargetInputV1 {
+  readonly snapshot: SwmAuthorInventorySnapshotV1;
+  /** Resolve the exact durable shared projection and seal named by one signed row. */
+  readonly resolveAsset: (
+    row: Readonly<SwmAuthorInventoryRowV1>,
+  ) => Promise<Rfc64PublicCatalogSuccessorAssetInputV1>;
+}
+
+export interface PreparedRfc64SwmInventoryCatalogTargetV1 {
+  readonly inventoryHeadObjectDigest: string;
+  readonly inventoryScope: Readonly<SwmAuthorInventoryScopeV1>;
+  readonly catalogScope: Readonly<AuthorCatalogScopeV1>;
+  /** Canonical inventory order, which is also mathematical packed-KA order. */
+  readonly assets: readonly Readonly<Rfc64PublicCatalogSuccessorAssetInputV1>[];
+}
+
+/**
+ * Authenticate and detach one signed exact SWM inventory before resolving any
+ * payload. Every resolved asset is then rebound to its signed row. A resolver
+ * cannot substitute a different version, projection, seal, author, or KA.
+ */
+export async function prepareRfc64SwmInventoryCatalogTargetV1(
+  input: PrepareRfc64SwmInventoryCatalogTargetInputV1,
+): Promise<PreparedRfc64SwmInventoryCatalogTargetV1> {
+  const snapshot = snapshotInventory(input?.snapshot);
+  if (snapshot.rows.length > RFC64_SWM_INVENTORY_CATALOG_TARGET_MAX_ROWS_V1) {
+    fail(
+      'swm-catalog-reconcile-capacity',
+      `bounded R1.1 catalog target exceeds ${RFC64_SWM_INVENTORY_CATALOG_TARGET_MAX_ROWS_V1} rows`,
+    );
+  }
+  if (typeof input?.resolveAsset !== 'function') {
+    fail('swm-catalog-reconcile-input', 'resolveAsset must be a function');
+  }
+  try {
+    await verifyControlEnvelopeIssuerSignatureV1(snapshot.head);
+  } catch (cause) {
+    fail(
+      'swm-catalog-reconcile-signature',
+      'SWM inventory head issuer signature is invalid',
+      cause,
+    );
+  }
+
+  const inventoryScope = Object.freeze(
+    deriveSwmAuthorInventoryScopeFromHeadV1(snapshot.head.payload),
+  );
+  const catalogScope = Object.freeze({
+    ...inventoryScope,
+    bucketCount: '1',
+  }) as AuthorCatalogScopeV1;
+  const assets: Rfc64PublicCatalogSuccessorAssetInputV1[] = [];
+  for (const row of snapshot.rows) {
+    let resolved: Rfc64PublicCatalogSuccessorAssetInputV1;
+    try {
+      resolved = await input.resolveAsset(row);
+    } catch (cause) {
+      fail(
+        'swm-catalog-reconcile-resolution',
+        `durable catalog asset could not be resolved for ${row.kaUal}`,
+        cause,
+      );
+    }
+    const asset = snapshotAsset(resolved);
+    assertAssetBindsInventoryRow(asset, row);
+    assets.push(asset);
+  }
+
+  return Object.freeze({
+    inventoryHeadObjectDigest: snapshot.head.objectDigest,
+    inventoryScope,
+    catalogScope,
+    assets: Object.freeze(assets),
+  });
+}
+
+function snapshotInventory(input: unknown): SwmAuthorInventorySnapshotV1 {
+  try {
+    const record = snapshotPlainDataRecordV1(input, 'R1.1 SWM inventory snapshot');
+    assertExactFieldSetV1(
+      record,
+      ['head', 'rows'],
+      'R1.1 SWM inventory snapshot',
+    );
+    const head = parseCanonicalSignedSwmAuthorInventoryHeadEnvelopeV1(
+      canonicalizeSignedSwmAuthorInventoryHeadEnvelopeBytesV1(record.head as never),
+    );
+    const rows = parseCanonicalSwmAuthorInventoryRowsV1(
+      canonicalizeSwmAuthorInventoryRowsBytesV1(record.rows as never),
+    );
+    const snapshot = Object.freeze({ head, rows });
+    assertSwmAuthorInventorySnapshotBindingV1(snapshot);
+    return snapshot;
+  } catch (cause) {
+    fail(
+      'swm-catalog-reconcile-input',
+      'SWM inventory snapshot is not canonical or internally bound',
+      cause,
+    );
+  }
+}
+
+function snapshotAsset(input: unknown): Rfc64PublicCatalogSuccessorAssetInputV1 {
+  try {
+    const record = snapshotPlainDataRecordV1(input, 'R1.1 catalog successor asset');
+    assertExactFieldSetV1(
+      record,
+      ['assertionCoordinate', 'projectionBytes', 'seal'],
+      'R1.1 catalog successor asset',
+    );
+    if (!(record.projectionBytes instanceof Uint8Array)) {
+      throw new TypeError('projectionBytes must be a Uint8Array');
+    }
+    const seal = parseCanonicalGraphScopedAuthorSealV1(
+      canonicalizeCanonicalGraphScopedAuthorSealV1(record.seal as never),
+    );
+    return Object.freeze({
+      assertionCoordinate: record.assertionCoordinate as never,
+      projectionBytes: new Uint8Array(record.projectionBytes),
+      seal,
+    });
+  } catch (cause) {
+    fail(
+      'swm-catalog-reconcile-resolution',
+      'resolved catalog asset is not one canonical immutable snapshot',
+      cause,
+    );
+  }
+}
+
+function assertAssetBindsInventoryRow(
+  asset: Readonly<Rfc64PublicCatalogSuccessorAssetInputV1>,
+  row: Readonly<SwmAuthorInventoryRowV1>,
+): void {
+  try {
+    if (asset.assertionCoordinate !== row.assertionCoordinate) {
+      throw new Error('assertionCoordinate differs');
+    }
+    if (asset.seal.assertionVersion !== row.assertionVersion) {
+      throw new Error('assertionVersion differs');
+    }
+    if (asset.seal.kaUal !== row.kaUal) throw new Error('kaUal differs');
+    if (asset.seal.publicTripleCount !== row.publicTripleCount) {
+      throw new Error('publicTripleCount differs');
+    }
+    if (asset.seal.privateTripleCount !== row.privateTripleCount) {
+      throw new Error('privateTripleCount differs');
+    }
+    if (computeKaProjectionDigestV1(asset.projectionBytes) !== row.projectionDigest) {
+      throw new Error('projectionDigest differs');
+    }
+    if (computeCanonicalGraphScopedAuthorSealDigestV1(asset.seal) !== row.sealDigest) {
+      throw new Error('sealDigest differs');
+    }
+  } catch (cause) {
+    fail(
+      'swm-catalog-reconcile-binding',
+      `resolved catalog asset differs from signed SWM inventory row ${row.kaUal}`,
+      cause,
+    );
+  }
+}
+
+function fail(
+  code: Rfc64SwmInventoryCatalogReconcilerErrorCodeV1,
+  message: string,
+  cause?: unknown,
+): never {
+  throw new Rfc64SwmInventoryCatalogReconcilerErrorV1(
+    code,
+    message,
+    cause === undefined ? {} : { cause },
+  );
+}

--- a/packages/agent/src/rfc64/swm-inventory-shadow-runtime-v1.ts
+++ b/packages/agent/src/rfc64/swm-inventory-shadow-runtime-v1.ts
@@ -43,6 +43,7 @@ export class Rfc64SwmInventoryShadowRuntimeV1 {
   };
   readonly #inFlight = new Set<Promise<void>>();
   readonly #assetTails = new Map<string, Promise<void>>();
+  readonly #scopeTails = new Map<string, Promise<void>>();
   readonly #vmConfirmedVersions = new Map<string, Set<string>>();
   readonly #pendingExecutions: Array<() => void> = [];
   #activeExecutions = 0;
@@ -54,6 +55,22 @@ export class Rfc64SwmInventoryShadowRuntimeV1 {
 
   runExclusive(assetKey: string, observer: () => Promise<void>): Promise<void> {
     return this.enqueue(assetKey, observer, true);
+  }
+
+  /** Serialize inventory mutations and catalog reads for one author/scope. */
+  async runScopeExclusive<T>(scopeKey: string, operation: () => Promise<T>): Promise<T> {
+    const predecessor = this.#scopeTails.get(scopeKey);
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const tail = (predecessor ?? Promise.resolve()).catch(() => undefined).then(() => gate);
+    this.#scopeTails.set(scopeKey, tail);
+    await predecessor?.catch(() => undefined);
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (this.#scopeTails.get(scopeKey) === tail) this.#scopeTails.delete(scopeKey);
+    }
   }
 
   markVmConfirmed(assetKey: string, assertionVersion: string): void {

--- a/packages/agent/test/rfc64-catalog-upsert-planner-v1.test.ts
+++ b/packages/agent/test/rfc64-catalog-upsert-planner-v1.test.ts
@@ -1,0 +1,39 @@
+import { MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1 } from '@origintrail-official/dkg-core';
+import { describe, expect, it } from 'vitest';
+
+import {
+  planNextRfc64CatalogExactSetV1,
+  type ReconcileRfc64PublicRootCatalogExactSetParamsV1,
+} from '../src/dkg-agent-rfc64-catalog-upsert.js';
+
+type Asset = ReconcileRfc64PublicRootCatalogExactSetParamsV1['assets'][number];
+
+function plannerAsset(kaId: bigint): Asset {
+  return Object.freeze({
+    assertionCoordinate: `asset-${kaId}`,
+    projectionBytes: new Uint8Array([Number(kaId % 251n)]),
+    seal: Object.freeze({ reservedKaId: kaId.toString() }),
+  }) as unknown as Asset;
+}
+
+describe('RFC-64 exact-set bounded planner v1', () => {
+  it('frees one current-only slot before inserting into a full 1,024-row set', () => {
+    const current = Array.from(
+      { length: MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1 },
+      (_value, index) => plannerAsset(BigInt(MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1 + index)),
+    );
+    const target = Array.from(
+      { length: MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1 },
+      (_value, index) => plannerAsset(BigInt(index)),
+    );
+
+    const freed = planNextRfc64CatalogExactSetV1(current, target);
+    expect(freed).toHaveLength(MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1 - 1);
+    expect(freed.some((asset) => asset.seal.reservedKaId === '2047')).toBe(false);
+
+    const inserted = planNextRfc64CatalogExactSetV1(freed, target);
+    expect(inserted).toHaveLength(MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1);
+    expect(inserted[0]?.seal.reservedKaId).toBe('0');
+    expect(Math.max(freed.length, inserted.length)).toBe(MAX_AUTHOR_CATALOG_BUCKET_ROWS_V1);
+  });
+});

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -759,6 +759,26 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       lifecycleAgentAddress: AUTHOR,
       shareOperationId,
     })).resolves.toMatchObject({ status: 'existing', attempts: 1 });
+    const firstCatalogReconcile = await author
+      .reconcileRfc64PublicCatalogFromSwmInventoryV1({
+        contextGraphId: CONTEXT_GRAPH_ID,
+        authorAddress: AUTHOR,
+      });
+    expect(firstCatalogReconcile).toMatchObject({
+      status: 'advanced',
+      successorsApplied: 1,
+      targetAssetCount: 1,
+      appliedHead: { catalogVersion: '1', inventoryRowCount: '1' },
+    });
+    await expect(author.reconcileRfc64PublicCatalogFromSwmInventoryV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      authorAddress: AUTHOR,
+    })).resolves.toMatchObject({
+      status: 'existing',
+      successorsApplied: 0,
+      targetAssetCount: 1,
+      appliedHead: { catalogVersion: '1', inventoryRowCount: '1' },
+    });
     expect(author.rfc64SwmAuthorInventoryShadowStatusV1()).toMatchObject({
       attemptedUpserts: 3,
       appliedUpserts: 1,
@@ -798,6 +818,15 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     })).toMatchObject({
       head: { payload: { version: '1', totalRows: '0' } },
       rows: [],
+    });
+    await expect(restarted.reconcileRfc64PublicCatalogFromSwmInventoryV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      authorAddress: AUTHOR,
+    })).resolves.toMatchObject({
+      status: 'advanced',
+      successorsApplied: 1,
+      targetAssetCount: 0,
+      appliedHead: { catalogVersion: '2', inventoryRowCount: '0' },
     });
     await expect(restarted.removeRfc64SwmAuthorInventoryShadowV1({
       contextGraphId: CONTEXT_GRAPH_ID,
@@ -1913,6 +1942,94 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     ));
   }, 60_000);
 
+  it('reconciles deterministic multi-step add, replacement, removal, and replay targets', async () => {
+    const author = await startNativeAgent('r1-1-exact-reconcile-author');
+    author.acceptOpenContextGraphPolicyV1({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+    });
+    const scope = Object.freeze({
+      networkId: NETWORK_ID,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      governanceChainId: null,
+      governanceContractAddress: null,
+      ownershipTransitionDigest: null,
+      subGraphName: null,
+      authorAddress: AUTHOR,
+      era: '0',
+      bucketCount: '1',
+    }) as const;
+    const firstSeal = await authorSeal(71n);
+    const secondSeal = await authorSeal(72n);
+    const firstAsset = Object.freeze({
+      assertionCoordinate: 'r1-1-first' as never,
+      projectionBytes: PROJECTION,
+      seal: firstSeal,
+    });
+    const secondAsset = Object.freeze({
+      assertionCoordinate: 'r1-1-second' as never,
+      projectionBytes: PROJECTION,
+      seal: secondSeal,
+    });
+    const common = {
+      scope,
+      author: AUTHOR_WALLET,
+      deployment: NATIVE_DEPLOYMENT,
+      peers: [],
+      catalogIssuerDelegationEffectiveAt: '0' as TimestampMsV1,
+      catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+    };
+
+    await expect(author.reconcileRfc64PublicRootCatalogExactSetV1({
+      ...common,
+      assets: [secondAsset, firstAsset],
+    })).resolves.toMatchObject({
+      status: 'advanced',
+      successorsApplied: 2,
+      targetAssetCount: 2,
+      appliedHead: { catalogVersion: '2', inventoryRowCount: '2' },
+    });
+    await expect(author.reconcileRfc64PublicRootCatalogExactSetV1({
+      ...common,
+      assets: [firstAsset, secondAsset],
+    })).resolves.toMatchObject({
+      status: 'existing',
+      successorsApplied: 0,
+      appliedHead: { catalogVersion: '2', inventoryRowCount: '2' },
+    });
+
+    const firstV2 = Object.freeze({
+      ...firstAsset,
+      seal: Object.freeze({ ...firstSeal, assertionVersion: '2' }) as never,
+    });
+    await expect(author.reconcileRfc64PublicRootCatalogExactSetV1({
+      ...common,
+      assets: [firstV2, secondAsset],
+    })).resolves.toMatchObject({
+      status: 'advanced',
+      successorsApplied: 1,
+      appliedHead: { catalogVersion: '3', inventoryRowCount: '2' },
+    });
+    await expect(author.reconcileRfc64PublicRootCatalogExactSetV1({
+      ...common,
+      assets: [firstV2],
+    })).resolves.toMatchObject({
+      status: 'advanced',
+      successorsApplied: 1,
+      appliedHead: { catalogVersion: '4', inventoryRowCount: '1' },
+    });
+    await expect(author.reconcileRfc64PublicRootCatalogExactSetV1({
+      ...common,
+      assets: [],
+    })).resolves.toMatchObject({
+      status: 'advanced',
+      successorsApplied: 1,
+      targetAssetCount: 0,
+      appliedHead: { catalogVersion: '5', inventoryRowCount: '0' },
+    });
+  }, 60_000);
+
   registerM0RecoveryScenario('cold-restart', rfc64M0RecoveryTitle('cold-restart'), async () => {
     const author = await startNativeAgent(
       'bootstrap-author',
@@ -2585,6 +2702,70 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       applied: 3,
       dedupedAlreadyApplied: 1,
     });
+
+    const oneRow = await author.publishAuthorCatalogExactSetSuccessorV1({
+      previousHead: {
+        objectDigest: successor.headObjectDigest,
+        signatureVariantDigest: successor.signatureVariantDigest,
+      },
+      author: AUTHOR_WALLET,
+      catalogIssuerAuthorization: genesis.catalogIssuerAuthorization,
+      assets: [firstAsset],
+      deployment: NATIVE_DEPLOYMENT,
+      issuedAt: '1773900003000' as TimestampMsV1,
+      peers: [receiver.peerId],
+    });
+    await receiver.whenRfc64PublicCatalogReceiverIdleV1();
+    const empty = await author.publishAuthorCatalogExactSetSuccessorV1({
+      previousHead: {
+        objectDigest: oneRow.headObjectDigest,
+        signatureVariantDigest: oneRow.signatureVariantDigest,
+      },
+      author: AUTHOR_WALLET,
+      catalogIssuerAuthorization: genesis.catalogIssuerAuthorization,
+      assets: [],
+      deployment: NATIVE_DEPLOYMENT,
+      issuedAt: '1773900004000' as TimestampMsV1,
+      peers: [receiver.peerId],
+    });
+    await receiver.whenRfc64PublicCatalogReceiverIdleV1();
+    expect(empty).toMatchObject({
+      inventoryRowCount: '0',
+      signedBucketRowCount: '0',
+      assets: [],
+    });
+    expect(receiver.readRfc64PublicCatalogReconciliationFailureV1(
+      empty.headObjectDigest,
+    )).toBeNull();
+    expect(receiver.readRfc64PublicCatalogSynchronizationEvidenceV1(
+      empty.headObjectDigest,
+    )).toMatchObject({
+      catalogHeadDigest: empty.headObjectDigest,
+      inventoryRowCount: 0,
+      activatedTripleCount: 0,
+      rows: [],
+      removedRowCount: 1,
+      appliedHeadStatus: 'applied',
+    });
+    expect(receiver.readRfc64AppliedCatalogHeadV1({
+      catalogScopeDigest: catalogScopeDigest(),
+      authorAddress: AUTHOR,
+    })).toMatchObject({
+      currentCatalogHeadDigest: empty.headObjectDigest,
+      catalogVersion: '4',
+      inventoryRowCount: '0',
+    });
+    for (const kaNumber of [7, 8]) {
+      const swmGraph = contextGraphLayerUri(
+        CONTEXT_GRAPH_ID,
+        MemoryLayer.SharedWorkingMemory,
+        AUTHOR,
+        kaNumber,
+      );
+      await expect(receiver.store.query(
+        `SELECT ?s WHERE { GRAPH <${swmGraph}> { ?s ?p ?o } } LIMIT 1`,
+      )).resolves.toMatchObject({ type: 'bindings', bindings: [] });
+    }
   }, 60_000);
 
   it('preserves a single-provider discovery error without aggregation', async () => {

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -786,6 +786,35 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       failed: 1,
     });
 
+    const appliedBeforeWorkspaceDrift = author.readRfc64AppliedCatalogHeadV1({
+      catalogScopeDigest: catalogScopeDigest(),
+      authorAddress: AUTHOR,
+    });
+    await storeKnowledgeAssetWorkspaceHead({
+      store: author.store,
+      graphManager,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      kaUal: canonicalSeal.kaUal,
+      assertionVersion: canonicalSeal.assertionVersion,
+      shareOperationId: 'different-durable-workspace-operation',
+    });
+    await expect(author.reconcileRfc64PublicCatalogFromSwmInventoryV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      authorAddress: AUTHOR,
+    })).rejects.toThrow(/durable catalog asset could not be resolved/u);
+    expect(author.readRfc64AppliedCatalogHeadV1({
+      catalogScopeDigest: catalogScopeDigest(),
+      authorAddress: AUTHOR,
+    })).toEqual(appliedBeforeWorkspaceDrift);
+    await storeKnowledgeAssetWorkspaceHead({
+      store: author.store,
+      graphManager,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      kaUal: canonicalSeal.kaUal,
+      assertionVersion: canonicalSeal.assertionVersion,
+      shareOperationId,
+    });
+
     await author.stop();
     agents.splice(agents.indexOf(author), 1);
     const restarted = await startNativeAgent(
@@ -879,6 +908,158 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       inventoryScopeDigest: scopeDigest,
       authorAddress: AUTHOR,
     })?.rows).toEqual([]);
+
+    // A catalog reconciliation must fence the complete inventory snapshot it
+    // resolved. Otherwise a slow one-row pass can land after a newer two-row
+    // pass and regress the signed applied head back to the stale set.
+    await restarted.store.insert(buildAssertionSealQuads({
+      assertionUri,
+      metaGraph: contextGraphMetaUri(CONTEXT_GRAPH_ID),
+      merkleRoot: seal.merkleRoot,
+      authorAddress: seal.authorAddress,
+      authorAttestationR: seal.authorAttestationR,
+      authorAttestationVS: seal.authorAttestationVS,
+      authorSchemeVersion: seal.authorSchemeVersion,
+      chainId: seal.chainId,
+      kav10Address: seal.kav10Address,
+      reservedKaId: seal.reservedKaId!,
+      finalizedAtIso: seal.finalizedAtIso,
+      contentScopeVersion: seal.contentScopeVersion!,
+      kaUal: seal.kaUal!,
+      assertionVersion: seal.assertionVersion!,
+      publicTripleCount: seal.publicTripleCount!,
+      privateTripleCount: seal.privateTripleCount!,
+    }));
+    const restartedGraphManager = new GraphManager(restarted.store);
+    await storeKnowledgeAssetOperationPublicQuads({
+      store: restarted.store,
+      graphManager: restartedGraphManager,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      shareOperationId,
+      kaUal: canonicalSeal.kaUal,
+      assertionVersion: canonicalSeal.assertionVersion,
+      quads: publicQuads,
+      privateTripleCount: 0,
+      publisherPeerId: restarted.peerId,
+      accessPolicy: 'public',
+      agentAddress: AUTHOR,
+      timestamp: new Date('2026-07-19T12:35:00.000Z'),
+    });
+    await storeKnowledgeAssetWorkspaceHead({
+      store: restarted.store,
+      graphManager: restartedGraphManager,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      kaUal: canonicalSeal.kaUal,
+      assertionVersion: canonicalSeal.assertionVersion,
+      shareOperationId,
+    });
+    await expect(restarted.recordRfc64SwmAuthorInventoryShadowV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      assertionCoordinate,
+      lifecycleAgentAddress: AUTHOR,
+      shareOperationId,
+    })).resolves.toMatchObject({ status: 'applied' });
+    await expect(restarted.reconcileRfc64PublicCatalogFromSwmInventoryV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      authorAddress: AUTHOR,
+    })).resolves.toMatchObject({ targetAssetCount: 1 });
+
+    const secondAssertionCoordinate = 'swm-only-shadow-second';
+    const secondShareOperationId = 'swm-only-shadow-operation-second';
+    const secondCanonicalSeal = await authorSeal(22n, publicQuads);
+    const secondSeal = assertionSealFromCanonical(secondCanonicalSeal);
+    const secondAssertionUri = contextGraphAssertionUri(
+      CONTEXT_GRAPH_ID,
+      AUTHOR,
+      secondAssertionCoordinate,
+    );
+    await restarted.store.insert(buildAssertionSealQuads({
+      assertionUri: secondAssertionUri,
+      metaGraph: contextGraphMetaUri(CONTEXT_GRAPH_ID),
+      merkleRoot: secondSeal.merkleRoot,
+      authorAddress: secondSeal.authorAddress,
+      authorAttestationR: secondSeal.authorAttestationR,
+      authorAttestationVS: secondSeal.authorAttestationVS,
+      authorSchemeVersion: secondSeal.authorSchemeVersion,
+      chainId: secondSeal.chainId,
+      kav10Address: secondSeal.kav10Address,
+      reservedKaId: secondSeal.reservedKaId!,
+      finalizedAtIso: secondSeal.finalizedAtIso,
+      contentScopeVersion: secondSeal.contentScopeVersion!,
+      kaUal: secondSeal.kaUal!,
+      assertionVersion: secondSeal.assertionVersion!,
+      publicTripleCount: secondSeal.publicTripleCount!,
+      privateTripleCount: secondSeal.privateTripleCount!,
+    }));
+    await storeKnowledgeAssetOperationPublicQuads({
+      store: restarted.store,
+      graphManager: restartedGraphManager,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      shareOperationId: secondShareOperationId,
+      kaUal: secondCanonicalSeal.kaUal,
+      assertionVersion: secondCanonicalSeal.assertionVersion,
+      quads: publicQuads,
+      privateTripleCount: 0,
+      publisherPeerId: restarted.peerId,
+      accessPolicy: 'public',
+      agentAddress: AUTHOR,
+      timestamp: new Date('2026-07-19T12:36:00.000Z'),
+    });
+    await storeKnowledgeAssetWorkspaceHead({
+      store: restarted.store,
+      graphManager: restartedGraphManager,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      kaUal: secondCanonicalSeal.kaUal,
+      assertionVersion: secondCanonicalSeal.assertionVersion,
+      shareOperationId: secondShareOperationId,
+    });
+
+    const originalResolveCatalogAsset = (restarted as any)
+      .resolveRfc64SwmInventoryCatalogAssetV1.bind(restarted);
+    let releaseStaleReconcile!: () => void;
+    let markStaleReconcileEntered!: () => void;
+    const staleGate = new Promise<void>((resolve) => { releaseStaleReconcile = resolve; });
+    const staleEntered = new Promise<void>((resolve) => { markStaleReconcileEntered = resolve; });
+    const resolveCatalogAssetSpy = vi.spyOn(
+      restarted as any,
+      'resolveRfc64SwmInventoryCatalogAssetV1',
+    ).mockImplementationOnce(async (...args: unknown[]) => {
+      markStaleReconcileEntered();
+      await staleGate;
+      return originalResolveCatalogAsset(...args);
+    });
+    const staleReconcile = restarted.reconcileRfc64PublicCatalogFromSwmInventoryV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      authorAddress: AUTHOR,
+    });
+    await staleEntered;
+    let secondRecordSettled = false;
+    const secondRecord = restarted.recordRfc64SwmAuthorInventoryShadowV1({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      assertionCoordinate: secondAssertionCoordinate,
+      lifecycleAgentAddress: AUTHOR,
+      shareOperationId: secondShareOperationId,
+    }).finally(() => { secondRecordSettled = true; });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(secondRecordSettled).toBe(false);
+    const currentReconcile = secondRecord.then(() => (
+      restarted.reconcileRfc64PublicCatalogFromSwmInventoryV1({
+        contextGraphId: CONTEXT_GRAPH_ID,
+        authorAddress: AUTHOR,
+      })
+    ));
+    releaseStaleReconcile();
+    await expect(staleReconcile).resolves.toMatchObject({ targetAssetCount: 1 });
+    await expect(secondRecord).resolves.toMatchObject({ status: 'applied' });
+    await expect(currentReconcile).resolves.toMatchObject({
+      targetAssetCount: 2,
+      appliedHead: { inventoryRowCount: '2' },
+    });
+    resolveCatalogAssetSpy.mockRestore();
+    expect(restarted.readRfc64AppliedCatalogHeadV1({
+      catalogScopeDigest: catalogScopeDigest(),
+      authorAddress: AUTHOR,
+    })).toMatchObject({ inventoryRowCount: '2' });
   }, 60_000);
 
   it('normalizes legacy and selected auto-publish into one internal policy', () => {
@@ -2003,6 +2184,28 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       ...firstAsset,
       seal: Object.freeze({ ...firstSeal, assertionVersion: '2' }) as never,
     });
+    const appliedBeforeInvalidReplacement = author.readRfc64AppliedCatalogHeadV1({
+      catalogScopeDigest: catalogScopeDigest(),
+      authorAddress: AUTHOR,
+    });
+    await expect(author.reconcileRfc64PublicRootCatalogExactSetV1({
+      ...common,
+      assets: [{
+        ...firstAsset,
+        seal: Object.freeze({ ...firstSeal, assertionVersion: '3' }) as never,
+      }, secondAsset],
+    })).rejects.toThrow(/not the next assertion version/u);
+    await expect(author.reconcileRfc64PublicRootCatalogExactSetV1({
+      ...common,
+      assets: [{
+        ...firstV2,
+        assertionCoordinate: 'r1-1-renamed-first' as never,
+      }, secondAsset],
+    })).rejects.toThrow(/not the next assertion version/u);
+    expect(author.readRfc64AppliedCatalogHeadV1({
+      catalogScopeDigest: catalogScopeDigest(),
+      authorAddress: AUTHOR,
+    })).toEqual(appliedBeforeInvalidReplacement);
     await expect(author.reconcileRfc64PublicRootCatalogExactSetV1({
       ...common,
       assets: [firstV2, secondAsset],

--- a/packages/agent/test/rfc64-public-catalog-inventory-completeness-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-inventory-completeness-v1.test.ts
@@ -61,10 +61,23 @@ describe('RFC-64 public catalog bounded inventory completeness', () => {
 
   it('preserves the exact Gate-1 empty and one-row digest vectors', () => {
     const catalogScopeDigest = computeAuthorCatalogScopeDigestV1(SCOPE);
-    expect(computeRfc64AppliedInventoryDigestV1({
+    const emptyDigest = computeRfc64AppliedInventoryDigestV1({
       catalogScopeDigest,
       rows: [],
-    })).toBe('0xcd36c729c972b50de1b2e562fa7e2200513d8ba282af29ebf4e403a806605aee');
+    });
+    expect(emptyDigest).toBe(
+      '0xcd36c729c972b50de1b2e562fa7e2200513d8ba282af29ebf4e403a806605aee',
+    );
+    expect(verifyRfc64PublicCatalogInventoryCompletenessV1({
+      catalogScope: SCOPE,
+      expectedTotalRows: '0' as CountV1,
+      expectedRows: [],
+      observedRows: [],
+    })).toMatchObject({
+      inventoryRowCount: '0',
+      inventoryDigest: emptyDigest,
+      rows: [],
+    });
 
     const only = row(7);
     const evidence = verifyRfc64PublicCatalogInventoryCompletenessV1({
@@ -157,20 +170,13 @@ describe('RFC-64 public catalog bounded inventory completeness', () => {
     }), 'catalog-inventory-completeness-input');
   });
 
-  it('enforces the signed-bucket 1..1024 row boundary before enumerating rows', () => {
+  it('enforces the signed-descriptor 0..1024 row boundary before enumerating rows', () => {
     expectCode(() => verifyRfc64PublicCatalogInventoryCompletenessV1({
       catalogScope: { ...SCOPE, bucketCount: '2' as CountV1 },
       expectedTotalRows: '1' as CountV1,
       expectedRows: [row(1)],
       observedRows: [row(1)],
     }), 'catalog-inventory-completeness-slice');
-
-    expectCode(() => verifyRfc64PublicCatalogInventoryCompletenessV1({
-      catalogScope: SCOPE,
-      expectedTotalRows: '0' as CountV1,
-      expectedRows: [],
-      observedRows: [],
-    }), 'catalog-inventory-completeness-count');
 
     const maximum = Array.from({ length: 1024 }, (_value, index) => row(index + 1));
     const evidence = verifyRfc64PublicCatalogInventoryCompletenessV1({

--- a/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { multiaddr } from '@multiformats/multiaddr';
 import {
   AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1,
+  AUTHOR_CATALOG_DIRECTORY_NODE_OBJECT_TYPE_V1,
   AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
   CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
   DKGNode,
@@ -352,6 +353,55 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
     })).resolves.toMatchObject({
       envelope: { objectDigest: fixture.catalogIssuerDelegation.objectDigest },
     });
+  }, 30_000);
+
+  it('cold-bootstraps a zero-row successor on a fresh receiver', async () => {
+    const fixture = await setupLiveReceiver();
+
+    await expect(fixture.synchronizeAny(fixture.emptySuccessorAnnouncement)).resolves.toMatchObject({
+      catalogHeadDigest: fixture.emptySuccessor.head.objectDigest,
+      inventoryRowCount: 0,
+      activatedTripleCount: 0,
+      appliedHeadStatus: 'applied',
+    });
+    expect(fixture.receiverPersistence.inventory.readAppliedCatalogHeadV1(
+      fixture.scopeDigest,
+      AUTHOR,
+    )).toMatchObject({
+      currentCatalogHeadDigest: fixture.emptySuccessor.head.objectDigest,
+      catalogVersion: '2',
+      inventoryRowCount: '0',
+    });
+    await expect(fixture.receiverStore.countQuads()).resolves.toBe(0);
+  }, 30_000);
+
+  it('rejects malformed zero-row successor descriptors before bundle fetch or head CAS', async () => {
+    const fixture = await setupLiveReceiver();
+    const fetchKaBundle = vi.fn(async () => null);
+    const observed = fixture.createCasObservedReceiver({
+      fetchCatalogObject: async (_remotePeerId, request) => {
+        const envelope = fixture.authorObjects.get(request.targetObjectDigest);
+        if (envelope === undefined) return null;
+        return Object.freeze({
+          envelope,
+          issuerSignature: await verifyControlEnvelopeIssuerSignatureV1(envelope),
+        });
+      },
+      fetchKaBundle,
+    });
+
+    for (const malformed of fixture.malformedEmptySuccessorAnnouncements) {
+      await expect(fixture.synchronizeAny(malformed, observed.receiver)).rejects.toMatchObject({
+        code: 'catalog-native-receiver-catalog',
+      });
+    }
+
+    expect(fetchKaBundle).not.toHaveBeenCalled();
+    expect(observed.compareAndSwapAppliedCatalogHeadV1).not.toHaveBeenCalled();
+    expect(fixture.receiverPersistence.inventory.readAppliedCatalogHeadV1(
+      fixture.scopeDigest,
+      AUTHOR,
+    )).toBeNull();
   }, 30_000);
 
   it('activates every row in one exact bounded multi-asset inventory before one head CAS', async () => {
@@ -2171,6 +2221,27 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
     issuedAt: '1773900001002' as never,
     signer,
   });
+  const emptySuccessor = await produceSparseAuthorCatalogSuccessorV1({
+    previousHead: successor.head,
+    previousDirectoryPath: successor.directoryPath,
+    previousBucket: successor.bucket,
+    selectedBucketId: '0' as never,
+    nextRows: [],
+    issuedAt: '1773900001001' as never,
+    signer,
+  });
+  const malformedEmptySuccessors = await Promise.all([
+    buildMalformedEmptySuccessor(
+      emptySuccessor.head,
+      emptySuccessor.directoryPath[0]!,
+      { byteLength: '1' },
+    ),
+    buildMalformedEmptySuccessor(
+      emptySuccessor.head,
+      emptySuccessor.directoryPath[0]!,
+      { bucketDigest: `0x${'91'.repeat(32)}` },
+    ),
+  ]);
   const removalSuccessor = await produceSparseAuthorCatalogSuccessorV1({
     previousHead: multiAssetSuccessor.head,
     previousDirectoryPath: multiAssetSuccessor.directoryPath,
@@ -2245,6 +2316,8 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
     ...governedGenesis.stagedObjects,
     ...invalidGenesis.stagedObjects,
     ...successor.stagedObjects,
+    ...emptySuccessor.stagedObjects,
+    ...malformedEmptySuccessors.flatMap(({ stagedObjects }) => stagedObjects),
     ...multiAssetSuccessor.stagedObjects,
     ...removalSuccessor.stagedObjects,
     ...threeAssetSuccessor.stagedObjects,
@@ -2414,6 +2487,10 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
   const announcement = announcementFor(successor.head);
   const genesisAnnouncement = announcementFor(genesis.head);
   const multiAssetAnnouncement = announcementFor(multiAssetSuccessor.head);
+  const emptySuccessorAnnouncement = announcementFor(emptySuccessor.head);
+  const malformedEmptySuccessorAnnouncements = malformedEmptySuccessors.map(({ head }) => (
+    announcementFor(head)
+  ));
   const removalAnnouncement = announcementFor(removalSuccessor.head);
   const replacementAnnouncement = announcementFor(replacementSuccessor.head);
   const threeAssetAnnouncement = announcementFor(threeAssetSuccessor.head);
@@ -2529,6 +2606,9 @@ async function setupLiveReceiver(signingWallet = AUTHOR_WALLET) {
     createCasObservedReceiver,
     createReceiver,
     expiredAnnouncement,
+    emptySuccessor,
+    emptySuccessorAnnouncement,
+    malformedEmptySuccessorAnnouncements,
     forgedCatalogIssuerDelegation,
     genesis,
     genesisAnnouncement,
@@ -2748,6 +2828,40 @@ async function buildInvalidEmptyGenesis(
     computeAuthorCatalogHeadObjectDigestV1(headUnsigned),
   ) as SignedAuthorCatalogHeadEnvelopeV1;
   return Object.freeze({ head, stagedObjects: Object.freeze([sourceDirectory, head]) });
+}
+
+async function buildMalformedEmptySuccessor(
+  sourceHead: SignedAuthorCatalogHeadEnvelopeV1,
+  sourceDirectory: SignedAuthorCatalogDirectoryNodeEnvelopeV1,
+  descriptorOverrides: Readonly<Record<string, string>>,
+): Promise<{
+  head: SignedAuthorCatalogHeadEnvelopeV1;
+  stagedObjects: readonly SignedControlEnvelopeV1[];
+}> {
+  const sourceDescriptor = sourceDirectory.payload.entries[0];
+  if (sourceDescriptor === undefined) throw new Error('empty successor descriptor is missing');
+  const directoryUnsigned = testUnsignedEnvelope(
+    AUTHOR_CATALOG_DIRECTORY_NODE_OBJECT_TYPE_V1,
+    {
+      ...sourceDirectory.payload,
+      entries: [{ ...sourceDescriptor, ...descriptorOverrides }],
+    },
+  );
+  // Deliberately bypass the directory-specific encoder: these fixtures prove
+  // the receiver rejects signed but structurally malformed empty descriptors.
+  const directory = await signTestEnvelope(
+    directoryUnsigned,
+    computeControlObjectDigestHex(directoryUnsigned) as Digest32V1,
+  ) as SignedAuthorCatalogDirectoryNodeEnvelopeV1;
+  const headUnsigned = testUnsignedEnvelope(AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1, {
+    ...sourceHead.payload,
+    directoryRootDigest: directory.objectDigest,
+  });
+  const head = await signTestEnvelope(
+    headUnsigned,
+    computeAuthorCatalogHeadObjectDigestV1(headUnsigned),
+  ) as SignedAuthorCatalogHeadEnvelopeV1;
+  return Object.freeze({ head, stagedObjects: Object.freeze([directory, head]) });
 }
 
 function testUnsignedEnvelope(

--- a/packages/agent/test/rfc64-public-catalog-native-reconciler-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-reconciler-v1.test.ts
@@ -193,7 +193,6 @@ describe('RFC-64 bounded public root native reconciler v1', () => {
     for (const mismatch of [
       { currentCatalogHeadDigest: `0x${'aa'.repeat(32)}` as Digest32V1 },
       { catalogVersion: '2' },
-      { inventoryRowCount: '0' },
       { catalogScopeDigest: `0x${'bb'.repeat(32)}` as Digest32V1 },
       { authorAddress: '0xcccccccccccccccccccccccccccccccccccccccc' as EvmAddressV1 },
     ] satisfies Array<Partial<AppliedCatalogHeadSnapshotV1>>) {
@@ -286,6 +285,37 @@ describe('RFC-64 bounded public root native reconciler v1', () => {
       resolveTrustedCatalogScope,
       resolveDeployment: async () => DEPLOYMENT,
     });
+    await expect(legacyOnly.isHeadApplied(successor)).resolves.toBe(false);
+  });
+
+  it('dedupes an exact zero-row successor with and without staged-head support', async () => {
+    const successor = announcement('2');
+    const readAppliedCatalogHeadV1 = vi.fn(() => snapshot(successor, {
+      inventoryRowCount: '0',
+    }));
+    const readStagedCatalogHead = vi.fn(async () => stagedHead(successor, '0'));
+    const withStagedHead = createRfc64BoundedPublicRootCatalogNativeReconcilerV1({
+      nativeReceiver: receiver(vi.fn()),
+      inventory: { readAppliedCatalogHeadV1 },
+      resolveTrustedCatalogScope,
+      resolveDeployment: async () => DEPLOYMENT,
+      readStagedCatalogHead,
+    });
+
+    await expect(withStagedHead.isHeadApplied(successor)).resolves.toBe(true);
+    expect(readStagedCatalogHead).toHaveBeenCalledWith(successor);
+
+    const legacyOnly = createRfc64BoundedPublicRootCatalogNativeReconcilerV1({
+      nativeReceiver: receiver(vi.fn()),
+      inventory: { readAppliedCatalogHeadV1 },
+      resolveTrustedCatalogScope,
+      resolveDeployment: async () => DEPLOYMENT,
+    });
+    await expect(legacyOnly.isHeadApplied(successor)).resolves.toBe(true);
+
+    readAppliedCatalogHeadV1.mockReturnValueOnce(snapshot(successor, {
+      inventoryRowCount: '2',
+    }));
     await expect(legacyOnly.isHeadApplied(successor)).resolves.toBe(false);
   });
 

--- a/packages/agent/test/rfc64-public-catalog-successor-producer-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-successor-producer-v1.test.ts
@@ -219,7 +219,53 @@ describe('RFC-64 public/open one-row successor producer', () => {
     expect(stageVerifiedObjects).toHaveBeenCalledTimes(3);
   });
 
-  it('rejects empty, oversized, and duplicate exact sets before signing or staging', async () => {
+  it('produces the canonical zero-row successor for the final removal', async () => {
+    const { genesis, authorization } = await producerHistory();
+    const first = await stageOne(
+      { head: genesis.head, directoryPath: genesis.directoryPath, bucket: null },
+      authorization,
+    );
+    let stagedObjects: readonly { envelope: { objectType: string } }[] = [];
+    const stageKaBundle = vi.fn(durableBundleReceipt);
+    const stageVerifiedObjects = vi.fn(async (input) => {
+      stagedObjects = input;
+      return Object.freeze({
+        durable: true as const,
+        namespaceDurability: 'test-exact-durable' as never,
+        objects: Object.freeze([]),
+      });
+    });
+    const producer = new Rfc64PublicCatalogSuccessorProducerV1({
+      controlObjects: { stageVerifiedObjects } as never,
+      stageKaBundle,
+    });
+
+    const removed = await producer.produceAndStageExactSet({
+      previousHead: first.publication.head,
+      previousDirectoryPath: first.publication.directoryPath,
+      previousBucket: first.publication.bucket,
+      assets: [],
+      deployment: DEPLOYMENT,
+      issuedAt: '1773900002000' as never,
+      catalogSigner: catalogSigner(),
+      catalogIssuerAuthorization: authorization,
+    });
+
+    expect(removed.publication.head.payload).toMatchObject({
+      totalRows: '0',
+      version: '2',
+      previousHeadDigest: first.publication.head.objectDigest,
+    });
+    expect(removed.publication.bucket).toBeNull();
+    expect(removed.assets).toEqual([]);
+    expect(stageKaBundle).not.toHaveBeenCalled();
+    expect(stagedObjects.map(({ envelope }) => envelope.objectType)).toEqual([
+      AUTHOR_CATALOG_DIRECTORY_NODE_OBJECT_TYPE_V1,
+      AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
+    ]);
+  });
+
+  it('rejects oversized and duplicate exact sets before signing or staging', async () => {
     const { genesis, authorization } = await producerHistory();
     const signDigest = vi.fn(async (digest: Uint8Array) => AUTHOR_WALLET.signMessage(digest));
     const stageKaBundle = vi.fn(durableBundleReceipt);
@@ -243,10 +289,6 @@ describe('RFC-64 public/open one-row successor producer', () => {
       catalogIssuerAuthorization: authorization,
     };
 
-    await expect(producer.produceAndStageExactSet({
-      ...common,
-      assets: [],
-    })).rejects.toMatchObject({ code: 'catalog-successor-producer-input' });
     await expect(producer.produceAndStageExactSet({
       ...common,
       assets: Array.from({ length: 1025 }, () => asset),

--- a/packages/agent/test/rfc64-public-catalog-successor-producer-v1.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-successor-producer-v1.test.ts
@@ -21,6 +21,9 @@ import { produceDirectAuthorCatalogIssuerDelegationV1 } from '../src/rfc64/publi
 import {
   Rfc64PublicCatalogSuccessorProducerV1,
 } from '../src/rfc64/public-catalog-successor-producer-v1.js';
+import {
+  snapshotAndSortRfc64PublicCatalogSuccessorAssetsV1,
+} from '../src/rfc64/public-catalog-successor-asset-v1.js';
 import { RFC64_PUBLIC_CATALOG_BUNDLE_FETCH_RESPONSE_MAX_BYTES_V1 } from '../src/rfc64/public-catalog-native-transport-v1.js';
 
 const AUTHOR_WALLET = new ethers.Wallet(`0x${'66'.repeat(32)}`);
@@ -217,6 +220,31 @@ describe('RFC-64 public/open one-row successor producer', () => {
     expect(ordered.publication.bucket).toEqual(unordered.publication.bucket);
     expect(stageKaBundle).toHaveBeenCalledTimes(5);
     expect(stageVerifiedObjects).toHaveBeenCalledTimes(3);
+  });
+
+  it('shares one ordered immutable asset snapshot across producer and reconciler boundaries', async () => {
+    const firstProjection = new Uint8Array(PROJECTION);
+    const first = {
+      assertionCoordinate: 'gate-1-object' as never,
+      projectionBytes: firstProjection,
+      seal: await authorSeal(AUTHOR_WALLET),
+    };
+    const second = {
+      assertionCoordinate: 'gate-2-object' as never,
+      projectionBytes: PROJECTION,
+      seal: await authorSeal(AUTHOR_WALLET, SECOND_KA_NUMBER),
+    };
+
+    const snapshot = snapshotAndSortRfc64PublicCatalogSuccessorAssetsV1([second, first]);
+    firstProjection[0] = 0;
+
+    expect(snapshot.map((asset) => asset.seal.reservedKaId)).toEqual([KA_ID, SECOND_KA_ID]);
+    expect(snapshot[0]?.projectionBytes).toEqual(PROJECTION);
+    expect(snapshot[0]?.projectionBytes).not.toBe(firstProjection);
+    expect(Object.isFrozen(snapshot)).toBe(true);
+    expect(Object.isFrozen(snapshot[0])).toBe(true);
+    expect(() => snapshotAndSortRfc64PublicCatalogSuccessorAssetsV1([first, first]))
+      .toThrow(/duplicate KA/u);
   });
 
   it('produces the canonical zero-row successor for the final removal', async () => {
@@ -527,7 +555,7 @@ describe('RFC-64 public/open one-row successor producer', () => {
     expect(stageVerifiedObjects).not.toHaveBeenCalled();
   });
 
-  it('snapshots a stateful projection getter once before validation and encoding', async () => {
+  it('rejects a stateful projection getter without invoking it', async () => {
     const { genesis, authorization } = await producerHistory();
     const stageKaBundle = vi.fn(durableBundleReceipt);
     const stageVerifiedObjects = vi.fn(async () => Object.freeze({
@@ -551,7 +579,7 @@ describe('RFC-64 public/open one-row successor producer', () => {
       seal: await authorSeal(AUTHOR_WALLET),
     };
 
-    const result = await producer.produceAndStageExactSet({
+    await expect(producer.produceAndStageExactSet({
       previousHead: genesis.head,
       previousDirectoryPath: genesis.directoryPath,
       previousBucket: null,
@@ -560,14 +588,11 @@ describe('RFC-64 public/open one-row successor producer', () => {
       issuedAt: '1773900001000' as never,
       catalogSigner: catalogSigner(),
       catalogIssuerAuthorization: authorization,
-    });
+    })).rejects.toMatchObject({ code: 'catalog-successor-producer-input' });
 
-    expect(projectionReads).toBe(1);
-    expect(decodeOpaqueKaBundleV1(result.assets[0]!.bundleBytes).projectionBytes).toEqual(
-      PROJECTION,
-    );
-    expect(stageKaBundle).toHaveBeenCalledOnce();
-    expect(stageVerifiedObjects).toHaveBeenCalledOnce();
+    expect(projectionReads).toBe(0);
+    expect(stageKaBundle).not.toHaveBeenCalled();
+    expect(stageVerifiedObjects).not.toHaveBeenCalled();
   });
 
   it('fails control-object staging only after the bundle is durably staged first', async () => {

--- a/packages/agent/test/rfc64-swm-inventory-catalog-reconciler-v1.test.ts
+++ b/packages/agent/test/rfc64-swm-inventory-catalog-reconciler-v1.test.ts
@@ -1,0 +1,202 @@
+import {
+  SWM_AUTHOR_INVENTORY_HEAD_OBJECT_TYPE_V1,
+  assertCanonicalGraphScopedAuthorSealV1,
+  buildAuthorAttestationTypedData,
+  computeCanonicalGraphScopedAuthorSealDigestV1,
+  computeKaProjectionDigestV1,
+  computeSwmAuthorInventoryHeadObjectDigestV1,
+  computeSwmAuthorInventoryRowsDigestV1,
+  type CanonicalGraphScopedAuthorSealV1,
+  type CatalogSealDeploymentProfileV1,
+  type ContextGraphIdV1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type SignedSwmAuthorInventoryHeadEnvelopeV1,
+  type SwmAuthorInventoryHeadV1,
+  type SwmAuthorInventoryRowV1,
+  type SwmAuthorInventoryScopeV1,
+  type SwmAuthorInventorySnapshotV1,
+  type UnsignedSwmAuthorInventoryHeadEnvelopeV1,
+} from '@origintrail-official/dkg-core';
+import { ethers } from 'ethers';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  prepareRfc64SwmInventoryCatalogTargetV1,
+} from '../src/rfc64/swm-inventory-catalog-reconciler-v1.js';
+
+const AUTHOR_WALLET = new ethers.Wallet(`0x${'41'.repeat(32)}`);
+const OTHER_WALLET = new ethers.Wallet(`0x${'42'.repeat(32)}`);
+const AUTHOR = AUTHOR_WALLET.address.toLowerCase() as EvmAddressV1;
+const NETWORK_ID = 'otp:20430';
+const CONTEXT_GRAPH_ID =
+  '0x1111111111111111111111111111111111111111/r1-1-reconcile' as ContextGraphIdV1;
+const GOVERNANCE = '0x2222222222222222222222222222222222222222' as EvmAddressV1;
+const KAV10 = '0x4444444444444444444444444444444444444444' as EvmAddressV1;
+const ASSERTION_ROOT = `0x${'ab'.repeat(32)}` as Digest32V1;
+const PROJECTION = new TextEncoder().encode(
+  '<https://example.org/r1> <https://schema.org/name> "R1.1" .\n',
+);
+const SCOPE = Object.freeze({
+  networkId: NETWORK_ID,
+  contextGraphId: CONTEXT_GRAPH_ID,
+  governanceChainId: '20430',
+  governanceContractAddress: GOVERNANCE,
+  ownershipTransitionDigest: null,
+  subGraphName: null,
+  authorAddress: AUTHOR,
+  era: '0',
+}) as SwmAuthorInventoryScopeV1;
+const DEPLOYMENT = Object.freeze({
+  networkId: NETWORK_ID,
+  assertedAtChainId: '20430',
+  assertedAtKav10Address: KAV10,
+}) as CatalogSealDeploymentProfileV1;
+
+describe('RFC-64 R1.1 signed SWM inventory to catalog target', () => {
+  it('authenticates and detaches one complete target before catalog mutation', async () => {
+    const seal = await authorSeal();
+    const row = inventoryRow(seal, PROJECTION);
+    const snapshot = await signedSnapshot([row], AUTHOR_WALLET);
+    const callerProjection = new Uint8Array(PROJECTION);
+    const resolveAsset = vi.fn(async (resolvedRow: Readonly<SwmAuthorInventoryRowV1>) => ({
+      assertionCoordinate: resolvedRow.assertionCoordinate,
+      projectionBytes: callerProjection,
+      seal,
+    }));
+
+    const target = await prepareRfc64SwmInventoryCatalogTargetV1({
+      snapshot,
+      resolveAsset,
+    });
+    callerProjection.fill(0);
+
+    expect(resolveAsset).toHaveBeenCalledOnce();
+    expect(resolveAsset.mock.calls[0]![0]).not.toBe(row);
+    expect(target).toMatchObject({
+      inventoryHeadObjectDigest: snapshot.head.objectDigest,
+      inventoryScope: SCOPE,
+      catalogScope: { ...SCOPE, bucketCount: '1' },
+    });
+    expect(target.assets).toHaveLength(1);
+    expect(target.assets[0]).toMatchObject({
+      assertionCoordinate: row.assertionCoordinate,
+      seal,
+    });
+    expect(target.assets[0]!.projectionBytes).toEqual(PROJECTION);
+    expect(Object.isFrozen(target.assets)).toBe(true);
+    expect(Object.isFrozen(target.assets[0])).toBe(true);
+  });
+
+  it('rejects a signed row whose resolver substitutes different projection bytes', async () => {
+    const seal = await authorSeal();
+    const row = inventoryRow(seal, PROJECTION);
+    const snapshot = await signedSnapshot([row], AUTHOR_WALLET);
+
+    await expect(prepareRfc64SwmInventoryCatalogTargetV1({
+      snapshot,
+      resolveAsset: async () => ({
+        assertionCoordinate: row.assertionCoordinate,
+        projectionBytes: new TextEncoder().encode(
+          '<https://example.org/r1> <https://schema.org/name> "substituted" .\n',
+        ),
+        seal,
+      }),
+    })).rejects.toMatchObject({ code: 'swm-catalog-reconcile-binding' });
+  });
+
+  it('rejects an inventory head whose signature does not recover to its scoped author', async () => {
+    const seal = await authorSeal();
+    const row = inventoryRow(seal, PROJECTION);
+    const snapshot = await signedSnapshot([row], OTHER_WALLET);
+    const resolveAsset = vi.fn();
+
+    await expect(prepareRfc64SwmInventoryCatalogTargetV1({
+      snapshot,
+      resolveAsset,
+    })).rejects.toMatchObject({ code: 'swm-catalog-reconcile-signature' });
+    expect(resolveAsset).not.toHaveBeenCalled();
+  });
+});
+
+function inventoryRow(
+  seal: CanonicalGraphScopedAuthorSealV1,
+  projectionBytes: Uint8Array,
+): SwmAuthorInventoryRowV1 {
+  return Object.freeze({
+    assertionCoordinate: 'r1-draft',
+    assertionVersion: seal.assertionVersion,
+    kaUal: seal.kaUal,
+    shareOperationId: 'r1-share-operation',
+    projectionDigest: computeKaProjectionDigestV1(projectionBytes),
+    publicTripleCount: seal.publicTripleCount,
+    privateTripleCount: seal.privateTripleCount,
+    sealDigest: computeCanonicalGraphScopedAuthorSealDigestV1(seal),
+    sharedAt: '1773900000000',
+    expiresAt: null,
+  }) as SwmAuthorInventoryRowV1;
+}
+
+async function signedSnapshot(
+  rows: readonly SwmAuthorInventoryRowV1[],
+  signingWallet: ethers.Wallet,
+): Promise<SwmAuthorInventorySnapshotV1> {
+  const payload = Object.freeze({
+    ...SCOPE,
+    version: '0',
+    previousHeadDigest: null,
+    totalRows: rows.length.toString(),
+    rowsDigest: computeSwmAuthorInventoryRowsDigestV1(rows),
+    issuedAt: '1773900001000',
+  }) as SwmAuthorInventoryHeadV1;
+  const unsigned = Object.freeze({
+    issuer: AUTHOR,
+    objectType: SWM_AUTHOR_INVENTORY_HEAD_OBJECT_TYPE_V1,
+    payload,
+    signatureEvidence: Object.freeze({ kind: 'none' as const }),
+    signatureSuite: 'eip191-personal-sign-digest-v1' as const,
+  }) as UnsignedSwmAuthorInventoryHeadEnvelopeV1;
+  const objectDigest = computeSwmAuthorInventoryHeadObjectDigestV1(unsigned);
+  const head = Object.freeze({
+    ...unsigned,
+    objectDigest,
+    signature: await signingWallet.signMessage(ethers.getBytes(objectDigest)),
+  }) as SignedSwmAuthorInventoryHeadEnvelopeV1;
+  return Object.freeze({ head, rows: Object.freeze([...rows]) });
+}
+
+async function authorSeal(): Promise<CanonicalGraphScopedAuthorSealV1> {
+  const kaNumber = 7n;
+  const reservedKaId = ((BigInt(AUTHOR) << 96n) | kaNumber).toString();
+  const typedData = buildAuthorAttestationTypedData({
+    chainId: BigInt(DEPLOYMENT.assertedAtChainId),
+    kav10Address: DEPLOYMENT.assertedAtKav10Address,
+    merkleRoot: ethers.getBytes(ASSERTION_ROOT),
+    authorAddress: AUTHOR,
+    reservedKaId: BigInt(reservedKaId),
+  });
+  const signature = ethers.Signature.from(await AUTHOR_WALLET.signTypedData(
+    typedData.domain,
+    typedData.types,
+    typedData.message,
+  ));
+  const seal = {
+    assertionMerkleRoot: ASSERTION_ROOT,
+    authorAddress: AUTHOR,
+    authorAttestationR: signature.r,
+    authorAttestationVS: signature.yParityAndS,
+    authorSchemeVersion: '1',
+    assertedAtChainId: DEPLOYMENT.assertedAtChainId,
+    assertedAtKav10Address: KAV10,
+    reservedKaId,
+    assertionFinalizedAt: '2026-08-28T10:00:00.000Z',
+    contentScopeVersion: '2',
+    kaUal: `did:dkg:${NETWORK_ID}/${AUTHOR}/${kaNumber}`,
+    assertionVersion: '1',
+    publicTripleCount: '1',
+    privateTripleCount: '0',
+    privateMerkleRoot: null,
+  } as unknown as CanonicalGraphScopedAuthorSealV1;
+  assertCanonicalGraphScopedAuthorSealV1(seal);
+  return seal;
+}

--- a/packages/agent/test/rfc64-swm-inventory-shadow-runtime-v1.test.ts
+++ b/packages/agent/test/rfc64-swm-inventory-shadow-runtime-v1.test.ts
@@ -68,4 +68,37 @@ describe('RFC-64 SWM inventory shadow runtime', () => {
     expect(runtime.inFlightCount).toBe(0);
     expect(runtime.isVmConfirmed(assetKey, '1')).toBe(false);
   });
+
+  it('serializes one author scope while leaving unrelated scopes concurrent', async () => {
+    const runtime = new Rfc64SwmInventoryShadowRuntimeV1();
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+    let markFirstEntered!: () => void;
+    const firstGate = new Promise<void>((resolve) => { releaseFirst = resolve; });
+    const firstEntered = new Promise<void>((resolve) => { markFirstEntered = resolve; });
+
+    const first = runtime.runScopeExclusive('scope-a', async () => {
+      events.push('first-enter');
+      markFirstEntered();
+      await firstGate;
+      events.push('first-exit');
+      return 1;
+    });
+    await firstEntered;
+    const second = runtime.runScopeExclusive('scope-a', async () => {
+      events.push('second');
+      return 2;
+    });
+    const unrelated = runtime.runScopeExclusive('scope-b', async () => {
+      events.push('unrelated');
+      return 3;
+    });
+    await expect(unrelated).resolves.toBe(3);
+    expect(events).toEqual(['first-enter', 'unrelated']);
+
+    releaseFirst();
+    await expect(first).resolves.toBe(1);
+    await expect(second).resolves.toBe(2);
+    expect(events).toEqual(['first-enter', 'unrelated', 'first-exit', 'second']);
+  });
 });

--- a/packages/agent/vitest.rfc64-unit-tests.ts
+++ b/packages/agent/vitest.rfc64-unit-tests.ts
@@ -5,6 +5,7 @@ export const RFC64_UNIT_TESTS = [
   "test/rfc64-inventory-v1-applied-head.test.ts",
   "test/rfc64-swm-author-inventory-persistence-v1.test.ts",
   "test/rfc64-swm-author-inventory-producer-v1.test.ts",
+  "test/rfc64-swm-inventory-catalog-reconciler-v1.test.ts",
   "test/rfc64-swm-inventory-shadow-runtime-v1.test.ts",
   "test/rfc64-inventory-v1-candidate-plans.test.ts",
   "test/rfc64-inventory-v1-candidate-latency.test.ts",

--- a/packages/agent/vitest.rfc64-unit-tests.ts
+++ b/packages/agent/vitest.rfc64-unit-tests.ts
@@ -7,6 +7,7 @@ export const RFC64_UNIT_TESTS = [
   "test/rfc64-swm-author-inventory-producer-v1.test.ts",
   "test/rfc64-swm-inventory-catalog-reconciler-v1.test.ts",
   "test/rfc64-swm-inventory-shadow-runtime-v1.test.ts",
+  "test/rfc64-catalog-upsert-planner-v1.test.ts",
   "test/rfc64-inventory-v1-candidate-plans.test.ts",
   "test/rfc64-inventory-v1-candidate-latency.test.ts",
   "test/rfc64-inventory-v1-candidate-faults.test.ts",


### PR DESCRIPTION
## Outcome

R1.1 adds the dormant producer foundation that turns one author's authenticated, exact SWM inventory into deterministic RFC-64 public catalog successors.

It supports:

- adding newly shared SWM assets;
- replacing an asset only with its next assertion version;
- removing assets no longer present in the signed inventory;
- converging through deterministic one-KA successors;
- exact replay without another successor;
- a canonical zero-row successor when the final asset is removed.

The receiver now accepts and applies that canonical empty successor, so a catalog can prove and enact complete removal rather than retaining its final stale asset.

## User impact

This is the authenticated producer foundation for reliable public SWM catch-up. It closes the gap between the durable signed SWM inventory introduced by R0 and the RFC-64 catalog protocol receivers already understand.

This increment is intentionally dormant: ordinary SHARE operations do not invoke reconciliation yet. Therefore merging it changes no default publication or synchronization behavior. R1.2 will own atomic lifecycle coupling; R1.3 will own activation and rollout.

## Before

```mermaid
sequenceDiagram
    participant Client
    participant Agent as Publishing agent
    participant Store as Durable SWM store
    participant Inventory as Signed SWM inventory
    participant Catalog as RFC-64 catalog

    Client->>Agent: SHARE public asset
    Agent->>Store: Persist public projection and author seal
    Agent->>Inventory: Commit exact signed inventory row
    Note over Inventory,Catalog: No authenticated bridge advances the catalog
    Catalog-->>Agent: Previous catalog remains unchanged
```

## After

```mermaid
sequenceDiagram
    participant Caller as Explicit R1.1 caller
    participant Agent as Publishing agent
    participant Inventory as Signed SWM inventory
    participant Store as Durable SWM store
    participant Catalog as RFC-64 catalog
    participant Receiver

    Caller->>Agent: Reconcile author inventory
    Agent->>Inventory: Read exact signed snapshot
    Agent->>Agent: Verify signature, scope and row binding
    loop Every signed inventory row
        Agent->>Store: Resolve exact projection and author seal
        Agent->>Agent: Recompute projection and seal digests
    end
    loop Until current set equals target set
        Agent->>Catalog: Stage deterministic one-KA successor
        Agent->>Catalog: Compare-and-swap applied head
        Agent-->>Receiver: Announce successor
    end
    Receiver->>Receiver: Apply exact additions, replacements and removals
    Agent-->>Caller: Return applied head and successor count
```

## Safety boundaries

- Requires an accepted public root catalog lane and durable RFC-64 persistence.
- Verifies the inventory-head issuer signature before resolving any asset.
- Rebinds each resolved projection and seal to the signed inventory row.
- Rejects duplicate KAs, oversized targets, cross-author assets and skipped replacement versions.
- Serializes mutation per catalog scope and author.
- Does not activate automatic scheduling or alter ordinary SHARE behavior.

## Validation

- `pnpm --filter @origintrail-official/dkg-agent build`
- `pnpm lint`
- focused R1.1/RFC-64 lane: 81 passed, 0 failed
- full agent unit lane: 215 files; 3,195 passed, 5 skipped, 0 failed
- `git diff --check`

## Stack

- R0 / policy and recovery foundation: #2367 (merged)
- R1.1 / signed SWM inventory to catalog reconciliation: this PR
- R1.2 / atomic author commit: follow-up
- R1.3 / runtime activation and rollout: follow-up
