### PR TITLE
perf(agent): remove graph sort allocations

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -88,6 +88,7 @@
   },
   "scripts": {
     "build": "tsc && pnpm run test:types && pnpm run test:package-root",
+    "benchmark:code-point-comparator": "pnpm run build && node --expose-gc scripts/code-point-comparator-benchmark.cjs",
     "benchmark:sync-responder-pages": "node --expose-gc scripts/sync-responder-page-benchmark.cjs",
     "benchmark:sync-worker": "node scripts/sync-worker-benchmark.cjs",
     "benchmark:sync-worker-responsiveness": "node scripts/sync-worker-responsiveness-benchmark.cjs",

--- a/packages/agent/scripts/code-point-comparator-benchmark.cjs
+++ b/packages/agent/scripts/code-point-comparator-benchmark.cjs
@@ -54,7 +54,7 @@ async function runWorker(mode, graphCount, rounds) {
   }
   const comparator = mode === 'old'
     ? allocatingComparator
-    : (await import('../dist/sync/responder/graph-plan.js')).compareCodePoint;
+    : (await import('../dist/sync/code-point-order.js')).compareCodePoint;
   const names = makeGraphNames(graphCount);
   names.slice(0, Math.min(2_000, names.length)).sort(comparator);
   global.gc();

--- a/packages/agent/scripts/code-point-comparator-benchmark.cjs
+++ b/packages/agent/scripts/code-point-comparator-benchmark.cjs
@@ -59,7 +59,6 @@ async function runWorker(mode, graphCount, rounds) {
   names.slice(0, Math.min(2_000, names.length)).sort(comparator);
   global.gc();
 
-  const baseline = process.memoryUsage();
   let comparisons = 0;
   let finalOrder = [];
   const countedComparator = (left, right) => {
@@ -71,7 +70,6 @@ async function runWorker(mode, graphCount, rounds) {
     finalOrder = [...names].sort(countedComparator);
   }
   const durationMs = performance.now() - startedAt;
-  const usage = process.memoryUsage();
   return {
     mode,
     graphCount,
@@ -79,7 +77,6 @@ async function runWorker(mode, graphCount, rounds) {
     durationMs,
     comparisons,
     temporaryCodePointArrays: mode === 'old' ? comparisons * 2 : 0,
-    heapUsedDeltaBytes: Math.max(0, usage.heapUsed - baseline.heapUsed),
     fingerprint: fingerprint(finalOrder),
   };
 }
@@ -106,7 +103,6 @@ function runIsolatedTrial(mode, graphCount, rounds) {
 function summarize(trials) {
   return {
     durationMs: median(trials.map((trial) => trial.durationMs)),
-    heapUsedDeltaBytes: median(trials.map((trial) => trial.heapUsedDeltaBytes)),
     comparisons: trials[0].comparisons,
     temporaryCodePointArrays: trials[0].temporaryCodePointArrays,
     fingerprint: trials[0].fingerprint,
@@ -115,10 +111,6 @@ function summarize(trials) {
 
 function formatInteger(value) {
   return new Intl.NumberFormat('en-US').format(Math.round(value));
-}
-
-function formatBytes(bytes) {
-  return `${(bytes / (1024 * 1024)).toFixed(2)} MiB`;
 }
 
 function runController() {
@@ -158,15 +150,14 @@ function runController() {
   console.log('Graph-plan code-point comparator benchmark');
   console.log(`Node ${process.version}; ${rounds} sort round(s); ${trialsPerMode} isolated trial(s) per mode`);
   console.log('');
-  console.log('| Graphs | Comparisons | Old median | New median | Speedup | Old temporary arrays | New temporary arrays | Old heap delta | New heap delta |');
-  console.log('| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |');
+  console.log('| Graphs | Comparisons | Old median | New median | Speedup | Old temporary arrays | New temporary arrays |');
+  console.log('| ---: | ---: | ---: | ---: | ---: | ---: | ---: |');
   for (const result of results) {
     console.log(
       `| ${formatInteger(result.graphCount)} | ${formatInteger(result.old.comparisons)} | ` +
       `${result.old.durationMs.toFixed(2)} ms | ${result.new.durationMs.toFixed(2)} ms | ` +
       `${result.speedup.toFixed(1)}x | ${formatInteger(result.old.temporaryCodePointArrays)} | ` +
-      `${formatInteger(result.new.temporaryCodePointArrays)} | ${formatBytes(result.old.heapUsedDeltaBytes)} | ` +
-      `${formatBytes(result.new.heapUsedDeltaBytes)} |`,
+      `${formatInteger(result.new.temporaryCodePointArrays)} |`,
     );
   }
   console.log('');

--- a/packages/agent/scripts/code-point-comparator-benchmark.cjs
+++ b/packages/agent/scripts/code-point-comparator-benchmark.cjs
@@ -1,0 +1,196 @@
+const { spawnSync } = require('node:child_process');
+const { performance } = require('node:perf_hooks');
+
+const DEFAULT_SIZES = [10_000, 50_000];
+const DEFAULT_ROUNDS = 3;
+const DEFAULT_TRIALS = 3;
+
+function parsePositiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function allocatingComparator(a, b) {
+  const left = Array.from(a);
+  const right = Array.from(b);
+  const length = Math.min(left.length, right.length);
+  for (let index = 0; index < length; index += 1) {
+    const delta = left[index].codePointAt(0) - right[index].codePointAt(0);
+    if (delta !== 0) return delta;
+  }
+  return left.length - right.length;
+}
+
+function makeGraphNames(count) {
+  const names = Array.from({ length: count }, (_, index) => {
+    const bucket = Math.floor(index / 500).toString().padStart(5, '0');
+    const ordinal = index.toString().padStart(8, '0');
+    const unicodeTail = index % 17 === 0 ? `/${String.fromCodePoint(0x1F600 + (index % 64))}` : '';
+    return `did:dkg:context-graph:benchmark/data/${bucket}/assertion/${ordinal}${unicodeTail}`;
+  });
+  let state = 0x6D2B79F5;
+  for (let index = names.length - 1; index > 0; index -= 1) {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    const target = state % (index + 1);
+    [names[index], names[target]] = [names[target], names[index]];
+  }
+  return names;
+}
+
+function fingerprint(values) {
+  let hash = 2166136261;
+  for (const value of values) {
+    for (let index = 0; index < value.length; index += 1) {
+      hash ^= value.charCodeAt(index);
+      hash = Math.imul(hash, 16777619);
+    }
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+async function runWorker(mode, graphCount, rounds) {
+  if (typeof global.gc !== 'function') {
+    throw new Error('Run with --expose-gc so trials start from a comparable heap baseline');
+  }
+  const comparator = mode === 'old'
+    ? allocatingComparator
+    : (await import('../dist/sync/responder/graph-plan.js')).compareCodePoint;
+  const names = makeGraphNames(graphCount);
+  names.slice(0, Math.min(2_000, names.length)).sort(comparator);
+  global.gc();
+
+  const baseline = process.memoryUsage();
+  let comparisons = 0;
+  let finalOrder = [];
+  const countedComparator = (left, right) => {
+    comparisons += 1;
+    return comparator(left, right);
+  };
+  const startedAt = performance.now();
+  for (let round = 0; round < rounds; round += 1) {
+    finalOrder = [...names].sort(countedComparator);
+  }
+  const durationMs = performance.now() - startedAt;
+  const usage = process.memoryUsage();
+  return {
+    mode,
+    graphCount,
+    rounds,
+    durationMs,
+    comparisons,
+    temporaryCodePointArrays: mode === 'old' ? comparisons * 2 : 0,
+    heapUsedDeltaBytes: Math.max(0, usage.heapUsed - baseline.heapUsed),
+    fingerprint: fingerprint(finalOrder),
+  };
+}
+
+function median(values) {
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+function runIsolatedTrial(mode, graphCount, rounds) {
+  const child = spawnSync(
+    process.execPath,
+    ['--expose-gc', '--max-old-space-size=512', __filename, '--worker', mode, String(graphCount), String(rounds)],
+    { encoding: 'utf8', maxBuffer: 1024 * 1024 },
+  );
+  if (child.status !== 0) {
+    throw new Error(
+      `benchmark worker failed for mode=${mode} graphs=${graphCount}\n${child.stderr || child.stdout}`,
+    );
+  }
+  return JSON.parse(child.stdout);
+}
+
+function summarize(trials) {
+  return {
+    durationMs: median(trials.map((trial) => trial.durationMs)),
+    heapUsedDeltaBytes: median(trials.map((trial) => trial.heapUsedDeltaBytes)),
+    comparisons: trials[0].comparisons,
+    temporaryCodePointArrays: trials[0].temporaryCodePointArrays,
+    fingerprint: trials[0].fingerprint,
+  };
+}
+
+function formatInteger(value) {
+  return new Intl.NumberFormat('en-US').format(Math.round(value));
+}
+
+function formatBytes(bytes) {
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MiB`;
+}
+
+function runController() {
+  const sizesArg = process.argv.find((argument) => argument.startsWith('--sizes='));
+  const roundsArg = process.argv.find((argument) => argument.startsWith('--rounds='));
+  const trialsArg = process.argv.find((argument) => argument.startsWith('--trials='));
+  const sizes = sizesArg
+    ? sizesArg.slice('--sizes='.length).split(',').map((value) => parsePositiveInteger(value, 0)).filter(Boolean)
+    : DEFAULT_SIZES;
+  const rounds = parsePositiveInteger(roundsArg?.slice('--rounds='.length), DEFAULT_ROUNDS);
+  const trialsPerMode = parsePositiveInteger(trialsArg?.slice('--trials='.length), DEFAULT_TRIALS);
+  const results = [];
+
+  for (const graphCount of sizes) {
+    const oldTrials = [];
+    const newTrials = [];
+    for (let trial = 0; trial < trialsPerMode; trial += 1) {
+      const modes = trial % 2 === 0 ? ['old', 'new'] : ['new', 'old'];
+      for (const mode of modes) {
+        const result = runIsolatedTrial(mode, graphCount, rounds);
+        (mode === 'old' ? oldTrials : newTrials).push(result);
+      }
+    }
+    const oldSummary = summarize(oldTrials);
+    const newSummary = summarize(newTrials);
+    if (oldSummary.fingerprint !== newSummary.fingerprint) {
+      throw new Error(`old/new ordering mismatch for ${graphCount} graphs`);
+    }
+    results.push({
+      graphCount,
+      old: oldSummary,
+      new: newSummary,
+      speedup: oldSummary.durationMs / newSummary.durationMs,
+    });
+  }
+
+  console.log('Graph-plan code-point comparator benchmark');
+  console.log(`Node ${process.version}; ${rounds} sort round(s); ${trialsPerMode} isolated trial(s) per mode`);
+  console.log('');
+  console.log('| Graphs | Comparisons | Old median | New median | Speedup | Old temporary arrays | New temporary arrays | Old heap delta | New heap delta |');
+  console.log('| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |');
+  for (const result of results) {
+    console.log(
+      `| ${formatInteger(result.graphCount)} | ${formatInteger(result.old.comparisons)} | ` +
+      `${result.old.durationMs.toFixed(2)} ms | ${result.new.durationMs.toFixed(2)} ms | ` +
+      `${result.speedup.toFixed(1)}x | ${formatInteger(result.old.temporaryCodePointArrays)} | ` +
+      `${formatInteger(result.new.temporaryCodePointArrays)} | ${formatBytes(result.old.heapUsedDeltaBytes)} | ` +
+      `${formatBytes(result.new.heapUsedDeltaBytes)} |`,
+    );
+  }
+  console.log('');
+  console.log('Machine-readable results:');
+  console.log(JSON.stringify({ node: process.version, rounds, trialsPerMode, results }, null, 2));
+}
+
+if (process.argv[2] === '--worker') {
+  runWorker(
+    process.argv[3],
+    parsePositiveInteger(process.argv[4], 0),
+    parsePositiveInteger(process.argv[5], DEFAULT_ROUNDS),
+  ).then(
+    (result) => process.stdout.write(JSON.stringify(result)),
+    (error) => {
+      console.error(error);
+      process.exitCode = 1;
+    },
+  );
+} else {
+  try {
+    runController();
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  }
+}

--- a/packages/agent/src/sync/code-point-order.ts
+++ b/packages/agent/src/sync/code-point-order.ts
@@ -1,0 +1,24 @@
+/**
+ * Compare strings lexicographically by Unicode code point.
+ *
+ * The return value follows the conventional comparator contract: negative,
+ * zero, or positive. It deliberately does not expose a distance between
+ * prefix lengths, which keeps an exhausted-prefix decision constant-time.
+ */
+export function compareCodePoint(leftValue: string, rightValue: string): number {
+  let leftIndex = 0;
+  let rightIndex = 0;
+  while (leftIndex < leftValue.length && rightIndex < rightValue.length) {
+    const leftCodePoint = leftValue.codePointAt(leftIndex)!;
+    const rightCodePoint = rightValue.codePointAt(rightIndex)!;
+    const delta = leftCodePoint - rightCodePoint;
+    if (delta !== 0) return delta;
+
+    leftIndex += leftCodePoint > 0xFFFF ? 2 : 1;
+    rightIndex += rightCodePoint > 0xFFFF ? 2 : 1;
+  }
+
+  if (leftIndex < leftValue.length) return 1;
+  if (rightIndex < rightValue.length) return -1;
+  return 0;
+}

--- a/packages/agent/src/sync/durable-integrity.ts
+++ b/packages/agent/src/sync/durable-integrity.ts
@@ -14,6 +14,7 @@ import {
 } from '@origintrail-official/dkg-publisher';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import { appendInPlace } from './append-in-place.js';
+import { compareCodePoint } from './code-point-order.js';
 import { isIriMetaSubject } from './iri-term.js';
 
 const DKG_NS = 'http://dkg.io/ontology/';
@@ -150,17 +151,6 @@ export interface BoundedGraphScopedDurableBatch {
   manifestRowCount: number;
 }
 
-function compareUnicodeCodePoints(leftValue: string, rightValue: string): number {
-  const left = Array.from(leftValue);
-  const right = Array.from(rightValue);
-  const length = Math.min(left.length, right.length);
-  for (let index = 0; index < length; index++) {
-    const delta = left[index]!.codePointAt(0)! - right[index]!.codePointAt(0)!;
-    if (delta !== 0) return delta;
-  }
-  return left.length - right.length;
-}
-
 function digestGraphScopedMetadataRows(rows: readonly Quad[]): string {
   const hash = createHash('sha256');
   const encoder = new TextEncoder();
@@ -172,10 +162,10 @@ function digestGraphScopedMetadataRows(rows: readonly Quad[]): string {
     hash.update(bytes);
   };
   const canonical = [...rows].sort((left, right) => (
-    compareUnicodeCodePoints(left.subject, right.subject)
-    || compareUnicodeCodePoints(left.predicate, right.predicate)
-    || compareUnicodeCodePoints(left.object, right.object)
-    || compareUnicodeCodePoints(left.graph, right.graph)
+    compareCodePoint(left.subject, right.subject)
+    || compareCodePoint(left.predicate, right.predicate)
+    || compareCodePoint(left.object, right.object)
+    || compareCodePoint(left.graph, right.graph)
   ));
   append('origintrail.dkg.durable-graph-metadata');
   append('1');
@@ -208,7 +198,7 @@ function readOrderedGraphScopedDescriptors(
 
   const descriptors = (parsed.candidates as GraphScopedCandidate[])
     .map((candidate) => candidate.descriptor)
-    .sort((left, right) => compareUnicodeCodePoints(left.assertionGraph, right.assertionGraph));
+    .sort((left, right) => compareCodePoint(left.assertionGraph, right.assertionGraph));
   const descriptorByGraph = new Map(
     descriptors.map((descriptor) => [descriptor.assertionGraph, descriptor] as const),
   );

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -38,6 +38,7 @@ import { durableMetaDelegationSubjectAdmissionExpression } from './durable-meta-
 import { exactAssetFilterKey } from '../exact-assets.js';
 import { isIriTerm } from '../iri-term.js';
 import type { ExactGraphReadMode } from './durable-data-request-policy.js';
+import { compareCodePoint } from '../code-point-order.js';
 
 export {
   createResponderSyncRowListMemo,
@@ -45,6 +46,7 @@ export {
   type SyncRow,
   type SyncRowListMemo,
 } from './snapshot-cache.js';
+export { compareCodePoint } from '../code-point-order.js';
 
 const DKG = 'http://dkg.io/ontology/';
 const DKG_SUB_GRAPH = `${DKG}SubGraph`;
@@ -561,38 +563,6 @@ function createSubGraphNameMemo(
       return [...names];
     },
   };
-}
-
-export function compareCodePoint(a: string, b: string): number {
-  let leftIndex = 0;
-  let rightIndex = 0;
-  while (leftIndex < a.length && rightIndex < b.length) {
-    const leftCodePoint = a.codePointAt(leftIndex)!;
-    const rightCodePoint = b.codePointAt(rightIndex)!;
-    const delta = leftCodePoint - rightCodePoint;
-    if (delta !== 0) return delta;
-
-    leftIndex += leftCodePoint > 0xFFFF ? 2 : 1;
-    rightIndex += rightCodePoint > 0xFFFF ? 2 : 1;
-  }
-
-  // Preserve the previous comparator's exact numeric result for prefix pairs:
-  // Array.from(a).length - Array.from(b).length. Usually only the sign matters
-  // to Array#sort, but callers and cursors should not observe an avoidable
-  // contract change. Counting only the unmatched suffix keeps the hot equal
-  // prefix path allocation-free.
-  let remainingCodePointDelta = 0;
-  while (leftIndex < a.length) {
-    const codePoint = a.codePointAt(leftIndex)!;
-    leftIndex += codePoint > 0xFFFF ? 2 : 1;
-    remainingCodePointDelta += 1;
-  }
-  while (rightIndex < b.length) {
-    const codePoint = b.codePointAt(rightIndex)!;
-    rightIndex += codePoint > 0xFFFF ? 2 : 1;
-    remainingCodePointDelta -= 1;
-  }
-  return remainingCodePointDelta;
 }
 
 export function compareRows(a: SyncRow, b: SyncRow): number {

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -564,14 +564,35 @@ function createSubGraphNameMemo(
 }
 
 export function compareCodePoint(a: string, b: string): number {
-  const left = Array.from(a);
-  const right = Array.from(b);
-  const len = Math.min(left.length, right.length);
-  for (let i = 0; i < len; i++) {
-    const delta = left[i].codePointAt(0)! - right[i].codePointAt(0)!;
+  let leftIndex = 0;
+  let rightIndex = 0;
+  while (leftIndex < a.length && rightIndex < b.length) {
+    const leftCodePoint = a.codePointAt(leftIndex)!;
+    const rightCodePoint = b.codePointAt(rightIndex)!;
+    const delta = leftCodePoint - rightCodePoint;
     if (delta !== 0) return delta;
+
+    leftIndex += leftCodePoint > 0xFFFF ? 2 : 1;
+    rightIndex += rightCodePoint > 0xFFFF ? 2 : 1;
   }
-  return left.length - right.length;
+
+  // Preserve the previous comparator's exact numeric result for prefix pairs:
+  // Array.from(a).length - Array.from(b).length. Usually only the sign matters
+  // to Array#sort, but callers and cursors should not observe an avoidable
+  // contract change. Counting only the unmatched suffix keeps the hot equal
+  // prefix path allocation-free.
+  let remainingCodePointDelta = 0;
+  while (leftIndex < a.length) {
+    const codePoint = a.codePointAt(leftIndex)!;
+    leftIndex += codePoint > 0xFFFF ? 2 : 1;
+    remainingCodePointDelta += 1;
+  }
+  while (rightIndex < b.length) {
+    const codePoint = b.codePointAt(rightIndex)!;
+    rightIndex += codePoint > 0xFFFF ? 2 : 1;
+    remainingCodePointDelta -= 1;
+  }
+  return remainingCodePointDelta;
 }
 
 export function compareRows(a: SyncRow, b: SyncRow): number {

--- a/packages/agent/test/graph-plan-codepoint-order.test.ts
+++ b/packages/agent/test/graph-plan-codepoint-order.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { compareCodePoint } from '../src/sync/responder/graph-plan.js';
+
+function allocatingReference(a: string, b: string): number {
+  const left = Array.from(a);
+  const right = Array.from(b);
+  const length = Math.min(left.length, right.length);
+  for (let index = 0; index < length; index += 1) {
+    const delta = left[index].codePointAt(0)! - right[index].codePointAt(0)!;
+    if (delta !== 0) return delta;
+  }
+  return left.length - right.length;
+}
+
+function buildCorpus(): string[] {
+  const atoms = [
+    '',
+    '\0',
+    'a',
+    'z',
+    '\u007F',
+    '\u0080',
+    '\u07FF',
+    '\u0800',
+    '\uD7FF',
+    '\uD800',
+    '\uDBFF',
+    '\uDC00',
+    '\uDFFF',
+    '\uE000',
+    '\uFFFF',
+    String.fromCodePoint(0x10000),
+    String.fromCodePoint(0x1F600),
+    String.fromCodePoint(0x10FFFF),
+  ];
+  const corpus = new Set<string>([
+    ...atoms,
+    'did:dkg:context-graph:profile/data',
+    'did:dkg:context-graph:profile/data/assertion/000001',
+    'did:dkg:context-graph:profile/data/assertion/000002',
+    'did:dkg:context-graph:profile/swm/_meta',
+  ]);
+  for (const left of atoms) {
+    corpus.add(`urn:dkg:graph:${left}`);
+    for (const right of atoms) corpus.add(`${left}${right}`);
+  }
+  return [...corpus];
+}
+
+describe('graph-plan code-point ordering', () => {
+  it('matches the allocating comparator exactly across Unicode boundaries', () => {
+    const corpus = buildCorpus();
+    let comparisons = 0;
+    for (const left of corpus) {
+      for (const right of corpus) {
+        const expected = allocatingReference(left, right);
+        const actual = compareCodePoint(left, right);
+        if (actual !== expected) {
+          throw new Error(
+            `comparison mismatch for ${JSON.stringify(left)} and ${JSON.stringify(right)}: ` +
+            `expected ${expected}, received ${actual}`,
+          );
+        }
+        comparisons += 1;
+      }
+    }
+    expect(comparisons).toBeGreaterThan(100_000);
+  });
+
+  it('produces the same deterministic graph order as the allocating comparator', () => {
+    const corpus = buildCorpus().reverse();
+    expect([...corpus].sort(compareCodePoint)).toEqual([...corpus].sort(allocatingReference));
+  });
+});

--- a/packages/agent/test/graph-plan-codepoint-order.test.ts
+++ b/packages/agent/test/graph-plan-codepoint-order.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { compareCodePoint } from '../src/sync/responder/graph-plan.js';
+import { compareCodePoint } from '../src/sync/code-point-order.js';
 
 function allocatingReference(a: string, b: string): number {
   const left = Array.from(a);
@@ -48,14 +48,14 @@ function buildCorpus(): string[] {
 }
 
 describe('graph-plan code-point ordering', () => {
-  it('matches the allocating comparator exactly across Unicode boundaries', () => {
+  it('matches the allocating comparator direction across Unicode boundaries', () => {
     const corpus = buildCorpus();
     let comparisons = 0;
     for (const left of corpus) {
       for (const right of corpus) {
         const expected = allocatingReference(left, right);
         const actual = compareCodePoint(left, right);
-        if (actual !== expected) {
+        if (Math.sign(actual) !== Math.sign(expected)) {
           throw new Error(
             `comparison mismatch for ${JSON.stringify(left)} and ${JSON.stringify(right)}: ` +
             `expected ${expected}, received ${actual}`,
@@ -65,6 +65,12 @@ describe('graph-plan code-point ordering', () => {
       }
     }
     expect(comparisons).toBeGreaterThan(100_000);
+  });
+
+  it('returns normalized results for exhausted prefixes', () => {
+    const longSuffix = 'x'.repeat(1_000_000);
+    expect(compareCodePoint('a', `a${longSuffix}`)).toBe(-1);
+    expect(compareCodePoint(`a${longSuffix}`, 'a')).toBe(1);
   });
 
   it('produces the same deterministic graph order as the allocating comparator', () => {


### PR DESCRIPTION
## Summary

- replace allocating Unicode comparators with one canonical allocation-free sync ordering primitive
- use the shared comparator in responder graph planning and durable/requester integrity ordering
- make exhausted-prefix comparisons constant-time while preserving negative/zero/positive ordering
- add exhaustive Unicode equivalence coverage and a reproducible isolated benchmark

## Why

The latest 500/500 profile identified `compareCodePoint` as the hottest DKG function: 137.9 seconds, or 11.84% of active receiver CPU. The previous implementation allocated two code-point arrays on every sort comparison. The durable integrity path contained the same allocating algorithm and now shares the optimized primitive.

## Benchmark

Node v24.19.0, 3 sort rounds, median of 3 isolated trials per implementation:

| Graphs | Old | New | Speedup | Temporary arrays |
| ---: | ---: | ---: | ---: | ---: |
| 10,000 | 355.85 ms | 99.14 ms | 3.6x | 719,976 -> 0 |
| 50,000 | 2,276.77 ms | 655.95 ms | 3.5x | 4,287,804 -> 0 |

Old and new implementations produced identical sorted fingerprints at both sizes. Run with `pnpm --filter @origintrail-official/dkg-agent benchmark:code-point-comparator`.

## Validation

- exact ordering-direction equivalence across more than 100,000 Unicode cases, including lone surrogates
- constant-time exhausted-prefix contract covered with a million-character suffix
- 250 responder, graph-plan, durable integrity, and requester tests across 15 focused files
- agent dependency-closure build and package-root/type checks
- repository lint
- GitHub integration matrix in progress

This PR addresses the allocation-heavy comparator slice from the profile. Sorted graph membership/prefix-range caching remains a separate follow-up, and the end-to-end gain should be measured with another 500/500 profile after merge.