### PR TITLE
refactor(publisher): extract the reconciliation snapshot coordinator; lease vocabulary; truthful concurrency contract

### DIFF
--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -7,6 +7,7 @@ import {
   type ChainProofSchedulePass,
   type ChainProofScheduleTurn,
 } from './chain-proof-retry-schedule.js';
+import { ReconciliationSnapshotCoordinator } from './reconciliation-snapshot-coordinator.js';
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import {
@@ -474,17 +475,17 @@ export class TripleStoreAsyncLiftPublisher
   });
 
   /**
-   * The tail of the acquisition queue in {@link takeReconciliationSnapshot}: each slot carries
-   * the acquisition's settlement AND its lease expiry (capMs after it STARTED executing), so a
-   * successor is promoted only past an owner that actually held the seam too long — never past
-   * a healthy owner mid-read, and never in a burst (r12 🔴 3884393225).
+   * Owns the whole snapshot-acquisition ordering protocol (FIFO tail, owner lease,
+   * scope-before-read) — see reconciliation-snapshot-coordinator.ts for the model. The
+   * publisher only wires its collaborators and calls `acquire()`.
    */
-  private reconciliationAcquisitionTail: { settled: Promise<void>; leaseExpired: Promise<void> } = {
-    settled: Promise.resolve(),
-    leaseExpired: Promise.resolve(),
-  };
+  private readonly reconciliationSnapshotCoordinator = new ReconciliationSnapshotCoordinator({
+    readInventory: () => this.list(),
+    beginScope: () => this.chainProofRetrySchedule.beginPass(this.now()),
+    leaseMs: () => this.reconciliationAcquisitionLeaseMs,
+  });
 
-  private readonly reconciliationAcquisitionWaitCapMs: number;
+  private readonly reconciliationAcquisitionLeaseMs: number;
   /**
    * r26 (🔴 3821028709) — jobs whose MUTATING recovery repair is currently running. A deadline
    * may stop the dispatcher waiting, but it must never let a second pass enter the same repair
@@ -620,7 +621,7 @@ export class TripleStoreAsyncLiftPublisher
     this.chainProofCapableForWallet = config.chainProofCapableForWallet;
     this.chainProofDispatchBatchSize = config.chainProofDispatchBatchSize ?? 25;
     this.chainProofDispatchTimeBudgetMs = config.chainProofDispatchTimeBudgetMs ?? 15_000;
-    this.reconciliationAcquisitionWaitCapMs = config.reconciliationAcquisitionWaitCapMs ?? 30_000;
+    this.reconciliationAcquisitionLeaseMs = config.reconciliationAcquisitionLeaseMs ?? 30_000;
     this.knowledgeAssetVmPublishRecoveryResolver = config.knowledgeAssetVmPublishRecoveryResolver;
     this.detachReceiptReconciliation = config.detachReceiptReconciliation ?? false;
     this.publishExecutor = config.publishExecutor;
@@ -2127,73 +2128,6 @@ export class TripleStoreAsyncLiftPublisher
   }
 
   /**
-   * The ONE acquisition seam for a reconciliation pass's shared state: the queue inventory and
-   * the chain-proof pass scope, taken together so the scope's ordering token reflects SNAPSHOT
-   * order (opening it later — e.g. at the dispatcher — would order by arrival, which
-   * overlapping passes can invert; PR #2380 r4 🔴 3883088105). One inventory per pass because
-   * per-lane full reads at an active cadence move the bottleneck into store/control-plane
-   * work; each lane re-reads its candidates under the transition lock before acting, so the
-   * shared snapshot only selects candidates and staleness cannot change a disposition.
-   */
-  private async takeReconciliationSnapshot(): Promise<{
-    inventory: LiftJob[];
-    chainProofPass: ChainProofSchedulePass;
-  }> {
-    // r6 (🔴 3883453447) — acquisition is SERIALIZED, not merely adjacent: two overlapping
-    // `list()` reads can resolve out of store-side capture order (the store runs on a worker
-    // pool), so adjacency alone orders tokens by query COMPLETION. Chaining acquisitions makes
-    // capture order equal completion order equal token order — a real linearization boundary,
-    // scoped to the seam so passes themselves still overlap everywhere else.
-    //
-    // r10 (🔴 3883959795) — the wait on the predecessor is BOUNDED: one non-settling store
-    // read must degrade ordering, not availability — an unbounded chain turns it into a
-    // permanent reconciliation outage for every later pass, the opposite of the documented
-    // fresh-pass contract. A successor that stops waiting replaces the chain with its own
-    // settlement, so the hung acquisition wedges nobody after it. Within the cap the FIFO is
-    // exact; past it, the rare inversion this window re-opens is still bounded by the
-    // schedule's write-time identity guards and the claim-locked re-read. This is deliberately
-    // NOT the package's `withKeyedLocks`: that primitive's contract is strict unbounded
-    // exclusion (what its publish/CAS/SWM callers need), and borrowing it would import the
-    // very unbounded wait this bound removes.
-    // r12 (🔴 3884393225) — the cap is a LEASE on the owner's execution, not a per-waiter
-    // timer: a waiter is promoted only when its immediate predecessor has either settled or
-    // held the seam for capMs after STARTING to execute. A burst of waiters queued behind one
-    // hung read therefore promotes exactly one head (whose fresh lease then covers the next
-    // waiter), instead of all bypassing on their own entry-relative timers and re-opening the
-    // overlapping-read inversion the queue exists to prevent. A healthy-but-slow owner
-    // mid-read is likewise never bypassed before ITS lease runs out.
-    const predecessor = this.reconciliationAcquisitionTail;
-    let markStarted!: () => void;
-    const started = new Promise<void>((resolve) => { markStarted = resolve; });
-    const acquisition = (async () => {
-      await Promise.race([predecessor.settled, predecessor.leaseExpired]);
-      markStarted();
-      // r11 (🔴 3884193885) — ordering authority is reserved BEFORE the read, not after it:
-      // a hung read whose successor was promoted past it keeps the token it drew at its
-      // section start, so when it eventually completes it is fenced as OLDER — its sweep (the
-      // one consumer of token order with deletion authority over other jobs' entries, which no
-      // identity guard contains) cannot collect what the successor installed from genuinely
-      // newer state. In the serialized normal case start order equals capture order, so
-      // nothing changes; in the bypass case the ambiguity resolves conservatively (a late pass
-      // can be under-ranked, never over-ranked).
-      const chainProofPass = this.chainProofRetrySchedule.beginPass(this.now());
-      const inventory = await this.list();
-      return { inventory, chainProofPass };
-    })();
-    // The queue must survive a failed acquisition — carry only settlement, never the result.
-    const settled = acquisition.then(() => undefined, () => undefined);
-    const leaseExpired = started.then(() => new Promise<void>((resolve) => {
-      const lease = setTimeout(resolve, Math.max(0, this.reconciliationAcquisitionWaitCapMs));
-      void settled.finally(() => {
-        clearTimeout(lease);
-        resolve();
-      });
-    }));
-    this.reconciliationAcquisitionTail = { settled, leaseExpired };
-    return acquisition;
-  }
-
-  /**
    * The ONE canonical pass: reports both what it settled and whether actionable live work
    * remains, computed DURING the walk (per-job, from the under-lock re-reads the pass already
    * pays for) — never by a second queue inventory afterwards. The scheduling caller consumes
@@ -2203,7 +2137,14 @@ export class TripleStoreAsyncLiftPublisher
    */
   private async runReconciliationPass(): Promise<{ reconciled: number; pendingWork: boolean }> {
     await this.ensureGraph();
-    const { inventory, chainProofPass } = await this.takeReconciliationSnapshot();
+    // The ONE acquisition seam for a pass's shared state: inventory and chain-proof scope,
+    // taken together (scope BEFORE read, acquisitions lease-ordered) by the coordinator, which
+    // owns the whole ordering protocol — see reconciliation-snapshot-coordinator.ts. One
+    // inventory per pass because per-lane full reads at an active cadence move the bottleneck
+    // into store/control-plane work; each lane re-reads its candidates under the transition
+    // lock before acting, so the shared snapshot only selects candidates and staleness cannot
+    // change a disposition.
+    const { inventory, scope: chainProofPass } = await this.reconciliationSnapshotCoordinator.acquire();
     let reconciled = await this.recoverInterruptedPreBroadcastJobs(inventory);
     // Same actionability rule the scheduling outlook answers with: executor-owned jobs are
     // skipped up front rather than each burning a transition-lock turn to be skipped deeper in.

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -475,17 +475,15 @@ export class TripleStoreAsyncLiftPublisher
   });
 
   /**
-   * Owns the whole snapshot-acquisition ordering protocol (FIFO tail, owner lease,
+   * Owns the whole snapshot-acquisition ordering protocol (FIFO release gates, owner lease,
    * scope-before-read) — see reconciliation-snapshot-coordinator.ts for the model. The
-   * publisher only wires its collaborators and calls `acquire()`.
+   * publisher only wires its collaborators and calls `acquire()`; constructed in the
+   * constructor body so the resolved lease value is passed directly.
    */
-  private readonly reconciliationSnapshotCoordinator = new ReconciliationSnapshotCoordinator({
-    readInventory: () => this.list(),
-    beginScope: () => this.chainProofRetrySchedule.beginPass(this.now()),
-    leaseMs: () => this.reconciliationAcquisitionLeaseMs,
-  });
-
-  private readonly reconciliationAcquisitionLeaseMs: number;
+  private readonly reconciliationSnapshotCoordinator: ReconciliationSnapshotCoordinator<
+    LiftJob[],
+    ChainProofSchedulePass
+  >;
   /**
    * r26 (🔴 3821028709) — jobs whose MUTATING recovery repair is currently running. A deadline
    * may stop the dispatcher waiting, but it must never let a second pass enter the same repair
@@ -621,7 +619,11 @@ export class TripleStoreAsyncLiftPublisher
     this.chainProofCapableForWallet = config.chainProofCapableForWallet;
     this.chainProofDispatchBatchSize = config.chainProofDispatchBatchSize ?? 25;
     this.chainProofDispatchTimeBudgetMs = config.chainProofDispatchTimeBudgetMs ?? 15_000;
-    this.reconciliationAcquisitionLeaseMs = config.reconciliationAcquisitionLeaseMs ?? 30_000;
+    this.reconciliationSnapshotCoordinator = new ReconciliationSnapshotCoordinator({
+      readInventory: () => this.list(),
+      beginScope: () => this.chainProofRetrySchedule.beginPass(this.now()),
+      leaseMs: config.reconciliationAcquisitionLeaseMs ?? 30_000,
+    });
     this.knowledgeAssetVmPublishRecoveryResolver = config.knowledgeAssetVmPublishRecoveryResolver;
     this.detachReceiptReconciliation = config.detachReceiptReconciliation ?? false;
     this.publishExecutor = config.publishExecutor;

--- a/packages/publisher/src/async-lift-publisher-types.ts
+++ b/packages/publisher/src/async-lift-publisher-types.ts
@@ -193,8 +193,11 @@ export interface AsyncLiftPublisher {
    * Run one reconciliation pass and report how many jobs it settled.
    *
    * CONCURRENCY CONTRACT: safe to call at any time, including concurrently with any other
-   * in-flight pass; every call performs its own FRESH pass over fresh state — calls are
-   * neither queued behind nor coalesced into an existing pass.
+   * in-flight pass. Every call performs its own pass over its own freshly read inventory —
+   * passes are never coalesced. Inventory ACQUISITION, however, is FIFO-ordered: a concurrent
+   * call's read starts only once the previous acquisition completes or exceeds its owner
+   * lease ({@link AsyncLiftPublisherConfig.reconciliationAcquisitionLeaseMs}), so added
+   * latency is bounded per predecessor and a hung read cannot block the seam indefinitely.
    */
   recover(): Promise<number>;
   /**
@@ -762,11 +765,13 @@ export interface AsyncLiftPublisherConfig {
    */
   chainProofDispatchTimeBudgetMs?: number;
   /**
-   * How long one reconciliation pass's inventory acquisition waits behind the previous pass's
-   * (acquisitions are ordered; the wait is bounded so one hung store read degrades ordering,
-   * not availability). Default 30s.
+   * The owner LEASE on the serialized inventory-acquisition seam: how long one acquisition may
+   * execute (measured from its execution start) before the next queued acquisition is promoted
+   * past it. Acquisitions are FIFO-ordered; a queued burst therefore waits up to one lease per
+   * predecessor ahead of it, and one hung store read degrades ordering, never availability.
+   * Default 30s.
    */
-  reconciliationAcquisitionWaitCapMs?: number;
+  reconciliationAcquisitionLeaseMs?: number;
   /**
    * GH#2270 PR-3 r20 (🔴 3815617109) — can the chain-proof lane actually settle a job signed by
    * THIS wallet? A node may mix adapters, and the presence of a resolver is a node-wide fact while

--- a/packages/publisher/src/reconciliation-snapshot-coordinator.ts
+++ b/packages/publisher/src/reconciliation-snapshot-coordinator.ts
@@ -3,20 +3,22 @@
  * (PR #2380 r13 3884734172) so the protocol's sequencing is a property of this module's only
  * code path rather than caller discipline spread across an orchestration class.
  *
- * MODEL — acquisitions form a FIFO queue. The head acquisition (the "owner") executes: it
- * draws the ordering SCOPE first — structurally before the inventory read, so a snapshot's
- * rank can never be assigned by read-completion order (PR #2380 r11 🔴 3884193885: a hung
- * read completing late must not outrank what a successor installed from newer state; the
- * sweep acts on absence, where no identity guard applies). A successor waits for its
- * predecessor to SETTLE or for the predecessor's LEASE — measured from the moment the
- * predecessor STARTED executing, never from the waiter's own entry — to expire, whichever
- * comes first (r12 🔴 3884393225: entry-relative timers release a queued burst together and
- * re-open overlapping reads; owner leases promote exactly the head waiter, and every later
- * waiter stays behind the new owner's fresh lease). Serialization therefore degrades to
- * overlap only past a lease — availability over exactness for a hung read (r10 🔴
- * 3883959795) — and a bypassed owner completes still holding its pre-drawn older scope:
- * refusable by rank, never destructive. A failed acquisition never poisons the queue — the
- * tail carries settlement only (r7 🟡 3883690945).
+ * MODEL — acquisitions form a FIFO queue of release GATES (PR #2381 r1 3884946389: one
+ * resolve-only promise per owner, representing the sole event a successor cares about —
+ * permission to proceed). An acquisition installs its own gate synchronously, then awaits its
+ * predecessor's. Once it owns the seam it draws the ordering SCOPE first — structurally
+ * before the inventory read, so a snapshot's rank can never be assigned by read-completion
+ * order (PR #2380 r11 🔴 3884193885: a hung read completing late must not outrank what a
+ * successor installed from newer state; the sweep acts on absence, where no identity guard
+ * applies). The owner's gate resolves at whichever comes first: its settlement (`finally`) or
+ * its LEASE — a timer started when the owner starts executing, never at a waiter's entry
+ * (r12 🔴 3884393225: entry-relative timers release a queued burst together and re-open
+ * overlapping reads; owner leases promote exactly the head waiter, and every later waiter
+ * stays behind the new owner's fresh lease). Serialization therefore degrades to overlap only
+ * past a lease — availability over exactness for a hung read (r10 🔴 3883959795) — and a
+ * bypassed owner completes still holding its pre-drawn older scope: refusable by rank, never
+ * destructive. The gate is resolve-only, so a failed read rejects its own caller and can
+ * never poison the queue (r7 🟡 3883690945).
  */
 
 export interface ReconciliationSnapshotCoordinatorDeps<TInventory, TScope> {
@@ -24,38 +26,28 @@ export interface ReconciliationSnapshotCoordinatorDeps<TInventory, TScope> {
   readInventory(): Promise<TInventory>;
   /** Draw this acquisition's ordering scope; invoked before its read, in promotion order. */
   beginScope(): TScope;
-  /** The owner lease in milliseconds; read per acquisition so configuration stays live. */
-  leaseMs(): number;
+  /** The owner lease in milliseconds. */
+  leaseMs: number;
 }
 
 export class ReconciliationSnapshotCoordinator<TInventory, TScope> {
-  private tail: { settled: Promise<void>; leaseExpired: Promise<void> } = {
-    settled: Promise.resolve(),
-    leaseExpired: Promise.resolve(),
-  };
+  private tail: Promise<void> = Promise.resolve();
 
   constructor(private readonly deps: ReconciliationSnapshotCoordinatorDeps<TInventory, TScope>) {}
 
   async acquire(): Promise<{ inventory: TInventory; scope: TScope }> {
     const predecessor = this.tail;
-    let markStarted!: () => void;
-    const started = new Promise<void>((resolve) => { markStarted = resolve; });
-    const acquisition = (async () => {
-      await Promise.race([predecessor.settled, predecessor.leaseExpired]);
-      markStarted();
+    let release!: () => void;
+    this.tail = new Promise<void>((resolve) => { release = resolve; });
+    await predecessor;
+    const lease = setTimeout(release, Math.max(0, this.deps.leaseMs));
+    try {
       const scope = this.deps.beginScope();
       const inventory = await this.deps.readInventory();
       return { inventory, scope };
-    })();
-    const settled = acquisition.then(() => undefined, () => undefined);
-    const leaseExpired = started.then(() => new Promise<void>((resolve) => {
-      const lease = setTimeout(resolve, Math.max(0, this.deps.leaseMs()));
-      void settled.finally(() => {
-        clearTimeout(lease);
-        resolve();
-      });
-    }));
-    this.tail = { settled, leaseExpired };
-    return acquisition;
+    } finally {
+      clearTimeout(lease);
+      release();
+    }
   }
 }

--- a/packages/publisher/src/reconciliation-snapshot-coordinator.ts
+++ b/packages/publisher/src/reconciliation-snapshot-coordinator.ts
@@ -1,0 +1,61 @@
+/**
+ * The ONE owner of reconciliation snapshot-acquisition ordering, extracted from the publisher
+ * (PR #2380 r13 3884734172) so the protocol's sequencing is a property of this module's only
+ * code path rather than caller discipline spread across an orchestration class.
+ *
+ * MODEL — acquisitions form a FIFO queue. The head acquisition (the "owner") executes: it
+ * draws the ordering SCOPE first — structurally before the inventory read, so a snapshot's
+ * rank can never be assigned by read-completion order (PR #2380 r11 🔴 3884193885: a hung
+ * read completing late must not outrank what a successor installed from newer state; the
+ * sweep acts on absence, where no identity guard applies). A successor waits for its
+ * predecessor to SETTLE or for the predecessor's LEASE — measured from the moment the
+ * predecessor STARTED executing, never from the waiter's own entry — to expire, whichever
+ * comes first (r12 🔴 3884393225: entry-relative timers release a queued burst together and
+ * re-open overlapping reads; owner leases promote exactly the head waiter, and every later
+ * waiter stays behind the new owner's fresh lease). Serialization therefore degrades to
+ * overlap only past a lease — availability over exactness for a hung read (r10 🔴
+ * 3883959795) — and a bypassed owner completes still holding its pre-drawn older scope:
+ * refusable by rank, never destructive. A failed acquisition never poisons the queue — the
+ * tail carries settlement only (r7 🟡 3883690945).
+ */
+
+export interface ReconciliationSnapshotCoordinatorDeps<TInventory, TScope> {
+  /** One fresh inventory read. Runs while this acquisition owns the seam (or past a lease). */
+  readInventory(): Promise<TInventory>;
+  /** Draw this acquisition's ordering scope; invoked before its read, in promotion order. */
+  beginScope(): TScope;
+  /** The owner lease in milliseconds; read per acquisition so configuration stays live. */
+  leaseMs(): number;
+}
+
+export class ReconciliationSnapshotCoordinator<TInventory, TScope> {
+  private tail: { settled: Promise<void>; leaseExpired: Promise<void> } = {
+    settled: Promise.resolve(),
+    leaseExpired: Promise.resolve(),
+  };
+
+  constructor(private readonly deps: ReconciliationSnapshotCoordinatorDeps<TInventory, TScope>) {}
+
+  async acquire(): Promise<{ inventory: TInventory; scope: TScope }> {
+    const predecessor = this.tail;
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => { markStarted = resolve; });
+    const acquisition = (async () => {
+      await Promise.race([predecessor.settled, predecessor.leaseExpired]);
+      markStarted();
+      const scope = this.deps.beginScope();
+      const inventory = await this.deps.readInventory();
+      return { inventory, scope };
+    })();
+    const settled = acquisition.then(() => undefined, () => undefined);
+    const leaseExpired = started.then(() => new Promise<void>((resolve) => {
+      const lease = setTimeout(resolve, Math.max(0, this.deps.leaseMs()));
+      void settled.finally(() => {
+        clearTimeout(lease);
+        resolve();
+      });
+    }));
+    this.tail = { settled, leaseExpired };
+    return acquisition;
+  }
+}

--- a/packages/publisher/test/async-lift-chain-proof-cadence.test.ts
+++ b/packages/publisher/test/async-lift-chain-proof-cadence.test.ts
@@ -550,7 +550,7 @@ describe('GH#2270 chain-proof cadence', () => {
       const publisher = h.createPublisher({
         chainProofDispatchBatchSize: 1,
         rand: () => 0,
-        reconciliationAcquisitionWaitCapMs: 50,
+        reconciliationAcquisitionLeaseMs: 50,
         chainProofResolver: async () => ({ status: 'pending-mempool' }),
       });
       await h.failAfterRecordedTxHash(publisher, kaVmPublishRequest());
@@ -606,7 +606,7 @@ describe('GH#2270 chain-proof cadence', () => {
       const publisher = h.createPublisher({
         chainProofDispatchBatchSize: 1,
         rand: () => 0,
-        reconciliationAcquisitionWaitCapMs: 50,
+        reconciliationAcquisitionLeaseMs: 50,
         chainProofResolver: async () => {
           asks += 1;
           return { status: 'pending-mempool' };
@@ -723,7 +723,7 @@ describe('GH#2270 chain-proof cadence', () => {
       const publisher = h.createPublisher({
         chainProofDispatchBatchSize: 1,
         rand: () => 0,
-        reconciliationAcquisitionWaitCapMs: 50,
+        reconciliationAcquisitionLeaseMs: 50,
         chainProofResolver: async () => {
           asks += 1;
           return { status: 'pending-mempool' };

--- a/packages/publisher/test/reconciliation-snapshot-coordinator.test.ts
+++ b/packages/publisher/test/reconciliation-snapshot-coordinator.test.ts
@@ -26,7 +26,7 @@ function scripted(reads: Array<() => Promise<string>>, leaseMs = 50): Scripted {
       events.push(`scope${scopeCounter}`);
       return scopeCounter;
     },
-    leaseMs: () => leaseMs,
+    leaseMs,
   });
   return { events, coordinator };
 }
@@ -58,6 +58,23 @@ describe('ReconciliationSnapshotCoordinator', () => {
     release('a');
     await first;
     await second;
+    expect(events).toEqual(['scope1', 'read1:enter', 'read1:exit', 'scope2', 'read2:enter', 'read2:exit']);
+  });
+
+  it("settlement releases the successor IMMEDIATELY — the lease is a bound, not the successor's schedule", async () => {
+    // PR #2381 r1 (🟡 3884946389) — the single release gate resolves from the owner's finally,
+    // not only from the lease timer. The lease here is far beyond the test timeout, so a
+    // regression that leaves release() to the timer alone hangs this row instead of passing
+    // slowly.
+    let release!: (value: string) => void;
+    const gated = new Promise<string>((resolve) => { release = resolve; });
+    const { events, coordinator } = scripted([() => gated, immediate('b')], 300_000);
+    const first = coordinator.acquire();
+    const second = coordinator.acquire();
+    await Promise.resolve();
+    release('a');
+    await first;
+    await second; // must complete with NO lease elapsing at all
     expect(events).toEqual(['scope1', 'read1:enter', 'read1:exit', 'scope2', 'read2:enter', 'read2:exit']);
   });
 

--- a/packages/publisher/test/reconciliation-snapshot-coordinator.test.ts
+++ b/packages/publisher/test/reconciliation-snapshot-coordinator.test.ts
@@ -1,0 +1,100 @@
+/**
+ * The coordinator's ordering protocol tested directly, with a scripted inventory read — fast
+ * unit twins of the publisher-path rows in async-lift-chain-proof-cadence.test.ts, which keep
+ * proving the wiring through the real `recover()`.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ReconciliationSnapshotCoordinator } from '../src/reconciliation-snapshot-coordinator.js';
+
+type Scripted = { events: string[]; coordinator: ReconciliationSnapshotCoordinator<string, number> };
+
+function scripted(reads: Array<() => Promise<string>>, leaseMs = 50): Scripted {
+  const events: string[] = [];
+  let scopeCounter = 0;
+  let call = 0;
+  const coordinator = new ReconciliationSnapshotCoordinator<string, number>({
+    readInventory: async () => {
+      call += 1;
+      const mine = call;
+      events.push(`read${mine}:enter`);
+      const result = await reads[mine - 1]();
+      events.push(`read${mine}:exit`);
+      return result;
+    },
+    beginScope: () => {
+      scopeCounter += 1;
+      events.push(`scope${scopeCounter}`);
+      return scopeCounter;
+    },
+    leaseMs: () => leaseMs,
+  });
+  return { events, coordinator };
+}
+
+const immediate = (value: string) => () => Promise.resolve(value);
+const never = () => () => new Promise<string>(() => undefined);
+
+describe('ReconciliationSnapshotCoordinator', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('draws the scope BEFORE the read, in promotion order', async () => {
+    const { events, coordinator } = scripted([immediate('a'), immediate('b')]);
+    const first = await coordinator.acquire();
+    const second = await coordinator.acquire();
+    expect(first).toEqual({ inventory: 'a', scope: 1 });
+    expect(second).toEqual({ inventory: 'b', scope: 2 });
+    expect(events).toEqual(['scope1', 'read1:enter', 'read1:exit', 'scope2', 'read2:enter', 'read2:exit']);
+  });
+
+  it('serializes concurrent acquisitions — the second read starts after the first settles', async () => {
+    let release!: (value: string) => void;
+    const gated = new Promise<string>((resolve) => { release = resolve; });
+    const { events, coordinator } = scripted([() => gated, immediate('b')]);
+    const first = coordinator.acquire();
+    const second = coordinator.acquire();
+    await Promise.resolve();
+    release('a');
+    await first;
+    await second;
+    expect(events).toEqual(['scope1', 'read1:enter', 'read1:exit', 'scope2', 'read2:enter', 'read2:exit']);
+  });
+
+  it('a failed read does not poison the queue — the next acquisition reads fresh', async () => {
+    const { coordinator } = scripted([
+      () => Promise.reject(new Error('transient store failure')),
+      immediate('b'),
+    ]);
+    await expect(coordinator.acquire()).rejects.toThrow('transient store failure');
+    await expect(coordinator.acquire()).resolves.toEqual({ inventory: 'b', scope: 2 });
+  });
+
+  it("the lease clock runs from the owner's START, not the waiter's entry — head-only promotion", async () => {
+    // The unit twin of the publisher-path burst row: A hangs, B and C queue together. C must
+    // still be fenced at t=99 (its entry-relative clock is long past one lease) and is
+    // promoted only at t=100, when B — promoted at t=50 — has held its own full lease. The
+    // bypassed owners keep their earlier scopes (drawn in promotion order).
+    vi.useFakeTimers();
+    let releaseB!: (value: string) => void;
+    const gatedB = new Promise<string>((resolve) => { releaseB = resolve; });
+    const { events, coordinator } = scripted([never(), () => gatedB, immediate('c')]);
+    const passA = coordinator.acquire();
+    void passA;
+    const passB = coordinator.acquire();
+    const passC = coordinator.acquire();
+    await vi.advanceTimersByTimeAsync(49);
+    expect(events).toEqual(['scope1', 'read1:enter']); // A owns; B and C fenced
+    await vi.advanceTimersByTimeAsync(1); // t=50: A's lease expires — B alone promoted
+    expect(events).toEqual(['scope1', 'read1:enter', 'scope2', 'read2:enter']);
+    await vi.advanceTimersByTimeAsync(49); // t=99: C's entry clock long past 50, still fenced
+    expect(events).toEqual(['scope1', 'read1:enter', 'scope2', 'read2:enter']);
+    await vi.advanceTimersByTimeAsync(1); // t=100: B held its full lease — C promoted
+    await passC;
+    expect(events).toEqual(['scope1', 'read1:enter', 'scope2', 'read2:enter', 'scope3', 'read3:enter', 'read3:exit']);
+    releaseB('b');
+    await passB;
+    expect((await passC).scope).toBe(3);
+    expect((await passB).scope).toBe(2); // the bypassed owner kept its older rank
+  });
+});


### PR DESCRIPTION
## Summary

- Extracts the reconciliation snapshot-acquisition ordering protocol out of `TripleStoreAsyncLiftPublisher` into a focused `ReconciliationSnapshotCoordinator` (new module, generic over inventory and scope, no publisher imports). The FIFO acquisition tail, the owner lease, and ordering-scope issuance — the invariants hardened across PR #2380 rounds 6–12 — are now properties of one ~60-line code path instead of caller discipline inside a 3,800-line class. The publisher wires three collaborators and calls `acquire()`.
- Renames `reconciliationAcquisitionWaitCapMs` → `reconciliationAcquisitionLeaseMs`. The r12 semantics are an owner lease (measured from the owner's execution start; a queued burst waits up to one lease per predecessor), which the old per-waiter "wait cap" name contradicted. No compatibility alias: the option merged hours ago and was never released.
- Corrects the public `recover()`/`reconcileTransactions()` concurrency contract, which claimed calls are "neither queued behind" an in-flight pass while acquisition is deliberately FIFO-ordered. The doc now states: passes are never coalesced and each call reads its own fresh inventory, but acquisition is ordered with per-owner lease-bounded latency.
- One deliberate boundary against the full review suggestion: snapshot admission (`observeSnapshot`) stays in the dispatcher, because it runs against the mid-pass refreshed inventory (`dispatcherInventory`), which does not exist at acquisition time; the single-use pass guard from #2380 r11 covers the handle in transit.

## Related

- Follow-up to #2380 (merged as e6a2fa315) — closes its three post-merge review comments: 3884734172 (coordinator extraction), 3884734271 (contract contradiction), 3884734274 (lease vocabulary).
- Part of the GH#2270 10.0.14 observation-layer robustness line (#2373 → #2380 → this).

## Diagrams

### Reconciliation snapshot acquisition

Before:

```mermaid
sequenceDiagram
    participant Caller
    participant Publisher
    participant Schedule
    participant Store
    Caller->>Publisher: recover
    Publisher->>Publisher: wait on own acquisition tail, per-owner lease
    Publisher->>Schedule: beginPass ordering token
    Publisher->>Store: list inventory
    Store-->>Publisher: inventory
    Publisher->>Publisher: dispatch lanes with the pass handle
```

After:

```mermaid
sequenceDiagram
    participant Caller
    participant Publisher
    participant Coordinator
    participant Schedule
    participant Store
    Caller->>Publisher: recover
    Publisher->>Coordinator: acquire
    Coordinator->>Coordinator: FIFO wait, bounded by owner lease
    Coordinator->>Schedule: beginPass ordering token
    Coordinator->>Store: read inventory
    Store-->>Coordinator: inventory
    Coordinator-->>Publisher: inventory plus ordering scope
    Publisher->>Publisher: dispatch lanes with the pass handle
```

The protocol's behavior is identical; what changes is ownership — token-before-read and lease-from-owner-start are now unbreakable by publisher edits.

## Files changed

| File | What |
|------|------|
| `packages/publisher/src/reconciliation-snapshot-coordinator.ts` | New module owning the acquisition protocol: FIFO tail, owner lease, scope-before-read |
| `packages/publisher/src/async-lift-publisher-impl.ts` | Tail/lease fields and `takeReconciliationSnapshot` removed; coordinator wired; one `acquire()` call |
| `packages/publisher/src/async-lift-publisher-types.ts` | Config renamed to `reconciliationAcquisitionLeaseMs` with lease vocabulary; truthful concurrency contract |
| `packages/publisher/test/reconciliation-snapshot-coordinator.test.ts` | New unit rows: scope-before-read, serialization, poison-safety, lease-from-owner-start boundaries, bypassed-owner rank retention |
| `packages/publisher/test/async-lift-chain-proof-cadence.test.ts` | Option rename only — every #2380 integration row (linearization, hung-cap, burst lease, late-ranked-old, poison chain) is retained UNCHANGED as the behavior-preservation proof |

## Test plan

- [x] `tsc --noEmit` clean on the publisher package
- [x] Coordinator unit lane + chain-proof schedule lane + cadence integration lane green
- [x] Full publisher package suite green
- [x] Mutants on the extracted module, each killed by a named row: ordering scope drawn after the read (completion-order regression), lease measured from waiter entry (burst-bypass regression), lease hard-coded ignoring config
- [x] All #2380 acquisition integration rows pass unchanged against the extracted implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
