### PR TITLE
fix(sync): preserve backoff after partial progress

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -1622,7 +1622,7 @@ export class DKGAgentBase {
   protected readonly skippedNoSyncPeers = new Set<string>();
   /**
    * Per-peer timestamp of the most recent successful run of sync-on-connect.
-   * Driven by `runSyncOnConnect.onPeerSynced`. Used by the periodic
+   * Driven by `runSyncOnConnect.onSyncAccounting`. Used by the periodic
    * reconciler to skip peers that have already synced recently — the
    * staleness threshold is intentionally larger than the reconciler
    * interval so a single missed tick doesn't immediately retry every
@@ -1645,7 +1645,7 @@ export class DKGAgentBase {
    * consecutive reconciler attempts that did NOT produce a successful
    * sync; `nextRetryAt` is the epoch-ms before which the reconciler
    * skips this peer. Reset on useful progress or a clean denial-only response
-   * (`onPeerSynced`) and pruned after stale disconnects. See
+   * (`onSyncAccounting`) and pruned after stale disconnects. See
    * `SYNC_BACKOFF_BASE_MS`.
    */
   protected readonly syncReconcilerBackoff = new Map<string, SyncReconcilerBackoff>();

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -4818,6 +4818,9 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         syncAccounting = outcome;
       };
       const outcome = await attempt(onSyncAccounting);
+      if (syncAccounting) {
+        this.applySyncOnConnectAccounting(remotePeer, syncAccounting, probe);
+      }
       if (outcome === 'deferred-backpressure') {
         this.log.info(
           createOperationContext('sync'),
@@ -4825,9 +4828,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         );
         return outcome;
       }
-      if (syncAccounting?.retryBackoff) {
-        this.recordSyncReconcilerFailure(remotePeer, probe);
-      } else if (
+      if (
         outcome !== 'skipped-no-sync' &&
         outcome !== 'already-syncing' &&
         outcome !== 'not-started' &&
@@ -5058,25 +5059,21 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       onPeerSkippedNoSync: (peerId) => {
         this.skippedNoSyncPeers.add(peerId);
       },
-      onPeerSynced: (peerId, outcome) => {
+      onSyncAccounting: (peerId, outcome) => {
         const selectedRetryStillRequired = mode === 'ordinary-after-selected'
           && this.selectedSwmBootstrapAdmission.isRetryRequired(peerId);
-        const progressAt = Math.max(Date.now(), (this.lastSyncProgressAt.get(peerId) ?? 0) + 1);
-        if (outcome?.progress) {
-          this.lastSyncProgressAt.set(peerId, progressAt);
-        }
-        if ((outcome?.fresh ?? true) && !selectedRetryStillRequired) {
-          this.lastSuccessfulSyncAt.set(peerId, progressAt);
-        }
-        this.skippedNoSyncPeers.delete(peerId);
-        // An owed ordinary replay may succeed after selected recovery reported
-        // an incomplete scope. Preserve that selected lane's retry/backoff;
-        // ordinary freshness must not consume its recovery ownership.
-        if (!selectedRetryStillRequired && !outcome?.retryBackoff) {
-          this.syncReconcilerBackoff.delete(peerId);
-        }
-        if (outcome) {
-          onSyncAccounting?.(outcome);
+        const effectiveOutcome: SyncOnConnectPeerOutcome =
+          selectedRetryStillRequired && outcome.reconcilerDisposition === 'clear'
+            ? {
+                reconcilerDisposition: 'defer',
+                fresh: false,
+                progress: outcome.progress,
+              }
+            : outcome;
+        if (onSyncAccounting) {
+          onSyncAccounting(effectiveOutcome);
+        } else {
+          this.applySyncOnConnectAccounting(peerId, effectiveOutcome);
         }
       },
     });
@@ -5153,16 +5150,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       onPeerSkippedNoSync: (peerId) => {
         this.skippedNoSyncPeers.add(peerId);
       },
-      onPeerSynced: (peerId, outcome) => {
-        const progressAt = Math.max(Date.now(), (this.lastSyncProgressAt.get(peerId) ?? 0) + 1);
-        if (outcome?.progress) {
-          this.lastSyncProgressAt.set(peerId, progressAt);
+      onSyncAccounting: (peerId, outcome) => {
+        if (onSyncAccounting) {
+          onSyncAccounting(outcome);
+        } else {
+          this.applySyncOnConnectAccounting(peerId, outcome);
         }
-        // A selected-only retry never stamps the whole peer fresh; durable and
-        // unrelated CG lanes were deliberately outside this invocation.
-        this.skippedNoSyncPeers.delete(peerId);
-        this.syncReconcilerBackoff.delete(peerId);
-        if (outcome) onSyncAccounting?.(outcome);
       },
     });
   }
@@ -5547,13 +5540,36 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     return backoff.protocolsKey !== probe.protocolsKey || backoff.connectionKey !== probe.connectionKey;
   }
 
+  /** Apply one coherent sync result to freshness, progress, and retry state. */
+  applySyncOnConnectAccounting(
+    this: DKGAgent,
+    peerId: string,
+    outcome: SyncOnConnectPeerOutcome,
+    probe?: SyncReconcilerProbe,
+  ): void {
+    const progressAt = Math.max(Date.now(), (this.lastSyncProgressAt.get(peerId) ?? 0) + 1);
+    if (outcome.progress) {
+      this.lastSyncProgressAt.set(peerId, progressAt);
+    }
+    if (outcome.fresh) {
+      this.lastSuccessfulSyncAt.set(peerId, progressAt);
+    }
+    this.skippedNoSyncPeers.delete(peerId);
+
+    if (outcome.reconcilerDisposition === 'clear') {
+      this.syncReconcilerBackoff.delete(peerId);
+    } else if (outcome.reconcilerDisposition === 'retry' && probe) {
+      this.recordSyncReconcilerFailure(peerId, probe);
+    }
+  }
+
   /**
    * Grow the per-peer sync-reconciler backoff after an attempt that did
    * not produce a successful sync. `nextRetryAt` advances by
    * `SYNC_BACKOFF_BASE_MS * 2^(failures-1)` (capped at
    * `SYNC_BACKOFF_MAX_MS`) with ±`SYNC_BACKOFF_JITTER` randomisation to
    * de-correlate retries across peers. Reset to absent on successful
-   * progress / denial-only clean response (`onPeerSynced`). Disconnect
+   * progress / denial-only clean response (`reconcilerDisposition: clear`). Disconnect
    * no longer clears this immediately; stale disconnected entries are
    * pruned by `pruneSyncReconcilerState`.
    */

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -5388,7 +5388,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       this.skippedNoSyncPeers.delete(peerId);
       this.log.info(ctx, `Peer ${shortPeer} now advertises sync protocol — retrying sync-on-connect`);
       setTimeout(() => {
-        this.trySyncFromPeer(peerId).catch((err: unknown) => {
+        void (async () => {
+          const probe = await this.getSyncReconcilerProbe(peerId);
+          await this.attemptSyncFromPeerWithReconcilerAccounting(
+            peerId,
+            probe,
+            'on-connect',
+          );
+        })().catch((err: unknown) => {
           const message = err instanceof Error ? err.message : String(err);
           this.log.warn(ctx, `Sync retry after peer:update failed for ${shortPeer}: ${message}`);
         });

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -4812,10 +4812,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   ): Promise<SyncReconcilerAttemptOutcome> {
     const lastOk = this.lastSuccessfulSyncAt.get(remotePeer);
     const lastProgress = this.lastSyncProgressAt.get(remotePeer);
-    let syncAccountingClearedBackoff = false;
+    let syncAccounting: SyncOnConnectPeerOutcome | undefined;
     try {
-      const onSyncAccounting = () => {
-        syncAccountingClearedBackoff = true;
+      const onSyncAccounting = (outcome: SyncOnConnectPeerOutcome) => {
+        syncAccounting = outcome;
       };
       const outcome = await attempt(onSyncAccounting);
       if (outcome === 'deferred-backpressure') {
@@ -4825,11 +4825,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         );
         return outcome;
       }
-      if (
+      if (syncAccounting?.retryBackoff) {
+        this.recordSyncReconcilerFailure(remotePeer, probe);
+      } else if (
         outcome !== 'skipped-no-sync' &&
         outcome !== 'already-syncing' &&
         outcome !== 'not-started' &&
-        !syncAccountingClearedBackoff &&
+        !syncAccounting &&
         this.lastSuccessfulSyncAt.get(remotePeer) === lastOk &&
         this.lastSyncProgressAt.get(remotePeer) === lastProgress
       ) {
@@ -5070,7 +5072,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         // An owed ordinary replay may succeed after selected recovery reported
         // an incomplete scope. Preserve that selected lane's retry/backoff;
         // ordinary freshness must not consume its recovery ownership.
-        if (!selectedRetryStillRequired) {
+        if (!selectedRetryStillRequired && !outcome?.retryBackoff) {
           this.syncReconcilerBackoff.delete(peerId);
         }
         if (outcome) {

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -580,7 +580,7 @@ export interface PeerDiagnostics {
  * Per-peer sync-reconciler backoff state. `failures` is the count of
  * consecutive reconciler attempts that did NOT produce a successful sync;
  * `nextRetryAt` is the epoch-ms before which the reconciler skips this peer.
- * Reset on a successful sync (`onPeerSynced`) and on `connection:close`.
+ * Reset on a successful sync (`onSyncAccounting`) and on `connection:close`.
  * See `SYNC_BACKOFF_BASE_MS`.
  */
 export type SyncReconcilerBackoff = {

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -370,7 +370,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
           && !sawExplicitIncompleteSharedResult
           && cleanDurableRound,
         progress: madeProgress,
-        retryBackoff: sawBackoffWorthyFailure,
+        ...(sawBackoffWorthyFailure ? { retryBackoff: true } : {}),
       });
     }
     return 'synced';

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -30,15 +30,17 @@ interface SelectedSharedMemorySyncLane {
 
 type SyncAccountingResult = DurableSyncFromPeerResult | SelectedSharedMemorySyncResult;
 
-export interface SyncOnConnectPeerOutcome {
-  fresh: boolean;
-  progress?: boolean;
-  /**
-   * Useful progress was committed, but the same round also hit peer/transport
-   * pressure that must retain the reconciler retry backoff.
-   */
-  retryBackoff?: boolean;
-}
+export type SyncOnConnectPeerOutcome =
+  | {
+      reconcilerDisposition: 'clear';
+      fresh: boolean;
+      progress: boolean;
+    }
+  | {
+      reconcilerDisposition: 'retry' | 'defer';
+      fresh: false;
+      progress: boolean;
+    };
 
 interface SyncOnConnectContext {
   remotePeer: string;
@@ -81,7 +83,7 @@ interface SyncOnConnectContext {
    * marking the peer as cleanly fresh for reconnect suppression; `progress`
    * controls whether the periodic reconciler may write its long cooldown.
    */
-  onPeerSynced?: (peerId: string, outcome?: SyncOnConnectPeerOutcome) => void;
+  onSyncAccounting?: (peerId: string, outcome: SyncOnConnectPeerOutcome) => void;
 }
 
 /**
@@ -97,7 +99,7 @@ interface SelectedSharedMemoryRetryContext {
   selectedSharedMemoryLane: SelectedSharedMemorySyncLane;
   logInfo: (ctx: OperationContext, message: string) => void;
   onPeerSkippedNoSync?: (peerId: string, protocols: string[]) => void;
-  onPeerSynced?: (peerId: string, outcome?: SyncOnConnectPeerOutcome) => void;
+  onSyncAccounting?: (peerId: string, outcome: SyncOnConnectPeerOutcome) => void;
 }
 
 export type SyncOnConnectOutcome = 'synced' | 'skipped-no-sync' | 'already-syncing' | 'deferred-backpressure';
@@ -243,7 +245,11 @@ export async function runSelectedSharedMemoryRetry(
 
     if (accounting.deferredByBackpressure) {
       if (accounting.madeProgress) {
-        context.onPeerSynced?.(remotePeer, { fresh: false, progress: true });
+        context.onSyncAccounting?.(remotePeer, {
+          reconcilerDisposition: 'defer',
+          fresh: false,
+          progress: true,
+        });
       }
       return 'deferred-backpressure';
     }
@@ -257,7 +263,8 @@ export async function runSelectedSharedMemoryRetry(
       && !accounting.failed
       && !accounting.denied;
     if (accounting.madeProgress || accounting.denied || selectedRetryResolved) {
-      context.onPeerSynced?.(remotePeer, {
+      context.onSyncAccounting?.(remotePeer, {
+        reconcilerDisposition: selectedRetryResolved || accounting.denied ? 'clear' : 'retry',
         fresh: false,
         progress: accounting.madeProgress,
       });
@@ -353,25 +360,33 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
       && !sawExplicitIncompleteDurableResult;
     if (sawBackpressureDeferral) {
       if (madeProgress) {
-        context.onPeerSynced?.(remotePeer, { fresh: false, progress: true });
+        context.onSyncAccounting?.(remotePeer, {
+          reconcilerDisposition: 'defer',
+          fresh: false,
+          progress: true,
+        });
       }
       return 'deferred-backpressure';
     }
-    const recordsPeerAccounting = madeProgress || (
-      !sawBackoffWorthyFailure
-      && !sawExplicitIncompleteSharedResult
-      && (cleanDurableRound || sawDeniedPhase)
-    );
+    const retryRequired = sawBackoffWorthyFailure
+      || sawExplicitIncompleteSharedResult
+      || (sawFailedPhase && !madeProgress);
+    const recordsPeerAccounting = madeProgress || retryRequired || cleanDurableRound || sawDeniedPhase;
     if (recordsPeerAccounting) {
-      context.onPeerSynced?.(remotePeer, {
-        fresh: !sawBackoffWorthyFailure
-          && !sawDeniedPhase
-          && !sawFailedPhase
-          && !sawExplicitIncompleteSharedResult
-          && cleanDurableRound,
-        progress: madeProgress,
-        ...(sawBackoffWorthyFailure ? { retryBackoff: true } : {}),
-      });
+      context.onSyncAccounting?.(
+        remotePeer,
+        retryRequired
+          ? {
+              reconcilerDisposition: 'retry',
+              fresh: false,
+              progress: madeProgress,
+            }
+          : {
+              reconcilerDisposition: 'clear',
+              fresh: !sawDeniedPhase && !sawFailedPhase && cleanDurableRound,
+              progress: madeProgress,
+            },
+      );
     }
     return 'synced';
   };

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -33,6 +33,11 @@ type SyncAccountingResult = DurableSyncFromPeerResult | SelectedSharedMemorySync
 export interface SyncOnConnectPeerOutcome {
   fresh: boolean;
   progress?: boolean;
+  /**
+   * Useful progress was committed, but the same round also hit peer/transport
+   * pressure that must retain the reconciler retry backoff.
+   */
+  retryBackoff?: boolean;
 }
 
 interface SyncOnConnectContext {
@@ -352,12 +357,12 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
       }
       return 'deferred-backpressure';
     }
-    const clearsPeerBackoff = madeProgress || (
+    const recordsPeerAccounting = madeProgress || (
       !sawBackoffWorthyFailure
       && !sawExplicitIncompleteSharedResult
       && (cleanDurableRound || sawDeniedPhase)
     );
-    if (clearsPeerBackoff) {
+    if (recordsPeerAccounting) {
       context.onPeerSynced?.(remotePeer, {
         fresh: !sawBackoffWorthyFailure
           && !sawDeniedPhase
@@ -365,6 +370,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
           && !sawExplicitIncompleteSharedResult
           && cleanDurableRound,
         progress: madeProgress,
+        retryBackoff: sawBackoffWorthyFailure,
       });
     }
     return 'synced';

--- a/packages/agent/test/selected-swm-lifecycle-core.test.ts
+++ b/packages/agent/test/selected-swm-lifecycle-core.test.ts
@@ -65,6 +65,10 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
       const accountingAgent = {
         lastSuccessfulSyncAt: new Map<string, number>(),
         lastSyncProgressAt: new Map<string, number>(),
+        skippedNoSyncPeers: new Set<string>(),
+        syncReconcilerBackoff: backoff,
+        applySyncOnConnectAccounting:
+          LifecycleSyncMethods.prototype.applySyncOnConnectAccounting,
         recordSyncReconcilerFailure: (peerId: string) => {
           backoff.set(peerId, { failures: 1 });
         },
@@ -82,7 +86,7 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
             getContextGraphIds: () => [privateCg],
             syncFromPeer: async () => recovery,
           },
-          onPeerSynced: (_peerId, outcome) => {
+          onSyncAccounting: (_peerId, outcome) => {
             if (outcome) onSyncAccounting(outcome);
           },
           logInfo: () => {},
@@ -351,6 +355,8 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
       lastSuccessfulSyncAt: new Map<string, number>(),
       lastSyncProgressAt: new Map<string, number>(),
       syncReconcilerBackoff: new Map<string, unknown>(),
+      applySyncOnConnectAccounting:
+        LifecycleSyncMethods.prototype.applySyncOnConnectAccounting,
       selectedSwmBootstrapAdmission: new SelectedSwmBootstrapAdmission(),
       rfc64SwmRecoveryCoordinatorV1: {
         admitSelectedPublic: (peerId, contextGraphIds) => (
@@ -448,6 +454,8 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
       lastSuccessfulSyncAt: new Map<string, number>(),
       lastSyncProgressAt: new Map<string, number>(),
       syncReconcilerBackoff: new Map<string, unknown>(),
+      applySyncOnConnectAccounting:
+        LifecycleSyncMethods.prototype.applySyncOnConnectAccounting,
       selectedSwmBootstrapAdmission: new SelectedSwmBootstrapAdmission(),
       rfc64SwmRecoveryCoordinatorV1: {
         admitSelectedPublic: (peerId, contextGraphIds) => (
@@ -488,9 +496,11 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
 
     expect(agent.selectedSwmBootstrapAdmission.isRetryRequired(PEER)).toBe(true);
     expect(agent.lastSuccessfulSyncAt.has(PEER)).toBe(false);
-    // No freshness/progress callback means the reconciler wrapper classifies
-    // this explicit incomplete result as a failed attempt and grows backoff.
-    expect(accounting).toEqual([]);
+    expect(accounting).toEqual([{
+      reconcilerDisposition: 'retry',
+      fresh: false,
+      progress: false,
+    }]);
   });
 
   it('continues a voluntary 672/905 public snapshot yield to 905/905 with fresh admission', async () => {
@@ -567,7 +577,7 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
         { contextGraphId: publicCg, selected: true, priority: 2_000, event: 'end' },
       ]);
 
-      const onPeerSynced = vi.fn();
+      const onSyncAccounting = vi.fn();
       const outcome = await runSyncOnConnect({
         remotePeer: PEER,
         syncingPeers: new Set(),
@@ -585,11 +595,12 @@ describe('selected RFC-64 SWM lifecycle wiring', () => {
         refreshMetaSyncedFlags: async () => undefined,
         discoverContextGraphsFromStore: async () => 0,
         syncSharedMemoryFromPeer: async () => summary,
-        onPeerSynced,
+        onSyncAccounting,
         logInfo: () => {},
       });
       expect(outcome).toBe('synced');
-      expect(onPeerSynced).toHaveBeenCalledWith(PEER, {
+      expect(onSyncAccounting).toHaveBeenCalledWith(PEER, {
+        reconcilerDisposition: 'clear',
         fresh: true,
         progress: false,
       });

--- a/packages/agent/test/selected-swm-lifecycle-queue.test.ts
+++ b/packages/agent/test/selected-swm-lifecycle-queue.test.ts
@@ -355,7 +355,7 @@ describe('selected RFC-64 SWM lifecycle queue and budgets', () => {
 
   it('does not hide an unrelated shared-memory phase failure', async () => {
     const contextGraphId = 'selected-with-unrelated-failure';
-    const onPeerSynced = vi.fn();
+    const onSyncAccounting = vi.fn();
     const shared = {
       ...result(contextGraphId, 3, 3),
       failedPhases: 2,
@@ -392,11 +392,12 @@ describe('selected RFC-64 SWM lifecycle queue and budgets', () => {
       refreshMetaSyncedFlags: async () => undefined,
       discoverContextGraphsFromStore: async () => 0,
       syncSharedMemoryFromPeer: async () => shared,
-      onPeerSynced,
+      onSyncAccounting,
       logInfo: () => {},
     });
 
-    expect(onPeerSynced).toHaveBeenCalledWith(PEER, {
+    expect(onSyncAccounting).toHaveBeenCalledWith(PEER, {
+      reconcilerDisposition: 'clear',
       fresh: false,
       progress: true,
     });

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -946,6 +946,49 @@ describe('sync-on-connect churn gates', () => {
     expect((agent as any).catchupOnConnectAt.get(PEER_A)).toBe(staleQueuedAt);
   });
 
+  it('retains progress while backing off a mixed progress-and-failure round', async () => {
+    const agent = await createUnstartedAgent('SyncReconnectPartialProgressBackoff', {
+      syncContextGraphs: ['cg-a'],
+    });
+    allowAllNetworkAdmission(agent);
+    (agent as any).started = true;
+    (agent.node as any).node = {
+      getPeers: () => [{ toString: () => PEER_A }],
+      getConnections: () => [{
+        remotePeer: { toString: () => PEER_A },
+        direction: 'outbound',
+        timeline: { open: 123 },
+        remoteAddr: { toString: () => '/ip4/127.0.0.1/tcp/9090' },
+      }],
+    };
+    (agent as any).getPeerProtocols = async () => [PROTOCOL_SYNC];
+    (agent as any).syncFromPeerDetailed = async () => emptyDetailedSync({
+      insertedTriples: 3,
+      insertedDataTriples: 3,
+      completedPhases: 1,
+      checkpointAdvances: 1,
+      timedOutPhases: 1,
+      backoffWorthyFailures: 1,
+    });
+    (agent as any).refreshMetaSyncedFlags = async () => undefined;
+    (agent as any).discoverContextGraphsFromStore = async () => 0;
+    (agent as any).planSharedMemorySyncContextGraphs = async () => ({ targets: [] });
+
+    await (agent as any).runSyncFromPeerOnConnect(PEER_A, () => undefined);
+
+    expect((agent as any).lastSyncProgressAt.get(PEER_A)).toBeGreaterThan(0);
+    expect((agent as any).lastSuccessfulSyncAt.has(PEER_A)).toBe(false);
+    const backoff = (agent as any).syncReconcilerBackoff.get(PEER_A);
+    expect(backoff?.failures).toBe(1);
+    expect(backoff?.nextRetryAt).toBeGreaterThan(Date.now());
+
+    (agent as any).catchupOnConnectAt.set(
+      PEER_A,
+      Date.now() - CATCHUP_ON_CONNECT_COOLDOWN_MS - 1,
+    );
+    expect((agent as any).queueSyncFromPeerOnConnect(PEER_A, () => undefined, 0)).toBe(false);
+  });
+
   it('records reconciler backoff when selected SWM is explicitly incomplete without progress', async () => {
     const agent = await createUnstartedAgent('SelectedSwmIncompleteBackoff');
     (agent as any).started = true;
@@ -1220,7 +1263,12 @@ describe('sync-on-connect churn gates', () => {
     const refreshMetaSyncedFlags = recorder(async () => undefined);
     const discoverContextGraphsFromStore = recorder(async () => 0);
     const syncSharedMemoryFromPeer = recorder(async () => 0);
-    const syncedPeers: Array<{ peerId: string; fresh: boolean; progress?: boolean }> = [];
+    const syncedPeers: Array<{
+      peerId: string;
+      fresh: boolean;
+      progress?: boolean;
+      retryBackoff?: boolean;
+    }> = [];
 
     const outcome = await runSyncOnConnect({
       remotePeer: PEER_A,
@@ -1241,7 +1289,12 @@ describe('sync-on-connect churn gates', () => {
       syncSharedMemoryFromPeer,
       logInfo: noopLog,
       onPeerSynced: (peerId, syncOutcome) => {
-        syncedPeers.push({ peerId, fresh: syncOutcome?.fresh ?? false, progress: syncOutcome?.progress });
+        syncedPeers.push({
+          peerId,
+          fresh: syncOutcome?.fresh ?? false,
+          progress: syncOutcome?.progress,
+          retryBackoff: syncOutcome?.retryBackoff,
+        });
       },
     });
 
@@ -1252,7 +1305,12 @@ describe('sync-on-connect churn gates', () => {
     expect(refreshMetaSyncedFlags.calls).toHaveLength(1);
     expect(discoverContextGraphsFromStore.calls).toEqual([[]]);
     expect(syncSharedMemoryFromPeer.calls).toEqual([[PEER_A, ['cg-a']]]);
-    expect(syncedPeers).toEqual([{ peerId: PEER_A, fresh: false, progress: true }]);
+    expect(syncedPeers).toEqual([{
+      peerId: PEER_A,
+      fresh: false,
+      progress: true,
+      retryBackoff: true,
+    }]);
   });
 
   it('stops post-durable sync-on-connect fanout when the peer never answered and nothing progressed', async () => {
@@ -1328,7 +1386,12 @@ describe('sync-on-connect churn gates', () => {
       return 1;
     });
     const syncSharedMemoryFromPeer = recorder(async () => 0);
-    const syncedPeers: Array<{ peerId: string; fresh: boolean; progress?: boolean }> = [];
+    const syncedPeers: Array<{
+      peerId: string;
+      fresh: boolean;
+      progress?: boolean;
+      retryBackoff?: boolean;
+    }> = [];
     const syncFromPeer = recorder(async (_peerId: string, contextGraphIds?: string[]) => {
       if (contextGraphIds?.includes('cg-b')) {
         return emptyDetailedSync({
@@ -1355,7 +1418,12 @@ describe('sync-on-connect churn gates', () => {
       syncSharedMemoryFromPeer,
       logInfo: noopLog,
       onPeerSynced: (peerId, syncOutcome) => {
-        syncedPeers.push({ peerId, fresh: syncOutcome?.fresh ?? false, progress: syncOutcome?.progress });
+        syncedPeers.push({
+          peerId,
+          fresh: syncOutcome?.fresh ?? false,
+          progress: syncOutcome?.progress,
+          retryBackoff: syncOutcome?.retryBackoff,
+        });
       },
     });
 
@@ -1364,7 +1432,12 @@ describe('sync-on-connect churn gates', () => {
     expect(refreshMetaSyncedFlags.calls).toHaveLength(2);
     expect(discoverContextGraphsFromStore.calls).toEqual([[]]);
     expect(syncSharedMemoryFromPeer.calls).toEqual([[PEER_A, ['cg-a', 'cg-b']]]);
-    expect(syncedPeers).toEqual([{ peerId: PEER_A, fresh: false, progress: true }]);
+    expect(syncedPeers).toEqual([{
+      peerId: PEER_A,
+      fresh: false,
+      progress: true,
+      retryBackoff: true,
+    }]);
   });
 
   it('skips SWM sync-on-connect fanout when no CG is locally eligible', async () => {

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -141,7 +141,7 @@ describe('sync-on-connect churn gates', () => {
       discoverContextGraphsFromStore,
       syncSharedMemoryFromPeer: async () => 0,
       logInfo: noopLog,
-      onPeerSynced: (peerId, syncOutcome) => {
+      onSyncAccounting: (peerId, syncOutcome) => {
         syncedPeers.push({ peerId, fresh: syncOutcome?.fresh ?? false, progress: syncOutcome?.progress });
       },
     });
@@ -995,6 +995,55 @@ describe('sync-on-connect churn gates', () => {
     expect((agent as any).queueSyncFromPeerOnConnect(PEER_A, () => undefined, 0)).toBe(false);
   });
 
+  it.each([
+    {
+      disposition: 'clear' as const,
+      fresh: true as const,
+      expectedFailures: undefined,
+      expectedFresh: true,
+    },
+    {
+      disposition: 'retry' as const,
+      fresh: false as const,
+      expectedFailures: 3,
+      expectedFresh: false,
+    },
+    {
+      disposition: 'defer' as const,
+      fresh: false as const,
+      expectedFailures: 2,
+      expectedFresh: false,
+    },
+  ])(
+    'applies $disposition accounting as one coherent lifecycle update',
+    async ({ disposition, fresh, expectedFailures, expectedFresh }) => {
+      const agent = await createUnstartedAgent(`SyncAccounting-${disposition}`);
+      (agent as any).started = true;
+      (agent as any).isPeerConnectedForSyncBackoff = () => true;
+      (agent as any).syncReconcilerBackoff.set(PEER_A, {
+        failures: 2,
+        nextRetryAt: Date.now() - 1,
+        protocolsKey: null,
+        connectionKey: null,
+      });
+
+      (agent as any).applySyncOnConnectAccounting(
+        PEER_A,
+        {
+          reconcilerDisposition: disposition,
+          fresh,
+          progress: true,
+        },
+        { protocolsKey: PROTOCOL_SYNC, connectionKey: 'accounting-test' },
+      );
+
+      expect((agent as any).lastSyncProgressAt.get(PEER_A)).toBeGreaterThan(0);
+      expect((agent as any).lastSuccessfulSyncAt.has(PEER_A)).toBe(expectedFresh);
+      expect((agent as any).syncReconcilerBackoff.get(PEER_A)?.failures)
+        .toBe(expectedFailures);
+    },
+  );
+
   it('records reconciler backoff when selected SWM is explicitly incomplete without progress', async () => {
     const agent = await createUnstartedAgent('SelectedSwmIncompleteBackoff');
     (agent as any).started = true;
@@ -1026,7 +1075,7 @@ describe('sync-on-connect churn gates', () => {
           },
         }),
       },
-      onPeerSynced: (_peerId, outcome) => {
+      onSyncAccounting: (_peerId, outcome) => {
         if (outcome) onSyncAccounting?.(outcome);
       },
       logInfo: noopLog,
@@ -1046,7 +1095,7 @@ describe('sync-on-connect churn gates', () => {
       .toBeGreaterThan(Date.now());
   });
 
-  it('records selected SWM progress without freshness and admits one bounded retry', async () => {
+  it('records selected SWM progress and preserves a bounded retry backoff', async () => {
     const agent = await createUnstartedAgent('SelectedSwmIncompleteProgress');
     allowAllNetworkAdmission(agent);
     (agent as any).started = true;
@@ -1093,13 +1142,20 @@ describe('sync-on-connect churn gates', () => {
 
     expect((agent as any).lastSyncProgressAt.has(PEER_A)).toBe(true);
     expect((agent as any).lastSuccessfulSyncAt.has(PEER_A)).toBe(false);
-    expect((agent as any).syncReconcilerBackoff.has(PEER_A)).toBe(false);
+    expect((agent as any).syncReconcilerBackoff.get(PEER_A)?.failures).toBe(1);
 
     const calls: string[] = [];
     (agent as any).runSelectedSwmRetryFromPeerOnConnect = async (peerId: string) => {
       calls.push(peerId);
     };
     const handleSyncError = () => undefined;
+    expect((agent as any).queueSyncFromPeerOnConnect(
+      PEER_A,
+      handleSyncError,
+      0,
+      { selectedSwmRetry: true },
+    )).toBe(false);
+    (agent as any).syncReconcilerBackoff.get(PEER_A).nextRetryAt = Date.now() - 1;
     expect((agent as any).queueSyncFromPeerOnConnect(
       PEER_A,
       handleSyncError,
@@ -1273,7 +1329,7 @@ describe('sync-on-connect churn gates', () => {
       peerId: string;
       fresh: boolean;
       progress?: boolean;
-      retryBackoff?: boolean;
+      reconcilerDisposition: 'clear' | 'retry' | 'defer';
     }> = [];
 
     const outcome = await runSyncOnConnect({
@@ -1294,12 +1350,12 @@ describe('sync-on-connect churn gates', () => {
       discoverContextGraphsFromStore,
       syncSharedMemoryFromPeer,
       logInfo: noopLog,
-      onPeerSynced: (peerId, syncOutcome) => {
+      onSyncAccounting: (peerId, syncOutcome) => {
         syncedPeers.push({
           peerId,
           fresh: syncOutcome?.fresh ?? false,
           progress: syncOutcome?.progress,
-          retryBackoff: syncOutcome?.retryBackoff,
+          reconcilerDisposition: syncOutcome.reconcilerDisposition,
         });
       },
     });
@@ -1315,7 +1371,7 @@ describe('sync-on-connect churn gates', () => {
       peerId: PEER_A,
       fresh: false,
       progress: true,
-      retryBackoff: true,
+      reconcilerDisposition: 'retry',
     }]);
   });
 
@@ -1339,7 +1395,7 @@ describe('sync-on-connect churn gates', () => {
       discoverContextGraphsFromStore,
       syncSharedMemoryFromPeer,
       logInfo: noopLog,
-      onPeerSynced: (peerId, syncOutcome) => {
+      onSyncAccounting: (peerId, syncOutcome) => {
         syncedPeers.push({ peerId, fresh: syncOutcome?.fresh ?? false, progress: syncOutcome?.progress });
       },
     });
@@ -1349,7 +1405,11 @@ describe('sync-on-connect churn gates', () => {
     expect(refreshMetaSyncedFlags.calls).toEqual([]);
     expect(discoverContextGraphsFromStore.calls).toEqual([]);
     expect(syncSharedMemoryFromPeer.calls).toEqual([]);
-    expect(syncedPeers).toEqual([]);
+    expect(syncedPeers).toEqual([{
+      peerId: PEER_A,
+      fresh: false,
+      progress: false,
+    }]);
   });
 
   it('continues sync-on-connect when a sibling CG proves the peer answered', async () => {
@@ -1396,7 +1456,7 @@ describe('sync-on-connect churn gates', () => {
       peerId: string;
       fresh: boolean;
       progress?: boolean;
-      retryBackoff?: boolean;
+      reconcilerDisposition: 'clear' | 'retry' | 'defer';
     }> = [];
     const syncFromPeer = recorder(async (_peerId: string, contextGraphIds?: string[]) => {
       if (contextGraphIds?.includes('cg-b')) {
@@ -1423,12 +1483,12 @@ describe('sync-on-connect churn gates', () => {
       discoverContextGraphsFromStore,
       syncSharedMemoryFromPeer,
       logInfo: noopLog,
-      onPeerSynced: (peerId, syncOutcome) => {
+      onSyncAccounting: (peerId, syncOutcome) => {
         syncedPeers.push({
           peerId,
           fresh: syncOutcome?.fresh ?? false,
           progress: syncOutcome?.progress,
-          retryBackoff: syncOutcome?.retryBackoff,
+          reconcilerDisposition: syncOutcome.reconcilerDisposition,
         });
       },
     });
@@ -1442,7 +1502,7 @@ describe('sync-on-connect churn gates', () => {
       peerId: PEER_A,
       fresh: false,
       progress: true,
-      retryBackoff: true,
+      reconcilerDisposition: 'retry',
     }]);
   });
 

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -973,13 +973,19 @@ describe('sync-on-connect churn gates', () => {
     (agent as any).refreshMetaSyncedFlags = async () => undefined;
     (agent as any).discoverContextGraphsFromStore = async () => 0;
     (agent as any).planSharedMemorySyncContextGraphs = async () => ({ targets: [] });
+    (agent as any).syncReconcilerBackoff.set(PEER_A, {
+      failures: 2,
+      nextRetryAt: Date.now() - 1,
+      protocolsKey: null,
+      connectionKey: null,
+    });
 
     await (agent as any).runSyncFromPeerOnConnect(PEER_A, () => undefined);
 
     expect((agent as any).lastSyncProgressAt.get(PEER_A)).toBeGreaterThan(0);
     expect((agent as any).lastSuccessfulSyncAt.has(PEER_A)).toBe(false);
     const backoff = (agent as any).syncReconcilerBackoff.get(PEER_A);
-    expect(backoff?.failures).toBe(1);
+    expect(backoff?.failures).toBe(3);
     expect(backoff?.nextRetryAt).toBeGreaterThan(Date.now());
 
     (agent as any).catchupOnConnectAt.set(

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -1194,6 +1194,55 @@ describe('DKGAgent sync retry — event-driven via peer:update', () => {
     }
   });
 
+  it('records mixed progress-and-failure backoff on the peer:update retry path', async () => {
+    const agent = await DKGAgent.create({
+      name: 'PeerUpdateMixedBackoff',
+      listenHost: '127.0.0.1',
+      chainAdapter: new MockChainAdapter(),
+    });
+    try {
+      await agent.start();
+      const remotePeer = freshPeerIdString();
+      allowAllNetworkAdmission(agent);
+      (agent as any).skippedNoSyncPeers.add(remotePeer);
+      (agent as any).isPeerConnectedForSyncBackoff = () => true;
+      (agent as any).getSyncReconcilerProbe = async () => ({
+        protocolsKey: PROTOCOL_SYNC,
+        connectionKey: 'peer-update-test',
+      });
+      (agent as any).trySyncFromPeer = async (
+        _peerId: string,
+        onSyncAccounting?: (outcome: {
+          fresh: boolean;
+          progress?: boolean;
+          retryBackoff?: boolean;
+        }) => void,
+      ) => {
+        onSyncAccounting?.({ fresh: false, progress: true, retryBackoff: true });
+        return 'synced';
+      };
+
+      agent.node.libp2p.dispatchEvent(new CustomEvent('peer:update', {
+        detail: {
+          peer: {
+            id: { toString: () => remotePeer },
+            protocols: [PROTOCOL_SYNC],
+          },
+        },
+      } as any));
+
+      for (let i = 0; i < 50 && !(agent as any).syncReconcilerBackoff.has(remotePeer); i++) {
+        await new Promise(r => setTimeout(r, 10));
+      }
+
+      const backoff = (agent as any).syncReconcilerBackoff.get(remotePeer);
+      expect(backoff?.failures).toBe(1);
+      expect(backoff?.nextRetryAt).toBeGreaterThan(Date.now());
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
   it('does not retry when the updated protocol list still lacks PROTOCOL_SYNC', async () => {
     const agent = await DKGAgent.create({
       name: 'PeerUpdateNoRetry',

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -178,7 +178,7 @@ describe('runSyncOnConnect callbacks', () => {
         return 0;
       },
       logInfo: noopLog,
-      onPeerSynced: (_peerId, accounting) => {
+      onSyncAccounting: (_peerId, accounting) => {
         if (accounting) synced.push(accounting);
       },
     });
@@ -209,13 +209,17 @@ describe('runSyncOnConnect callbacks', () => {
       discoverContextGraphsFromStore: async () => 0,
       syncSharedMemoryFromPeer: async () => 0,
       logInfo: noopLog,
-      onPeerSynced: (_peerId, accounting) => {
+      onSyncAccounting: (_peerId, accounting) => {
         if (accounting) synced.push(accounting);
       },
     });
 
     expect(outcome).toBe('deferred-backpressure');
-    expect(synced).toEqual([{ fresh: false, progress: true }]);
+    expect(synced).toEqual([{
+      reconcilerDisposition: 'defer',
+      fresh: false,
+      progress: true,
+    }]);
   });
 
   it('accepts omitted knownCorePeerIdsV2 for backwards-compatible call sites', async () => {
@@ -300,7 +304,7 @@ describe('runSyncOnConnect callbacks', () => {
       onPeerSkippedNoSync: (peerId, protocols) => {
         skipped.push({ peerId, protocols: [...protocols] });
       },
-      onPeerSynced: (peerId) => {
+      onSyncAccounting: (peerId) => {
         synced.push(peerId);
       },
     });
@@ -311,7 +315,7 @@ describe('runSyncOnConnect callbacks', () => {
     expect(syncFromPeer.calls).toEqual([]);
   });
 
-  it('fires onPeerSynced after a successful sync', async () => {
+  it('fires onSyncAccounting after a successful sync', async () => {
     const remotePeer = freshPeerIdString();
     const skipped: string[] = [];
     const synced: Array<{ peerId: string; fresh: boolean | undefined }> = [];
@@ -328,7 +332,7 @@ describe('runSyncOnConnect callbacks', () => {
       syncSharedMemoryFromPeer: async () => 0,
       logInfo: noopLog,
       onPeerSkippedNoSync: (peerId) => skipped.push(peerId),
-      onPeerSynced: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh }),
+      onSyncAccounting: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh }),
     });
 
     expect(outcome).toBe('synced');
@@ -336,7 +340,7 @@ describe('runSyncOnConnect callbacks', () => {
     expect(synced).toEqual([{ peerId: remotePeer, fresh: true }]);
   });
 
-  it('does not fire onPeerSynced when detailed sync summaries only time out', async () => {
+  it('returns retry accounting when detailed sync summaries only time out', async () => {
     const remotePeer = freshPeerIdString();
     const synced: Array<{ peerId: string; fresh: boolean | undefined }> = [];
 
@@ -362,11 +366,11 @@ describe('runSyncOnConnect callbacks', () => {
         checkpointAdvances: 0,
       }),
       logInfo: noopLog,
-      onPeerSynced: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh }),
+      onSyncAccounting: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh }),
     });
 
     expect(outcome).toBe('synced');
-    expect(synced).toEqual([]);
+    expect(synced).toEqual([{ peerId: remotePeer, fresh: false }]);
   });
 
   it('does not classify integrity-rejected durable summaries as clean progress', async () => {
@@ -403,18 +407,18 @@ describe('runSyncOnConnect callbacks', () => {
           deniedPhases: 0,
         }),
         logInfo: noopLog,
-        onPeerSynced: (peerId, peerOutcome) => synced.push({
+        onSyncAccounting: (peerId, peerOutcome) => synced.push({
           peerId,
           fresh: peerOutcome?.fresh,
         }),
       });
 
       expect(outcome).toBe('synced');
-      expect(synced).toEqual([]);
+      expect(synced).toEqual([{ peerId: remotePeer, fresh: false }]);
     }
   });
 
-  it('fires onPeerSynced when detailed sync summaries are clean but empty', async () => {
+  it('fires onSyncAccounting when detailed sync summaries are clean but empty', async () => {
     const remotePeer = freshPeerIdString();
     const synced: Array<{ peerId: string; fresh: boolean | undefined }> = [];
 
@@ -439,14 +443,14 @@ describe('runSyncOnConnect callbacks', () => {
         deniedPhases: 0,
       }),
       logInfo: noopLog,
-      onPeerSynced: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh }),
+      onSyncAccounting: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh }),
     });
 
     expect(outcome).toBe('synced');
     expect(synced).toEqual([{ peerId: remotePeer, fresh: true }]);
   });
 
-  it('does not fire onPeerSynced when clean empty accounting later times out', async () => {
+  it('returns retry accounting when clean empty accounting later times out', async () => {
     const remotePeer = freshPeerIdString();
     const synced: Array<{ peerId: string; fresh: boolean | undefined }> = [];
 
@@ -473,11 +477,11 @@ describe('runSyncOnConnect callbacks', () => {
         deniedPhases: 0,
       }),
       logInfo: noopLog,
-      onPeerSynced: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh }),
+      onSyncAccounting: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh }),
     });
 
     expect(outcome).toBe('synced');
-    expect(synced).toEqual([]);
+    expect(synced).toEqual([{ peerId: remotePeer, fresh: false }]);
   });
 
   it('marks denial-only sync as backoff-clearing but not fresh or progress', async () => {
@@ -509,14 +513,14 @@ describe('runSyncOnConnect callbacks', () => {
         deniedPhases: 0,
       }),
       logInfo: noopLog,
-      onPeerSynced: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh, progress: outcome?.progress }),
+      onSyncAccounting: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh, progress: outcome?.progress }),
     });
 
     expect(outcome).toBe('synced');
     expect(synced).toEqual([{ peerId: remotePeer, fresh: false, progress: false }]);
   });
 
-  it('does not fire onPeerSynced when denial-only accounting also has a timeout', async () => {
+  it('returns retry accounting when denial-only accounting also has a timeout', async () => {
     const remotePeer = freshPeerIdString();
     const synced: Array<{ peerId: string; fresh: boolean | undefined }> = [];
 
@@ -545,14 +549,14 @@ describe('runSyncOnConnect callbacks', () => {
         deniedPhases: 0,
       }),
       logInfo: noopLog,
-      onPeerSynced: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh }),
+      onSyncAccounting: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh }),
     });
 
     expect(outcome).toBe('synced');
-    expect(synced).toEqual([]);
+    expect(synced).toEqual([{ peerId: remotePeer, fresh: false }]);
   });
 
-  it('fires onPeerSynced when a detailed sync summary advances a checkpoint', async () => {
+  it('fires onSyncAccounting when a detailed sync summary advances a checkpoint', async () => {
     const remotePeer = freshPeerIdString();
     const synced: Array<{ peerId: string; fresh: boolean | undefined }> = [];
 
@@ -575,7 +579,7 @@ describe('runSyncOnConnect callbacks', () => {
         checkpointAdvances: 0,
       }),
       logInfo: noopLog,
-      onPeerSynced: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh }),
+      onSyncAccounting: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh }),
     });
 
     expect(outcome).toBe('synced');
@@ -611,7 +615,7 @@ describe('runSyncOnConnect callbacks', () => {
         deniedPhases: 0,
       }),
       logInfo: noopLog,
-      onPeerSynced: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh }),
+      onSyncAccounting: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh }),
     });
 
     expect(outcome).toBe('synced');
@@ -643,7 +647,7 @@ describe('runSyncOnConnect callbacks', () => {
         deniedPhases: 0,
       }),
       logInfo: noopLog,
-      onPeerSynced: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh, progress: outcome?.progress }),
+      onSyncAccounting: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh, progress: outcome?.progress }),
     });
 
     expect(outcome).toBe('synced');
@@ -688,7 +692,7 @@ describe('runSyncOnConnect callbacks', () => {
         deniedPhases: 0,
       }),
       logInfo: noopLog,
-      onPeerSynced: (peerId, outcome) => synced.push({
+      onSyncAccounting: (peerId, outcome) => synced.push({
         peerId,
         fresh: outcome?.fresh,
         progress: outcome?.progress,
@@ -737,7 +741,7 @@ describe('runSyncOnConnect callbacks', () => {
         deniedPhases: 0,
       }),
       logInfo: noopLog,
-      onPeerSynced: (peerId, syncOutcome) => synced.push({
+      onSyncAccounting: (peerId, syncOutcome) => synced.push({
         peerId,
         fresh: syncOutcome?.fresh,
         progress: syncOutcome?.progress,
@@ -787,7 +791,7 @@ describe('runSyncOnConnect callbacks', () => {
         deniedPhases: 0,
       }),
       logInfo: noopLog,
-      onPeerSynced: (peerId, syncOutcome) => synced.push({
+      onSyncAccounting: (peerId, syncOutcome) => synced.push({
         peerId,
         fresh: syncOutcome?.fresh,
         progress: syncOutcome?.progress,
@@ -842,7 +846,7 @@ describe('runSyncOnConnect callbacks', () => {
         deniedPhases: 0,
       }),
       logInfo: noopLog,
-      onPeerSynced: (peerId, syncOutcome) => synced.push({
+      onSyncAccounting: (peerId, syncOutcome) => synced.push({
         peerId,
         fresh: syncOutcome?.fresh,
         progress: syncOutcome?.progress,
@@ -899,7 +903,7 @@ describe('runSyncOnConnect callbacks', () => {
         deniedPhases: 0,
       }),
       logInfo: noopLog,
-      onPeerSynced: (peerId, syncOutcome) => synced.push({
+      onSyncAccounting: (peerId, syncOutcome) => synced.push({
         peerId,
         fresh: syncOutcome?.fresh,
         progress: syncOutcome?.progress,
@@ -907,7 +911,7 @@ describe('runSyncOnConnect callbacks', () => {
     });
 
     expect(outcome).toBe('synced');
-    expect(synced).toEqual([]);
+    expect(synced).toEqual([{ peerId: remotePeer, fresh: false, progress: false }]);
   });
 
   it('does not let clean shared-memory accounting make durable metadata-only sync fresh', async () => {
@@ -938,7 +942,7 @@ describe('runSyncOnConnect callbacks', () => {
         deniedPhases: 0,
       }),
       logInfo: noopLog,
-      onPeerSynced: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh }),
+      onSyncAccounting: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh }),
     });
 
     expect(outcome).toBe('synced');
@@ -972,7 +976,7 @@ describe('runSyncOnConnect callbacks', () => {
         deniedPhases: 0,
       }),
       logInfo: noopLog,
-      onPeerSynced: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh }),
+      onSyncAccounting: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh }),
     });
 
     expect(outcome).toBe('synced');
@@ -1008,7 +1012,7 @@ describe('runSyncOnConnect callbacks', () => {
         deniedPhases: 0,
       }),
       logInfo: noopLog,
-      onPeerSynced: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh }),
+      onSyncAccounting: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh }),
     });
 
     expect(outcome).toBe('synced');
@@ -1036,7 +1040,7 @@ describe('runSyncOnConnect callbacks', () => {
         },
         syncSharedMemoryFromPeer: async () => 0,
         logInfo: noopLog,
-        onPeerSynced: (peerId) => synced.push(peerId),
+        onSyncAccounting: (peerId) => synced.push(peerId),
       });
     } catch (err) {
       caught = err;
@@ -1108,7 +1112,7 @@ describe('runSyncOnConnect callbacks', () => {
       syncSharedMemoryFromPeer,
       syncSharedMemoryOnConnect: false,
       logInfo: noopLog,
-      onPeerSynced: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh }),
+      onSyncAccounting: (peerId, outcome) => synced.push({ peerId, fresh: outcome?.fresh }),
     });
 
     expect(outcome).toBe('synced');
@@ -1213,12 +1217,16 @@ describe('DKGAgent sync retry — event-driven via peer:update', () => {
       (agent as any).trySyncFromPeer = async (
         _peerId: string,
         onSyncAccounting?: (outcome: {
-          fresh: boolean;
-          progress?: boolean;
-          retryBackoff?: boolean;
+          reconcilerDisposition: 'clear' | 'retry' | 'defer';
+          fresh: false;
+          progress: boolean;
         }) => void,
       ) => {
-        onSyncAccounting?.({ fresh: false, progress: true, retryBackoff: true });
+        onSyncAccounting?.({
+          reconcilerDisposition: 'retry',
+          fresh: false,
+          progress: true,
+        });
         return 'synced';
       };
 


### PR DESCRIPTION
## Impact

A sync round can commit useful triples and still hit peer or transport pressure. That mixed outcome now records progress without erasing the per-peer retry backoff, preventing reconnect churn from immediately replaying the same failing scope.

This is the narrow current-canary replacement for #1952 and preserves the selected-SWM retry behavior added since the original branch.

## Validation

- Sync-on-connect focused Vitest: 90/90 passed
- Agent build, type tests, and package-root test: passed
- Runtime package build: passed
- Diff/whitespace check: passed

Closes #1952 after replacement adoption.