### PR TITLE
fix(daemon): a rejected chain-discovery scan no longer consumes its run slot (#2323)

### DIFF
--- a/packages/cli/src/daemon/chain-discovery-scan.ts
+++ b/packages/cli/src/daemon/chain-discovery-scan.ts
@@ -137,7 +137,18 @@ export interface ScanPlan {
  */
 export type ScanPlanStep =
   | { readonly kind: 'ready'; readonly plan: ScanPlan }
-  | { readonly kind: 'needsWatermark'; readonly complete: (watermarkSeeded: boolean) => ScanPlan };
+  | {
+      readonly kind: 'needsWatermark';
+      /**
+       * The scheduler state with this tick's accounting (overdue aging)
+       * already applied. A caller whose probe FAILS must commit this state —
+       * discarding it would let a persistently failing probe postpone the
+       * overdue resync forever, in exactly the store-outage scenario the
+       * resync exists to recover from.
+       */
+      readonly agedState: ScanSchedulerState;
+      readonly complete: (watermarkSeeded: boolean) => ScanPlan;
+    };
 
 /**
  * Pure: choose this tick's scan and account for overdue-cadence time.
@@ -176,6 +187,7 @@ export function planScan(
   const planned = state;
   return {
     kind: 'needsWatermark',
+    agedState: planned,
     complete: (watermarkSeeded: boolean): ScanPlan => ({
       scan: chainDiscoveryScanOptions({
         run: planned.run,
@@ -332,8 +344,11 @@ export function createChainDiscoveryScanRunner(input: {
         } catch (err) {
           // Scoped to the probe call alone, so nothing else — least of all a
           // throwing log line — can be misclassified as a probe failure. The
-          // tick planned nothing, so state (overdue aging included) is
-          // untouched: the debt ages only on ticks that actually plan.
+          // tick's ACCOUNTING is kept even though no scan ran: the overdue
+          // debt must keep aging under a failing probe, or four consecutive
+          // probe failures would postpone the probe-independent resync
+          // forever. The run does not advance and nothing is pinned.
+          state = step.agedState;
           safeLog(
             `Chain scan run ${state.run} skipped (watermark probe failed; retrying next tick): ` +
               `${describeError(err)}`,

--- a/packages/cli/src/daemon/chain-discovery-scan.ts
+++ b/packages/cli/src/daemon/chain-discovery-scan.ts
@@ -244,8 +244,22 @@ export function commitScanOutcome(
   };
 }
 
-const describeError = (error: unknown): string =>
-  error instanceof Error ? error.message : String(error);
+/**
+ * TOTAL error description: chain discovery is non-critical and the lifecycle
+ * hands the runner straight to a timer with no rejection handler, so a
+ * throw ANYWHERE in reporting escapes as an unhandled rejection and can take
+ * the daemon down. A rejection value is arbitrary — `Object.create(null)`
+ * has no toString, and a poisoned `toString`/`message` getter throws — so
+ * both the property access and the coercion sit inside the catch.
+ */
+const describeError = (error: unknown): string => {
+  try {
+    if (error instanceof Error && typeof error.message === 'string') return error.message;
+    return String(error);
+  } catch {
+    return 'unknown error (rejection value could not be formatted)';
+  }
+};
 
 /**
  * The I/O shell (GH#2323): single-flight guard, the watermark probe with its
@@ -336,8 +350,15 @@ export function createChainDiscoveryScanRunner(input: {
       }
       const committed = commitScanOutcome(plan, outcome);
       state = committed.state; // committed before ANY logging
-      const line = reportLine(committed.report);
-      if (line !== undefined) safeLog(line);
+      try {
+        // describeError is total, but reporting stays inside its own no-throw
+        // boundary anyway — nothing after the state commit may reject the
+        // runner the timer never observes.
+        const line = reportLine(committed.report);
+        if (line !== undefined) safeLog(line);
+      } catch {
+        /* reporting must never affect scheduling or the timer */
+      }
     } finally {
       inFlight = false;
     }

--- a/packages/cli/src/daemon/chain-discovery-scan.ts
+++ b/packages/cli/src/daemon/chain-discovery-scan.ts
@@ -2,29 +2,37 @@
  * Chain-discovery scan scheduling: which scan mode each run issues, and the
  * runner the daemon's 30-minute timer drives (GH#2323).
  *
- * Extracted from lifecycle.ts — the runner is a self-contained state machine
- * with a narrow dependency surface (two agent methods and a log sink), and
- * retry/cadence policy changes should not require editing the module that
- * also owns boot, servers, workers and shutdown.
+ * Extracted from lifecycle.ts — the scheduler is a self-contained state
+ * machine with a narrow dependency surface (two agent methods and a log
+ * sink), and retry/cadence policy changes should not require editing the
+ * module that also owns boot, servers, workers and shutdown.
+ *
+ * The policy lives in two PURE functions over a discriminated state —
+ * `planScan` (what this tick runs) and `commitScanOutcome` (how the result
+ * moves the state) — so invalid combinations (a retry count without a pinned
+ * scan, overdue ticks without an overdue resync) are unrepresentable, and
+ * the runner itself does nothing but single-flight orchestration and I/O.
  */
 
 export const CHAIN_FULL_SCAN_EVERY = 48; // about once per day at the 30-minute cadence
 export const CHAIN_DISCOVERY_SCAN_PAGE_BUDGET = 30;
 
 /**
- * How many consecutive ticks a failed scan is retried AS-IS before the runner
- * releases its slot and lets the normal cadence proceed. Bounded because an
- * unbounded pin trades one liveness bug for another: a deterministically
- * failing historical page would otherwise block incremental discovery of new
- * blocks forever.
+ * How many consecutive ticks a failed scan is retried AS-IS before the
+ * scheduler releases its slot and lets the normal cadence proceed. Bounded
+ * because an unbounded pin trades one liveness bug for another: a
+ * deterministically failing historical page would otherwise block
+ * incremental discovery of new blocks forever.
  */
 export const MAX_CONSECUTIVE_SAME_SCAN_RETRIES = 3;
 
 /**
  * While a full resync is overdue (a `seedFull` exhausted its retries), a
- * fresh attempt is injected every this-many ticks (~2h at the 30-minute
- * cadence). Incremental scans run on the ticks in between, so recent blocks
- * keep being discovered while the historical re-walk stays scheduled.
+ * fresh attempt fires every this-many RUNNER TICKS (~2h at the 30-minute
+ * cadence) — ticks, not completed slots, so a failing incremental's retry
+ * cycle cannot postpone the owed resync. Incremental scans run on the ticks
+ * in between, keeping recent-block discovery live while the historical
+ * re-walk stays scheduled.
  */
 export const OVERDUE_FULL_RESYNC_RETRY_EVERY = 4;
 
@@ -65,36 +73,147 @@ export function chainDiscoveryScanOptions(input: {
     : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
 }
 
-type ScanOptions = ReturnType<typeof chainDiscoveryScanOptions>;
+export type ScanOptions = ReturnType<typeof chainDiscoveryScanOptions>;
+
+export interface ScanSchedulerConfig {
+  pageBudget?: number;
+  fullScanEvery?: number;
+}
 
 /**
- * The scan runner (GH#2323). Its scheduling invariants, each pinned by a
- * test:
+ * The scheduler state. Invalid combinations are unrepresentable by
+ * construction: a retry count exists only inside `pinned`, overdue ticks
+ * only inside `overdueResync`.
  *
- * SLOT ON RESOLVE. The run counter advances only when a scan settles the
- * slot — success, or a failure that exhausted its retries. `runs++` before
- * the awaits meant a rejected run-0 `seedFull` burned its slot and silently
- * downgraded the startup recovery to `incremental` until run 48 (~24h).
+ * `pinned` — a failed scan retried AS-IS. Captured options, not a
+ * recomputed mode: the mode derives from the run number AND the mutable
+ * watermark, and a partially-successful scan moves the watermark, so a
+ * fresh node's failed `seedFromCursor` recomputed would become an unbounded
+ * `seedFull` from block zero instead of resuming its cursor.
  *
- * SAME SCAN, NOT SAME NUMBER. A failed attempt is retried with its CAPTURED
- * options. The mode derives from the run number AND the mutable watermark,
- * and a partially-successful scan moves the watermark — recomputed, a fresh
- * node's failed `seedFromCursor` would become an unbounded `seedFull` from
- * block zero instead of resuming its cursor.
+ * `overdueResync` — a `seedFull` that exhausted its retries. Released, not
+ * forgotten: it fires again every OVERDUE_FULL_RESYNC_RETRY_EVERY ticks.
+ */
+export interface ScanSchedulerState {
+  /** Advances only when a scan settles its slot (success or exhausted). */
+  readonly run: number;
+  readonly pinned?: { readonly options: ScanOptions; readonly failures: number };
+  readonly overdueResync?: { readonly ticksSinceAttempt: number };
+}
+
+export const INITIAL_SCAN_SCHEDULER_STATE: ScanSchedulerState = { run: 0 };
+
+export type ScanOutcome =
+  | { readonly ok: true; readonly found: number }
+  | { readonly ok: false; readonly error: unknown };
+
+/** What the runner should tell the operator, decided by the pure layer. */
+export type ScanReport =
+  | { kind: 'discovered'; found: number }
+  | { kind: 'quiet' }
+  | { kind: 'retryScheduled'; run: number; mode: ScanOptions['mode']; failures: number; error: unknown }
+  | { kind: 'slotReleased'; run: number; mode: ScanOptions['mode']; attempts: number; resyncStaysScheduled: boolean; error: unknown };
+
+/**
+ * Pure: choose this tick's scan and account for overdue-cadence time.
  *
- * BOUNDED PIN. The same failed scan is retried at most
- * MAX_CONSECUTIVE_SAME_SCAN_RETRIES ticks in a row, then its slot is
- * released so the normal cadence (usually `incremental`) resumes — a
- * deterministic failure must not starve discovery of new blocks forever.
- *
- * OVERDUE RESYNC. A released `seedFull` is not forgotten: while overdue, a
- * fresh attempt is injected every OVERDUE_FULL_RESYNC_RETRY_EVERY ticks in
- * place of an incremental scan, until one succeeds.
- *
- * ATOMIC COMMITS. All scheduling state is committed before anything is
- * logged, and the watermark probe has its own error boundary — a throwing
- * log line must neither corrupt the state machine nor be misclassified as a
- * probe failure.
+ * Overdue ticks count on EVERY planned tick, and when the cadence comes due
+ * the owed `seedFull` fires — replacing a pinned `incremental` retry if one
+ * exists (an incremental's work is subsumed by the full re-walk), but never
+ * preempting a pinned `seedFull`/`seedFromCursor`, whose own retries are the
+ * more specific recovery already in progress.
+ */
+export function planScan(
+  state: ScanSchedulerState,
+  watermarkSeeded: boolean,
+  config: ScanSchedulerConfig = {},
+): { scan: ScanOptions; state: ScanSchedulerState } {
+  if (state.overdueResync) {
+    const ticks = state.overdueResync.ticksSinceAttempt + 1;
+    const preemptable = state.pinned === undefined || state.pinned.options.mode === 'incremental';
+    if (ticks >= OVERDUE_FULL_RESYNC_RETRY_EVERY && preemptable) {
+      return {
+        scan: { mode: 'seedFull', throwOnChainScanFailure: true },
+        state: { run: state.run, overdueResync: { ticksSinceAttempt: 0 } },
+      };
+    }
+    state = { ...state, overdueResync: { ticksSinceAttempt: ticks } };
+  }
+  if (state.pinned) {
+    return { scan: state.pinned.options, state };
+  }
+  return {
+    scan: chainDiscoveryScanOptions({
+      run: state.run,
+      watermarkSeeded,
+      pageBudget: config.pageBudget,
+      fullScanEvery: config.fullScanEvery,
+    }),
+    state,
+  };
+}
+
+/**
+ * Pure: fold a scan's outcome into the next state, and say what to report.
+ * The outcome is discriminated — `Promise.reject(undefined)` is a FAILURE
+ * carrying `undefined`, not a success (a sentinel comparison would commit it
+ * as one, consuming the slot and clearing an overdue resync no scan earned).
+ */
+export function commitScanOutcome(
+  state: ScanSchedulerState,
+  scan: ScanOptions,
+  outcome: ScanOutcome,
+): { state: ScanSchedulerState; report: ScanReport } {
+  if (outcome.ok) {
+    return {
+      state: {
+        run: state.run + 1,
+        // A completed full resync settles the overdue debt; any other success
+        // leaves it (still owed, still on cadence).
+        ...(scan.mode !== 'seedFull' && state.overdueResync !== undefined
+          ? { overdueResync: state.overdueResync }
+          : {}),
+      },
+      report: outcome.found > 0 ? { kind: 'discovered', found: outcome.found } : { kind: 'quiet' },
+    };
+  }
+  const failures = (state.pinned?.options === scan ? state.pinned.failures : 0) + 1;
+  if (failures <= MAX_CONSECUTIVE_SAME_SCAN_RETRIES) {
+    return {
+      state: { ...state, pinned: { options: scan, failures } },
+      report: { kind: 'retryScheduled', run: state.run, mode: scan.mode, failures, error: outcome.error },
+    };
+  }
+  // Retries exhausted: release the slot so the cadence proceeds; keep a
+  // failed full resync scheduled instead of forgetting it.
+  return {
+    state: {
+      run: state.run + 1,
+      ...(scan.mode === 'seedFull'
+        ? { overdueResync: { ticksSinceAttempt: 0 } }
+        : state.overdueResync !== undefined
+          ? { overdueResync: state.overdueResync }
+          : {}),
+    },
+    report: {
+      kind: 'slotReleased',
+      run: state.run,
+      mode: scan.mode,
+      attempts: failures,
+      resyncStaysScheduled: scan.mode === 'seedFull',
+      error: outcome.error,
+    },
+  };
+}
+
+const describeError = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+/**
+ * The I/O shell (GH#2323): single-flight guard, the watermark probe with its
+ * own narrow error boundary, one state assignment per tick committed BEFORE
+ * any logging, and a log sink that cannot affect scheduling — every policy
+ * decision lives in the pure functions above.
  */
 export function createChainDiscoveryScanRunner(input: {
   agent: {
@@ -105,12 +224,8 @@ export function createChainDiscoveryScanRunner(input: {
   pageBudget?: number;
   fullScanEvery?: number;
 }): () => Promise<void> {
-  let runs = 0;
+  let state = INITIAL_SCAN_SCHEDULER_STATE;
   let inFlight = false;
-  let retryOptions: ScanOptions | undefined;
-  let consecutiveRetries = 0;
-  let fullResyncOverdue = false;
-  let ticksSinceOverdueAttempt = 0;
 
   const safeLog = (msg: string): void => {
     try {
@@ -120,98 +235,63 @@ export function createChainDiscoveryScanRunner(input: {
     }
   };
 
+  const reportLine = (report: ScanReport): string | undefined => {
+    switch (report.kind) {
+      case 'quiet':
+        return undefined;
+      case 'discovered':
+        return `Chain scan: discovered ${report.found} new context graph(s)`;
+      case 'retryScheduled':
+        return (
+          `Chain scan run ${report.run} (${report.mode}) failed; ` +
+          `the same scan retries next tick: ${describeError(report.error)}`
+        );
+      case 'slotReleased':
+        return (
+          `Chain scan run ${report.run} (${report.mode}) failed ${report.attempts}x; ` +
+          `releasing the slot so discovery continues` +
+          (report.resyncStaysScheduled
+            ? ` — the full resync stays scheduled and retries every ${OVERDUE_FULL_RESYNC_RETRY_EVERY} tick(s)`
+            : '') +
+          `: ${describeError(report.error)}`
+        );
+    }
+  };
+
   return async () => {
     if (inFlight) return;
     inFlight = true;
     try {
-      const run = runs;
-
-      // ── Select the scan ────────────────────────────────────────────────
-      let options: ScanOptions;
-      if (retryOptions !== undefined) {
-        options = retryOptions;
-      } else {
-        let watermarkSeeded: boolean;
+      // The probe result only matters when nothing is pinned; a pinned scan
+      // replays its captured options regardless.
+      let watermarkSeeded = false;
+      if (state.pinned === undefined) {
         try {
           watermarkSeeded = await input.agent.hasContextGraphRegistryScanWatermark();
         } catch (err) {
-          // Probe failure: no options exist to pin, and the slot survives —
-          // scoped to the probe call so nothing else can be misclassified.
+          // Scoped to the probe call alone, so nothing else — least of all a
+          // throwing log line — can be misclassified as a probe failure.
           safeLog(
-            `Chain scan run ${run} skipped (watermark probe failed; retrying next tick): ` +
-              `${err instanceof Error ? err.message : String(err)}`,
+            `Chain scan run ${state.run} skipped (watermark probe failed; retrying next tick): ` +
+              `${describeError(err)}`,
           );
           return;
         }
-        options = chainDiscoveryScanOptions({
-          run,
-          watermarkSeeded,
-          pageBudget: input.pageBudget,
-          fullScanEvery: input.fullScanEvery,
-        });
-        if (fullResyncOverdue && options.mode === 'incremental') {
-          ticksSinceOverdueAttempt += 1;
-          if (ticksSinceOverdueAttempt >= OVERDUE_FULL_RESYNC_RETRY_EVERY) {
-            ticksSinceOverdueAttempt = 0;
-            options = { mode: 'seedFull', throwOnChainScanFailure: true };
-          }
-        }
       }
-
-      // ── Run it ─────────────────────────────────────────────────────────
-      let found: number | undefined;
-      let failure: unknown;
+      const planned = planScan(state, watermarkSeeded, {
+        pageBudget: input.pageBudget,
+        fullScanEvery: input.fullScanEvery,
+      });
+      let outcome: ScanOutcome;
       try {
-        found = await input.agent.discoverContextGraphsFromChain(options);
-      } catch (err) {
-        failure = err;
+        outcome = { ok: true, found: await input.agent.discoverContextGraphsFromChain(planned.scan) };
+      } catch (error) {
+        outcome = { ok: false, error };
       }
-
-      // ── Commit ALL state atomically, before any logging ────────────────
-      let released = false;
-      if (failure === undefined) {
-        retryOptions = undefined;
-        consecutiveRetries = 0;
-        runs = run + 1;
-        if (options.mode === 'seedFull') {
-          fullResyncOverdue = false;
-          ticksSinceOverdueAttempt = 0;
-        }
-      } else if (consecutiveRetries < MAX_CONSECUTIVE_SAME_SCAN_RETRIES) {
-        retryOptions = options;
-        consecutiveRetries += 1;
-      } else {
-        // Retries exhausted: release the slot so the cadence proceeds, and
-        // keep a failed full resync scheduled instead of forgetting it.
-        released = true;
-        retryOptions = undefined;
-        consecutiveRetries = 0;
-        runs = run + 1;
-        if (options.mode === 'seedFull') {
-          fullResyncOverdue = true;
-          ticksSinceOverdueAttempt = 0;
-        }
-      }
-
-      // ── Report ─────────────────────────────────────────────────────────
-      if (failure === undefined) {
-        if (found !== undefined && found > 0) {
-          safeLog(`Chain scan: discovered ${found} new context graph(s)`);
-        }
-      } else {
-        const reason = failure instanceof Error ? failure.message : String(failure);
-        safeLog(
-          released
-            ? `Chain scan run ${run} (${options.mode}) failed ${MAX_CONSECUTIVE_SAME_SCAN_RETRIES + 1}x; ` +
-              `releasing the slot so discovery continues` +
-              (options.mode === 'seedFull'
-                ? ` — the full resync stays scheduled and retries every ${OVERDUE_FULL_RESYNC_RETRY_EVERY} tick(s)`
-                : '') +
-              `: ${reason}`
-            : `Chain scan run ${run} (${options.mode}) failed; ` +
-              `the same scan retries next tick: ${reason}`,
-        );
-      }
+      const committed = commitScanOutcome(planned.state, planned.scan, outcome);
+      state = committed.state; // committed before ANY logging
+      const line = reportLine(committed.report);
+      if (line !== undefined) safeLog(line);
     } finally {
       inFlight = false;
     }

--- a/packages/cli/src/daemon/chain-discovery-scan.ts
+++ b/packages/cli/src/daemon/chain-discovery-scan.ts
@@ -11,6 +11,23 @@
 export const CHAIN_FULL_SCAN_EVERY = 48; // about once per day at the 30-minute cadence
 export const CHAIN_DISCOVERY_SCAN_PAGE_BUDGET = 30;
 
+/**
+ * How many consecutive ticks a failed scan is retried AS-IS before the runner
+ * releases its slot and lets the normal cadence proceed. Bounded because an
+ * unbounded pin trades one liveness bug for another: a deterministically
+ * failing historical page would otherwise block incremental discovery of new
+ * blocks forever.
+ */
+export const MAX_CONSECUTIVE_SAME_SCAN_RETRIES = 3;
+
+/**
+ * While a full resync is overdue (a `seedFull` exhausted its retries), a
+ * fresh attempt is injected every this-many ticks (~2h at the 30-minute
+ * cadence). Incremental scans run on the ticks in between, so recent blocks
+ * keep being discovered while the historical re-walk stays scheduled.
+ */
+export const OVERDUE_FULL_RESYNC_RETRY_EVERY = 4;
+
 export function chainDiscoveryScanOptions(input: {
   watermarkSeeded: boolean;
   run?: number;
@@ -48,12 +65,41 @@ export function chainDiscoveryScanOptions(input: {
     : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
 }
 
+type ScanOptions = ReturnType<typeof chainDiscoveryScanOptions>;
+
+/**
+ * The scan runner (GH#2323). Its scheduling invariants, each pinned by a
+ * test:
+ *
+ * SLOT ON RESOLVE. The run counter advances only when a scan settles the
+ * slot — success, or a failure that exhausted its retries. `runs++` before
+ * the awaits meant a rejected run-0 `seedFull` burned its slot and silently
+ * downgraded the startup recovery to `incremental` until run 48 (~24h).
+ *
+ * SAME SCAN, NOT SAME NUMBER. A failed attempt is retried with its CAPTURED
+ * options. The mode derives from the run number AND the mutable watermark,
+ * and a partially-successful scan moves the watermark — recomputed, a fresh
+ * node's failed `seedFromCursor` would become an unbounded `seedFull` from
+ * block zero instead of resuming its cursor.
+ *
+ * BOUNDED PIN. The same failed scan is retried at most
+ * MAX_CONSECUTIVE_SAME_SCAN_RETRIES ticks in a row, then its slot is
+ * released so the normal cadence (usually `incremental`) resumes — a
+ * deterministic failure must not starve discovery of new blocks forever.
+ *
+ * OVERDUE RESYNC. A released `seedFull` is not forgotten: while overdue, a
+ * fresh attempt is injected every OVERDUE_FULL_RESYNC_RETRY_EVERY ticks in
+ * place of an incremental scan, until one succeeds.
+ *
+ * ATOMIC COMMITS. All scheduling state is committed before anything is
+ * logged, and the watermark probe has its own error boundary — a throwing
+ * log line must neither corrupt the state machine nor be misclassified as a
+ * probe failure.
+ */
 export function createChainDiscoveryScanRunner(input: {
   agent: {
     hasContextGraphRegistryScanWatermark(): Promise<boolean>;
-    discoverContextGraphsFromChain(
-      options: ReturnType<typeof chainDiscoveryScanOptions>,
-    ): Promise<number>;
+    discoverContextGraphsFromChain(options: ScanOptions): Promise<number>;
   };
   log: (msg: string) => void;
   pageBudget?: number;
@@ -61,58 +107,111 @@ export function createChainDiscoveryScanRunner(input: {
 }): () => Promise<void> {
   let runs = 0;
   let inFlight = false;
-  // GH#2323 — a failed attempt is retried as the SAME SCAN, not merely the
-  // same run number. The mode is derived from the run number AND the mutable
-  // watermark, and a partially-successful scan moves the watermark: a fresh
-  // node's run-0 `seedFromCursor` that seeds blocks 0..1999 and then fails
-  // would, recomputed, become a `seedFull` (run 0 + now-seeded watermark) —
-  // discarding cursor resumption and the page budget for an unbounded
-  // re-walk from block zero. Retrying the CAPTURED options instead resumes
-  // `seedFromCursor` from the saved cursor, which is what "retry" means.
-  let retryOptions: ReturnType<typeof chainDiscoveryScanOptions> | undefined;
+  let retryOptions: ScanOptions | undefined;
+  let consecutiveRetries = 0;
+  let fullResyncOverdue = false;
+  let ticksSinceOverdueAttempt = 0;
+
+  const safeLog = (msg: string): void => {
+    try {
+      input.log(msg);
+    } catch {
+      /* a broken log sink must not affect scan scheduling */
+    }
+  };
+
   return async () => {
     if (inFlight) return;
     inFlight = true;
-    // GH#2323 — peek at the slot, commit it only after the scan RESOLVES.
-    // `runs++` before the awaits meant a rejected scan still consumed its
-    // slot, and the run number is what selects the mode: a run-0 `seedFull`
-    // startup-recovery scan that failed on a transient RPC error left runs
-    // 1..47 issuing `incremental` scans, so the history it existed to
-    // re-walk stayed unwalked until run 48 — roughly 24 hours at the
-    // 30-minute cadence — with nothing in the log. A rejected scan now
-    // retries the SAME run next tick: a failed full scan re-runs in 30
-    // minutes, not a day.
-    const run = runs;
     try {
-      const options = retryOptions ?? chainDiscoveryScanOptions({
-        run,
-        watermarkSeeded: await input.agent.hasContextGraphRegistryScanWatermark(),
-        pageBudget: input.pageBudget,
-        fullScanEvery: input.fullScanEvery,
-      });
-      try {
-        const found = await input.agent.discoverContextGraphsFromChain(options);
-        retryOptions = undefined;
-        runs = run + 1;
-        if (found > 0) {
-          input.log(`Chain scan: discovered ${found} new context graph(s)`);
+      const run = runs;
+
+      // ── Select the scan ────────────────────────────────────────────────
+      let options: ScanOptions;
+      if (retryOptions !== undefined) {
+        options = retryOptions;
+      } else {
+        let watermarkSeeded: boolean;
+        try {
+          watermarkSeeded = await input.agent.hasContextGraphRegistryScanWatermark();
+        } catch (err) {
+          // Probe failure: no options exist to pin, and the slot survives —
+          // scoped to the probe call so nothing else can be misclassified.
+          safeLog(
+            `Chain scan run ${run} skipped (watermark probe failed; retrying next tick): ` +
+              `${err instanceof Error ? err.message : String(err)}`,
+          );
+          return;
         }
+        options = chainDiscoveryScanOptions({
+          run,
+          watermarkSeeded,
+          pageBudget: input.pageBudget,
+          fullScanEvery: input.fullScanEvery,
+        });
+        if (fullResyncOverdue && options.mode === 'incremental') {
+          ticksSinceOverdueAttempt += 1;
+          if (ticksSinceOverdueAttempt >= OVERDUE_FULL_RESYNC_RETRY_EVERY) {
+            ticksSinceOverdueAttempt = 0;
+            options = { mode: 'seedFull', throwOnChainScanFailure: true };
+          }
+        }
+      }
+
+      // ── Run it ─────────────────────────────────────────────────────────
+      let found: number | undefined;
+      let failure: unknown;
+      try {
+        found = await input.agent.discoverContextGraphsFromChain(options);
       } catch (err) {
-        // Still non-critical — the daemon keeps running — but no longer
-        // silent, and the slot survives for the retry.
+        failure = err;
+      }
+
+      // ── Commit ALL state atomically, before any logging ────────────────
+      let released = false;
+      if (failure === undefined) {
+        retryOptions = undefined;
+        consecutiveRetries = 0;
+        runs = run + 1;
+        if (options.mode === 'seedFull') {
+          fullResyncOverdue = false;
+          ticksSinceOverdueAttempt = 0;
+        }
+      } else if (consecutiveRetries < MAX_CONSECUTIVE_SAME_SCAN_RETRIES) {
         retryOptions = options;
-        input.log(
-          `Chain scan run ${run} (${options.mode}) failed; ` +
-            `the same scan retries next tick: ${err instanceof Error ? err.message : String(err)}`,
+        consecutiveRetries += 1;
+      } else {
+        // Retries exhausted: release the slot so the cadence proceeds, and
+        // keep a failed full resync scheduled instead of forgetting it.
+        released = true;
+        retryOptions = undefined;
+        consecutiveRetries = 0;
+        runs = run + 1;
+        if (options.mode === 'seedFull') {
+          fullResyncOverdue = true;
+          ticksSinceOverdueAttempt = 0;
+        }
+      }
+
+      // ── Report ─────────────────────────────────────────────────────────
+      if (failure === undefined) {
+        if (found !== undefined && found > 0) {
+          safeLog(`Chain scan: discovered ${found} new context graph(s)`);
+        }
+      } else {
+        const reason = failure instanceof Error ? failure.message : String(failure);
+        safeLog(
+          released
+            ? `Chain scan run ${run} (${options.mode}) failed ${MAX_CONSECUTIVE_SAME_SCAN_RETRIES + 1}x; ` +
+              `releasing the slot so discovery continues` +
+              (options.mode === 'seedFull'
+                ? ` — the full resync stays scheduled and retries every ${OVERDUE_FULL_RESYNC_RETRY_EVERY} tick(s)`
+                : '') +
+              `: ${reason}`
+            : `Chain scan run ${run} (${options.mode}) failed; ` +
+              `the same scan retries next tick: ${reason}`,
         );
       }
-    } catch (err) {
-      // Watermark probe failed before any options existed — nothing to pin;
-      // the next tick recomputes from scratch.
-      input.log(
-        `Chain scan run ${run} skipped (watermark probe failed; retrying next tick): ` +
-          `${err instanceof Error ? err.message : String(err)}`,
-      );
     } finally {
       inFlight = false;
     }

--- a/packages/cli/src/daemon/chain-discovery-scan.ts
+++ b/packages/cli/src/daemon/chain-discovery-scan.ts
@@ -115,6 +115,31 @@ export type ScanReport =
   | { kind: 'slotReleased'; run: number; mode: ScanOptions['mode']; attempts: number; resyncStaysScheduled: boolean; error: unknown };
 
 /**
+ * An executable plan: the scan to run plus everything commit needs, carried
+ * AS ONE UNIT. The retry history travels inside the plan, so structurally
+ * copying the scan options cannot reset it, and commit needs no reference
+ * identity with the scheduler's pin.
+ */
+export interface ScanPlan {
+  readonly scan: ScanOptions;
+  /** Failures already recorded against THIS scan before this attempt. */
+  readonly priorFailures: number;
+  /** Scheduler state as of planning, tick accounting applied. */
+  readonly state: ScanSchedulerState;
+}
+
+/**
+ * Planning names its own prerequisite instead of making the caller predict
+ * it: a pinned retry and a DUE overdue resync are executable immediately —
+ * in particular, an overdue `seedFull` must not be skippable by a failing,
+ * irrelevant watermark probe — while only the canonical cadence selection
+ * needs the probe, via `complete`.
+ */
+export type ScanPlanStep =
+  | { readonly kind: 'ready'; readonly plan: ScanPlan }
+  | { readonly kind: 'needsWatermark'; readonly complete: (watermarkSeeded: boolean) => ScanPlan };
+
+/**
  * Pure: choose this tick's scan and account for overdue-cadence time.
  *
  * Overdue ticks count on EVERY planned tick, and when the cadence comes due
@@ -125,45 +150,56 @@ export type ScanReport =
  */
 export function planScan(
   state: ScanSchedulerState,
-  watermarkSeeded: boolean,
   config: ScanSchedulerConfig = {},
-): { scan: ScanOptions; state: ScanSchedulerState } {
+): ScanPlanStep {
   if (state.overdueResync) {
     const ticks = state.overdueResync.ticksSinceAttempt + 1;
     const preemptable = state.pinned === undefined || state.pinned.options.mode === 'incremental';
     if (ticks >= OVERDUE_FULL_RESYNC_RETRY_EVERY && preemptable) {
       return {
-        scan: { mode: 'seedFull', throwOnChainScanFailure: true },
-        state: { run: state.run, overdueResync: { ticksSinceAttempt: 0 } },
+        kind: 'ready',
+        plan: {
+          scan: { mode: 'seedFull', throwOnChainScanFailure: true },
+          priorFailures: 0,
+          state: { run: state.run, overdueResync: { ticksSinceAttempt: 0 } },
+        },
       };
     }
     state = { ...state, overdueResync: { ticksSinceAttempt: ticks } };
   }
   if (state.pinned) {
-    return { scan: state.pinned.options, state };
+    return {
+      kind: 'ready',
+      plan: { scan: state.pinned.options, priorFailures: state.pinned.failures, state },
+    };
   }
+  const planned = state;
   return {
-    scan: chainDiscoveryScanOptions({
-      run: state.run,
-      watermarkSeeded,
-      pageBudget: config.pageBudget,
-      fullScanEvery: config.fullScanEvery,
+    kind: 'needsWatermark',
+    complete: (watermarkSeeded: boolean): ScanPlan => ({
+      scan: chainDiscoveryScanOptions({
+        run: planned.run,
+        watermarkSeeded,
+        pageBudget: config.pageBudget,
+        fullScanEvery: config.fullScanEvery,
+      }),
+      priorFailures: 0,
+      state: planned,
     }),
-    state,
   };
 }
 
 /**
- * Pure: fold a scan's outcome into the next state, and say what to report.
+ * Pure: fold a plan's outcome into the next state, and say what to report.
  * The outcome is discriminated — `Promise.reject(undefined)` is a FAILURE
  * carrying `undefined`, not a success (a sentinel comparison would commit it
  * as one, consuming the slot and clearing an overdue resync no scan earned).
  */
 export function commitScanOutcome(
-  state: ScanSchedulerState,
-  scan: ScanOptions,
+  plan: ScanPlan,
   outcome: ScanOutcome,
 ): { state: ScanSchedulerState; report: ScanReport } {
+  const { scan, state } = plan;
   if (outcome.ok) {
     return {
       state: {
@@ -177,7 +213,9 @@ export function commitScanOutcome(
       report: outcome.found > 0 ? { kind: 'discovered', found: outcome.found } : { kind: 'quiet' },
     };
   }
-  const failures = (state.pinned?.options === scan ? state.pinned.failures : 0) + 1;
+  // Retry history comes from the plan itself — never from comparing object
+  // identities, which a structural copy would silently defeat.
+  const failures = plan.priorFailures + 1;
   if (failures <= MAX_CONSECUTIVE_SAME_SCAN_RETRIES) {
     return {
       state: { ...state, pinned: { options: scan, failures } },
@@ -262,33 +300,41 @@ export function createChainDiscoveryScanRunner(input: {
     if (inFlight) return;
     inFlight = true;
     try {
-      // The probe result only matters when nothing is pinned; a pinned scan
-      // replays its captured options regardless.
-      let watermarkSeeded = false;
-      if (state.pinned === undefined) {
+      // Planning names its own prerequisite: only the canonical cadence
+      // selection needs the watermark probe. A pinned retry or a DUE overdue
+      // resync executes without it — so an irrelevant probe failure cannot
+      // skip either.
+      const step = planScan(state, {
+        pageBudget: input.pageBudget,
+        fullScanEvery: input.fullScanEvery,
+      });
+      let plan: ScanPlan;
+      if (step.kind === 'ready') {
+        plan = step.plan;
+      } else {
+        let watermarkSeeded: boolean;
         try {
           watermarkSeeded = await input.agent.hasContextGraphRegistryScanWatermark();
         } catch (err) {
           // Scoped to the probe call alone, so nothing else — least of all a
-          // throwing log line — can be misclassified as a probe failure.
+          // throwing log line — can be misclassified as a probe failure. The
+          // tick planned nothing, so state (overdue aging included) is
+          // untouched: the debt ages only on ticks that actually plan.
           safeLog(
             `Chain scan run ${state.run} skipped (watermark probe failed; retrying next tick): ` +
               `${describeError(err)}`,
           );
           return;
         }
+        plan = step.complete(watermarkSeeded);
       }
-      const planned = planScan(state, watermarkSeeded, {
-        pageBudget: input.pageBudget,
-        fullScanEvery: input.fullScanEvery,
-      });
       let outcome: ScanOutcome;
       try {
-        outcome = { ok: true, found: await input.agent.discoverContextGraphsFromChain(planned.scan) };
+        outcome = { ok: true, found: await input.agent.discoverContextGraphsFromChain(plan.scan) };
       } catch (error) {
         outcome = { ok: false, error };
       }
-      const committed = commitScanOutcome(planned.state, planned.scan, outcome);
+      const committed = commitScanOutcome(plan, outcome);
       state = committed.state; // committed before ANY logging
       const line = reportLine(committed.report);
       if (line !== undefined) safeLog(line);

--- a/packages/cli/src/daemon/chain-discovery-scan.ts
+++ b/packages/cli/src/daemon/chain-discovery-scan.ts
@@ -1,0 +1,120 @@
+/**
+ * Chain-discovery scan scheduling: which scan mode each run issues, and the
+ * runner the daemon's 30-minute timer drives (GH#2323).
+ *
+ * Extracted from lifecycle.ts — the runner is a self-contained state machine
+ * with a narrow dependency surface (two agent methods and a log sink), and
+ * retry/cadence policy changes should not require editing the module that
+ * also owns boot, servers, workers and shutdown.
+ */
+
+export const CHAIN_FULL_SCAN_EVERY = 48; // about once per day at the 30-minute cadence
+export const CHAIN_DISCOVERY_SCAN_PAGE_BUDGET = 30;
+
+export function chainDiscoveryScanOptions(input: {
+  watermarkSeeded: boolean;
+  run?: number;
+  fullScanEvery?: number;
+  pageBudget?: number;
+}):
+  | { mode: 'incremental'; pageBudget: number }
+  | { mode: 'seedFromCursor'; throwOnChainScanFailure: true; pageBudget: number }
+  | { mode: 'seedFull'; throwOnChainScanFailure: true } {
+  const configuredFullScanEvery = input.fullScanEvery;
+  let fullScanEvery = CHAIN_FULL_SCAN_EVERY;
+  if (
+    typeof configuredFullScanEvery === 'number' &&
+    Number.isFinite(configuredFullScanEvery) &&
+    configuredFullScanEvery >= 1
+  ) {
+    fullScanEvery = Math.floor(configuredFullScanEvery);
+  }
+  const configuredPageBudget = input.pageBudget;
+  const pageBudget = (
+    typeof configuredPageBudget === 'number' &&
+    Number.isFinite(configuredPageBudget) &&
+    configuredPageBudget >= 1
+  )
+    ? Math.floor(configuredPageBudget)
+    : CHAIN_DISCOVERY_SCAN_PAGE_BUDGET;
+  const run = input.run ?? 0;
+  const startupRecoveryScan = input.watermarkSeeded && run === 0;
+  const periodicFullResync = input.watermarkSeeded && run > 0 && run % fullScanEvery === 0;
+  if (startupRecoveryScan || periodicFullResync) {
+    return { mode: 'seedFull', throwOnChainScanFailure: true };
+  }
+  return input.watermarkSeeded && !periodicFullResync
+    ? { mode: 'incremental', pageBudget }
+    : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
+}
+
+export function createChainDiscoveryScanRunner(input: {
+  agent: {
+    hasContextGraphRegistryScanWatermark(): Promise<boolean>;
+    discoverContextGraphsFromChain(
+      options: ReturnType<typeof chainDiscoveryScanOptions>,
+    ): Promise<number>;
+  };
+  log: (msg: string) => void;
+  pageBudget?: number;
+  fullScanEvery?: number;
+}): () => Promise<void> {
+  let runs = 0;
+  let inFlight = false;
+  // GH#2323 — a failed attempt is retried as the SAME SCAN, not merely the
+  // same run number. The mode is derived from the run number AND the mutable
+  // watermark, and a partially-successful scan moves the watermark: a fresh
+  // node's run-0 `seedFromCursor` that seeds blocks 0..1999 and then fails
+  // would, recomputed, become a `seedFull` (run 0 + now-seeded watermark) —
+  // discarding cursor resumption and the page budget for an unbounded
+  // re-walk from block zero. Retrying the CAPTURED options instead resumes
+  // `seedFromCursor` from the saved cursor, which is what "retry" means.
+  let retryOptions: ReturnType<typeof chainDiscoveryScanOptions> | undefined;
+  return async () => {
+    if (inFlight) return;
+    inFlight = true;
+    // GH#2323 — peek at the slot, commit it only after the scan RESOLVES.
+    // `runs++` before the awaits meant a rejected scan still consumed its
+    // slot, and the run number is what selects the mode: a run-0 `seedFull`
+    // startup-recovery scan that failed on a transient RPC error left runs
+    // 1..47 issuing `incremental` scans, so the history it existed to
+    // re-walk stayed unwalked until run 48 — roughly 24 hours at the
+    // 30-minute cadence — with nothing in the log. A rejected scan now
+    // retries the SAME run next tick: a failed full scan re-runs in 30
+    // minutes, not a day.
+    const run = runs;
+    try {
+      const options = retryOptions ?? chainDiscoveryScanOptions({
+        run,
+        watermarkSeeded: await input.agent.hasContextGraphRegistryScanWatermark(),
+        pageBudget: input.pageBudget,
+        fullScanEvery: input.fullScanEvery,
+      });
+      try {
+        const found = await input.agent.discoverContextGraphsFromChain(options);
+        retryOptions = undefined;
+        runs = run + 1;
+        if (found > 0) {
+          input.log(`Chain scan: discovered ${found} new context graph(s)`);
+        }
+      } catch (err) {
+        // Still non-critical — the daemon keeps running — but no longer
+        // silent, and the slot survives for the retry.
+        retryOptions = options;
+        input.log(
+          `Chain scan run ${run} (${options.mode}) failed; ` +
+            `the same scan retries next tick: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    } catch (err) {
+      // Watermark probe failed before any options existed — nothing to pin;
+      // the next tick recomputes from scratch.
+      input.log(
+        `Chain scan run ${run} skipped (watermark probe failed; retrying next tick): ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      inFlight = false;
+    }
+  };
+}

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -749,21 +749,42 @@ export function createChainDiscoveryScanRunner(input: {
   return async () => {
     if (inFlight) return;
     inFlight = true;
+    // GH#2323 — peek at the slot, commit it only after the scan RESOLVES.
+    // `runs++` before the awaits meant a rejected scan still consumed its
+    // slot, and the run number is what selects the mode: a run-0 `seedFull`
+    // startup-recovery scan that failed on a transient RPC error left runs
+    // 1..47 issuing `incremental` scans, so the history it existed to
+    // re-walk stayed unwalked until run 48 — roughly 24 hours at the
+    // 30-minute cadence — with nothing in the log. A rejected scan now
+    // retries the SAME run next tick: a failed full scan re-runs in 30
+    // minutes, not a day.
+    const run = runs;
     try {
-      const run = runs++;
-      const found = await input.agent.discoverContextGraphsFromChain(
-        chainDiscoveryScanOptions({
-          run,
-          watermarkSeeded: await input.agent.hasContextGraphRegistryScanWatermark(),
-          pageBudget: input.pageBudget,
-          fullScanEvery: input.fullScanEvery,
-        }),
-      );
-      if (found > 0) {
-        input.log(`Chain scan: discovered ${found} new context graph(s)`);
+      const options = chainDiscoveryScanOptions({
+        run,
+        watermarkSeeded: await input.agent.hasContextGraphRegistryScanWatermark(),
+        pageBudget: input.pageBudget,
+        fullScanEvery: input.fullScanEvery,
+      });
+      try {
+        const found = await input.agent.discoverContextGraphsFromChain(options);
+        runs = run + 1;
+        if (found > 0) {
+          input.log(`Chain scan: discovered ${found} new context graph(s)`);
+        }
+      } catch (err) {
+        // Still non-critical — the daemon keeps running — but no longer
+        // silent, and the slot survives for the retry.
+        input.log(
+          `Chain scan run ${run} (${options.mode}) failed; ` +
+            `the same scan retries next tick: ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
-    } catch {
-      /* non-critical */
+    } catch (err) {
+      input.log(
+        `Chain scan run ${run} skipped (watermark probe failed; retrying next tick): ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+      );
     } finally {
       inFlight = false;
     }

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -168,6 +168,14 @@ import {
   CHAIN_DISCOVERY_SCAN_PAGE_BUDGET,
   createChainDiscoveryScanRunner,
 } from './chain-discovery-scan.js';
+// The scan policy lived here until GH#2323; the implementation moved to its
+// own module, but the public import path stays valid for existing consumers.
+export {
+  CHAIN_DISCOVERY_SCAN_PAGE_BUDGET,
+  CHAIN_FULL_SCAN_EVERY,
+  chainDiscoveryScanOptions,
+  createChainDiscoveryScanRunner,
+} from './chain-discovery-scan.js';
 import { createDaemonLocalLlmService } from './local-llm-service.js';
 import { appendBoundedDaemonLogDiagnostic } from './daemon-log-diagnostics.js';
 import {

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -164,6 +164,10 @@ import {
   type DaemonLogExporterStartResult,
 } from './log-lifecycle.js';
 import { startDaemonLogFileWriter } from './daemon-log-file-writer.js';
+import {
+  CHAIN_DISCOVERY_SCAN_PAGE_BUDGET,
+  createChainDiscoveryScanRunner,
+} from './chain-discovery-scan.js';
 import { createDaemonLocalLlmService } from './local-llm-service.js';
 import { appendBoundedDaemonLogDiagnostic } from './daemon-log-diagnostics.js';
 import {
@@ -691,104 +695,6 @@ export function orderACKCandidatePeerIds(input: {
     verifiedSameNetworkPeerIds: input.verifiedSameNetworkPeerIds,
     requiredACKs: Number.MAX_SAFE_INTEGER,
   });
-}
-
-export const CHAIN_FULL_SCAN_EVERY = 48; // about once per day at the 30-minute cadence
-export const CHAIN_DISCOVERY_SCAN_PAGE_BUDGET = 30;
-
-export function chainDiscoveryScanOptions(input: {
-  watermarkSeeded: boolean;
-  run?: number;
-  fullScanEvery?: number;
-  pageBudget?: number;
-}):
-  | { mode: 'incremental'; pageBudget: number }
-  | { mode: 'seedFromCursor'; throwOnChainScanFailure: true; pageBudget: number }
-  | { mode: 'seedFull'; throwOnChainScanFailure: true } {
-  const configuredFullScanEvery = input.fullScanEvery;
-  let fullScanEvery = CHAIN_FULL_SCAN_EVERY;
-  if (
-    typeof configuredFullScanEvery === 'number' &&
-    Number.isFinite(configuredFullScanEvery) &&
-    configuredFullScanEvery >= 1
-  ) {
-    fullScanEvery = Math.floor(configuredFullScanEvery);
-  }
-  const configuredPageBudget = input.pageBudget;
-  const pageBudget = (
-    typeof configuredPageBudget === 'number' &&
-    Number.isFinite(configuredPageBudget) &&
-    configuredPageBudget >= 1
-  )
-    ? Math.floor(configuredPageBudget)
-    : CHAIN_DISCOVERY_SCAN_PAGE_BUDGET;
-  const run = input.run ?? 0;
-  const startupRecoveryScan = input.watermarkSeeded && run === 0;
-  const periodicFullResync = input.watermarkSeeded && run > 0 && run % fullScanEvery === 0;
-  if (startupRecoveryScan || periodicFullResync) {
-    return { mode: 'seedFull', throwOnChainScanFailure: true };
-  }
-  return input.watermarkSeeded && !periodicFullResync
-    ? { mode: 'incremental', pageBudget }
-    : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
-}
-
-export function createChainDiscoveryScanRunner(input: {
-  agent: {
-    hasContextGraphRegistryScanWatermark(): Promise<boolean>;
-    discoverContextGraphsFromChain(
-      options: ReturnType<typeof chainDiscoveryScanOptions>,
-    ): Promise<number>;
-  };
-  log: (msg: string) => void;
-  pageBudget?: number;
-  fullScanEvery?: number;
-}): () => Promise<void> {
-  let runs = 0;
-  let inFlight = false;
-  return async () => {
-    if (inFlight) return;
-    inFlight = true;
-    // GH#2323 — peek at the slot, commit it only after the scan RESOLVES.
-    // `runs++` before the awaits meant a rejected scan still consumed its
-    // slot, and the run number is what selects the mode: a run-0 `seedFull`
-    // startup-recovery scan that failed on a transient RPC error left runs
-    // 1..47 issuing `incremental` scans, so the history it existed to
-    // re-walk stayed unwalked until run 48 — roughly 24 hours at the
-    // 30-minute cadence — with nothing in the log. A rejected scan now
-    // retries the SAME run next tick: a failed full scan re-runs in 30
-    // minutes, not a day.
-    const run = runs;
-    try {
-      const options = chainDiscoveryScanOptions({
-        run,
-        watermarkSeeded: await input.agent.hasContextGraphRegistryScanWatermark(),
-        pageBudget: input.pageBudget,
-        fullScanEvery: input.fullScanEvery,
-      });
-      try {
-        const found = await input.agent.discoverContextGraphsFromChain(options);
-        runs = run + 1;
-        if (found > 0) {
-          input.log(`Chain scan: discovered ${found} new context graph(s)`);
-        }
-      } catch (err) {
-        // Still non-critical — the daemon keeps running — but no longer
-        // silent, and the slot survives for the retry.
-        input.log(
-          `Chain scan run ${run} (${options.mode}) failed; ` +
-            `the same scan retries next tick: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-    } catch (err) {
-      input.log(
-        `Chain scan run ${run} skipped (watermark probe failed; retrying next tick): ` +
-          `${err instanceof Error ? err.message : String(err)}`,
-      );
-    } finally {
-      inFlight = false;
-    }
-  };
 }
 
 export interface PromoteWorkerDaemonLifecycle {

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { chainDiscoveryScanOptions, createChainDiscoveryScanRunner } from '../src/daemon/lifecycle.js';
+import { chainDiscoveryScanOptions, createChainDiscoveryScanRunner } from '../src/daemon/chain-discovery-scan.js';
 
 describe('chainDiscoveryScanOptions', () => {
   it('uses bounded cursor-resumable watermark seeding before a seed exists', () => {
@@ -173,6 +173,42 @@ describe('chainDiscoveryScanOptions', () => {
       mode: 'seedFull',
       throwOnChainScanFailure: true,
     });
+  });
+
+  // Review RED on the first version of this fix: "same run" is not "same
+  // scan". The mode derives from the run number AND the mutable watermark,
+  // and a partially-successful scan MOVES the watermark — so recomputing the
+  // options on retry can silently change what retries. The failed attempt's
+  // options are captured and reused instead.
+  it('a partially seeded seedFromCursor retries as seedFromCursor, not an unbounded seedFull', async () => {
+    const agent = {
+      // Fresh node: no watermark on the first probe. The scan then seeds
+      // blocks 0..1999, SAVES the watermark, and fails on 2000..3999 —
+      // so every later probe reports seeded.
+      hasContextGraphRegistryScanWatermark: vi
+        .fn<() => Promise<boolean>>()
+        .mockResolvedValueOnce(false)
+        .mockResolvedValue(true),
+      discoverContextGraphsFromChain: vi
+        .fn<(options: ReturnType<typeof chainDiscoveryScanOptions>) => Promise<number>>()
+        .mockRejectedValueOnce(new Error('rpc failed mid-seed'))
+        .mockResolvedValueOnce(2)
+        .mockResolvedValueOnce(0),
+    };
+    const runner = createChainDiscoveryScanRunner({ agent, log: vi.fn() });
+
+    await runner(); // run 0: seedFromCursor, partial progress, REJECTED
+    await runner(); // run 0 retried — MUST resume the cursor scan, not restart history
+    await runner(); // run 1: watermark seeded => incremental
+
+    const calls = agent.discoverContextGraphsFromChain.mock.calls.map((c) => c[0]!);
+    expect(calls[0]).toEqual({ mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget: 30 });
+    // Recomputed from the moved watermark this would be seedFull (run 0 +
+    // seeded = startup recovery): unbounded, from block zero, no page budget.
+    expect(calls[1]).toEqual({ mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget: 30 });
+    expect(calls[2]).toEqual({ mode: 'incremental', pageBudget: 30 });
+    // The successful retry released the pin: nothing later reuses stale options.
+    expect(agent.hasContextGraphRegistryScanWatermark).toHaveBeenCalledTimes(2);
   });
 
   it('a failed periodic full resync retries in one tick, not one day', async () => {

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -72,6 +72,32 @@ describe('chainDiscoveryScanOptions', () => {
     })).toEqual({ mode: 'incremental', pageBudget: 7 });
   });
 
+});
+
+describe('createChainDiscoveryScanRunner (GH#2323)', () => {
+  /**
+   * Runner + spies for the common shape: a probe that reports the watermark
+   * seeded, and a discover implementation supplied per test. Pass a
+   * preconfigured vi.fn (mock chains) or a plain implementation.
+   */
+  const makeRunner = (input: {
+    discover:
+      | ReturnType<typeof vi.fn>
+      | ((options: ReturnType<typeof chainDiscoveryScanOptions>) => Promise<number>);
+    log?: ReturnType<typeof vi.fn>;
+    fullScanEvery?: number;
+  }) => {
+    const discover = 'mock' in input.discover ? input.discover : vi.fn(input.discover);
+    const agent = {
+      hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
+      discoverContextGraphsFromChain: discover as (
+        options: ReturnType<typeof chainDiscoveryScanOptions>,
+      ) => Promise<number>,
+    };
+    const log = input.log ?? vi.fn();
+    return { agent, log, runner: createChainDiscoveryScanRunner({ agent, log, fullScanEvery: input.fullScanEvery }) };
+  };
+
   it('serializes overlapping scheduled chain scans and resets after settle', async () => {
     let resolveFirstScan: ((value: number) => void) | undefined;
     const firstScan = new Promise<number>((resolve) => {
@@ -246,18 +272,13 @@ describe('chainDiscoveryScanOptions', () => {
   // historical page would block incremental discovery of new blocks forever.
   it('a permanently failing seedFull releases its slot and incremental discovery continues', async () => {
     const modes: string[] = [];
-    const agent = {
-      hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
-      discoverContextGraphsFromChain: vi.fn(
-        async (options: ReturnType<typeof chainDiscoveryScanOptions>) => {
-          modes.push(options.mode);
-          if (options.mode === 'seedFull') throw new Error('historical page 404s deterministically');
-          return 0;
-        },
-      ),
-    };
-    const log = vi.fn();
-    const runner = createChainDiscoveryScanRunner({ agent, log });
+    const { log, runner } = makeRunner({
+      discover: async (options) => {
+        modes.push(options.mode);
+        if (options.mode === 'seedFull') throw new Error('historical page 404s deterministically');
+        return 0;
+      },
+    });
 
     // Initial attempt + MAX consecutive retries, all seedFull, all failing.
     for (let i = 0; i <= MAX_CONSECUTIVE_SAME_SCAN_RETRIES; i++) await runner();
@@ -279,17 +300,13 @@ describe('chainDiscoveryScanOptions', () => {
   it('an overdue full resync clears once an injected attempt succeeds', async () => {
     let seedFullFails = true;
     const modes: string[] = [];
-    const agent = {
-      hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
-      discoverContextGraphsFromChain: vi.fn(
-        async (options: ReturnType<typeof chainDiscoveryScanOptions>) => {
-          modes.push(options.mode);
-          if (options.mode === 'seedFull' && seedFullFails) throw new Error('flaky RPC');
-          return 0;
-        },
-      ),
-    };
-    const runner = createChainDiscoveryScanRunner({ agent, log: vi.fn() });
+    const { runner } = makeRunner({
+      discover: async (options) => {
+        modes.push(options.mode);
+        if (options.mode === 'seedFull' && seedFullFails) throw new Error('flaky RPC');
+        return 0;
+      },
+    });
 
     for (let i = 0; i <= MAX_CONSECUTIVE_SAME_SCAN_RETRIES; i++) await runner(); // exhaust
     seedFullFails = false;
@@ -420,16 +437,12 @@ describe('chainDiscoveryScanOptions', () => {
 
   it('an overdue resync fires on schedule even while incremental scans fail', async () => {
     const modes: string[] = [];
-    const agent = {
-      hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
-      discoverContextGraphsFromChain: vi.fn(
-        async (options: ReturnType<typeof chainDiscoveryScanOptions>) => {
-          modes.push(options.mode);
-          throw new Error('everything fails');
-        },
-      ),
-    };
-    const runner = createChainDiscoveryScanRunner({ agent, log: vi.fn() });
+    const { runner } = makeRunner({
+      discover: async (options) => {
+        modes.push(options.mode);
+        throw new Error('everything fails');
+      },
+    });
 
     // Exhaust the startup seedFull: initial attempt + MAX retries.
     for (let i = 0; i <= MAX_CONSECUTIVE_SAME_SCAN_RETRIES; i++) await runner();
@@ -444,10 +457,7 @@ describe('chainDiscoveryScanOptions', () => {
     expect(window.slice(0, -1).every((m) => m === 'incremental')).toBe(true);
     expect(window.at(-1)).toBe('seedFull');
   });
-});
 
-// The policy is two pure functions over a discriminated state; pin the
-// transition table directly, not only through tick sequences.
   // A rejection VALUE is arbitrary: `Object.create(null)` has no toString
   // and a poisoned toString throws during formatting. The lifecycle hands
   // this runner to a timer with no rejection handler, so a throw escaping
@@ -490,7 +500,10 @@ describe('chainDiscoveryScanOptions', () => {
     expect(log).toHaveBeenCalledWith(expect.stringContaining('watermark probe failed'));
     expect(agent.discoverContextGraphsFromChain).not.toHaveBeenCalled();
   });
+});
 
+// The policy is two pure functions over a discriminated state; pin the
+// transition table directly, not only through tick sequences.
 describe('scan scheduler transitions (GH#2323)', () => {
   const seedFull = { mode: 'seedFull', throwOnChainScanFailure: true } as const;
   const incremental = { mode: 'incremental', pageBudget: 30 } as const;

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -397,6 +397,35 @@ describe('chainDiscoveryScanOptions', () => {
   // Review round 3 — the overdue cadence is a TICK contract, and it must
   // hold even while incremental scans are themselves failing and retrying:
   // a failing incremental's retry cycle cannot postpone the owed resync.
+  it('a DUE overdue resync fires even when the watermark probe is failing', async () => {
+    // Review round 4 — the probe is irrelevant to a due resync, so a probe
+    // outage must not be able to skip it.
+    const modes: string[] = [];
+    let probeHealthy = true;
+    const agent = {
+      hasContextGraphRegistryScanWatermark: vi.fn(async () => {
+        if (!probeHealthy) throw new Error('registry store unavailable');
+        return true;
+      }),
+      discoverContextGraphsFromChain: vi.fn(
+        async (options: ReturnType<typeof chainDiscoveryScanOptions>) => {
+          modes.push(options.mode);
+          if (options.mode === 'seedFull') throw new Error('flaky RPC');
+          return 0;
+        },
+      ),
+    };
+    const runner = createChainDiscoveryScanRunner({ agent, log: vi.fn() });
+
+    for (let i = 0; i <= MAX_CONSECUTIVE_SAME_SCAN_RETRIES; i++) await runner(); // exhaust seedFull
+    // Age the debt to one tick short of due with healthy probes, then break
+    // the probe for the due tick.
+    for (let i = 1; i < OVERDUE_FULL_RESYNC_RETRY_EVERY; i++) await runner();
+    probeHealthy = false;
+    await runner();
+    expect(modes.at(-1)).toBe('seedFull');
+  });
+
   it('an overdue resync fires on schedule even while incremental scans fail', async () => {
     const modes: string[] = [];
     const agent = {
@@ -431,38 +460,71 @@ describe('scan scheduler transitions (GH#2323)', () => {
   const seedFull = { mode: 'seedFull', throwOnChainScanFailure: true } as const;
   const incremental = { mode: 'incremental', pageBudget: 30 } as const;
 
-  it('failure pins the executed scan; success releases the pin and advances the run', () => {
-    const planned = planScan(INITIAL_SCAN_SCHEDULER_STATE, true);
-    expect(planned.scan).toEqual(seedFull);
+  /** Resolve a plan, providing the watermark only when planning asks. */
+  const plan = (state: Parameters<typeof planScan>[0], watermarkSeeded = true) => {
+    const step = planScan(state);
+    return step.kind === 'ready' ? step.plan : step.complete(watermarkSeeded);
+  };
 
-    const failed = commitScanOutcome(planned.state, planned.scan, { ok: false, error: new Error('x') });
+  it('failure pins the executed scan; success releases the pin and advances the run', () => {
+    const first = plan(INITIAL_SCAN_SCHEDULER_STATE);
+    expect(first.scan).toEqual(seedFull);
+
+    const failed = commitScanOutcome(first, { ok: false, error: new Error('x') });
     expect(failed.state).toEqual({ run: 0, pinned: { options: seedFull, failures: 1 } });
     expect(failed.report.kind).toBe('retryScheduled');
 
-    const replanned = planScan(failed.state, /* probe irrelevant when pinned */ false);
-    expect(replanned.scan).toBe(failed.state.pinned!.options);
+    // A pinned retry is executable WITHOUT the watermark probe.
+    const step = planScan(failed.state);
+    expect(step.kind).toBe('ready');
+    if (step.kind !== 'ready') return;
+    expect(step.plan.scan).toBe(failed.state.pinned!.options);
+    expect(step.plan.priorFailures).toBe(1);
 
-    const succeeded = commitScanOutcome(replanned.state, replanned.scan, { ok: true, found: 0 });
+    const succeeded = commitScanOutcome(step.plan, { ok: true, found: 0 });
     expect(succeeded.state).toEqual({ run: 1 });
     expect(succeeded.report.kind).toBe('quiet');
+  });
+
+  it('structurally copying a plan cannot reset its retry history', () => {
+    // Review round 4: commit must not depend on object identity with the
+    // scheduler's pin — the history travels IN the plan.
+    const failed = commitScanOutcome(plan(INITIAL_SCAN_SCHEDULER_STATE), { ok: false, error: 'e' });
+    const step = planScan(failed.state);
+    if (step.kind !== 'ready') throw new Error('pinned retry must be ready');
+    const copied = { ...step.plan, scan: { ...step.plan.scan } };
+    const refailed = commitScanOutcome(copied, { ok: false, error: 'e' });
+    expect(refailed.state.pinned!.failures).toBe(2);
+  });
+
+  it('a DUE overdue resync plans ready — no watermark prerequisite', () => {
+    const step = planScan({
+      run: 5,
+      overdueResync: { ticksSinceAttempt: OVERDUE_FULL_RESYNC_RETRY_EVERY - 1 },
+    });
+    expect(step.kind).toBe('ready');
+    if (step.kind !== 'ready') return;
+    expect(step.plan.scan).toEqual(seedFull);
+    expect(step.plan.state.overdueResync).toEqual({ ticksSinceAttempt: 0 });
   });
 
   it('exhaustion of a seedFull releases the slot AND records the overdue resync', () => {
     let state = INITIAL_SCAN_SCHEDULER_STATE;
     for (let i = 0; i <= MAX_CONSECUTIVE_SAME_SCAN_RETRIES; i++) {
-      const planned = planScan(state, true);
-      state = commitScanOutcome(planned.state, planned.scan, { ok: false, error: 'e' }).state;
+      state = commitScanOutcome(plan(state), { ok: false, error: 'e' }).state;
     }
     expect(state).toEqual({ run: 1, overdueResync: { ticksSinceAttempt: 0 } });
   });
 
   it('a non-seedFull success and a non-seedFull release both PRESERVE the overdue debt', () => {
     const owing = { run: 3, overdueResync: { ticksSinceAttempt: 1 } };
-    const success = commitScanOutcome(owing, incremental, { ok: true, found: 0 });
+    const success = commitScanOutcome(
+      { scan: incremental, priorFailures: 0, state: owing },
+      { ok: true, found: 0 },
+    );
     expect(success.state.overdueResync).toEqual({ ticksSinceAttempt: 1 });
     const exhausted = commitScanOutcome(
-      { ...owing, pinned: { options: incremental, failures: MAX_CONSECUTIVE_SAME_SCAN_RETRIES } },
-      incremental,
+      { scan: incremental, priorFailures: MAX_CONSECUTIVE_SAME_SCAN_RETRIES, state: owing },
       { ok: false, error: 'e' },
     );
     expect(exhausted.report.kind).toBe('slotReleased');
@@ -471,7 +533,10 @@ describe('scan scheduler transitions (GH#2323)', () => {
 
   it('only a completed seedFull settles the overdue debt', () => {
     const owing = { run: 3, overdueResync: { ticksSinceAttempt: 2 } };
-    const settled = commitScanOutcome(owing, seedFull, { ok: true, found: 0 });
+    const settled = commitScanOutcome(
+      { scan: seedFull, priorFailures: 0, state: owing },
+      { ok: true, found: 0 },
+    );
     expect(settled.state.overdueResync).toBeUndefined();
   });
 
@@ -482,10 +547,12 @@ describe('scan scheduler transitions (GH#2323)', () => {
       pinned: { options: seeding, failures: 1 },
       overdueResync: { ticksSinceAttempt: OVERDUE_FULL_RESYNC_RETRY_EVERY },
     };
-    const planned = planScan(state, true);
+    const step = planScan(state);
+    expect(step.kind).toBe('ready');
+    if (step.kind !== 'ready') return;
     // The bootstrap retry is the more specific recovery already in progress.
-    expect(planned.scan).toBe(state.pinned.options);
+    expect(step.plan.scan).toBe(state.pinned.options);
     // The debt keeps aging rather than resetting from an attempt that never ran.
-    expect(planned.state.overdueResync!.ticksSinceAttempt).toBeGreaterThan(OVERDUE_FULL_RESYNC_RETRY_EVERY);
+    expect(step.plan.state.overdueResync!.ticksSinceAttempt).toBeGreaterThan(OVERDUE_FULL_RESYNC_RETRY_EVERY);
   });
 });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -108,12 +108,9 @@ describe('chainDiscoveryScanOptions', () => {
   // `discoverContextGraphsFromChain` must be swallowed and must clear the
   // `inFlight` guard via the `finally`, or the first transient RPC failure
   // would permanently disable every later scheduled scan.
-  // GH#2323 — these three tests DELIBERATELY flip the behaviour their
-  // predecessors pinned. The old runner consumed the run slot before any
-  // await (`const run = runs++`), so a rejected run-0 `seedFull` silently
-  // downgraded the startup recovery to `incremental` until run 48 — roughly
-  // 24h at the 30-minute cadence. The slot is now committed only when the
-  // scan resolves: a rejected scan retries the SAME run next tick.
+  // GH#2323 — the slot is committed only when a scan settles it: a rejected
+  // scan retries the SAME run next tick instead of silently downgrading the
+  // startup recovery to `incremental` until run 48 (~24h at the cadence).
   it('retries a rejected startup-recovery seedFull on the next tick instead of degrading to incremental', async () => {
     const agent = {
       hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
@@ -187,8 +184,7 @@ describe('chainDiscoveryScanOptions', () => {
     });
   });
 
-  // Review RED on the first version of this fix: "same run" is not "same
-  // scan". The mode derives from the run number AND the mutable watermark,
+  // "Same run" is not "same scan". The mode derives from the run number AND the mutable watermark,
   // and a partially-successful scan MOVES the watermark — so recomputing the
   // options on retry can silently change what retries. The failed attempt's
   // options are captured and reused instead.
@@ -246,8 +242,7 @@ describe('chainDiscoveryScanOptions', () => {
     expect(modes).toEqual(['seedFull', 'incremental', 'seedFull', 'seedFull']);
   });
 
-  // Review round 2 RED — the pin must be BOUNDED. Unbounded same-scan retry
-  // trades one liveness bug for another: a deterministically failing
+  // The pin must be BOUNDED. Unbounded same-scan retry trades one liveness bug for another: a deterministically failing
   // historical page would block incremental discovery of new blocks forever.
   it('a permanently failing seedFull releases its slot and incremental discovery continues', async () => {
     const modes: string[] = [];
@@ -307,10 +302,9 @@ describe('chainDiscoveryScanOptions', () => {
     expect(modes.slice(afterRecovery).every((m) => m === 'incremental')).toBe(true);
   });
 
-  // Review round 2 — state commits must be atomic with respect to logging: a
-  // throwing success-log used to advance `runs` AND re-pin the completed
-  // scan's options, so the next tick executed a stale scan under a new run
-  // number, and a throwing failure-log was misclassified as a probe failure.
+  // State commits are atomic with respect to logging: a throwing success-log
+  // must not advance `runs` while re-pinning a completed scan, and a throwing
+  // failure-log must not be misclassified as a probe failure.
   it('a throwing log sink cannot corrupt the scheduling state', async () => {
     const agent = {
       hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
@@ -337,16 +331,15 @@ describe('chainDiscoveryScanOptions', () => {
     });
   });
 
-  // Review round 2 RED — the extraction must not break the pre-existing
-  // import path: daemon/index.ts re-exports lifecycle wholesale, and this
+  // The extraction must not break the pre-existing import path: daemon/index.ts re-exports lifecycle wholesale, and this
   // test file itself imported from lifecycle.js before the move.
   it('the relocated scan APIs remain importable from lifecycle.js', () => {
     expect(reExportedOptions).toBe(chainDiscoveryScanOptions);
     expect(reExportedRunner).toBe(createChainDiscoveryScanRunner);
   });
 
-  // Review round 3 RED — a promise may legally reject with `undefined`; a
-  // sentinel comparison committed that as SUCCESS, consuming the slot (and
+  // A promise may legally reject with `undefined`; a sentinel comparison
+  // would commit that as SUCCESS, consuming the slot (and
   // able to clear an overdue resync no scan earned).
   it('a rejection carrying undefined is a failure, not a success', async () => {
     const agent = {
@@ -370,8 +363,7 @@ describe('chainDiscoveryScanOptions', () => {
     });
   });
 
-  // Review round 3 RED — the throwing-log-sink guarantee must hold on the
-  // FAILURE branch too: a failed scan whose failure line throws must neither
+  // The throwing-log-sink guarantee must hold on the FAILURE branch too: a failed scan whose failure line throws must neither
   // reject the timer callback nor lose its captured retry.
   it('a throwing log sink on the failure branch keeps the retry pinned and the runner resolved', async () => {
     const agent = {
@@ -394,12 +386,12 @@ describe('chainDiscoveryScanOptions', () => {
     });
   });
 
-  // Review round 3 — the overdue cadence is a TICK contract, and it must
+  // The overdue cadence is a TICK contract, and it must
   // hold even while incremental scans are themselves failing and retrying:
   // a failing incremental's retry cycle cannot postpone the owed resync.
   it('a DUE overdue resync fires even when the watermark probe is failing', async () => {
-    // Review round 4 — the probe is irrelevant to a due resync, so a probe
-    // outage must not be able to skip it.
+    // The probe is irrelevant to a due resync, so a probe outage must not
+    // be able to skip it.
     const modes: string[] = [];
     let probeHealthy = true;
     const agent = {
@@ -454,8 +446,8 @@ describe('chainDiscoveryScanOptions', () => {
   });
 });
 
-// Review round 3 — the policy is now two pure functions over a discriminated
-// state; pin the transition table directly, not only through tick sequences.
+// The policy is two pure functions over a discriminated state; pin the
+// transition table directly, not only through tick sequences.
 describe('scan scheduler transitions (GH#2323)', () => {
   const seedFull = { mode: 'seedFull', throwOnChainScanFailure: true } as const;
   const incremental = { mode: 'incremental', pageBudget: 30 } as const;
@@ -487,8 +479,8 @@ describe('scan scheduler transitions (GH#2323)', () => {
   });
 
   it('structurally copying a plan cannot reset its retry history', () => {
-    // Review round 4: commit must not depend on object identity with the
-    // scheduler's pin — the history travels IN the plan.
+    // Commit must not depend on object identity with the scheduler's pin —
+    // the history travels IN the plan.
     const failed = commitScanOutcome(plan(INITIAL_SCAN_SCHEDULER_STATE), { ok: false, error: 'e' });
     const step = planScan(failed.state);
     if (step.kind !== 'ready') throw new Error('pinned retry must be ready');

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  INITIAL_SCAN_SCHEDULER_STATE,
   MAX_CONSECUTIVE_SAME_SCAN_RETRIES,
   OVERDUE_FULL_RESYNC_RETRY_EVERY,
   chainDiscoveryScanOptions,
+  commitScanOutcome,
   createChainDiscoveryScanRunner,
+  planScan,
 } from '../src/daemon/chain-discovery-scan.js';
 import {
   chainDiscoveryScanOptions as reExportedOptions,
@@ -340,5 +343,149 @@ describe('chainDiscoveryScanOptions', () => {
   it('the relocated scan APIs remain importable from lifecycle.js', () => {
     expect(reExportedOptions).toBe(chainDiscoveryScanOptions);
     expect(reExportedRunner).toBe(createChainDiscoveryScanRunner);
+  });
+
+  // Review round 3 RED — a promise may legally reject with `undefined`; a
+  // sentinel comparison committed that as SUCCESS, consuming the slot (and
+  // able to clear an overdue resync no scan earned).
+  it('a rejection carrying undefined is a failure, not a success', async () => {
+    const agent = {
+      hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
+      discoverContextGraphsFromChain: vi
+        .fn<(options: ReturnType<typeof chainDiscoveryScanOptions>) => Promise<number>>()
+        .mockRejectedValueOnce(undefined)
+        .mockResolvedValueOnce(0),
+    };
+    const log = vi.fn();
+    const runner = createChainDiscoveryScanRunner({ agent, log });
+
+    await runner();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Chain scan run 0 (seedFull) failed'));
+    await runner();
+
+    // The slot was NOT consumed: the same seedFull retries.
+    expect(agent.discoverContextGraphsFromChain).toHaveBeenNthCalledWith(2, {
+      mode: 'seedFull',
+      throwOnChainScanFailure: true,
+    });
+  });
+
+  // Review round 3 RED — the throwing-log-sink guarantee must hold on the
+  // FAILURE branch too: a failed scan whose failure line throws must neither
+  // reject the timer callback nor lose its captured retry.
+  it('a throwing log sink on the failure branch keeps the retry pinned and the runner resolved', async () => {
+    const agent = {
+      hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
+      discoverContextGraphsFromChain: vi
+        .fn<(options: ReturnType<typeof chainDiscoveryScanOptions>) => Promise<number>>()
+        .mockRejectedValueOnce(new Error('rpc down'))
+        .mockResolvedValueOnce(0),
+    };
+    const log = vi.fn(() => { throw new Error('log sink broken'); });
+    const runner = createChainDiscoveryScanRunner({ agent, log });
+
+    await expect(runner()).resolves.toBeUndefined();
+    await runner();
+
+    // The captured seedFull retried; the broken sink changed nothing.
+    expect(agent.discoverContextGraphsFromChain).toHaveBeenNthCalledWith(2, {
+      mode: 'seedFull',
+      throwOnChainScanFailure: true,
+    });
+  });
+
+  // Review round 3 — the overdue cadence is a TICK contract, and it must
+  // hold even while incremental scans are themselves failing and retrying:
+  // a failing incremental's retry cycle cannot postpone the owed resync.
+  it('an overdue resync fires on schedule even while incremental scans fail', async () => {
+    const modes: string[] = [];
+    const agent = {
+      hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
+      discoverContextGraphsFromChain: vi.fn(
+        async (options: ReturnType<typeof chainDiscoveryScanOptions>) => {
+          modes.push(options.mode);
+          throw new Error('everything fails');
+        },
+      ),
+    };
+    const runner = createChainDiscoveryScanRunner({ agent, log: vi.fn() });
+
+    // Exhaust the startup seedFull: initial attempt + MAX retries.
+    for (let i = 0; i <= MAX_CONSECUTIVE_SAME_SCAN_RETRIES; i++) await runner();
+    const afterExhaustion = modes.length;
+
+    // Incrementals now fail too (getting pinned and retried). Exactly
+    // OVERDUE_FULL_RESYNC_RETRY_EVERY runner ticks later, the owed seedFull
+    // must fire — replacing the pinned incremental retry, which the full
+    // re-walk subsumes anyway.
+    for (let i = 0; i < OVERDUE_FULL_RESYNC_RETRY_EVERY; i++) await runner();
+    const window = modes.slice(afterExhaustion);
+    expect(window.slice(0, -1).every((m) => m === 'incremental')).toBe(true);
+    expect(window.at(-1)).toBe('seedFull');
+  });
+});
+
+// Review round 3 — the policy is now two pure functions over a discriminated
+// state; pin the transition table directly, not only through tick sequences.
+describe('scan scheduler transitions (GH#2323)', () => {
+  const seedFull = { mode: 'seedFull', throwOnChainScanFailure: true } as const;
+  const incremental = { mode: 'incremental', pageBudget: 30 } as const;
+
+  it('failure pins the executed scan; success releases the pin and advances the run', () => {
+    const planned = planScan(INITIAL_SCAN_SCHEDULER_STATE, true);
+    expect(planned.scan).toEqual(seedFull);
+
+    const failed = commitScanOutcome(planned.state, planned.scan, { ok: false, error: new Error('x') });
+    expect(failed.state).toEqual({ run: 0, pinned: { options: seedFull, failures: 1 } });
+    expect(failed.report.kind).toBe('retryScheduled');
+
+    const replanned = planScan(failed.state, /* probe irrelevant when pinned */ false);
+    expect(replanned.scan).toBe(failed.state.pinned!.options);
+
+    const succeeded = commitScanOutcome(replanned.state, replanned.scan, { ok: true, found: 0 });
+    expect(succeeded.state).toEqual({ run: 1 });
+    expect(succeeded.report.kind).toBe('quiet');
+  });
+
+  it('exhaustion of a seedFull releases the slot AND records the overdue resync', () => {
+    let state = INITIAL_SCAN_SCHEDULER_STATE;
+    for (let i = 0; i <= MAX_CONSECUTIVE_SAME_SCAN_RETRIES; i++) {
+      const planned = planScan(state, true);
+      state = commitScanOutcome(planned.state, planned.scan, { ok: false, error: 'e' }).state;
+    }
+    expect(state).toEqual({ run: 1, overdueResync: { ticksSinceAttempt: 0 } });
+  });
+
+  it('a non-seedFull success and a non-seedFull release both PRESERVE the overdue debt', () => {
+    const owing = { run: 3, overdueResync: { ticksSinceAttempt: 1 } };
+    const success = commitScanOutcome(owing, incremental, { ok: true, found: 0 });
+    expect(success.state.overdueResync).toEqual({ ticksSinceAttempt: 1 });
+    const exhausted = commitScanOutcome(
+      { ...owing, pinned: { options: incremental, failures: MAX_CONSECUTIVE_SAME_SCAN_RETRIES } },
+      incremental,
+      { ok: false, error: 'e' },
+    );
+    expect(exhausted.report.kind).toBe('slotReleased');
+    expect(exhausted.state.overdueResync).toEqual({ ticksSinceAttempt: 1 });
+  });
+
+  it('only a completed seedFull settles the overdue debt', () => {
+    const owing = { run: 3, overdueResync: { ticksSinceAttempt: 2 } };
+    const settled = commitScanOutcome(owing, seedFull, { ok: true, found: 0 });
+    expect(settled.state.overdueResync).toBeUndefined();
+  });
+
+  it('the owed resync never preempts a pinned seeding scan', () => {
+    const seeding = { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget: 30 } as const;
+    const state = {
+      run: 0,
+      pinned: { options: seeding, failures: 1 },
+      overdueResync: { ticksSinceAttempt: OVERDUE_FULL_RESYNC_RETRY_EVERY },
+    };
+    const planned = planScan(state, true);
+    // The bootstrap retry is the more specific recovery already in progress.
+    expect(planned.scan).toBe(state.pinned.options);
+    // The debt keeps aging rather than resetting from an attempt that never ran.
+    expect(planned.state.overdueResync!.ticksSinceAttempt).toBeGreaterThan(OVERDUE_FULL_RESYNC_RETRY_EVERY);
   });
 });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -96,54 +96,55 @@ describe('chainDiscoveryScanOptions', () => {
   // `discoverContextGraphsFromChain` must be swallowed and must clear the
   // `inFlight` guard via the `finally`, or the first transient RPC failure
   // would permanently disable every later scheduled scan.
-  it('swallows a rejected scan and still runs the next scheduled invocation', async () => {
+  // GH#2323 — these three tests DELIBERATELY flip the behaviour their
+  // predecessors pinned. The old runner consumed the run slot before any
+  // await (`const run = runs++`), so a rejected run-0 `seedFull` silently
+  // downgraded the startup recovery to `incremental` until run 48 — roughly
+  // 24h at the 30-minute cadence. The slot is now committed only when the
+  // scan resolves: a rejected scan retries the SAME run next tick.
+  it('retries a rejected startup-recovery seedFull on the next tick instead of degrading to incremental', async () => {
     const agent = {
       hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
       discoverContextGraphsFromChain: vi
         .fn<(options: ReturnType<typeof chainDiscoveryScanOptions>) => Promise<number>>()
         .mockRejectedValueOnce(new Error('chain RPC unavailable'))
-        .mockResolvedValueOnce(3),
+        .mockResolvedValueOnce(3)
+        .mockResolvedValueOnce(0),
     };
     const log = vi.fn();
     const runner = createChainDiscoveryScanRunner({ agent, log });
 
+    // Tick 1: run-0 seedFull rejects. Not silent any more — the operator can
+    // see the recovery scan failed and that it will be retried.
     await expect(runner()).resolves.toBeUndefined();
-    expect(agent.discoverContextGraphsFromChain).toHaveBeenCalledTimes(1);
-    expect(log).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Chain scan run 0 (seedFull) failed'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('chain RPC unavailable'));
 
+    // Tick 2: the SAME run retries — still seedFull, the missed history walk
+    // actually happens. Tick 3: only now does the counter advance.
+    await runner();
     await runner();
 
-    expect(agent.hasContextGraphRegistryScanWatermark).toHaveBeenCalledTimes(2);
-    expect(agent.discoverContextGraphsFromChain).toHaveBeenCalledTimes(2);
-    expect(log).toHaveBeenCalledWith('Chain scan: discovered 3 new context graph(s)');
-
-    // Pin WHICH scan each call was, not just that two happened — asserting
-    // counts alone passes identically whether the retry recovers the missed
-    // work or silently degrades (PR #2132 review).
-    //
-    // `const run = runs++` sits at lifecycle.ts:740, BEFORE either await, so a
-    // rejection still consumes the run slot. Call 1 is run 0 with the
-    // watermark seeded => the `seedFull` startup-recovery scan. Call 2 is
-    // run 1, and 1 % CHAIN_FULL_SCAN_EVERY (48) !== 0, so it is `incremental`:
-    // the failed full-history scan is NOT re-attempted. The next `seedFull` is
-    // run 48, roughly 24h out at the 30-minute cadence.
-    //
-    // This documents current behaviour rather than endorsing it — whether the
-    // consumed run slot is a defect or intended backoff is tracked separately.
     expect(agent.discoverContextGraphsFromChain).toHaveBeenNthCalledWith(1, {
       mode: 'seedFull',
       throwOnChainScanFailure: true,
     });
     expect(agent.discoverContextGraphsFromChain).toHaveBeenNthCalledWith(2, {
+      mode: 'seedFull',
+      throwOnChainScanFailure: true,
+    });
+    expect(agent.discoverContextGraphsFromChain).toHaveBeenNthCalledWith(3, {
       mode: 'incremental',
       pageBudget: 30,
     });
+    expect(log).toHaveBeenCalledWith('Chain scan: discovered 3 new context graph(s)');
   });
 
   // A rejection from the watermark probe happens before
   // `discoverContextGraphsFromChain` is reached, so it takes a different path
-  // out of the `try` — it must clear `inFlight` just the same.
-  it('swallows a rejected watermark probe and still runs the next scheduled invocation', async () => {
+  // out of the `try` — it must clear `inFlight` just the same, and (GH#2323)
+  // it must not consume the slot either.
+  it('a rejected watermark probe does not consume run 0 — the next tick still issues the startup seedFull', async () => {
     const agent = {
       hasContextGraphRegistryScanWatermark: vi
         .fn<() => Promise<boolean>>()
@@ -154,22 +155,46 @@ describe('chainDiscoveryScanOptions', () => {
           async () => 0,
         ),
     };
-    const runner = createChainDiscoveryScanRunner({ agent, log: vi.fn() });
+    const log = vi.fn();
+    const runner = createChainDiscoveryScanRunner({ agent, log });
 
     await expect(runner()).resolves.toBeUndefined();
     expect(agent.discoverContextGraphsFromChain).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('watermark probe failed'));
 
     await runner();
 
     expect(agent.hasContextGraphRegistryScanWatermark).toHaveBeenCalledTimes(2);
     expect(agent.discoverContextGraphsFromChain).toHaveBeenCalledTimes(1);
 
-    // The probe rejection also consumed run 0, so the one scan that does reach
-    // the agent is run 1 => `incremental`, not the `seedFull` a fresh startup
-    // would have issued. Same run-slot accounting as the test above.
+    // Run 0 survived the probe failure, so the scan that reaches the agent is
+    // the seedFull startup recovery a fresh boot owes — not incremental.
     expect(agent.discoverContextGraphsFromChain).toHaveBeenNthCalledWith(1, {
-      mode: 'incremental',
-      pageBudget: 30,
+      mode: 'seedFull',
+      throwOnChainScanFailure: true,
     });
+  });
+
+  it('a failed periodic full resync retries in one tick, not one day', async () => {
+    // fullScanEvery=2 reaches the periodic seedFull quickly: run 0 seedFull,
+    // run 1 incremental, run 2 seedFull (2 % 2 === 0).
+    const agent = {
+      hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
+      discoverContextGraphsFromChain: vi
+        .fn<(options: ReturnType<typeof chainDiscoveryScanOptions>) => Promise<number>>()
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(0)
+        .mockRejectedValueOnce(new Error('rpc flake'))
+        .mockResolvedValueOnce(0),
+    };
+    const runner = createChainDiscoveryScanRunner({ agent, log: vi.fn(), fullScanEvery: 2 });
+
+    await runner(); // run 0 seedFull, ok
+    await runner(); // run 1 incremental, ok
+    await runner(); // run 2 seedFull, REJECTED — slot must survive
+    await runner(); // run 2 again, seedFull, ok
+
+    const modes = agent.discoverContextGraphsFromChain.mock.calls.map((c) => c[0]!.mode);
+    expect(modes).toEqual(['seedFull', 'incremental', 'seedFull', 'seedFull']);
   });
 });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
-import { chainDiscoveryScanOptions, createChainDiscoveryScanRunner } from '../src/daemon/chain-discovery-scan.js';
+import {
+  MAX_CONSECUTIVE_SAME_SCAN_RETRIES,
+  OVERDUE_FULL_RESYNC_RETRY_EVERY,
+  chainDiscoveryScanOptions,
+  createChainDiscoveryScanRunner,
+} from '../src/daemon/chain-discovery-scan.js';
+import {
+  chainDiscoveryScanOptions as reExportedOptions,
+  createChainDiscoveryScanRunner as reExportedRunner,
+} from '../src/daemon/lifecycle.js';
 
 describe('chainDiscoveryScanOptions', () => {
   it('uses bounded cursor-resumable watermark seeding before a seed exists', () => {
@@ -232,5 +241,104 @@ describe('chainDiscoveryScanOptions', () => {
 
     const modes = agent.discoverContextGraphsFromChain.mock.calls.map((c) => c[0]!.mode);
     expect(modes).toEqual(['seedFull', 'incremental', 'seedFull', 'seedFull']);
+  });
+
+  // Review round 2 RED — the pin must be BOUNDED. Unbounded same-scan retry
+  // trades one liveness bug for another: a deterministically failing
+  // historical page would block incremental discovery of new blocks forever.
+  it('a permanently failing seedFull releases its slot and incremental discovery continues', async () => {
+    const modes: string[] = [];
+    const agent = {
+      hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
+      discoverContextGraphsFromChain: vi.fn(
+        async (options: ReturnType<typeof chainDiscoveryScanOptions>) => {
+          modes.push(options.mode);
+          if (options.mode === 'seedFull') throw new Error('historical page 404s deterministically');
+          return 0;
+        },
+      ),
+    };
+    const log = vi.fn();
+    const runner = createChainDiscoveryScanRunner({ agent, log });
+
+    // Initial attempt + MAX consecutive retries, all seedFull, all failing.
+    for (let i = 0; i <= MAX_CONSECUTIVE_SAME_SCAN_RETRIES; i++) await runner();
+    expect(modes).toEqual(Array(MAX_CONSECUTIVE_SAME_SCAN_RETRIES + 1).fill('seedFull'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('releasing the slot so discovery continues'));
+
+    // Liveness: the very next tick is a normal incremental scan.
+    await runner();
+    expect(modes.at(-1)).toBe('incremental');
+
+    // The resync is scheduled, not forgotten: after
+    // OVERDUE_FULL_RESYNC_RETRY_EVERY incremental-cadence ticks, a fresh
+    // seedFull attempt is injected in place of one of them.
+    for (let i = 1; i < OVERDUE_FULL_RESYNC_RETRY_EVERY; i++) await runner();
+    expect(modes.at(-1)).toBe('seedFull');
+    expect(modes.filter((m) => m === 'incremental').length).toBe(OVERDUE_FULL_RESYNC_RETRY_EVERY - 1);
+  });
+
+  it('an overdue full resync clears once an injected attempt succeeds', async () => {
+    let seedFullFails = true;
+    const modes: string[] = [];
+    const agent = {
+      hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
+      discoverContextGraphsFromChain: vi.fn(
+        async (options: ReturnType<typeof chainDiscoveryScanOptions>) => {
+          modes.push(options.mode);
+          if (options.mode === 'seedFull' && seedFullFails) throw new Error('flaky RPC');
+          return 0;
+        },
+      ),
+    };
+    const runner = createChainDiscoveryScanRunner({ agent, log: vi.fn() });
+
+    for (let i = 0; i <= MAX_CONSECUTIVE_SAME_SCAN_RETRIES; i++) await runner(); // exhaust
+    seedFullFails = false;
+    for (let i = 0; i < OVERDUE_FULL_RESYNC_RETRY_EVERY; i++) await runner();    // ...injected attempt succeeds
+    expect(modes.at(-1)).toBe('seedFull');
+    const afterRecovery = modes.length;
+
+    // Overdue cleared: a long quiet stretch stays purely incremental.
+    for (let i = 0; i < 2 * OVERDUE_FULL_RESYNC_RETRY_EVERY; i++) await runner();
+    expect(modes.slice(afterRecovery).every((m) => m === 'incremental')).toBe(true);
+  });
+
+  // Review round 2 — state commits must be atomic with respect to logging: a
+  // throwing success-log used to advance `runs` AND re-pin the completed
+  // scan's options, so the next tick executed a stale scan under a new run
+  // number, and a throwing failure-log was misclassified as a probe failure.
+  it('a throwing log sink cannot corrupt the scheduling state', async () => {
+    const agent = {
+      hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
+      discoverContextGraphsFromChain: vi
+        .fn<(options: ReturnType<typeof chainDiscoveryScanOptions>) => Promise<number>>()
+        .mockResolvedValueOnce(1)   // run 0 seedFull SUCCEEDS, but the log throws
+        .mockResolvedValueOnce(0),
+    };
+    const log = vi.fn(() => { throw new Error('log sink broken'); });
+    const runner = createChainDiscoveryScanRunner({ agent, log });
+
+    await expect(runner()).resolves.toBeUndefined();
+    await runner();
+
+    // Run 0 completed and committed; run 1 must be a FRESH incremental scan,
+    // not the pinned replay of the already-successful seedFull.
+    expect(agent.discoverContextGraphsFromChain).toHaveBeenNthCalledWith(1, {
+      mode: 'seedFull',
+      throwOnChainScanFailure: true,
+    });
+    expect(agent.discoverContextGraphsFromChain).toHaveBeenNthCalledWith(2, {
+      mode: 'incremental',
+      pageBudget: 30,
+    });
+  });
+
+  // Review round 2 RED — the extraction must not break the pre-existing
+  // import path: daemon/index.ts re-exports lifecycle wholesale, and this
+  // test file itself imported from lifecycle.js before the move.
+  it('the relocated scan APIs remain importable from lifecycle.js', () => {
+    expect(reExportedOptions).toBe(chainDiscoveryScanOptions);
+    expect(reExportedRunner).toBe(createChainDiscoveryScanRunner);
   });
 });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -458,6 +458,44 @@ describe('createChainDiscoveryScanRunner (GH#2323)', () => {
     expect(window.at(-1)).toBe('seedFull');
   });
 
+  // The overdue debt must age even on ticks whose probe FAILS — otherwise
+  // four consecutive probe failures postpone the probe-independent resync
+  // forever, in exactly the store outage it exists to recover from.
+  it('a failing probe cannot postpone the overdue resync past its cadence', async () => {
+    const modes: string[] = [];
+    let probeHealthy = true;
+    let probeCalls = 0;
+    const agent = {
+      hasContextGraphRegistryScanWatermark: vi.fn(async () => {
+        probeCalls += 1;
+        if (!probeHealthy) throw new Error('registry store unavailable');
+        return true;
+      }),
+      discoverContextGraphsFromChain: vi.fn(
+        async (options: ReturnType<typeof chainDiscoveryScanOptions>) => {
+          modes.push(options.mode);
+          if (options.mode === 'seedFull' && probeHealthy === false) return 0;
+          if (options.mode === 'seedFull') throw new Error('flaky RPC');
+          return 0;
+        },
+      ),
+    };
+    const runner = createChainDiscoveryScanRunner({ agent, log: vi.fn() });
+
+    // Exhaust the startup seedFull, recording the overdue debt.
+    for (let i = 0; i <= MAX_CONSECUTIVE_SAME_SCAN_RETRIES; i++) await runner();
+    // The probe now fails on EVERY tick. Ticks 1..3 skip but must age the
+    // debt; the 4th tick is due — and a due resync needs no probe at all.
+    probeHealthy = false;
+    const probeCallsAtOutage = probeCalls;
+    for (let i = 1; i < OVERDUE_FULL_RESYNC_RETRY_EVERY; i++) await runner();
+    expect(modes.filter((m) => m === 'incremental')).toHaveLength(0);
+    await runner();
+    expect(modes.at(-1)).toBe('seedFull');
+    // The due tick executed WITHOUT probing.
+    expect(probeCalls).toBe(probeCallsAtOutage + OVERDUE_FULL_RESYNC_RETRY_EVERY - 1);
+  });
+
   // A rejection VALUE is arbitrary: `Object.create(null)` has no toString
   // and a poisoned toString throws during formatting. The lifecycle hands
   // this runner to a timer with no rejection handler, so a throw escaping

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -448,6 +448,49 @@ describe('chainDiscoveryScanOptions', () => {
 
 // The policy is two pure functions over a discriminated state; pin the
 // transition table directly, not only through tick sequences.
+  // A rejection VALUE is arbitrary: `Object.create(null)` has no toString
+  // and a poisoned toString throws during formatting. The lifecycle hands
+  // this runner to a timer with no rejection handler, so a throw escaping
+  // here is an unhandled rejection — potentially fatal to the daemon.
+  it('rejection values that cannot be formatted neither crash the runner nor lose the retry', async () => {
+    for (const poison of [
+      Object.create(null),
+      { toString() { throw new Error('bad coercion'); } },
+    ]) {
+      const agent = {
+        hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
+        discoverContextGraphsFromChain: vi
+          .fn<(options: ReturnType<typeof chainDiscoveryScanOptions>) => Promise<number>>()
+          .mockRejectedValueOnce(poison)
+          .mockResolvedValueOnce(0),
+      };
+      const log = vi.fn();
+      const runner = createChainDiscoveryScanRunner({ agent, log });
+
+      await expect(runner()).resolves.toBeUndefined();
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('Chain scan run 0 (seedFull) failed'));
+      await runner();
+      expect(agent.discoverContextGraphsFromChain).toHaveBeenNthCalledWith(2, {
+        mode: 'seedFull',
+        throwOnChainScanFailure: true,
+      });
+    }
+  });
+
+  it('a probe rejecting with an unformattable value still resolves and logs the skip', async () => {
+    const agent = {
+      hasContextGraphRegistryScanWatermark: vi
+        .fn<() => Promise<boolean>>()
+        .mockRejectedValueOnce(Object.create(null)),
+      discoverContextGraphsFromChain: vi.fn(async () => 0),
+    };
+    const log = vi.fn();
+    const runner = createChainDiscoveryScanRunner({ agent, log });
+    await expect(runner()).resolves.toBeUndefined();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('watermark probe failed'));
+    expect(agent.discoverContextGraphsFromChain).not.toHaveBeenCalled();
+  });
+
 describe('scan scheduler transitions (GH#2323)', () => {
   const seedFull = { mode: 'seedFull', throwOnChainScanFailure: true } as const;
   const incremental = { mode: 'incremental', pageBudget: 30 } as const;


### PR DESCRIPTION
## Summary

`createChainDiscoveryScanRunner` incremented its run counter **before either await** (`const run = runs++`), and the run number is what selects the scan mode (`run === 0` or `run % 48 === 0` ⇒ `seedFull`). So a rejected scan still burned its slot — and the rejection is reachable in production exactly from the scans that matter, because only `seedFull`/`seedFromCursor` set `throwOnChainScanFailure`.

**Consequence (#2323):** a daemon boots with a seeded watermark; the run-0 `seedFull` startup-recovery scan fires at +15s and rejects on a transient RPC error; runs 1..47 all issue `incremental` scans that resume from the watermark and never re-walk history. The next `seedFull` is run 48 — **~24 hours later** at the 30-minute cadence — and the `catch` was silent, so the log never said any of this happened. A rejected watermark probe consumed run 0 the same way.

## Fix

Commit the slot only when the scan **resolves**. A rejected scan (or probe) retries the *same* run next tick — a failed full scan re-runs in 30 minutes, not a day. Both failure paths now log with run number and mode; "non-critical" no longer means "invisible".

Retry semantics note: a *persistently* failing seedFull now retries seedFull every tick rather than degrading to incremental. That's deliberate — the degraded mode was the bug, and the failure is now visible to operators either way.

## Testing

The three tests that previously **pinned** the consumed-slot behaviour did so deliberately (PR #2132 review: *"a fix will show up as a deliberate test change rather than a silent behaviour flip"*) — this PR is that deliberate change. Flipped to the new semantics plus a periodic-resync case (`fullScanEvery: 2`: `seedFull, incremental, seedFull-rejected, seedFull-retried`).

Mutation-verified:
| mutant | killed by |
|---|---|
| revert to `runs++` before the awaits | 3 tests |
| commit the slot on failure too | 2 tests |
| remove the failure log (silent again) | 1 test |

Full `packages/cli`: 252 files / 3717 tests green (serialized run).

Closes #2323

🤖 Generated with [Claude Code](https://claude.com/claude-code)
