### PR TITLE
perf(agent): carry graph membership snapshot to canary

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -89,6 +89,7 @@
   "scripts": {
     "build": "tsc && pnpm run test:types && pnpm run test:package-root",
     "benchmark:code-point-comparator": "pnpm run build && node --expose-gc scripts/code-point-comparator-benchmark.cjs",
+    "benchmark:graph-membership-snapshot": "pnpm run build && node --expose-gc scripts/graph-membership-snapshot-benchmark.cjs",
     "benchmark:sync-responder-pages": "node --expose-gc scripts/sync-responder-page-benchmark.cjs",
     "benchmark:sync-worker": "node scripts/sync-worker-benchmark.cjs",
     "benchmark:sync-worker-responsiveness": "node scripts/sync-worker-responsiveness-benchmark.cjs",

--- a/packages/agent/scripts/graph-membership-snapshot-benchmark.cjs
+++ b/packages/agent/scripts/graph-membership-snapshot-benchmark.cjs
@@ -1,0 +1,167 @@
+const { spawnSync } = require('node:child_process');
+const { performance } = require('node:perf_hooks');
+
+const DEFAULT_SIZES = [10_000, 50_000];
+const DEFAULT_QUERIES = 200;
+const DEFAULT_TRIALS = 3;
+
+function positiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function makeGraphs(count) {
+  const familyCount = Math.max(1, Math.ceil(count / 100));
+  const graphs = Array.from({ length: count }, (_, index) => {
+    const family = String(index % familyCount).padStart(6, '0');
+    const ordinal = String(Math.floor(index / familyCount)).padStart(6, '0');
+    return `did:dkg:context-graph:benchmark-${family}/_shared_memory/0x${'a'.repeat(40)}/${ordinal}`;
+  });
+  return { graphs, familyCount };
+}
+
+function fingerprintSelection(hash, graphs) {
+  let next = hash;
+  for (const graph of graphs) {
+    for (let index = 0; index < graph.length; index += 1) {
+      next ^= graph.charCodeAt(index);
+      next = Math.imul(next, 16777619);
+    }
+  }
+  return next >>> 0;
+}
+
+async function runWorker(mode, graphCount, queryCount) {
+  if (typeof global.gc !== 'function') throw new Error('Run with --expose-gc');
+  const { compareCodePoint } = await import('../dist/sync/code-point-order.js');
+  const { createGraphMembershipSnapshot } = await import('../dist/sync/graph-membership-snapshot.js');
+  const { graphs: unsorted, familyCount } = makeGraphs(graphCount);
+  const graphs = [...unsorted].sort(compareCodePoint);
+  const snapshot = createGraphMembershipSnapshot(graphs);
+  const roots = Array.from({ length: queryCount }, (_, index) => (
+    `did:dkg:context-graph:benchmark-${String((index * 97) % familyCount).padStart(6, '0')}`
+  ));
+  const select = mode === 'scan'
+    ? (root) => graphs
+      .filter((graph) => graph === root || graph.startsWith(`${root}/`))
+      .sort(compareCodePoint)
+    : (root) => snapshot.equalOrUnder(root);
+
+  for (const root of roots.slice(0, 20)) select(root);
+  global.gc();
+
+  let fingerprint = 2166136261;
+  let selectedGraphs = 0;
+  const startedAt = performance.now();
+  for (const root of roots) {
+    const selected = select(root);
+    selectedGraphs += selected.length;
+    fingerprint = fingerprintSelection(fingerprint, selected);
+  }
+  const durationMs = performance.now() - startedAt;
+  return {
+    mode,
+    graphCount,
+    queryCount,
+    durationMs,
+    selectedGraphs,
+    fullListEntriesInspected: mode === 'scan' ? graphCount * queryCount : 0,
+    fingerprint: fingerprint.toString(16).padStart(8, '0'),
+  };
+}
+
+function isolatedTrial(mode, graphCount, queryCount) {
+  const child = spawnSync(
+    process.execPath,
+    ['--expose-gc', '--max-old-space-size=512', __filename, '--worker', mode, String(graphCount), String(queryCount)],
+    { encoding: 'utf8', maxBuffer: 1024 * 1024 },
+  );
+  if (child.status !== 0) {
+    throw new Error(`benchmark worker failed for mode=${mode}\n${child.stderr || child.stdout}`);
+  }
+  return JSON.parse(child.stdout);
+}
+
+function median(values) {
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+function controller() {
+  const sizesArgument = process.argv.find((argument) => argument.startsWith('--sizes='));
+  const queriesArgument = process.argv.find((argument) => argument.startsWith('--queries='));
+  const trialsArgument = process.argv.find((argument) => argument.startsWith('--trials='));
+  const sizes = sizesArgument
+    ? sizesArgument.slice('--sizes='.length).split(',').map((value) => positiveInteger(value, 0)).filter(Boolean)
+    : DEFAULT_SIZES;
+  const queryCount = positiveInteger(queriesArgument?.slice('--queries='.length), DEFAULT_QUERIES);
+  const trialCount = positiveInteger(trialsArgument?.slice('--trials='.length), DEFAULT_TRIALS);
+  const results = [];
+
+  for (const graphCount of sizes) {
+    const scanTrials = [];
+    const snapshotTrials = [];
+    for (let trial = 0; trial < trialCount; trial += 1) {
+      const modes = trial % 2 === 0 ? ['scan', 'snapshot'] : ['snapshot', 'scan'];
+      for (const mode of modes) {
+        const result = isolatedTrial(mode, graphCount, queryCount);
+        (mode === 'scan' ? scanTrials : snapshotTrials).push(result);
+      }
+    }
+    const scanMs = median(scanTrials.map((trial) => trial.durationMs));
+    const snapshotMs = median(snapshotTrials.map((trial) => trial.durationMs));
+    if (
+      scanTrials.some((trial) => trial.fingerprint !== scanTrials[0].fingerprint)
+      || snapshotTrials.some((trial) => trial.fingerprint !== scanTrials[0].fingerprint)
+      || snapshotTrials[0].selectedGraphs !== scanTrials[0].selectedGraphs
+    ) {
+      throw new Error(`scan/snapshot selection mismatch for ${graphCount} graphs`);
+    }
+    results.push({
+      graphCount,
+      queryCount,
+      scanMs,
+      snapshotMs,
+      speedup: scanMs / snapshotMs,
+      selectedGraphs: scanTrials[0].selectedGraphs,
+      scanEntries: scanTrials[0].fullListEntriesInspected,
+      fingerprint: scanTrials[0].fingerprint,
+    });
+  }
+
+  console.log('Graph membership prefix-range benchmark');
+  console.log(`Node ${process.version}; ${queryCount} queries; ${trialCount} isolated trial(s) per mode`);
+  console.log('');
+  console.log('| Graphs | Queries | Full scan median | Snapshot median | Speedup | Full-list entries avoided |');
+  console.log('| ---: | ---: | ---: | ---: | ---: | ---: |');
+  for (const result of results) {
+    console.log(
+      `| ${result.graphCount.toLocaleString()} | ${result.queryCount.toLocaleString()} | `
+      + `${result.scanMs.toFixed(2)} ms | ${result.snapshotMs.toFixed(2)} ms | `
+      + `${result.speedup.toFixed(1)}x | ${result.scanEntries.toLocaleString()} |`,
+    );
+  }
+  console.log('');
+  console.log(JSON.stringify({ node: process.version, trialCount, results }, null, 2));
+}
+
+if (process.argv[2] === '--worker') {
+  runWorker(
+    process.argv[3],
+    positiveInteger(process.argv[4], 0),
+    positiveInteger(process.argv[5], DEFAULT_QUERIES),
+  ).then(
+    (result) => process.stdout.write(JSON.stringify(result)),
+    (error) => {
+      console.error(error);
+      process.exitCode = 1;
+    },
+  );
+} else {
+  try {
+    controller();
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  }
+}

--- a/packages/agent/src/sync/graph-membership-snapshot.ts
+++ b/packages/agent/src/sync/graph-membership-snapshot.ts
@@ -32,21 +32,40 @@ export function createGraphMembershipSnapshot(
   sourceGraphs: readonly string[],
 ): GraphMembershipSnapshot {
   const graphs = Object.freeze([...new Set(sourceGraphs)].sort(compareCodePoint));
-  const membership = new Set(graphs);
+  const membershipIndex = new Map<string, number>();
+  for (let index = 0; index < graphs.length; index += 1) {
+    membershipIndex.set(graphs[index]!, index);
+  }
+  // Reuse one mark table for allocation-free membership equality checks. JS is
+  // single-threaded between these synchronous operations, so one monotonically
+  // stamped table also detects duplicate entries in a fresh graph listing.
+  const matchMarks = new Uint32Array(graphs.length);
+  let matchEpoch = 0;
+  const matches = (candidates: readonly string[]): boolean => {
+    if (candidates.length !== graphs.length) return false;
+    matchEpoch = (matchEpoch + 1) >>> 0;
+    if (matchEpoch === 0) {
+      matchMarks.fill(0);
+      matchEpoch = 1;
+    }
+    for (const graph of candidates) {
+      const index = membershipIndex.get(graph);
+      if (index === undefined || matchMarks[index] === matchEpoch) return false;
+      matchMarks[index] = matchEpoch;
+    }
+    return true;
+  };
   const snapshot: GraphMembershipSnapshot = Object.freeze({
     graphs,
     size: graphs.length,
-    has: (graph: string) => membership.has(graph),
-    matches: (candidates: readonly string[]) => (
-      candidates.length === graphs.length
-      && candidates.every((graph) => membership.has(graph))
-    ),
+    has: (graph: string) => membershipIndex.has(graph),
+    matches,
     equalOrUnder: (
       graph: string,
       accept: (candidate: string) => boolean = acceptEveryGraph,
     ): string[] => {
       const selected: string[] = [];
-      if (membership.has(graph) && accept(graph)) selected.push(graph);
+      if (membershipIndex.has(graph) && accept(graph)) selected.push(graph);
 
       const prefix = `${graph}/`;
       for (let index = lowerBound(graphs, prefix); index < graphs.length; index += 1) {

--- a/packages/agent/src/sync/graph-membership-snapshot.ts
+++ b/packages/agent/src/sync/graph-membership-snapshot.ts
@@ -1,0 +1,72 @@
+import { compareCodePoint } from './code-point-order.js';
+
+export interface GraphMembershipSnapshot {
+  /** Immutable, unique graph names in protocol code-point order. */
+  readonly graphs: readonly string[];
+  readonly size: number;
+  has(graph: string): boolean;
+  /** True when `graphs` describes the same membership, regardless of order. */
+  matches(graphs: readonly string[]): boolean;
+  /** Select an exact graph plus descendants below `${graph}/`. */
+  equalOrUnder(
+    graph: string,
+    accept?: (candidate: string) => boolean,
+  ): string[];
+}
+
+const snapshotByGraphArray = new WeakMap<readonly string[], GraphMembershipSnapshot>();
+const acceptEveryGraph = () => true;
+
+function lowerBound(graphs: readonly string[], target: string): number {
+  let low = 0;
+  let high = graphs.length;
+  while (low < high) {
+    const middle = low + Math.floor((high - low) / 2);
+    if (compareCodePoint(graphs[middle]!, target) < 0) low = middle + 1;
+    else high = middle;
+  }
+  return low;
+}
+
+export function createGraphMembershipSnapshot(
+  sourceGraphs: readonly string[],
+): GraphMembershipSnapshot {
+  const graphs = Object.freeze([...new Set(sourceGraphs)].sort(compareCodePoint));
+  const membership = new Set(graphs);
+  const snapshot: GraphMembershipSnapshot = Object.freeze({
+    graphs,
+    size: graphs.length,
+    has: (graph: string) => membership.has(graph),
+    matches: (candidates: readonly string[]) => (
+      candidates.length === graphs.length
+      && candidates.every((graph) => membership.has(graph))
+    ),
+    equalOrUnder: (
+      graph: string,
+      accept: (candidate: string) => boolean = acceptEveryGraph,
+    ): string[] => {
+      const selected: string[] = [];
+      if (membership.has(graph) && accept(graph)) selected.push(graph);
+
+      const prefix = `${graph}/`;
+      for (let index = lowerBound(graphs, prefix); index < graphs.length; index += 1) {
+        const candidate = graphs[index]!;
+        if (!candidate.startsWith(prefix)) break;
+        if (accept(candidate)) selected.push(candidate);
+      }
+      return selected;
+    },
+  });
+  snapshotByGraphArray.set(graphs, snapshot);
+  return snapshot;
+}
+
+/**
+ * Recover the index attached to a responder memo result. Direct callers that
+ * supply an ordinary array receive an equivalent one-shot snapshot.
+ */
+export function graphMembershipSnapshotFor(
+  graphs: readonly string[],
+): GraphMembershipSnapshot {
+  return snapshotByGraphArray.get(graphs) ?? createGraphMembershipSnapshot(graphs);
+}

--- a/packages/agent/src/sync/graph-membership-snapshot.ts
+++ b/packages/agent/src/sync/graph-membership-snapshot.ts
@@ -14,7 +14,6 @@ export interface GraphMembershipSnapshot {
   ): string[];
 }
 
-const snapshotByGraphArray = new WeakMap<readonly string[], GraphMembershipSnapshot>();
 const acceptEveryGraph = () => true;
 
 function lowerBound(graphs: readonly string[], target: string): number {
@@ -76,16 +75,5 @@ export function createGraphMembershipSnapshot(
       return selected;
     },
   });
-  snapshotByGraphArray.set(graphs, snapshot);
   return snapshot;
-}
-
-/**
- * Recover the index attached to a responder memo result. Direct callers that
- * supply an ordinary array receive an equivalent one-shot snapshot.
- */
-export function graphMembershipSnapshotFor(
-  graphs: readonly string[],
-): GraphMembershipSnapshot {
-  return snapshotByGraphArray.get(graphs) ?? createGraphMembershipSnapshot(graphs);
 }

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -39,6 +39,11 @@ import { exactAssetFilterKey } from '../exact-assets.js';
 import { isIriTerm } from '../iri-term.js';
 import type { ExactGraphReadMode } from './durable-data-request-policy.js';
 import { compareCodePoint } from '../code-point-order.js';
+import {
+  createGraphMembershipSnapshot,
+  graphMembershipSnapshotFor,
+  type GraphMembershipSnapshot,
+} from '../graph-membership-snapshot.js';
 
 export {
   createResponderSyncRowListMemo,
@@ -264,13 +269,14 @@ export function createResponderGraphListMemo(
     }
     return current !== undefined && stored !== current;
   };
+  let lastSnapshot: GraphMembershipSnapshot | null = null;
   let cached: {
-    value: readonly string[];
+    value: GraphMembershipSnapshot;
     cachedAt: number;
     revision: Revision;
   } | null = null;
   let inflight: {
-    promise: Promise<readonly string[]>;
+    promise: Promise<GraphMembershipSnapshot>;
     revision: Revision;
   } | null = null;
   return {
@@ -287,7 +293,7 @@ export function createResponderGraphListMemo(
         // identity. Concurrent reads at the same unstable generation share
         // one enumeration; the result is simply discarded for later callers.
         if (!supersedesInflight(pending.revision, revision)) {
-          return [...(await raceAgainstAbort(pending.promise, options?.signal))];
+          return (await raceAgainstAbort(pending.promise, options?.signal)).graphs;
         }
         try {
           await raceAgainstAbort(pending.promise, options?.signal);
@@ -302,19 +308,26 @@ export function createResponderGraphListMemo(
         cached &&
         now - cached.cachedAt < ttlMs &&
         (!options?.refresh || (writeRevisionSource !== null && isWriteRevision(revision) && revision.stable))
-      ) return [...cached.value];
+      ) return cached.value.graphs;
       // This load is shared by concurrent responders. Do not bind it to the
       // first stream's abort signal; waiters race their own abort locally via
       // raceAgainstAbort/throwIfAborted below.
       const load = store.listGraphs(syncResponderStoreOptions(undefined, 'sync.responder.listGraphs'))
         .then((graphs) => {
-          const sorted = [...new Set(graphs)].sort(compareCodePoint);
+          // Content writes advance the store revision even when named-graph
+          // membership is unchanged. Reuse the immutable index in that case:
+          // enumeration stays freshness-safe, while sorting, Set construction,
+          // and every downstream membership index remain stable.
+          const snapshot = lastSnapshot?.matches(graphs)
+            ? lastSnapshot
+            : createGraphMembershipSnapshot(graphs);
+          lastSnapshot = snapshot;
           cached = {
-            value: sorted,
+            value: snapshot,
             cachedAt: Date.now(),
             revision,
           };
-          return sorted;
+          return snapshot;
         })
         .finally(() => {
           if (inflight?.promise === load) inflight = null;
@@ -323,9 +336,9 @@ export function createResponderGraphListMemo(
         promise: load,
         revision,
       };
-      const graphs = await load;
+      const snapshot = await load;
       throwIfAborted(options?.signal);
-      return [...graphs];
+      return snapshot.graphs;
     },
   };
 }
@@ -815,8 +828,8 @@ export async function readSwmMetaPage(params: {
   freshMetaPlanMemo?: FreshSwmMetaPlanMemo;
 }): Promise<SyncRow[]> {
   const graphs = swmGraphsForRegisteredSubGraphs(params.contextGraphId, params.registeredSubGraphNames, true);
-  const graphSet = new Set(params.graphList);
-  const candidateGraphs = graphs.filter((graph) => graphSet.has(graph));
+  const graphMembership = graphMembershipSnapshotFor(params.graphList);
+  const candidateGraphs = graphs.filter((graph) => graphMembership.has(graph));
   const cache = params.rowListMemo && params.rowListCacheKey
     ? {
       memo: params.rowListMemo,
@@ -939,10 +952,11 @@ export async function readSwmDataPage(params: {
   exactGraphPlanMemo?: ExactGraphPagePlanMemo;
 }): Promise<SyncRow[]> {
   const dataGraphs = swmGraphsForRegisteredSubGraphs(params.contextGraphId, params.registeredSubGraphNames, false);
-  const graphSet = new Set(params.graphList);
-  const candidateGraphsFor = (graph: string) => params.graphList
-    .filter((candidate) => candidate === graph || isSharedMemoryBucketDescendantDataGraph(candidate, graph))
-    .sort(compareCodePoint);
+  const graphMembership = graphMembershipSnapshotFor(params.graphList);
+  const candidateGraphsFor = (graph: string) => graphMembership.equalOrUnder(
+    graph,
+    (candidate) => candidate === graph || isSharedMemoryBucketDescendantDataGraph(candidate, graph),
+  );
   const cache = params.rowListMemo && params.rowListCacheKey
     ? {
       memo: params.rowListMemo,
@@ -971,7 +985,7 @@ export async function readSwmDataPage(params: {
     const loadPlan = () => buildFreshSwmDataGraphPlan(
       params.store,
       dataGraphs,
-      graphSet,
+      graphMembership,
       params.cutoffIso!,
       signal,
     );
@@ -1647,6 +1661,8 @@ export async function readDurableDataPage(params: {
     );
   }
 
+  const graphMembership = graphMembershipSnapshotFor(params.graphList);
+
   if (params.sinceBatchId == null) {
     return readPagedRowsFromExactGraphPlanLoader(
       params.store,
@@ -1661,7 +1677,7 @@ export async function readDurableDataPage(params: {
           params.contextGraphId,
           planSignal,
         );
-        const { isCandidateGraph, isAdmitted } = createAdmissionContext(
+        const { cgPrefix, isCandidateGraph, isAdmitted } = createAdmissionContext(
           params.store,
           params.contextGraphId,
           { graphScopedVmManifest: manifest },
@@ -1678,7 +1694,7 @@ export async function readDurableDataPage(params: {
         // Legacy-only CGs retain the graph-list path, so their existing local
         // data remains readable and can still be synchronized on that lane.
         const legacyCandidateGraphs = manifest.knownGraphs.size === 0
-          ? params.graphList.filter(isCandidateGraph)
+          ? graphMembership.equalOrUnder(cgPrefix, isCandidateGraph)
           : [];
         const candidateGraphs = dedupeStrings([
           ...legacyCandidateGraphs,
@@ -1714,7 +1730,7 @@ export async function readDurableDataPage(params: {
       graphScopedVmManifest: manifest,
     });
   const candidateGraphs = dedupeStrings([
-    ...params.graphList.filter(isCandidateGraph),
+    ...graphMembership.equalOrUnder(cgPrefix, isCandidateGraph),
     ...manifest.confirmedEntries
       .filter((entry) => entry.rowCount > 0)
       .map((entry) => entry.graph),
@@ -3306,7 +3322,7 @@ async function readBoundedFreshSwmMetaSnapshot(
 async function readFreshSwmDataRows(
   store: TripleStore,
   dataGraphs: readonly string[],
-  graphSet: ReadonlySet<string>,
+  graphSet: Pick<ReadonlySet<string>, 'has'>,
   candidateGraphsFor: (graph: string) => string[],
   cutoffIso: string,
   signal?: AbortSignal,
@@ -3375,7 +3391,7 @@ function parseSparqlInteger(value: string | undefined): number {
 async function buildFreshSwmDataGraphPlan(
   store: TripleStore,
   dataGraphs: readonly string[],
-  graphSet: ReadonlySet<string>,
+  graphSet: Pick<ReadonlySet<string>, 'has'>,
   cutoffIso: string,
   signal?: AbortSignal,
 ): Promise<FreshSwmDataGraphPlan> {

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -41,7 +41,6 @@ import type { ExactGraphReadMode } from './durable-data-request-policy.js';
 import { compareCodePoint } from '../code-point-order.js';
 import {
   createGraphMembershipSnapshot,
-  graphMembershipSnapshotFor,
   type GraphMembershipSnapshot,
 } from '../graph-membership-snapshot.js';
 
@@ -87,7 +86,7 @@ export interface GraphListMemo {
     refresh?: boolean;
     refreshGeneration?: string;
     signal?: AbortSignal;
-  }): Promise<readonly string[]>;
+  }): Promise<GraphMembershipSnapshot>;
 }
 
 export interface SubGraphNameMemo {
@@ -293,7 +292,7 @@ export function createResponderGraphListMemo(
         // identity. Concurrent reads at the same unstable generation share
         // one enumeration; the result is simply discarded for later callers.
         if (!supersedesInflight(pending.revision, revision)) {
-          return (await raceAgainstAbort(pending.promise, options?.signal)).graphs;
+          return raceAgainstAbort(pending.promise, options?.signal);
         }
         try {
           await raceAgainstAbort(pending.promise, options?.signal);
@@ -308,7 +307,7 @@ export function createResponderGraphListMemo(
         cached &&
         now - cached.cachedAt < ttlMs &&
         (!options?.refresh || (writeRevisionSource !== null && isWriteRevision(revision) && revision.stable))
-      ) return cached.value.graphs;
+      ) return cached.value;
       // This load is shared by concurrent responders. Do not bind it to the
       // first stream's abort signal; waiters race their own abort locally via
       // raceAgainstAbort/throwIfAborted below.
@@ -338,7 +337,7 @@ export function createResponderGraphListMemo(
       };
       const snapshot = await load;
       throwIfAborted(options?.signal);
-      return snapshot.graphs;
+      return snapshot;
     },
   };
 }
@@ -814,7 +813,7 @@ export function serializeResponderRowsWithinByteBudget(
 
 export async function readSwmMetaPage(params: {
   store: TripleStore;
-  graphList: readonly string[];
+  graphMembership: GraphMembershipSnapshot;
   registeredSubGraphNames: readonly string[];
   contextGraphId: string;
   cutoffIso: string | null;
@@ -828,8 +827,7 @@ export async function readSwmMetaPage(params: {
   freshMetaPlanMemo?: FreshSwmMetaPlanMemo;
 }): Promise<SyncRow[]> {
   const graphs = swmGraphsForRegisteredSubGraphs(params.contextGraphId, params.registeredSubGraphNames, true);
-  const graphMembership = graphMembershipSnapshotFor(params.graphList);
-  const candidateGraphs = graphs.filter((graph) => graphMembership.has(graph));
+  const candidateGraphs = graphs.filter((graph) => params.graphMembership.has(graph));
   const cache = params.rowListMemo && params.rowListCacheKey
     ? {
       memo: params.rowListMemo,
@@ -937,7 +935,7 @@ export async function readSwmMetaPage(params: {
 
 export async function readSwmDataPage(params: {
   store: TripleStore;
-  graphList: readonly string[];
+  graphMembership: GraphMembershipSnapshot;
   registeredSubGraphNames: readonly string[];
   contextGraphId: string;
   cutoffIso: string | null;
@@ -952,8 +950,7 @@ export async function readSwmDataPage(params: {
   exactGraphPlanMemo?: ExactGraphPagePlanMemo;
 }): Promise<SyncRow[]> {
   const dataGraphs = swmGraphsForRegisteredSubGraphs(params.contextGraphId, params.registeredSubGraphNames, false);
-  const graphMembership = graphMembershipSnapshotFor(params.graphList);
-  const candidateGraphsFor = (graph: string) => graphMembership.equalOrUnder(
+  const candidateGraphsFor = (graph: string) => params.graphMembership.equalOrUnder(
     graph,
     (candidate) => candidate === graph || isSharedMemoryBucketDescendantDataGraph(candidate, graph),
   );
@@ -985,7 +982,7 @@ export async function readSwmDataPage(params: {
     const loadPlan = () => buildFreshSwmDataGraphPlan(
       params.store,
       dataGraphs,
-      graphMembership,
+      params.graphMembership,
       params.cutoffIso!,
       signal,
     );
@@ -1596,7 +1593,7 @@ export async function readChangelogDeltaPage(params: {
 
 export async function readDurableDataPage(params: {
   store: TripleStore;
-  graphList: readonly string[];
+  graphMembership: GraphMembershipSnapshot;
   contextGraphId: string;
   sinceBatchId: bigint | null;
   offset: number;
@@ -1661,8 +1658,6 @@ export async function readDurableDataPage(params: {
     );
   }
 
-  const graphMembership = graphMembershipSnapshotFor(params.graphList);
-
   if (params.sinceBatchId == null) {
     return readPagedRowsFromExactGraphPlanLoader(
       params.store,
@@ -1694,7 +1689,7 @@ export async function readDurableDataPage(params: {
         // Legacy-only CGs retain the graph-list path, so their existing local
         // data remains readable and can still be synchronized on that lane.
         const legacyCandidateGraphs = manifest.knownGraphs.size === 0
-          ? graphMembership.equalOrUnder(cgPrefix, isCandidateGraph)
+          ? params.graphMembership.equalOrUnder(cgPrefix, isCandidateGraph)
           : [];
         const candidateGraphs = dedupeStrings([
           ...legacyCandidateGraphs,
@@ -1730,7 +1725,7 @@ export async function readDurableDataPage(params: {
       graphScopedVmManifest: manifest,
     });
   const candidateGraphs = dedupeStrings([
-    ...graphMembership.equalOrUnder(cgPrefix, isCandidateGraph),
+    ...params.graphMembership.equalOrUnder(cgPrefix, isCandidateGraph),
     ...manifest.confirmedEntries
       .filter((entry) => entry.rowCount > 0)
       .map((entry) => entry.graph),
@@ -3322,7 +3317,7 @@ async function readBoundedFreshSwmMetaSnapshot(
 async function readFreshSwmDataRows(
   store: TripleStore,
   dataGraphs: readonly string[],
-  graphSet: Pick<ReadonlySet<string>, 'has'>,
+  graphMembership: GraphMembershipSnapshot,
   candidateGraphsFor: (graph: string) => string[],
   cutoffIso: string,
   signal?: AbortSignal,
@@ -3330,7 +3325,7 @@ async function readFreshSwmDataRows(
   const rows: SyncRow[] = [];
   for (const graph of dataGraphs) {
     const metaGraph = `${graph}_meta`;
-    if (!graphSet.has(metaGraph)) continue;
+    if (!graphMembership.has(metaGraph)) continue;
     const roots = await readFreshSwmRoots(store, metaGraph, cutoffIso, signal);
     if (roots.size === 0) continue;
     const rootPrefixes = [...roots].map((root) => `${root}/.well-known/genid/`);
@@ -3391,7 +3386,7 @@ function parseSparqlInteger(value: string | undefined): number {
 async function buildFreshSwmDataGraphPlan(
   store: TripleStore,
   dataGraphs: readonly string[],
-  graphSet: Pick<ReadonlySet<string>, 'has'>,
+  graphMembership: GraphMembershipSnapshot,
   cutoffIso: string,
   signal?: AbortSignal,
 ): Promise<FreshSwmDataGraphPlan> {
@@ -3399,7 +3394,7 @@ async function buildFreshSwmDataGraphPlan(
   for (const bucketGraph of dedupeStrings(dataGraphs).sort(compareCodePoint)) {
     throwIfAborted(signal);
     const metaGraph = `${bucketGraph}_meta`;
-    if (!graphSet.has(metaGraph)) continue;
+    if (!graphMembership.has(metaGraph)) continue;
     const roots = [...await readFreshSwmRoots(store, metaGraph, cutoffIso, signal)]
       .sort(compareCodePoint);
     for (const chunk of chunkValues(roots, FRESH_SWM_PLAN_QUERY_GRAPH_CHUNK)) {
@@ -3426,7 +3421,7 @@ async function buildFreshSwmDataGraphPlan(
         if (
           !graph
           || !root
-          || !graphSet.has(graph)
+          || !graphMembership.has(graph)
           || !chunkSet.has(root)
           || (graph !== bucketGraph
             && !isSharedMemoryBucketDescendantDataGraph(graph, bucketGraph))

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -679,7 +679,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           );
           const rows = await readSwmMetaPage({
             store,
-            graphList: await graphListMemo.get({
+            graphMembership: await graphListMemo.get({
               refresh: session?.refreshRowList ?? offset === 0,
               refreshGeneration: offset === 0 ? session?.refreshGeneration : undefined,
               signal,
@@ -719,7 +719,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
           );
           const rows = await readSwmDataPage({
             store,
-            graphList: await graphListMemo.get({
+            graphMembership: await graphListMemo.get({
               refresh: session?.refreshRowList ?? offset === 0,
               refreshGeneration: offset === 0 ? session?.refreshGeneration : undefined,
               signal,
@@ -843,7 +843,7 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
         );
         const rows = await readDurableDataPage({
           store,
-          graphList: await graphListMemo.get({
+          graphMembership: await graphListMemo.get({
             refresh: session?.refreshRowList ?? offset === 0,
             refreshGeneration: offset === 0 ? session?.refreshGeneration : undefined,
             signal,

--- a/packages/agent/test/exact-asset-responder.test.ts
+++ b/packages/agent/test/exact-asset-responder.test.ts
@@ -12,6 +12,7 @@ import {
   readDurableDataPage,
   readDurableMetaPage,
 } from '../src/sync/responder/graph-plan.js';
+import { createGraphMembershipSnapshot } from '../src/sync/graph-membership-snapshot.js';
 
 const DKG = 'http://dkg.io/ontology/';
 const CG_ID = 'exact-asset-responder';
@@ -61,7 +62,7 @@ describe('exact asset responder', () => {
     });
     const data = await readDurableDataPage({
       store,
-      graphList: [requested.graph, alreadyPresent.graph],
+      graphMembership: createGraphMembershipSnapshot([requested.graph, alreadyPresent.graph]),
       contextGraphId: CG_ID,
       sinceBatchId: null,
       offset: 0,

--- a/packages/agent/test/exact-asset-wire-parse.test.ts
+++ b/packages/agent/test/exact-asset-wire-parse.test.ts
@@ -23,6 +23,7 @@ import {
   readDurableDataPage,
   serializeResponderRows,
 } from '../src/sync/responder/graph-plan.js';
+import { createGraphMembershipSnapshot } from '../src/sync/graph-membership-snapshot.js';
 import {
   linesFromNquads,
   registerTestSyncHandler,
@@ -232,7 +233,7 @@ describe('exact-asset wire parsing (parseSyncRequest)', () => {
 
     const directPage = await readDurableDataPage({
       store,
-      graphList: payloadGraphs,
+      graphMembership: createGraphMembershipSnapshot(payloadGraphs),
       contextGraphId,
       sinceBatchId: null,
       offset: 0,
@@ -371,7 +372,7 @@ describe('exact-asset wire parsing (parseSyncRequest)', () => {
 
     await expect(readDurableDataPage({
       store,
-      graphList: payloadGraphs,
+      graphMembership: createGraphMembershipSnapshot(payloadGraphs),
       contextGraphId,
       sinceBatchId: null,
       offset: 0,

--- a/packages/agent/test/graph-membership-snapshot.test.ts
+++ b/packages/agent/test/graph-membership-snapshot.test.ts
@@ -58,6 +58,7 @@ describe('graph membership snapshot', () => {
   it('matches reordered graph listings and rejects membership changes', () => {
     const snapshot = createGraphMembershipSnapshot(['urn:graph:a', 'urn:graph:b']);
     expect(snapshot.matches(['urn:graph:b', 'urn:graph:a'])).toBe(true);
+    expect(snapshot.matches(['urn:graph:a', 'urn:graph:a'])).toBe(false);
     expect(snapshot.matches(['urn:graph:a', 'urn:graph:c'])).toBe(false);
     expect(snapshot.matches(['urn:graph:a'])).toBe(false);
   });

--- a/packages/agent/test/graph-membership-snapshot.test.ts
+++ b/packages/agent/test/graph-membership-snapshot.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { compareCodePoint } from '../src/sync/code-point-order.js';
-import {
-  createGraphMembershipSnapshot,
-  graphMembershipSnapshotFor,
-} from '../src/sync/graph-membership-snapshot.js';
+import { createGraphMembershipSnapshot } from '../src/sync/graph-membership-snapshot.js';
 
 describe('graph membership snapshot', () => {
   it('keeps one immutable sorted membership index', () => {
@@ -21,8 +18,8 @@ describe('graph membership snapshot', () => {
       'urn:graph:a/😀',
       'urn:graph:z',
     ].sort(compareCodePoint));
+    expect(Object.isFrozen(snapshot)).toBe(true);
     expect(Object.isFrozen(snapshot.graphs)).toBe(true);
-    expect(graphMembershipSnapshotFor(snapshot.graphs)).toBe(snapshot);
     expect(snapshot.has('urn:graph:a/child')).toBe(true);
     expect(snapshot.has('urn:graph:missing')).toBe(false);
   });

--- a/packages/agent/test/graph-membership-snapshot.test.ts
+++ b/packages/agent/test/graph-membership-snapshot.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { compareCodePoint } from '../src/sync/code-point-order.js';
+import {
+  createGraphMembershipSnapshot,
+  graphMembershipSnapshotFor,
+} from '../src/sync/graph-membership-snapshot.js';
+
+describe('graph membership snapshot', () => {
+  it('keeps one immutable sorted membership index', () => {
+    const snapshot = createGraphMembershipSnapshot([
+      'urn:graph:z',
+      'urn:graph:a/child',
+      'urn:graph:a',
+      'urn:graph:z',
+      'urn:graph:a/😀',
+    ]);
+
+    expect(snapshot.graphs).toEqual([
+      'urn:graph:a',
+      'urn:graph:a/child',
+      'urn:graph:a/😀',
+      'urn:graph:z',
+    ].sort(compareCodePoint));
+    expect(Object.isFrozen(snapshot.graphs)).toBe(true);
+    expect(graphMembershipSnapshotFor(snapshot.graphs)).toBe(snapshot);
+    expect(snapshot.has('urn:graph:a/child')).toBe(true);
+    expect(snapshot.has('urn:graph:missing')).toBe(false);
+  });
+
+  it('selects only the exact graph and slash-delimited descendants', () => {
+    const root = 'did:dkg:context-graph:alpha';
+    const graphs = [
+      root,
+      `${root}/_meta`,
+      `${root}/_shared_memory`,
+      `${root}/_shared_memory/0xabc/1`,
+      `${root}/sub/_meta`,
+      `${root}-lookalike`,
+      'did:dkg:context-graph:beta/data',
+    ];
+    const snapshot = createGraphMembershipSnapshot([...graphs].reverse());
+
+    expect(snapshot.equalOrUnder(root)).toEqual(
+      [...graphs]
+        .filter((graph) => graph === root || graph.startsWith(`${root}/`))
+        .sort(compareCodePoint),
+    );
+    expect(snapshot.equalOrUnder(root, (graph) => !graph.endsWith('/_meta'))).toEqual(
+      [...graphs]
+        .filter((graph) => (
+          (graph === root || graph.startsWith(`${root}/`))
+          && !graph.endsWith('/_meta')
+        ))
+        .sort(compareCodePoint),
+    );
+  });
+
+  it('matches reordered graph listings and rejects membership changes', () => {
+    const snapshot = createGraphMembershipSnapshot(['urn:graph:a', 'urn:graph:b']);
+    expect(snapshot.matches(['urn:graph:b', 'urn:graph:a'])).toBe(true);
+    expect(snapshot.matches(['urn:graph:a', 'urn:graph:c'])).toBe(false);
+    expect(snapshot.matches(['urn:graph:a'])).toBe(false);
+  });
+
+  it('matches full-scan selection across large graph families', () => {
+    const graphs = Array.from({ length: 20_000 }, (_, index) => (
+      `did:dkg:context-graph:${String(index % 200).padStart(3, '0')}`
+      + `/_shared_memory/0x${String(index % 37).padStart(40, '0')}/${index}`
+    ));
+    const snapshot = createGraphMembershipSnapshot([...graphs].reverse());
+
+    for (const contextGraphIndex of [0, 1, 17, 99, 199, 250]) {
+      const root = `did:dkg:context-graph:${String(contextGraphIndex).padStart(3, '0')}`;
+      const expected = [...graphs]
+        .filter((graph) => graph === root || graph.startsWith(`${root}/`))
+        .sort(compareCodePoint);
+      expect(snapshot.equalOrUnder(root)).toEqual(expected);
+    }
+  });
+});

--- a/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
+++ b/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
@@ -1470,16 +1470,16 @@ describe('sync responder pagination interleaving', () => {
 
     const initial = memo.get({ refresh: true });
     firstRefresh.resolve(['old']);
-    await expect(initial).resolves.toEqual(['old']);
+    expect((await initial).graphs).toEqual(['old']);
 
     const refreshing = memo.get({ refresh: true });
     const overlappingRefresh = memo.get({ refresh: true });
     const deepPage = memo.get();
     secondRefresh.resolve(['new']);
 
-    await expect(refreshing).resolves.toEqual(['new']);
-    await expect(overlappingRefresh).resolves.toEqual(['new']);
-    await expect(deepPage).resolves.toEqual(['new']);
+    expect((await refreshing).graphs).toEqual(['new']);
+    expect((await overlappingRefresh).graphs).toEqual(['new']);
+    expect((await deepPage).graphs).toEqual(['new']);
     expect(calls).toBe(2);
   });
 
@@ -1500,33 +1500,33 @@ describe('sync responder pagination interleaving', () => {
     } as unknown as OxigraphStore;
     const memo = createResponderGraphListMemo(store);
 
-    await expect(memo.get({
+    expect((await memo.get({
       refresh: true,
       refreshGeneration: 'session-1',
-    })).resolves.toEqual(['urn:graph:a', 'urn:graph:b']);
-    await expect(memo.get({
+    })).graphs).toEqual(['urn:graph:a', 'urn:graph:b']);
+    expect((await memo.get({
       refresh: true,
       refreshGeneration: 'session-2',
-    })).resolves.toEqual(['urn:graph:a', 'urn:graph:b']);
+    })).graphs).toEqual(['urn:graph:a', 'urn:graph:b']);
     expect(calls).toBe(1);
 
     // Dispatch: the endpoint has not committed yet, so a refresh can still
     // observe and memoize the old graph set at this intermediate generation.
     generation++;
     stable = false;
-    await expect(memo.get({
+    expect((await memo.get({
       refresh: true,
       refreshGeneration: 'pending-mutation',
-    })).resolves.toEqual(['urn:graph:a', 'urn:graph:b']);
+    })).graphs).toEqual(['urn:graph:a', 'urn:graph:b']);
     expect(calls).toBe(2);
 
     // The remote mutation is still pending at the same revision. Stability,
     // not generation change alone, must prevent reuse of the completed read.
     graphs = ['urn:graph:c', 'urn:graph:a'];
-    await expect(memo.get({
+    expect((await memo.get({
       refresh: true,
       refreshGeneration: 'same-pending-mutation',
-    })).resolves.toEqual(['urn:graph:a', 'urn:graph:c']);
+    })).graphs).toEqual(['urn:graph:a', 'urn:graph:c']);
     expect(calls).toBe(3);
 
     // Settlement must advance again so the next session cannot reuse the
@@ -1534,10 +1534,10 @@ describe('sync responder pagination interleaving', () => {
     graphs = ['urn:graph:d', 'urn:graph:a'];
     generation++;
     stable = true;
-    await expect(memo.get({
+    expect((await memo.get({
       refresh: true,
       refreshGeneration: 'session-3',
-    })).resolves.toEqual(['urn:graph:a', 'urn:graph:d']);
+    })).graphs).toEqual(['urn:graph:a', 'urn:graph:d']);
     expect(calls).toBe(4);
   });
 
@@ -1558,8 +1558,8 @@ describe('sync responder pagination interleaving', () => {
     const simultaneous = memo.get({ refresh: true });
     await vi.waitFor(() => expect(calls).toBe(1));
     firstRead.resolve(['urn:graph:b', 'urn:graph:a']);
-    await expect(first).resolves.toEqual(['urn:graph:a', 'urn:graph:b']);
-    await expect(simultaneous).resolves.toEqual(['urn:graph:a', 'urn:graph:b']);
+    expect((await first).graphs).toEqual(['urn:graph:a', 'urn:graph:b']);
+    expect((await simultaneous).graphs).toEqual(['urn:graph:a', 'urn:graph:b']);
     expect(calls).toBe(1);
 
     // Unstable completed results are never reused, even though simultaneous
@@ -1567,7 +1567,7 @@ describe('sync responder pagination interleaving', () => {
     const later = memo.get({ refresh: true });
     await vi.waitFor(() => expect(calls).toBe(2));
     secondRead.resolve(['urn:graph:c']);
-    await expect(later).resolves.toEqual(['urn:graph:c']);
+    expect((await later).graphs).toEqual(['urn:graph:c']);
   });
 
   it('supersedes an in-flight graph list when write generation changes', async () => {
@@ -1590,10 +1590,10 @@ describe('sync responder pagination interleaving', () => {
     const afterWrite = memo.get({ refresh: true, refreshGeneration: 'new-session' });
 
     oldGraphs.resolve(['urn:graph:old']);
-    await expect(beforeWrite).resolves.toEqual(['urn:graph:old']);
+    expect((await beforeWrite).graphs).toEqual(['urn:graph:old']);
     await vi.waitFor(() => expect(calls).toBe(2));
     newGraphs.resolve(['urn:graph:new']);
-    await expect(afterWrite).resolves.toEqual(['urn:graph:new']);
+    expect((await afterWrite).graphs).toEqual(['urn:graph:new']);
   });
 
   it('retains the TTL backstop for writers outside the tracked store process', async () => {
@@ -1627,8 +1627,9 @@ describe('sync responder pagination interleaving', () => {
     const memo = createResponderGraphListMemo(store);
 
     const initial = await memo.get({ refresh: true, refreshGeneration: 'initial' });
-    expect(initial).toEqual(['urn:graph:a', 'urn:graph:b']);
+    expect(initial.graphs).toEqual(['urn:graph:a', 'urn:graph:b']);
     expect(Object.isFrozen(initial)).toBe(true);
+    expect(Object.isFrozen(initial.graphs)).toBe(true);
 
     // A write inside an existing graph advances the store revision, but the
     // named-graph listing still describes the same set in a different order.
@@ -1641,7 +1642,7 @@ describe('sync responder pagination interleaving', () => {
     graphs = ['urn:graph:c', 'urn:graph:a', 'urn:graph:b'];
     const membershipChange = await memo.get({ refresh: true, refreshGeneration: 'graph-added' });
     expect(membershipChange).not.toBe(initial);
-    expect(membershipChange).toEqual(['urn:graph:a', 'urn:graph:b', 'urn:graph:c']);
+    expect(membershipChange.graphs).toEqual(['urn:graph:a', 'urn:graph:b', 'urn:graph:c']);
 
     // Preserve the old deduplication contract: a malformed duplicate listing
     // cannot make a same-length equality check retain absent graphs.
@@ -1649,7 +1650,7 @@ describe('sync responder pagination interleaving', () => {
     graphs = ['urn:graph:a', 'urn:graph:a', 'urn:graph:b'];
     const duplicateListing = await memo.get({ refresh: true, refreshGeneration: 'graph-removed' });
     expect(duplicateListing).not.toBe(membershipChange);
-    expect(duplicateListing).toEqual(['urn:graph:a', 'urn:graph:b']);
+    expect(duplicateListing.graphs).toEqual(['urn:graph:a', 'urn:graph:b']);
     expect(calls).toBe(4);
   });
 
@@ -1676,10 +1677,10 @@ describe('sync responder pagination interleaving', () => {
     await Promise.resolve();
     expect(graphCalls).toBe(1);
     oldGraphs.resolve(['urn:graph:old']);
-    await expect(oldGraphSession).resolves.toEqual(['urn:graph:old']);
+    expect((await oldGraphSession).graphs).toEqual(['urn:graph:old']);
     await vi.waitFor(() => expect(graphCalls).toBe(2));
     newGraphs.resolve(['urn:graph:new']);
-    await expect(newGraphSession).resolves.toEqual(['urn:graph:new']);
+    expect((await newGraphSession).graphs).toEqual(['urn:graph:new']);
 
     const cgId = 'generation-aware-subgraphs';
     const cgPrefix = `did:dkg:context-graph:${cgId}`;

--- a/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
+++ b/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
@@ -1613,6 +1613,38 @@ describe('sync responder pagination interleaving', () => {
     expect(calls).toBe(2);
   });
 
+  it('reuses the immutable graph membership snapshot across content-only writes', async () => {
+    let generation = 0;
+    let graphs = ['urn:graph:b', 'urn:graph:a'];
+    let calls = 0;
+    const store = {
+      getWriteRevision: () => ({ generation, stable: true }),
+      listGraphs: async () => {
+        calls += 1;
+        return graphs;
+      },
+    } as unknown as OxigraphStore;
+    const memo = createResponderGraphListMemo(store);
+
+    const initial = await memo.get({ refresh: true, refreshGeneration: 'initial' });
+    expect(initial).toEqual(['urn:graph:a', 'urn:graph:b']);
+    expect(Object.isFrozen(initial)).toBe(true);
+
+    // A write inside an existing graph advances the store revision, but the
+    // named-graph listing still describes the same set in a different order.
+    generation += 1;
+    graphs = ['urn:graph:a', 'urn:graph:b'];
+    const contentOnly = await memo.get({ refresh: true, refreshGeneration: 'content-write' });
+    expect(contentOnly).toBe(initial);
+
+    generation += 1;
+    graphs = ['urn:graph:c', 'urn:graph:a', 'urn:graph:b'];
+    const membershipChange = await memo.get({ refresh: true, refreshGeneration: 'graph-added' });
+    expect(membershipChange).not.toBe(initial);
+    expect(membershipChange).toEqual(['urn:graph:a', 'urn:graph:b', 'urn:graph:c']);
+    expect(calls).toBe(3);
+  });
+
   it('reloads graph-list and subgraph prerequisites for a newer session generation', async () => {
     const oldGraphs = deferred<string[]>();
     const newGraphs = deferred<string[]>();

--- a/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
+++ b/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
@@ -1642,7 +1642,15 @@ describe('sync responder pagination interleaving', () => {
     const membershipChange = await memo.get({ refresh: true, refreshGeneration: 'graph-added' });
     expect(membershipChange).not.toBe(initial);
     expect(membershipChange).toEqual(['urn:graph:a', 'urn:graph:b', 'urn:graph:c']);
-    expect(calls).toBe(3);
+
+    // Preserve the old deduplication contract: a malformed duplicate listing
+    // cannot make a same-length equality check retain absent graphs.
+    generation += 1;
+    graphs = ['urn:graph:a', 'urn:graph:a', 'urn:graph:b'];
+    const duplicateListing = await memo.get({ refresh: true, refreshGeneration: 'graph-removed' });
+    expect(duplicateListing).not.toBe(membershipChange);
+    expect(duplicateListing).toEqual(['urn:graph:a', 'urn:graph:b']);
+    expect(calls).toBe(4);
   });
 
   it('reloads graph-list and subgraph prerequisites for a newer session generation', async () => {

--- a/packages/agent/test/sync-responder-large-graph-stack-overflow.test.ts
+++ b/packages/agent/test/sync-responder-large-graph-stack-overflow.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { TripleStore } from '@origintrail-official/dkg-storage';
 import { readSwmDataPage } from '../src/sync/responder/graph-plan.js';
+import { createGraphMembershipSnapshot } from '../src/sync/graph-membership-snapshot.js';
 import { createResponderSyncRowListMemo } from '../src/sync/responder/snapshot-cache.js';
 
 /**
@@ -66,12 +67,13 @@ describe('sync responder tolerates a shared-memory graph larger than the spread 
     // No explicit budget still gets the hard 10k/32MiB build cap. Once crossed,
     // this session is remembered as store-paged and never retries a full load.
     const memo = createResponderSyncRowListMemo(120_000, 32, { phase: 'durable_data' });
+    const graphMembership = createGraphMembershipSnapshot([dataGraph, metaGraph]);
 
     let received = 0;
     for (let offset = 0; offset < rowCount; offset += 500) {
       const rows = await readSwmDataPage({
         store,
-        graphList: [dataGraph, metaGraph],
+        graphMembership,
         registeredSubGraphNames: [],
         contextGraphId: cg,
         cutoffIso: '2020-01-01T00:00:00.000Z',


### PR DESCRIPTION
## Summary

- carry the three reviewed commits from #2400 onto the current `testnet-canary` tip
- preserve the immutable graph membership snapshot across content-only revisions
- use binary prefix-range selection in SWM and durable responder paths
- carry the snapshot explicitly through typed page-reader boundaries

## Why this PR exists

#2400 was merged into its stacked base branch, `codex/perf-codepoint-comparator`, after #2396 had already merged into `testnet-canary`. GitHub therefore marked #2400 merged, but its commits never reached `testnet-canary`.

This PR contains the same three reviewed #2400 commits, cleanly replayed on the latest canary. There are no additional functional changes.

## Performance

The isolated benchmark measured 32.5x faster prefix selection at 10,000 graphs and 123.6x at 50,000 graphs, avoiding 2 million and 10 million full-list entry visits respectively across 200 queries. This is an isolated selection benchmark, not an end-to-end speedup claim.

## Validation

- agent, core, and storage builds
- agent type tests and package-root smoke test
- 150 responder, exact-asset, concurrency, paging, and graph-membership tests across 11 files
- repository lint
- clean application onto current `testnet-canary`

Closes the integration gap left by #2400.