### PR TITLE
fix(publisher): retry one exact failed lift job

### DIFF
--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -13,6 +13,10 @@ import type {
   LiftJobRetryProjection,
   PersistedLiftJob,
 } from '@origintrail-official/dkg-publisher';
+import {
+  isSafeJobId,
+  SAFE_JOB_ID_ERROR,
+} from '@origintrail-official/dkg-publisher';
 import { readApiPort, readPid, isProcessRunning, configExists, loadConfig } from './config.js';
 import { loadTokens } from './auth.js';
 import {
@@ -1376,7 +1380,7 @@ export class ApiClient {
   }
 
   async publisherRetryJob(jobId: string): Promise<AsyncLiftRetryOutcome> {
-    if (!jobId) throw new Error('jobId must be a non-empty string');
+    if (!isSafeJobId(jobId)) throw new Error(SAFE_JOB_ID_ERROR);
     return this.post('/api/publisher/retry', { status: 'failed', jobId });
   }
 

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -1375,6 +1375,11 @@ export class ApiClient {
     return this.post('/api/publisher/retry', { status });
   }
 
+  async publisherRetryJob(jobId: string): Promise<AsyncLiftRetryOutcome> {
+    if (!jobId) throw new Error('jobId must be a non-empty string');
+    return this.post('/api/publisher/retry', { status: 'failed', jobId });
+  }
+
   async publisherClear(status: 'failed' | 'finalized'): Promise<{ cleared: number; status: 'failed' | 'finalized' }> {
     return this.post('/api/publisher/clear', { status });
   }

--- a/packages/cli/src/daemon/routes/publisher.ts
+++ b/packages/cli/src/daemon/routes/publisher.ts
@@ -59,7 +59,7 @@ const execFileAsync = promisify(execFile);
 import { enrichEvmError, MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
 import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri } from '@origintrail-official/dkg-core';
-import { findReservedSubjectPrefix, isSkolemizedUri } from '@origintrail-official/dkg-publisher';
+import { findReservedSubjectPrefix, isSafeJobId, isSkolemizedUri } from '@origintrail-official/dkg-publisher';
 import type { AsyncPreparedPublishPayload, LiftJobRetryProjection, PersistedLiftJob } from '@origintrail-official/dkg-publisher';
 import {
   DashboardDB,
@@ -612,7 +612,7 @@ export async function handlePublisherRoutes(ctx: RequestContext): Promise<void> 
         error: "Only status=failed is supported",
       });
     const jobId = parsed.jobId;
-    if (jobId !== undefined && (typeof jobId !== "string" || jobId.length === 0)) {
+    if (jobId !== undefined && (typeof jobId !== "string" || !isSafeJobId(jobId))) {
       return jsonResponse(res, 400, {
         error: "jobId must be a non-empty string when supplied",
       });
@@ -621,11 +621,10 @@ export async function handlePublisherRoutes(ctx: RequestContext): Promise<void> 
     // operator script reading it is unaffected; the two additive counts explain the jobs
     // left failed instead of leaving them invisible: `blockedPendingRecovery` may carry an
     // on-chain transaction and needs chain proof, `skipped` has nothing left to reaccept.
-    const retryFilter: { status: "failed"; jobId?: string } = {
+    const outcome = await publisherControl.retryDetailed({
       status: "failed",
       ...(typeof jobId === "string" ? { jobId } : {}),
-    };
-    const outcome = await publisherControl.retryDetailed(retryFilter);
+    });
     return jsonResponse(res, 200, {
       retried: outcome.retried,
       blockedPendingRecovery: outcome.blockedPendingRecovery,

--- a/packages/cli/src/daemon/routes/publisher.ts
+++ b/packages/cli/src/daemon/routes/publisher.ts
@@ -611,11 +611,21 @@ export async function handlePublisherRoutes(ctx: RequestContext): Promise<void> 
       return jsonResponse(res, 400, {
         error: "Only status=failed is supported",
       });
+    const jobId = parsed.jobId;
+    if (jobId !== undefined && (typeof jobId !== "string" || jobId.length === 0)) {
+      return jsonResponse(res, 400, {
+        error: "jobId must be a non-empty string when supplied",
+      });
+    }
     // GH#2270 — `retried` keeps its exact pre-#2270 meaning (jobs reaccepted), so an
     // operator script reading it is unaffected; the two additive counts explain the jobs
     // left failed instead of leaving them invisible: `blockedPendingRecovery` may carry an
     // on-chain transaction and needs chain proof, `skipped` has nothing left to reaccept.
-    const outcome = await publisherControl.retryDetailed({ status: "failed" });
+    const retryFilter: { status: "failed"; jobId?: string } = {
+      status: "failed",
+      ...(typeof jobId === "string" ? { jobId } : {}),
+    };
+    const outcome = await publisherControl.retryDetailed(retryFilter);
     return jsonResponse(res, 200, {
       retried: outcome.retried,
       blockedPendingRecovery: outcome.blockedPendingRecovery,

--- a/packages/cli/src/daemon/routes/publisher.ts
+++ b/packages/cli/src/daemon/routes/publisher.ts
@@ -59,7 +59,12 @@ const execFileAsync = promisify(execFile);
 import { enrichEvmError, MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
 import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri } from '@origintrail-official/dkg-core';
-import { findReservedSubjectPrefix, isSafeJobId, isSkolemizedUri } from '@origintrail-official/dkg-publisher';
+import {
+  findReservedSubjectPrefix,
+  isSafeJobId,
+  isSkolemizedUri,
+  SAFE_JOB_ID_ERROR,
+} from '@origintrail-official/dkg-publisher';
 import type { AsyncPreparedPublishPayload, LiftJobRetryProjection, PersistedLiftJob } from '@origintrail-official/dkg-publisher';
 import {
   DashboardDB,
@@ -614,7 +619,7 @@ export async function handlePublisherRoutes(ctx: RequestContext): Promise<void> 
     const jobId = parsed.jobId;
     if (jobId !== undefined && (typeof jobId !== "string" || !isSafeJobId(jobId))) {
       return jsonResponse(res, 400, {
-        error: "jobId must be a non-empty string when supplied",
+        error: SAFE_JOB_ID_ERROR,
       });
     }
     // GH#2270 — `retried` keeps its exact pre-#2270 meaning (jobs reaccepted), so an

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -1309,14 +1309,18 @@ describe('ApiClient — GitHub-shaped knowledge-assets SDK (OT-RFC-43 §10.5)', 
     expect(JSON.parse(calls[0].opts.body as string)).toEqual({ jobId: 'lift job 7' });
   });
 
-  it('publisherRetryJob serializes an exact job selection and rejects an empty id before HTTP', async () => {
+  it('publisherRetryJob serializes a safe exact job selection and rejects unsafe ids before HTTP', async () => {
     const calls = track({ retried: 1, blockedPendingRecovery: 0, skipped: 0 });
-    await client.publisherRetryJob('lift job 7');
+    await client.publisherRetryJob('lift-job-7');
     expect(calls[0].url).toBe(`${base}/api/publisher/retry`);
     expect(calls[0].opts.method).toBe('POST');
-    expect(JSON.parse(calls[0].opts.body as string)).toEqual({ status: 'failed', jobId: 'lift job 7' });
+    expect(JSON.parse(calls[0].opts.body as string)).toEqual({ status: 'failed', jobId: 'lift-job-7' });
 
-    await expect(client.publisherRetryJob('')).rejects.toThrow('jobId must be a non-empty string');
+    await expect(client.publisherRetryJob('')).rejects.toThrow('jobId must be 1-256 characters');
+    await expect(client.publisherRetryJob('lift job 7')).rejects
+      .toThrow('contain only ASCII letters');
+    await expect(client.publisherRetryJob('a'.repeat(257))).rejects
+      .toThrow('jobId must be 1-256 characters');
     expect(calls).toHaveLength(1);
   });
 

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -1309,6 +1309,17 @@ describe('ApiClient — GitHub-shaped knowledge-assets SDK (OT-RFC-43 §10.5)', 
     expect(JSON.parse(calls[0].opts.body as string)).toEqual({ jobId: 'lift job 7' });
   });
 
+  it('publisherRetryJob serializes an exact job selection and rejects an empty id before HTTP', async () => {
+    const calls = track({ retried: 1, blockedPendingRecovery: 0, skipped: 0 });
+    await client.publisherRetryJob('lift job 7');
+    expect(calls[0].url).toBe(`${base}/api/publisher/retry`);
+    expect(calls[0].opts.method).toBe('POST');
+    expect(JSON.parse(calls[0].opts.body as string)).toEqual({ status: 'failed', jobId: 'lift job 7' });
+
+    await expect(client.publisherRetryJob('')).rejects.toThrow('jobId must be a non-empty string');
+    expect(calls).toHaveLength(1);
+  });
+
   // GH#2270 follow-up (🟡 3824484894) — the escape-hatch option is the CHANGED public behaviour,
   // and only the unchanged default was covered. Removing or inverting the conditional spread would
   // have sent the plain body while every existing row stayed green — and the plain body is exactly

--- a/packages/cli/test/publisher-admin-body-boundary.test.ts
+++ b/packages/cli/test/publisher-admin-body-boundary.test.ts
@@ -1,8 +1,9 @@
 import type { ServerResponse } from 'node:http';
 import { Readable } from 'node:stream';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { handlePublisherRoutes } from '../src/daemon/routes/publisher.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
+import { SAFE_JOB_ID_ERROR } from '@origintrail-official/dkg-publisher';
 
 // #1890 — the four publisher admin POST routes now share one request-body boundary
 // (readSmallJsonObject). This pins each route's body handling — importantly the previously
@@ -11,22 +12,29 @@ import type { RequestContext } from '../src/daemon/routes/context.js';
 // route keeps its own field validation + response shape. clear-job's wire contract is
 // asserted byte-identical (also guarded end-to-end by publisher-clear-job-route.test.ts).
 describe('#1890 publisher admin POST body boundary', () => {
-  function control(): RequestContext['publisherControl'] {
+  function control(
+    overrides: Partial<NonNullable<RequestContext['publisherControl']>> = {},
+  ): RequestContext['publisherControl'] {
     return {
       cancel: async () => {},
       // GH#2270 — the route reads the DETAILED disposition; `retry` stays on the fake
       // because it is still the base-contract method (delegating to this one in the real
       // publisher), and a body-boundary row must not depend on which one the route picked.
       retry: async () => 3,
-      retryDetailed: async (filter) => filter?.jobId === 'j1'
+      retryDetailed: async (filter) => filter?.jobId === 'lift-job-7'
         ? { retried: 1, blockedPendingRecovery: 0, skipped: 0 }
         : { retried: 3, blockedPendingRecovery: 1, skipped: 2 },
       clear: async () => 2,
       clearTerminalJob: async () => ({ outcome: 'already_absent' as const }),
+      ...overrides,
     } as unknown as RequestContext['publisherControl'];
   }
 
-  async function post(path: string, rawBody: string) {
+  async function post(
+    path: string,
+    rawBody: string,
+    publisherControl = control(),
+  ) {
     const url = new URL(`http://127.0.0.1${path}`);
     const req = Readable.from([]);
     Object.assign(req, {
@@ -42,7 +50,7 @@ describe('#1890 publisher admin POST body boundary', () => {
       req: req as RequestContext['req'],
       res: res as unknown as ServerResponse,
       agent: {} as RequestContext['agent'],
-      publisherControl: control(),
+      publisherControl,
       publisherState: { runtime: null, availability: { available: false, reason: 'publisher_disabled', retryable: false, operatorActionRequired: true } },
       config: {} as RequestContext['config'],
       startedAt: 0,
@@ -98,7 +106,10 @@ describe('#1890 publisher admin POST body boundary', () => {
       expect(await post('/api/publisher/retry', JSON.stringify({ status: 'queued' }))).toEqual({ status: 400, body: { error: 'Only status=failed is supported' } });
     });
     it('exact jobId → retries only the selected job', async () => {
-      expect(await post('/api/publisher/retry', JSON.stringify({ status: 'failed', jobId: 'j1' }))).toEqual({
+      expect(await post('/api/publisher/retry', JSON.stringify({
+        status: 'failed',
+        jobId: 'lift-job-7',
+      }))).toEqual({
         status: 200,
         body: { retried: 1, blockedPendingRecovery: 0, skipped: 0 },
       });
@@ -106,14 +117,31 @@ describe('#1890 publisher admin POST body boundary', () => {
     it('invalid jobId → 400', async () => {
       expect(await post('/api/publisher/retry', JSON.stringify({ status: 'failed', jobId: 42 }))).toEqual({
         status: 400,
-        body: { error: 'jobId must be a non-empty string when supplied' },
+        body: { error: SAFE_JOB_ID_ERROR },
       });
     });
     it('empty jobId → 400 without broadening to retry-all', async () => {
       expect(await post('/api/publisher/retry', JSON.stringify({ status: 'failed', jobId: '' }))).toEqual({
         status: 400,
-        body: { error: 'jobId must be a non-empty string when supplied' },
+        body: { error: SAFE_JOB_ID_ERROR },
       });
+    });
+    it('rejects unsafe and overlength jobIds before querying publisher control', async () => {
+      const retryDetailed = vi.fn(async () => ({
+        retried: 0,
+        blockedPendingRecovery: 0,
+        skipped: 0,
+      }));
+      const publisherControl = control({ retryDetailed });
+
+      for (const jobId of ['bad>id', 'a'.repeat(257)]) {
+        expect(await post(
+          '/api/publisher/retry',
+          JSON.stringify({ status: 'failed', jobId }),
+          publisherControl,
+        )).toEqual({ status: 400, body: { error: SAFE_JOB_ID_ERROR } });
+      }
+      expect(retryDetailed).not.toHaveBeenCalled();
     });
     it('null body → 200 (hardened, not a 500)', async () => {
       expect(await post('/api/publisher/retry', 'null')).toEqual({ status: 200, body: { retried: 3, blockedPendingRecovery: 1, skipped: 2 } });

--- a/packages/cli/test/publisher-admin-body-boundary.test.ts
+++ b/packages/cli/test/publisher-admin-body-boundary.test.ts
@@ -18,7 +18,9 @@ describe('#1890 publisher admin POST body boundary', () => {
       // because it is still the base-contract method (delegating to this one in the real
       // publisher), and a body-boundary row must not depend on which one the route picked.
       retry: async () => 3,
-      retryDetailed: async () => ({ retried: 3, blockedPendingRecovery: 1, skipped: 2 }),
+      retryDetailed: async (filter) => filter?.jobId === 'j1'
+        ? { retried: 1, blockedPendingRecovery: 0, skipped: 0 }
+        : { retried: 3, blockedPendingRecovery: 1, skipped: 2 },
       clear: async () => 2,
       clearTerminalJob: async () => ({ outcome: 'already_absent' as const }),
     } as unknown as RequestContext['publisherControl'];
@@ -94,6 +96,24 @@ describe('#1890 publisher admin POST body boundary', () => {
     });
     it('unsupported status → 400', async () => {
       expect(await post('/api/publisher/retry', JSON.stringify({ status: 'queued' }))).toEqual({ status: 400, body: { error: 'Only status=failed is supported' } });
+    });
+    it('exact jobId → retries only the selected job', async () => {
+      expect(await post('/api/publisher/retry', JSON.stringify({ status: 'failed', jobId: 'j1' }))).toEqual({
+        status: 200,
+        body: { retried: 1, blockedPendingRecovery: 0, skipped: 0 },
+      });
+    });
+    it('invalid jobId → 400', async () => {
+      expect(await post('/api/publisher/retry', JSON.stringify({ status: 'failed', jobId: 42 }))).toEqual({
+        status: 400,
+        body: { error: 'jobId must be a non-empty string when supplied' },
+      });
+    });
+    it('empty jobId → 400 without broadening to retry-all', async () => {
+      expect(await post('/api/publisher/retry', JSON.stringify({ status: 'failed', jobId: '' }))).toEqual({
+        status: 400,
+        body: { error: 'jobId must be a non-empty string when supplied' },
+      });
     });
     it('null body → 200 (hardened, not a 500)', async () => {
       expect(await post('/api/publisher/retry', 'null')).toEqual({ status: 200, body: { retried: 3, blockedPendingRecovery: 1, skipped: 2 } });

--- a/packages/cli/test/publisher-retry-surfacing-2270.test.ts
+++ b/packages/cli/test/publisher-retry-surfacing-2270.test.ts
@@ -168,6 +168,24 @@ describe('GH#2270 publisher retry surfacing (routes over a real publisher)', () 
     expect((await statusOf(control, terminalJobId)).status).toBe('failed');
   });
 
+  it('POST /api/publisher/retry can select one exact failed job without sweeping the rest', async () => {
+    const control = newControl();
+    const selectedJobId = await failWithUnmetQuorum(control);
+    const untouchedJobId = await failWithUnmetQuorum(control, 'untouched');
+
+    const res = await request(
+      control,
+      'POST',
+      '/api/publisher/retry',
+      JSON.stringify({ status: 'failed', jobId: selectedJobId }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ retried: 1, blockedPendingRecovery: 0, skipped: 0 });
+    expect((await statusOf(control, selectedJobId)).status).toBe('accepted');
+    expect((await statusOf(control, untouchedJobId)).status).toBe('failed');
+  });
+
   it('GET /api/publisher/job serves retryState beside a byte-identical job', async () => {
     const control = newControl();
     const jobId = await failWithUnmetQuorum(control);

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -54,6 +54,7 @@ import type {
   AsyncKnowledgeAssetVmPublishRecoveryEvidence,
   AsyncLiftPublisherRecoveryResolver,
   AsyncLiftPublisherRecoveryResult,
+  AsyncLiftRetryFilter,
   AsyncLiftRetryOutcome,
   AsyncLiftRetryStateReader,
   IntentLookupInput,
@@ -2748,10 +2749,30 @@ export class TripleStoreAsyncLiftPublisher
    * {@link describeConfiguredRetryState} projects its reason from, so the counts an operator gets and
    * the reason shown per job are ONE partition rather than two orderings kept in step by hand.
    */
-  async retryDetailed(filter: { status?: 'failed'; jobId?: string } = {}): Promise<AsyncLiftRetryOutcome> {
+  async retryDetailed(filter: AsyncLiftRetryFilter = {}): Promise<AsyncLiftRetryOutcome> {
     await this.ensureGraph();
     if (filter.status && filter.status !== 'failed') {
       return { retried: 0, blockedPendingRecovery: 0, skipped: 0 };
+    }
+
+    if (filter.jobId !== undefined) {
+      if (!isSafeJobId(filter.jobId)) {
+        return { retried: 0, blockedPendingRecovery: 0, skipped: 0 };
+      }
+      return this.claimCoordinator.runClaimJobTransaction(filter.jobId, async (transaction) => {
+        const counts = { retried: 0, blockedPendingRecovery: 0, skipped: 0 };
+        if (transaction.kind === 'missing' || !isFailedJob(transaction.current)) return counts;
+        const action = classifyRetryAction(transaction.current);
+        if (action === 'reaccept') {
+          await this.reacceptFailedJobWithinScope(
+            transaction.current,
+            { kind: 'retry' },
+            transaction.scope,
+          );
+        }
+        counts[FAILED_JOB_RETRY_ACTION_COUNT[action]] += 1;
+        return counts;
+      });
     }
 
     // #1837 — reaccept (failed→accepted) is a terminal→active transition; it MUST be
@@ -2761,10 +2782,7 @@ export class TripleStoreAsyncLiftPublisher
     // swept" guarantee does not hold.
     return this.claimCoordinator.runClaimTransaction(async () => {
       const counts = { retried: 0, blockedPendingRecovery: 0, skipped: 0 };
-      const failedJobs = (await this.list({ status: 'failed' }))
-        .filter(isFailedJob)
-        .filter((job) => filter.jobId === undefined || job.jobId === filter.jobId);
-      for (const job of failedJobs) {
+      for (const job of (await this.list({ status: 'failed' })).filter(isFailedJob)) {
         // The WRITE decision, taken over the job alone — the operator's kill-switch is not an
         // input here and the signature cannot accept one.
         const action = classifyRetryAction(job);
@@ -3459,36 +3477,39 @@ export class TripleStoreAsyncLiftPublisher
       if (!isFailedJob(current)) {
         throw new Error(`Only failed LiftJobs can be reaccepted. Current status: ${current.status}`);
       }
-      if (isHeldForChainProof(current)) {
-        throw new LiftJobPendingChainProofError(
-          `LiftJob ${current.jobId} failed as ${current.failure.code} after a transaction may have been submitted; `
-            + 'it cannot be republished until chain recovery proves the transaction absent',
-          current.jobId,
-          // PR #2300 r1 — per-job: does an automatic lane exist that can move THIS record, or is
-          // the operator's by-id clear its only exit? The HTTP boundary forwards the answer.
-          // r4 (3811993669) — record eligibility is only half of it: a publisher with no chain-proof
-          // resolver wired never touches the job, so promising a retry would send clients into a loop
-          // that cannot converge. The answer is the record AND this instance's configured capability.
-          this.automaticExitIsConfiguredFor(current),
-        );
-      }
-      const reset = resetFailedLiftJobToAccepted(current, this.now());
-      const retriedAt = this.now();
-      const reaccepted: LiftJobAccepted = {
-        ...reset,
-        retries: {
-          ...reset.retries,
-          retryCount: intent.kind === 'freshClientMandate' ? 0 : current.retries.retryCount + 1,
-          lastRetryReason: current.failure.code,
-        },
-        timestamps: {
-          ...reset.timestamps,
-          lastRetriedAt: retriedAt,
-          updatedAt: retriedAt,
-        },
-      };
-      return await scope.commitReaccept(reaccepted);
+      return await this.reacceptFailedJobWithinScope(current, intent, scope);
     });
+  }
+
+  private async reacceptFailedJobWithinScope(
+    current: PersistedFailedJob,
+    intent: ReacceptIntent,
+    scope: LiftJobRecoveryTransitionScope,
+  ): Promise<LiftJobAccepted> {
+    if (isHeldForChainProof(current)) {
+      throw new LiftJobPendingChainProofError(
+        `LiftJob ${current.jobId} failed as ${current.failure.code} after a transaction may have been submitted; `
+          + 'it cannot be republished until chain recovery proves the transaction absent',
+        current.jobId,
+        this.automaticExitIsConfiguredFor(current),
+      );
+    }
+    const reset = resetFailedLiftJobToAccepted(current, this.now());
+    const retriedAt = this.now();
+    const reaccepted: LiftJobAccepted = {
+      ...reset,
+      retries: {
+        ...reset.retries,
+        retryCount: intent.kind === 'freshClientMandate' ? 0 : current.retries.retryCount + 1,
+        lastRetryReason: current.failure.code,
+      },
+      timestamps: {
+        ...reset.timestamps,
+        lastRetriedAt: retriedAt,
+        updatedAt: retriedAt,
+      },
+    };
+    return await scope.commitReaccept(reaccepted);
   }
 
   /**

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -2750,7 +2750,6 @@ export class TripleStoreAsyncLiftPublisher
    * the reason shown per job are ONE partition rather than two orderings kept in step by hand.
    */
   async retryDetailed(filter: AsyncLiftRetryFilter = {}): Promise<AsyncLiftRetryOutcome> {
-    await this.ensureGraph();
     if (filter.status && filter.status !== 'failed') {
       return { retried: 0, blockedPendingRecovery: 0, skipped: 0 };
     }
@@ -2759,6 +2758,11 @@ export class TripleStoreAsyncLiftPublisher
       if (!isSafeJobId(filter.jobId)) {
         return { retried: 0, blockedPendingRecovery: 0, skipped: 0 };
       }
+    }
+
+    await this.ensureGraph();
+
+    if (filter.jobId !== undefined) {
       return this.claimCoordinator.runClaimJobTransaction(filter.jobId, async (transaction) => {
         const counts = { retried: 0, blockedPendingRecovery: 0, skipped: 0 };
         if (transaction.kind === 'missing' || !isFailedJob(transaction.current)) return counts;

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -2748,7 +2748,7 @@ export class TripleStoreAsyncLiftPublisher
    * {@link describeConfiguredRetryState} projects its reason from, so the counts an operator gets and
    * the reason shown per job are ONE partition rather than two orderings kept in step by hand.
    */
-  async retryDetailed(filter: { status?: 'failed' } = {}): Promise<AsyncLiftRetryOutcome> {
+  async retryDetailed(filter: { status?: 'failed'; jobId?: string } = {}): Promise<AsyncLiftRetryOutcome> {
     await this.ensureGraph();
     if (filter.status && filter.status !== 'failed') {
       return { retried: 0, blockedPendingRecovery: 0, skipped: 0 };
@@ -2761,7 +2761,10 @@ export class TripleStoreAsyncLiftPublisher
     // swept" guarantee does not hold.
     return this.claimCoordinator.runClaimTransaction(async () => {
       const counts = { retried: 0, blockedPendingRecovery: 0, skipped: 0 };
-      for (const job of (await this.list({ status: 'failed' })).filter(isFailedJob)) {
+      const failedJobs = (await this.list({ status: 'failed' }))
+        .filter(isFailedJob)
+        .filter((job) => filter.jobId === undefined || job.jobId === filter.jobId);
+      for (const job of failedJobs) {
         // The WRITE decision, taken over the job alone — the operator's kill-switch is not an
         // input here and the signature cannot accept one.
         const action = classifyRetryAction(job);

--- a/packages/publisher/src/async-lift-publisher-types.ts
+++ b/packages/publisher/src/async-lift-publisher-types.ts
@@ -291,13 +291,20 @@ export interface AsyncLiftRetryOutcome {
   readonly skipped: number;
 }
 
+/** Selection contract shared by bulk and exact failed-job retry callers. */
+export interface AsyncLiftRetryFilter {
+  readonly status?: 'failed';
+  /** When present, inspect and transition only this exact persisted job. */
+  readonly jobId?: string;
+}
+
 /**
  * GH#2270 — the reporting counterpart of `retry()`. Segregated off the base contract (like the
  * #1828/#1829/#1837 capabilities): the wire-stable count stays on `AsyncLiftPublisher`, and the
  * paths that report to an operator read the full disposition here.
  */
 export interface AsyncLiftDetailedRetrier {
-  retryDetailed(filter?: { status?: 'failed' }): Promise<AsyncLiftRetryOutcome>;
+  retryDetailed(filter?: AsyncLiftRetryFilter): Promise<AsyncLiftRetryOutcome>;
 }
 
 /**

--- a/packages/publisher/src/async-lift-publisher.ts
+++ b/packages/publisher/src/async-lift-publisher.ts
@@ -4,6 +4,7 @@ export type {
   ActiveLiftJobClaimSession,
   AsyncLiftAdministrativeMutations,
   AsyncLiftDetailedRetrier,
+  AsyncLiftRetryFilter,
   AsyncLiftRetryOutcome,
   AsyncLiftRetryStateReader,
   AsyncKnowledgeAssetVmPublishExecutionInput,

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -343,6 +343,7 @@ export {
 export {
   SAFE_JOB_ID_PATTERN,
   SAFE_JOB_ID_MAX_LENGTH,
+  SAFE_JOB_ID_ERROR,
   isSafeJobId,
 } from './job-id.js';
 export {

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -308,6 +308,7 @@ export {
   type ActiveLiftJobClaimSession,
   type AsyncLiftAdministrativeMutations,
   type AsyncLiftDetailedRetrier,
+  type AsyncLiftRetryFilter,
   type AsyncLiftPublisher,
   type ClaimSessionAsyncLiftPublisher,
   type AsyncLiftPublisherConfig,

--- a/packages/publisher/src/job-id.ts
+++ b/packages/publisher/src/job-id.ts
@@ -11,6 +11,9 @@
 // '"' '{' '}' '|' '^' '`', control chars).
 export const SAFE_JOB_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
 export const SAFE_JOB_ID_MAX_LENGTH = 256;
+export const SAFE_JOB_ID_ERROR =
+  `jobId must be 1-${SAFE_JOB_ID_MAX_LENGTH} characters, start with an ASCII letter or digit, `
+  + 'and contain only ASCII letters, digits, ".", "_", ":", or "-"';
 
 /**
  * True iff `jobId` is safe to interpolate into a control-plane SPARQL IRI. A by-jobId

--- a/packages/publisher/test/async-lift-retry-disposition-2270.test.ts
+++ b/packages/publisher/test/async-lift-retry-disposition-2270.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { type LiftJob } from '../src/index.js';
 import {
   queuedLiftOperationKind,
@@ -95,6 +95,22 @@ describe('GH#2270 failed-job retry disposition', () => {
     const after = await publisher.getStatus(failed.jobId);
     expect(after?.status).toBe('failed');
     expect(after?.retries.retryCount).toBe(0);
+  });
+
+  it('rejects unsafe exact job IDs before any control-plane store access', async () => {
+    const publisher = createPublisher();
+    const query = vi.spyOn(h.store, 'query');
+    const insert = vi.spyOn(h.store, 'insert');
+    const deleteByPattern = vi.spyOn(h.store, 'deleteByPattern');
+
+    for (const jobId of ['bad>id', 'a'.repeat(257)]) {
+      expect(await publisher.retryDetailed({ jobId }))
+        .toEqual({ retried: 0, blockedPendingRecovery: 0, skipped: 0 });
+    }
+
+    expect(query).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+    expect(deleteByPattern).not.toHaveBeenCalled();
   });
 
   it('reaccepts a pre-send-safe failed job and partitions the rest into blocked and skipped', async () => {


### PR DESCRIPTION
## Impact

Adds a safe exact-job retry path for failed async publisher jobs. Operators and the Blackbox harness can requeue one `jobId` without sweeping unrelated historical failures, while retaining the current evidence-aware retry classification from #2270.

This is the current-canary replacement for #2279. It reapplies only that PRs useful delta on top of the present publisher recovery design.

## Validation

- CLI focused Vitest: 120/120 passed
- Publisher build and helper type checks: passed
- CLI build: passed
- Runtime package build: passed
- Diff/whitespace check: passed

Closes #2279 after replacement adoption.