### PR TITLE
perf(storage): skip counts for discarded pattern deletes

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -1774,14 +1774,6 @@ export class DKGAgentBase {
     this.changelogCursors = config.changelogCursorStore ?? this.changelogCursors;
   }
 
-  /** Use the backend's one-round-trip delete path when no exact count is consumed. */
-  protected deleteStoreByPatternWithoutCount(
-    pattern: Partial<Quad>,
-    options?: QueryOptions,
-  ): Promise<void> {
-    return deleteByPatternWithoutCount(this.store, pattern, options);
-  }
-
   /**
    * Acquire the RFC-64 inventory, finish bounded stale-candidate cleanup, and
    * open the inherited-owner control-object tree before network consumers.

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -118,7 +118,7 @@ import {
   pickNetworkTunables,
   isSparqlUpdateOperation,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, createTripleStore, isExternalBackend, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig, type QueryOptions } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, createTripleStore, deleteByPatternWithoutCount, isExternalBackend, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig, type QueryOptions } from '@origintrail-official/dkg-storage';
 import { emptyRpcUsageWindow, EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo, type RpcUsageWindow } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -481,6 +481,13 @@ export function createListContextGraphsCacheInvalidatingStore(
       return invalidateAfterMutation(
         () => innerStore.deleteByPattern(pattern, options),
         removed => removed > 0,
+        () => markProjectionDirty?.(),
+      );
+    },
+    deleteByPatternWithoutCount(pattern, options) {
+      return invalidateAfterMutation(
+        () => deleteByPatternWithoutCount(innerStore, pattern, options),
+        () => true,
         () => markProjectionDirty?.(),
       );
     },
@@ -1765,6 +1772,14 @@ export class DKGAgentBase {
     this.publisher.setWorkspaceSenderKeyEncryptor((input) => (this as unknown as DKGAgent).encryptWorkspacePayloadWithSenderKey(input));
     this.syncCheckpoints = config.syncCheckpointStore ?? this.syncCheckpoints;
     this.changelogCursors = config.changelogCursorStore ?? this.changelogCursors;
+  }
+
+  /** Use the backend's one-round-trip delete path when no exact count is consumed. */
+  protected deleteStoreByPatternWithoutCount(
+    pattern: Partial<Quad>,
+    options?: QueryOptions,
+  ): Promise<void> {
+    return deleteByPatternWithoutCount(this.store, pattern, options);
   }
 
   /**

--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -95,7 +95,7 @@ import {
   pickNetworkTunables,
   assertRdfLiteralMutf8Safe,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, createTripleStore, tryUpdateWithTouchedGraphs, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, createTripleStore, deleteByPatternWithoutCount, tryUpdateWithTouchedGraphs, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -986,7 +986,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     } catch {
       // SPARQL DELETE WHERE may not be supported — delete quads manually
       const subGraphUri = `did:dkg:context-graph:${contextGraphId}/${subGraphName}`;
-      await this.deleteStoreByPatternWithoutCount({ graph: metaGraph, subject: subGraphUri });
+      await deleteByPatternWithoutCount(this.store, { graph: metaGraph, subject: subGraphUri });
     }
 
     const dataUri = gm.subGraphUri(contextGraphId, subGraphName);
@@ -1185,7 +1185,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
   ): Promise<void> {
     const quads = buildTrustLevelQuads(subjects, level, graph) as Quad[];
     for (const quad of quads) {
-      await this.deleteStoreByPatternWithoutCount({
+      await deleteByPatternWithoutCount(this.store, {
         graph: quad.graph,
         subject: quad.subject,
         predicate: TRUST_LEVEL_PREDICATE,

--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -986,7 +986,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     } catch {
       // SPARQL DELETE WHERE may not be supported — delete quads manually
       const subGraphUri = `did:dkg:context-graph:${contextGraphId}/${subGraphName}`;
-      await this.store.deleteByPattern({ graph: metaGraph, subject: subGraphUri });
+      await this.deleteStoreByPatternWithoutCount({ graph: metaGraph, subject: subGraphUri });
     }
 
     const dataUri = gm.subGraphUri(contextGraphId, subGraphName);
@@ -1185,7 +1185,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
   ): Promise<void> {
     const quads = buildTrustLevelQuads(subjects, level, graph) as Quad[];
     for (const quad of quads) {
-      await this.store.deleteByPattern({
+      await this.deleteStoreByPatternWithoutCount({
         graph: quad.graph,
         subject: quad.subject,
         predicate: TRUST_LEVEL_PREDICATE,

--- a/packages/agent/src/dkg-agent-context-graph.ts
+++ b/packages/agent/src/dkg-agent-context-graph.ts
@@ -93,7 +93,7 @@ import {
   pickNetworkTunables,
   assertRdfLiteralMutf8Safe,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, createTripleStore, deleteByPatternWithoutCount, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -940,9 +940,9 @@ export class ContextGraphMethods extends DKGAgentBase {
       // Defensive: replace any stray creator/curator triples (e.g. from
       // a previous build that backfilled per node) so this register call
       // becomes the single source of truth.
-      await this.deleteStoreByPatternWithoutCount({ graph: defGraph, subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CREATOR });
-      await this.deleteStoreByPatternWithoutCount({ graph: cgMetaGraph, subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CREATOR });
-      await this.deleteStoreByPatternWithoutCount({ graph: cgMetaGraph, subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CURATOR });
+      await deleteByPatternWithoutCount(this.store, { graph: defGraph, subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CREATOR });
+      await deleteByPatternWithoutCount(this.store, { graph: cgMetaGraph, subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CREATOR });
+      await deleteByPatternWithoutCount(this.store, { graph: cgMetaGraph, subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CURATOR });
       const authorityQuads: Quad[] = [
         { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CREATOR, object: creatorPeerDid, graph: defGraph },
         { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: curatorDid, graph: cgMetaGraph },
@@ -1164,7 +1164,7 @@ export class ContextGraphMethods extends DKGAgentBase {
       }
       if (onChainLive) {
         this.log.info(ctx, `Context graph "${id}" already has on-chain ID ${existingOnChainId} — skipping chain call`);
-        await this.deleteStoreByPatternWithoutCount({
+        await deleteByPatternWithoutCount(this.store, {
           graph: cgMetaGraph,
           subject: contextGraphUri,
           predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS,
@@ -1180,7 +1180,7 @@ export class ContextGraphMethods extends DKGAgentBase {
         `Context graph "${id}" has local on-chain id ${existingOnChainId} but it is not active on-chain — re-registering`,
       );
       const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
-      await this.deleteStoreByPatternWithoutCount({
+      await deleteByPatternWithoutCount(this.store, {
         graph: ontologyGraph,
         subject: contextGraphUri,
         predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
@@ -1442,7 +1442,7 @@ export class ContextGraphMethods extends DKGAgentBase {
     // slot from the curator's private `_meta` snapshot.  A private joiner may
     // have missed the one-shot ontology gossip emitted below and must not be
     // left unable to start chain-driven VM reconciliation as a result.
-    await this.deleteStoreByPatternWithoutCount({
+    await deleteByPatternWithoutCount(this.store, {
       graph: cgMetaGraph,
       subject: contextGraphUri,
       predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS,
@@ -1450,12 +1450,12 @@ export class ContextGraphMethods extends DKGAgentBase {
     // Single-valued binding guard (RS heal): the on-chain id is immutable, so
     // clear any prior value before insert — the cgId resolver / heal read this
     // and must never see a multi-valued (LIMIT-1-nondeterministic) binding.
-    await this.deleteStoreByPatternWithoutCount({
+    await deleteByPatternWithoutCount(this.store, {
       graph: ontologyGraph,
       subject: contextGraphUri,
       predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
     });
-    await this.deleteStoreByPatternWithoutCount({
+    await deleteByPatternWithoutCount(this.store, {
       graph: cgMetaGraph,
       subject: contextGraphUri,
       predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
@@ -1832,7 +1832,7 @@ export class ContextGraphMethods extends DKGAgentBase {
     // and immediately before this call. The first awaited operation here is
     // therefore also the first persistent membership mutation.
     if (delegationUri) {
-      await this.deleteStoreByPatternWithoutCount({ graph: cgMetaGraph, subject: delegationUri });
+      await deleteByPatternWithoutCount(this.store, { graph: cgMetaGraph, subject: delegationUri });
     }
     await this.store.insert(quadsToInsert);
     this.invalidateListContextGraphsCache();
@@ -1929,7 +1929,7 @@ export class ContextGraphMethods extends DKGAgentBase {
     const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
     const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
 
-    await this.deleteStoreByPatternWithoutCount({
+    await deleteByPatternWithoutCount(this.store, {
       graph: cgMetaGraph,
       subject: contextGraphUri,
       predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
@@ -1941,7 +1941,7 @@ export class ContextGraphMethods extends DKGAgentBase {
     // primary allowlist. See `inviteAgentToContextGraph` for the
     // matching write side.
     const delegationUri = `did:dkg:agent-delegation:${contextGraphId}:${agentAddress.toLowerCase()}`;
-    await this.deleteStoreByPatternWithoutCount({ graph: cgMetaGraph, subject: delegationUri });
+    await deleteByPatternWithoutCount(this.store, { graph: cgMetaGraph, subject: delegationUri });
     // Persist a LOCAL tombstone so the recipient resolver excludes this
     // agent from future sender-key wraps even when peer-sync has
     // replicated the original `dkg:allowedAgent` triple onto this store
@@ -2027,12 +2027,12 @@ export class ContextGraphMethods extends DKGAgentBase {
     const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
     const schemaName = DKG_ONTOLOGY.SCHEMA_NAME;
 
-    await this.deleteStoreByPatternWithoutCount({
+    await deleteByPatternWithoutCount(this.store, {
       subject: contextGraphUri,
       predicate: schemaName,
       graph: ontologyGraph,
     });
-    await this.deleteStoreByPatternWithoutCount({
+    await deleteByPatternWithoutCount(this.store, {
       subject: contextGraphUri,
       predicate: schemaName,
       graph: cgMetaGraph,

--- a/packages/agent/src/dkg-agent-context-graph.ts
+++ b/packages/agent/src/dkg-agent-context-graph.ts
@@ -940,9 +940,9 @@ export class ContextGraphMethods extends DKGAgentBase {
       // Defensive: replace any stray creator/curator triples (e.g. from
       // a previous build that backfilled per node) so this register call
       // becomes the single source of truth.
-      await this.store.deleteByPattern({ graph: defGraph, subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CREATOR });
-      await this.store.deleteByPattern({ graph: cgMetaGraph, subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CREATOR });
-      await this.store.deleteByPattern({ graph: cgMetaGraph, subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CURATOR });
+      await this.deleteStoreByPatternWithoutCount({ graph: defGraph, subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CREATOR });
+      await this.deleteStoreByPatternWithoutCount({ graph: cgMetaGraph, subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CREATOR });
+      await this.deleteStoreByPatternWithoutCount({ graph: cgMetaGraph, subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CURATOR });
       const authorityQuads: Quad[] = [
         { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CREATOR, object: creatorPeerDid, graph: defGraph },
         { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: curatorDid, graph: cgMetaGraph },
@@ -1164,7 +1164,7 @@ export class ContextGraphMethods extends DKGAgentBase {
       }
       if (onChainLive) {
         this.log.info(ctx, `Context graph "${id}" already has on-chain ID ${existingOnChainId} — skipping chain call`);
-        await this.store.deleteByPattern({
+        await this.deleteStoreByPatternWithoutCount({
           graph: cgMetaGraph,
           subject: contextGraphUri,
           predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS,
@@ -1180,7 +1180,7 @@ export class ContextGraphMethods extends DKGAgentBase {
         `Context graph "${id}" has local on-chain id ${existingOnChainId} but it is not active on-chain — re-registering`,
       );
       const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
-      await this.store.deleteByPattern({
+      await this.deleteStoreByPatternWithoutCount({
         graph: ontologyGraph,
         subject: contextGraphUri,
         predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
@@ -1442,7 +1442,7 @@ export class ContextGraphMethods extends DKGAgentBase {
     // slot from the curator's private `_meta` snapshot.  A private joiner may
     // have missed the one-shot ontology gossip emitted below and must not be
     // left unable to start chain-driven VM reconciliation as a result.
-    await this.store.deleteByPattern({
+    await this.deleteStoreByPatternWithoutCount({
       graph: cgMetaGraph,
       subject: contextGraphUri,
       predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS,
@@ -1450,12 +1450,12 @@ export class ContextGraphMethods extends DKGAgentBase {
     // Single-valued binding guard (RS heal): the on-chain id is immutable, so
     // clear any prior value before insert — the cgId resolver / heal read this
     // and must never see a multi-valued (LIMIT-1-nondeterministic) binding.
-    await this.store.deleteByPattern({
+    await this.deleteStoreByPatternWithoutCount({
       graph: ontologyGraph,
       subject: contextGraphUri,
       predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
     });
-    await this.store.deleteByPattern({
+    await this.deleteStoreByPatternWithoutCount({
       graph: cgMetaGraph,
       subject: contextGraphUri,
       predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
@@ -1832,7 +1832,7 @@ export class ContextGraphMethods extends DKGAgentBase {
     // and immediately before this call. The first awaited operation here is
     // therefore also the first persistent membership mutation.
     if (delegationUri) {
-      await this.store.deleteByPattern({ graph: cgMetaGraph, subject: delegationUri });
+      await this.deleteStoreByPatternWithoutCount({ graph: cgMetaGraph, subject: delegationUri });
     }
     await this.store.insert(quadsToInsert);
     this.invalidateListContextGraphsCache();
@@ -1929,7 +1929,7 @@ export class ContextGraphMethods extends DKGAgentBase {
     const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
     const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
 
-    await this.store.deleteByPattern({
+    await this.deleteStoreByPatternWithoutCount({
       graph: cgMetaGraph,
       subject: contextGraphUri,
       predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
@@ -1941,7 +1941,7 @@ export class ContextGraphMethods extends DKGAgentBase {
     // primary allowlist. See `inviteAgentToContextGraph` for the
     // matching write side.
     const delegationUri = `did:dkg:agent-delegation:${contextGraphId}:${agentAddress.toLowerCase()}`;
-    await this.store.deleteByPattern({ graph: cgMetaGraph, subject: delegationUri });
+    await this.deleteStoreByPatternWithoutCount({ graph: cgMetaGraph, subject: delegationUri });
     // Persist a LOCAL tombstone so the recipient resolver excludes this
     // agent from future sender-key wraps even when peer-sync has
     // replicated the original `dkg:allowedAgent` triple onto this store
@@ -2027,12 +2027,12 @@ export class ContextGraphMethods extends DKGAgentBase {
     const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
     const schemaName = DKG_ONTOLOGY.SCHEMA_NAME;
 
-    await this.store.deleteByPattern({
+    await this.deleteStoreByPatternWithoutCount({
       subject: contextGraphUri,
       predicate: schemaName,
       graph: ontologyGraph,
     });
-    await this.store.deleteByPattern({
+    await this.deleteStoreByPatternWithoutCount({
       subject: contextGraphUri,
       predicate: schemaName,
       graph: cgMetaGraph,

--- a/packages/agent/src/dkg-agent-join.ts
+++ b/packages/agent/src/dkg-agent-join.ts
@@ -1212,7 +1212,7 @@ export class JoinRequestMethods extends DKGAgentBase {
       if (!updatedAtomically) {
         // Compatibility fallback for custom stores without SPARQL UPDATE.
         // Restore the prior row best-effort if the replacement insert fails.
-        await this.store.deleteByPattern({ graph: REQUESTER_JOIN_STATE_GRAPH, subject });
+        await this.deleteStoreByPatternWithoutCount({ graph: REQUESTER_JOIN_STATE_GRAPH, subject });
         try {
           await this.store.insert(quads);
         } catch (error) {
@@ -1258,7 +1258,7 @@ export class JoinRequestMethods extends DKGAgentBase {
     const key = requesterJoinStateKey(contextGraphId, agentAddress);
     const cache = this.requesterJoinStateCache();
     try {
-      await this.store.deleteByPattern({
+      await this.deleteStoreByPatternWithoutCount({
         graph: REQUESTER_JOIN_STATE_GRAPH,
         subject: requesterJoinStateSubject(contextGraphId, agentAddress),
       });
@@ -1676,7 +1676,7 @@ export class JoinRequestMethods extends DKGAgentBase {
       }
     }
 
-    await this.store.deleteByPattern({ graph: cgMetaGraph, subject: requestUri });
+    await this.deleteStoreByPatternWithoutCount({ graph: cgMetaGraph, subject: requestUri });
 
     // Escape every user-controllable literal. `contextGraphId`, `delegation.scope`,
     // and `agentName` flow from joiner input and can contain `"` or `\`, which
@@ -2294,12 +2294,12 @@ export class JoinRequestMethods extends DKGAgentBase {
       // Compatibility fallback for custom stores without SPARQL UPDATE.
       // The curator remains authoritative if a crash lands between these two
       // mutations, and an approval can be redelivered to repair local state.
-      await this.store.deleteByPattern({
+      await this.deleteStoreByPatternWithoutCount({
         graph: cgMetaGraph,
         subject: requestUri,
         predicate: requestStatus,
       });
-      await this.store.deleteByPattern({
+      await this.deleteStoreByPatternWithoutCount({
         graph: cgMetaGraph,
         subject: requestUri,
         predicate: decisionTimestamp,

--- a/packages/agent/src/dkg-agent-join.ts
+++ b/packages/agent/src/dkg-agent-join.ts
@@ -96,7 +96,7 @@ import {
   OPEN_ENROLLMENT_MAX_APPROVALS_PER_HOUR,
   isBoundedOpenEnrollmentPolicy,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, createTripleStore, tryUpdateWithTouchedGraphs, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, createTripleStore, deleteByPatternWithoutCount, tryUpdateWithTouchedGraphs, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -1212,7 +1212,7 @@ export class JoinRequestMethods extends DKGAgentBase {
       if (!updatedAtomically) {
         // Compatibility fallback for custom stores without SPARQL UPDATE.
         // Restore the prior row best-effort if the replacement insert fails.
-        await this.deleteStoreByPatternWithoutCount({ graph: REQUESTER_JOIN_STATE_GRAPH, subject });
+        await deleteByPatternWithoutCount(this.store, { graph: REQUESTER_JOIN_STATE_GRAPH, subject });
         try {
           await this.store.insert(quads);
         } catch (error) {
@@ -1258,7 +1258,7 @@ export class JoinRequestMethods extends DKGAgentBase {
     const key = requesterJoinStateKey(contextGraphId, agentAddress);
     const cache = this.requesterJoinStateCache();
     try {
-      await this.deleteStoreByPatternWithoutCount({
+      await deleteByPatternWithoutCount(this.store, {
         graph: REQUESTER_JOIN_STATE_GRAPH,
         subject: requesterJoinStateSubject(contextGraphId, agentAddress),
       });
@@ -1676,7 +1676,7 @@ export class JoinRequestMethods extends DKGAgentBase {
       }
     }
 
-    await this.deleteStoreByPatternWithoutCount({ graph: cgMetaGraph, subject: requestUri });
+    await deleteByPatternWithoutCount(this.store, { graph: cgMetaGraph, subject: requestUri });
 
     // Escape every user-controllable literal. `contextGraphId`, `delegation.scope`,
     // and `agentName` flow from joiner input and can contain `"` or `\`, which
@@ -2294,12 +2294,12 @@ export class JoinRequestMethods extends DKGAgentBase {
       // Compatibility fallback for custom stores without SPARQL UPDATE.
       // The curator remains authoritative if a crash lands between these two
       // mutations, and an approval can be redelivered to repair local state.
-      await this.deleteStoreByPatternWithoutCount({
+      await deleteByPatternWithoutCount(this.store, {
         graph: cgMetaGraph,
         subject: requestUri,
         predicate: requestStatus,
       });
-      await this.deleteStoreByPatternWithoutCount({
+      await deleteByPatternWithoutCount(this.store, {
         graph: cgMetaGraph,
         subject: requestUri,
         predicate: decisionTimestamp,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -100,7 +100,7 @@ import {
   withRetry,
 } from '@origintrail-official/dkg-core';
 import type { RandomSamplingRepairOperation } from '@origintrail-official/dkg-random-sampling';
-import { GraphManager, PrivateContentStore, createTripleStore, asChangelogReader, tryReplaceGraphAtomically, type ChangelogReader, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, createTripleStore, asChangelogReader, deleteByPatternWithoutCount, tryReplaceGraphAtomically, type ChangelogReader, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { readChangelogDeltaPage } from './sync/responder/graph-plan.js';
 import { decodeChangelogRequest, encodeChangelogResponse } from './sync/changelog/wire.js';
 import { runChangelogSync, planPageApply } from './sync/requester/changelog-sync.js';
@@ -10730,7 +10730,8 @@ async function runRecoverContextGraphSwmFromPeer(
             const raw = remaining.type === 'bindings' ? remaining.bindings[0]?.['c'] : undefined;
             const countVal = raw ? parseInt(String(raw).match(/\d+/)?.[0] ?? '0', 10) : 0;
             if (countVal === 0) {
-              await dependencies.store.deleteByPattern(
+              await deleteByPatternWithoutCount(
+                dependencies.store,
                 { graph: metaGraph, subject: op },
                 {
                   priority: 'background',

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -109,6 +109,7 @@ import {
 } from '@origintrail-official/dkg-core';
 import { SpanStatusCode } from '@opentelemetry/api';
 import {
+  deleteByPatternWithoutCount,
   GraphManager,
   PrivateContentStore,
   createTripleStore,
@@ -1960,7 +1961,7 @@ export class PublishMethods extends DKGAgentBase {
           publishProjection: async (_id, quads, graph) => {
             const subjects = new Set(quads.map((q) => q.subject));
             for (const subject of subjects) {
-              await this.deleteStoreByPatternWithoutCount({ graph, subject });
+              await deleteByPatternWithoutCount(this.store, { graph, subject });
             }
             await this.store.insert(quads);
             this.contextGraphMetaProjection.markDirtyFromQuads(quads);
@@ -2779,7 +2780,7 @@ export class PublishMethods extends DKGAgentBase {
       // version may need replacement, but a failure after its delete is safe:
       // the durable seal is written first and an idempotent finalize retry
       // repairs this row before returning.
-      await this.deleteStoreByPatternWithoutCount({
+      await deleteByPatternWithoutCount(this.store, {
         graph: metaGraph,
         subject: lifecycleUri,
         predicate: ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION,
@@ -5717,7 +5718,7 @@ export class PublishMethods extends DKGAgentBase {
           : contextGraphWorkspaceMetaGraphUri(request.contextGraphId);
         const keepLiteral = `"${keepRootCopyOnLabel}"`;
         for (const root of rootEntities.filter(isSafeIri)) {
-          await this.deleteStoreByPatternWithoutCount({
+          await deleteByPatternWithoutCount(this.store, {
             subject: root,
             predicate: KEEP_ROOT_COPY_PREDICATE,
             graph: wsMetaGraph,
@@ -6195,12 +6196,12 @@ export class PublishMethods extends DKGAgentBase {
         const MEMORY_LAYER_PRED = 'http://dkg.io/ontology/memoryLayer';
         const STATE_PRED = 'http://dkg.io/ontology/state';
         for (const subj of [lifecycleUri, assertionUri]) {
-          await this.deleteStoreByPatternWithoutCount({ subject: subj, predicate: MEMORY_LAYER_PRED, graph: metaGraph });
+          await deleteByPatternWithoutCount(this.store, { subject: subj, predicate: MEMORY_LAYER_PRED, graph: metaGraph });
           await this.store.insert([
             { subject: subj, predicate: MEMORY_LAYER_PRED, object: `"${MemoryLayer.VerifiableMemory}"`, graph: metaGraph },
           ]);
         }
-        await this.deleteStoreByPatternWithoutCount({ subject: lifecycleUri, predicate: STATE_PRED, graph: metaGraph });
+        await deleteByPatternWithoutCount(this.store, { subject: lifecycleUri, predicate: STATE_PRED, graph: metaGraph });
         await this.store.insert([
           { subject: lifecycleUri, predicate: STATE_PRED, object: '"published"', graph: metaGraph },
         ]);
@@ -6219,7 +6220,7 @@ export class PublishMethods extends DKGAgentBase {
         if (result.ual) {
           try {
             const PUBLISHED_UAL_PRED = 'http://dkg.io/ontology/publishedUal';
-            await this.deleteStoreByPatternWithoutCount({ subject: lifecycleUri, predicate: PUBLISHED_UAL_PRED, graph: metaGraph });
+            await deleteByPatternWithoutCount(this.store, { subject: lifecycleUri, predicate: PUBLISHED_UAL_PRED, graph: metaGraph });
             await this.store.insert([
               { subject: lifecycleUri, predicate: PUBLISHED_UAL_PRED, object: `"${result.ual}"`, graph: metaGraph },
             ]);
@@ -6263,7 +6264,7 @@ export class PublishMethods extends DKGAgentBase {
             const vmAuthor = '0x' + (vmKaIdBig >> 96n).toString(16).padStart(40, '0');
             const vmNumber = vmKaIdBig & ((1n << 96n) - 1n);
             const vmGraph = contextGraphLayerUri(contextGraphId, MemoryLayer.VerifiableMemory, vmAuthor, vmNumber, opts?.subGraphName);
-            await this.deleteStoreByPatternWithoutCount({ subject: lifecycleUri, predicate: ASSERTION_GRAPH_PRED, graph: metaGraph });
+            await deleteByPatternWithoutCount(this.store, { subject: lifecycleUri, predicate: ASSERTION_GRAPH_PRED, graph: metaGraph });
             await this.store.insert([
               { subject: lifecycleUri, predicate: ASSERTION_GRAPH_PRED, object: vmGraph, graph: metaGraph },
             ]);
@@ -6283,7 +6284,7 @@ export class PublishMethods extends DKGAgentBase {
             // Any non-"WM" value short-circuits that guard, so "VM" keeps the
             // no-op witness AND tells the truth about the layer.
             const wmGraph = contextGraphLayerUri(contextGraphId, MemoryLayer.WorkingMemory, vmAuthor, vmNumber, opts?.subGraphName);
-            await this.deleteStoreByPatternWithoutCount({ subject: wmGraph, predicate: MEMORY_LAYER_PRED, graph: metaGraph });
+            await deleteByPatternWithoutCount(this.store, { subject: wmGraph, predicate: MEMORY_LAYER_PRED, graph: metaGraph });
             await this.store.insert([
               { subject: wmGraph, predicate: MEMORY_LAYER_PRED, object: `"${MemoryLayer.VerifiableMemory}"`, graph: metaGraph },
             ]);
@@ -6441,7 +6442,7 @@ export class PublishMethods extends DKGAgentBase {
     metaGraph: string,
   ): Promise<void> {
     const bare = merkleHex.startsWith('0x') ? merkleHex.slice(2) : merkleHex;
-    await this.deleteStoreByPatternWithoutCount({ subject: lifecycleUri, predicate: pred, graph: metaGraph });
+    await deleteByPatternWithoutCount(this.store, { subject: lifecycleUri, predicate: pred, graph: metaGraph });
     await this.store.insert([
       { subject: lifecycleUri, predicate: pred, object: `"${bare}"`, graph: metaGraph },
     ]);
@@ -6479,7 +6480,7 @@ export class PublishMethods extends DKGAgentBase {
       // divergent row is not.
     }
     if (vmBare !== undefined && vmBare === bare) {
-      await this.deleteStoreByPatternWithoutCount({ subject: lifecycleUri, predicate: pred, graph: metaGraph });
+      await deleteByPatternWithoutCount(this.store, { subject: lifecycleUri, predicate: pred, graph: metaGraph });
       return;
     }
     await this._stampPointer(lifecycleUri, pred, bare, metaGraph);
@@ -6924,7 +6925,7 @@ export class PublishMethods extends DKGAgentBase {
           : contextGraphWorkspaceMetaGraphUri(contextGraphId);
         const keepLiteral = `"${keepRootCopyOnLabel}"`;
         for (const root of rootEntities.filter(isSafeIri)) {
-          await this.deleteStoreByPatternWithoutCount({
+          await deleteByPatternWithoutCount(this.store, {
             subject: root,
             predicate: KEEP_ROOT_COPY_PREDICATE,
             graph: wsMetaGraph,

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -1960,7 +1960,7 @@ export class PublishMethods extends DKGAgentBase {
           publishProjection: async (_id, quads, graph) => {
             const subjects = new Set(quads.map((q) => q.subject));
             for (const subject of subjects) {
-              await this.store.deleteByPattern({ graph, subject });
+              await this.deleteStoreByPatternWithoutCount({ graph, subject });
             }
             await this.store.insert(quads);
             this.contextGraphMetaProjection.markDirtyFromQuads(quads);
@@ -2779,7 +2779,7 @@ export class PublishMethods extends DKGAgentBase {
       // version may need replacement, but a failure after its delete is safe:
       // the durable seal is written first and an idempotent finalize retry
       // repairs this row before returning.
-      await this.store.deleteByPattern({
+      await this.deleteStoreByPatternWithoutCount({
         graph: metaGraph,
         subject: lifecycleUri,
         predicate: ASSERTION_SEAL_PREDICATES.ASSERTION_VERSION,
@@ -5717,7 +5717,7 @@ export class PublishMethods extends DKGAgentBase {
           : contextGraphWorkspaceMetaGraphUri(request.contextGraphId);
         const keepLiteral = `"${keepRootCopyOnLabel}"`;
         for (const root of rootEntities.filter(isSafeIri)) {
-          await this.store.deleteByPattern({
+          await this.deleteStoreByPatternWithoutCount({
             subject: root,
             predicate: KEEP_ROOT_COPY_PREDICATE,
             graph: wsMetaGraph,
@@ -6195,12 +6195,12 @@ export class PublishMethods extends DKGAgentBase {
         const MEMORY_LAYER_PRED = 'http://dkg.io/ontology/memoryLayer';
         const STATE_PRED = 'http://dkg.io/ontology/state';
         for (const subj of [lifecycleUri, assertionUri]) {
-          await this.store.deleteByPattern({ subject: subj, predicate: MEMORY_LAYER_PRED, graph: metaGraph });
+          await this.deleteStoreByPatternWithoutCount({ subject: subj, predicate: MEMORY_LAYER_PRED, graph: metaGraph });
           await this.store.insert([
             { subject: subj, predicate: MEMORY_LAYER_PRED, object: `"${MemoryLayer.VerifiableMemory}"`, graph: metaGraph },
           ]);
         }
-        await this.store.deleteByPattern({ subject: lifecycleUri, predicate: STATE_PRED, graph: metaGraph });
+        await this.deleteStoreByPatternWithoutCount({ subject: lifecycleUri, predicate: STATE_PRED, graph: metaGraph });
         await this.store.insert([
           { subject: lifecycleUri, predicate: STATE_PRED, object: '"published"', graph: metaGraph },
         ]);
@@ -6219,7 +6219,7 @@ export class PublishMethods extends DKGAgentBase {
         if (result.ual) {
           try {
             const PUBLISHED_UAL_PRED = 'http://dkg.io/ontology/publishedUal';
-            await this.store.deleteByPattern({ subject: lifecycleUri, predicate: PUBLISHED_UAL_PRED, graph: metaGraph });
+            await this.deleteStoreByPatternWithoutCount({ subject: lifecycleUri, predicate: PUBLISHED_UAL_PRED, graph: metaGraph });
             await this.store.insert([
               { subject: lifecycleUri, predicate: PUBLISHED_UAL_PRED, object: `"${result.ual}"`, graph: metaGraph },
             ]);
@@ -6263,7 +6263,7 @@ export class PublishMethods extends DKGAgentBase {
             const vmAuthor = '0x' + (vmKaIdBig >> 96n).toString(16).padStart(40, '0');
             const vmNumber = vmKaIdBig & ((1n << 96n) - 1n);
             const vmGraph = contextGraphLayerUri(contextGraphId, MemoryLayer.VerifiableMemory, vmAuthor, vmNumber, opts?.subGraphName);
-            await this.store.deleteByPattern({ subject: lifecycleUri, predicate: ASSERTION_GRAPH_PRED, graph: metaGraph });
+            await this.deleteStoreByPatternWithoutCount({ subject: lifecycleUri, predicate: ASSERTION_GRAPH_PRED, graph: metaGraph });
             await this.store.insert([
               { subject: lifecycleUri, predicate: ASSERTION_GRAPH_PRED, object: vmGraph, graph: metaGraph },
             ]);
@@ -6283,7 +6283,7 @@ export class PublishMethods extends DKGAgentBase {
             // Any non-"WM" value short-circuits that guard, so "VM" keeps the
             // no-op witness AND tells the truth about the layer.
             const wmGraph = contextGraphLayerUri(contextGraphId, MemoryLayer.WorkingMemory, vmAuthor, vmNumber, opts?.subGraphName);
-            await this.store.deleteByPattern({ subject: wmGraph, predicate: MEMORY_LAYER_PRED, graph: metaGraph });
+            await this.deleteStoreByPatternWithoutCount({ subject: wmGraph, predicate: MEMORY_LAYER_PRED, graph: metaGraph });
             await this.store.insert([
               { subject: wmGraph, predicate: MEMORY_LAYER_PRED, object: `"${MemoryLayer.VerifiableMemory}"`, graph: metaGraph },
             ]);
@@ -6441,7 +6441,7 @@ export class PublishMethods extends DKGAgentBase {
     metaGraph: string,
   ): Promise<void> {
     const bare = merkleHex.startsWith('0x') ? merkleHex.slice(2) : merkleHex;
-    await this.store.deleteByPattern({ subject: lifecycleUri, predicate: pred, graph: metaGraph });
+    await this.deleteStoreByPatternWithoutCount({ subject: lifecycleUri, predicate: pred, graph: metaGraph });
     await this.store.insert([
       { subject: lifecycleUri, predicate: pred, object: `"${bare}"`, graph: metaGraph },
     ]);
@@ -6479,7 +6479,7 @@ export class PublishMethods extends DKGAgentBase {
       // divergent row is not.
     }
     if (vmBare !== undefined && vmBare === bare) {
-      await this.store.deleteByPattern({ subject: lifecycleUri, predicate: pred, graph: metaGraph });
+      await this.deleteStoreByPatternWithoutCount({ subject: lifecycleUri, predicate: pred, graph: metaGraph });
       return;
     }
     await this._stampPointer(lifecycleUri, pred, bare, metaGraph);
@@ -6924,7 +6924,7 @@ export class PublishMethods extends DKGAgentBase {
           : contextGraphWorkspaceMetaGraphUri(contextGraphId);
         const keepLiteral = `"${keepRootCopyOnLabel}"`;
         for (const root of rootEntities.filter(isSafeIri)) {
-          await this.store.deleteByPattern({
+          await this.deleteStoreByPatternWithoutCount({
             subject: root,
             predicate: KEEP_ROOT_COPY_PREDICATE,
             graph: wsMetaGraph,

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -89,7 +89,7 @@ import {
   LegacyKnowledgeAssetReadOnlyError,
   isAllocatableKaAuthorV1,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, createTripleStore, deleteByPatternWithoutCount, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { canonicalRootlessLifecycleGraph } from './rootless-lifecycle-graph.js';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, isContextGraphChainScanPartialError, type EVMAdapterConfig, type ChainAdapter, type ContextGraphOnChain, type ContextGraphChainScanOptions, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
@@ -1806,7 +1806,7 @@ export class DKGAgent extends DKGAgentBase {
         // Keep this durable write before in-memory catalogue mutation: cursor
         // pages are acked after this function returns, and an in-memory onChainId
         // alone must not make a retry skip the RDF binding.
-        await this.deleteStoreByPatternWithoutCount({
+        await deleteByPatternWithoutCount(this.store, {
           graph: ontoGraph,
           subject: cgUri,
           predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1806,7 +1806,7 @@ export class DKGAgent extends DKGAgentBase {
         // Keep this durable write before in-memory catalogue mutation: cursor
         // pages are acked after this function returns, and an in-memory onChainId
         // alone must not make a retry skip the RDF binding.
-        await this.store.deleteByPattern({
+        await this.deleteStoreByPatternWithoutCount({
           graph: ontoGraph,
           subject: cgUri,
           predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -19,6 +19,7 @@ import {
   sparqlString,
 } from '@origintrail-official/dkg-core';
 import {
+  deleteByPatternWithoutCount,
   GraphManager,
   loadSelectedSharedMemoryQuads,
   loadSharedMemorySliceWithKaBoundFallback,
@@ -3609,8 +3610,8 @@ export class FinalizationHandler {
     try {
       const quads: Quad[] = [];
       for (const [op, { root, digest }] of restamp) {
-        await this.store.deleteByPattern({ graph: wsMetaGraph, subject: op, predicate: SWM_SNAPSHOT_MERKLE_ROOT_PREDICATE });
-        await this.store.deleteByPattern({ graph: wsMetaGraph, subject: op, predicate: SWM_SNAPSHOT_CONTENT_DIGEST_PREDICATE });
+        await deleteByPatternWithoutCount(this.store, { graph: wsMetaGraph, subject: op, predicate: SWM_SNAPSHOT_MERKLE_ROOT_PREDICATE });
+        await deleteByPatternWithoutCount(this.store, { graph: wsMetaGraph, subject: op, predicate: SWM_SNAPSHOT_CONTENT_DIGEST_PREDICATE });
         quads.push(
           { subject: op, predicate: SWM_SNAPSHOT_MERKLE_ROOT_PREDICATE, object: `"${root}"`, graph: wsMetaGraph },
           { subject: op, predicate: SWM_SNAPSHOT_CONTENT_DIGEST_PREDICATE, object: `"${digest}"`, graph: wsMetaGraph },
@@ -3668,8 +3669,8 @@ export class FinalizationHandler {
       // The stamp no longer reflects the op's content — drop the whole (root, digest)
       // memo so the recompute scan re-evaluates and re-stamps it this pass.
       try {
-        await this.store.deleteByPattern({ graph: wsMetaGraph, subject: op, predicate: SWM_SNAPSHOT_MERKLE_ROOT_PREDICATE });
-        await this.store.deleteByPattern({ graph: wsMetaGraph, subject: op, predicate: SWM_SNAPSHOT_CONTENT_DIGEST_PREDICATE });
+        await deleteByPatternWithoutCount(this.store, { graph: wsMetaGraph, subject: op, predicate: SWM_SNAPSHOT_MERKLE_ROOT_PREDICATE });
+        await deleteByPatternWithoutCount(this.store, { graph: wsMetaGraph, subject: op, predicate: SWM_SNAPSHOT_CONTENT_DIGEST_PREDICATE });
       } catch { /* best-effort self-heal */ }
     }
     return null;
@@ -4127,13 +4128,13 @@ export class FinalizationHandler {
     );
     for (const rootEntity of rootEntities) {
       for (const g of swmGraphsForClear) {
-        await this.store.deleteByPattern({ graph: g, subject: rootEntity });
+        await deleteByPatternWithoutCount(this.store, { graph: g, subject: rootEntity });
         await this.store.deleteBySubjectPrefix(g, rootEntity + '/.well-known/genid/');
-        await this.store.deleteByPattern({
+        await deleteByPatternWithoutCount(this.store, {
           graph: g, subject: rootEntity, predicate: 'http://dkg.io/ontology/workspaceOwner',
         });
       }
-      await this.store.deleteByPattern({
+      await deleteByPatternWithoutCount(this.store, {
         graph: swmMetaGraph, subject: rootEntity, predicate: 'http://dkg.io/ontology/workspaceOwner',
       });
       await this.deleteMetaForRoot(swmMetaGraph, rootEntity);
@@ -4200,7 +4201,7 @@ export class FinalizationHandler {
         ? Number(rawCount.replace(/^"/, '').replace(/"(\^\^<[^>]+>)?$/, ''))
         : NaN;
       if (countVal === 0) {
-        await this.store.deleteByPattern({ graph: metaGraph, subject: op });
+        await deleteByPatternWithoutCount(this.store, { graph: metaGraph, subject: op });
       }
     }
   }

--- a/packages/agent/src/gossip-publish-handler.ts
+++ b/packages/agent/src/gossip-publish-handler.ts
@@ -11,6 +11,7 @@ import {
   type OperationContext,
 } from '@origintrail-official/dkg-core';
 import {
+  deleteByPatternWithoutCount,
   GraphManager,
   tryReplaceGraphAtomically,
   type TripleStore,
@@ -653,7 +654,7 @@ export class GossipPublishHandler {
                 { code: 'VM_ATOMIC_REPLACE_UNSUPPORTED' },
               );
             }
-            await this.store.deleteByPattern({
+            await deleteByPatternWithoutCount(this.store, {
               graph: metaGraph,
               subject: graphPublish.scope.ual,
             });

--- a/packages/agent/src/join-request-retention.ts
+++ b/packages/agent/src/join-request-retention.ts
@@ -3,7 +3,10 @@ import {
   contextGraphMetaGraphUri,
   sparqlString,
 } from '@origintrail-official/dkg-core';
-import type { TripleStore } from '@origintrail-official/dkg-storage';
+import {
+  deleteByPatternWithoutCount,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
 
 const JOIN_REQUEST_SUBJECT_PREFIX = 'did:dkg:join-request:';
 const REQUEST_STATUS = 'https://dkg.network/ontology#requestStatus';
@@ -102,7 +105,8 @@ export async function pruneTerminalJoinRequestRecords(
     .map((row) => row['request'])
     .filter((subject): subject is string => Boolean(subject));
   for (const subject of subjects) {
-    await store.deleteByPattern(
+    await deleteByPatternWithoutCount(
+      store,
       { graph: metaGraph, subject },
       { priority: 'background', source: 'join.moderationRetention.pruneFallback' },
     );

--- a/packages/agent/src/named-ka-vm-lifecycle.ts
+++ b/packages/agent/src/named-ka-vm-lifecycle.ts
@@ -7,7 +7,10 @@ import {
   contextGraphLayerUri,
   contextGraphMetaUri,
 } from '@origintrail-official/dkg-core';
-import type { TripleStore } from '@origintrail-official/dkg-storage';
+import {
+  deleteByPatternWithoutCount,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
 import { VM_CURRENT_ASSERTION_PRED } from '@origintrail-official/dkg-publisher';
 
 const MEMORY_LAYER_PRED = 'http://dkg.io/ontology/memoryLayer';
@@ -51,7 +54,7 @@ export async function applyPublishedNamedKaVmLifecycle(
     );
   }
 
-  await store.deleteByPattern({ subject: lifecycleUri, predicate: VM_CURRENT_ASSERTION_PRED, graph: metaGraph });
+  await deleteByPatternWithoutCount(store, { subject: lifecycleUri, predicate: VM_CURRENT_ASSERTION_PRED, graph: metaGraph });
   await store.insert([{
     subject: lifecycleUri,
     predicate: VM_CURRENT_ASSERTION_PRED,
@@ -60,7 +63,7 @@ export async function applyPublishedNamedKaVmLifecycle(
   }]);
 
   for (const subject of [lifecycleUri, assertionUri]) {
-    await store.deleteByPattern({ subject, predicate: MEMORY_LAYER_PRED, graph: metaGraph });
+    await deleteByPatternWithoutCount(store, { subject, predicate: MEMORY_LAYER_PRED, graph: metaGraph });
     await store.insert([{
       subject,
       predicate: MEMORY_LAYER_PRED,
@@ -68,14 +71,14 @@ export async function applyPublishedNamedKaVmLifecycle(
       graph: metaGraph,
     }]);
   }
-  await store.deleteByPattern({ subject: lifecycleUri, predicate: STATE_PRED, graph: metaGraph });
+  await deleteByPatternWithoutCount(store, { subject: lifecycleUri, predicate: STATE_PRED, graph: metaGraph });
   await store.insert([{
     subject: lifecycleUri,
     predicate: STATE_PRED,
     object: '"published"',
     graph: metaGraph,
   }]);
-  await store.deleteByPattern({ subject: lifecycleUri, predicate: PUBLISHED_UAL_PRED, graph: metaGraph });
+  await deleteByPatternWithoutCount(store, { subject: lifecycleUri, predicate: PUBLISHED_UAL_PRED, graph: metaGraph });
   await store.insert([{
     subject: lifecycleUri,
     predicate: PUBLISHED_UAL_PRED,
@@ -93,7 +96,7 @@ export async function applyPublishedNamedKaVmLifecycle(
     vmNumber,
     input.subGraphName,
   );
-  await store.deleteByPattern({ subject: lifecycleUri, predicate: ASSERTION_GRAPH_PRED, graph: metaGraph });
+  await deleteByPatternWithoutCount(store, { subject: lifecycleUri, predicate: ASSERTION_GRAPH_PRED, graph: metaGraph });
   await store.insert([{
     subject: lifecycleUri,
     predicate: ASSERTION_GRAPH_PRED,
@@ -108,7 +111,7 @@ export async function applyPublishedNamedKaVmLifecycle(
     vmNumber,
     input.subGraphName,
   );
-  await store.deleteByPattern({ subject: wmGraph, predicate: MEMORY_LAYER_PRED, graph: metaGraph });
+  await deleteByPatternWithoutCount(store, { subject: wmGraph, predicate: MEMORY_LAYER_PRED, graph: metaGraph });
   await store.insert([{
     subject: wmGraph,
     predicate: MEMORY_LAYER_PRED,

--- a/packages/agent/src/sync/oversize-sweep.ts
+++ b/packages/agent/src/sync/oversize-sweep.ts
@@ -35,7 +35,10 @@ import {
   DKG_RDF_LITERAL_SAFE_MUTF8_BYTES,
   rdfLiteralTermMutf8ByteLength,
 } from '@origintrail-official/dkg-core';
-import type { Quad } from '@origintrail-official/dkg-storage';
+import {
+  deleteByPatternWithoutCount,
+  type Quad,
+} from '@origintrail-official/dkg-storage';
 import type { OversizeDrop } from './oversize-filter.js';
 
 const SWEEP_MARKER = '.oversize-sweep-v1.done';
@@ -117,7 +120,7 @@ export async function runOversizeSweep(options: OversizeSweepOptions): Promise<O
         }
       }
       for (const offender of offenders) {
-        await store.deleteByPattern({
+        await deleteByPatternWithoutCount(store, {
           graph,
           subject: offender.quad.subject,
           predicate: offender.quad.predicate,

--- a/packages/agent/src/sync/requester/swm-recovery-apply.ts
+++ b/packages/agent/src/sync/requester/swm-recovery-apply.ts
@@ -1,4 +1,7 @@
-import type { Quad } from '@origintrail-official/dkg-storage';
+import {
+  deleteByPatternWithoutCount,
+  type Quad,
+} from '@origintrail-official/dkg-storage';
 
 /**
  * WS-0.0: per-root REPLACE apply for SWM recovery.
@@ -64,7 +67,7 @@ export async function applySwmRecovery(params: {
     const key = `${dataGraph}\u0000${entity}`;
     if (cleared.has(key)) continue;
     cleared.add(key);
-    await params.store.deleteByPattern({ graph: dataGraph, subject: entity });
+    await deleteByPatternWithoutCount(params.store, { graph: dataGraph, subject: entity });
     await params.store.deleteBySubjectPrefix(dataGraph, `${entity}${SKOLEM_CHILD_INFIX}`);
   }
 

--- a/packages/agent/src/sync/requester/swm-snapshot-materializer.ts
+++ b/packages/agent/src/sync/requester/swm-snapshot-materializer.ts
@@ -21,6 +21,7 @@ import {
 } from '@origintrail-official/dkg-publisher';
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import {
+  deleteByPatternWithoutCount,
   invalidateSwmMaterializationWitness,
   readSwmMaterializationWitness,
   writeSwmMaterializationWitness,
@@ -593,7 +594,8 @@ export function createSharedMemorySnapshotMaterializer(deps: {
       .map((quad) => quad.predicate === `${DKG}shareOperationId`
         ? { ...quad, object: JSON.stringify(winnerShareOperationId) }
         : { ...quad });
-    await deps.store.deleteByPattern(
+    await deleteByPatternWithoutCount(
+      deps.store,
       { graph: descriptor.metaGraph, subject: descriptor.headSubject },
       { priority: 'background', source: 'agent.sharedMemorySync.snapshotMaterializer.deleteHead' },
     );
@@ -602,7 +604,8 @@ export function createSharedMemorySnapshotMaterializer(deps: {
       source: 'agent.sharedMemorySync.snapshotMaterializer.writePreservedHead',
     });
     for (const operationSubject of loserSubjects) {
-      await deps.store.deleteByPattern(
+      await deleteByPatternWithoutCount(
+        deps.store,
         { graph: descriptor.metaGraph, subject: operationSubject },
         { priority: 'background', source: 'agent.sharedMemorySync.snapshotMaterializer.deleteOperation' },
       );
@@ -739,12 +742,14 @@ export function createSharedMemorySnapshotMaterializer(deps: {
       const operationSubjects = await collectOwnedHeadOperationSubjects(descriptor, {
         seed: [descriptor.operationSubject],
       });
-      await deps.store.deleteByPattern(
+      await deleteByPatternWithoutCount(
+        deps.store,
         { graph: descriptor.metaGraph, subject: descriptor.headSubject },
         { priority: 'background', source: 'agent.sharedMemorySync.snapshotMaterializer.deleteHead' },
       );
       for (const operationSubject of operationSubjects) {
-        await deps.store.deleteByPattern(
+        await deleteByPatternWithoutCount(
+          deps.store,
           { graph: descriptor.metaGraph, subject: operationSubject },
           { priority: 'background', source: 'agent.sharedMemorySync.snapshotMaterializer.deleteOperation' },
         );
@@ -760,12 +765,14 @@ export function createSharedMemorySnapshotMaterializer(deps: {
           asset,
           { seed: [asset.operationSubject] },
         );
-        await deps.store.deleteByPattern(
+        await deleteByPatternWithoutCount(
+          deps.store,
           { graph: asset.metaGraph, subject: asset.headSubject },
           { priority: 'background', source: 'agent.swmRecovery.replaceMetaForGraphAssets.deleteHead' },
         );
         for (const operationSubject of operationSubjects) {
-          await deps.store.deleteByPattern(
+          await deleteByPatternWithoutCount(
+            deps.store,
             { graph: asset.metaGraph, subject: operationSubject },
             { priority: 'background', source: 'agent.swmRecovery.replaceMetaForGraphAssets.deleteOperation' },
           );

--- a/packages/agent/test/ka-graph-finalization-recovery.test.ts
+++ b/packages/agent/test/ka-graph-finalization-recovery.test.ts
@@ -144,9 +144,10 @@ describe('graph-scoped assertion finalization recovery', () => {
       { subject: 'urn:after:seal', predicate: 'urn:predicate:value', object: '"sealed"' },
     ]);
     const lifecycle = assertionLifecycleUri(contextGraphId, author, afterSeal);
-    const realDeleteByPattern = agent.store.deleteByPattern.bind(agent.store);
+    const realDeleteByPatternWithoutCount = agent.store.deleteByPatternWithoutCount?.bind(agent.store);
+    if (!realDeleteByPatternWithoutCount) throw new Error('no-count delete capability unavailable');
     let stoppedAfterSeal = false;
-    agent.store.deleteByPattern = async (pattern, options) => {
+    agent.store.deleteByPatternWithoutCount = async (pattern, options) => {
       if (
         !stoppedAfterSeal &&
         pattern.subject === lifecycle &&
@@ -155,13 +156,13 @@ describe('graph-scoped assertion finalization recovery', () => {
         stoppedAfterSeal = true;
         throw new Error('injected after-seal failure');
       }
-      return realDeleteByPattern(pattern, options);
+      return realDeleteByPatternWithoutCount(pattern, options);
     };
     await expect(agent.assertion.finalize(contextGraphId, afterSeal)).rejects.toThrow(
       'injected after-seal failure',
     );
     expect(await hasSeal(agent, contextGraphId, afterSeal)).toBe(true);
-    agent.store.deleteByPattern = realDeleteByPattern;
+    agent.store.deleteByPatternWithoutCount = realDeleteByPatternWithoutCount;
     const afterSealRecovered = await agent.assertion.finalize(contextGraphId, afterSeal) as never as {
       kaUal: string; assertionVersion: string; publicTripleCount: number;
     };

--- a/packages/agent/test/remove-sub-graph-index-hint.test.ts
+++ b/packages/agent/test/remove-sub-graph-index-hint.test.ts
@@ -77,7 +77,7 @@ describe('removeSubGraph graph-set maintenance', () => {
     expect(queryCalls[0]).toContain('DELETE WHERE');
   });
 
-  it('falls back to deleteByPattern() when the SPARQL update fails', async () => {
+  it('falls back to a no-count pattern delete when the SPARQL update fails', async () => {
     const inner = new OxigraphStore();
     const deletePatterns: Array<{ graph?: string; subject?: string }> = [];
     const store = new Proxy(inner, {
@@ -85,10 +85,9 @@ describe('removeSubGraph graph-set maintenance', () => {
         if (prop === 'update') {
           return async () => { throw new Error('update unsupported'); };
         }
-        if (prop === 'deleteByPattern') {
+        if (prop === 'deleteByPatternWithoutCount') {
           return async (pattern: { graph?: string; subject?: string }) => {
             deletePatterns.push(pattern);
-            return 0;
           };
         }
         const value = Reflect.get(target, prop, receiver);

--- a/packages/agent/test/rs-heal-stranded-kc-decorated.test.ts
+++ b/packages/agent/test/rs-heal-stranded-kc-decorated.test.ts
@@ -247,6 +247,44 @@ describe('healStrandedScopedKCs — through the production store decorator stack
     await wrapped.close();
   });
 
+  it('forwards no-count deletes and invalidates caches only after success', async () => {
+    const failure = new Error('injected no-count delete failure');
+    let rejectDelete = false;
+    const countedDelete = vi.fn(async () => 1);
+    const noCountDelete = vi.fn(async () => {
+      if (rejectDelete) throw failure;
+    });
+    const adapter = new Proxy(new OxigraphStore(), {
+      get(target, prop, receiver) {
+        if (prop === 'deleteByPattern') return countedDelete;
+        if (prop === 'deleteByPatternWithoutCount') return noCountDelete;
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as TripleStore;
+    let invalidations = 0;
+    let projectionInvalidations = 0;
+    const wrapped = createListContextGraphsCacheInvalidatingStore(
+      adapter,
+      () => { invalidations += 1; },
+      () => { projectionInvalidations += 1; },
+    );
+    const pattern = { graph: 'urn:test:no-count', subject: 'urn:test:subject' };
+    const options: QueryOptions = { source: 'test.no-count', priority: 'background' };
+
+    await expect(wrapped.deleteByPatternWithoutCount?.(pattern, options)).resolves.toBeUndefined();
+    expect(noCountDelete).toHaveBeenCalledWith(pattern, options);
+    expect(countedDelete).not.toHaveBeenCalled();
+    expect(invalidations).toBe(1);
+    expect(projectionInvalidations).toBe(1);
+
+    rejectDelete = true;
+    await expect(wrapped.deleteByPatternWithoutCount?.(pattern, options)).rejects.toBe(failure);
+    expect(invalidations).toBe(1);
+    expect(projectionInvalidations).toBe(1);
+    await wrapped.close();
+  });
+
   it('invalidates caches for query updates with dotted PREFIX labels', async () => {
     const adapter = new OxigraphStore();
     const queryStore = new Proxy(adapter, {

--- a/packages/cli/src/daemon/routes/knowledge-assets-import.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets-import.ts
@@ -30,6 +30,7 @@ import {
   verifyDkgContentHash,
 } from "@origintrail-official/dkg-core";
 import { findReservedSubjectPrefix, isSkolemizedUri, listAssertionScopedGraphUris } from "@origintrail-official/dkg-publisher";
+import { deleteByPatternWithoutCount } from "@origintrail-official/dkg-storage";
 import type { RequestContext } from "./context.js";
 import {
   jsonResponse,
@@ -1194,7 +1195,7 @@ export async function handleKaImportFile(ctx: RequestContext, name: string): Pro
           ...(await listCreateMetaSubjects()),
         ]);
         for (const subject of subjects) {
-          await agent.store.deleteByPattern({
+          await deleteByPatternWithoutCount(agent.store, {
             subject,
             graph: skippedMetaGraph,
           });
@@ -1432,7 +1433,7 @@ export async function handleKaImportFile(ctx: RequestContext, name: string): Pro
       let skippedMetaCleanupSucceeded = false;
       let skippedDataDropSucceeded = false;
       try {
-        await agent.store.deleteByPattern({
+        await deleteByPatternWithoutCount(agent.store, {
           subject: assertionUri,
           graph: skippedMetaGraph,
         });
@@ -1445,7 +1446,7 @@ export async function handleKaImportFile(ctx: RequestContext, name: string): Pro
         const rollbackErrors: string[] = [];
         if (skippedMetaCleanupSucceeded) {
           try {
-            await agent.store.deleteByPattern({
+            await deleteByPatternWithoutCount(agent.store, {
               subject: assertionUri,
               graph: skippedMetaGraph,
             });
@@ -2060,7 +2061,7 @@ export async function handleKaImportFile(ctx: RequestContext, name: string): Pro
       let dataDropSucceeded = false;
       const droppedDataGraphs = new Set<string>();
       try {
-        await agent.store.deleteByPattern({
+        await deleteByPatternWithoutCount(agent.store, {
           subject: assertionUri,
           graph: metaGraph,
         });

--- a/packages/publisher/src/async-lift-claim-session.ts
+++ b/packages/publisher/src/async-lift-claim-session.ts
@@ -1,5 +1,8 @@
 import type { PublishResult } from './publisher.js';
-import type { TripleStore } from '@origintrail-official/dkg-storage';
+import {
+  deleteByPatternWithoutCount,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
 import type {
   JournalKind,
   LiftJob,
@@ -942,7 +945,7 @@ export class AsyncLiftClaimCoordinator {
   }
 
   private async deleteWalletLock(walletId: string): Promise<void> {
-    await this.store.deleteByPattern({
+    await deleteByPatternWithoutCount(this.store, {
       subject: walletLockSubject(walletId),
       graph: this.config.walletLockGraphUri,
     });

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -9,7 +9,7 @@ import {
 } from './chain-proof-retry-schedule.js';
 import { ReconciliationSnapshotCoordinator } from './reconciliation-snapshot-coordinator.js';
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
-import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
+import { deleteByPatternWithoutCount, GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import {
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   LegacyKnowledgeAssetReadOnlyError,
@@ -3090,8 +3090,8 @@ export class TripleStoreAsyncLiftPublisher
   }
 
   private async deleteJob(jobId: string): Promise<void> {
-    await this.store.deleteByPattern({ subject: jobSubject(jobId), graph: this.graphUri });
-    await this.store.deleteByPattern({ subject: requestSubject(jobId), graph: this.graphUri });
+    await deleteByPatternWithoutCount(this.store, { subject: jobSubject(jobId), graph: this.graphUri });
+    await deleteByPatternWithoutCount(this.store, { subject: requestSubject(jobId), graph: this.graphUri });
   }
 
   // Scheduling-only — the claim attempt re-checks every guard — and it must never throw into

--- a/packages/publisher/src/async-promote-queue-impl.ts
+++ b/packages/publisher/src/async-promote-queue-impl.ts
@@ -17,7 +17,10 @@
  * `docs/specs/SPEC_ASYNC_PROMOTE_QUEUE_IMPLEMENTATION_PLAN.md` (plan).
  */
 
-import { type TripleStore } from '@origintrail-official/dkg-storage';
+import {
+  deleteByPatternWithoutCount,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
 import { type TerminalJobClearOutcome } from './terminal-job-clear.js';
 import { isSafeJobId } from './job-id.js';
 import { replaceSubjectAtomicallyOrFallback } from './subject-atomic-write.js';
@@ -693,7 +696,7 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue, PromoteT
   // All of a job's triples live under jobSubject(jobId) in the single control-plane
   // graph, so this provably cannot touch another job or another graph.
   private async deleteJob(jobId: string): Promise<void> {
-    await this.store.deleteByPattern({ subject: jobSubject(jobId), graph: this.graphUri });
+    await deleteByPatternWithoutCount(this.store, { subject: jobSubject(jobId), graph: this.graphUri });
     await this.store.flush?.();
   }
 

--- a/packages/publisher/src/catalog-persistence.ts
+++ b/packages/publisher/src/catalog-persistence.ts
@@ -1,4 +1,5 @@
 import {
+  deleteByPatternWithoutCount,
   tryUpdateWithTouchedGraphs,
   type Quad,
   type QueryOptions,
@@ -46,7 +47,8 @@ WHERE { GRAPH ${sparqlIri(catalogGraph)} {
 
   if (!usedTargetedUpdate) {
     for (const subject of catalogSubjects) {
-      await store.deleteByPattern(
+      await deleteByPatternWithoutCount(
+        store,
         { graph: catalogGraph, subject },
         catalogStoreOptions('deleteByPattern', signal),
       );

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -5,7 +5,7 @@ import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import type { EventBus, GraphKnowledgeAssetScope, OperationContext } from '@origintrail-official/dkg-core';
 import type { AssertionSeal } from '@origintrail-official/dkg-core';
 import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphPrivateUri, contextGraphAssertionUri, contextGraphLayerUri, MemoryLayer, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, contextGraphSubGraphPrivateUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, assertQuadLiteralsMutf8Safe, DKG_GOSSIP_MAX_MESSAGE_BYTES, SwmGossipPayloadTooLargeError, STORAGE_ACK_MAX_STAGING_BYTES, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, isSwmMerkleExcludedQuad, WORKSPACE_OWNER_PREDICATE, DKG_ENTITY, DKG_ROOT_ENTITY_LEGACY, ENTITY_PRED_ALT, parseAssertionSealQuads, ASSERTION_SEAL_PREDICATES, DKG_ONTOLOGY, GRAPH_KA_CONTENT_SCOPE_VERSION, isAllocatableKaAuthorV1, LegacyKnowledgeAssetReadOnlyError, createGraphKnowledgeAssetScope, knowledgeAssetLayerGraphUri } from '@origintrail-official/dkg-core';
-import { GraphManager, invalidateSwmMaterializationWitness, PrivateContentStore, loadSharedMemoryQuadsForScope, loadSelectedSharedMemoryQuads, resolveSharedMemoryScopeGraphs, tryReplaceGraphAtomically } from '@origintrail-official/dkg-storage';
+import { GraphManager, deleteByPatternWithoutCount, invalidateSwmMaterializationWitness, PrivateContentStore, loadSharedMemoryQuadsForScope, loadSelectedSharedMemoryQuads, resolveSharedMemoryScopeGraphs, tryReplaceGraphAtomically } from '@origintrail-official/dkg-storage';
 import { bestEffortNotify } from './best-effort-notify.js';
 import { pickPublishLifecycleHooks } from './publish-lifecycle-hooks.js';
 import { DEFAULT_PUBLISH_EPOCHS, MAX_PUBLISH_EPOCHS, type Publisher, type PublishOptions, type PublishLifecycleHooks, type PublishResult, type KAManifestEntry, type PhaseCallback, type V10CoreNodeACK, type V10ACKProviderParams, type V10ACKProviderObject, type LegacyV10ACKProvider } from './publisher.js';
@@ -1073,7 +1073,7 @@ async function stampTrustLevel(
 ): Promise<void> {
   const quads = buildTrustLevelQuads(subjects, level, graph) as Quad[];
   for (const quad of quads) {
-    await store.deleteByPattern({
+    await deleteByPatternWithoutCount(store, {
       graph: quad.graph,
       subject: quad.subject,
       predicate: TRUST_LEVEL_PREDICATE,
@@ -1225,6 +1225,11 @@ export class DKGPublisher implements Publisher {
         warn: (ctx, message) => this.log.warn(ctx, message),
       },
     });
+  }
+
+  /** Use one remote UPDATE when the caller does not consume a deletion count. */
+  private deleteStoreByPatternWithoutCount(pattern: Partial<Quad>): Promise<void> {
+    return deleteByPatternWithoutCount(this.store, pattern);
   }
 
   setWorkspaceAgentRecipientResolver(resolver: WorkspaceAgentRecipientResolver | undefined): void {
@@ -1921,7 +1926,7 @@ export class DKGPublisher implements Publisher {
     // Delete-then-insert for upserted entities (replace old triples).
     for (const m of manifestEntries) {
       if (swmOwned.has(m.rootEntity)) {
-        await this.store.deleteByPattern({ graph: swmGraph, subject: m.rootEntity });
+        await this.deleteStoreByPatternWithoutCount({ graph: swmGraph, subject: m.rootEntity });
         await this.store.deleteBySubjectPrefix(swmGraph, m.rootEntity + '/.well-known/genid/');
         await this.deleteMetaForRoot(swmMetaGraph, m.rootEntity);
       }
@@ -1958,7 +1963,7 @@ export class DKGPublisher implements Publisher {
     }
     if (newOwnershipEntries.length > 0) {
       for (const entry of newOwnershipEntries) {
-        await this.store.deleteByPattern({
+        await this.deleteStoreByPatternWithoutCount({
           graph: swmMetaGraph,
           subject: entry.rootEntity,
           predicate: 'http://dkg.io/ontology/workspaceOwner',
@@ -2478,7 +2483,7 @@ export class DKGPublisher implements Publisher {
           if (ctxGraphId) {
             await this.store.delete(storedQuads);
             for (const subject of trustSubjects) {
-              await this.store.deleteByPattern({
+              await this.deleteStoreByPatternWithoutCount({
                 graph: remapVmGraph,
                 subject,
                 predicate: TRUST_LEVEL_PREDICATE,
@@ -3068,7 +3073,7 @@ export class DKGPublisher implements Publisher {
       const catalogGraph = contextGraphCatalogUri(contextGraphId);
       const catalogSubjects = new Set(catalogQuads.map((q) => q.subject));
       for (const subject of catalogSubjects) {
-        await this.store.deleteByPattern({ graph: catalogGraph, subject });
+        await this.deleteStoreByPatternWithoutCount({ graph: catalogGraph, subject });
       }
       await this.store.insert(catalogQuads.map((q) => ({ ...q, graph: catalogGraph })));
     };
@@ -5201,7 +5206,7 @@ export class DKGPublisher implements Publisher {
       const catalogGraph = contextGraphCatalogUri(contextGraphId);
       const catalogSubjects = new Set(updateCatalogQuads.map((q) => q.subject));
       for (const subject of catalogSubjects) {
-        await this.store.deleteByPattern({ graph: catalogGraph, subject });
+        await this.deleteStoreByPatternWithoutCount({ graph: catalogGraph, subject });
       }
       await this.store.insert(updateCatalogQuads.map((q) => ({ ...q, graph: catalogGraph })));
     };
@@ -5949,7 +5954,7 @@ export class DKGPublisher implements Publisher {
           if (!hasBrokenDuplicates) continue;
           // Drop the stale marker so we record a fresh `appliedAt`
           // timestamp when the (now-fixed) pass completes.
-          await this.store.deleteByPattern({
+          await this.deleteStoreByPatternWithoutCount({
             graph: markerGraph,
             subject: MIGRATION_MARKER_SUBJECT,
             predicate: `${DKG}appliedAt`,
@@ -6026,7 +6031,7 @@ export class DKGPublisher implements Publisher {
             // Pattern-based delete is form-agnostic; safe to wipe all
             // wasAttributedTo for this subject because writers only ever
             // emit one (we're about to insert the canonical URI).
-            await this.store.deleteByPattern({
+            await this.deleteStoreByPatternWithoutCount({
               graph: swmMetaGraph,
               subject,
               predicate: `${PROV}wasAttributedTo`,
@@ -6252,7 +6257,7 @@ export class DKGPublisher implements Publisher {
       const rawCount = remaining.type === 'bindings' && remaining.bindings[0]?.['c'];
       const countVal = parseCountLiteral(rawCount);
       if (countVal === 0) {
-        await this.store.deleteByPattern({ graph: metaGraph, subject: op });
+        await this.deleteStoreByPatternWithoutCount({ graph: metaGraph, subject: op });
       }
     }
   }
@@ -6323,7 +6328,7 @@ export class DKGPublisher implements Publisher {
     const metaGraph = contextGraphMetaUri(contextGraphId);
     const lifecycleUri = assertionLifecycleUri(contextGraphId, agentAddress, name, subGraphName);
     // Idempotent: drop any prior marker first, then insert exactly one.
-    await this.store.deleteByPattern({
+    await this.deleteStoreByPatternWithoutCount({
       graph: metaGraph,
       subject: lifecycleUri,
       predicate: SWM_SHARE_COMPLETE_PRED,
@@ -6372,7 +6377,7 @@ export class DKGPublisher implements Publisher {
   ): Promise<void> {
     const metaGraph = contextGraphMetaUri(contextGraphId);
     const lifecycleUri = assertionLifecycleUri(contextGraphId, agentAddress, name, subGraphName);
-    await this.store.deleteByPattern({
+    await this.deleteStoreByPatternWithoutCount({
       graph: metaGraph,
       subject: lifecycleUri,
       predicate: SWM_SHARE_COMPLETE_PRED,
@@ -6448,7 +6453,7 @@ export class DKGPublisher implements Publisher {
       subGraphName,
     );
     for (const predicate of Object.values(ASSERTION_SEAL_PREDICATES)) {
-      await this.store.deleteByPattern({ graph: recoveryGraph, subject: recoverySubject, predicate });
+      await this.deleteStoreByPatternWithoutCount({ graph: recoveryGraph, subject: recoverySubject, predicate });
     }
   }
 
@@ -6505,7 +6510,7 @@ export class DKGPublisher implements Publisher {
       subGraphName,
     )) {
       for (const predicate of Object.values(ASSERTION_SEAL_PREDICATES)) {
-        await this.store.deleteByPattern({ graph: metaGraph, subject, predicate });
+        await this.deleteStoreByPatternWithoutCount({ graph: metaGraph, subject, predicate });
       }
     }
   }
@@ -6548,7 +6553,7 @@ export class DKGPublisher implements Publisher {
       }
       if (matchesConfirmedVm) continue;
       for (const predicate of Object.values(ASSERTION_SEAL_PREDICATES)) {
-        await this.store.deleteByPattern({ graph: metaGraph, subject, predicate });
+        await this.deleteStoreByPatternWithoutCount({ graph: metaGraph, subject, predicate });
       }
     }
   }
@@ -6617,7 +6622,7 @@ export class DKGPublisher implements Publisher {
       .map((quad) => ({ ...quad, subject: recoverySubject, graph: recoveryGraph }));
     if (loaded.subject !== recoverySubject) {
       for (const predicate of sealPredicates) {
-        await this.store.deleteByPattern({ graph: recoveryGraph, subject: recoverySubject, predicate });
+        await this.deleteStoreByPatternWithoutCount({ graph: recoveryGraph, subject: recoverySubject, predicate });
       }
       await this.store.insert(recoveryQuads);
     }
@@ -7327,9 +7332,9 @@ export class DKGPublisher implements Publisher {
     for (const graph of graphs) {
       await this.store.dropGraph(graph);
     }
-    await this.store.deleteByPattern({ graph: swmMetaGraph, subject: headSubject });
+    await this.deleteStoreByPatternWithoutCount({ graph: swmMetaGraph, subject: headSubject });
     for (const operationSubject of operationSubjects) {
-      await this.store.deleteByPattern({
+      await this.deleteStoreByPatternWithoutCount({
         graph: swmMetaGraph,
         subject: assertSafeIri(operationSubject),
       });
@@ -7357,9 +7362,9 @@ export class DKGPublisher implements Publisher {
   ): Promise<void> {
     for (const rootEntity of rootEntities) {
       for (const g of swmGraphsForClear) {
-        await this.store.deleteByPattern({ graph: g, subject: rootEntity });
+        await this.deleteStoreByPatternWithoutCount({ graph: g, subject: rootEntity });
         await this.store.deleteBySubjectPrefix(g, rootEntity + '/.well-known/genid/');
-        await this.store.deleteByPattern({
+        await this.deleteStoreByPatternWithoutCount({
           graph: g, subject: rootEntity, predicate: WORKSPACE_OWNER_PREDICATE,
         });
       }
@@ -7617,7 +7622,7 @@ export class DKGPublisher implements Publisher {
     if (staleEvents.type === 'bindings') {
       for (const row of staleEvents.bindings) {
         const subj = row['s'];
-        if (subj) await this.store.deleteByPattern({ graph: metaGraph, subject: subj });
+        if (subj) await this.deleteStoreByPatternWithoutCount({ graph: metaGraph, subject: subj });
       }
     }
     if (preserved.length > 0) {
@@ -8853,7 +8858,7 @@ export class DKGPublisher implements Publisher {
     // Update the assertion's memory layer from WM → SWM in _meta
     const assertionMetaGraph = contextGraphMetaUri(contextGraphId);
     const DKG_MEMORY_LAYER = 'http://dkg.io/ontology/memoryLayer';
-    await this.store.deleteByPattern({
+    await this.deleteStoreByPatternWithoutCount({
       graph: assertionMetaGraph,
       subject: graphUri,
       predicate: DKG_MEMORY_LAYER,
@@ -8866,8 +8871,8 @@ export class DKGPublisher implements Publisher {
     }]);
     const promotedAllRoots = true; // compatibility return name; v2 has no roots.
     const isFullCompletePromote = true;
-    await this.store.deleteByPattern({ graph: promoteMetaGraph, subject: lifecycleSubject, predicate: DKG_ROOT_ENTITY_LEGACY });
-    await this.store.deleteByPattern({ graph: promoteMetaGraph, subject: lifecycleSubject, predicate: DKG_ENTITY });
+    await this.deleteStoreByPatternWithoutCount({ graph: promoteMetaGraph, subject: lifecycleSubject, predicate: DKG_ROOT_ENTITY_LEGACY });
+    await this.deleteStoreByPatternWithoutCount({ graph: promoteMetaGraph, subject: lifecycleSubject, predicate: DKG_ENTITY });
 
     // Update assertion lifecycle record in _meta: created → promoted
     const promoted = generateAssertionPromotedMetadata({
@@ -9106,7 +9111,7 @@ export class DKGPublisher implements Publisher {
     await this.store.insert(discarded.insert);
 
     const metaGraph = contextGraphMetaUri(contextGraphId);
-    await this.store.deleteByPattern({ subject: graphUri, graph: metaGraph });
+    await this.deleteStoreByPatternWithoutCount({ subject: graphUri, graph: metaGraph });
     // #1116 (review A1, round 5) — drop the SWM-share-complete marker too. A
     // marker survives discard via A2_PRESERVE on recreate, so a full-share →
     // discard → recreate → subset-share cycle would otherwise leave a stale
@@ -9123,7 +9128,7 @@ export class DKGPublisher implements Publisher {
     // marker's absence misleads a consumer about a surviving seal: the marker gates
     // "publishable full share", and a published KA is correctly NOT re-publishable
     // as a fresh full share (its seal is the published one, used only for VM ops).
-    await this.store.deleteByPattern({
+    await this.deleteStoreByPatternWithoutCount({
       graph: metaGraph,
       subject: lifecycleSubject,
       predicate: SWM_SHARE_COMPLETE_PRED,
@@ -9139,8 +9144,8 @@ export class DKGPublisher implements Publisher {
     // REPLACEs them with the current set anyway). A SWM-only / never-published
     // asset has no membership once discarded.
     if (!hasVmVersion) {
-      await this.store.deleteByPattern({ graph: metaGraph, subject: lifecycleSubject, predicate: DKG_ROOT_ENTITY_LEGACY });
-      await this.store.deleteByPattern({ graph: metaGraph, subject: lifecycleSubject, predicate: DKG_ENTITY });
+      await this.deleteStoreByPatternWithoutCount({ graph: metaGraph, subject: lifecycleSubject, predicate: DKG_ROOT_ENTITY_LEGACY });
+      await this.deleteStoreByPatternWithoutCount({ graph: metaGraph, subject: lifecycleSubject, predicate: DKG_ENTITY });
     }
     // A never-shared draft has no durable source and must lose its seal. An
     // exact graph-scoped SWM head, however, is immutable recovery state just
@@ -9216,7 +9221,7 @@ export class DKGPublisher implements Publisher {
     DKGPublisher.validateOptionalSubGraph(subGraphName);
     const graphUri = await this.wmGraphUri(contextGraphId, agentAddress, name, subGraphName);
     const metaGraph = contextGraphMetaUri(contextGraphId);
-    await this.store.deleteByPattern({ subject: graphUri, graph: metaGraph });
+    await this.deleteStoreByPatternWithoutCount({ subject: graphUri, graph: metaGraph });
     await this.dropAssertionScopedGraphs(graphUri);
 
     // #1116 FIX 2 — retire the stale WM lifecycle pointer once the WM draft is
@@ -9229,7 +9234,7 @@ export class DKGPublisher implements Publisher {
     );
     const isSwmResident = swmPointerRes.type === 'boolean' && swmPointerRes.value === true;
     if (isSwmResident) {
-      await this.store.deleteByPattern({
+      await this.deleteStoreByPatternWithoutCount({
         subject: lifecycleUri,
         predicate: WM_CURRENT_ASSERTION_PRED,
         graph: metaGraph,

--- a/packages/publisher/src/legacy-raw-lift-import.ts
+++ b/packages/publisher/src/legacy-raw-lift-import.ts
@@ -1,4 +1,7 @@
-import type { TripleStore } from '@origintrail-official/dkg-storage';
+import {
+  deleteByPatternWithoutCount,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
 import type { LiftJob } from './lift-job.js';
 import {
   DEFAULT_GRAPH_URI,
@@ -32,7 +35,7 @@ export async function restorePersistedLegacyRawLiftJob(params: {
   }
 
   await params.store.createGraph(graphUri);
-  await params.store.deleteByPattern({ subject: expectedJobRef, graph: graphUri });
-  await params.store.deleteByPattern({ subject: requestSubject(jobId), graph: graphUri });
+  await deleteByPatternWithoutCount(params.store, { subject: expectedJobRef, graph: graphUri });
+  await deleteByPatternWithoutCount(params.store, { subject: requestSubject(jobId), graph: graphUri });
   await params.store.insert(serializeJob(params.job, graphUri, { payloadSchema: 'legacy-v0' }));
 }

--- a/packages/publisher/src/legacy-wm-migration.ts
+++ b/packages/publisher/src/legacy-wm-migration.ts
@@ -43,7 +43,11 @@
  * - public data is copied into a newly allocated graph-scoped WM graph while
  *   private draft data stays intact under its stable lifecycle key.
  */
-import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
+import {
+  deleteByPatternWithoutCount,
+  type Quad,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
 import {
   ASSERTION_SEAL_PREDICATES,
   GRAPH_KA_CONTENT_SCOPE_VERSION,
@@ -533,7 +537,7 @@ async function createGraphScopedDraft(
   lifecycleRows: LifecycleRow[],
 ): Promise<void> {
   for (const subject of new Set(lifecycleRows.map((row) => row.s))) {
-    await host.store.deleteByPattern({ graph: uris.metaGraph, subject });
+    await deleteByPatternWithoutCount(host.store, { graph: uris.metaGraph, subject });
   }
   await host.createGraphScopedDraft(
     request.contextGraphId,
@@ -594,7 +598,7 @@ async function completeMarker(
   uris: MigrationUris,
   targetGraph: string,
 ): Promise<void> {
-  await store.deleteByPattern({
+  await deleteByPatternWithoutCount(store, {
     graph: uris.backupGraph,
     subject: uris.markerSubject,
     predicate: STATE_PRED,

--- a/packages/publisher/src/metadata.ts
+++ b/packages/publisher/src/metadata.ts
@@ -1,5 +1,5 @@
 import type { Quad, QueryOptions, TripleStore } from '@origintrail-official/dkg-storage';
-import { GraphManager, LOCAL_TRUSTED_KA_CONTROLS_GRAPH } from '@origintrail-official/dkg-storage';
+import { deleteByPatternWithoutCount, GraphManager, LOCAL_TRUSTED_KA_CONTROLS_GRAPH } from '@origintrail-official/dkg-storage';
 import {
   validateSubGraphName,
   isSafeIri,
@@ -1397,7 +1397,8 @@ export async function writeMaterializedVersion(
 ): Promise<void> {
   assertSafeGraphIriForSparql(metaGraph);
   assertSafeGraphIriForSparql(ual);
-  await store.deleteByPattern(
+  await deleteByPatternWithoutCount(
+    store,
     { graph: metaGraph, subject: ual, predicate: MATERIALIZED_VERSION_PRED },
     options,
   );
@@ -1576,7 +1577,7 @@ async function _restateKaPartitionLocked(opts: {
     }
   }
   for (const root of rootsToPurge) {
-    await store.deleteByPattern({ graph: dataGraph, subject: root });
+    await deleteByPatternWithoutCount(store, { graph: dataGraph, subject: root });
     await store.deleteBySubjectPrefix(dataGraph, root + SKOLEM_INFIX);
   }
 
@@ -1590,11 +1591,11 @@ async function _restateKaPartitionLocked(opts: {
   if (priorKaRes.type === 'bindings') {
     for (const row of priorKaRes.bindings) {
       const ka = row['ka'];
-      if (ka && ka !== ual) await store.deleteByPattern({ graph: metaGraph, subject: ka });
+      if (ka && ka !== ual) await deleteByPatternWithoutCount(store, { graph: metaGraph, subject: ka });
     }
   }
   for (const pred of [DKG_ROOT_ENTITY_LEGACY, DKG_ENTITY, `${DKG}privateMerkleRoot`, `${DKG}privateTripleCount`]) {
-    await store.deleteByPattern({ graph: metaGraph, subject: ual, predicate: pred });
+    await deleteByPatternWithoutCount(store, { graph: metaGraph, subject: ual, predicate: pred });
   }
 
   // 3. Insert payload public triples.
@@ -1642,7 +1643,7 @@ async function _restateKaPartitionLocked(opts: {
   // 5. Refresh resolution edges (batchId) + current merkleRoot.
   const batchLit = `"${kaId}"^^<${XSD}integer>`;
   const rootLit = `"${toHex(merkleRoot)}"`;
-  await store.deleteByPattern({ graph: metaGraph, subject: ual, predicate: `${DKG}merkleRoot` });
+  await deleteByPatternWithoutCount(store, { graph: metaGraph, subject: ual, predicate: `${DKG}merkleRoot` });
   await store.insert([
     { subject: ual, predicate: `${DKG}merkleRoot`, object: rootLit, graph: metaGraph },
     { subject: ual, predicate: `${DKG}batchId`, object: batchLit, graph: metaGraph },
@@ -1738,7 +1739,7 @@ async function _restateLabelGraphForUpdateLocked(opts: {
   const rootsToPurge = new Set<string>(newRoots);
   for (const { root } of priorKaRows) rootsToPurge.add(root);
   for (const root of rootsToPurge) {
-    await store.deleteByPattern({ graph: dataGraph, subject: root });
+    await deleteByPatternWithoutCount(store, { graph: dataGraph, subject: root });
     await store.deleteBySubjectPrefix(dataGraph, root + SKOLEM_INFIX);
   }
   const dataQuads: Quad[] = [];
@@ -1757,10 +1758,10 @@ async function _restateLabelGraphForUpdateLocked(opts: {
   //    merkleRoot, batchId, …) is preserved.
   const legacyKaSubjects = [...new Set(priorKaRows.map((r) => r.ka))].filter((ka) => ka !== ual);
   for (const ka of legacyKaSubjects) {
-    await store.deleteByPattern({ graph: metaGraph, subject: ka });
+    await deleteByPatternWithoutCount(store, { graph: metaGraph, subject: ka });
   }
   for (const pred of [DKG_ROOT_ENTITY_LEGACY, DKG_ENTITY, `${DKG}privateMerkleRoot`]) {
-    await store.deleteByPattern({ graph: metaGraph, subject: ual, predicate: pred });
+    await deleteByPatternWithoutCount(store, { graph: metaGraph, subject: ual, predicate: pred });
   }
   // Codex review "multi-root-access": MULTI-root updates additionally
   // re-emit the legacy `<ual>/<n>` token rows (manifest order, matching the
@@ -1792,7 +1793,7 @@ async function _restateLabelGraphForUpdateLocked(opts: {
 
   // 4. Refresh merkleRoot.
   const rootLit = `"${toHex(merkleRoot)}"`;
-  await store.deleteByPattern({ graph: metaGraph, subject: ual, predicate: `${DKG}merkleRoot` });
+  await deleteByPatternWithoutCount(store, { graph: metaGraph, subject: ual, predicate: `${DKG}merkleRoot` });
   await store.insert([{ subject: ual, predicate: `${DKG}merkleRoot`, object: rootLit, graph: metaGraph }]);
 
   if (version) await writeMaterializedVersion(store, metaGraph, ual, version);

--- a/packages/publisher/src/publish-handler.ts
+++ b/packages/publisher/src/publish-handler.ts
@@ -1,5 +1,5 @@
 import type { TripleStore, Quad } from '@origintrail-official/dkg-storage';
-import { GraphManager, tryReplaceGraphAtomically } from '@origintrail-official/dkg-storage';
+import { deleteByPatternWithoutCount, GraphManager, tryReplaceGraphAtomically } from '@origintrail-official/dkg-storage';
 import type { EventBus, StreamHandler, OperationContext } from '@origintrail-official/dkg-core';
 import {
   DKGEvent,
@@ -333,13 +333,13 @@ export class PublishHandler {
       const rootEntities = new Set(pending.dataQuads.map(q => q.subject));
       for (const rootEntity of rootEntities) {
         for (const g of swmGraphs) {
-          await this.store.deleteByPattern({ graph: g, subject: rootEntity });
+          await deleteByPatternWithoutCount(this.store, { graph: g, subject: rootEntity });
           await this.store.deleteBySubjectPrefix(g, rootEntity + '/.well-known/genid/');
-          await this.store.deleteByPattern({
+          await deleteByPatternWithoutCount(this.store, {
             graph: g, subject: rootEntity, predicate: 'http://dkg.io/ontology/workspaceOwner',
           });
         }
-        await this.store.deleteByPattern({
+        await deleteByPatternWithoutCount(this.store, {
           graph: swmMetaGraph, subject: rootEntity, predicate: 'http://dkg.io/ontology/workspaceOwner',
         });
       }
@@ -628,7 +628,7 @@ export class PublishHandler {
             { code: 'VM_ATOMIC_REPLACE_UNSUPPORTED' },
           );
         }
-        await this.store.deleteByPattern({ graph: metaGraph, subject: graphPublish.scope.ual });
+        await deleteByPatternWithoutCount(this.store, { graph: metaGraph, subject: graphPublish.scope.ual });
         await this.store.insert(metadataQuads);
         await writeMaterializedVersion(
           this.store,
@@ -921,7 +921,7 @@ export class PublishHandler {
         } else {
           const dataGraph = this.graphManager.dataGraphUri(pending.contextGraphId);
           for (const rootEntity of pending.rootEntities) {
-            await this.store.deleteByPattern({ graph: dataGraph, subject: rootEntity });
+            await deleteByPatternWithoutCount(this.store, { graph: dataGraph, subject: rootEntity });
             await this.store.deleteBySubjectPrefix(dataGraph, rootEntity + '/.well-known/genid/');
           }
         }

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -1,4 +1,5 @@
 import {
+  deleteByPatternWithoutCount,
   GraphManager,
   loadSelectedSharedMemoryQuads,
   tryReplaceGraphAtomically,
@@ -935,7 +936,8 @@ export class StorageACKHandler {
           ackStoreOptions('storage-ack.persistGraphScoped.witnessInvalidate', signal),
         ).catch(() => {});
       }
-      await this.store.deleteByPattern(
+      await deleteByPatternWithoutCount(
+        this.store,
         { graph: metaGraph, subject: operationSubject },
         ackStoreOptions('storage-ack.persistGraphScoped.deleteOperationMeta', signal),
       );

--- a/packages/publisher/src/subject-atomic-write.ts
+++ b/packages/publisher/src/subject-atomic-write.ts
@@ -8,6 +8,7 @@
 
 import {
   assertSubjectReplacementPayload,
+  deleteByPatternWithoutCount,
   tryReplaceSubjectAtomically,
   type Quad,
   type TripleStore,
@@ -51,6 +52,6 @@ export async function replaceSubjectAtomicallyOrFallback(
   assertSubjectReplacementPayload(graphUri, subject, quads);
   const replaced = await tryReplaceSubjectAtomically(store, graphUri, subject, quads, { source });
   if (replaced) return;
-  await store.deleteByPattern({ subject, graph: graphUri });
+  await deleteByPatternWithoutCount(store, { subject, graph: graphUri });
   await store.insert(quads);
 }

--- a/packages/publisher/src/update-handler.ts
+++ b/packages/publisher/src/update-handler.ts
@@ -1,5 +1,5 @@
 import type { TripleStore, Quad } from '@origintrail-official/dkg-storage';
-import { GraphManager } from '@origintrail-official/dkg-storage';
+import { deleteByPatternWithoutCount, GraphManager } from '@origintrail-official/dkg-storage';
 import type {
   EventBus,
   KAUpdateRequestMsg,
@@ -405,7 +405,7 @@ export class UpdateHandler {
           for (const g of swmGraphs) {
             await this.deleteEntityTriples(g, m.rootEntity);
           }
-          await this.store.deleteByPattern({ graph: swmMeta, subject: m.rootEntity });
+          await deleteByPatternWithoutCount(this.store, { graph: swmMeta, subject: m.rootEntity });
           // Detach the root from its WorkspaceOperation rows (and drop ops
           // that reference nothing else) so the PROTOCOL_SYNC TTL branch
           // stops serving the drained content to late subscribers.
@@ -424,7 +424,7 @@ export class UpdateHandler {
                 `ASK { GRAPH <${swmMeta}> { <${op}> (<http://dkg.io/ontology/rootEntity>|<http://dkg.io/ontology/entity>) ?r } }`,
               );
               if (remaining.type === 'boolean' && remaining.value === false) {
-                await this.store.deleteByPattern({ graph: swmMeta, subject: op });
+                await deleteByPatternWithoutCount(this.store, { graph: swmMeta, subject: op });
               }
             }
           }
@@ -933,7 +933,7 @@ export class UpdateHandler {
    * Avoids prefix collision (e.g. "urn:x:foo" must not delete "urn:x:foobar").
    */
   private async deleteEntityTriples(graph: string, rootEntity: string): Promise<void> {
-    await this.store.deleteByPattern({ graph, subject: rootEntity });
+    await deleteByPatternWithoutCount(this.store, { graph, subject: rootEntity });
     const skolemPrefix = rootEntity + SKOLEM_INFIX;
     await this.store.deleteBySubjectPrefix(graph, skolemPrefix);
   }

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -1,5 +1,6 @@
 import type { TripleStore, Quad } from '@origintrail-official/dkg-storage';
 import {
+  deleteByPatternWithoutCount,
   GraphManager,
   invalidateSwmMaterializationWitness,
   tryReplaceGraphAtomically,
@@ -2300,7 +2301,7 @@ export class SharedMemoryHandler {
       const rawCount = remaining.type === 'bindings' && remaining.bindings[0]?.['c'];
       const countVal = parseCountLiteral(rawCount);
       if (countVal === 0) {
-        await this.store.deleteByPattern({ graph: metaGraph, subject: op });
+        await deleteByPatternWithoutCount(this.store, { graph: metaGraph, subject: op });
       }
     }
   }

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -1,5 +1,5 @@
 import type { Quad, QueryOptions, TripleStore } from '@origintrail-official/dkg-storage';
-import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
+import { deleteByPatternWithoutCount, GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import {
   GRAPH_KA_CONTENT_SCOPE_VERSION,
   MemoryLayer,
@@ -586,7 +586,8 @@ export async function storeKnowledgeAssetWorkspaceHead(params: {
     scope,
     subGraphName,
   );
-  await params.store.deleteByPattern(
+  await deleteByPatternWithoutCount(
+    params.store,
     { graph: metaGraph, subject },
     workspaceHeadStoreOptions(params.queryOptions, 'deleteByPattern'),
   );
@@ -665,10 +666,10 @@ export async function storeWorkspaceOperationPublicQuads(params: {
       root,
       subGraphName,
     );
-    await params.store.deleteByPattern({ graph: workspaceMetaGraph, subject: legacySubject });
+    await deleteByPatternWithoutCount(params.store, { graph: workspaceMetaGraph, subject: legacySubject });
   }
 
-  await params.store.deleteByPattern({ graph: workspaceMetaGraph, subject: operationSubject });
+  await deleteByPatternWithoutCount(params.store, { graph: workspaceMetaGraph, subject: operationSubject });
   await params.store.insert(generateShareMetadata(
     {
       shareOperationId: params.shareOperationId,
@@ -791,7 +792,7 @@ export async function storeKnowledgeAssetOperationPublicQuads(params: {
     );
   }
 
-  await params.store.deleteByPattern({
+  await deleteByPatternWithoutCount(params.store, {
     graph: workspaceMetaGraph,
     subject: operationSubject,
   });

--- a/packages/publisher/test/async-lift-writejob-atomicity.test.ts
+++ b/packages/publisher/test/async-lift-writejob-atomicity.test.ts
@@ -92,6 +92,14 @@ describe('#1863 async-lift writeJob atomicity', () => {
             }).deleteByPattern(pattern, options);
           };
         }
+        if (prop === 'deleteByPatternWithoutCount') {
+          return async (pattern: { graph?: string }, options?: unknown) => {
+            if (pattern?.graph === DEFAULT_CONTROL_GRAPH_URI) jobGraphDeletes++;
+            return (target as unknown as {
+              deleteByPatternWithoutCount: (p: unknown, o?: unknown) => Promise<void>;
+            }).deleteByPatternWithoutCount(pattern, options);
+          };
+        }
         const value = Reflect.get(target, prop, target);
         return typeof value === 'function' ? value.bind(target) : value;
       },
@@ -136,6 +144,14 @@ describe('#1863 async-lift writeJob atomicity', () => {
             }).deleteByPattern(pattern, options);
           };
         }
+        if (prop === 'deleteByPatternWithoutCount') {
+          return async (pattern: { graph?: string }, options?: unknown) => {
+            if (pattern?.graph === DEFAULT_CONTROL_GRAPH_URI) jobGraphDeletes++;
+            return (target as unknown as {
+              deleteByPatternWithoutCount: (p: unknown, o?: unknown) => Promise<void>;
+            }).deleteByPatternWithoutCount(pattern, options);
+          };
+        }
         const value = Reflect.get(target, prop, target);
         return typeof value === 'function' ? value.bind(target) : value;
       },
@@ -172,6 +188,14 @@ describe('#1863 async-lift writeJob atomicity', () => {
             return (target as unknown as {
               deleteByPattern: (p: unknown, o?: unknown) => Promise<unknown>;
             }).deleteByPattern(pattern, options);
+          };
+        }
+        if (prop === 'deleteByPatternWithoutCount') {
+          return async (pattern: { graph?: string }, options?: unknown) => {
+            if (pattern?.graph === DEFAULT_CONTROL_GRAPH_URI) jobGraphDeletes++;
+            return (target as unknown as {
+              deleteByPatternWithoutCount: (p: unknown, o?: unknown) => Promise<void>;
+            }).deleteByPatternWithoutCount(pattern, options);
           };
         }
         const value = Reflect.get(target, prop, target);

--- a/packages/publisher/test/async-promote-writejob-atomicity.test.ts
+++ b/packages/publisher/test/async-promote-writejob-atomicity.test.ts
@@ -43,6 +43,7 @@ import { TripleStoreAsyncPromoteQueue } from '../src/async-promote-queue-impl.js
 type RealStore = {
   replaceSubject: (g: string, s: string, q: unknown, o?: unknown) => Promise<void>;
   deleteByPattern: (p: unknown, o?: unknown) => Promise<unknown>;
+  deleteByPatternWithoutCount: (p: unknown, o?: unknown) => Promise<void>;
 };
 
 describe('#1933 async-promote-queue writeJob atomicity', () => {
@@ -103,6 +104,12 @@ describe('#1933 async-promote-queue writeJob atomicity', () => {
           return async (pattern: { graph?: string }, o?: unknown) => {
             if (pattern?.graph === graphUri) counts.jobGraphDeletes++;
             return (target as unknown as RealStore).deleteByPattern(pattern, o);
+          };
+        }
+        if (prop === 'deleteByPatternWithoutCount') {
+          return async (pattern: { graph?: string }, o?: unknown) => {
+            if (pattern?.graph === graphUri) counts.jobGraphDeletes++;
+            return (target as unknown as RealStore).deleteByPatternWithoutCount(pattern, o);
           };
         }
         const value = Reflect.get(target, prop, target);

--- a/packages/publisher/test/storage-ack-handler.test.ts
+++ b/packages/publisher/test/storage-ack-handler.test.ts
@@ -1095,16 +1095,16 @@ describe('StorageACKHandler', () => {
       expect(unrelated).toMatchObject({ type: 'boolean', value: true });
     });
 
-    it('falls back to per-subject deleteByPattern when update() is unavailable', async () => {
+    it('falls back to per-subject no-count delete when update() is unavailable', async () => {
       const base = new OxigraphStore();
-      let deleteByPatternCalls = 0;
+      let deleteWithoutCountCalls = 0;
       const store = new Proxy(base as unknown as TripleStore, {
         get(target, prop, receiver) {
           if (prop === 'update') return undefined;
-          if (prop === 'deleteByPattern') {
-            return async (...args: Parameters<TripleStore['deleteByPattern']>) => {
-              deleteByPatternCalls += 1;
-              return target.deleteByPattern.call(target, ...args);
+          if (prop === 'deleteByPatternWithoutCount') {
+            return async (...args: Parameters<NonNullable<TripleStore['deleteByPatternWithoutCount']>>) => {
+              deleteWithoutCountCalls += 1;
+              return target.deleteByPatternWithoutCount!.call(target, ...args);
             };
           }
           const value = Reflect.get(target, prop, receiver);
@@ -1116,19 +1116,19 @@ describe('StorageACKHandler', () => {
       const decoded = decodeStorageACK(await handler.handler(curatedIntent(), fakePeerId));
 
       expect(isStorageACKDecline(decoded)).toBe(false);
-      expect(deleteByPatternCalls).toBe(1);
+      expect(deleteWithoutCountCalls).toBe(1);
     });
 
     it('falls back through a decorator whose inner store does not support update()', async () => {
       const base = new OxigraphStore();
-      let deleteByPatternCalls = 0;
+      let deleteWithoutCountCalls = 0;
       const innerWithoutUpdate = new Proxy(base as unknown as TripleStore, {
         get(target, prop, receiver) {
           if (prop === 'update') return undefined;
-          if (prop === 'deleteByPattern') {
-            return async (...args: Parameters<TripleStore['deleteByPattern']>) => {
-              deleteByPatternCalls += 1;
-              return target.deleteByPattern.call(target, ...args);
+          if (prop === 'deleteByPatternWithoutCount') {
+            return async (...args: Parameters<NonNullable<TripleStore['deleteByPatternWithoutCount']>>) => {
+              deleteWithoutCountCalls += 1;
+              return target.deleteByPatternWithoutCount!.call(target, ...args);
             };
           }
           const value = Reflect.get(target, prop, receiver);
@@ -1142,7 +1142,7 @@ describe('StorageACKHandler', () => {
       const decoded = decodeStorageACK(await handler.handler(curatedIntent(), fakePeerId));
 
       expect(isStorageACKDecline(decoded)).toBe(false);
-      expect(deleteByPatternCalls).toBe(1);
+      expect(deleteWithoutCountCalls).toBe(1);
       await expect(base.countQuads(`${cgDid}/_catalog`)).resolves.toBe(catalogTriples.length);
     });
 
@@ -1166,15 +1166,15 @@ describe('StorageACKHandler', () => {
               return target.update!.call(target, ...args);
             };
           }
-          if (prop === 'deleteByPattern') {
-            return async (...args: Parameters<TripleStore['deleteByPattern']>) => {
+          if (prop === 'deleteByPatternWithoutCount') {
+            return async (...args: Parameters<NonNullable<TripleStore['deleteByPatternWithoutCount']>>) => {
               deletedPatterns.push(args[0]);
               // This regression targets the ACK routing policy. Blank-node
               // labels are operation-local, so the spy records the requested
-              // legacy delete without asking the embedded backend to resolve
+              // no-count delete without asking the embedded backend to resolve
               // that label in a separate operation.
-              if (args[0].subject?.startsWith('_:')) return 0;
-              return target.deleteByPattern.call(target, ...args);
+              if (args[0].subject?.startsWith('_:')) return;
+              return target.deleteByPatternWithoutCount!.call(target, ...args);
             };
           }
           const value = Reflect.get(target, prop, receiver);

--- a/packages/publisher/test/subject-atomic-write.test.ts
+++ b/packages/publisher/test/subject-atomic-write.test.ts
@@ -47,6 +47,7 @@ function countingStore(
   type RealStore = {
     replaceSubject: (g: string, s: string, q: unknown, o?: unknown) => Promise<void>;
     deleteByPattern: (p: unknown, o?: unknown) => Promise<unknown>;
+    deleteByPatternWithoutCount: (p: unknown, o?: unknown) => Promise<void>;
   };
   const store = new Proxy(inner, {
     get(target, prop) {
@@ -64,6 +65,12 @@ function countingStore(
         return async (pattern: { graph?: string }, o?: unknown) => {
           if (pattern?.graph === GRAPH) counts.graphDeletes++;
           return (target as unknown as RealStore).deleteByPattern(pattern, o);
+        };
+      }
+      if (prop === 'deleteByPatternWithoutCount') {
+        return async (pattern: { graph?: string }, o?: unknown) => {
+          if (pattern?.graph === GRAPH) counts.graphDeletes++;
+          return (target as unknown as RealStore).deleteByPatternWithoutCount(pattern, o);
         };
       }
       const value = Reflect.get(target, prop, target);

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
+    "benchmark:delete-no-count": "pnpm run build && node scripts/delete-by-pattern-no-count-benchmark.mjs",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "clean": "rm -rf dist tsconfig.tsbuildinfo"

--- a/packages/storage/scripts/delete-by-pattern-no-count-benchmark.mjs
+++ b/packages/storage/scripts/delete-by-pattern-no-count-benchmark.mjs
@@ -1,0 +1,65 @@
+import { performance } from 'node:perf_hooks';
+import { SparqlHttpStore } from '../dist/adapters/sparql-http.js';
+
+const iterations = Number.parseInt(process.env.DKG_DELETE_BENCH_ITERATIONS ?? '100', 10);
+const latencyMs = Number.parseFloat(process.env.DKG_DELETE_BENCH_LATENCY_MS ?? '2');
+if (!Number.isSafeInteger(iterations) || iterations <= 0) {
+  throw new Error('DKG_DELETE_BENCH_ITERATIONS must be a positive integer');
+}
+if (!Number.isFinite(latencyMs) || latencyMs < 0) {
+  throw new Error('DKG_DELETE_BENCH_LATENCY_MS must be a non-negative number');
+}
+
+const originalFetch = globalThis.fetch;
+let requests = 0;
+globalThis.fetch = async (_input, init) => {
+  requests += 1;
+  if (latencyMs > 0) {
+    await new Promise((resolve) => setTimeout(resolve, latencyMs));
+  }
+  const body = String(init?.body ?? '');
+  if (body.startsWith('SELECT')) {
+    return new Response(JSON.stringify({
+      head: { vars: ['c'] },
+      results: { bindings: [{ c: { type: 'literal', value: '1' } }] },
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/sparql-results+json' },
+    });
+  }
+  return new Response(null, { status: 200 });
+};
+
+const pattern = { graph: 'urn:benchmark:graph', subject: 'urn:benchmark:subject' };
+const store = new SparqlHttpStore({
+  queryEndpoint: 'http://benchmark.invalid/query',
+  updateEndpoint: 'http://benchmark.invalid/update',
+  timeout: 30_000,
+});
+
+async function measure(run) {
+  requests = 0;
+  const started = performance.now();
+  for (let index = 0; index < iterations; index += 1) await run();
+  return {
+    elapsedMs: performance.now() - started,
+    requests,
+    requestsPerDelete: requests / iterations,
+  };
+}
+
+try {
+  const counted = await measure(() => store.deleteByPattern(pattern));
+  const noCount = await measure(() => store.deleteByPatternWithoutCount(pattern));
+  process.stdout.write(`${JSON.stringify({
+    iterations,
+    simulatedRequestLatencyMs: latencyMs,
+    counted,
+    noCount,
+    requestReductionPercent: (1 - noCount.requests / counted.requests) * 100,
+    elapsedSpeedup: counted.elapsedMs / noCount.elapsedMs,
+  }, null, 2)}\n`);
+} finally {
+  await store.close();
+  globalThis.fetch = originalFetch;
+}

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -316,6 +316,25 @@ export class BlazegraphStore implements TripleStore {
       ...options,
       source: options?.source ?? 'blazegraph.deleteByPattern.countBefore',
     });
+    await this.applyDeleteByPattern(pattern, options);
+    const after = await this.countQuads(pattern.graph, {
+      ...options,
+      source: options?.source ?? 'blazegraph.deleteByPattern.countAfter',
+    });
+    return Math.max(0, before - after);
+  }
+
+  async deleteByPatternWithoutCount(
+    pattern: Partial<DKGQuad>,
+    options?: QueryOptions,
+  ): Promise<void> {
+    await this.applyDeleteByPattern(pattern, options);
+  }
+
+  private async applyDeleteByPattern(
+    pattern: Partial<DKGQuad>,
+    options?: QueryOptions,
+  ): Promise<void> {
     const s = pattern.subject ? `<${escapeUri(pattern.subject)}>` : '?s';
     const p = pattern.predicate ? `<${escapeUri(pattern.predicate)}>` : '?p';
     const o = pattern.object ? formatTerm(pattern.object) : '?o';
@@ -335,11 +354,6 @@ export class BlazegraphStore implements TripleStore {
         'deleteByPattern',
       );
     }
-    const after = await this.countQuads(pattern.graph, {
-      ...options,
-      source: options?.source ?? 'blazegraph.deleteByPattern.countAfter',
-    });
-    return Math.max(0, before - after);
   }
 
   async deleteBySubjectPrefix(graphUri: string, prefix: string, options?: QueryOptions): Promise<number> {

--- a/packages/storage/src/adapters/oxigraph-worker.ts
+++ b/packages/storage/src/adapters/oxigraph-worker.ts
@@ -648,6 +648,9 @@ export class OxigraphWorkerStore implements TripleStore {
       () => this.call<number>('deleteByPattern', pattern),
     );
   }
+  async deleteByPatternWithoutCount(pattern: Partial<Quad>): Promise<void> {
+    await this.deleteByPattern(pattern);
+  }
   // Server-side SPARQL UPDATE forwarded to the worker's OxigraphStore (which
   // implements `update`); same atomic single-message contract as `insert`.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/storage/src/adapters/oxigraph.ts
+++ b/packages/storage/src/adapters/oxigraph.ts
@@ -273,6 +273,10 @@ export class OxigraphStore implements TripleStore {
     return matches.length;
   }
 
+  async deleteByPatternWithoutCount(pattern: Partial<DKGQuad>): Promise<void> {
+    await this.deleteByPattern(pattern);
+  }
+
   async query(sparql: string, options?: TripleStoreQueryOptions): Promise<QueryResult> {
     throwIfAborted(options?.signal);
     // The embedded Oxigraph binding executes synchronously, so a caller abort

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -567,6 +567,26 @@ export class SparqlHttpStore implements TripleStore {
       ...options,
       source: options?.source ?? 'sparql-http.deleteByPattern.countBefore',
     });
+    await this.applyDeleteByPattern(pattern, options);
+    const after = await this.countQuads(graphUri, {
+      ...options,
+      source: options?.source ?? 'sparql-http.deleteByPattern.countAfter',
+    });
+    return Math.max(0, before - after);
+  }
+
+  async deleteByPatternWithoutCount(
+    pattern: Partial<DKGQuad>,
+    options?: QueryOptions,
+  ): Promise<void> {
+    await this.applyDeleteByPattern(pattern, options);
+  }
+
+  private async applyDeleteByPattern(
+    pattern: Partial<DKGQuad>,
+    options?: QueryOptions,
+  ): Promise<void> {
+    const graphUri = pattern.graph;
     const s = pattern.subject ? `<${escapeUri(pattern.subject)}>` : '?s';
     const p = pattern.predicate ? `<${escapeUri(pattern.predicate)}>` : '?p';
     const o = pattern.object ? formatTerm(pattern.object) : '?o';
@@ -590,11 +610,6 @@ export class SparqlHttpStore implements TripleStore {
       },
       operation: 'deleteByPattern',
     });
-    const after = await this.countQuads(graphUri, {
-      ...options,
-      source: options?.source ?? 'sparql-http.deleteByPattern.countAfter',
-    });
-    return Math.max(0, before - after);
   }
 
   async deleteBySubjectPrefix(graphUri: string, prefix: string, options?: QueryOptions): Promise<number> {

--- a/packages/storage/src/changelog-store.ts
+++ b/packages/storage/src/changelog-store.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import { isSparqlUpdateOperation } from '@origintrail-official/dkg-core';
-import { findTripleStoreCapability } from './triple-store.js';
+import {
+  deleteByPatternWithoutCount,
+  findTripleStoreCapability,
+} from './triple-store.js';
 import type {
   Quad,
   QueryOptions,
@@ -303,6 +306,32 @@ export class ChangelogStore implements TripleStoreDecorator, ChangelogReader {
         }
       }
       return removed;
+    });
+  }
+
+  async deleteByPatternWithoutCount(
+    pattern: Partial<Quad>,
+    options?: QueryOptions,
+  ): Promise<void> {
+    if (!this.enabled) {
+      await deleteByPatternWithoutCount(this.inner, pattern, options);
+      return;
+    }
+    if (pattern.graph) {
+      this.assertNotReserved(pattern.graph, 'deleteByPatternWithoutCount');
+    } else {
+      this.assertNoReservedTerm(pattern);
+    }
+    await this.runExclusive(async () => {
+      await deleteByPatternWithoutCount(this.inner, pattern, options);
+      if (pattern.graph) {
+        // No count is available to distinguish a no-op. Emitting a
+        // conservative post-mutation marker matches delete(quads) semantics
+        // and keeps every committed change discoverable.
+        await this.markPostMutation([pattern.graph], options);
+      } else {
+        this.flagReconcile('deleteByPatternWithoutCount(no-graph)');
+      }
     });
   }
 
@@ -711,7 +740,7 @@ export class ChangelogStore implements TripleStoreDecorator, ChangelogReader {
 
   /** Replace the single `#era` marker in the reserved graph (delete-any + insert). */
   private async writeEra(era: string): Promise<void> {
-    await this.inner.deleteByPattern({
+    await deleteByPatternWithoutCount(this.inner, {
       subject: META_SUBJECT, predicate: P_ERA, graph: CHANGELOG_GRAPH,
     });
     await this.inner.insert([{

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -10,6 +10,7 @@ import type {
   TripleStoreDecorator,
   UpdateOptions,
 } from './triple-store.js';
+import { deleteByPatternWithoutCount } from './triple-store.js';
 import { storeWorkPriorityRank } from './store-priority-scheduler.js';
 import {
   UnsupportedTripleStoreCapabilityError,
@@ -278,6 +279,27 @@ export class GraphSetIndexStore implements TripleStoreDecorator {
       this.scheduleFullRefresh('deleteByPattern');
     }
     return removed;
+  }
+
+  async deleteByPatternWithoutCount(
+    pattern: Partial<Quad>,
+    options?: QueryOptions,
+  ): Promise<void> {
+    if (!this.enabled) {
+      await deleteByPatternWithoutCount(this.inner, pattern, options);
+      return;
+    }
+    await deleteByPatternWithoutCount(this.inner, pattern, options);
+    const graph = pattern.graph;
+    if (graph) {
+      this.bumpMutation();
+      await this.maintainTouchedGraphs([graph], 'deleteByPattern', options);
+    } else {
+      // Without an exact count, conservatively invalidate even when the
+      // pattern may have matched no rows. This preserves graph membership
+      // correctness without reintroducing count-before/count-after scans.
+      this.scheduleFullRefresh('deleteByPattern');
+    }
   }
 
   async query(sparql: string, options?: QueryOptions): Promise<QueryResult> {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -16,6 +16,7 @@ export {
   type LargeLiteralStorageConfig,
   registerTripleStoreAdapter,
   findTripleStoreCapability,
+  deleteByPatternWithoutCount,
   createTripleStore,
   tryUpdateWithTouchedGraphs,
   tryReplaceGraphAtomically,

--- a/packages/storage/src/private-store.ts
+++ b/packages/storage/src/private-store.ts
@@ -7,7 +7,12 @@ import {
   isSafeIri,
   type GraphKnowledgeAssetScope,
 } from '@origintrail-official/dkg-core';
-import { tryReplaceGraphAtomically, type TripleStore, type Quad } from './triple-store.js';
+import {
+  deleteByPatternWithoutCount,
+  tryReplaceGraphAtomically,
+  type TripleStore,
+  type Quad,
+} from './triple-store.js';
 import type { ContextGraphManager } from './graph-manager.js';
 import {
   readExactGraphPaged,
@@ -386,7 +391,7 @@ export class PrivateContentStore {
           // commitment marker. Repeated stores under the SAME commitment fall
           // through to the append+dedup path below (chunked/retry-safe).
           await this.deleteRootPrivateSlice(graphUri, rootEntity);
-          await this.store.deleteByPattern({ graph: graphUri, subject: markerSubject });
+          await deleteByPatternWithoutCount(this.store, { graph: graphUri, subject: markerSubject });
           await this.store.insert([{
             subject: markerSubject,
             predicate: PRIVATE_COMMITMENT_PRED,
@@ -446,7 +451,7 @@ export class PrivateContentStore {
       predicate,
       graph: graphUri,
     });
-    await this.store.deleteByPattern({ graph: graphUri, subject });
+    await deleteByPatternWithoutCount(this.store, { graph: graphUri, subject });
     await this.store.insert([{
       subject,
       predicate,
@@ -489,7 +494,7 @@ export class PrivateContentStore {
 
     const graphUri = this.privateStagingGraph(contextGraphId, shareOperationId, subGraphName);
     const subject = privateStageSubject(contextGraphId, shareOperationId, rootEntity, subGraphName);
-    await this.store.deleteByPattern({ graph: graphUri, subject });
+    await deleteByPatternWithoutCount(this.store, { graph: graphUri, subject });
   }
 
   async getPrivateTriples(
@@ -563,7 +568,7 @@ export class PrivateContentStore {
    */
   private async deleteRootPrivateSlice(graphUri: string, rootEntity: string): Promise<void> {
     assertSafeIri(rootEntity);
-    await this.store.deleteByPattern({ graph: graphUri, subject: rootEntity });
+    await deleteByPatternWithoutCount(this.store, { graph: graphUri, subject: rootEntity });
     await this.store.deleteBySubjectPrefix(graphUri, `${rootEntity}/.well-known/genid/`);
   }
 

--- a/packages/storage/src/shared-memory-literal-blob-store.ts
+++ b/packages/storage/src/shared-memory-literal-blob-store.ts
@@ -12,6 +12,7 @@ import type {
   TripleStore,
   TripleStoreDecorator,
 } from './triple-store.js';
+import { deleteByPatternWithoutCount } from './triple-store.js';
 import { UnsupportedTripleStoreCapabilityError } from './unsupported-capability-error.js';
 
 export const EXTERNAL_LITERAL_REF_DATATYPE = 'http://dkg.io/ontology/externalLiteralRef';
@@ -84,6 +85,20 @@ export class SharedMemoryLiteralBlobStore implements TripleStoreDecorator {
       removed += await this.inner.deleteByPattern(item, options);
     }
     return removed;
+  }
+
+  async deleteByPatternWithoutCount(
+    pattern: Partial<Quad>,
+    options?: QueryOptions,
+  ): Promise<void> {
+    const translated = this.translateDeletePattern(pattern);
+    if (!Array.isArray(translated)) {
+      await deleteByPatternWithoutCount(this.inner, translated, options);
+      return;
+    }
+    for (const item of translated) {
+      await deleteByPatternWithoutCount(this.inner, item, options);
+    }
   }
 
   async replaceGraph(

--- a/packages/storage/src/swm-materialization-witness.ts
+++ b/packages/storage/src/swm-materialization-witness.ts
@@ -107,7 +107,10 @@
  */
 import { assertSafeIri, sparqlString } from '@origintrail-official/dkg-core';
 import type { QueryOptions, Quad, TripleStore } from './triple-store.js';
-import { tryReplaceSubjectAtomically } from './triple-store.js';
+import {
+  deleteByPatternWithoutCount,
+  tryReplaceSubjectAtomically,
+} from './triple-store.js';
 
 export const SWM_MATERIALIZATION_WITNESS_GRAPH = 'urn:dkg:local:swm-materialization-witness';
 
@@ -214,15 +217,21 @@ export async function invalidateSwmMaterializationWitness(
   // regardless of how rich its store handle is. The private recovery lane holds
   // a `SwmRecoveryStore`, which is not a full `TripleStore` — requiring one here
   // would have made that site uncallable and quietly left it out of the set.
-  store: { deleteByPattern(pattern: { graph: string; subject: string }, options?: QueryOptions): Promise<unknown> },
+  store: {
+    deleteByPattern(
+      pattern: { graph: string; subject: string },
+      options?: QueryOptions,
+    ): Promise<unknown>;
+    deleteByPatternWithoutCount?(
+      pattern: { graph: string; subject: string },
+      options?: QueryOptions,
+    ): Promise<void>;
+  },
   assertionGraph: string,
   options: QueryOptions = {},
 ): Promise<void> {
-  await store.deleteByPattern(
-    {
-      graph: SWM_MATERIALIZATION_WITNESS_GRAPH,
-      subject: swmMaterializationWitnessSubject(assertionGraph),
-    },
-    options,
-  );
+  await deleteByPatternWithoutCount(store, {
+    graph: SWM_MATERIALIZATION_WITNESS_GRAPH,
+    subject: swmMaterializationWitnessSubject(assertionGraph),
+  }, options);
 }

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -120,6 +120,19 @@ export interface TripleStore {
   insert(quads: Quad[], options?: QueryOptions): Promise<void>;
   delete(quads: Quad[], options?: QueryOptions): Promise<void>;
   deleteByPattern(pattern: Partial<Quad>, options?: QueryOptions): Promise<number>;
+  /**
+   * Delete every matching quad without calculating the exact number removed.
+   *
+   * Remote SPARQL adapters can execute this as one UPDATE instead of the
+   * count-before / update / count-after sequence required by
+   * {@link deleteByPattern}. Optional so third-party stores remain compatible;
+   * callers should use {@link deleteByPatternWithoutCount}, which falls back to
+   * the counted operation when this capability is unavailable.
+   */
+  deleteByPatternWithoutCount?(
+    pattern: Partial<Quad>,
+    options?: QueryOptions,
+  ): Promise<void>;
   query(sparql: string, options?: QueryOptions): Promise<QueryResult>;
 
   hasGraph(graphUri: string, options?: QueryOptions): Promise<boolean>;
@@ -230,6 +243,32 @@ export function findTripleStoreCapability<T>(
     candidate = (candidate as { innerStore?: unknown }).innerStore;
   }
   return null;
+}
+
+/**
+ * Delete matching quads when the caller does not consume an exact count.
+ *
+ * The call deliberately stays on the outermost decorator so graph indexes,
+ * changelogs, literal translation, and cache invalidation still observe the
+ * mutation. Stores that have not implemented the optional fast path retain
+ * the old semantics through the counted fallback.
+ */
+export async function deleteByPatternWithoutCount<Pattern>(
+  store: {
+    deleteByPattern(pattern: Pattern, options?: QueryOptions): Promise<unknown>;
+    deleteByPatternWithoutCount?(
+      pattern: Pattern,
+      options?: QueryOptions,
+    ): Promise<void>;
+  },
+  pattern: Pattern,
+  options?: QueryOptions,
+): Promise<void> {
+  if (typeof store.deleteByPatternWithoutCount === 'function') {
+    await store.deleteByPatternWithoutCount(pattern, options);
+    return;
+  }
+  await store.deleteByPattern(pattern, options);
 }
 
 /**

--- a/packages/storage/test/blazegraph.unit.test.ts
+++ b/packages/storage/test/blazegraph.unit.test.ts
@@ -896,6 +896,20 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     expect(removed).toBe(3);
   });
 
+  it('deleteByPatternWithoutCount sends one UPDATE and no COUNT queries', async () => {
+    setFetch(async () => new Response(null, { status: 200 }));
+    const s = new BlazegraphStore(baseUrl);
+
+    await s.deleteByPatternWithoutCount({
+      graph: 'http://g',
+      subject: 'http://s',
+    });
+
+    expect(fetchCalls).toHaveLength(1);
+    expect(String(fetchCalls[0]?.[1]?.body)).toContain('DELETE');
+    expect(String(fetchCalls[0]?.[1]?.body)).not.toContain('SELECT');
+  });
+
   it('deleteByPattern count branch keyed on direct-POST SELECT body', async () => {
     // Guards the direct-POST migration: count queries are sent as a raw
     // SPARQL body starting with SELECT, not as `query=...` form data.

--- a/packages/storage/test/changelog-store.test.ts
+++ b/packages/storage/test/changelog-store.test.ts
@@ -463,8 +463,10 @@ describe('ChangelogStore — reserved-graph write protection', () => {
     // aimed at it would erase or corrupt the log, so it is rejected outright.
     await expect(log.dropGraph(CHANGELOG_GRAPH)).rejects.toThrow(/reserved/i);
     await expect(log.deleteByPattern({ graph: CHANGELOG_GRAPH })).rejects.toThrow(/reserved/i);
+    await expect(log.deleteByPatternWithoutCount({ graph: CHANGELOG_GRAPH })).rejects.toThrow(/reserved/i);
     await expect(log.deleteBySubjectPrefix(CHANGELOG_GRAPH, 'x')).rejects.toThrow(/reserved/i);
     expect(spy.insertCalls.length).toBe(callsBefore); // nothing reached the store
+    expect(await log.headSeq()).toBe(1); // log intact
     await base.close();
   });
 
@@ -496,6 +498,8 @@ describe('ChangelogStore — reserved-graph write protection', () => {
     await log.insert([q('http://ex.org/a', G1)]); // seq 1
     await expect(log.deleteByPattern({ predicate: 'urn:dkg:changelog#seq' })).rejects.toThrow(/reserved/i);
     await expect(log.deleteByPattern({ subject: 'urn:dkg:changelog:e:1' })).rejects.toThrow(/reserved/i);
+    await expect(log.deleteByPatternWithoutCount({ predicate: 'urn:dkg:changelog#seq' })).rejects.toThrow(/reserved/i);
+    await expect(log.deleteByPatternWithoutCount({ subject: 'urn:dkg:changelog:e:1' })).rejects.toThrow(/reserved/i);
     expect(await log.headSeq()).toBe(1); // log intact
     await base.close();
   });

--- a/packages/storage/test/changelog-store.test.ts
+++ b/packages/storage/test/changelog-store.test.ts
@@ -571,6 +571,28 @@ describe('ChangelogStore — delete-path op attribution & reconcile', () => {
     expect((await log.readChanges(0, 100)).map((c) => c.op)).toEqual(['upsert', 'upsert', 'drop']);
     expect(log.needsReconcile).toBe(false); // graph-hinted path is fully attributed
   });
+
+  it('no-count deleteByPattern emits a conservative marker and preserves drop attribution', async () => {
+    await log.insert([q('http://ex.org/a', G1), q('http://ex.org/b', G1)]);
+
+    await log.deleteByPatternWithoutCount({ subject: 'http://ex.org/a', graph: G1 });
+    await log.deleteByPatternWithoutCount({ subject: 'http://ex.org/b', graph: G1 });
+
+    expect((await log.readChanges(0, 100)).map((c) => c.op)).toEqual([
+      'upsert',
+      'upsert',
+      'drop',
+    ]);
+    expect(log.needsReconcile).toBe(false);
+  });
+
+  it('no-count graph-less delete flags reconcile without requiring a count', async () => {
+    await log.insert([q('http://ex.org/s1', G1)]);
+
+    await log.deleteByPatternWithoutCount({ predicate: 'http://ex.org/p' });
+
+    expect(log.needsReconcile).toBe(true);
+  });
 });
 
 describe('ChangelogStore — reserved-graph hiding (prefix) & post-mutation failure', () => {

--- a/packages/storage/test/external-literal-store.test.ts
+++ b/packages/storage/test/external-literal-store.test.ts
@@ -188,6 +188,22 @@ describe('SharedMemoryLiteralBlobStore', () => {
     expect(await inner.countQuads(SWM_GRAPH)).toBe(0);
   });
 
+  it('translates no-count pattern deletes with the original large literal term', async () => {
+    const blobDir = await tempBlobDir();
+    const inner = new OxigraphStore();
+    const store = new SharedMemoryLiteralBlobStore(inner, { blobDir, thresholdBytes: 20 });
+    const largeLiteral = `"${'fast-pattern-delete'.repeat(8)}"`;
+
+    await store.insert([
+      quad('http://ex.org/fast-delete-1', largeLiteral, SWM_GRAPH),
+      quad('http://ex.org/fast-delete-2', largeLiteral, SWM_GRAPH),
+    ]);
+
+    await store.deleteByPatternWithoutCount({ object: largeLiteral, graph: SWM_GRAPH });
+
+    expect(await inner.countQuads(SWM_GRAPH)).toBe(0);
+  });
+
   it('fails loudly when hydrating a missing or corrupt blob', async () => {
     const blobDir = await tempBlobDir();
     const store = new SharedMemoryLiteralBlobStore(new OxigraphStore(), { blobDir, thresholdBytes: 20 });

--- a/packages/storage/test/graph-set-index-store.test.ts
+++ b/packages/storage/test/graph-set-index-store.test.ts
@@ -447,6 +447,32 @@ describe('GraphSetIndexStore', () => {
     });
   });
 
+  it('keeps graph membership correct after a no-count pattern delete', async () => {
+    const graph = 'did:dkg:context-graph:no-count-delete';
+    const counting = new CountingStore(new OxigraphStore());
+    const store = new GraphSetIndexStore(counting);
+    await store.insert([q(graph)]);
+    await expect(store.listGraphs()).resolves.toEqual([graph]);
+
+    await store.deleteByPatternWithoutCount({ graph, predicate: 'urn:p' });
+
+    await expect(store.listGraphs()).resolves.toEqual([]);
+  });
+
+  it('invalidates the full index after a graph-less no-count pattern delete', async () => {
+    const counting = new CountingStore(new OxigraphStore());
+    const store = new GraphSetIndexStore(counting);
+    await store.insert([q('did:dkg:context-graph:no-count-one')]);
+    await expect(store.listGraphs()).resolves.toHaveLength(1);
+    expect(counting.listGraphsCalls).toBe(1);
+
+    await store.deleteByPatternWithoutCount({ predicate: 'urn:p' });
+    expect(counting.listGraphsCalls).toBe(1);
+
+    await expect(store.listGraphs()).resolves.toEqual([]);
+    expect(counting.listGraphsCalls).toBe(2);
+  });
+
   it('preserves deferred mutation source when hasGraph reads before listGraphs', async () => {
     const graph = 'did:dkg:context-graph:has-before-list';
     const counting = new CountingStore(new OxigraphStore());

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -1400,6 +1400,11 @@ describe('SparqlHttpStore (test server)', () => {
         attempt: (store) => store.deleteByPattern({ subject, graph }),
       },
       {
+        name: 'deleteByPatternWithoutCount',
+        scope: graph,
+        attempt: (store) => store.deleteByPatternWithoutCount({ subject, graph }),
+      },
+      {
         name: 'deleteBySubjectPrefix',
         scope: graph,
         attempt: (store) => store.deleteBySubjectPrefix(graph, subject),

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -17,6 +17,7 @@ let server: Server;
 let queryUrl: string;
 let updateUrl: string;
 const insertedQuads: string[] = [];
+let countQuadsHits = 0;
 /** How many times the server received a listGraphs enumeration query (old `SELECT DISTINCT ?g` scan or the new index-read `GRAPH ?g {} FILTER EXISTS`). */
 let listGraphsHits = 0;
 /** The most recent listGraphs enumeration query the server received — asserted on to guard the query SHAPE (index-read, not the O(#quads) scan; dkg #1597). */
@@ -73,6 +74,7 @@ function startTestServer(): Promise<void> {
             return;
           }
           if (decoded.includes('COUNT(*)')) {
+            countQuadsHits++;
             res.writeHead(200, { 'Content-Type': 'application/sparql-results+json' });
             res.end(JSON.stringify({
               head: { vars: ['c'] },
@@ -1554,6 +1556,20 @@ describe('SparqlHttpStore (test server)', () => {
     insertedQuads.length = 0;
     await store.deleteByPattern({ subject: 'http://ex.org/s', graph: 'http://ex.org/g' });
     expect(insertedQuads.some(q => q.includes('DELETE'))).toBe(true);
+  });
+
+  it('deleteByPatternWithoutCount sends one UPDATE and skips both COUNT queries', async () => {
+    insertedQuads.length = 0;
+    const countHitsBefore = countQuadsHits;
+
+    await store.deleteByPatternWithoutCount({
+      subject: 'http://ex.org/s',
+      graph: 'http://ex.org/g',
+    });
+
+    expect(insertedQuads).toHaveLength(1);
+    expect(insertedQuads[0]).toContain('DELETE');
+    expect(countQuadsHits).toBe(countHitsBefore);
   });
 
   it('deleteBySubjectPrefix sends DELETE with FILTER STRSTARTS', async () => {

--- a/packages/storage/test/triple-store-update-capability.test.ts
+++ b/packages/storage/test/triple-store-update-capability.test.ts
@@ -1,9 +1,52 @@
 import { describe, expect, it } from 'vitest';
 import {
+  deleteByPatternWithoutCount,
   UnsupportedTripleStoreCapabilityError,
   tryUpdateWithTouchedGraphs,
   type TripleStore,
 } from '../src/index.js';
+
+describe('deleteByPatternWithoutCount', () => {
+  it('falls back to the counted operation for a third-party store without the capability', async () => {
+    const calls: Array<{ pattern: { graph?: string }; source?: string }> = [];
+    const store = {
+      deleteByPattern: async (pattern: { graph?: string }, options?: { source?: string }) => {
+        calls.push({ pattern, source: options?.source });
+        return 7;
+      },
+    };
+
+    await deleteByPatternWithoutCount(
+      store,
+      { graph: 'urn:test:graph' },
+      { source: 'test.third-party-fallback' },
+    );
+
+    expect(calls).toEqual([{
+      pattern: { graph: 'urn:test:graph' },
+      source: 'test.third-party-fallback',
+    }]);
+  });
+
+  it('prefers the no-count capability when the store provides it', async () => {
+    let countedCalls = 0;
+    let noCountCalls = 0;
+    const store = {
+      deleteByPattern: async () => {
+        countedCalls += 1;
+        return 1;
+      },
+      deleteByPatternWithoutCount: async () => {
+        noCountCalls += 1;
+      },
+    };
+
+    await deleteByPatternWithoutCount(store, { graph: 'urn:test:graph' });
+
+    expect(noCountCalls).toBe(1);
+    expect(countedCalls).toBe(0);
+  });
+});
 
 describe('tryUpdateWithTouchedGraphs', () => {
   it('returns false for a typed unsupported-update signal from a decorator', async () => {


### PR DESCRIPTION
## Summary

- add an optional `deleteByPatternWithoutCount` storage capability with a counted fallback for third-party stores
- make SPARQL HTTP and Blazegraph execute no-count deletes as one UPDATE, while preserving exact-count behavior for callers that consume it
- forward the capability through graph-index, changelog, literal-blob, and agent cache decorators without weakening their bookkeeping
- migrate production call sites whose deletion count was discarded; retain counted deletes in cleanup/accounting paths that use the result
- add adapter, decorator, compatibility, and publisher regression coverage plus a reproducible microbenchmark

## Why

The latest load profile showed pattern deletes contributing avoidable remote store work. The existing remote implementation performs count-before, UPDATE, and count-after even when the caller ignores the returned count. This change removes those two count queries only where the result is not consumed.

## Measured path impact

`pnpm --filter @origintrail-official/dkg-storage benchmark:delete-no-count` with 100 sequential deletes and 2 ms simulated latency per HTTP request:

| Path | Requests | Requests/delete | Elapsed |
| --- | ---: | ---: | ---: |
| Counted | 300 | 3 | 739.7 ms |
| No-count | 100 | 1 | 227.2 ms |

That is 66.7% fewer remote requests and a 3.26x elapsed-time speedup for this isolated delete path. It is not an end-to-end system gain claim; the blackbox profile should be rerun after merge to measure workload-level impact.

## Compatibility and correctness

- the new interface method is optional
- the exported helper falls back to `deleteByPattern` for third-party stores
- exact-count consumers are unchanged
- graph membership is revalidated or conservatively invalidated
- changelog/reserved-graph protections remain active
- large-literal delete-pattern translation remains active

## Validation

- `pnpm lint`
- storage full suite: 36 files passed, 3 skipped; 561 tests passed, 27 skipped
- focused storage capability/decorator/adapter suites: 210 tests passed
- publisher full suite: 144 files passed; 2,236 tests passed, 6 skipped
- focused publisher compatibility suites: 58 tests passed
- storage, publisher, agent, and CLI builds
- publisher helper type tests; agent type and package-root tests
- benchmark above
