### PR TITLE
perf(node-ui): eliminate routine log retention offset scans

### DIFF
--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -16,6 +16,7 @@
     "test:e2e:hw-mock": "playwright test --config playwright.hw-mock.config.ts",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:ui": "playwright test --ui",
+    "benchmark:routine-log-retention": "pnpm run build && node scripts/routine-log-retention-benchmark.mjs",
     "benchmark:stage5": "tsx scripts/stage5-scale-benchmark.mts",
     "benchmark:stage6": "tsx scripts/stage6-delta-benchmark.mts",
     "clean": "node -e \"const fs=require('fs'); ['dist','tsconfig.tsbuildinfo'].forEach((p)=>fs.rmSync(p,{recursive:true,force:true}))\""

--- a/packages/node-ui/scripts/routine-log-retention-benchmark.mjs
+++ b/packages/node-ui/scripts/routine-log-retention-benchmark.mjs
@@ -1,0 +1,120 @@
+import Database from 'better-sqlite3';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { performance } from 'node:perf_hooks';
+
+function integerSetting(name, fallback, minimum) {
+  const parsed = Number(process.env[name] ?? fallback);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum) {
+    throw new Error(`${name} must be a safe integer >= ${minimum}`);
+  }
+  return parsed;
+}
+
+const routineRows = integerSetting('DKG_BENCH_ROUTINE_ROWS', 1_050_000, 1);
+const rowCap = integerSetting('DKG_BENCH_ROUTINE_CAP', 1_000_000, 0);
+const checks = integerSetting('DKG_BENCH_RETENTION_CHECKS', 50, 1);
+const trials = integerSetting('DKG_BENCH_TRIALS', 5, 1);
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle];
+}
+
+function measure(operation) {
+  const samples = [];
+  for (let trial = 0; trial < trials; trial += 1) {
+    const startedAt = performance.now();
+    for (let check = 0; check < checks; check += 1) {
+      operation();
+    }
+    samples.push(performance.now() - startedAt);
+  }
+  return median(samples);
+}
+
+const directory = mkdtempSync(join(tmpdir(), 'dkg-routine-retention-bench-'));
+const databasePath = join(directory, 'node-ui.db');
+const db = new Database(databasePath);
+
+try {
+  db.pragma('journal_mode = WAL');
+  db.pragma('synchronous = OFF');
+  db.exec(`
+    CREATE TABLE logs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      ts INTEGER NOT NULL,
+      level TEXT NOT NULL,
+      module TEXT,
+      message TEXT NOT NULL
+    );
+    WITH RECURSIVE rows(id) AS (
+      SELECT 1
+      UNION ALL
+      SELECT id + 1 FROM rows WHERE id < ${routineRows}
+    )
+    INSERT INTO logs (ts, level, module, message)
+    SELECT id, 'info', 'benchmark', 'routine' FROM rows;
+    CREATE INDEX idx_logs_routine_id
+      ON logs(id)
+      WHERE level NOT IN ('warn', 'error');
+    CREATE TABLE routine_log_retention_state (
+      singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+      routine_rows INTEGER NOT NULL CHECK (routine_rows >= 0)
+    );
+    INSERT INTO routine_log_retention_state (singleton, routine_rows)
+    VALUES (1, ${routineRows});
+  `);
+
+  const legacyCutoff = db.prepare(`
+    SELECT id
+    FROM logs
+    WHERE level NOT IN ('warn', 'error')
+    ORDER BY id DESC
+    LIMIT 1 OFFSET ?
+  `);
+  const retainedCount = db.prepare(`
+    SELECT routine_rows
+    FROM routine_log_retention_state
+    WHERE singleton = 1
+  `);
+
+  // Warm both statements and prove they observe the seeded state before the
+  // isolated trials. With monotonically assigned ids, the legacy cutoff is the
+  // first row outside the newest `rowCap` routine rows.
+  const expectedCutoff = routineRows > rowCap ? routineRows - rowCap : undefined;
+  const observedCutoff = legacyCutoff.get(rowCap)?.id;
+  const observedCount = retainedCount.get()?.routine_rows;
+  if (observedCutoff !== expectedCutoff || observedCount !== routineRows) {
+    throw new Error(`Benchmark state mismatch: cutoff=${observedCutoff}, count=${observedCount}`);
+  }
+
+  const legacyMs = measure(() => legacyCutoff.get(rowCap)?.id);
+  const counterMs = measure(() => retainedCount.get()?.routine_rows);
+  const result = {
+    node: process.version,
+    routineRows,
+    rowCap,
+    checks,
+    trials,
+    legacyOffsetMedianMs: legacyMs,
+    counterMedianMs: counterMs,
+    speedup: legacyMs / counterMs,
+  };
+
+  console.log('Routine-log retention overflow-check benchmark');
+  console.log(`Node ${process.version}; ${routineRows.toLocaleString()} routine rows; ${checks} checks; ${trials} trials`);
+  console.log('');
+  console.log('| Legacy OFFSET median | Counter median | Speedup |');
+  console.log('| ---: | ---: | ---: |');
+  console.log(`| ${legacyMs.toFixed(2)} ms | ${counterMs.toFixed(3)} ms | ${result.speedup.toFixed(1)}x |`);
+  console.log('');
+  console.log(JSON.stringify(result, null, 2));
+} finally {
+  db.close();
+  rmSync(directory, { recursive: true, force: true });
+}

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -20,7 +20,10 @@ import {
   type DurableManifestPrefixDigest,
   type SyncCheckpointEntry,
 } from '@origintrail-official/dkg-core';
-import { RoutineLogRetention } from './routine-log-retention.js';
+import {
+  ensureRoutineLogRetentionSchema,
+  RoutineLogRetention,
+} from './routine-log-retention.js';
 export {
   SqliteChainEventCursorStore,
   SqliteContextGraphRegistryScanCursorStore,
@@ -249,6 +252,10 @@ export class DashboardDB {
     this.db = new Database(dbPath);
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('synchronous = NORMAL');
+    // INSERT OR REPLACE performs an implicit DELETE. SQLite only runs delete
+    // triggers for that replacement when recursive triggers are enabled, and
+    // the routine-log counter relies on seeing both halves of the write.
+    this.db.pragma('recursive_triggers = ON');
     // Cap the persisted WAL file. A PASSIVE autocheckpoint resets WAL
     // frames but leaves the -wal file at its high-water mark, so a node
     // that once took a heavy write burst (e.g. the pre-rc.14 sync-page
@@ -341,98 +348,6 @@ export class DashboardDB {
         this.db.exec(`ALTER TABLE sync_checkpoints ADD COLUMN terminal INTEGER NOT NULL DEFAULT 0 CHECK (terminal IN (0, 1));`);
       }
     };
-    const ensureRoutineLogRetentionState = () => {
-      const logsTable = this.db.prepare(`
-        SELECT 1 AS found FROM sqlite_master
-        WHERE type = 'table' AND name = 'logs'
-      `).get() as { found: number } | undefined;
-      if (!logsTable) return;
-
-      this.db.exec(`
-        CREATE TABLE IF NOT EXISTS routine_log_retention_state (
-          singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
-          routine_rows INTEGER NOT NULL CHECK (routine_rows >= 0)
-        );
-        CREATE INDEX IF NOT EXISTS idx_logs_routine_id
-          ON logs(id)
-          WHERE level NOT IN ('warn', 'error');
-      `);
-
-      const requiredTriggers = [
-        'track_routine_log_insert',
-        'track_routine_log_delete',
-        'track_routine_log_level_update',
-      ];
-      const triggerRows = this.db.prepare(`
-        SELECT name FROM sqlite_master
-        WHERE type = 'trigger'
-          AND name IN (
-            'track_routine_log_insert',
-            'track_routine_log_delete',
-            'track_routine_log_level_update'
-          )
-      `).all() as Array<{ name: string }>;
-      const state = this.db.prepare(`
-        SELECT routine_rows
-        FROM routine_log_retention_state
-        WHERE singleton = 1
-      `).get() as { routine_rows: number } | undefined;
-      if (state && requiredTriggers.every((name) => triggerRows.some((row) => row.name === name))) {
-        return;
-      }
-
-      // This one-time/recovery scan is protected by an IMMEDIATE transaction.
-      // The partial index makes it covering, and every later overflow check is
-      // an O(1) singleton lookup rather than OFFSET-walking one million rows.
-      this.db.transaction(() => {
-        this.db.exec(`
-          DROP TRIGGER IF EXISTS track_routine_log_insert;
-          DROP TRIGGER IF EXISTS track_routine_log_delete;
-          DROP TRIGGER IF EXISTS track_routine_log_level_update;
-        `);
-        const count = this.db.prepare(`
-          SELECT COUNT(*) AS routine_rows
-          FROM logs
-          WHERE level NOT IN ('warn', 'error')
-        `).get() as { routine_rows: number };
-        this.db.prepare(`
-          INSERT INTO routine_log_retention_state (singleton, routine_rows)
-          VALUES (1, @routineRows)
-          ON CONFLICT(singleton) DO UPDATE SET routine_rows = excluded.routine_rows
-        `).run({ routineRows: count.routine_rows });
-        this.db.exec(`
-          CREATE TRIGGER track_routine_log_insert
-          AFTER INSERT ON logs
-          WHEN NEW.level NOT IN ('warn', 'error')
-          BEGIN
-            UPDATE routine_log_retention_state
-            SET routine_rows = routine_rows + 1
-            WHERE singleton = 1;
-          END;
-
-          CREATE TRIGGER track_routine_log_delete
-          AFTER DELETE ON logs
-          WHEN OLD.level NOT IN ('warn', 'error')
-          BEGIN
-            UPDATE routine_log_retention_state
-            SET routine_rows = MAX(0, routine_rows - 1)
-            WHERE singleton = 1;
-          END;
-
-          CREATE TRIGGER track_routine_log_level_update
-          AFTER UPDATE OF level ON logs
-          WHEN (OLD.level IN ('warn', 'error')) <> (NEW.level IN ('warn', 'error'))
-          BEGIN
-            UPDATE routine_log_retention_state
-            SET routine_rows = routine_rows + CASE
-              WHEN NEW.level NOT IN ('warn', 'error') THEN 1
-              ELSE -1
-            END
-            WHERE singleton = 1;
-          END;
-        `);
-      }).immediate();
-    };
     if (version > SCHEMA_VERSION) return;
     if (version === SCHEMA_VERSION) {
       // Repair restored/development databases that carry the current version
@@ -440,7 +355,7 @@ export class DashboardDB {
       ensureJoinApprovalRepairMarker();
       ensureSyncCheckpointResumeColumns();
       ensureJoinPolicyAuditCapTrigger();
-      ensureRoutineLogRetentionState();
+      ensureRoutineLogRetentionSchema(this.db);
       return;
     }
 
@@ -1371,7 +1286,7 @@ export class DashboardDB {
       `).run();
     }
     if (version < 35) {
-      ensureRoutineLogRetentionState();
+      ensureRoutineLogRetentionSchema(this.db);
     }
     this.db.pragma(`user_version = ${SCHEMA_VERSION}`);
     if (upgradedExistingDb && !this.explicitRetentionDays) {

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -26,7 +26,7 @@ export {
   SqliteContextGraphRegistryScanCursorStore,
 } from './chain-cursor-stores.js';
 
-export const SCHEMA_VERSION = 34;
+export const SCHEMA_VERSION = 35;
 // Default operator retention. Lowered from 90 → 14 days on V15 (2026-05) after
 // a production incident in which the `logs` table + its FTS5 shadow tables
 // grew to ~9 GB on a 12-day-old node and corrupted the SQLite page (header
@@ -247,11 +247,6 @@ export class DashboardDB {
     this._memoTtlMs = resolveCacheTtlMs(opts.cacheTtlMs);
     const dbPath = join(opts.dataDir, 'node-ui.db');
     this.db = new Database(dbPath);
-    this.routineLogRetention = new RoutineLogRetention(
-      this.db,
-      routineLogRowCap,
-      logVolumePruneBatchRows,
-    );
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('synchronous = NORMAL');
     // Cap the persisted WAL file. A PASSIVE autocheckpoint resets WAL
@@ -264,6 +259,11 @@ export class DashboardDB {
     // autocheckpoint while bounding the worst case.
     this.db.pragma('journal_size_limit = 67108864');
     this.migrate();
+    this.routineLogRetention = new RoutineLogRetention(
+      this.db,
+      routineLogRowCap,
+      logVolumePruneBatchRows,
+    );
     this.loadRetentionSetting();
     this.prune();
   }
@@ -341,6 +341,98 @@ export class DashboardDB {
         this.db.exec(`ALTER TABLE sync_checkpoints ADD COLUMN terminal INTEGER NOT NULL DEFAULT 0 CHECK (terminal IN (0, 1));`);
       }
     };
+    const ensureRoutineLogRetentionState = () => {
+      const logsTable = this.db.prepare(`
+        SELECT 1 AS found FROM sqlite_master
+        WHERE type = 'table' AND name = 'logs'
+      `).get() as { found: number } | undefined;
+      if (!logsTable) return;
+
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS routine_log_retention_state (
+          singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+          routine_rows INTEGER NOT NULL CHECK (routine_rows >= 0)
+        );
+        CREATE INDEX IF NOT EXISTS idx_logs_routine_id
+          ON logs(id)
+          WHERE level NOT IN ('warn', 'error');
+      `);
+
+      const requiredTriggers = [
+        'track_routine_log_insert',
+        'track_routine_log_delete',
+        'track_routine_log_level_update',
+      ];
+      const triggerRows = this.db.prepare(`
+        SELECT name FROM sqlite_master
+        WHERE type = 'trigger'
+          AND name IN (
+            'track_routine_log_insert',
+            'track_routine_log_delete',
+            'track_routine_log_level_update'
+          )
+      `).all() as Array<{ name: string }>;
+      const state = this.db.prepare(`
+        SELECT routine_rows
+        FROM routine_log_retention_state
+        WHERE singleton = 1
+      `).get() as { routine_rows: number } | undefined;
+      if (state && requiredTriggers.every((name) => triggerRows.some((row) => row.name === name))) {
+        return;
+      }
+
+      // This one-time/recovery scan is protected by an IMMEDIATE transaction.
+      // The partial index makes it covering, and every later overflow check is
+      // an O(1) singleton lookup rather than OFFSET-walking one million rows.
+      this.db.transaction(() => {
+        this.db.exec(`
+          DROP TRIGGER IF EXISTS track_routine_log_insert;
+          DROP TRIGGER IF EXISTS track_routine_log_delete;
+          DROP TRIGGER IF EXISTS track_routine_log_level_update;
+        `);
+        const count = this.db.prepare(`
+          SELECT COUNT(*) AS routine_rows
+          FROM logs
+          WHERE level NOT IN ('warn', 'error')
+        `).get() as { routine_rows: number };
+        this.db.prepare(`
+          INSERT INTO routine_log_retention_state (singleton, routine_rows)
+          VALUES (1, @routineRows)
+          ON CONFLICT(singleton) DO UPDATE SET routine_rows = excluded.routine_rows
+        `).run({ routineRows: count.routine_rows });
+        this.db.exec(`
+          CREATE TRIGGER track_routine_log_insert
+          AFTER INSERT ON logs
+          WHEN NEW.level NOT IN ('warn', 'error')
+          BEGIN
+            UPDATE routine_log_retention_state
+            SET routine_rows = routine_rows + 1
+            WHERE singleton = 1;
+          END;
+
+          CREATE TRIGGER track_routine_log_delete
+          AFTER DELETE ON logs
+          WHEN OLD.level NOT IN ('warn', 'error')
+          BEGIN
+            UPDATE routine_log_retention_state
+            SET routine_rows = MAX(0, routine_rows - 1)
+            WHERE singleton = 1;
+          END;
+
+          CREATE TRIGGER track_routine_log_level_update
+          AFTER UPDATE OF level ON logs
+          WHEN (OLD.level IN ('warn', 'error')) <> (NEW.level IN ('warn', 'error'))
+          BEGIN
+            UPDATE routine_log_retention_state
+            SET routine_rows = routine_rows + CASE
+              WHEN NEW.level NOT IN ('warn', 'error') THEN 1
+              ELSE -1
+            END
+            WHERE singleton = 1;
+          END;
+        `);
+      }).immediate();
+    };
     if (version > SCHEMA_VERSION) return;
     if (version === SCHEMA_VERSION) {
       // Repair restored/development databases that carry the current version
@@ -348,6 +440,7 @@ export class DashboardDB {
       ensureJoinApprovalRepairMarker();
       ensureSyncCheckpointResumeColumns();
       ensureJoinPolicyAuditCapTrigger();
+      ensureRoutineLogRetentionState();
       return;
     }
 
@@ -1276,6 +1369,9 @@ export class DashboardDB {
          WHERE key LIKE '%|durable|data%'
            AND key NOT LIKE '%|durable|data|checkpoint:v2%'
       `).run();
+    }
+    if (version < 35) {
+      ensureRoutineLogRetentionState();
     }
     this.db.pragma(`user_version = ${SCHEMA_VERSION}`);
     if (upgradedExistingDb && !this.explicitRetentionDays) {
@@ -3348,6 +3444,7 @@ export class DashboardDB {
 
   close(): void {
     if (!this.db.open) return;
+    this.routineLogRetention.close();
     this.db.close();
   }
 }

--- a/packages/node-ui/src/routine-log-retention.ts
+++ b/packages/node-ui/src/routine-log-retention.ts
@@ -10,6 +10,117 @@ interface RoutineLogCountRow {
   routine_rows: number;
 }
 
+type RoutineLogSchemaDatabase = Pick<
+  Database.Database,
+  'exec' | 'prepare' | 'transaction'
+>;
+
+const ROUTINE_LOG_TRIGGER_NAMES = [
+  'track_routine_log_insert',
+  'track_routine_log_delete',
+  'track_routine_log_level_update',
+] as const;
+
+/**
+ * Install or repair the durable schema owned by routine-log retention.
+ *
+ * DashboardDB keeps migration ordering, while this module keeps the counter,
+ * index, trigger predicates, and recount transaction together with the code
+ * that consumes them.
+ */
+export function ensureRoutineLogRetentionSchema(db: RoutineLogSchemaDatabase): void {
+  const logsTable = db.prepare(`
+    SELECT 1 AS found FROM sqlite_master
+    WHERE type = 'table' AND name = 'logs'
+  `).get() as { found: number } | undefined;
+  if (!logsTable) return;
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS routine_log_retention_state (
+      singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+      routine_rows INTEGER NOT NULL CHECK (routine_rows >= 0)
+    );
+    CREATE INDEX IF NOT EXISTS idx_logs_routine_id
+      ON logs(id)
+      WHERE level NOT IN ('warn', 'error');
+  `);
+
+  const triggerRows = db.prepare(`
+    SELECT name FROM sqlite_master
+    WHERE type = 'trigger'
+      AND name IN (
+        'track_routine_log_insert',
+        'track_routine_log_delete',
+        'track_routine_log_level_update'
+      )
+  `).all() as Array<{ name: string }>;
+  const state = db.prepare(`
+    SELECT routine_rows
+    FROM routine_log_retention_state
+    WHERE singleton = 1
+  `).get() as RoutineLogCountRow | undefined;
+  if (
+    state
+    && ROUTINE_LOG_TRIGGER_NAMES.every(
+      (name) => triggerRows.some((row) => row.name === name),
+    )
+  ) {
+    return;
+  }
+
+  // This one-time/recovery scan is protected by an IMMEDIATE transaction.
+  // The partial index makes it covering, and every later overflow check is
+  // an O(1) singleton lookup rather than OFFSET-walking one million rows.
+  db.transaction(() => {
+    db.exec(`
+      DROP TRIGGER IF EXISTS track_routine_log_insert;
+      DROP TRIGGER IF EXISTS track_routine_log_delete;
+      DROP TRIGGER IF EXISTS track_routine_log_level_update;
+    `);
+    const count = db.prepare(`
+      SELECT COUNT(*) AS routine_rows
+      FROM logs
+      WHERE level NOT IN ('warn', 'error')
+    `).get() as RoutineLogCountRow;
+    db.prepare(`
+      INSERT INTO routine_log_retention_state (singleton, routine_rows)
+      VALUES (1, @routineRows)
+      ON CONFLICT(singleton) DO UPDATE SET routine_rows = excluded.routine_rows
+    `).run({ routineRows: count.routine_rows });
+    db.exec(`
+      CREATE TRIGGER track_routine_log_insert
+      AFTER INSERT ON logs
+      WHEN NEW.level NOT IN ('warn', 'error')
+      BEGIN
+        UPDATE routine_log_retention_state
+        SET routine_rows = routine_rows + 1
+        WHERE singleton = 1;
+      END;
+
+      CREATE TRIGGER track_routine_log_delete
+      AFTER DELETE ON logs
+      WHEN OLD.level NOT IN ('warn', 'error')
+      BEGIN
+        UPDATE routine_log_retention_state
+        SET routine_rows = MAX(0, routine_rows - 1)
+        WHERE singleton = 1;
+      END;
+
+      CREATE TRIGGER track_routine_log_level_update
+      AFTER UPDATE OF level ON logs
+      WHEN (OLD.level IN ('warn', 'error')) <> (NEW.level IN ('warn', 'error'))
+      BEGIN
+        UPDATE routine_log_retention_state
+        SET routine_rows = routine_rows + CASE
+          WHEN NEW.level NOT IN ('warn', 'error') THEN 1
+          ELSE -1
+        END
+        WHERE singleton = 1;
+      END;
+    `);
+  }).immediate();
+}
+
 /**
  * Owns count-based retention for routine log rows.
  *

--- a/packages/node-ui/src/routine-log-retention.ts
+++ b/packages/node-ui/src/routine-log-retention.ts
@@ -6,26 +6,55 @@ export interface RoutineLogPruneBatch {
   filledBatch: boolean;
 }
 
+interface RoutineLogCountRow {
+  routine_rows: number;
+}
+
 /**
- * Owns the complete count-based retention policy for routine log rows.
- * Warning/error classification, guard cadence, overflow selection, and the
- * bounded deletion statement live together so compatibility writes and the
- * background pruner cannot drift onto different retention rules.
+ * Owns count-based retention for routine log rows.
+ *
+ * Schema triggers maintain an exact, crash-safe row count for every writer,
+ * including compatibility callers that write through `DashboardDB.db`. The
+ * hot path performs only O(1) counter accounting and schedules maintenance;
+ * bounded deletion runs after the insert returns and the independent daemon
+ * pruner remains its retry/backlog owner.
  */
 export class RoutineLogRetention {
   private writesSinceGuard = 0;
+  private scheduledMaintenance: ReturnType<typeof setImmediate> | null = null;
+  private readonly readRoutineCount: Database.Statement;
+  private readonly deleteOldestRoutineRows: Database.Statement;
+  private readonly runPruneTransaction: () => RoutineLogPruneBatch;
 
   constructor(
-    private readonly db: Pick<Database.Database, 'prepare'>,
+    db: Pick<Database.Database, 'prepare' | 'transaction'>,
     private readonly rowCap: number,
     private readonly batchRows: number,
-  ) {}
+  ) {
+    this.readRoutineCount = db.prepare(`
+      SELECT routine_rows
+      FROM routine_log_retention_state
+      WHERE singleton = 1
+    `);
+    this.deleteOldestRoutineRows = db.prepare(`
+      DELETE FROM logs
+      WHERE id IN (
+        SELECT id
+        FROM logs
+        WHERE level NOT IN ('warn', 'error')
+        ORDER BY id ASC
+        LIMIT @deleteRows
+      )
+    `);
+    const pruneTransaction = db.transaction(() => this.pruneWithinTransaction());
+    this.runPruneTransaction = () => pruneTransaction.immediate();
+  }
 
   noteCommittedInsert(level: string): void {
     if (!this.isRoutineLevel(level)) return;
     this.writesSinceGuard += 1;
-    // Each guard removes at most one configured batch, so its cadence must
-    // never admit more routine rows than that batch can remove.
+    // Each scheduled run removes at most one configured batch, so its cadence
+    // must never admit more routine rows than that batch can remove.
     const guardInterval = Math.min(
       1_000,
       Math.max(1, this.rowCap),
@@ -33,52 +62,58 @@ export class RoutineLogRetention {
     );
     if (this.writesSinceGuard < guardInterval) return;
     this.writesSinceGuard = 0;
-    try {
-      this.pruneOverflowBatch();
-    } catch {
-      // The INSERT has already committed. Inline retention is therefore
-      // best-effort: surfacing this maintenance failure would falsely report
-      // the durable write as failed and invite duplicate retries. The
-      // independent volume pruner will retry the same bounded cleanup later.
-    }
+    this.scheduleMaintenance();
   }
 
   hasOverflow(): boolean {
-    return this.overflowCutoff() !== null;
+    return this.routineRowCount() > this.rowCap;
   }
 
   pruneOverflowBatch(): RoutineLogPruneBatch {
-    const cutoff = this.overflowCutoff();
-    if (cutoff === null) {
+    return this.runPruneTransaction();
+  }
+
+  close(): void {
+    if (this.scheduledMaintenance) clearImmediate(this.scheduledMaintenance);
+    this.scheduledMaintenance = null;
+  }
+
+  private scheduleMaintenance(): void {
+    if (this.scheduledMaintenance) return;
+    this.scheduledMaintenance = setImmediate(() => {
+      this.scheduledMaintenance = null;
+      try {
+        const result = this.pruneOverflowBatch();
+        if (result.filledBatch) this.scheduleMaintenance();
+      } catch {
+        // The INSERT committed before maintenance was scheduled. A retention
+        // failure must not falsely report that durable write as failed; the
+        // independent daemon pruner or a later guard will retry the backlog.
+      }
+    });
+    this.scheduledMaintenance.unref?.();
+  }
+
+  private routineRowCount(): number {
+    const row = this.readRoutineCount.get() as RoutineLogCountRow | undefined;
+    if (!row) {
+      throw new Error('Routine-log retention state is missing');
+    }
+    return row.routine_rows;
+  }
+
+  private pruneWithinTransaction(): RoutineLogPruneBatch {
+    const overflow = Math.max(0, this.routineRowCount() - this.rowCap);
+    if (overflow === 0) {
       return { deleted: 0, hadOverflow: false, filledBatch: false };
     }
-    const deleted = this.db.prepare(`
-      DELETE FROM logs
-      WHERE id IN (
-        SELECT id
-        FROM logs
-        WHERE id <= @cutoff
-          AND level NOT IN ('warn', 'error')
-        ORDER BY id ASC
-        LIMIT @batchRows
-      )
-    `).run({ cutoff, batchRows: this.batchRows }).changes;
+    const deleteRows = Math.min(overflow, this.batchRows);
+    const deleted = this.deleteOldestRoutineRows.run({ deleteRows }).changes;
     return {
       deleted,
       hadOverflow: true,
       filledBatch: deleted === this.batchRows,
     };
-  }
-
-  private overflowCutoff(): number | null {
-    const row = this.db.prepare(`
-      SELECT id
-      FROM logs
-      WHERE level NOT IN ('warn', 'error')
-      ORDER BY id DESC
-      LIMIT 1 OFFSET ?
-    `).get(this.rowCap) as { id: number } | undefined;
-    return row?.id ?? null;
   }
 
   private isRoutineLevel(level: string): boolean {

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -410,6 +410,33 @@ describe('DashboardDB — retention', () => {
     expect(routineLogCount(db)).toBe(0);
   });
 
+  it('keeps replacement writes exact and does not prune the retained row', () => {
+    const volumeDir = mkdtempSync(join(tmpdir(), 'dkg-db-log-replace-'));
+    const volumeDb = new DashboardDB({
+      dataDir: volumeDir,
+      retentionDays: 365,
+      routineLogRowCap: 1,
+      logVolumePruneBatchRows: 1,
+    });
+    try {
+      const replace = volumeDb.db.prepare(`
+        INSERT OR REPLACE INTO logs (id, ts, level, module, message)
+        VALUES (1, ?, 'info', 'compatibility', ?)
+      `);
+      replace.run(Date.now(), 'original');
+      replace.run(Date.now() + 1, 'replacement');
+
+      expect(routineLogCount(volumeDb)).toBe(1);
+      expect(volumeDb.pruneLogVolumeBatch()).toEqual({ deleted: 0, status: 'done' });
+      expect(volumeDb.db.prepare(`
+        SELECT id, message FROM logs
+      `).all()).toEqual([{ id: 1, message: 'replacement' }]);
+    } finally {
+      volumeDb.close();
+      rmSync(volumeDir, { recursive: true, force: true });
+    }
+  });
+
   it('repairs missing current-version retention triggers by recounting once', () => {
     const dbPath = join(dir, 'node-ui.db');
     db.close();
@@ -580,6 +607,39 @@ describe('DashboardDB — retention', () => {
         { level: 'info', message: 'routine-5' },
       ]);
       expect(rows).toContainEqual({ level: 'warn', message: 'keep-warning' });
+    } finally {
+      volumeDb.close();
+      rmSync(volumeDir, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves overflow visible until deferred maintenance runs', async () => {
+    const volumeDir = mkdtempSync(join(tmpdir(), 'dkg-db-log-deferred-boundary-'));
+    const volumeDb = new DashboardDB({
+      dataDir: volumeDir,
+      retentionDays: 365,
+      routineLogRowCap: 0,
+      logVolumePruneBatchRows: 1,
+    });
+    try {
+      volumeDb.insertLog({
+        ts: Date.now(),
+        level: 'info',
+        module: 'deferred-boundary',
+        message: 'overflow',
+      });
+
+      expect(routineLogCount(volumeDb)).toBe(1);
+      expect((volumeDb.db.prepare(`SELECT COUNT(*) AS count FROM logs`).get() as {
+        count: number;
+      }).count).toBe(1);
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(routineLogCount(volumeDb)).toBe(0);
+      expect((volumeDb.db.prepare(`SELECT COUNT(*) AS count FROM logs`).get() as {
+        count: number;
+      }).count).toBe(0);
     } finally {
       volumeDb.close();
       rmSync(volumeDir, { recursive: true, force: true });

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -8,6 +8,27 @@ import { DashboardDB, SqliteChainEventCursorStore, SqliteContextGraphRegistrySca
 let db: DashboardDB;
 let dir: string;
 
+function routineLogCount(database: DashboardDB): number {
+  const row = database.db.prepare(`
+    SELECT routine_rows
+    FROM routine_log_retention_state
+    WHERE singleton = 1
+  `).get() as { routine_rows: number };
+  return row.routine_rows;
+}
+
+async function waitForRoutineLogCountAtMost(
+  database: DashboardDB,
+  maximum: number,
+  attempts = 2_000,
+): Promise<void> {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (routineLogCount(database) <= maximum) return;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  expect(routineLogCount(database)).toBeLessThanOrEqual(maximum);
+}
+
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'dkg-db-test-'));
   db = new DashboardDB({ dataDir: dir });
@@ -370,6 +391,86 @@ describe('DashboardDB — retention', () => {
     db2.close();
   });
 
+  it('tracks direct inserts, deletes, and level changes transactionally', () => {
+    const insert = db.db.prepare(
+      `INSERT INTO logs (ts, level, module, message) VALUES (?, ?, 'compatibility', ?)`,
+    );
+    const routine = insert.run(Date.now(), 'info', 'routine').lastInsertRowid;
+    const warning = insert.run(Date.now(), 'warn', 'warning').lastInsertRowid;
+    insert.run(Date.now(), 'error', 'error');
+    expect(routineLogCount(db)).toBe(1);
+
+    db.db.prepare(`UPDATE logs SET level = 'debug' WHERE id = ?`).run(warning);
+    expect(routineLogCount(db)).toBe(2);
+
+    db.db.prepare(`UPDATE logs SET level = 'error' WHERE id = ?`).run(routine);
+    expect(routineLogCount(db)).toBe(1);
+
+    db.db.prepare(`DELETE FROM logs WHERE id = ?`).run(warning);
+    expect(routineLogCount(db)).toBe(0);
+  });
+
+  it('repairs missing current-version retention triggers by recounting once', () => {
+    const dbPath = join(dir, 'node-ui.db');
+    db.close();
+
+    const raw = new Database(dbPath);
+    raw.exec(`DROP TRIGGER track_routine_log_insert;`);
+    raw.prepare(
+      `INSERT INTO logs (ts, level, module, message) VALUES (?, 'info', 'compatibility', 'untracked')`,
+    ).run(Date.now());
+    expect((raw.prepare(`
+      SELECT routine_rows FROM routine_log_retention_state WHERE singleton = 1
+    `).get() as { routine_rows: number }).routine_rows).toBe(0);
+    raw.pragma(`user_version = ${SCHEMA_VERSION}`);
+    raw.close();
+
+    db = new DashboardDB({ dataDir: dir, retentionDays: 365 });
+    expect(routineLogCount(db)).toBe(1);
+    db.db.prepare(
+      `INSERT INTO logs (ts, level, module, message) VALUES (?, 'debug', 'compatibility', 'tracked')`,
+    ).run(Date.now());
+    expect(routineLogCount(db)).toBe(2);
+  });
+
+  it('initializes exact retention state when upgrading a V34 database', () => {
+    const dbPath = join(dir, 'node-ui.db');
+    db.close();
+
+    const raw = new Database(dbPath);
+    raw.exec(`
+      DROP TRIGGER track_routine_log_insert;
+      DROP TRIGGER track_routine_log_delete;
+      DROP TRIGGER track_routine_log_level_update;
+      DROP INDEX idx_logs_routine_id;
+      DROP TABLE routine_log_retention_state;
+    `);
+    const insert = raw.prepare(
+      `INSERT INTO logs (ts, level, module, message) VALUES (?, ?, 'v34', ?)`,
+    );
+    insert.run(Date.now(), 'info', 'routine-a');
+    insert.run(Date.now(), 'debug', 'routine-b');
+    insert.run(Date.now(), 'warn', 'warning');
+    raw.pragma('user_version = 34');
+    raw.close();
+
+    db = new DashboardDB({ dataDir: dir, retentionDays: 365 });
+    expect(db.db.pragma('user_version', { simple: true })).toBe(SCHEMA_VERSION);
+    expect(routineLogCount(db)).toBe(2);
+  });
+
+  it('uses the routine-only id index for bounded oldest-row deletion', () => {
+    const plan = db.db.prepare(`
+      EXPLAIN QUERY PLAN
+      SELECT id
+      FROM logs
+      WHERE level NOT IN ('warn', 'error')
+      ORDER BY id ASC
+      LIMIT 25000
+    `).all() as Array<{ detail: string }>;
+    expect(plan.some((row) => row.detail.includes('idx_logs_routine_id'))).toBe(true);
+  });
+
   it('caps routine logs incrementally while preserving warning and error history', () => {
     const volumeDir = mkdtempSync(join(tmpdir(), 'dkg-db-log-volume-'));
     const volumeDb = new DashboardDB({
@@ -438,7 +539,7 @@ describe('DashboardDB — retention', () => {
     }
   });
 
-  it('bounds routine compatibility writes through the published row cap', () => {
+  it('bounds routine compatibility writes through deferred maintenance', async () => {
     const volumeDir = mkdtempSync(join(tmpdir(), 'dkg-db-log-compat-cap-'));
     const volumeDb = new DashboardDB({
       dataDir: volumeDir,
@@ -469,6 +570,7 @@ describe('DashboardDB — retention', () => {
         module: 'compatibility',
         message: 'keep-warning',
       });
+      await waitForRoutineLogCountAtMost(volumeDb, 2);
 
       const rows = volumeDb.db.prepare(
         `SELECT level, message FROM logs ORDER BY id ASC`,
@@ -484,7 +586,7 @@ describe('DashboardDB — retention', () => {
     }
   });
 
-  it('keeps pace when the compatibility cleanup batch is smaller than the old guard cadence', () => {
+  it('keeps pace when the deferred cleanup batch is smaller than the old guard cadence', async () => {
     const volumeDir = mkdtempSync(join(tmpdir(), 'dkg-db-log-small-compat-batch-'));
     const volumeDb = new DashboardDB({
       dataDir: volumeDir,
@@ -516,6 +618,7 @@ describe('DashboardDB — retention', () => {
         module: 'legacy-caller',
         message: 'keep-warning',
       });
+      await waitForRoutineLogCountAtMost(volumeDb, 100);
 
       const counts = volumeDb.db.prepare(`
         SELECT
@@ -530,7 +633,7 @@ describe('DashboardDB — retention', () => {
     }
   });
 
-  it('reports a committed insert as successful when inline retention fails', () => {
+  it('reports a committed insert as successful when deferred retention fails', async () => {
     const volumeDir = mkdtempSync(join(tmpdir(), 'dkg-db-log-retention-failure-'));
     const volumeDb = new DashboardDB({
       dataDir: volumeDir,
@@ -558,6 +661,8 @@ describe('DashboardDB — retention', () => {
       ).all()).toEqual([
         { level: 'info', message: 'committed-before-maintenance' },
       ]);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(routineLogCount(volumeDb)).toBe(1);
 
       volumeDb.db.exec('DROP TRIGGER fail_inline_log_retention');
       expect(volumeDb.pruneLogVolumeBatch()).toEqual({ deleted: 1, status: 'more' });


### PR DESCRIPTION
## Summary

- replace repeated synchronous `ORDER BY ... OFFSET rowCap` overflow checks with an O(1) durable routine-row counter
- maintain the counter transactionally for inserts, deletes, and routine/warning level changes, including direct compatibility writers
- select oldest routine rows through a partial id index and prune bounded batches after the insert returns
- add a V35 migration plus current-version repair for missing state/triggers
- add a reproducible million-row benchmark and migration/direct-writer/deferred-failure coverage

## Profiler motivation

The latest 500/500 profile attributed 52.7 receiver CPU-seconds, or 4.52% of active receiver CPU, to `RoutineLogRetention.overflowCutoff()`. Every guard walked up to the one-million-row cap synchronously on the daemon event loop, so the cost grew with retained state even when no deletion was necessary.

## Design

A singleton SQLite state row stores the exact routine-row count. Database triggers update it in the same transaction as every log insert, delete, or classification change, so crashes and compatibility writes cannot bypass accounting. A one-time V34→V35 migration creates a covering partial id index and initializes the counter under an IMMEDIATE transaction. Normal overflow checks then read one row.

`insertLog()` keeps only O(1) accounting on its synchronous path. Bounded deletion is deferred with `setImmediate`; the independent daemon volume pruner remains the retry and historical-backlog owner. Warning/error history remains exempt from the count cap and governed by time retention exactly as before.

## Benchmark

Node v24.5.0, 1,050,000 routine rows, one-million-row cap, 50 checks, median of 5 trials:

| Mode | Median |
| --- | ---: |
| Legacy ordered OFFSET | 785.92 ms |
| Durable counter | 0.064 ms |
| Speedup | 12,248x |

This isolates the overflow check that appeared in the CPU profile; it is not an end-to-end throughput claim. Run with `pnpm --filter @origintrail-official/dkg-node-ui benchmark:routine-log-retention`.

## Correctness coverage

- V34 migration initializes exact state while excluding warning/error rows
- current-version repair detects missing triggers and recounts once
- direct inserts, deletes, and level changes update the counter transactionally
- deferred cleanup preserves the cap even when the batch is smaller than the guard cadence
- failed deferred deletion cannot turn a committed insert into a reported failure
- existing oldest-row, warning/error preservation, bounded catch-up, WAL, and compaction behavior remains covered

## Validation

- Node UI build
- CLI build and package-boundary check
- 2,296 Node UI tests passed; 38 skipped
- 121 database tests passed
- focused CLI pruner lifecycle tests passed
- repository lint
- clean rebase onto current `testnet-canary`