### PR TITLE
fix(daemon): retry failed chain-discovery scan slots

### DIFF
--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -54,8 +54,7 @@ import type {
 import type {
   ApprovalPolicy,
   ChainAdapter,
-  ContextGraphRegistryScanCursorPersistence,
-  ContextGraphRegistryScanCursorStore,
+  ContextGraphRegistryScanCursorStoreConfig,
 } from '@origintrail-official/dkg-chain';
 import type { QueryAccessConfig } from '@origintrail-official/dkg-query';
 import type { SkillHandler } from './messaging.js';
@@ -1854,10 +1853,8 @@ export interface DKGAgentConfig {
   changelogCursorStore?: ChangelogCursorStore;
   /** Durable lane cursor store for the chain event poller. Defaults to in-memory. */
   chainEventCursorStore?: ChainEventCursorPersistence;
-  /** Durable ContextGraphNameRegistry discovery cursor store. Defaults to in-memory adapter state. */
-  contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStore;
-  /** Explicit role-aware or split legacy persistence for historical and tip registry progress. */
-  contextGraphRegistryScanCursorPersistence?: ContextGraphRegistryScanCursorPersistence;
+  /** Original historical store or tagged role-aware/split registry cursor persistence. */
+  contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStoreConfig;
   /**
    * Intentional cap on how many persisted context-graph subscriptions are
    * *activated* (gossip-subscribed + sync-tracked) when rehydrating at startup.

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -54,6 +54,7 @@ import type {
 import type {
   ApprovalPolicy,
   ChainAdapter,
+  ContextGraphRegistryRoleAwareScanCursorStore,
   ContextGraphRegistryScanCursorStore,
 } from '@origintrail-official/dkg-chain';
 import type { QueryAccessConfig } from '@origintrail-official/dkg-query';
@@ -1853,10 +1854,10 @@ export interface DKGAgentConfig {
   changelogCursorStore?: ChangelogCursorStore;
   /** Durable lane cursor store for the chain event poller. Defaults to in-memory. */
   chainEventCursorStore?: ChainEventCursorPersistence;
-  /** Original three-field-key historical registry cursor store. */
+  /** Original three-field-key historical registry cursor store retained for compatibility. */
   contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStore;
-  /** Independent three-field-key tip registry cursor store. */
-  contextGraphRegistryTipScanCursorStore?: ContextGraphRegistryScanCursorStore;
+  /** Canonical role-aware historical and tip registry cursor store. */
+  contextGraphRegistryRoleAwareScanCursorStore?: ContextGraphRegistryRoleAwareScanCursorStore;
   /**
    * Intentional cap on how many persisted context-graph subscriptions are
    * *activated* (gossip-subscribed + sync-tracked) when rehydrating at startup.

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -1851,6 +1851,8 @@ export interface DKGAgentConfig {
   chainEventCursorStore?: ChainEventCursorPersistence;
   /** Durable ContextGraphNameRegistry discovery cursor store. Defaults to in-memory adapter state. */
   contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStore;
+  /** Dedicated tip cursor store when the historical store uses the legacy role-less key contract. */
+  contextGraphRegistryTipScanCursorStore?: ContextGraphRegistryScanCursorStore;
   /**
    * Intentional cap on how many persisted context-graph subscriptions are
    * *activated* (gossip-subscribed + sync-tracked) when rehydrating at startup.

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -54,7 +54,7 @@ import type {
 import type {
   ApprovalPolicy,
   ChainAdapter,
-  ContextGraphRegistryScanCursorStoreConfig,
+  ContextGraphRegistryScanCursorStore,
 } from '@origintrail-official/dkg-chain';
 import type { QueryAccessConfig } from '@origintrail-official/dkg-query';
 import type { SkillHandler } from './messaging.js';
@@ -1853,8 +1853,10 @@ export interface DKGAgentConfig {
   changelogCursorStore?: ChangelogCursorStore;
   /** Durable lane cursor store for the chain event poller. Defaults to in-memory. */
   chainEventCursorStore?: ChainEventCursorPersistence;
-  /** Original historical store or tagged role-aware/split registry cursor persistence. */
-  contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStoreConfig;
+  /** Original three-field-key historical registry cursor store. */
+  contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStore;
+  /** Independent three-field-key tip registry cursor store. */
+  contextGraphRegistryTipScanCursorStore?: ContextGraphRegistryScanCursorStore;
   /**
    * Intentional cap on how many persisted context-graph subscriptions are
    * *activated* (gossip-subscribed + sync-tracked) when rehydrating at startup.

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -51,7 +51,12 @@ import type {
   WorkspacePublicSnapshotStore,
   CursorPersistence as ChainEventCursorPersistence,
 } from '@origintrail-official/dkg-publisher';
-import type { ApprovalPolicy, ChainAdapter, ContextGraphRegistryScanCursorStore } from '@origintrail-official/dkg-chain';
+import type {
+  ApprovalPolicy,
+  ChainAdapter,
+  ContextGraphRegistryScanCursorPersistence,
+  ContextGraphRegistryScanCursorStore,
+} from '@origintrail-official/dkg-chain';
 import type { QueryAccessConfig } from '@origintrail-official/dkg-query';
 import type { SkillHandler } from './messaging.js';
 import type { CclFactResolutionMode } from './ccl-fact-resolution.js';
@@ -1851,8 +1856,8 @@ export interface DKGAgentConfig {
   chainEventCursorStore?: ChainEventCursorPersistence;
   /** Durable ContextGraphNameRegistry discovery cursor store. Defaults to in-memory adapter state. */
   contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStore;
-  /** Dedicated tip cursor store when the historical store uses the legacy role-less key contract. */
-  contextGraphRegistryTipScanCursorStore?: ContextGraphRegistryScanCursorStore;
+  /** Explicit role-aware or split legacy persistence for historical and tip registry progress. */
+  contextGraphRegistryScanCursorPersistence?: ContextGraphRegistryScanCursorPersistence;
   /**
    * Intentional cap on how many persisted context-graph subscriptions are
    * *activated* (gossip-subscribed + sync-tracked) when rehydrating at startup.

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -717,6 +717,7 @@ function constructConfiguredChainAdapter(
       minPublisherNativeWei: config.chainConfig.minPublisherNativeWei,
       minPublisherTracWei: config.chainConfig.minPublisherTracWei,
       contextGraphRegistryScanCursorStore: config.contextGraphRegistryScanCursorStore,
+      contextGraphRegistryTipScanCursorStore: config.contextGraphRegistryTipScanCursorStore,
     };
     const chain = config.chainConfig.adminPrivateKey
       ? new EVMChainAdapter({ ...evmConfigBase, adminPrivateKey: config.chainConfig.adminPrivateKey })

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -717,7 +717,8 @@ function constructConfiguredChainAdapter(
       minPublisherNativeWei: config.chainConfig.minPublisherNativeWei,
       minPublisherTracWei: config.chainConfig.minPublisherTracWei,
       contextGraphRegistryScanCursorStore: config.contextGraphRegistryScanCursorStore,
-      contextGraphRegistryTipScanCursorStore: config.contextGraphRegistryTipScanCursorStore,
+      contextGraphRegistryRoleAwareScanCursorStore:
+        config.contextGraphRegistryRoleAwareScanCursorStore,
     };
     const chain = config.chainConfig.adminPrivateKey
       ? new EVMChainAdapter({ ...evmConfigBase, adminPrivateKey: config.chainConfig.adminPrivateKey })

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -717,7 +717,6 @@ function constructConfiguredChainAdapter(
       minPublisherNativeWei: config.chainConfig.minPublisherNativeWei,
       minPublisherTracWei: config.chainConfig.minPublisherTracWei,
       contextGraphRegistryScanCursorStore: config.contextGraphRegistryScanCursorStore,
-      contextGraphRegistryScanCursorPersistence: config.contextGraphRegistryScanCursorPersistence,
     };
     const chain = config.chainConfig.adminPrivateKey
       ? new EVMChainAdapter({ ...evmConfigBase, adminPrivateKey: config.chainConfig.adminPrivateKey })

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -717,7 +717,7 @@ function constructConfiguredChainAdapter(
       minPublisherNativeWei: config.chainConfig.minPublisherNativeWei,
       minPublisherTracWei: config.chainConfig.minPublisherTracWei,
       contextGraphRegistryScanCursorStore: config.contextGraphRegistryScanCursorStore,
-      contextGraphRegistryTipScanCursorStore: config.contextGraphRegistryTipScanCursorStore,
+      contextGraphRegistryScanCursorPersistence: config.contextGraphRegistryScanCursorPersistence,
     };
     const chain = config.chainConfig.adminPrivateKey
       ? new EVMChainAdapter({ ...evmConfigBase, adminPrivateKey: config.chainConfig.adminPrivateKey })

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -91,7 +91,7 @@ import {
 } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, createTripleStore, deleteByPatternWithoutCount, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { canonicalRootlessLifecycleGraph } from './rootless-lifecycle-graph.js';
-import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, isContextGraphChainScanPartialError, type EVMAdapterConfig, type ChainAdapter, type ContextGraphOnChain, type ContextGraphChainScanOptions, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
+import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, isContextGraphChainScanPartialError, type EVMAdapterConfig, type ChainAdapter, type ContextGraphOnChain, type ContextGraphChainScanOptions, type ContextGraphRegistryScanOptions, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
   PublishJournal, StaleWriteError,
@@ -536,7 +536,7 @@ export interface AssertionHistoryDescriptor extends AssertionDescriptor {
 export type DiscoverContextGraphsFromChainOptions = {
   throwOnChainScanFailure?: boolean;
   pageBudget?: number;
-  mode?: 'listAll' | 'incremental' | 'tip' | 'seedFull' | 'seedFromCursor';
+  mode?: 'listAll' | ContextGraphRegistryScanOptions['mode'];
   incremental?: boolean;
   seedIncrementalWatermark?: boolean;
   resumeFromCursor?: boolean;
@@ -544,10 +544,7 @@ export type DiscoverContextGraphsFromChainOptions = {
 
 type NormalizedContextGraphDiscoveryScan =
   | { mode: 'listAll' }
-  | { mode: 'incremental'; pageBudget?: number }
-  | { mode: 'tip' }
-  | { mode: 'seedFull' }
-  | { mode: 'seedFromCursor'; pageBudget?: number };
+  | ContextGraphRegistryScanOptions;
 
 function normalizeContextGraphDiscoveryScan(
   options: DiscoverContextGraphsFromChainOptions,

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -91,7 +91,7 @@ import {
 } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, createTripleStore, deleteByPatternWithoutCount, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { canonicalRootlessLifecycleGraph } from './rootless-lifecycle-graph.js';
-import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, isContextGraphChainScanPartialError, normalizeContextGraphRegistryScanCursorStore, type EVMAdapterConfig, type ChainAdapter, type ContextGraphOnChain, type ContextGraphChainScanOptions, type ContextGraphRegistryScanOptions, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
+import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, isContextGraphChainScanPartialError, type EVMAdapterConfig, type ChainAdapter, type ContextGraphOnChain, type ContextGraphChainScanOptions, type ContextGraphRegistryScanOptions, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
   PublishJournal, StaleWriteError,
@@ -716,11 +716,9 @@ function constructConfiguredChainAdapter(
       cgRegistryScanPageSize: config.chainConfig.cgRegistryScanPageSize,
       minPublisherNativeWei: config.chainConfig.minPublisherNativeWei,
       minPublisherTracWei: config.chainConfig.minPublisherTracWei,
+      contextGraphRegistryScanCursorStore: config.contextGraphRegistryScanCursorStore,
       contextGraphRegistryRoleAwareScanCursorStore:
-        normalizeContextGraphRegistryScanCursorStore({
-          legacy: config.contextGraphRegistryScanCursorStore,
-          roleAware: config.contextGraphRegistryRoleAwareScanCursorStore,
-        }),
+        config.contextGraphRegistryRoleAwareScanCursorStore,
     };
     const chain = config.chainConfig.adminPrivateKey
       ? new EVMChainAdapter({ ...evmConfigBase, adminPrivateKey: config.chainConfig.adminPrivateKey })

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -91,7 +91,7 @@ import {
 } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, createTripleStore, deleteByPatternWithoutCount, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { canonicalRootlessLifecycleGraph } from './rootless-lifecycle-graph.js';
-import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, isContextGraphChainScanPartialError, type EVMAdapterConfig, type ChainAdapter, type ContextGraphOnChain, type ContextGraphChainScanOptions, type ContextGraphRegistryScanOptions, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
+import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, isContextGraphChainScanPartialError, normalizeContextGraphRegistryScanCursorStore, type EVMAdapterConfig, type ChainAdapter, type ContextGraphOnChain, type ContextGraphChainScanOptions, type ContextGraphRegistryScanOptions, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
   PublishJournal, StaleWriteError,
@@ -716,9 +716,11 @@ function constructConfiguredChainAdapter(
       cgRegistryScanPageSize: config.chainConfig.cgRegistryScanPageSize,
       minPublisherNativeWei: config.chainConfig.minPublisherNativeWei,
       minPublisherTracWei: config.chainConfig.minPublisherTracWei,
-      contextGraphRegistryScanCursorStore: config.contextGraphRegistryScanCursorStore,
       contextGraphRegistryRoleAwareScanCursorStore:
-        config.contextGraphRegistryRoleAwareScanCursorStore,
+        normalizeContextGraphRegistryScanCursorStore({
+          legacy: config.contextGraphRegistryScanCursorStore,
+          roleAware: config.contextGraphRegistryRoleAwareScanCursorStore,
+        }),
     };
     const chain = config.chainConfig.adminPrivateKey
       ? new EVMChainAdapter({ ...evmConfigBase, adminPrivateKey: config.chainConfig.adminPrivateKey })

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -536,7 +536,7 @@ export interface AssertionHistoryDescriptor extends AssertionDescriptor {
 export type DiscoverContextGraphsFromChainOptions = {
   throwOnChainScanFailure?: boolean;
   pageBudget?: number;
-  mode?: 'listAll' | 'incremental' | 'seedFull' | 'seedFromCursor';
+  mode?: 'listAll' | 'incremental' | 'tip' | 'seedFull' | 'seedFromCursor';
   incremental?: boolean;
   seedIncrementalWatermark?: boolean;
   resumeFromCursor?: boolean;
@@ -545,6 +545,7 @@ export type DiscoverContextGraphsFromChainOptions = {
 type NormalizedContextGraphDiscoveryScan =
   | { mode: 'listAll' }
   | { mode: 'incremental'; pageBudget?: number }
+  | { mode: 'tip' }
   | { mode: 'seedFull' }
   | { mode: 'seedFromCursor'; pageBudget?: number };
 
@@ -558,6 +559,7 @@ function normalizeContextGraphDiscoveryScan(
         ...(options.pageBudget !== undefined ? { pageBudget: options.pageBudget } : {}),
       };
     }
+    if (options.mode === 'tip') return { mode: 'tip' };
     if (options.mode === 'seedFull') return { mode: 'seedFull' };
     if (options.mode === 'seedFromCursor') {
       return {

--- a/packages/agent/test/chain-cursor-wiring.test.ts
+++ b/packages/agent/test/chain-cursor-wiring.test.ts
@@ -14,11 +14,7 @@ describe('DKGAgent chain cursor wiring', () => {
   });
 
   it('passes EVM chainConfig fields into the constructed adapter', async () => {
-    const historicalRegistryCursorStore = {
-      load: vi.fn(async () => undefined),
-      save: vi.fn(async () => {}),
-    };
-    const tipRegistryCursorStore = {
+    const registryCursorStore = {
       load: vi.fn(async () => undefined),
       save: vi.fn(async () => {}),
     };
@@ -35,14 +31,26 @@ describe('DKGAgent chain cursor wiring', () => {
         minPublisherNativeWei: 123n,
         minPublisherTracWei: 456n,
       },
-      contextGraphRegistryScanCursorStore: historicalRegistryCursorStore,
-      contextGraphRegistryTipScanCursorStore: tipRegistryCursorStore,
+      contextGraphRegistryRoleAwareScanCursorStore: registryCursorStore,
     });
 
-    expect((agent as any).chain.contextGraphRegistryScanCursor?.input?.store)
-      .toBe(historicalRegistryCursorStore);
-    expect((agent as any).chain.contextGraphRegistryTipScanCursor?.input?.store)
-      .toBe(tipRegistryCursorStore);
+    const cursorKey = {
+      chainId: 'evm:31337',
+      deploymentId: 'evm:31337:hub=0x0000000000000000000000000000000000000001',
+      registryAddress: '0x3333333333333333333333333333333333333333',
+    };
+    await (agent as any).chain.contextGraphRegistryScanCursor.input.store.save(cursorKey, 111);
+    await (agent as any).chain.contextGraphRegistryTipScanCursor.input.store.save(cursorKey, 222);
+    expect(registryCursorStore.save).toHaveBeenNthCalledWith(
+      1,
+      { ...cursorKey, cursorKind: 'historical' },
+      111,
+    );
+    expect(registryCursorStore.save).toHaveBeenNthCalledWith(
+      2,
+      { ...cursorKey, cursorKind: 'tip' },
+      222,
+    );
     expect((agent as any).chain.minPublisherNativeWei).toBe(123n);
     expect((agent as any).chain.minPublisherTracWei).toBe(456n);
     expect((agent as any).chain.receiptTimeoutMs).toBe(1_200_000);

--- a/packages/agent/test/chain-cursor-wiring.test.ts
+++ b/packages/agent/test/chain-cursor-wiring.test.ts
@@ -14,7 +14,11 @@ describe('DKGAgent chain cursor wiring', () => {
   });
 
   it('passes EVM chainConfig fields into the constructed adapter', async () => {
-    const registryCursorStore = {
+    const historicalRegistryCursorStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+    };
+    const tipRegistryCursorStore = {
       load: vi.fn(async () => undefined),
       save: vi.fn(async () => {}),
     };
@@ -31,10 +35,21 @@ describe('DKGAgent chain cursor wiring', () => {
         minPublisherNativeWei: 123n,
         minPublisherTracWei: 456n,
       },
-      contextGraphRegistryScanCursorStore: registryCursorStore,
+      contextGraphRegistryScanCursorPersistence: {
+        kind: 'legacy',
+        historical: historicalRegistryCursorStore,
+        tip: tipRegistryCursorStore,
+      },
     });
 
-    expect((agent as any).chain.contextGraphRegistryScanCursor?.input?.store).toBe(registryCursorStore);
+    expect((agent as any).chain.contextGraphRegistryScanCursor?.input?.store).toEqual({
+      kind: 'legacy',
+      store: historicalRegistryCursorStore,
+    });
+    expect((agent as any).chain.contextGraphRegistryTipScanCursor?.input?.store).toEqual({
+      kind: 'legacy',
+      store: tipRegistryCursorStore,
+    });
     expect((agent as any).chain.minPublisherNativeWei).toBe(123n);
     expect((agent as any).chain.minPublisherTracWei).toBe(456n);
     expect((agent as any).chain.receiptTimeoutMs).toBe(1_200_000);

--- a/packages/agent/test/chain-cursor-wiring.test.ts
+++ b/packages/agent/test/chain-cursor-wiring.test.ts
@@ -35,11 +35,8 @@ describe('DKGAgent chain cursor wiring', () => {
         minPublisherNativeWei: 123n,
         minPublisherTracWei: 456n,
       },
-      contextGraphRegistryScanCursorStore: {
-        kind: 'legacy',
-        historical: historicalRegistryCursorStore,
-        tip: tipRegistryCursorStore,
-      },
+      contextGraphRegistryScanCursorStore: historicalRegistryCursorStore,
+      contextGraphRegistryTipScanCursorStore: tipRegistryCursorStore,
     });
 
     expect((agent as any).chain.contextGraphRegistryScanCursor?.input?.store)

--- a/packages/agent/test/chain-cursor-wiring.test.ts
+++ b/packages/agent/test/chain-cursor-wiring.test.ts
@@ -35,21 +35,17 @@ describe('DKGAgent chain cursor wiring', () => {
         minPublisherNativeWei: 123n,
         minPublisherTracWei: 456n,
       },
-      contextGraphRegistryScanCursorPersistence: {
+      contextGraphRegistryScanCursorStore: {
         kind: 'legacy',
         historical: historicalRegistryCursorStore,
         tip: tipRegistryCursorStore,
       },
     });
 
-    expect((agent as any).chain.contextGraphRegistryScanCursor?.input?.store).toEqual({
-      kind: 'legacy',
-      store: historicalRegistryCursorStore,
-    });
-    expect((agent as any).chain.contextGraphRegistryTipScanCursor?.input?.store).toEqual({
-      kind: 'legacy',
-      store: tipRegistryCursorStore,
-    });
+    expect((agent as any).chain.contextGraphRegistryScanCursor?.input?.store)
+      .toBe(historicalRegistryCursorStore);
+    expect((agent as any).chain.contextGraphRegistryTipScanCursor?.input?.store)
+      .toBe(tipRegistryCursorStore);
     expect((agent as any).chain.minPublisherNativeWei).toBe(123n);
     expect((agent as any).chain.minPublisherTracWei).toBe(456n);
     expect((agent as any).chain.receiptTimeoutMs).toBe(1_200_000);

--- a/packages/agent/test/chain-cursor-wiring.test.ts
+++ b/packages/agent/test/chain-cursor-wiring.test.ts
@@ -56,6 +56,57 @@ describe('DKGAgent chain cursor wiring', () => {
     expect((agent as any).chain.receiptTimeoutMs).toBe(1_200_000);
   });
 
+  it('preserves legacy historical keys without exposing tip persistence', async () => {
+    const legacyStore = {
+      load: vi.fn(async () => 100),
+      save: vi.fn(async () => {}),
+    };
+
+    agent = await DKGAgent.create({
+      name: 'LegacyRegistryCursorWiring',
+      listenPort: 0,
+      chainConfig: {
+        rpcUrl: 'http://127.0.0.1:59998',
+        hubAddress: '0x0000000000000000000000000000000000000001',
+        operationalKeys: [OPERATIONAL_KEY],
+        chainId: 'evm:31337',
+      },
+      contextGraphRegistryScanCursorStore: legacyStore,
+    });
+
+    const cursorKey = {
+      chainId: 'evm:31337',
+      deploymentId: 'evm:31337:hub=0x0000000000000000000000000000000000000001',
+      registryAddress: '0x3333333333333333333333333333333333333333',
+    };
+    const chain = (agent as any).chain;
+    await expect(
+      chain.contextGraphRegistryScanCursor.loadBestEffortWatermark(cursorKey.registryAddress),
+    ).resolves.toBe(100);
+    await chain.contextGraphRegistryScanCursor.saveBestEffortWatermark(
+      cursorKey.registryAddress,
+      111,
+    );
+    await expect(
+      chain.contextGraphRegistryTipScanCursor.loadStrictWatermark(cursorKey.registryAddress),
+    ).resolves.toBeUndefined();
+    await chain.contextGraphRegistryTipScanCursor.saveStrictWatermark(
+      cursorKey.registryAddress,
+      222,
+    );
+
+    expect(legacyStore.load).toHaveBeenCalledWith(cursorKey);
+    expect(legacyStore.save).toHaveBeenCalledWith(cursorKey, 111);
+    expect(Object.keys(legacyStore.load.mock.calls[0]?.[0] ?? {}).sort()).toEqual([
+      'chainId',
+      'deploymentId',
+      'registryAddress',
+    ]);
+    expect(chain.contextGraphRegistryTipScanCursor.input.store).toBeUndefined();
+    expect(legacyStore.load).toHaveBeenCalledTimes(1);
+    expect(legacyStore.save).toHaveBeenCalledTimes(1);
+  });
+
   it('passes the chain-event lane cursor store into the poller on start', async () => {
     const chainEventCursorStore = {
       loadLane: vi.fn(async () => undefined),

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -2392,6 +2392,7 @@ describe('discoverContextGraphsFromChain', () => {
     expect(await agent.discoverContextGraphsFromChain()).toBe(0);
     expect(await agent.discoverContextGraphsFromChain({ mode: 'incremental' })).toBe(0);
     expect(await agent.discoverContextGraphsFromChain({ mode: 'incremental', pageBudget: 7 })).toBe(0);
+    expect(await agent.discoverContextGraphsFromChain({ mode: 'tip' })).toBe(0);
     expect(await agent.discoverContextGraphsFromChain({ mode: 'seedFull' })).toBe(0);
     expect(await agent.discoverContextGraphsFromChain({
       mode: 'seedFromCursor',
@@ -2404,6 +2405,7 @@ describe('discoverContextGraphsFromChain', () => {
     expect(scanCalls).toEqual([
       { mode: 'incremental' },
       { mode: 'incremental', pageBudget: 7 },
+      { mode: 'tip' },
       { mode: 'seedFull' },
       { mode: 'seedFromCursor', pageBudget: 11 },
     ]);

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -578,6 +578,12 @@ export interface ContextGraphRegistryScanCursorKey {
 }
 
 export interface ContextGraphRegistryScanCursorStore {
+  /**
+   * Version 2 stores include `cursorKind` in their durable key. Stores that omit this marker are
+   * treated as legacy role-less stores: they remain the historical source, but are never shared
+   * with the independent tip cursor because doing so could alias both progress records.
+   */
+  readonly cursorKeyVersion?: 2;
   load(key: ContextGraphRegistryScanCursorKey): Promise<number | undefined>;
   save(key: ContextGraphRegistryScanCursorKey, nextBlock: number): Promise<void>;
 }

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -577,39 +577,11 @@ export interface ContextGraphRegistryScanCursorKey {
   registryAddress: string;
 }
 
-/** Role-aware cursor key used only by explicitly configured role-aware persistence. */
-export interface ContextGraphRegistryRoleAwareScanCursorKey extends ContextGraphRegistryScanCursorKey {
-  cursorKind: 'historical' | 'tip';
-}
-
 /** Pre-role persistence contract. It receives the exact original three-field key. */
 export interface ContextGraphRegistryScanCursorStore {
   load(key: ContextGraphRegistryScanCursorKey): Promise<number | undefined>;
   save(key: ContextGraphRegistryScanCursorKey, nextBlock: number): Promise<void>;
 }
-
-/** Store whose durable identity includes the cursor role. */
-export interface ContextGraphRegistryRoleAwareScanCursorStore {
-  load(key: ContextGraphRegistryRoleAwareScanCursorKey): Promise<number | undefined>;
-  save(key: ContextGraphRegistryRoleAwareScanCursorKey, nextBlock: number): Promise<void>;
-}
-
-/** Explicit compatibility boundary for historical and independent tip progress. */
-export type ContextGraphRegistryScanCursorPersistence =
-  | {
-      kind: 'legacy';
-      historical: ContextGraphRegistryScanCursorStore;
-      tip?: ContextGraphRegistryScanCursorStore;
-    }
-  | {
-      kind: 'roleAware';
-      store: ContextGraphRegistryRoleAwareScanCursorStore;
-    };
-
-/** Single public configuration slot: original stores remain valid; new persistence is tagged. */
-export type ContextGraphRegistryScanCursorStoreConfig =
-  | ContextGraphRegistryScanCursorStore
-  | ContextGraphRegistryScanCursorPersistence;
 
 // ----- On-Chain Context Graph types (ContextGraphs contract) -----
 

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -606,6 +606,11 @@ export type ContextGraphRegistryScanCursorPersistence =
       store: ContextGraphRegistryRoleAwareScanCursorStore;
     };
 
+/** Single public configuration slot: original stores remain valid; new persistence is tagged. */
+export type ContextGraphRegistryScanCursorStoreConfig =
+  | ContextGraphRegistryScanCursorStore
+  | ContextGraphRegistryScanCursorPersistence;
+
 // ----- On-Chain Context Graph types (ContextGraphs contract) -----
 
 /**

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -570,23 +570,41 @@ export function buildEvmDeploymentId(input: { chainId: string; hubAddress: strin
   return `${input.chainId}:hub=${input.hubAddress.toLowerCase()}`;
 }
 
+/** Original role-less cursor key retained for existing historical stores. */
 export interface ContextGraphRegistryScanCursorKey {
   chainId: string;
   deploymentId: string;
   registryAddress: string;
+}
+
+/** Role-aware cursor key used only by explicitly configured role-aware persistence. */
+export interface ContextGraphRegistryRoleAwareScanCursorKey extends ContextGraphRegistryScanCursorKey {
   cursorKind: 'historical' | 'tip';
 }
 
+/** Pre-role persistence contract. It receives the exact original three-field key. */
 export interface ContextGraphRegistryScanCursorStore {
-  /**
-   * Version 2 stores include `cursorKind` in their durable key. Stores that omit this marker are
-   * treated as legacy role-less stores: they remain the historical source, but are never shared
-   * with the independent tip cursor because doing so could alias both progress records.
-   */
-  readonly cursorKeyVersion?: 2;
   load(key: ContextGraphRegistryScanCursorKey): Promise<number | undefined>;
   save(key: ContextGraphRegistryScanCursorKey, nextBlock: number): Promise<void>;
 }
+
+/** Store whose durable identity includes the cursor role. */
+export interface ContextGraphRegistryRoleAwareScanCursorStore {
+  load(key: ContextGraphRegistryRoleAwareScanCursorKey): Promise<number | undefined>;
+  save(key: ContextGraphRegistryRoleAwareScanCursorKey, nextBlock: number): Promise<void>;
+}
+
+/** Explicit compatibility boundary for historical and independent tip progress. */
+export type ContextGraphRegistryScanCursorPersistence =
+  | {
+      kind: 'legacy';
+      historical: ContextGraphRegistryScanCursorStore;
+      tip?: ContextGraphRegistryScanCursorStore;
+    }
+  | {
+      kind: 'roleAware';
+      store: ContextGraphRegistryRoleAwareScanCursorStore;
+    };
 
 // ----- On-Chain Context Graph types (ContextGraphs contract) -----
 

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -583,6 +583,34 @@ export interface ContextGraphRegistryScanCursorStore {
   save(key: ContextGraphRegistryScanCursorKey, nextBlock: number): Promise<void>;
 }
 
+export type ContextGraphRegistryScanCursorRole = 'historical' | 'tip';
+
+/** Canonical key for independently persisted historical and tip progress. */
+export interface ContextGraphRegistryRoleAwareScanCursorKey
+  extends ContextGraphRegistryScanCursorKey {
+  cursorKind: ContextGraphRegistryScanCursorRole;
+}
+
+/** Canonical persistence contract. Cursor independence is encoded in every operation. */
+export interface ContextGraphRegistryRoleAwareScanCursorStore {
+  load(key: ContextGraphRegistryRoleAwareScanCursorKey): Promise<number | undefined>;
+  save(
+    key: ContextGraphRegistryRoleAwareScanCursorKey,
+    nextBlock: number,
+  ): Promise<void>;
+}
+
+/** Bind a canonical role-aware backing store to one scanner-owned cursor role. */
+export function contextGraphRegistryScanCursorStoreForRole(
+  store: ContextGraphRegistryRoleAwareScanCursorStore,
+  cursorKind: ContextGraphRegistryScanCursorRole,
+): ContextGraphRegistryScanCursorStore {
+  return {
+    load: (key) => store.load({ ...key, cursorKind }),
+    save: (key, nextBlock) => store.save({ ...key, cursorKind }, nextBlock),
+  };
+}
+
 // ----- On-Chain Context Graph types (ContextGraphs contract) -----
 
 /**

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -547,6 +547,10 @@ export type ContextGraphRegistryScanOptions =
       pageBudget?: number;
     }
   | {
+      /** Probe only the page containing the current chain tip without reading or advancing the historical cursor. */
+      mode: 'tip';
+    }
+  | {
       mode: 'seedFull';
     }
   | {

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -611,6 +611,36 @@ export function contextGraphRegistryScanCursorStoreForRole(
   };
 }
 
+/** Normalize legacy/canonical configuration once before scanner construction. */
+export function normalizeContextGraphRegistryScanCursorStore(input: {
+  legacy?: ContextGraphRegistryScanCursorStore;
+  roleAware?: ContextGraphRegistryRoleAwareScanCursorStore;
+}): ContextGraphRegistryRoleAwareScanCursorStore | undefined {
+  if (input.legacy && input.roleAware) {
+    throw new Error(
+      'Configure only one registry scan cursor store: legacy or role-aware, not both',
+    );
+  }
+  if (input.roleAware) return input.roleAware;
+  if (!input.legacy) return undefined;
+  const legacy = input.legacy;
+  const historicalKey = (
+    key: ContextGraphRegistryRoleAwareScanCursorKey,
+  ): ContextGraphRegistryScanCursorKey => ({
+    chainId: key.chainId,
+    deploymentId: key.deploymentId,
+    registryAddress: key.registryAddress,
+  });
+  return {
+    load: (key) => key.cursorKind === 'historical'
+      ? legacy.load(historicalKey(key))
+      : Promise.resolve(undefined),
+    save: (key, nextBlock) => key.cursorKind === 'historical'
+      ? legacy.save(historicalKey(key), nextBlock)
+      : Promise.resolve(),
+  };
+}
+
 // ----- On-Chain Context Graph types (ContextGraphs contract) -----
 
 /**

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -574,6 +574,7 @@ export interface ContextGraphRegistryScanCursorKey {
   chainId: string;
   deploymentId: string;
   registryAddress: string;
+  cursorKind: 'historical' | 'tip';
 }
 
 export interface ContextGraphRegistryScanCursorStore {

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -547,7 +547,10 @@ export type ContextGraphRegistryScanOptions =
       pageBudget?: number;
     }
   | {
-      /** Probe only the page containing the current chain tip without reading or advancing the historical cursor. */
+      /**
+       * Scan from independent tip progress through the current head without reading or advancing
+       * the historical cursor. The first probe is bounded to the current tip page.
+       */
       mode: 'tip';
     }
   | {

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -600,8 +600,13 @@ export interface ContextGraphRegistryRoleAwareScanCursorStore {
   ): Promise<void>;
 }
 
-/** Bind a canonical role-aware backing store to one scanner-owned cursor role. */
-export function contextGraphRegistryScanCursorStoreForRole(
+/** Internal store shape consumed by the two scanner-owned cursor roles. */
+interface ContextGraphRegistryScanCursorStores {
+  historicalStore?: ContextGraphRegistryScanCursorStore;
+  tipStore?: ContextGraphRegistryScanCursorStore;
+}
+
+function contextGraphRegistryScanCursorStoreForRole(
   store: ContextGraphRegistryRoleAwareScanCursorStore,
   cursorKind: ContextGraphRegistryScanCursorRole,
 ): ContextGraphRegistryScanCursorStore {
@@ -615,30 +620,22 @@ export function contextGraphRegistryScanCursorStoreForRole(
 export function normalizeContextGraphRegistryScanCursorStore(input: {
   legacy?: ContextGraphRegistryScanCursorStore;
   roleAware?: ContextGraphRegistryRoleAwareScanCursorStore;
-}): ContextGraphRegistryRoleAwareScanCursorStore | undefined {
+}): ContextGraphRegistryScanCursorStores {
   if (input.legacy && input.roleAware) {
     throw new Error(
       'Configure only one registry scan cursor store: legacy or role-aware, not both',
     );
   }
-  if (input.roleAware) return input.roleAware;
-  if (!input.legacy) return undefined;
-  const legacy = input.legacy;
-  const historicalKey = (
-    key: ContextGraphRegistryRoleAwareScanCursorKey,
-  ): ContextGraphRegistryScanCursorKey => ({
-    chainId: key.chainId,
-    deploymentId: key.deploymentId,
-    registryAddress: key.registryAddress,
-  });
-  return {
-    load: (key) => key.cursorKind === 'historical'
-      ? legacy.load(historicalKey(key))
-      : Promise.resolve(undefined),
-    save: (key, nextBlock) => key.cursorKind === 'historical'
-      ? legacy.save(historicalKey(key), nextBlock)
-      : Promise.resolve(),
-  };
+  if (input.roleAware) {
+    return {
+      historicalStore: contextGraphRegistryScanCursorStoreForRole(
+        input.roleAware,
+        'historical',
+      ),
+      tipStore: contextGraphRegistryScanCursorStoreForRole(input.roleAware, 'tip'),
+    };
+  }
+  return input.legacy ? { historicalStore: input.legacy } : {};
 }
 
 // ----- On-Chain Context Graph types (ContextGraphs contract) -----

--- a/packages/chain/src/context-graph-registry-scan-cursor.ts
+++ b/packages/chain/src/context-graph-registry-scan-cursor.ts
@@ -9,35 +9,21 @@ export type ContextGraphRegistryScanCursorLoadResult =
   | { status: 'loaded'; watermark?: number }
   | { status: 'failed'; error: unknown };
 
-/**
- * Durable cursor policy for ContextGraphNameRegistry scans.
- *
- * The cursor is feature-owned rather than generic EVM plumbing: it is scoped by
- * chain, deployment, and registry address, and it intentionally tolerates store
- * failures by falling back to process-local state.
- */
-export class ContextGraphRegistryScanCursor {
+type CursorInput = {
+  chainId: string;
+  deploymentId: string;
+  store?: ContextGraphRegistryScanCursorStore;
+};
+
+abstract class ContextGraphRegistryScanCursorBase {
   private readonly watermarks: Map<string, number> = new Map();
-  /** Strict writes retained in memory until the configured store confirms them. */
-  private readonly pendingStrictWatermarks: Map<string, number> = new Map();
 
-  constructor(
-    private readonly input: {
-      chainId: string;
-      deploymentId: string;
-      store?: ContextGraphRegistryScanCursorStore;
-      savePolicy?: 'bestEffort' | 'strict';
-    },
-  ) {}
-
-  clearMemoryCache(): void {
-    this.watermarks.clear();
-  }
+  constructor(protected readonly input: CursorInput) {}
 
   getCachedWatermark(registryAddress: string): number | undefined {
     const cacheKey = this.cacheKey(registryAddress);
     return this.normalize(this.watermarks.get(cacheKey))
-      ?? this.normalize(this.pendingStrictWatermarks.get(cacheKey));
+      ?? this.pendingWatermark(cacheKey);
   }
 
   async loadWatermark(registryAddress: string): Promise<number | undefined> {
@@ -51,18 +37,14 @@ export class ContextGraphRegistryScanCursor {
     const cacheKey = this.cacheKey(registryAddress);
     const cached = this.normalize(this.watermarks.get(cacheKey));
     if (cached != null) return { status: 'loaded', watermark: cached };
-    // A failed strict write is a safety anchor, not ordinary disposable cache.
-    // Prefer it across Hub/cache invalidation until the store confirms it.
-    const pending = this.normalize(this.pendingStrictWatermarks.get(cacheKey));
+    const pending = this.pendingWatermark(cacheKey);
     if (pending != null) return { status: 'loaded', watermark: pending };
 
     if (!this.input.store) return { status: 'loaded' };
     try {
       const persisted = await this.input.store.load(this.cursorKey(cacheKey));
       const normalized = this.normalize(persisted);
-      if (normalized != null) {
-        this.watermarks.set(cacheKey, normalized);
-      }
+      if (normalized != null) this.watermarks.set(cacheKey, normalized);
       return { status: 'loaded', watermark: normalized };
     } catch (err) {
       console.warn(
@@ -72,23 +54,57 @@ export class ContextGraphRegistryScanCursor {
     }
   }
 
-  async saveWatermark(registryAddress: string, nextBlock: number): Promise<void> {
-    if (this.input.savePolicy === 'strict') {
-      await this.saveStrict(registryAddress, nextBlock);
-      return;
-    }
-    await this.saveBestEffort(registryAddress, nextBlock);
+  protected clearCachedWatermarks(): void {
+    this.watermarks.clear();
   }
 
-  private async saveBestEffort(registryAddress: string, nextBlock: number): Promise<void> {
+  protected cachedWatermark(cacheKey: string): number | undefined {
+    return this.normalize(this.watermarks.get(cacheKey));
+  }
+
+  protected rememberWatermark(cacheKey: string, nextBlock: number): void {
+    this.watermarks.set(cacheKey, nextBlock);
+  }
+
+  protected pendingWatermark(_cacheKey: string): number | undefined {
+    return undefined;
+  }
+
+  protected cacheKey(registryAddress: string): string {
+    return registryAddress.toLowerCase();
+  }
+
+  protected cursorKey(registryAddress: string): ContextGraphRegistryScanCursorKey {
+    return {
+      chainId: this.input.chainId,
+      deploymentId: this.input.deploymentId,
+      registryAddress,
+    };
+  }
+
+  protected normalize(value: number | undefined): number | undefined {
+    if (value == null) return undefined;
+    if (!Number.isSafeInteger(value) || value <= 0) return undefined;
+    return value;
+  }
+}
+
+/** Historical scan cursor with an explicit best-effort persistence contract. */
+export class ContextGraphRegistryHistoricalScanCursor
+  extends ContextGraphRegistryScanCursorBase {
+  clearMemoryCache(): void {
+    this.clearCachedWatermarks();
+  }
+
+  async saveBestEffortWatermark(registryAddress: string, nextBlock: number): Promise<void> {
     const normalized = this.normalize(nextBlock);
     if (normalized == null) return;
 
     const cacheKey = this.cacheKey(registryAddress);
-    const existing = this.normalize(this.watermarks.get(cacheKey));
+    const existing = this.cachedWatermark(cacheKey);
     if (existing != null && existing >= normalized) return;
 
-    this.watermarks.set(cacheKey, normalized);
+    this.rememberWatermark(cacheKey, normalized);
     if (!this.input.store) return;
     try {
       await this.input.store.save(this.cursorKey(cacheKey), normalized);
@@ -98,25 +114,28 @@ export class ContextGraphRegistryScanCursor {
       );
     }
   }
+}
 
-  /**
-   * Save a watermark without hiding configured-store failures.
-   *
-   * Tip discovery uses this path because its initial lower bound is the durable
-   * restart anchor. The attempted value remains process-local after a failure,
-   * and a retry of the same value re-attempts persistence before scanning.
-   */
-  private async saveStrict(registryAddress: string, nextBlock: number): Promise<void> {
+/** Tip scan cursor with an explicit fail-closed persistence contract. */
+export class ContextGraphRegistryTipScanCursor extends ContextGraphRegistryScanCursorBase {
+  /** Failed strict writes remain safety anchors until the store confirms them. */
+  private readonly pendingStrictWatermarks: Map<string, number> = new Map();
+
+  protected override pendingWatermark(cacheKey: string): number | undefined {
+    return this.normalize(this.pendingStrictWatermarks.get(cacheKey));
+  }
+
+  async saveStrictWatermark(registryAddress: string, nextBlock: number): Promise<void> {
     const normalized = this.normalize(nextBlock);
     if (normalized == null) return;
 
     const cacheKey = this.cacheKey(registryAddress);
-    const existing = this.normalize(this.watermarks.get(cacheKey));
-    const pending = this.normalize(this.pendingStrictWatermarks.get(cacheKey));
+    const existing = this.cachedWatermark(cacheKey);
+    const pending = this.pendingWatermark(cacheKey);
     if (existing != null && existing >= normalized && pending == null) return;
 
     const target = Math.max(existing ?? 0, pending ?? 0, normalized);
-    this.watermarks.set(cacheKey, target);
+    this.rememberWatermark(cacheKey, target);
     if (!this.input.store) return;
 
     this.pendingStrictWatermarks.set(cacheKey, target);
@@ -127,27 +146,9 @@ export class ContextGraphRegistryScanCursor {
       }
     } catch (err) {
       console.warn(
-        `[chain] ContextGraphNameRegistry scan cursor strict save failed: ${err instanceof Error ? err.message : String(err)}`,
+        `[chain] ContextGraphNameRegistry tip cursor save failed: ${err instanceof Error ? err.message : String(err)}`,
       );
       throw err;
     }
-  }
-
-  private cacheKey(registryAddress: string): string {
-    return registryAddress.toLowerCase();
-  }
-
-  private cursorKey(registryAddress: string): ContextGraphRegistryScanCursorKey {
-    return {
-      chainId: this.input.chainId,
-      deploymentId: this.input.deploymentId,
-      registryAddress,
-    };
-  }
-
-  private normalize(value: number | undefined): number | undefined {
-    if (value == null) return undefined;
-    if (!Number.isSafeInteger(value) || value <= 0) return undefined;
-    return value;
   }
 }

--- a/packages/chain/src/context-graph-registry-scan-cursor.ts
+++ b/packages/chain/src/context-graph-registry-scan-cursor.ts
@@ -18,6 +18,8 @@ export type ContextGraphRegistryScanCursorLoadResult =
  */
 export class ContextGraphRegistryScanCursor {
   private readonly watermarks: Map<string, number> = new Map();
+  /** Strict writes retained in memory until the configured store confirms them. */
+  private readonly pendingStrictWatermarks: Map<string, number> = new Map();
 
   constructor(
     private readonly input: {
@@ -29,6 +31,7 @@ export class ContextGraphRegistryScanCursor {
 
   clearMemoryCache(): void {
     this.watermarks.clear();
+    this.pendingStrictWatermarks.clear();
   }
 
   getCachedWatermark(registryAddress: string): number | undefined {
@@ -79,6 +82,40 @@ export class ContextGraphRegistryScanCursor {
       console.warn(
         `[chain] ContextGraphNameRegistry scan cursor save failed: ${err instanceof Error ? err.message : String(err)}`,
       );
+    }
+  }
+
+  /**
+   * Save a watermark without hiding configured-store failures.
+   *
+   * Tip discovery uses this path because its initial lower bound is the durable
+   * restart anchor. The attempted value remains process-local after a failure,
+   * and a retry of the same value re-attempts persistence before scanning.
+   */
+  async saveWatermarkStrict(registryAddress: string, nextBlock: number): Promise<void> {
+    const normalized = this.normalize(nextBlock);
+    if (normalized == null) return;
+
+    const cacheKey = this.cacheKey(registryAddress);
+    const existing = this.normalize(this.watermarks.get(cacheKey));
+    const pending = this.normalize(this.pendingStrictWatermarks.get(cacheKey));
+    if (existing != null && existing >= normalized && pending == null) return;
+
+    const target = Math.max(existing ?? 0, pending ?? 0, normalized);
+    this.watermarks.set(cacheKey, target);
+    if (!this.input.store) return;
+
+    this.pendingStrictWatermarks.set(cacheKey, target);
+    try {
+      await this.input.store.save(this.cursorKey(cacheKey), target);
+      if (this.pendingStrictWatermarks.get(cacheKey) === target) {
+        this.pendingStrictWatermarks.delete(cacheKey);
+      }
+    } catch (err) {
+      console.warn(
+        `[chain] ContextGraphNameRegistry scan cursor strict save failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      throw err;
     }
   }
 

--- a/packages/chain/src/context-graph-registry-scan-cursor.ts
+++ b/packages/chain/src/context-graph-registry-scan-cursor.ts
@@ -11,22 +11,31 @@ type CursorInput = {
   store?: ContextGraphRegistryScanCursorStore;
 };
 
+interface CursorState {
+  cached?: number;
+  pending?: number;
+  persisting?: Promise<void>;
+}
+
 abstract class ContextGraphRegistryScanCursorBase {
-  private readonly watermarks: Map<string, number> = new Map();
+  private readonly states: Map<string, CursorState> = new Map();
 
   constructor(protected readonly input: CursorInput) {}
 
   getCachedWatermark(registryAddress: string): number | undefined {
     const cacheKey = this.cacheKey(registryAddress);
-    return this.normalize(this.watermarks.get(cacheKey))
-      ?? this.pendingWatermark(cacheKey);
+    const state = this.cursorState(cacheKey);
+    const cached = this.normalize(state.cached);
+    const pending = this.normalize(state.pending);
+    return cached === undefined ? pending : Math.max(cached, pending ?? 0);
   }
 
   protected async loadStoredWatermark(registryAddress: string): Promise<number | undefined> {
     const cacheKey = this.cacheKey(registryAddress);
-    const cached = this.normalize(this.watermarks.get(cacheKey));
+    const state = this.cursorState(cacheKey);
+    const cached = this.normalize(state.cached);
     if (cached != null) return cached;
-    const pending = this.pendingWatermark(cacheKey);
+    const pending = this.normalize(state.pending);
     if (pending != null) return pending;
 
     if (!this.input.store) return undefined;
@@ -37,24 +46,29 @@ abstract class ContextGraphRegistryScanCursorBase {
         `invalid persisted registry scan cursor: expected a positive safe integer, got ${String(persisted)}`,
       );
     }
-    if (normalized != null) this.watermarks.set(cacheKey, normalized);
+    if (normalized != null) state.cached = normalized;
     return normalized;
   }
 
   protected clearCachedWatermarks(): void {
-    this.watermarks.clear();
+    this.states.clear();
   }
 
   protected cachedWatermark(cacheKey: string): number | undefined {
-    return this.normalize(this.watermarks.get(cacheKey));
+    return this.normalize(this.cursorState(cacheKey).cached);
   }
 
   protected rememberWatermark(cacheKey: string, nextBlock: number): void {
-    this.watermarks.set(cacheKey, nextBlock);
+    this.cursorState(cacheKey).cached = nextBlock;
   }
 
-  protected pendingWatermark(_cacheKey: string): number | undefined {
-    return undefined;
+  protected cursorState(cacheKey: string): CursorState {
+    let state = this.states.get(cacheKey);
+    if (!state) {
+      state = {};
+      this.states.set(cacheKey, state);
+    }
+    return state;
   }
 
   protected cacheKey(registryAddress: string): string {
@@ -116,13 +130,6 @@ export class ContextGraphRegistryHistoricalScanCursor
 
 /** Tip scan cursor with an explicit fail-closed persistence contract. */
 export class ContextGraphRegistryTipScanCursor extends ContextGraphRegistryScanCursorBase {
-  /** Failed strict writes remain safety anchors until the store confirms them. */
-  private readonly pendingStrictWatermarks: Map<string, number> = new Map();
-
-  protected override pendingWatermark(cacheKey: string): number | undefined {
-    return this.normalize(this.pendingStrictWatermarks.get(cacheKey));
-  }
-
   async loadStrictWatermark(registryAddress: string): Promise<number | undefined> {
     try {
       return await this.loadStoredWatermark(registryAddress);
@@ -143,21 +150,37 @@ export class ContextGraphRegistryTipScanCursor extends ContextGraphRegistryScanC
     if (normalized == null) return;
 
     const cacheKey = this.cacheKey(registryAddress);
-    const existing = this.cachedWatermark(cacheKey);
-    const pending = this.pendingWatermark(cacheKey);
-    if (existing != null && existing >= normalized && pending == null) return;
+    const state = this.cursorState(cacheKey);
+    const existing = this.normalize(state.cached);
+    const pending = this.normalize(state.pending);
+    if (existing != null && existing >= normalized && pending == null) {
+      await state.persisting;
+      return;
+    }
 
     const target = Math.max(existing ?? 0, pending ?? 0, normalized);
-    this.rememberWatermark(cacheKey, target);
+    state.cached = target;
     if (!this.input.store) return;
 
-    this.pendingStrictWatermarks.set(cacheKey, target);
+    state.pending = target;
+    if (!state.persisting) {
+      const persist = (async () => {
+        while (state.pending !== undefined) {
+          const next = state.pending;
+          await this.input.store!.save(this.cursorKey(cacheKey), next);
+          if (state.pending === next) state.pending = undefined;
+        }
+      })().finally(() => {
+        if (state.persisting === persist) state.persisting = undefined;
+      });
+      state.persisting = persist;
+    }
     try {
-      await this.input.store.save(this.cursorKey(cacheKey), target);
-      if (this.pendingStrictWatermarks.get(cacheKey) === target) {
-        this.pendingStrictWatermarks.delete(cacheKey);
-      }
+      await state.persisting;
     } catch (err) {
+      if (state.pending === undefined) {
+        state.pending = target;
+      }
       console.warn(
         `[chain] ContextGraphNameRegistry tip cursor save failed: ${err instanceof Error ? err.message : String(err)}`,
       );

--- a/packages/chain/src/context-graph-registry-scan-cursor.ts
+++ b/packages/chain/src/context-graph-registry-scan-cursor.ts
@@ -3,13 +3,11 @@
 import type {
   ContextGraphRegistryScanCursorKey,
   ContextGraphRegistryScanCursorStore,
-  ContextGraphRegistryRoleAwareScanCursorKey,
-  ContextGraphRegistryRoleAwareScanCursorStore,
 } from './chain-adapter.js';
 
-export type ContextGraphRegistryScanCursorStoreBinding =
-  | { kind: 'legacy'; store: ContextGraphRegistryScanCursorStore }
-  | { kind: 'roleAware'; store: ContextGraphRegistryRoleAwareScanCursorStore };
+export type ContextGraphRegistryScanCursorLoadResult =
+  | { status: 'loaded'; watermark?: number }
+  | { status: 'failed'; error: unknown };
 
 /**
  * Durable cursor policy for ContextGraphNameRegistry scans.
@@ -25,8 +23,7 @@ export class ContextGraphRegistryScanCursor {
     private readonly input: {
       chainId: string;
       deploymentId: string;
-      cursorKind: ContextGraphRegistryRoleAwareScanCursorKey['cursorKind'];
-      store?: ContextGraphRegistryScanCursorStoreBinding;
+      store?: ContextGraphRegistryScanCursorStore;
     },
   ) {}
 
@@ -39,25 +36,30 @@ export class ContextGraphRegistryScanCursor {
   }
 
   async loadWatermark(registryAddress: string): Promise<number | undefined> {
+    const result = await this.loadWatermarkResult(registryAddress);
+    return result.status === 'loaded' ? result.watermark : undefined;
+  }
+
+  async loadWatermarkResult(
+    registryAddress: string,
+  ): Promise<ContextGraphRegistryScanCursorLoadResult> {
     const cacheKey = this.cacheKey(registryAddress);
     const cached = this.normalize(this.watermarks.get(cacheKey));
-    if (cached != null) return cached;
+    if (cached != null) return { status: 'loaded', watermark: cached };
 
-    if (!this.input.store) return undefined;
+    if (!this.input.store) return { status: 'loaded' };
     try {
-      const persisted = this.input.store.kind === 'roleAware'
-        ? await this.input.store.store.load(this.roleAwareCursorKey(cacheKey))
-        : await this.input.store.store.load(this.legacyCursorKey(cacheKey));
+      const persisted = await this.input.store.load(this.cursorKey(cacheKey));
       const normalized = this.normalize(persisted);
       if (normalized != null) {
         this.watermarks.set(cacheKey, normalized);
       }
-      return normalized;
+      return { status: 'loaded', watermark: normalized };
     } catch (err) {
       console.warn(
         `[chain] ContextGraphNameRegistry scan cursor load failed: ${err instanceof Error ? err.message : String(err)}`,
       );
-      return undefined;
+      return { status: 'failed', error: err };
     }
   }
 
@@ -72,11 +74,7 @@ export class ContextGraphRegistryScanCursor {
     this.watermarks.set(cacheKey, normalized);
     if (!this.input.store) return;
     try {
-      if (this.input.store.kind === 'roleAware') {
-        await this.input.store.store.save(this.roleAwareCursorKey(cacheKey), normalized);
-      } else {
-        await this.input.store.store.save(this.legacyCursorKey(cacheKey), normalized);
-      }
+      await this.input.store.save(this.cursorKey(cacheKey), normalized);
     } catch (err) {
       console.warn(
         `[chain] ContextGraphNameRegistry scan cursor save failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -88,18 +86,11 @@ export class ContextGraphRegistryScanCursor {
     return registryAddress.toLowerCase();
   }
 
-  private legacyCursorKey(registryAddress: string): ContextGraphRegistryScanCursorKey {
+  private cursorKey(registryAddress: string): ContextGraphRegistryScanCursorKey {
     return {
       chainId: this.input.chainId,
       deploymentId: this.input.deploymentId,
       registryAddress,
-    };
-  }
-
-  private roleAwareCursorKey(registryAddress: string): ContextGraphRegistryRoleAwareScanCursorKey {
-    return {
-      ...this.legacyCursorKey(registryAddress),
-      cursorKind: this.input.cursorKind,
     };
   }
 

--- a/packages/chain/src/context-graph-registry-scan-cursor.ts
+++ b/packages/chain/src/context-graph-registry-scan-cursor.ts
@@ -26,16 +26,18 @@ export class ContextGraphRegistryScanCursor {
       chainId: string;
       deploymentId: string;
       store?: ContextGraphRegistryScanCursorStore;
+      savePolicy?: 'bestEffort' | 'strict';
     },
   ) {}
 
   clearMemoryCache(): void {
     this.watermarks.clear();
-    this.pendingStrictWatermarks.clear();
   }
 
   getCachedWatermark(registryAddress: string): number | undefined {
-    return this.normalize(this.watermarks.get(this.cacheKey(registryAddress)));
+    const cacheKey = this.cacheKey(registryAddress);
+    return this.normalize(this.watermarks.get(cacheKey))
+      ?? this.normalize(this.pendingStrictWatermarks.get(cacheKey));
   }
 
   async loadWatermark(registryAddress: string): Promise<number | undefined> {
@@ -49,6 +51,10 @@ export class ContextGraphRegistryScanCursor {
     const cacheKey = this.cacheKey(registryAddress);
     const cached = this.normalize(this.watermarks.get(cacheKey));
     if (cached != null) return { status: 'loaded', watermark: cached };
+    // A failed strict write is a safety anchor, not ordinary disposable cache.
+    // Prefer it across Hub/cache invalidation until the store confirms it.
+    const pending = this.normalize(this.pendingStrictWatermarks.get(cacheKey));
+    if (pending != null) return { status: 'loaded', watermark: pending };
 
     if (!this.input.store) return { status: 'loaded' };
     try {
@@ -67,6 +73,14 @@ export class ContextGraphRegistryScanCursor {
   }
 
   async saveWatermark(registryAddress: string, nextBlock: number): Promise<void> {
+    if (this.input.savePolicy === 'strict') {
+      await this.saveStrict(registryAddress, nextBlock);
+      return;
+    }
+    await this.saveBestEffort(registryAddress, nextBlock);
+  }
+
+  private async saveBestEffort(registryAddress: string, nextBlock: number): Promise<void> {
     const normalized = this.normalize(nextBlock);
     if (normalized == null) return;
 
@@ -92,7 +106,7 @@ export class ContextGraphRegistryScanCursor {
    * restart anchor. The attempted value remains process-local after a failure,
    * and a retry of the same value re-attempts persistence before scanning.
    */
-  async saveWatermarkStrict(registryAddress: string, nextBlock: number): Promise<void> {
+  private async saveStrict(registryAddress: string, nextBlock: number): Promise<void> {
     const normalized = this.normalize(nextBlock);
     if (normalized == null) return;
 

--- a/packages/chain/src/context-graph-registry-scan-cursor.ts
+++ b/packages/chain/src/context-graph-registry-scan-cursor.ts
@@ -3,7 +3,13 @@
 import type {
   ContextGraphRegistryScanCursorKey,
   ContextGraphRegistryScanCursorStore,
+  ContextGraphRegistryRoleAwareScanCursorKey,
+  ContextGraphRegistryRoleAwareScanCursorStore,
 } from './chain-adapter.js';
+
+export type ContextGraphRegistryScanCursorStoreBinding =
+  | { kind: 'legacy'; store: ContextGraphRegistryScanCursorStore }
+  | { kind: 'roleAware'; store: ContextGraphRegistryRoleAwareScanCursorStore };
 
 /**
  * Durable cursor policy for ContextGraphNameRegistry scans.
@@ -19,8 +25,8 @@ export class ContextGraphRegistryScanCursor {
     private readonly input: {
       chainId: string;
       deploymentId: string;
-      cursorKind: ContextGraphRegistryScanCursorKey['cursorKind'];
-      store?: ContextGraphRegistryScanCursorStore;
+      cursorKind: ContextGraphRegistryRoleAwareScanCursorKey['cursorKind'];
+      store?: ContextGraphRegistryScanCursorStoreBinding;
     },
   ) {}
 
@@ -39,7 +45,9 @@ export class ContextGraphRegistryScanCursor {
 
     if (!this.input.store) return undefined;
     try {
-      const persisted = await this.input.store.load(this.cursorKey(cacheKey));
+      const persisted = this.input.store.kind === 'roleAware'
+        ? await this.input.store.store.load(this.roleAwareCursorKey(cacheKey))
+        : await this.input.store.store.load(this.legacyCursorKey(cacheKey));
       const normalized = this.normalize(persisted);
       if (normalized != null) {
         this.watermarks.set(cacheKey, normalized);
@@ -64,7 +72,11 @@ export class ContextGraphRegistryScanCursor {
     this.watermarks.set(cacheKey, normalized);
     if (!this.input.store) return;
     try {
-      await this.input.store.save(this.cursorKey(cacheKey), normalized);
+      if (this.input.store.kind === 'roleAware') {
+        await this.input.store.store.save(this.roleAwareCursorKey(cacheKey), normalized);
+      } else {
+        await this.input.store.store.save(this.legacyCursorKey(cacheKey), normalized);
+      }
     } catch (err) {
       console.warn(
         `[chain] ContextGraphNameRegistry scan cursor save failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -76,11 +88,17 @@ export class ContextGraphRegistryScanCursor {
     return registryAddress.toLowerCase();
   }
 
-  private cursorKey(registryAddress: string): ContextGraphRegistryScanCursorKey {
+  private legacyCursorKey(registryAddress: string): ContextGraphRegistryScanCursorKey {
     return {
       chainId: this.input.chainId,
       deploymentId: this.input.deploymentId,
       registryAddress,
+    };
+  }
+
+  private roleAwareCursorKey(registryAddress: string): ContextGraphRegistryRoleAwareScanCursorKey {
+    return {
+      ...this.legacyCursorKey(registryAddress),
       cursorKind: this.input.cursorKind,
     };
   }

--- a/packages/chain/src/context-graph-registry-scan-cursor.ts
+++ b/packages/chain/src/context-graph-registry-scan-cursor.ts
@@ -19,6 +19,7 @@ export class ContextGraphRegistryScanCursor {
     private readonly input: {
       chainId: string;
       deploymentId: string;
+      cursorKind: ContextGraphRegistryScanCursorKey['cursorKind'];
       store?: ContextGraphRegistryScanCursorStore;
     },
   ) {}
@@ -80,6 +81,7 @@ export class ContextGraphRegistryScanCursor {
       chainId: this.input.chainId,
       deploymentId: this.input.deploymentId,
       registryAddress,
+      cursorKind: this.input.cursorKind,
     };
   }
 

--- a/packages/chain/src/context-graph-registry-scan-cursor.ts
+++ b/packages/chain/src/context-graph-registry-scan-cursor.ts
@@ -32,6 +32,11 @@ abstract class ContextGraphRegistryScanCursorBase {
     if (!this.input.store) return undefined;
     const persisted = await this.input.store.load(this.cursorKey(cacheKey));
     const normalized = this.normalize(persisted);
+    if (persisted !== undefined && normalized === undefined) {
+      throw new Error(
+        `invalid persisted registry scan cursor: expected a positive safe integer, got ${String(persisted)}`,
+      );
+    }
     if (normalized != null) this.watermarks.set(cacheKey, normalized);
     return normalized;
   }

--- a/packages/chain/src/context-graph-registry-scan-cursor.ts
+++ b/packages/chain/src/context-graph-registry-scan-cursor.ts
@@ -5,10 +5,6 @@ import type {
   ContextGraphRegistryScanCursorStore,
 } from './chain-adapter.js';
 
-export type ContextGraphRegistryScanCursorLoadResult =
-  | { status: 'loaded'; watermark?: number }
-  | { status: 'failed'; error: unknown };
-
 type CursorInput = {
   chainId: string;
   deploymentId: string;
@@ -26,32 +22,18 @@ abstract class ContextGraphRegistryScanCursorBase {
       ?? this.pendingWatermark(cacheKey);
   }
 
-  async loadWatermark(registryAddress: string): Promise<number | undefined> {
-    const result = await this.loadWatermarkResult(registryAddress);
-    return result.status === 'loaded' ? result.watermark : undefined;
-  }
-
-  async loadWatermarkResult(
-    registryAddress: string,
-  ): Promise<ContextGraphRegistryScanCursorLoadResult> {
+  protected async loadStoredWatermark(registryAddress: string): Promise<number | undefined> {
     const cacheKey = this.cacheKey(registryAddress);
     const cached = this.normalize(this.watermarks.get(cacheKey));
-    if (cached != null) return { status: 'loaded', watermark: cached };
+    if (cached != null) return cached;
     const pending = this.pendingWatermark(cacheKey);
-    if (pending != null) return { status: 'loaded', watermark: pending };
+    if (pending != null) return pending;
 
-    if (!this.input.store) return { status: 'loaded' };
-    try {
-      const persisted = await this.input.store.load(this.cursorKey(cacheKey));
-      const normalized = this.normalize(persisted);
-      if (normalized != null) this.watermarks.set(cacheKey, normalized);
-      return { status: 'loaded', watermark: normalized };
-    } catch (err) {
-      console.warn(
-        `[chain] ContextGraphNameRegistry scan cursor load failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return { status: 'failed', error: err };
-    }
+    if (!this.input.store) return undefined;
+    const persisted = await this.input.store.load(this.cursorKey(cacheKey));
+    const normalized = this.normalize(persisted);
+    if (normalized != null) this.watermarks.set(cacheKey, normalized);
+    return normalized;
   }
 
   protected clearCachedWatermarks(): void {
@@ -92,6 +74,17 @@ abstract class ContextGraphRegistryScanCursorBase {
 /** Historical scan cursor with an explicit best-effort persistence contract. */
 export class ContextGraphRegistryHistoricalScanCursor
   extends ContextGraphRegistryScanCursorBase {
+  async loadBestEffortWatermark(registryAddress: string): Promise<number | undefined> {
+    try {
+      return await this.loadStoredWatermark(registryAddress);
+    } catch (err) {
+      console.warn(
+        `[chain] ContextGraphNameRegistry scan cursor load failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return undefined;
+    }
+  }
+
   clearMemoryCache(): void {
     this.clearCachedWatermarks();
   }
@@ -123,6 +116,21 @@ export class ContextGraphRegistryTipScanCursor extends ContextGraphRegistryScanC
 
   protected override pendingWatermark(cacheKey: string): number | undefined {
     return this.normalize(this.pendingStrictWatermarks.get(cacheKey));
+  }
+
+  async loadStrictWatermark(registryAddress: string): Promise<number | undefined> {
+    try {
+      return await this.loadStoredWatermark(registryAddress);
+    } catch (err) {
+      console.warn(
+        `[chain] ContextGraphNameRegistry tip cursor load failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      throw new Error(
+        'listContextGraphsFromChain: tip cursor load failed; refusing to initialize from ' +
+          'the current head because persisted progress may exist',
+        { cause: err },
+      );
+    }
   }
 
   async saveStrictWatermark(registryAddress: string, nextBlock: number): Promise<void> {

--- a/packages/chain/src/context-graph-registry-scanner.ts
+++ b/packages/chain/src/context-graph-registry-scanner.ts
@@ -58,6 +58,9 @@ type PreparedScan =
       acknowledge(nextBlock: number): Promise<void>;
     });
 
+type PreparedTipScan = Extract<PreparedScan, { kind: 'tip' }>;
+type QueryRegistryPage = (lo: number, hi: number) => Promise<ContextGraphOnChain[]>;
+
 type RegistryScannerInput = {
   registry: Contract;
   registryAddress: string;
@@ -168,9 +171,67 @@ export class ContextGraphRegistryScanner {
   async *pages(
     scanPlan: ContextGraphRegistryScanPlan,
   ): AsyncGenerator<ContextGraphRegistryScanPage, void, unknown> {
-    const eventFilter = this.input.registry.filters.NameClaimed();
     const prepared = await this.prepare(scanPlan);
-    const { start, head, scanProviders, degradedFromGenesis } = prepared;
+    if (prepared.kind === 'tip') {
+      yield* this.tipPages(prepared);
+      return;
+    }
+    yield* this.rangePages(prepared);
+  }
+
+  private createPageQuery(
+    scanProviders: ReadonlyArray<EvmEventLogScanProvider>,
+  ): QueryRegistryPage {
+    const eventFilter = this.input.registry.filters.NameClaimed();
+    const pageSession = this.input.createPageSession(scanProviders);
+    return async (lo: number, hi: number): Promise<ContextGraphOnChain[]> => {
+      const pageResults: ContextGraphOnChain[] = [];
+      for (const log of await pageSession.query(eventFilter, lo, hi)) {
+        const parsed = this.input.registry.interface.parseLog({
+          topics: [...log.topics],
+          data: log.data,
+        });
+        if (!parsed || parsed.name !== 'NameClaimed') continue;
+        pageResults.push({
+          contextGraphId: String(parsed.args.nameHash),
+          creator: String(parsed.args.creator),
+          accessPolicy: Number(parsed.args.accessPolicy),
+          blockNumber: log.blockNumber,
+          metadataRevealed: false,
+        });
+      }
+      return pageResults;
+    };
+  }
+
+  private async *tipPages(
+    prepared: PreparedTipScan,
+  ): AsyncGenerator<ContextGraphRegistryScanPage, void, unknown> {
+    const queryPage = this.createPageQuery(prepared.scanProviders);
+    const currentTipStart = Math.max(0, prepared.head - this.input.pageSize + 1);
+    try {
+      yield* this.rangePages(prepared, queryPage);
+    } catch (err) {
+      const failedFromBlock = err instanceof ContextGraphChainScanPartialError
+        ? err.failedFromBlock
+        : prepared.start;
+      if (failedFromBlock >= currentTipStart) throw err;
+
+      // Keep the stale gap pending, but independently surface the bounded
+      // current-tip window without acknowledging progress past that gap.
+      const contextGraphs = await queryPage(currentTipStart, prepared.head);
+      yield {
+        contextGraphs,
+        ack: async () => {},
+      };
+    }
+  }
+
+  private async *rangePages(
+    prepared: PreparedScan,
+    queryPage: QueryRegistryPage = this.createPageQuery(prepared.scanProviders),
+  ): AsyncGenerator<ContextGraphRegistryScanPage, void, unknown> {
+    const { start, head, degradedFromGenesis } = prepared;
     const pageBudget = 'pageBudget' in prepared ? prepared.pageBudget : undefined;
     if (start > head) {
       if (prepared.kind === 'historicalSeed') await prepared.acknowledge(head + 1);
@@ -197,26 +258,6 @@ export class ContextGraphRegistryScanner {
     }
 
     const results: ContextGraphOnChain[] = [];
-    const pageSession = this.input.createPageSession(scanProviders);
-    const queryPage = async (lo: number, hi: number): Promise<ContextGraphOnChain[]> => {
-      const pageResults: ContextGraphOnChain[] = [];
-      for (const log of await pageSession.query(eventFilter, lo, hi)) {
-        const parsed = this.input.registry.interface.parseLog({
-          topics: [...log.topics],
-          data: log.data,
-        });
-        if (!parsed || parsed.name !== 'NameClaimed') continue;
-        pageResults.push({
-          contextGraphId: String(parsed.args.nameHash),
-          creator: String(parsed.args.creator),
-          accessPolicy: Number(parsed.args.accessPolicy),
-          blockNumber: log.blockNumber,
-          metadataRevealed: false,
-        });
-      }
-      return pageResults;
-    };
-    const currentTipStart = Math.max(0, head - this.input.pageSize + 1);
     let scannedAnyPage = false;
     for (let lo = start; lo <= head; lo += this.input.pageSize) {
       const hi = Math.min(lo + this.input.pageSize - 1, head);
@@ -224,19 +265,6 @@ export class ContextGraphRegistryScanner {
       try {
         pageResults = await queryPage(lo, hi);
       } catch (err) {
-        // A persisted tip cursor is gap-safe progress, not permission for an
-        // unavailable old page to suppress recent discovery forever. Probe the
-        // bounded current-tip window independently, but deliberately do not
-        // acknowledge it: the failed gap remains the next catch-up attempt.
-        if (prepared.kind === 'tip' && lo < currentTipStart) {
-          const currentPageResults = await queryPage(currentTipStart, head);
-          results.push(...currentPageResults);
-          yield {
-            contextGraphs: currentPageResults,
-            ack: async () => {},
-          };
-          return;
-        }
         if (prepared.kind !== 'stateless' && scannedAnyPage) {
           const message = err instanceof Error ? err.message : String(err);
           throw new ContextGraphChainScanPartialError(

--- a/packages/chain/src/context-graph-registry-scanner.ts
+++ b/packages/chain/src/context-graph-registry-scanner.ts
@@ -271,7 +271,7 @@ export class ContextGraphRegistryScanner {
       };
     };
     const resolveHistoricalCursor = async (): Promise<ScanRange> => {
-      const watermark = await this.input.historicalCursor.loadWatermark(
+      const watermark = await this.input.historicalCursor.loadBestEffortWatermark(
         this.input.registryAddress,
       );
       if (watermark !== undefined) {
@@ -317,7 +317,7 @@ export class ContextGraphRegistryScanner {
       case 'historicalSeed': {
         if (scanPlan.start === 'deployment') {
           // Preserve monotonic store behavior while a full recovery replays old pages.
-          await this.input.historicalCursor.loadWatermark(this.input.registryAddress);
+          await this.input.historicalCursor.loadBestEffortWatermark(this.input.registryAddress);
         }
         const range = await (scanPlan.start === 'cursor'
           ? resolveHistoricalCursor()
@@ -331,17 +331,9 @@ export class ContextGraphRegistryScanner {
       }
       case 'tip': {
         const tip = await this.input.resolveHead();
-        const loaded = await this.input.tipCursor.loadWatermarkResult(
+        const watermark = await this.input.tipCursor.loadStrictWatermark(
           this.input.registryAddress,
         );
-        if (loaded.status === 'failed') {
-          throw new Error(
-            'listContextGraphsFromChain: tip cursor load failed; refusing to initialize from ' +
-              'the current head because persisted progress may exist',
-            { cause: loaded.error },
-          );
-        }
-        const watermark = loaded.watermark;
         const start = watermark === undefined
           ? Math.max(0, tip.head - this.input.pageSize + 1)
           : Math.max(0, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS);

--- a/packages/chain/src/context-graph-registry-scanner.ts
+++ b/packages/chain/src/context-graph-registry-scanner.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { Contract, ethers, type JsonRpcProvider } from 'ethers';
+import { Contract } from 'ethers';
 import {
   ContextGraphChainScanPartialError,
   type ContextGraphChainScanOptions,
@@ -16,6 +16,10 @@ import type {
   ContextGraphRegistryHistoricalScanCursor,
   ContextGraphRegistryTipScanCursor,
 } from './context-graph-registry-scan-cursor.js';
+import type {
+  EvmEventLogPageReader,
+  EvmEventLogScanProvider,
+} from './evm-event-log-page-session.js';
 
 type StatelessScanStart =
   | { kind: 'explicit'; fromBlock: number }
@@ -27,11 +31,10 @@ export type ContextGraphRegistryScanPlan =
   | { kind: 'historicalSeed'; start: 'deployment' | 'cursor'; pageBudget?: number }
   | { kind: 'tip' };
 
-type ScanProvider = { provider: JsonRpcProvider; backendHead: number };
 type ScanRange = {
   start: number;
   head: number;
-  scanProviders: ReadonlyArray<ScanProvider>;
+  scanProviders: ReadonlyArray<EvmEventLogScanProvider>;
   degradedFromGenesis: boolean;
 };
 
@@ -64,24 +67,16 @@ type RegistryScannerInput = {
   resolveDeployment(): Promise<{
     fromBlock: number;
     head: number;
-    scanProviders: ReadonlyArray<ScanProvider>;
+    scanProviders: ReadonlyArray<EvmEventLogScanProvider>;
     degradedFromGenesis?: boolean;
   }>;
   resolveHead(): Promise<{
     head: number;
-    scanProviders: ReadonlyArray<ScanProvider>;
+    scanProviders: ReadonlyArray<EvmEventLogScanProvider>;
   }>;
-  queryPage(
-    filter: unknown,
-    lo: number,
-    hi: number,
-    scanProviders: ReadonlyArray<ScanProvider>,
-    connected: Map<JsonRpcProvider, Contract>,
-    preferred?: JsonRpcProvider,
-  ): Promise<{
-    logs: ReadonlyArray<ethers.EventLog | ethers.Log>;
-    provider: JsonRpcProvider;
-  }>;
+  createPageSession(
+    scanProviders: ReadonlyArray<EvmEventLogScanProvider>,
+  ): EvmEventLogPageReader;
 };
 
 function normalizePageBudget(value: number | undefined): number | undefined {
@@ -202,38 +197,46 @@ export class ContextGraphRegistryScanner {
     }
 
     const results: ContextGraphOnChain[] = [];
-    const connected = new Map<JsonRpcProvider, Contract>();
-    let preferred: JsonRpcProvider | undefined;
+    const pageSession = this.input.createPageSession(scanProviders);
+    const queryPage = async (lo: number, hi: number): Promise<ContextGraphOnChain[]> => {
+      const pageResults: ContextGraphOnChain[] = [];
+      for (const log of await pageSession.query(eventFilter, lo, hi)) {
+        const parsed = this.input.registry.interface.parseLog({
+          topics: [...log.topics],
+          data: log.data,
+        });
+        if (!parsed || parsed.name !== 'NameClaimed') continue;
+        pageResults.push({
+          contextGraphId: String(parsed.args.nameHash),
+          creator: String(parsed.args.creator),
+          accessPolicy: Number(parsed.args.accessPolicy),
+          blockNumber: log.blockNumber,
+          metadataRevealed: false,
+        });
+      }
+      return pageResults;
+    };
+    const currentTipStart = Math.max(0, head - this.input.pageSize + 1);
     let scannedAnyPage = false;
     for (let lo = start; lo <= head; lo += this.input.pageSize) {
       const hi = Math.min(lo + this.input.pageSize - 1, head);
       let pageResults: ContextGraphOnChain[];
       try {
-        const page = await this.input.queryPage(
-          eventFilter,
-          lo,
-          hi,
-          scanProviders,
-          connected,
-          preferred,
-        );
-        preferred = page.provider;
-        pageResults = [];
-        for (const log of page.logs) {
-          const parsed = this.input.registry.interface.parseLog({
-            topics: [...log.topics],
-            data: log.data,
-          });
-          if (!parsed || parsed.name !== 'NameClaimed') continue;
-          pageResults.push({
-            contextGraphId: String(parsed.args.nameHash),
-            creator: String(parsed.args.creator),
-            accessPolicy: Number(parsed.args.accessPolicy),
-            blockNumber: log.blockNumber,
-            metadataRevealed: false,
-          });
-        }
+        pageResults = await queryPage(lo, hi);
       } catch (err) {
+        // A persisted tip cursor is gap-safe progress, not permission for an
+        // unavailable old page to suppress recent discovery forever. Probe the
+        // bounded current-tip window independently, but deliberately do not
+        // acknowledge it: the failed gap remains the next catch-up attempt.
+        if (prepared.kind === 'tip' && lo < currentTipStart) {
+          const currentPageResults = await queryPage(currentTipStart, head);
+          results.push(...currentPageResults);
+          yield {
+            contextGraphs: currentPageResults,
+            ack: async () => {},
+          };
+          return;
+        }
         if (prepared.kind !== 'stateless' && scannedAnyPage) {
           const message = err instanceof Error ? err.message : String(err);
           throw new ContextGraphChainScanPartialError(

--- a/packages/chain/src/context-graph-registry-scanner.ts
+++ b/packages/chain/src/context-graph-registry-scanner.ts
@@ -1,0 +1,364 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { Contract, ethers, type JsonRpcProvider } from 'ethers';
+import {
+  ContextGraphChainScanPartialError,
+  type ContextGraphChainScanOptions,
+  type ContextGraphOnChain,
+  type ContextGraphRegistryScanOptions,
+  type ContextGraphRegistryScanPage,
+} from './chain-adapter.js';
+import {
+  CG_REGISTRY_MAX_SCAN_PAGES,
+  CG_REGISTRY_REORG_BUFFER_BLOCKS,
+} from './evm-adapter-constants.js';
+import type { ContextGraphRegistryScanCursor } from './context-graph-registry-scan-cursor.js';
+
+type StatelessScanStart =
+  | { kind: 'explicit'; fromBlock: number }
+  | { kind: 'deployment' };
+
+export type ContextGraphRegistryScanPlan =
+  | { kind: 'stateless'; start: StatelessScanStart }
+  | { kind: 'historicalIncremental'; pageBudget?: number }
+  | { kind: 'historicalSeed'; start: 'deployment' | 'cursor'; pageBudget?: number }
+  | { kind: 'tip' };
+
+type ScanProvider = { provider: JsonRpcProvider; backendHead: number };
+type ScanRange = {
+  start: number;
+  head: number;
+  scanProviders: ReadonlyArray<ScanProvider>;
+  degradedFromGenesis: boolean;
+};
+
+type PreparedScan = ScanRange & {
+  kind: ContextGraphRegistryScanPlan['kind'];
+  pageBudget?: number;
+  pageLimit: { kind: 'unbounded' } | { kind: 'defaultCapUnlessBudget' };
+  pageFailure: { kind: 'allOrError' } | { kind: 'partialAfterProgress' };
+  emptyRange: { kind: 'return' } | { kind: 'acknowledge' };
+  acknowledge(nextBlock: number): Promise<void>;
+};
+
+type RegistryScannerInput = {
+  registry: Contract;
+  registryAddress: string;
+  pageSize: number;
+  historicalCursor: ContextGraphRegistryScanCursor;
+  tipCursor: ContextGraphRegistryScanCursor;
+  resolveDeployment(): Promise<{
+    fromBlock: number;
+    head: number;
+    scanProviders: ReadonlyArray<ScanProvider>;
+    degradedFromGenesis?: boolean;
+  }>;
+  resolveHead(): Promise<{
+    head: number;
+    scanProviders: ReadonlyArray<ScanProvider>;
+  }>;
+  queryPage(
+    filter: unknown,
+    lo: number,
+    hi: number,
+    scanProviders: ReadonlyArray<ScanProvider>,
+    connected: Map<JsonRpcProvider, Contract>,
+    preferred?: JsonRpcProvider,
+  ): Promise<{
+    logs: ReadonlyArray<ethers.EventLog | ethers.Log>;
+    provider: JsonRpcProvider;
+  }>;
+};
+
+function normalizePageBudget(value: number | undefined): number | undefined {
+  return Number.isFinite(value) && (value ?? 0) >= 1
+    ? Math.floor(value ?? 0)
+    : undefined;
+}
+
+export function buildPublicContextGraphRegistryScanPlan(
+  fromBlock: number | undefined,
+  options: ContextGraphChainScanOptions | undefined,
+): ContextGraphRegistryScanPlan {
+  const runtimeOptions = options as
+    | (ContextGraphChainScanOptions & { mode?: string })
+    | undefined;
+  const mode = runtimeOptions?.mode;
+
+  if (fromBlock !== undefined) {
+    return { kind: 'stateless', start: { kind: 'explicit', fromBlock } };
+  }
+  if (runtimeOptions && 'incremental' in runtimeOptions && runtimeOptions.incremental === true) {
+    return {
+      kind: 'historicalIncremental',
+      pageBudget: normalizePageBudget(runtimeOptions.pageBudget),
+    };
+  }
+  if (
+    runtimeOptions &&
+    'seedIncrementalWatermark' in runtimeOptions &&
+    runtimeOptions.seedIncrementalWatermark === true
+  ) {
+    if (runtimeOptions.resumeFromCursor === true) {
+      return {
+        kind: 'historicalSeed',
+        start: 'cursor',
+        pageBudget: normalizePageBudget(runtimeOptions.pageBudget),
+      };
+    }
+    return { kind: 'historicalSeed', start: 'deployment' };
+  }
+  if (mode !== undefined && mode !== 'listAll') {
+    throw new Error(
+      'listContextGraphsFromChain accepts only listAll or legacy boolean scan options; ' +
+      'use scanContextGraphRegistryPages for cursor-backed daemon scans.',
+    );
+  }
+  return { kind: 'stateless', start: { kind: 'deployment' } };
+}
+
+export function buildCursorContextGraphRegistryScanPlan(
+  options: ContextGraphRegistryScanOptions,
+): ContextGraphRegistryScanPlan {
+  switch (options.mode) {
+    case 'incremental':
+      return {
+        kind: 'historicalIncremental',
+        pageBudget: normalizePageBudget(options.pageBudget),
+      };
+    case 'tip':
+      return { kind: 'tip' };
+    case 'seedFull':
+      return { kind: 'historicalSeed', start: 'deployment' };
+    case 'seedFromCursor':
+      return {
+        kind: 'historicalSeed',
+        start: 'cursor',
+        pageBudget: normalizePageBudget(options.pageBudget),
+      };
+    default: {
+      const exhaustive: never = options;
+      throw new Error(`Unsupported ContextGraphNameRegistry scan mode: ${JSON.stringify(exhaustive)}`);
+    }
+  }
+}
+
+/** Focused planner/executor for ContextGraphNameRegistry discovery. */
+export class ContextGraphRegistryScanner {
+  constructor(private readonly input: RegistryScannerInput) {}
+
+  async collect(scanPlan: ContextGraphRegistryScanPlan): Promise<ContextGraphOnChain[]> {
+    const results: ContextGraphOnChain[] = [];
+    for await (const page of this.pages(scanPlan)) {
+      results.push(...page.contextGraphs);
+      await page.ack();
+    }
+    return results;
+  }
+
+  async *pages(
+    scanPlan: ContextGraphRegistryScanPlan,
+  ): AsyncGenerator<ContextGraphRegistryScanPage, void, unknown> {
+    const eventFilter = this.input.registry.filters.NameClaimed();
+    const prepared = await this.prepare(scanPlan);
+    const { start, head, scanProviders, degradedFromGenesis, pageBudget } = prepared;
+    if (start > head) {
+      if (prepared.emptyRange.kind === 'acknowledge') await prepared.acknowledge(head + 1);
+      return;
+    }
+
+    const pages = Math.ceil((head - start + 1) / this.input.pageSize);
+    const blockBudget = CG_REGISTRY_MAX_SCAN_PAGES * this.input.pageSize;
+    if (
+      prepared.pageLimit.kind === 'defaultCapUnlessBudget' &&
+      pageBudget === undefined &&
+      !degradedFromGenesis &&
+      pages > CG_REGISTRY_MAX_SCAN_PAGES
+    ) {
+      throw new Error(
+        `listContextGraphsFromChain: incremental ContextGraphNameRegistry scan would need ` +
+          `${pages} eth_getLogs calls over blocks [${start}, ${head}] at a ` +
+          `${this.input.pageSize}-block window (budget ${CG_REGISTRY_MAX_SCAN_PAGES} pages / ` +
+          `${blockBudget} blocks). ` +
+          `Use an RPC that can anchor the registry deploy block and serve the ` +
+          `requested log range, or increase cgRegistryScanPageSize for an RPC ` +
+          `known to support larger ranges.`,
+      );
+    }
+
+    const results: ContextGraphOnChain[] = [];
+    const connected = new Map<JsonRpcProvider, Contract>();
+    let preferred: JsonRpcProvider | undefined;
+    let scannedAnyPage = false;
+    for (let lo = start; lo <= head; lo += this.input.pageSize) {
+      const hi = Math.min(lo + this.input.pageSize - 1, head);
+      let pageResults: ContextGraphOnChain[];
+      try {
+        const page = await this.input.queryPage(
+          eventFilter,
+          lo,
+          hi,
+          scanProviders,
+          connected,
+          preferred,
+        );
+        preferred = page.provider;
+        pageResults = [];
+        for (const log of page.logs) {
+          const parsed = this.input.registry.interface.parseLog({
+            topics: [...log.topics],
+            data: log.data,
+          });
+          if (!parsed || parsed.name !== 'NameClaimed') continue;
+          pageResults.push({
+            contextGraphId: String(parsed.args.nameHash),
+            creator: String(parsed.args.creator),
+            accessPolicy: Number(parsed.args.accessPolicy),
+            blockNumber: log.blockNumber,
+            metadataRevealed: false,
+          });
+        }
+      } catch (err) {
+        if (prepared.pageFailure.kind === 'partialAfterProgress' && scannedAnyPage) {
+          const message = err instanceof Error ? err.message : String(err);
+          throw new ContextGraphChainScanPartialError(
+            `listContextGraphsFromChain: partial ContextGraphNameRegistry scan ` +
+              `stopped after block ${lo - 1}; failed page [${lo}, ${hi}]: ${message}`,
+            {
+              partialResults: results,
+              scannedToBlock: lo - 1,
+              failedFromBlock: lo,
+              failedToBlock: hi,
+              cause: err,
+            },
+          );
+        }
+        throw err;
+      }
+      results.push(...pageResults);
+      scannedAnyPage = true;
+      yield {
+        contextGraphs: pageResults,
+        ack: () => prepared.acknowledge(hi + 1),
+      };
+      const scannedPages = Math.floor((hi - start) / this.input.pageSize) + 1;
+      if (pageBudget !== undefined && scannedPages >= pageBudget && hi < head) return;
+    }
+  }
+
+  private async prepare(scanPlan: ContextGraphRegistryScanPlan): Promise<PreparedScan> {
+    const resolveDeployment = async (): Promise<ScanRange> => {
+      const { fromBlock, ...resolved } = await this.input.resolveDeployment();
+      return {
+        start: fromBlock,
+        ...resolved,
+        degradedFromGenesis: resolved.degradedFromGenesis ?? false,
+      };
+    };
+    const resolveHistoricalCursor = async (): Promise<ScanRange> => {
+      const watermark = await this.input.historicalCursor.loadWatermark(
+        this.input.registryAddress,
+      );
+      if (watermark !== undefined) {
+        return {
+          start: Math.max(0, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS),
+          ...(await this.input.resolveHead()),
+          degradedFromGenesis: false,
+        };
+      }
+      return resolveDeployment();
+    };
+    const historicalAcknowledge = (nextBlock: number) =>
+      this.input.historicalCursor.saveWatermark(this.input.registryAddress, nextBlock);
+    const tipAcknowledge = (nextBlock: number) =>
+      this.input.tipCursor.saveWatermarkStrict(this.input.registryAddress, nextBlock);
+    const noAcknowledge = async () => {};
+
+    switch (scanPlan.kind) {
+      case 'stateless': {
+        const range = scanPlan.start.kind === 'explicit'
+          ? {
+              start: scanPlan.start.fromBlock,
+              ...(await this.input.resolveHead()),
+              degradedFromGenesis: false,
+            }
+          : await resolveDeployment();
+        return {
+          kind: scanPlan.kind,
+          ...range,
+          pageLimit: { kind: 'unbounded' },
+          pageFailure: { kind: 'allOrError' },
+          emptyRange: { kind: 'return' },
+          acknowledge: noAcknowledge,
+        };
+      }
+      case 'historicalIncremental':
+        return {
+          kind: scanPlan.kind,
+          ...(await resolveHistoricalCursor()),
+          pageBudget: scanPlan.pageBudget,
+          pageLimit: { kind: 'defaultCapUnlessBudget' },
+          pageFailure: { kind: 'partialAfterProgress' },
+          emptyRange: { kind: 'return' },
+          acknowledge: historicalAcknowledge,
+        };
+      case 'historicalSeed': {
+        if (scanPlan.start === 'deployment') {
+          // Preserve monotonic store behavior while a full recovery replays old pages.
+          await this.input.historicalCursor.loadWatermark(this.input.registryAddress);
+        }
+        const range = await (scanPlan.start === 'cursor'
+          ? resolveHistoricalCursor()
+          : resolveDeployment());
+        return {
+          kind: scanPlan.kind,
+          ...range,
+          pageBudget: scanPlan.pageBudget,
+          pageLimit: { kind: 'unbounded' },
+          pageFailure: { kind: 'partialAfterProgress' },
+          emptyRange: { kind: 'acknowledge' },
+          acknowledge: historicalAcknowledge,
+        };
+      }
+      case 'tip': {
+        const tip = await this.input.resolveHead();
+        const loaded = await this.input.tipCursor.loadWatermarkResult(
+          this.input.registryAddress,
+        );
+        if (loaded.status === 'failed') {
+          throw new Error(
+            'listContextGraphsFromChain: tip cursor load failed; refusing to initialize from ' +
+              'the current head because persisted progress may exist',
+            { cause: loaded.error },
+          );
+        }
+        const watermark = loaded.watermark;
+        const start = watermark === undefined
+          ? Math.max(0, tip.head - this.input.pageSize + 1)
+          : Math.max(0, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS);
+        // Persist the conservative lower bound before the first query. Strict persistence makes a
+        // configured-store failure observable; an in-process pending marker is retried here.
+        await this.input.tipCursor.saveWatermarkStrict(
+          this.input.registryAddress,
+          watermark ?? Math.max(1, start),
+        );
+        return {
+          kind: scanPlan.kind,
+          ...tip,
+          start,
+          degradedFromGenesis: false,
+          pageLimit: { kind: 'unbounded' },
+          pageFailure: { kind: 'partialAfterProgress' },
+          emptyRange: { kind: 'return' },
+          acknowledge: tipAcknowledge,
+        };
+      }
+      default: {
+        const exhaustive: never = scanPlan;
+        throw new Error(
+          `Unsupported ContextGraphNameRegistry scan plan: ${JSON.stringify(exhaustive)}`,
+        );
+      }
+    }
+  }
+}

--- a/packages/chain/src/context-graph-registry-scanner.ts
+++ b/packages/chain/src/context-graph-registry-scanner.ts
@@ -12,7 +12,10 @@ import {
   CG_REGISTRY_MAX_SCAN_PAGES,
   CG_REGISTRY_REORG_BUFFER_BLOCKS,
 } from './evm-adapter-constants.js';
-import type { ContextGraphRegistryScanCursor } from './context-graph-registry-scan-cursor.js';
+import type {
+  ContextGraphRegistryHistoricalScanCursor,
+  ContextGraphRegistryTipScanCursor,
+} from './context-graph-registry-scan-cursor.js';
 
 type StatelessScanStart =
   | { kind: 'explicit'; fromBlock: number }
@@ -56,8 +59,8 @@ type RegistryScannerInput = {
   registry: Contract;
   registryAddress: string;
   pageSize: number;
-  historicalCursor: ContextGraphRegistryScanCursor;
-  tipCursor: ContextGraphRegistryScanCursor;
+  historicalCursor: ContextGraphRegistryHistoricalScanCursor;
+  tipCursor: ContextGraphRegistryTipScanCursor;
   resolveDeployment(): Promise<{
     fromBlock: number;
     head: number;
@@ -281,9 +284,12 @@ export class ContextGraphRegistryScanner {
       return resolveDeployment();
     };
     const historicalAcknowledge = (nextBlock: number) =>
-      this.input.historicalCursor.saveWatermark(this.input.registryAddress, nextBlock);
+      this.input.historicalCursor.saveBestEffortWatermark(
+        this.input.registryAddress,
+        nextBlock,
+      );
     const tipAcknowledge = (nextBlock: number) =>
-      this.input.tipCursor.saveWatermark(this.input.registryAddress, nextBlock);
+      this.input.tipCursor.saveStrictWatermark(this.input.registryAddress, nextBlock);
     const noAcknowledge = async () => {};
 
     switch (scanPlan.kind) {
@@ -341,7 +347,7 @@ export class ContextGraphRegistryScanner {
           : Math.max(0, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS);
         // Persist the conservative lower bound before the first query. Strict persistence makes a
         // configured-store failure observable; an in-process pending marker is retried here.
-        await this.input.tipCursor.saveWatermark(
+        await this.input.tipCursor.saveStrictWatermark(
           this.input.registryAddress,
           watermark ?? Math.max(1, start),
         );

--- a/packages/chain/src/context-graph-registry-scanner.ts
+++ b/packages/chain/src/context-graph-registry-scanner.ts
@@ -32,14 +32,25 @@ type ScanRange = {
   degradedFromGenesis: boolean;
 };
 
-type PreparedScan = ScanRange & {
-  kind: ContextGraphRegistryScanPlan['kind'];
-  pageBudget?: number;
-  pageLimit: { kind: 'unbounded' } | { kind: 'defaultCapUnlessBudget' };
-  pageFailure: { kind: 'allOrError' } | { kind: 'partialAfterProgress' };
-  emptyRange: { kind: 'return' } | { kind: 'acknowledge' };
-  acknowledge(nextBlock: number): Promise<void>;
-};
+type PreparedScan =
+  | (ScanRange & {
+      kind: 'stateless';
+      acknowledge(nextBlock: number): Promise<void>;
+    })
+  | (ScanRange & {
+      kind: 'historicalIncremental';
+      pageBudget?: number;
+      acknowledge(nextBlock: number): Promise<void>;
+    })
+  | (ScanRange & {
+      kind: 'historicalSeed';
+      pageBudget?: number;
+      acknowledge(nextBlock: number): Promise<void>;
+    })
+  | (ScanRange & {
+      kind: 'tip';
+      acknowledge(nextBlock: number): Promise<void>;
+    });
 
 type RegistryScannerInput = {
   registry: Contract;
@@ -161,16 +172,17 @@ export class ContextGraphRegistryScanner {
   ): AsyncGenerator<ContextGraphRegistryScanPage, void, unknown> {
     const eventFilter = this.input.registry.filters.NameClaimed();
     const prepared = await this.prepare(scanPlan);
-    const { start, head, scanProviders, degradedFromGenesis, pageBudget } = prepared;
+    const { start, head, scanProviders, degradedFromGenesis } = prepared;
+    const pageBudget = 'pageBudget' in prepared ? prepared.pageBudget : undefined;
     if (start > head) {
-      if (prepared.emptyRange.kind === 'acknowledge') await prepared.acknowledge(head + 1);
+      if (prepared.kind === 'historicalSeed') await prepared.acknowledge(head + 1);
       return;
     }
 
     const pages = Math.ceil((head - start + 1) / this.input.pageSize);
     const blockBudget = CG_REGISTRY_MAX_SCAN_PAGES * this.input.pageSize;
     if (
-      prepared.pageLimit.kind === 'defaultCapUnlessBudget' &&
+      prepared.kind === 'historicalIncremental' &&
       pageBudget === undefined &&
       !degradedFromGenesis &&
       pages > CG_REGISTRY_MAX_SCAN_PAGES
@@ -219,7 +231,7 @@ export class ContextGraphRegistryScanner {
           });
         }
       } catch (err) {
-        if (prepared.pageFailure.kind === 'partialAfterProgress' && scannedAnyPage) {
+        if (prepared.kind !== 'stateless' && scannedAnyPage) {
           const message = err instanceof Error ? err.message : String(err);
           throw new ContextGraphChainScanPartialError(
             `listContextGraphsFromChain: partial ContextGraphNameRegistry scan ` +
@@ -271,7 +283,7 @@ export class ContextGraphRegistryScanner {
     const historicalAcknowledge = (nextBlock: number) =>
       this.input.historicalCursor.saveWatermark(this.input.registryAddress, nextBlock);
     const tipAcknowledge = (nextBlock: number) =>
-      this.input.tipCursor.saveWatermarkStrict(this.input.registryAddress, nextBlock);
+      this.input.tipCursor.saveWatermark(this.input.registryAddress, nextBlock);
     const noAcknowledge = async () => {};
 
     switch (scanPlan.kind) {
@@ -286,9 +298,6 @@ export class ContextGraphRegistryScanner {
         return {
           kind: scanPlan.kind,
           ...range,
-          pageLimit: { kind: 'unbounded' },
-          pageFailure: { kind: 'allOrError' },
-          emptyRange: { kind: 'return' },
           acknowledge: noAcknowledge,
         };
       }
@@ -297,9 +306,6 @@ export class ContextGraphRegistryScanner {
           kind: scanPlan.kind,
           ...(await resolveHistoricalCursor()),
           pageBudget: scanPlan.pageBudget,
-          pageLimit: { kind: 'defaultCapUnlessBudget' },
-          pageFailure: { kind: 'partialAfterProgress' },
-          emptyRange: { kind: 'return' },
           acknowledge: historicalAcknowledge,
         };
       case 'historicalSeed': {
@@ -314,9 +320,6 @@ export class ContextGraphRegistryScanner {
           kind: scanPlan.kind,
           ...range,
           pageBudget: scanPlan.pageBudget,
-          pageLimit: { kind: 'unbounded' },
-          pageFailure: { kind: 'partialAfterProgress' },
-          emptyRange: { kind: 'acknowledge' },
           acknowledge: historicalAcknowledge,
         };
       }
@@ -338,7 +341,7 @@ export class ContextGraphRegistryScanner {
           : Math.max(0, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS);
         // Persist the conservative lower bound before the first query. Strict persistence makes a
         // configured-store failure observable; an in-process pending marker is retried here.
-        await this.input.tipCursor.saveWatermarkStrict(
+        await this.input.tipCursor.saveWatermark(
           this.input.registryAddress,
           watermark ?? Math.max(1, start),
         );
@@ -347,9 +350,6 @@ export class ContextGraphRegistryScanner {
           ...tip,
           start,
           degradedFromGenesis: false,
-          pageLimit: { kind: 'unbounded' },
-          pageFailure: { kind: 'partialAfterProgress' },
-          emptyRange: { kind: 'return' },
           acknowledge: tipAcknowledge,
         };
       }

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -58,6 +58,7 @@ import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, reso
 } from './evm-adapter-constants.js';
 import { decodeKnowledgeAssetUpdateContext } from './evm-knowledge-asset-update-context.js';
 import { applyTransactionFeeCap, resolveMaxFeePerGasWei } from './evm-fee-cap.js';
+import type { EvmEventLogScanProvider as ScanProvider } from './evm-event-log-page-session.js';
 
 export {
   CG_REGISTRY_MAX_SCAN_PAGES,
@@ -307,8 +308,6 @@ const HUB_ROTATION_REORG_BUFFER_BLOCKS = 50;
  * front of the line for subsequent pages).
  */
 const KA_HIGH_WATER_PAGE_TIMEOUT_MS = 15_000;
-
-type ScanProvider = { provider: JsonRpcProvider; backendHead: number };
 
 /**
  * B8 — decode the `CostCovered` event from a publish receipt's logs via the

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -1317,15 +1317,18 @@ export class EVMChainAdapterBase {
     }
     this.tokenAddress = config.tokenAddress ? ethers.getAddress(config.tokenAddress) : undefined;
     this.chainId = config.chainId ?? 'evm:31337';
-    const historicalRegistryCursorStore = config.contextGraphRegistryScanCursorStore;
-    const configuredTipRegistryCursorStore = config.contextGraphRegistryTipScanCursorStore;
-    const tipRegistryCursorStore = configuredTipRegistryCursorStore && (
-      configuredTipRegistryCursorStore !== historicalRegistryCursorStore ||
-      configuredTipRegistryCursorStore.cursorKeyVersion === 2
-    )
-      ? configuredTipRegistryCursorStore
-      : historicalRegistryCursorStore?.cursorKeyVersion === 2
-        ? historicalRegistryCursorStore
+    const registryCursorPersistence = config.contextGraphRegistryScanCursorPersistence;
+    const historicalRegistryCursorStore = registryCursorPersistence?.kind === 'roleAware'
+      ? { kind: 'roleAware' as const, store: registryCursorPersistence.store }
+      : registryCursorPersistence?.kind === 'legacy'
+        ? { kind: 'legacy' as const, store: registryCursorPersistence.historical }
+        : config.contextGraphRegistryScanCursorStore
+          ? { kind: 'legacy' as const, store: config.contextGraphRegistryScanCursorStore }
+          : undefined;
+    const tipRegistryCursorStore = registryCursorPersistence?.kind === 'roleAware'
+      ? { kind: 'roleAware' as const, store: registryCursorPersistence.store }
+      : registryCursorPersistence?.kind === 'legacy' && registryCursorPersistence.tip
+        ? { kind: 'legacy' as const, store: registryCursorPersistence.tip }
         : undefined;
     this.contextGraphRegistryScanCursor = new ContextGraphRegistryScanCursor({
       chainId: this.chainId,

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -17,7 +17,6 @@ import type { FilterErrorSilencer } from './filter-error-silencer.js';
 import {
   DEFAULT_APPROVAL_POLICY,
   buildEvmDeploymentId,
-  contextGraphRegistryScanCursorStoreForRole,
   normalizeContextGraphRegistryScanCursorStore,
 } from './chain-adapter.js';
 import type {
@@ -1324,23 +1323,19 @@ export class EVMChainAdapterBase {
     }
     this.tokenAddress = config.tokenAddress ? ethers.getAddress(config.tokenAddress) : undefined;
     this.chainId = config.chainId ?? 'evm:31337';
-    const roleAwareCursorStore = normalizeContextGraphRegistryScanCursorStore({
+    const cursorStores = normalizeContextGraphRegistryScanCursorStore({
       legacy: config.contextGraphRegistryScanCursorStore,
       roleAware: config.contextGraphRegistryRoleAwareScanCursorStore,
     });
     this.contextGraphRegistryScanCursor = new ContextGraphRegistryHistoricalScanCursor({
       chainId: this.chainId,
       deploymentId: this.deploymentId,
-      store: roleAwareCursorStore
-        ? contextGraphRegistryScanCursorStoreForRole(roleAwareCursorStore, 'historical')
-        : undefined,
+      store: cursorStores.historicalStore,
     });
     this.contextGraphRegistryTipScanCursor = new ContextGraphRegistryTipScanCursor({
       chainId: this.chainId,
       deploymentId: this.deploymentId,
-      store: roleAwareCursorStore
-        ? contextGraphRegistryScanCursorStoreForRole(roleAwareCursorStore, 'tip')
-        : undefined,
+      store: cursorStores.tipStore,
     });
     this.approvalPolicy = config.approvalPolicy ?? DEFAULT_APPROVAL_POLICY;
     this.minPublisherNativeWei = config.minPublisherNativeWei ?? 0n;

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -55,7 +55,10 @@ import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, reso
 import { decodeKnowledgeAssetUpdateContext } from './evm-knowledge-asset-update-context.js';
 import { applyTransactionFeeCap, resolveMaxFeePerGasWei } from './evm-fee-cap.js';
 
-export { CG_REGISTRY_MAX_SCAN_PAGES } from './evm-adapter-constants.js';
+export {
+  CG_REGISTRY_MAX_SCAN_PAGES,
+  CG_REGISTRY_REORG_BUFFER_BLOCKS,
+} from './evm-adapter-constants.js';
 
 function bindRoleAwareRegistryCursorStore(
   store: ContextGraphRegistryRoleAwareScanCursorStore,
@@ -67,6 +70,15 @@ function bindRoleAwareRegistryCursorStore(
   };
 }
 
+function isRegistryCursorStore(value: unknown): value is ContextGraphRegistryScanCursorStore {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { load?: unknown }).load === 'function' &&
+    typeof (value as { save?: unknown }).save === 'function'
+  );
+}
+
 function normalizeRegistryCursorStores(
   config: ContextGraphRegistryScanCursorStoreConfig | undefined,
 ): {
@@ -74,14 +86,23 @@ function normalizeRegistryCursorStores(
   tip?: ContextGraphRegistryScanCursorStore;
 } {
   if (!config) return {};
-  if (!('kind' in config)) return { historical: config };
-  if (config.kind === 'legacy') {
+  // Structural legacy stores may expose unrelated metadata named `kind`.
+  // Recognize the original load/save contract positively before tagged forms.
+  if (isRegistryCursorStore(config)) return { historical: config };
+  if (
+    config.kind === 'legacy' &&
+    isRegistryCursorStore(config.historical) &&
+    (config.tip === undefined || isRegistryCursorStore(config.tip))
+  ) {
     return { historical: config.historical, tip: config.tip };
   }
-  return {
-    historical: bindRoleAwareRegistryCursorStore(config.store, 'historical'),
-    tip: bindRoleAwareRegistryCursorStore(config.store, 'tip'),
-  };
+  if (config.kind === 'roleAware' && isRegistryCursorStore(config.store)) {
+    return {
+      historical: bindRoleAwareRegistryCursorStore(config.store, 'historical'),
+      tip: bindRoleAwareRegistryCursorStore(config.store, 'tip'),
+    };
+  }
+  throw new TypeError('Invalid ContextGraphNameRegistry cursor persistence configuration');
 }
 
 type ContractWriteSender = (
@@ -313,8 +334,6 @@ const KA_HIGH_WATER_MAX_SCAN_PAGES = 1_500;
 
 /** Default pre-10.0.4 fallback eth_getLogs window — the smallest common cap. */
 const KA_HIGH_WATER_DEFAULT_PAGE_SIZE = 2_000;
-
-export const CG_REGISTRY_REORG_BUFFER_BLOCKS = 50;
 
 // Keep generic Hub binding invalidation responsive for read paths while still
 // replacing four hidden ethers subscription pollers with one owned log poller.

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -18,6 +18,7 @@ import {
   DEFAULT_APPROVAL_POLICY,
   buildEvmDeploymentId,
   contextGraphRegistryScanCursorStoreForRole,
+  normalizeContextGraphRegistryScanCursorStore,
 } from './chain-adapter.js';
 import type {
   ApprovalPolicy,
@@ -1323,13 +1324,16 @@ export class EVMChainAdapterBase {
     }
     this.tokenAddress = config.tokenAddress ? ethers.getAddress(config.tokenAddress) : undefined;
     this.chainId = config.chainId ?? 'evm:31337';
-    const roleAwareCursorStore = config.contextGraphRegistryRoleAwareScanCursorStore;
+    const roleAwareCursorStore = normalizeContextGraphRegistryScanCursorStore({
+      legacy: config.contextGraphRegistryScanCursorStore,
+      roleAware: config.contextGraphRegistryRoleAwareScanCursorStore,
+    });
     this.contextGraphRegistryScanCursor = new ContextGraphRegistryHistoricalScanCursor({
       chainId: this.chainId,
       deploymentId: this.deploymentId,
       store: roleAwareCursorStore
         ? contextGraphRegistryScanCursorStoreForRole(roleAwareCursorStore, 'historical')
-        : config.contextGraphRegistryScanCursorStore,
+        : undefined,
     });
     this.contextGraphRegistryTipScanCursor = new ContextGraphRegistryTipScanCursor({
       chainId: this.chainId,

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -14,7 +14,11 @@
 import { JsonRpcProvider, Wallet, Contract, ethers } from 'ethers';
 import { createFilterErrorSilencer, installFilterNotFoundConsoleSuppressor, formatProviderError } from './filter-error-silencer.js';
 import type { FilterErrorSilencer } from './filter-error-silencer.js';
-import { DEFAULT_APPROVAL_POLICY, buildEvmDeploymentId } from './chain-adapter.js';
+import {
+  DEFAULT_APPROVAL_POLICY,
+  buildEvmDeploymentId,
+  contextGraphRegistryScanCursorStoreForRole,
+} from './chain-adapter.js';
 import type {
   ApprovalPolicy,
   ChainReadOptions,
@@ -1320,15 +1324,20 @@ export class EVMChainAdapterBase {
     }
     this.tokenAddress = config.tokenAddress ? ethers.getAddress(config.tokenAddress) : undefined;
     this.chainId = config.chainId ?? 'evm:31337';
+    const roleAwareCursorStore = config.contextGraphRegistryRoleAwareScanCursorStore;
     this.contextGraphRegistryScanCursor = new ContextGraphRegistryHistoricalScanCursor({
       chainId: this.chainId,
       deploymentId: this.deploymentId,
-      store: config.contextGraphRegistryScanCursorStore,
+      store: roleAwareCursorStore
+        ? contextGraphRegistryScanCursorStoreForRole(roleAwareCursorStore, 'historical')
+        : config.contextGraphRegistryScanCursorStore,
     });
     this.contextGraphRegistryTipScanCursor = new ContextGraphRegistryTipScanCursor({
       chainId: this.chainId,
       deploymentId: this.deploymentId,
-      store: config.contextGraphRegistryTipScanCursorStore,
+      store: roleAwareCursorStore
+        ? contextGraphRegistryScanCursorStoreForRole(roleAwareCursorStore, 'tip')
+        : undefined,
     });
     this.approvalPolicy = config.approvalPolicy ?? DEFAULT_APPROVAL_POLICY;
     this.minPublisherNativeWei = config.minPublisherNativeWei ?? 0n;

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -23,9 +23,6 @@ import type {
   OnChainPublishResult,
   PreBroadcastSignal,
   SignedTransactionEnvelope,
-  ContextGraphRegistryRoleAwareScanCursorStore,
-  ContextGraphRegistryScanCursorStore,
-  ContextGraphRegistryScanCursorStoreConfig,
 } from './chain-adapter.js';
 import { HubResolutionCache } from './hub-resolution-cache.js';
 import { SignerTxSerializer, type SignerTxLaneState } from './signer-tx-serializer.js';
@@ -59,51 +56,6 @@ export {
   CG_REGISTRY_MAX_SCAN_PAGES,
   CG_REGISTRY_REORG_BUFFER_BLOCKS,
 } from './evm-adapter-constants.js';
-
-function bindRoleAwareRegistryCursorStore(
-  store: ContextGraphRegistryRoleAwareScanCursorStore,
-  cursorKind: 'historical' | 'tip',
-): ContextGraphRegistryScanCursorStore {
-  return {
-    load: (key) => store.load({ ...key, cursorKind }),
-    save: (key, nextBlock) => store.save({ ...key, cursorKind }, nextBlock),
-  };
-}
-
-function isRegistryCursorStore(value: unknown): value is ContextGraphRegistryScanCursorStore {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as { load?: unknown }).load === 'function' &&
-    typeof (value as { save?: unknown }).save === 'function'
-  );
-}
-
-function normalizeRegistryCursorStores(
-  config: ContextGraphRegistryScanCursorStoreConfig | undefined,
-): {
-  historical?: ContextGraphRegistryScanCursorStore;
-  tip?: ContextGraphRegistryScanCursorStore;
-} {
-  if (!config) return {};
-  // Structural legacy stores may expose unrelated metadata named `kind`.
-  // Recognize the original load/save contract positively before tagged forms.
-  if (isRegistryCursorStore(config)) return { historical: config };
-  if (
-    config.kind === 'legacy' &&
-    isRegistryCursorStore(config.historical) &&
-    (config.tip === undefined || isRegistryCursorStore(config.tip))
-  ) {
-    return { historical: config.historical, tip: config.tip };
-  }
-  if (config.kind === 'roleAware' && isRegistryCursorStore(config.store)) {
-    return {
-      historical: bindRoleAwareRegistryCursorStore(config.store, 'historical'),
-      tip: bindRoleAwareRegistryCursorStore(config.store, 'tip'),
-    };
-  }
-  throw new TypeError('Invalid ContextGraphNameRegistry cursor persistence configuration');
-}
 
 type ContractWriteSender = (
   contract: Contract,
@@ -1366,18 +1318,16 @@ export class EVMChainAdapterBase {
     }
     this.tokenAddress = config.tokenAddress ? ethers.getAddress(config.tokenAddress) : undefined;
     this.chainId = config.chainId ?? 'evm:31337';
-    const registryCursorStores = normalizeRegistryCursorStores(
-      config.contextGraphRegistryScanCursorStore,
-    );
     this.contextGraphRegistryScanCursor = new ContextGraphRegistryScanCursor({
       chainId: this.chainId,
       deploymentId: this.deploymentId,
-      store: registryCursorStores.historical,
+      store: config.contextGraphRegistryScanCursorStore,
     });
     this.contextGraphRegistryTipScanCursor = new ContextGraphRegistryScanCursor({
       chainId: this.chainId,
       deploymentId: this.deploymentId,
-      store: registryCursorStores.tip,
+      store: config.contextGraphRegistryTipScanCursorStore,
+      savePolicy: 'strict',
     });
     this.approvalPolicy = config.approvalPolicy ?? DEFAULT_APPROVAL_POLICY;
     this.minPublisherNativeWei = config.minPublisherNativeWei ?? 0n;

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -1317,17 +1317,27 @@ export class EVMChainAdapterBase {
     }
     this.tokenAddress = config.tokenAddress ? ethers.getAddress(config.tokenAddress) : undefined;
     this.chainId = config.chainId ?? 'evm:31337';
+    const historicalRegistryCursorStore = config.contextGraphRegistryScanCursorStore;
+    const configuredTipRegistryCursorStore = config.contextGraphRegistryTipScanCursorStore;
+    const tipRegistryCursorStore = configuredTipRegistryCursorStore && (
+      configuredTipRegistryCursorStore !== historicalRegistryCursorStore ||
+      configuredTipRegistryCursorStore.cursorKeyVersion === 2
+    )
+      ? configuredTipRegistryCursorStore
+      : historicalRegistryCursorStore?.cursorKeyVersion === 2
+        ? historicalRegistryCursorStore
+        : undefined;
     this.contextGraphRegistryScanCursor = new ContextGraphRegistryScanCursor({
       chainId: this.chainId,
       deploymentId: this.deploymentId,
       cursorKind: 'historical',
-      store: config.contextGraphRegistryScanCursorStore,
+      store: historicalRegistryCursorStore,
     });
     this.contextGraphRegistryTipScanCursor = new ContextGraphRegistryScanCursor({
       chainId: this.chainId,
       deploymentId: this.deploymentId,
       cursorKind: 'tip',
-      store: config.contextGraphRegistryScanCursorStore,
+      store: tipRegistryCursorStore,
     });
     this.approvalPolicy = config.approvalPolicy ?? DEFAULT_APPROVAL_POLICY;
     this.minPublisherNativeWei = config.minPublisherNativeWei ?? 0n;

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -23,6 +23,9 @@ import type {
   OnChainPublishResult,
   PreBroadcastSignal,
   SignedTransactionEnvelope,
+  ContextGraphRegistryRoleAwareScanCursorStore,
+  ContextGraphRegistryScanCursorStore,
+  ContextGraphRegistryScanCursorStoreConfig,
 } from './chain-adapter.js';
 import { HubResolutionCache } from './hub-resolution-cache.js';
 import { SignerTxSerializer, type SignerTxLaneState } from './signer-tx-serializer.js';
@@ -53,6 +56,33 @@ import { decodeKnowledgeAssetUpdateContext } from './evm-knowledge-asset-update-
 import { applyTransactionFeeCap, resolveMaxFeePerGasWei } from './evm-fee-cap.js';
 
 export { CG_REGISTRY_MAX_SCAN_PAGES } from './evm-adapter-constants.js';
+
+function bindRoleAwareRegistryCursorStore(
+  store: ContextGraphRegistryRoleAwareScanCursorStore,
+  cursorKind: 'historical' | 'tip',
+): ContextGraphRegistryScanCursorStore {
+  return {
+    load: (key) => store.load({ ...key, cursorKind }),
+    save: (key, nextBlock) => store.save({ ...key, cursorKind }, nextBlock),
+  };
+}
+
+function normalizeRegistryCursorStores(
+  config: ContextGraphRegistryScanCursorStoreConfig | undefined,
+): {
+  historical?: ContextGraphRegistryScanCursorStore;
+  tip?: ContextGraphRegistryScanCursorStore;
+} {
+  if (!config) return {};
+  if (!('kind' in config)) return { historical: config };
+  if (config.kind === 'legacy') {
+    return { historical: config.historical, tip: config.tip };
+  }
+  return {
+    historical: bindRoleAwareRegistryCursorStore(config.store, 'historical'),
+    tip: bindRoleAwareRegistryCursorStore(config.store, 'tip'),
+  };
+}
 
 type ContractWriteSender = (
   contract: Contract,
@@ -1317,30 +1347,18 @@ export class EVMChainAdapterBase {
     }
     this.tokenAddress = config.tokenAddress ? ethers.getAddress(config.tokenAddress) : undefined;
     this.chainId = config.chainId ?? 'evm:31337';
-    const registryCursorPersistence = config.contextGraphRegistryScanCursorPersistence;
-    const historicalRegistryCursorStore = registryCursorPersistence?.kind === 'roleAware'
-      ? { kind: 'roleAware' as const, store: registryCursorPersistence.store }
-      : registryCursorPersistence?.kind === 'legacy'
-        ? { kind: 'legacy' as const, store: registryCursorPersistence.historical }
-        : config.contextGraphRegistryScanCursorStore
-          ? { kind: 'legacy' as const, store: config.contextGraphRegistryScanCursorStore }
-          : undefined;
-    const tipRegistryCursorStore = registryCursorPersistence?.kind === 'roleAware'
-      ? { kind: 'roleAware' as const, store: registryCursorPersistence.store }
-      : registryCursorPersistence?.kind === 'legacy' && registryCursorPersistence.tip
-        ? { kind: 'legacy' as const, store: registryCursorPersistence.tip }
-        : undefined;
+    const registryCursorStores = normalizeRegistryCursorStores(
+      config.contextGraphRegistryScanCursorStore,
+    );
     this.contextGraphRegistryScanCursor = new ContextGraphRegistryScanCursor({
       chainId: this.chainId,
       deploymentId: this.deploymentId,
-      cursorKind: 'historical',
-      store: historicalRegistryCursorStore,
+      store: registryCursorStores.historical,
     });
     this.contextGraphRegistryTipScanCursor = new ContextGraphRegistryScanCursor({
       chainId: this.chainId,
       deploymentId: this.deploymentId,
-      cursorKind: 'tip',
-      store: tipRegistryCursorStore,
+      store: registryCursorStores.tip,
     });
     this.approvalPolicy = config.approvalPolicy ?? DEFAULT_APPROVAL_POLICY;
     this.minPublisherNativeWei = config.minPublisherNativeWei ?? 0n;

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -1320,11 +1320,13 @@ export class EVMChainAdapterBase {
     this.contextGraphRegistryScanCursor = new ContextGraphRegistryScanCursor({
       chainId: this.chainId,
       deploymentId: this.deploymentId,
+      cursorKind: 'historical',
       store: config.contextGraphRegistryScanCursorStore,
     });
     this.contextGraphRegistryTipScanCursor = new ContextGraphRegistryScanCursor({
       chainId: this.chainId,
-      deploymentId: `${this.deploymentId}:tip-recovery`,
+      deploymentId: this.deploymentId,
+      cursorKind: 'tip',
       store: config.contextGraphRegistryScanCursorStore,
     });
     this.approvalPolicy = config.approvalPolicy ?? DEFAULT_APPROVAL_POLICY;

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -980,6 +980,11 @@ export class EVMChainAdapterBase {
   }
 
   protected readonly contextGraphRegistryScanCursor: ContextGraphRegistryScanCursor;
+  /**
+   * Independent recovery-tip progress. Keeping this cursor separate prevents a blocked historical
+   * recovery range from either rewinding tip discovery or being mistaken for current-chain progress.
+   */
+  protected readonly contextGraphRegistryTipScanCursor: ContextGraphRegistryScanCursor;
 
   /**
    * eth_getLogs block-window for the pre-10.0.4 getMaxKaNumberForAuthor fallback
@@ -1006,6 +1011,7 @@ export class EVMChainAdapterBase {
     this.cachedContractDeployBlocks.clear();
     this.contextGraphNameHashResolver?.invalidateAll();
     this.contextGraphRegistryScanCursor.clearMemoryCache();
+    this.contextGraphRegistryTipScanCursor.clearMemoryCache();
   }
 
   protected clearIdentityIdForAddress(address: string): void {
@@ -1314,6 +1320,11 @@ export class EVMChainAdapterBase {
     this.contextGraphRegistryScanCursor = new ContextGraphRegistryScanCursor({
       chainId: this.chainId,
       deploymentId: this.deploymentId,
+      store: config.contextGraphRegistryScanCursorStore,
+    });
+    this.contextGraphRegistryTipScanCursor = new ContextGraphRegistryScanCursor({
+      chainId: this.chainId,
+      deploymentId: `${this.deploymentId}:tip-recovery`,
       store: config.contextGraphRegistryScanCursorStore,
     });
     this.approvalPolicy = config.approvalPolicy ?? DEFAULT_APPROVAL_POLICY;

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -40,7 +40,10 @@ import { formatProviderContext } from './evm-adapter-types.js';
 import { ReadThroughTtlCache } from './keyed-ttl-single-flight-cache.js';
 import { PcaReadCache } from './pca-read-cache.js';
 import { HubRotationPoller } from './hub-rotation-poller.js';
-import { ContextGraphRegistryScanCursor } from './context-graph-registry-scan-cursor.js';
+import {
+  ContextGraphRegistryHistoricalScanCursor,
+  ContextGraphRegistryTipScanCursor,
+} from './context-graph-registry-scan-cursor.js';
 import { EvmContextGraphNameHashFence } from './evm-context-graph-name-hash-fence.js';
 import { EvmContextGraphNameHashResolver } from './evm-context-graph-name-hash-resolver.js';
 import type { ContractCache, EVMAdapterConfig } from './evm-adapter-types.js';
@@ -980,12 +983,12 @@ export class EVMChainAdapterBase {
     return this.contextGraphNameHashResolver;
   }
 
-  protected readonly contextGraphRegistryScanCursor: ContextGraphRegistryScanCursor;
+  protected readonly contextGraphRegistryScanCursor: ContextGraphRegistryHistoricalScanCursor;
   /**
    * Independent recovery-tip progress. Keeping this cursor separate prevents a blocked historical
    * recovery range from either rewinding tip discovery or being mistaken for current-chain progress.
    */
-  protected readonly contextGraphRegistryTipScanCursor: ContextGraphRegistryScanCursor;
+  protected readonly contextGraphRegistryTipScanCursor: ContextGraphRegistryTipScanCursor;
 
   /**
    * eth_getLogs block-window for the pre-10.0.4 getMaxKaNumberForAuthor fallback
@@ -1012,7 +1015,6 @@ export class EVMChainAdapterBase {
     this.cachedContractDeployBlocks.clear();
     this.contextGraphNameHashResolver?.invalidateAll();
     this.contextGraphRegistryScanCursor.clearMemoryCache();
-    this.contextGraphRegistryTipScanCursor.clearMemoryCache();
   }
 
   protected clearIdentityIdForAddress(address: string): void {
@@ -1318,16 +1320,15 @@ export class EVMChainAdapterBase {
     }
     this.tokenAddress = config.tokenAddress ? ethers.getAddress(config.tokenAddress) : undefined;
     this.chainId = config.chainId ?? 'evm:31337';
-    this.contextGraphRegistryScanCursor = new ContextGraphRegistryScanCursor({
+    this.contextGraphRegistryScanCursor = new ContextGraphRegistryHistoricalScanCursor({
       chainId: this.chainId,
       deploymentId: this.deploymentId,
       store: config.contextGraphRegistryScanCursorStore,
     });
-    this.contextGraphRegistryTipScanCursor = new ContextGraphRegistryScanCursor({
+    this.contextGraphRegistryTipScanCursor = new ContextGraphRegistryTipScanCursor({
       chainId: this.chainId,
       deploymentId: this.deploymentId,
       store: config.contextGraphRegistryTipScanCursorStore,
-      savePolicy: 'strict',
     });
     this.approvalPolicy = config.approvalPolicy ?? DEFAULT_APPROVAL_POLICY;
     this.minPublisherNativeWei = config.minPublisherNativeWei ?? 0n;

--- a/packages/chain/src/evm-adapter-constants.ts
+++ b/packages/chain/src/evm-adapter-constants.ts
@@ -59,6 +59,9 @@ export const CG_REGISTRY_MAX_SCAN_PAGES = Math.ceil(
   CG_REGISTRY_DEFAULT_PAGE_SIZE,
 );
 
+/** Re-read overlap used by resumable registry scans to tolerate short reorgs. */
+export const CG_REGISTRY_REORG_BUFFER_BLOCKS = 50;
+
 /**
  * TTL (ms) for the `RpcFailoverClient` endpoint-stickiness "primary re-probe"
  * cadence (Mechanism B, #1340 retry residual + #1337 policy-read fail-close).

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -39,6 +39,14 @@ type ContextGraphRegistryScanPlan =
       pageBudget?: number;
     }
   | {
+      mode: 'tip';
+      resumeFromWatermark: false;
+      persistProgress: false;
+      allowPartialFailure: false;
+      seedAtEnd: false;
+      pageBudget?: undefined;
+    }
+  | {
       mode: 'seedFull';
       resumeFromWatermark: false;
       persistProgress: true;
@@ -142,6 +150,16 @@ function buildCursorContextGraphRegistryScanPlan(
       allowPartialFailure: true,
       seedAtEnd: false,
       pageBudget: normalizePageBudget(options.pageBudget),
+    };
+  }
+
+  if (options.mode === 'tip') {
+    return {
+      mode: 'tip',
+      resumeFromWatermark: false,
+      persistProgress: false,
+      allowPartialFailure: false,
+      seedAtEnd: false,
     };
   }
 
@@ -312,6 +330,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     scanPlan: ContextGraphRegistryScanPlan,
   ): AsyncGenerator<ContextGraphRegistryScanPage, void, unknown> {
     const eventFilter = registry.filters.NameClaimed();
+    const pageSize = this.cgRegistryScanPageSize;
     const persistedWatermark = (scanPlan.resumeFromWatermark || scanPlan.seedAtEnd)
       ? await this.contextGraphRegistryScanCursor.loadWatermark(registryAddress)
       : undefined;
@@ -320,6 +339,12 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
       fromBlock === undefined
         ? canResumeFromWatermark
           ? { fromBlock: 0, ...(await this.resolveLogScanHead('listContextGraphsFromChain')) }
+          : scanPlan.mode === 'tip'
+            ? await this.resolveLogScanHead('listContextGraphsFromChain').then((tipScan) => ({
+              ...tipScan,
+              fromBlock: Math.max(0, tipScan.head - pageSize + 1),
+              degradedFromGenesis: false,
+            }))
           : await this.resolveContractDeployBlock(
               registryAddress,
               'listContextGraphsFromChain',
@@ -339,7 +364,6 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
       return;
     }
 
-    const pageSize = this.cgRegistryScanPageSize;
     const pages = Math.ceil((head - start + 1) / pageSize);
     const blockBudget = CG_REGISTRY_MAX_SCAN_PAGES * pageSize;
     if (scanPlan.mode === 'incremental' && scanPlan.pageBudget === undefined && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -6,147 +6,22 @@
  * Mixin holder extracted from evm-adapter.ts. `extends EVMChainAdapterBase`
  * for shared state (providers, signers, caches) reached via `this`. Bodies
  * are a 1:1 move — no behaviour change. Mixed into the concrete EVMChainAdapter
- * via applyMixins(); see evm-adapter.ts for the assembly.
+ * via applyMixins(); see evm-adapter.ts for the assembly. Registry discovery
+ * delegates to the focused planner/executor in context-graph-registry-scanner.
  */
 
-import {
-  EVMChainAdapterBase,
-  CG_REGISTRY_MAX_SCAN_PAGES,
-  CG_REGISTRY_REORG_BUFFER_BLOCKS,
-} from './evm-adapter-base.js';
+import { EVMChainAdapterBase } from './evm-adapter-base.js';
 import {
   isTooLowAllowanceError,
 } from './evm-adapter-errors.js';
-import { ethers, Contract, type JsonRpcProvider } from 'ethers';
-import { ContextGraphChainScanPartialError, type ChainReadOptions, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type ContextGraphRegistryScanOptions, type ContextGraphRegistryScanPage, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
+import { ethers, Contract } from 'ethers';
+import { type ChainReadOptions, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type ContextGraphRegistryScanOptions, type ContextGraphRegistryScanPage, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
-
-type StatelessContextGraphRegistryScanStart =
-  | { kind: 'explicit'; fromBlock: number }
-  | { kind: 'deployment' };
-
-type ContextGraphRegistryScanPlan =
-  | {
-      kind: 'stateless';
-      start: StatelessContextGraphRegistryScanStart;
-    }
-  | {
-      kind: 'historicalIncremental';
-      pageBudget?: number;
-    }
-  | {
-      kind: 'historicalSeed';
-      start: 'deployment' | 'cursor';
-      pageBudget?: number;
-    }
-  | {
-      kind: 'tip';
-    };
-
-type PreparedContextGraphRegistryScan = {
-  start: number;
-  head: number;
-  scanProviders: ReadonlyArray<{ provider: JsonRpcProvider; backendHead: number }>;
-  degradedFromGenesis: boolean;
-  pageBudget?: number;
-  enforceDefaultPageLimit: boolean;
-  partialFailures: boolean;
-  advanceOnEmpty: boolean;
-  acknowledge(nextBlock: number): Promise<void>;
-};
-
-function normalizePageBudget(value: number | undefined): number | undefined {
-  return Number.isFinite(value) && (value ?? 0) >= 1
-    ? Math.floor(value ?? 0)
-    : undefined;
-}
-
-function buildPublicContextGraphRegistryScanPlan(
-  fromBlock: number | undefined,
-  options: ContextGraphChainScanOptions | undefined,
-): ContextGraphRegistryScanPlan {
-  const runtimeOptions = options as
-    | (ContextGraphChainScanOptions & { mode?: string })
-    | undefined;
-  const mode = runtimeOptions?.mode;
-
-  if (fromBlock !== undefined) {
-    return {
-      kind: 'stateless',
-      start: { kind: 'explicit', fromBlock },
-    };
-  }
-
-  if (runtimeOptions && 'incremental' in runtimeOptions && runtimeOptions.incremental === true) {
-    return {
-      kind: 'historicalIncremental',
-      pageBudget: normalizePageBudget(runtimeOptions.pageBudget),
-    };
-  }
-
-  if (
-    runtimeOptions &&
-    'seedIncrementalWatermark' in runtimeOptions &&
-    runtimeOptions.seedIncrementalWatermark === true
-  ) {
-    if (runtimeOptions.resumeFromCursor === true) {
-      return {
-        kind: 'historicalSeed',
-        start: 'cursor',
-        pageBudget: normalizePageBudget(runtimeOptions.pageBudget),
-      };
-    }
-    return {
-      kind: 'historicalSeed',
-      start: 'deployment',
-    };
-  }
-
-  if (mode !== undefined && mode !== 'listAll') {
-    throw new Error(
-      'listContextGraphsFromChain accepts only listAll or legacy boolean scan options; ' +
-      'use scanContextGraphRegistryPages for cursor-backed daemon scans.',
-    );
-  }
-
-  return {
-    kind: 'stateless',
-    start: { kind: 'deployment' },
-  };
-}
-
-function buildCursorContextGraphRegistryScanPlan(
-  options: ContextGraphRegistryScanOptions,
-): ContextGraphRegistryScanPlan {
-  if (options.mode === 'incremental') {
-    return {
-      kind: 'historicalIncremental',
-      pageBudget: normalizePageBudget(options.pageBudget),
-    };
-  }
-
-  if (options.mode === 'tip') {
-    return { kind: 'tip' };
-  }
-
-  if (options?.mode === 'seedFull') {
-    return {
-      kind: 'historicalSeed',
-      start: 'deployment',
-    };
-  }
-
-  if (options?.mode === 'seedFromCursor') {
-    return {
-      kind: 'historicalSeed',
-      start: 'cursor',
-      pageBudget: normalizePageBudget(options.pageBudget),
-    };
-  }
-
-  const exhaustive: never = options;
-  throw new Error(`Unsupported ContextGraphNameRegistry scan mode: ${JSON.stringify(exhaustive)}`);
-}
+import {
+  ContextGraphRegistryScanner,
+  buildCursorContextGraphRegistryScanPlan,
+  buildPublicContextGraphRegistryScanPlan,
+} from './context-graph-registry-scanner.js';
 
 export class ContextGraphMethods extends EVMChainAdapterBase {
   /**
@@ -249,8 +124,9 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const registry = this.contracts.contextGraphNameRegistry;
     if (!registry) return [];
     const registryAddress = (await registry.getAddress()).toLowerCase();
-    const scanPlan = buildPublicContextGraphRegistryScanPlan(fromBlock, options);
-    return this._collectContextGraphRegistryScan(registry, registryAddress, scanPlan);
+    return this._contextGraphRegistryScanner(registry, registryAddress).collect(
+      buildPublicContextGraphRegistryScanPlan(fromBlock, options),
+    );
   }
 
   async *scanContextGraphRegistryPages(
@@ -260,247 +136,41 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const registry = this.contracts.contextGraphNameRegistry;
     if (!registry) return;
     const registryAddress = (await registry.getAddress()).toLowerCase();
-    const scanPlan = buildCursorContextGraphRegistryScanPlan(options);
-    yield* this._iterateContextGraphRegistryScanPages(registry, registryAddress, scanPlan);
+    yield* this._contextGraphRegistryScanner(registry, registryAddress).pages(
+      buildCursorContextGraphRegistryScanPlan(options),
+    );
   }
 
-  private async _collectContextGraphRegistryScan(
+  private _contextGraphRegistryScanner(
     registry: Contract,
     registryAddress: string,
-    scanPlan: ContextGraphRegistryScanPlan,
-  ): Promise<ContextGraphOnChain[]> {
-    const results: ContextGraphOnChain[] = [];
-    for await (const page of this._iterateContextGraphRegistryScanPages(
+  ): ContextGraphRegistryScanner {
+    const scanLabel = 'listContextGraphsFromChain';
+    return new ContextGraphRegistryScanner({
       registry,
       registryAddress,
-      scanPlan,
-    )) {
-      results.push(...page.contextGraphs);
-      await page.ack();
-    }
-    return results;
-  }
-
-  private async _prepareContextGraphRegistryScan(
-    registryAddress: string,
-    scanPlan: ContextGraphRegistryScanPlan,
-  ): Promise<PreparedContextGraphRegistryScan> {
-    const scanLabel = 'listContextGraphsFromChain';
-    const resolveDeployment = async () => {
-      const deployment = await this.resolveContractDeployBlock(
+      pageSize: this.cgRegistryScanPageSize,
+      historicalCursor: this.contextGraphRegistryScanCursor,
+      tipCursor: this.contextGraphRegistryTipScanCursor,
+      resolveDeployment: () => this.resolveContractDeployBlock(
         registryAddress,
         scanLabel,
         'ContextGraphNameRegistry',
-      );
-      const { fromBlock, ...resolved } = deployment;
-      return { start: fromBlock, ...resolved };
-    };
-    const resolveHistoricalCursor = async () => {
-      const watermark = await this.contextGraphRegistryScanCursor.loadWatermark(registryAddress);
-      if (watermark !== undefined) {
-        return {
-          start: Math.max(0, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS),
-          ...(await this.resolveLogScanHead(scanLabel)),
-          degradedFromGenesis: false,
-        };
-      }
-      return resolveDeployment();
-    };
-    const historicalAcknowledge = (nextBlock: number) =>
-      this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, nextBlock);
-    const tipAcknowledge = (nextBlock: number) =>
-      this.contextGraphRegistryTipScanCursor.saveWatermark(registryAddress, nextBlock);
-    const noAcknowledge = async () => {};
-
-    switch (scanPlan.kind) {
-      case 'stateless': {
-        const range = scanPlan.start.kind === 'explicit'
-          ? {
-              start: scanPlan.start.fromBlock,
-              ...(await this.resolveLogScanHead(scanLabel)),
-              degradedFromGenesis: false,
-            }
-          : await resolveDeployment();
-        return {
-          ...range,
-          degradedFromGenesis: range.degradedFromGenesis ?? false,
-          enforceDefaultPageLimit: false,
-          partialFailures: false,
-          advanceOnEmpty: false,
-          acknowledge: noAcknowledge,
-        };
-      }
-      case 'historicalIncremental': {
-        const range = await resolveHistoricalCursor();
-        return {
-          ...range,
-          degradedFromGenesis: range.degradedFromGenesis ?? false,
-          pageBudget: scanPlan.pageBudget,
-          enforceDefaultPageLimit: true,
-          partialFailures: true,
-          advanceOnEmpty: false,
-          acknowledge: historicalAcknowledge,
-        };
-      }
-      case 'historicalSeed': {
-        if (scanPlan.start === 'deployment') {
-          // Preserve monotonic store behavior while a full recovery replays old pages.
-          await this.contextGraphRegistryScanCursor.loadWatermark(registryAddress);
-        }
-        const range = await (scanPlan.start === 'cursor'
-          ? resolveHistoricalCursor()
-          : resolveDeployment());
-        return {
-          ...range,
-          degradedFromGenesis: range.degradedFromGenesis ?? false,
-          pageBudget: scanPlan.pageBudget,
-          enforceDefaultPageLimit: false,
-          partialFailures: true,
-          advanceOnEmpty: true,
-          acknowledge: historicalAcknowledge,
-        };
-      }
-      case 'tip': {
-        const tip = await this.resolveLogScanHead(scanLabel);
-        const loaded = await this.contextGraphRegistryTipScanCursor.loadWatermarkResult(
-          registryAddress,
-        );
-        if (loaded.status === 'failed') {
-          throw new Error(
-            'listContextGraphsFromChain: tip cursor load failed; refusing to initialize from ' +
-              'the current head because persisted progress may exist',
-            { cause: loaded.error },
-          );
-        }
-        const watermark = loaded.watermark;
-        const start = watermark === undefined
-          ? Math.max(0, tip.head - this.cgRegistryScanPageSize + 1)
-          : Math.max(0, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS);
-        if (watermark === undefined) {
-          // Persist the conservative lower bound before the first query. A failed first page then
-          // restarts from this attempted range rather than jumping to a newer tip page.
-          // Cursor storage uses positive integers; marker 1 still replays block 0 through overlap.
-          await this.contextGraphRegistryTipScanCursor.saveWatermark(
-            registryAddress,
-            Math.max(1, start),
-          );
-        }
-        return {
-          ...tip,
-          start,
-          degradedFromGenesis: false,
-          enforceDefaultPageLimit: false,
-          partialFailures: true,
-          advanceOnEmpty: false,
-          acknowledge: tipAcknowledge,
-        };
-      }
-      default: {
-        const exhaustive: never = scanPlan;
-        throw new Error(`Unsupported ContextGraphNameRegistry scan plan: ${JSON.stringify(exhaustive)}`);
-      }
-    }
-  }
-
-  private async *_iterateContextGraphRegistryScanPages(
-    registry: Contract,
-    registryAddress: string,
-    scanPlan: ContextGraphRegistryScanPlan,
-  ): AsyncGenerator<ContextGraphRegistryScanPage, void, unknown> {
-    const eventFilter = registry.filters.NameClaimed();
-    const pageSize = this.cgRegistryScanPageSize;
-    const {
-      start,
-      head,
-      scanProviders,
-      degradedFromGenesis,
-      pageBudget,
-      enforceDefaultPageLimit,
-      partialFailures,
-      advanceOnEmpty,
-      acknowledge,
-    } = await this._prepareContextGraphRegistryScan(registryAddress, scanPlan);
-    if (start > head) {
-      if (advanceOnEmpty) await acknowledge(head + 1);
-      return;
-    }
-
-    const pages = Math.ceil((head - start + 1) / pageSize);
-    const blockBudget = CG_REGISTRY_MAX_SCAN_PAGES * pageSize;
-    if (enforceDefaultPageLimit && pageBudget === undefined && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
-      throw new Error(
-        `listContextGraphsFromChain: incremental ContextGraphNameRegistry scan would need ` +
-          `${pages} eth_getLogs calls over blocks [${start}, ${head}] at a ` +
-          `${pageSize}-block window (budget ${CG_REGISTRY_MAX_SCAN_PAGES} pages / ` +
-          `${blockBudget} blocks). ` +
-          `Use an RPC that can anchor the registry deploy block and serve the ` +
-          `requested log range, or increase cgRegistryScanPageSize for an RPC ` +
-          `known to support larger ranges.`,
-      );
-    }
-
-    const results: ContextGraphOnChain[] = [];
-    const connected = new Map<JsonRpcProvider, Contract>();
-    let preferred: JsonRpcProvider | undefined;
-    let scannedAnyPage = false;
-
-    // Daemon scans can resume from the scanned prefix after a later page
-    // failure. Public list-all calls should remain all-or-error.
-    for (let lo = start; lo <= head; lo += pageSize) {
-      const hi = Math.min(lo + pageSize - 1, head);
-      let pageResults: ContextGraphOnChain[];
-      try {
-        const page = await this.queryEventLogsPage(
+      ),
+      resolveHead: () => this.resolveLogScanHead(scanLabel),
+      queryPage: (filter, lo, hi, scanProviders, connected, preferred) =>
+        this.queryEventLogsPage(
           registry,
-          eventFilter,
+          filter,
           lo,
           hi,
           scanProviders,
           connected,
           'listContextGraphsFromChain NameClaimed',
           preferred,
-        );
-        preferred = page.provider;
-        pageResults = [];
-        for (const log of page.logs) {
-          const parsed = registry.interface.parseLog({ topics: [...log.topics], data: log.data });
-          if (!parsed || parsed.name !== 'NameClaimed') continue;
-          pageResults.push({
-            contextGraphId: String(parsed.args.nameHash),
-            creator: String(parsed.args.creator),
-            accessPolicy: Number(parsed.args.accessPolicy),
-            blockNumber: log.blockNumber,
-            metadataRevealed: false,
-          });
-        }
-      } catch (err) {
-        if (partialFailures && scannedAnyPage) {
-          const message = err instanceof Error ? err.message : String(err);
-          throw new ContextGraphChainScanPartialError(
-            `listContextGraphsFromChain: partial ContextGraphNameRegistry scan ` +
-              `stopped after block ${lo - 1}; failed page [${lo}, ${hi}]: ${message}`,
-            {
-              partialResults: results,
-              scannedToBlock: lo - 1,
-              failedFromBlock: lo,
-              failedToBlock: hi,
-              cause: err,
-            },
-          );
-        }
-        throw err;
-      }
-      results.push(...pageResults);
-      scannedAnyPage = true;
-      yield {
-        contextGraphs: pageResults,
-        ack: () => acknowledge(hi + 1),
-      };
-      const scannedPages = Math.floor((hi - start) / pageSize) + 1;
-      if (pageBudget !== undefined && scannedPages >= pageBudget && hi < head) return;
-    }
+        ),
+    });
   }
-
   // =====================================================================
   // On-Chain Context Graphs (ContextGraphs contract)
   // =====================================================================

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -21,47 +21,22 @@ import { ethers, Contract, type JsonRpcProvider } from 'ethers';
 import { ContextGraphChainScanPartialError, type ChainReadOptions, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type ContextGraphRegistryScanOptions, type ContextGraphRegistryScanPage, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
 
-type ContextGraphRegistryScanPlan =
-  | {
-      mode: 'explicitFromBlock' | 'listAll';
-      resumeFromWatermark: false;
-      persistProgress: false;
-      allowPartialFailure: false;
-      seedAtEnd: false;
-      pageBudget?: undefined;
-    }
-  | {
-      mode: 'incremental';
-      resumeFromWatermark: true;
-      persistProgress: true;
-      allowPartialFailure: true;
-      seedAtEnd: false;
-      pageBudget?: number;
-    }
-  | {
-      mode: 'tip';
-      resumeFromWatermark: false;
-      persistProgress: false;
-      allowPartialFailure: false;
-      seedAtEnd: false;
-      pageBudget?: undefined;
-    }
-  | {
-      mode: 'seedFull';
-      resumeFromWatermark: false;
-      persistProgress: true;
-      allowPartialFailure: true;
-      seedAtEnd: true;
-      pageBudget?: undefined;
-    }
-  | {
-      mode: 'seedFromCursor';
-      resumeFromWatermark: true;
-      persistProgress: true;
-      allowPartialFailure: true;
-      seedAtEnd: true;
-      pageBudget?: number;
-    };
+type ContextGraphRegistryScanStart =
+  | { kind: 'explicit'; fromBlock: number }
+  | { kind: 'deployment' }
+  | { kind: 'historicalCursor' }
+  | { kind: 'tipCursor' };
+
+type ContextGraphRegistryScanProgress = 'none' | 'historical' | 'tip';
+
+interface ContextGraphRegistryScanPlan {
+  start: ContextGraphRegistryScanStart;
+  progress: ContextGraphRegistryScanProgress;
+  allowPartialFailure: boolean;
+  seedAtEnd: boolean;
+  enforceDefaultPageLimit: boolean;
+  pageBudget?: number;
+}
 
 function normalizePageBudget(value: number | undefined): number | undefined {
   return Number.isFinite(value) && (value ?? 0) >= 1
@@ -80,21 +55,21 @@ function buildPublicContextGraphRegistryScanPlan(
 
   if (fromBlock !== undefined) {
     return {
-      mode: 'explicitFromBlock',
-      resumeFromWatermark: false,
-      persistProgress: false,
+      start: { kind: 'explicit', fromBlock },
+      progress: 'none',
       allowPartialFailure: false,
       seedAtEnd: false,
+      enforceDefaultPageLimit: false,
     };
   }
 
   if (runtimeOptions && 'incremental' in runtimeOptions && runtimeOptions.incremental === true) {
     return {
-      mode: 'incremental',
-      resumeFromWatermark: true,
-      persistProgress: true,
+      start: { kind: 'historicalCursor' },
+      progress: 'historical',
       allowPartialFailure: true,
       seedAtEnd: false,
+      enforceDefaultPageLimit: true,
       pageBudget: normalizePageBudget(runtimeOptions.pageBudget),
     };
   }
@@ -106,20 +81,20 @@ function buildPublicContextGraphRegistryScanPlan(
   ) {
     if (runtimeOptions.resumeFromCursor === true) {
       return {
-        mode: 'seedFromCursor',
-        resumeFromWatermark: true,
-        persistProgress: true,
+        start: { kind: 'historicalCursor' },
+        progress: 'historical',
         allowPartialFailure: true,
         seedAtEnd: true,
+        enforceDefaultPageLimit: false,
         pageBudget: normalizePageBudget(runtimeOptions.pageBudget),
       };
     }
     return {
-      mode: 'seedFull',
-      resumeFromWatermark: false,
-      persistProgress: true,
+      start: { kind: 'deployment' },
+      progress: 'historical',
       allowPartialFailure: true,
       seedAtEnd: true,
+      enforceDefaultPageLimit: false,
     };
   }
 
@@ -131,11 +106,11 @@ function buildPublicContextGraphRegistryScanPlan(
   }
 
   return {
-    mode: 'listAll',
-    resumeFromWatermark: false,
-    persistProgress: false,
+    start: { kind: 'deployment' },
+    progress: 'none',
     allowPartialFailure: false,
     seedAtEnd: false,
+    enforceDefaultPageLimit: false,
   };
 }
 
@@ -144,42 +119,42 @@ function buildCursorContextGraphRegistryScanPlan(
 ): ContextGraphRegistryScanPlan {
   if (options.mode === 'incremental') {
     return {
-      mode: 'incremental',
-      resumeFromWatermark: true,
-      persistProgress: true,
+      start: { kind: 'historicalCursor' },
+      progress: 'historical',
       allowPartialFailure: true,
       seedAtEnd: false,
+      enforceDefaultPageLimit: true,
       pageBudget: normalizePageBudget(options.pageBudget),
     };
   }
 
   if (options.mode === 'tip') {
     return {
-      mode: 'tip',
-      resumeFromWatermark: false,
-      persistProgress: false,
-      allowPartialFailure: false,
+      start: { kind: 'tipCursor' },
+      progress: 'tip',
+      allowPartialFailure: true,
       seedAtEnd: false,
+      enforceDefaultPageLimit: false,
     };
   }
 
   if (options?.mode === 'seedFull') {
     return {
-      mode: 'seedFull',
-      resumeFromWatermark: false,
-      persistProgress: true,
+      start: { kind: 'deployment' },
+      progress: 'historical',
       allowPartialFailure: true,
       seedAtEnd: true,
+      enforceDefaultPageLimit: false,
     };
   }
 
   if (options?.mode === 'seedFromCursor') {
     return {
-      mode: 'seedFromCursor',
-      resumeFromWatermark: true,
-      persistProgress: true,
+      start: { kind: 'historicalCursor' },
+      progress: 'historical',
       allowPartialFailure: true,
       seedAtEnd: true,
+      enforceDefaultPageLimit: false,
       pageBudget: normalizePageBudget(options.pageBudget),
     };
   }
@@ -290,7 +265,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     if (!registry) return [];
     const registryAddress = (await registry.getAddress()).toLowerCase();
     const scanPlan = buildPublicContextGraphRegistryScanPlan(fromBlock, options);
-    return this._collectContextGraphRegistryScan(registry, registryAddress, fromBlock, scanPlan);
+    return this._collectContextGraphRegistryScan(registry, registryAddress, scanPlan);
   }
 
   async *scanContextGraphRegistryPages(
@@ -301,20 +276,18 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     if (!registry) return;
     const registryAddress = (await registry.getAddress()).toLowerCase();
     const scanPlan = buildCursorContextGraphRegistryScanPlan(options);
-    yield* this._iterateContextGraphRegistryScanPages(registry, registryAddress, undefined, scanPlan);
+    yield* this._iterateContextGraphRegistryScanPages(registry, registryAddress, scanPlan);
   }
 
   private async _collectContextGraphRegistryScan(
     registry: Contract,
     registryAddress: string,
-    fromBlock: number | undefined,
     scanPlan: ContextGraphRegistryScanPlan,
   ): Promise<ContextGraphOnChain[]> {
     const results: ContextGraphOnChain[] = [];
     for await (const page of this._iterateContextGraphRegistryScanPages(
       registry,
       registryAddress,
-      fromBlock,
       scanPlan,
     )) {
       results.push(...page.contextGraphs);
@@ -323,50 +296,95 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     return results;
   }
 
+  private async _resolveContextGraphRegistryScanRange(
+    registryAddress: string,
+    startPolicy: ContextGraphRegistryScanStart,
+  ) {
+    const scanLabel = 'listContextGraphsFromChain';
+    if (startPolicy.kind === 'explicit') {
+      return {
+        start: startPolicy.fromBlock,
+        ...(await this.resolveLogScanHead(scanLabel)),
+        degradedFromGenesis: false,
+      };
+    }
+
+    if (startPolicy.kind === 'historicalCursor') {
+      const watermark = await this.contextGraphRegistryScanCursor.loadWatermark(registryAddress);
+      if (watermark !== undefined) {
+        return {
+          start: Math.max(0, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS),
+          ...(await this.resolveLogScanHead(scanLabel)),
+          degradedFromGenesis: false,
+        };
+      }
+    }
+
+    if (startPolicy.kind === 'tipCursor') {
+      const tip = await this.resolveLogScanHead(scanLabel);
+      const watermark = await this.contextGraphRegistryTipScanCursor.loadWatermark(registryAddress);
+      return {
+        ...tip,
+        start: watermark === undefined
+          ? Math.max(0, tip.head - this.cgRegistryScanPageSize + 1)
+          : Math.max(0, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS),
+        degradedFromGenesis: false,
+      };
+    }
+
+    const deployment = await this.resolveContractDeployBlock(
+      registryAddress,
+      scanLabel,
+      'ContextGraphNameRegistry',
+    );
+    const { fromBlock, ...resolved } = deployment;
+    return { start: fromBlock, ...resolved };
+  }
+
+  private async _saveContextGraphRegistryScanProgress(
+    progress: ContextGraphRegistryScanProgress,
+    registryAddress: string,
+    nextBlock: number,
+  ): Promise<void> {
+    if (progress === 'historical') {
+      await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, nextBlock);
+    } else if (progress === 'tip') {
+      await this.contextGraphRegistryTipScanCursor.saveWatermark(registryAddress, nextBlock);
+    }
+  }
+
   private async *_iterateContextGraphRegistryScanPages(
     registry: Contract,
     registryAddress: string,
-    fromBlock: number | undefined,
     scanPlan: ContextGraphRegistryScanPlan,
   ): AsyncGenerator<ContextGraphRegistryScanPage, void, unknown> {
     const eventFilter = registry.filters.NameClaimed();
     const pageSize = this.cgRegistryScanPageSize;
-    const persistedWatermark = (scanPlan.resumeFromWatermark || scanPlan.seedAtEnd)
-      ? await this.contextGraphRegistryScanCursor.loadWatermark(registryAddress)
-      : undefined;
-    const canResumeFromWatermark = scanPlan.resumeFromWatermark && persistedWatermark !== undefined;
-    const scan =
-      fromBlock === undefined
-        ? canResumeFromWatermark
-          ? { fromBlock: 0, ...(await this.resolveLogScanHead('listContextGraphsFromChain')) }
-          : scanPlan.mode === 'tip'
-            ? await this.resolveLogScanHead('listContextGraphsFromChain').then((tipScan) => ({
-              ...tipScan,
-              fromBlock: Math.max(0, tipScan.head - pageSize + 1),
-              degradedFromGenesis: false,
-            }))
-          : await this.resolveContractDeployBlock(
-              registryAddress,
-              'listContextGraphsFromChain',
-              'ContextGraphNameRegistry',
-            )
-        : { fromBlock, ...(await this.resolveLogScanHead('listContextGraphsFromChain')) };
-    const { fromBlock: deployBlock, head, scanProviders, degradedFromGenesis = false } = scan;
-    const start = fromBlock ?? (
-      canResumeFromWatermark
-        ? Math.max(0, persistedWatermark - CG_REGISTRY_REORG_BUFFER_BLOCKS)
-        : deployBlock
-    );
+    // A full recovery deliberately starts at deployment, but loading existing historical progress
+    // first preserves the cursor store's monotonic-write behavior while those old pages are acked.
+    if (scanPlan.progress === 'historical' && scanPlan.start.kind === 'deployment') {
+      await this.contextGraphRegistryScanCursor.loadWatermark(registryAddress);
+    }
+    const {
+      start,
+      head,
+      scanProviders,
+      degradedFromGenesis = false,
+    } = await this._resolveContextGraphRegistryScanRange(registryAddress, scanPlan.start);
     if (start > head) {
       if (scanPlan.seedAtEnd) {
-        await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, head + 1);
+        await this._saveContextGraphRegistryScanProgress(
+          scanPlan.progress,
+          registryAddress,
+          head + 1,
+        );
       }
       return;
     }
 
     const pages = Math.ceil((head - start + 1) / pageSize);
     const blockBudget = CG_REGISTRY_MAX_SCAN_PAGES * pageSize;
-    if (scanPlan.mode === 'incremental' && scanPlan.pageBudget === undefined && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
+    if (scanPlan.enforceDefaultPageLimit && scanPlan.pageBudget === undefined && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
       throw new Error(
         `listContextGraphsFromChain: incremental ContextGraphNameRegistry scan would need ` +
           `${pages} eth_getLogs calls over blocks [${start}, ${head}] at a ` +
@@ -433,9 +451,13 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
       scannedAnyPage = true;
       yield {
         contextGraphs: pageResults,
-        ack: scanPlan.persistProgress
+        ack: scanPlan.progress !== 'none'
           ? async () => {
-              await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, hi + 1);
+              await this._saveContextGraphRegistryScanProgress(
+                scanPlan.progress,
+                registryAddress,
+                hi + 1,
+              );
             }
           : async () => {},
       };

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -21,22 +21,27 @@ import { ethers, Contract, type JsonRpcProvider } from 'ethers';
 import { ContextGraphChainScanPartialError, type ChainReadOptions, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type ContextGraphRegistryScanOptions, type ContextGraphRegistryScanPage, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
 
-type ContextGraphRegistryScanStart =
+type StatelessContextGraphRegistryScanStart =
   | { kind: 'explicit'; fromBlock: number }
-  | { kind: 'deployment' }
-  | { kind: 'historicalCursor' }
-  | { kind: 'tipCursor' };
+  | { kind: 'deployment' };
 
-type ContextGraphRegistryScanProgress = 'none' | 'historical' | 'tip';
-
-interface ContextGraphRegistryScanPlan {
-  start: ContextGraphRegistryScanStart;
-  progress: ContextGraphRegistryScanProgress;
-  allowPartialFailure: boolean;
-  seedAtEnd: boolean;
-  enforceDefaultPageLimit: boolean;
-  pageBudget?: number;
-}
+type ContextGraphRegistryScanPlan =
+  | {
+      kind: 'stateless';
+      start: StatelessContextGraphRegistryScanStart;
+    }
+  | {
+      kind: 'historicalIncremental';
+      pageBudget?: number;
+    }
+  | {
+      kind: 'historicalSeed';
+      start: 'deployment' | 'cursor';
+      pageBudget?: number;
+    }
+  | {
+      kind: 'tip';
+    };
 
 function normalizePageBudget(value: number | undefined): number | undefined {
   return Number.isFinite(value) && (value ?? 0) >= 1
@@ -55,21 +60,14 @@ function buildPublicContextGraphRegistryScanPlan(
 
   if (fromBlock !== undefined) {
     return {
+      kind: 'stateless',
       start: { kind: 'explicit', fromBlock },
-      progress: 'none',
-      allowPartialFailure: false,
-      seedAtEnd: false,
-      enforceDefaultPageLimit: false,
     };
   }
 
   if (runtimeOptions && 'incremental' in runtimeOptions && runtimeOptions.incremental === true) {
     return {
-      start: { kind: 'historicalCursor' },
-      progress: 'historical',
-      allowPartialFailure: true,
-      seedAtEnd: false,
-      enforceDefaultPageLimit: true,
+      kind: 'historicalIncremental',
       pageBudget: normalizePageBudget(runtimeOptions.pageBudget),
     };
   }
@@ -81,20 +79,14 @@ function buildPublicContextGraphRegistryScanPlan(
   ) {
     if (runtimeOptions.resumeFromCursor === true) {
       return {
-        start: { kind: 'historicalCursor' },
-        progress: 'historical',
-        allowPartialFailure: true,
-        seedAtEnd: true,
-        enforceDefaultPageLimit: false,
+        kind: 'historicalSeed',
+        start: 'cursor',
         pageBudget: normalizePageBudget(runtimeOptions.pageBudget),
       };
     }
     return {
-      start: { kind: 'deployment' },
-      progress: 'historical',
-      allowPartialFailure: true,
-      seedAtEnd: true,
-      enforceDefaultPageLimit: false,
+      kind: 'historicalSeed',
+      start: 'deployment',
     };
   }
 
@@ -106,11 +98,8 @@ function buildPublicContextGraphRegistryScanPlan(
   }
 
   return {
+    kind: 'stateless',
     start: { kind: 'deployment' },
-    progress: 'none',
-    allowPartialFailure: false,
-    seedAtEnd: false,
-    enforceDefaultPageLimit: false,
   };
 }
 
@@ -119,42 +108,26 @@ function buildCursorContextGraphRegistryScanPlan(
 ): ContextGraphRegistryScanPlan {
   if (options.mode === 'incremental') {
     return {
-      start: { kind: 'historicalCursor' },
-      progress: 'historical',
-      allowPartialFailure: true,
-      seedAtEnd: false,
-      enforceDefaultPageLimit: true,
+      kind: 'historicalIncremental',
       pageBudget: normalizePageBudget(options.pageBudget),
     };
   }
 
   if (options.mode === 'tip') {
-    return {
-      start: { kind: 'tipCursor' },
-      progress: 'tip',
-      allowPartialFailure: true,
-      seedAtEnd: false,
-      enforceDefaultPageLimit: false,
-    };
+    return { kind: 'tip' };
   }
 
   if (options?.mode === 'seedFull') {
     return {
-      start: { kind: 'deployment' },
-      progress: 'historical',
-      allowPartialFailure: true,
-      seedAtEnd: true,
-      enforceDefaultPageLimit: false,
+      kind: 'historicalSeed',
+      start: 'deployment',
     };
   }
 
   if (options?.mode === 'seedFromCursor') {
     return {
-      start: { kind: 'historicalCursor' },
-      progress: 'historical',
-      allowPartialFailure: true,
-      seedAtEnd: true,
-      enforceDefaultPageLimit: false,
+      kind: 'historicalSeed',
+      start: 'cursor',
       pageBudget: normalizePageBudget(options.pageBudget),
     };
   }
@@ -298,18 +271,19 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
 
   private async _resolveContextGraphRegistryScanRange(
     registryAddress: string,
-    startPolicy: ContextGraphRegistryScanStart,
+    scanPlan: ContextGraphRegistryScanPlan,
   ) {
     const scanLabel = 'listContextGraphsFromChain';
-    if (startPolicy.kind === 'explicit') {
-      return {
-        start: startPolicy.fromBlock,
-        ...(await this.resolveLogScanHead(scanLabel)),
-        degradedFromGenesis: false,
-      };
-    }
-
-    if (startPolicy.kind === 'historicalCursor') {
+    const resolveDeployment = async () => {
+      const deployment = await this.resolveContractDeployBlock(
+        registryAddress,
+        scanLabel,
+        'ContextGraphNameRegistry',
+      );
+      const { fromBlock, ...resolved } = deployment;
+      return { start: fromBlock, ...resolved };
+    };
+    const resolveHistoricalCursor = async () => {
       const watermark = await this.contextGraphRegistryScanCursor.loadWatermark(registryAddress);
       if (watermark !== undefined) {
         return {
@@ -318,38 +292,71 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           degradedFromGenesis: false,
         };
       }
-    }
+      return resolveDeployment();
+    };
 
-    if (startPolicy.kind === 'tipCursor') {
-      const tip = await this.resolveLogScanHead(scanLabel);
-      const watermark = await this.contextGraphRegistryTipScanCursor.loadWatermark(registryAddress);
-      return {
-        ...tip,
-        start: watermark === undefined
+    switch (scanPlan.kind) {
+      case 'stateless':
+        return scanPlan.start.kind === 'explicit'
+          ? {
+              start: scanPlan.start.fromBlock,
+              ...(await this.resolveLogScanHead(scanLabel)),
+              degradedFromGenesis: false,
+            }
+          : resolveDeployment();
+      case 'historicalIncremental':
+        return resolveHistoricalCursor();
+      case 'historicalSeed':
+        return scanPlan.start === 'cursor'
+          ? resolveHistoricalCursor()
+          : resolveDeployment();
+      case 'tip': {
+        const tip = await this.resolveLogScanHead(scanLabel);
+        const watermark = await this.contextGraphRegistryTipScanCursor.loadWatermark(registryAddress);
+        const start = watermark === undefined
           ? Math.max(0, tip.head - this.cgRegistryScanPageSize + 1)
-          : Math.max(0, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS),
-        degradedFromGenesis: false,
-      };
+          : Math.max(0, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS);
+        if (watermark === undefined) {
+          // Persist the conservative lower bound before the first query. A failed first page then
+          // restarts from this attempted range rather than jumping to a newer tip page.
+          // Cursor storage uses positive integers; marker 1 still replays block 0 through overlap.
+          await this.contextGraphRegistryTipScanCursor.saveWatermark(
+            registryAddress,
+            Math.max(1, start),
+          );
+        }
+        return {
+          ...tip,
+          start,
+          degradedFromGenesis: false,
+        };
+      }
+      default: {
+        const exhaustive: never = scanPlan;
+        throw new Error(`Unsupported ContextGraphNameRegistry scan plan: ${JSON.stringify(exhaustive)}`);
+      }
     }
-
-    const deployment = await this.resolveContractDeployBlock(
-      registryAddress,
-      scanLabel,
-      'ContextGraphNameRegistry',
-    );
-    const { fromBlock, ...resolved } = deployment;
-    return { start: fromBlock, ...resolved };
   }
 
   private async _saveContextGraphRegistryScanProgress(
-    progress: ContextGraphRegistryScanProgress,
+    scanPlan: ContextGraphRegistryScanPlan,
     registryAddress: string,
     nextBlock: number,
   ): Promise<void> {
-    if (progress === 'historical') {
-      await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, nextBlock);
-    } else if (progress === 'tip') {
-      await this.contextGraphRegistryTipScanCursor.saveWatermark(registryAddress, nextBlock);
+    switch (scanPlan.kind) {
+      case 'stateless':
+        return;
+      case 'tip':
+        await this.contextGraphRegistryTipScanCursor.saveWatermark(registryAddress, nextBlock);
+        return;
+      case 'historicalIncremental':
+      case 'historicalSeed':
+        await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, nextBlock);
+        return;
+      default: {
+        const exhaustive: never = scanPlan;
+        throw new Error(`Unsupported ContextGraphNameRegistry progress plan: ${JSON.stringify(exhaustive)}`);
+      }
     }
   }
 
@@ -362,7 +369,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const pageSize = this.cgRegistryScanPageSize;
     // A full recovery deliberately starts at deployment, but loading existing historical progress
     // first preserves the cursor store's monotonic-write behavior while those old pages are acked.
-    if (scanPlan.progress === 'historical' && scanPlan.start.kind === 'deployment') {
+    if (scanPlan.kind === 'historicalSeed' && scanPlan.start === 'deployment') {
       await this.contextGraphRegistryScanCursor.loadWatermark(registryAddress);
     }
     const {
@@ -370,11 +377,11 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
       head,
       scanProviders,
       degradedFromGenesis = false,
-    } = await this._resolveContextGraphRegistryScanRange(registryAddress, scanPlan.start);
+    } = await this._resolveContextGraphRegistryScanRange(registryAddress, scanPlan);
     if (start > head) {
-      if (scanPlan.seedAtEnd) {
+      if (scanPlan.kind === 'historicalSeed') {
         await this._saveContextGraphRegistryScanProgress(
-          scanPlan.progress,
+          scanPlan,
           registryAddress,
           head + 1,
         );
@@ -384,7 +391,8 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
 
     const pages = Math.ceil((head - start + 1) / pageSize);
     const blockBudget = CG_REGISTRY_MAX_SCAN_PAGES * pageSize;
-    if (scanPlan.enforceDefaultPageLimit && scanPlan.pageBudget === undefined && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
+    const pageBudget = 'pageBudget' in scanPlan ? scanPlan.pageBudget : undefined;
+    if (scanPlan.kind === 'historicalIncremental' && pageBudget === undefined && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
       throw new Error(
         `listContextGraphsFromChain: incremental ContextGraphNameRegistry scan would need ` +
           `${pages} eth_getLogs calls over blocks [${start}, ${head}] at a ` +
@@ -431,7 +439,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           });
         }
       } catch (err) {
-        if (scanPlan.allowPartialFailure && scannedAnyPage) {
+        if (scanPlan.kind !== 'stateless' && scannedAnyPage) {
           const message = err instanceof Error ? err.message : String(err);
           throw new ContextGraphChainScanPartialError(
             `listContextGraphsFromChain: partial ContextGraphNameRegistry scan ` +
@@ -451,10 +459,10 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
       scannedAnyPage = true;
       yield {
         contextGraphs: pageResults,
-        ack: scanPlan.progress !== 'none'
+        ack: scanPlan.kind !== 'stateless'
           ? async () => {
               await this._saveContextGraphRegistryScanProgress(
-                scanPlan.progress,
+                scanPlan,
                 registryAddress,
                 hi + 1,
               );
@@ -462,7 +470,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           : async () => {},
       };
       const scannedPages = Math.floor((hi - start) / pageSize) + 1;
-      if (scanPlan.pageBudget !== undefined && scannedPages >= scanPlan.pageBudget && hi < head) return;
+      if (pageBudget !== undefined && scannedPages >= pageBudget && hi < head) return;
     }
   }
 

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -22,6 +22,7 @@ import {
   buildCursorContextGraphRegistryScanPlan,
   buildPublicContextGraphRegistryScanPlan,
 } from './context-graph-registry-scanner.js';
+import { EvmEventLogPageSession } from './evm-event-log-page-session.js';
 
 export class ContextGraphMethods extends EVMChainAdapterBase {
   /**
@@ -160,17 +161,19 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         'ContextGraphNameRegistry',
       ),
       resolveHead: () => this.resolveLogScanHead(scanLabel),
-      queryPage: (filter, lo, hi, scanProviders, connected, preferred) =>
-        this.queryEventLogsPage(
+      createPageSession: (scanProviders) => new EvmEventLogPageSession(
+        scanProviders,
+        (filter, lo, hi, providers, connected, preferred) => this.queryEventLogsPage(
           registry,
           filter,
           lo,
           hi,
-          scanProviders,
+          providers,
           connected,
           'listContextGraphsFromChain NameClaimed',
           preferred,
         ),
+      ),
     });
   }
   // =====================================================================

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -113,7 +113,9 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const registry = this.contracts.contextGraphNameRegistry;
     if (!registry) return false;
     const registryAddress = (await registry.getAddress()).toLowerCase();
-    return (await this.contextGraphRegistryScanCursor.loadWatermark(registryAddress)) != null;
+    return (
+      await this.contextGraphRegistryScanCursor.loadBestEffortWatermark(registryAddress)
+    ) != null;
   }
 
   async listContextGraphsFromChain(

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -43,6 +43,18 @@ type ContextGraphRegistryScanPlan =
       kind: 'tip';
     };
 
+type PreparedContextGraphRegistryScan = {
+  start: number;
+  head: number;
+  scanProviders: ReadonlyArray<{ provider: JsonRpcProvider; backendHead: number }>;
+  degradedFromGenesis: boolean;
+  pageBudget?: number;
+  enforceDefaultPageLimit: boolean;
+  partialFailures: boolean;
+  advanceOnEmpty: boolean;
+  acknowledge(nextBlock: number): Promise<void>;
+};
+
 function normalizePageBudget(value: number | undefined): number | undefined {
   return Number.isFinite(value) && (value ?? 0) >= 1
     ? Math.floor(value ?? 0)
@@ -269,10 +281,10 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     return results;
   }
 
-  private async _resolveContextGraphRegistryScanRange(
+  private async _prepareContextGraphRegistryScan(
     registryAddress: string,
     scanPlan: ContextGraphRegistryScanPlan,
-  ) {
+  ): Promise<PreparedContextGraphRegistryScan> {
     const scanLabel = 'listContextGraphsFromChain';
     const resolveDeployment = async () => {
       const deployment = await this.resolveContractDeployBlock(
@@ -294,25 +306,73 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
       }
       return resolveDeployment();
     };
+    const historicalAcknowledge = (nextBlock: number) =>
+      this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, nextBlock);
+    const tipAcknowledge = (nextBlock: number) =>
+      this.contextGraphRegistryTipScanCursor.saveWatermark(registryAddress, nextBlock);
+    const noAcknowledge = async () => {};
 
     switch (scanPlan.kind) {
-      case 'stateless':
-        return scanPlan.start.kind === 'explicit'
+      case 'stateless': {
+        const range = scanPlan.start.kind === 'explicit'
           ? {
               start: scanPlan.start.fromBlock,
               ...(await this.resolveLogScanHead(scanLabel)),
               degradedFromGenesis: false,
             }
-          : resolveDeployment();
-      case 'historicalIncremental':
-        return resolveHistoricalCursor();
-      case 'historicalSeed':
-        return scanPlan.start === 'cursor'
+          : await resolveDeployment();
+        return {
+          ...range,
+          degradedFromGenesis: range.degradedFromGenesis ?? false,
+          enforceDefaultPageLimit: false,
+          partialFailures: false,
+          advanceOnEmpty: false,
+          acknowledge: noAcknowledge,
+        };
+      }
+      case 'historicalIncremental': {
+        const range = await resolveHistoricalCursor();
+        return {
+          ...range,
+          degradedFromGenesis: range.degradedFromGenesis ?? false,
+          pageBudget: scanPlan.pageBudget,
+          enforceDefaultPageLimit: true,
+          partialFailures: true,
+          advanceOnEmpty: false,
+          acknowledge: historicalAcknowledge,
+        };
+      }
+      case 'historicalSeed': {
+        if (scanPlan.start === 'deployment') {
+          // Preserve monotonic store behavior while a full recovery replays old pages.
+          await this.contextGraphRegistryScanCursor.loadWatermark(registryAddress);
+        }
+        const range = await (scanPlan.start === 'cursor'
           ? resolveHistoricalCursor()
-          : resolveDeployment();
+          : resolveDeployment());
+        return {
+          ...range,
+          degradedFromGenesis: range.degradedFromGenesis ?? false,
+          pageBudget: scanPlan.pageBudget,
+          enforceDefaultPageLimit: false,
+          partialFailures: true,
+          advanceOnEmpty: true,
+          acknowledge: historicalAcknowledge,
+        };
+      }
       case 'tip': {
         const tip = await this.resolveLogScanHead(scanLabel);
-        const watermark = await this.contextGraphRegistryTipScanCursor.loadWatermark(registryAddress);
+        const loaded = await this.contextGraphRegistryTipScanCursor.loadWatermarkResult(
+          registryAddress,
+        );
+        if (loaded.status === 'failed') {
+          throw new Error(
+            'listContextGraphsFromChain: tip cursor load failed; refusing to initialize from ' +
+              'the current head because persisted progress may exist',
+            { cause: loaded.error },
+          );
+        }
+        const watermark = loaded.watermark;
         const start = watermark === undefined
           ? Math.max(0, tip.head - this.cgRegistryScanPageSize + 1)
           : Math.max(0, watermark - CG_REGISTRY_REORG_BUFFER_BLOCKS);
@@ -329,33 +389,15 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           ...tip,
           start,
           degradedFromGenesis: false,
+          enforceDefaultPageLimit: false,
+          partialFailures: true,
+          advanceOnEmpty: false,
+          acknowledge: tipAcknowledge,
         };
       }
       default: {
         const exhaustive: never = scanPlan;
         throw new Error(`Unsupported ContextGraphNameRegistry scan plan: ${JSON.stringify(exhaustive)}`);
-      }
-    }
-  }
-
-  private async _saveContextGraphRegistryScanProgress(
-    scanPlan: ContextGraphRegistryScanPlan,
-    registryAddress: string,
-    nextBlock: number,
-  ): Promise<void> {
-    switch (scanPlan.kind) {
-      case 'stateless':
-        return;
-      case 'tip':
-        await this.contextGraphRegistryTipScanCursor.saveWatermark(registryAddress, nextBlock);
-        return;
-      case 'historicalIncremental':
-      case 'historicalSeed':
-        await this.contextGraphRegistryScanCursor.saveWatermark(registryAddress, nextBlock);
-        return;
-      default: {
-        const exhaustive: never = scanPlan;
-        throw new Error(`Unsupported ContextGraphNameRegistry progress plan: ${JSON.stringify(exhaustive)}`);
       }
     }
   }
@@ -367,32 +409,25 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
   ): AsyncGenerator<ContextGraphRegistryScanPage, void, unknown> {
     const eventFilter = registry.filters.NameClaimed();
     const pageSize = this.cgRegistryScanPageSize;
-    // A full recovery deliberately starts at deployment, but loading existing historical progress
-    // first preserves the cursor store's monotonic-write behavior while those old pages are acked.
-    if (scanPlan.kind === 'historicalSeed' && scanPlan.start === 'deployment') {
-      await this.contextGraphRegistryScanCursor.loadWatermark(registryAddress);
-    }
     const {
       start,
       head,
       scanProviders,
-      degradedFromGenesis = false,
-    } = await this._resolveContextGraphRegistryScanRange(registryAddress, scanPlan);
+      degradedFromGenesis,
+      pageBudget,
+      enforceDefaultPageLimit,
+      partialFailures,
+      advanceOnEmpty,
+      acknowledge,
+    } = await this._prepareContextGraphRegistryScan(registryAddress, scanPlan);
     if (start > head) {
-      if (scanPlan.kind === 'historicalSeed') {
-        await this._saveContextGraphRegistryScanProgress(
-          scanPlan,
-          registryAddress,
-          head + 1,
-        );
-      }
+      if (advanceOnEmpty) await acknowledge(head + 1);
       return;
     }
 
     const pages = Math.ceil((head - start + 1) / pageSize);
     const blockBudget = CG_REGISTRY_MAX_SCAN_PAGES * pageSize;
-    const pageBudget = 'pageBudget' in scanPlan ? scanPlan.pageBudget : undefined;
-    if (scanPlan.kind === 'historicalIncremental' && pageBudget === undefined && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
+    if (enforceDefaultPageLimit && pageBudget === undefined && !degradedFromGenesis && pages > CG_REGISTRY_MAX_SCAN_PAGES) {
       throw new Error(
         `listContextGraphsFromChain: incremental ContextGraphNameRegistry scan would need ` +
           `${pages} eth_getLogs calls over blocks [${start}, ${head}] at a ` +
@@ -439,7 +474,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           });
         }
       } catch (err) {
-        if (scanPlan.kind !== 'stateless' && scannedAnyPage) {
+        if (partialFailures && scannedAnyPage) {
           const message = err instanceof Error ? err.message : String(err);
           throw new ContextGraphChainScanPartialError(
             `listContextGraphsFromChain: partial ContextGraphNameRegistry scan ` +
@@ -459,15 +494,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
       scannedAnyPage = true;
       yield {
         contextGraphs: pageResults,
-        ack: scanPlan.kind !== 'stateless'
-          ? async () => {
-              await this._saveContextGraphRegistryScanProgress(
-                scanPlan,
-                registryAddress,
-                hi + 1,
-              );
-            }
-          : async () => {},
+        ack: () => acknowledge(hi + 1),
       };
       const scannedPages = Math.floor((hi - start) / pageSize) + 1;
       if (pageBudget !== undefined && scannedPages >= pageBudget && hi < head) return;

--- a/packages/chain/src/evm-adapter-types.ts
+++ b/packages/chain/src/evm-adapter-types.ts
@@ -8,7 +8,7 @@
 import { Contract } from 'ethers';
 import type {
   ApprovalPolicy,
-  ContextGraphRegistryScanCursorStoreConfig,
+  ContextGraphRegistryScanCursorStore,
 } from './chain-adapter.js';
 
 export interface EVMAdapterBaseConfig {
@@ -95,11 +95,12 @@ export interface EVMAdapterBaseConfig {
    */
   cgRegistryScanPageSize?: number;
   /**
-   * Optional durable cursor for daemon ContextGraphNameRegistry discovery scans. The original
-   * raw-store form remains historical-only. Tagged roleAware or split legacy forms additionally
-   * configure independent tip persistence. The adapter normalizes all forms at construction.
+   * Original durable historical cursor for daemon ContextGraphNameRegistry discovery scans.
+   * The exact three-field key contract remains unchanged.
    */
-  contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStoreConfig;
+  contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStore;
+  /** Independent durable tip cursor. Omit to keep tip progress process-local. */
+  contextGraphRegistryTipScanCursorStore?: ContextGraphRegistryScanCursorStore;
   /**
    * Funding-aware publish wallet selection: minimum NATIVE gas balance (wei) an
    * operational wallet must hold to be PREFERRED when selecting the publish

--- a/packages/chain/src/evm-adapter-types.ts
+++ b/packages/chain/src/evm-adapter-types.ts
@@ -8,8 +8,7 @@
 import { Contract } from 'ethers';
 import type {
   ApprovalPolicy,
-  ContextGraphRegistryScanCursorPersistence,
-  ContextGraphRegistryScanCursorStore,
+  ContextGraphRegistryScanCursorStoreConfig,
 } from './chain-adapter.js';
 
 export interface EVMAdapterBaseConfig {
@@ -96,17 +95,11 @@ export interface EVMAdapterBaseConfig {
    */
   cgRegistryScanPageSize?: number;
   /**
-   * Optional durable cursor for daemon ContextGraphNameRegistry discovery scans.
-   * The adapter still keeps an in-memory mirror; this store lets process
-   * restarts resume from the last successfully covered prefix instead of
-   * repeating a historical `eth_getLogs` walk.
+   * Optional durable cursor for daemon ContextGraphNameRegistry discovery scans. The original
+   * raw-store form remains historical-only. Tagged roleAware or split legacy forms additionally
+   * configure independent tip persistence. The adapter normalizes all forms at construction.
    */
-  contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStore;
-  /**
-   * Explicit role-aware or split legacy persistence. When supplied, this takes precedence over
-   * contextGraphRegistryScanCursorStore and defines both historical and tip ownership.
-   */
-  contextGraphRegistryScanCursorPersistence?: ContextGraphRegistryScanCursorPersistence;
+  contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStoreConfig;
   /**
    * Funding-aware publish wallet selection: minimum NATIVE gas balance (wei) an
    * operational wallet must hold to be PREFERRED when selecting the publish

--- a/packages/chain/src/evm-adapter-types.ts
+++ b/packages/chain/src/evm-adapter-types.ts
@@ -99,6 +99,11 @@ export interface EVMAdapterBaseConfig {
    */
   contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStore;
   /**
+   * Optional dedicated tip-progress store for compatibility with legacy role-less historical
+   * stores. When omitted, the historical store is shared only if it advertises cursor key v2.
+   */
+  contextGraphRegistryTipScanCursorStore?: ContextGraphRegistryScanCursorStore;
+  /**
    * Funding-aware publish wallet selection: minimum NATIVE gas balance (wei) an
    * operational wallet must hold to be PREFERRED when selecting the publish
    * signer. Default `0n` (strictly-positive: a wallet at exactly zero gas is

--- a/packages/chain/src/evm-adapter-types.ts
+++ b/packages/chain/src/evm-adapter-types.ts
@@ -8,6 +8,7 @@
 import { Contract } from 'ethers';
 import type {
   ApprovalPolicy,
+  ContextGraphRegistryRoleAwareScanCursorStore,
   ContextGraphRegistryScanCursorStore,
 } from './chain-adapter.js';
 
@@ -95,12 +96,12 @@ export interface EVMAdapterBaseConfig {
    */
   cgRegistryScanPageSize?: number;
   /**
-   * Original durable historical cursor for daemon ContextGraphNameRegistry discovery scans.
-   * The exact three-field key contract remains unchanged.
+   * Original durable historical cursor retained for compatibility. Prefer the
+   * role-aware store below for independently durable historical and tip scans.
    */
   contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStore;
-  /** Independent durable tip cursor. Omit to keep tip progress process-local. */
-  contextGraphRegistryTipScanCursorStore?: ContextGraphRegistryScanCursorStore;
+  /** Canonical durable store whose keys encode independent historical and tip roles. */
+  contextGraphRegistryRoleAwareScanCursorStore?: ContextGraphRegistryRoleAwareScanCursorStore;
   /**
    * Funding-aware publish wallet selection: minimum NATIVE gas balance (wei) an
    * operational wallet must hold to be PREFERRED when selecting the publish

--- a/packages/chain/src/evm-adapter-types.ts
+++ b/packages/chain/src/evm-adapter-types.ts
@@ -6,7 +6,11 @@
  * evm-adapter.ts. Bodies are a 1:1 move from the original module.
  */
 import { Contract } from 'ethers';
-import type { ApprovalPolicy, ContextGraphRegistryScanCursorStore } from './chain-adapter.js';
+import type {
+  ApprovalPolicy,
+  ContextGraphRegistryScanCursorPersistence,
+  ContextGraphRegistryScanCursorStore,
+} from './chain-adapter.js';
 
 export interface EVMAdapterBaseConfig {
   rpcUrl: string;
@@ -99,10 +103,10 @@ export interface EVMAdapterBaseConfig {
    */
   contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStore;
   /**
-   * Optional dedicated tip-progress store for compatibility with legacy role-less historical
-   * stores. When omitted, the historical store is shared only if it advertises cursor key v2.
+   * Explicit role-aware or split legacy persistence. When supplied, this takes precedence over
+   * contextGraphRegistryScanCursorStore and defines both historical and tip ownership.
    */
-  contextGraphRegistryTipScanCursorStore?: ContextGraphRegistryScanCursorStore;
+  contextGraphRegistryScanCursorPersistence?: ContextGraphRegistryScanCursorPersistence;
   /**
    * Funding-aware publish wallet selection: minimum NATIVE gas balance (wei) an
    * operational wallet must hold to be PREFERRED when selecting the publish

--- a/packages/chain/src/evm-event-log-page-session.ts
+++ b/packages/chain/src/evm-event-log-page-session.ts
@@ -1,0 +1,56 @@
+import { Contract, ethers, type JsonRpcProvider } from 'ethers';
+
+/** One reachable RPC backend paired with the latest head it reported. */
+export type EvmEventLogScanProvider = {
+  provider: JsonRpcProvider;
+  backendHead: number;
+};
+
+type PageResult = {
+  logs: ReadonlyArray<ethers.EventLog | ethers.Log>;
+  provider: JsonRpcProvider;
+};
+
+type PageExecutor = (
+  filter: unknown,
+  lo: number,
+  hi: number,
+  scanProviders: ReadonlyArray<EvmEventLogScanProvider>,
+  connected: Map<JsonRpcProvider, Contract>,
+  preferred?: JsonRpcProvider,
+) => Promise<PageResult>;
+
+export interface EvmEventLogPageReader {
+  query(filter: unknown, lo: number, hi: number): Promise<ReadonlyArray<ethers.EventLog | ethers.Log>>;
+}
+
+/**
+ * One paging session owns provider affinity and connected contract bindings.
+ * Domain scanners see only a narrow page query and cannot leak RPC internals.
+ */
+export class EvmEventLogPageSession implements EvmEventLogPageReader {
+  private readonly connected = new Map<JsonRpcProvider, Contract>();
+  private preferred: JsonRpcProvider | undefined;
+
+  constructor(
+    private readonly scanProviders: ReadonlyArray<EvmEventLogScanProvider>,
+    private readonly execute: PageExecutor,
+  ) {}
+
+  async query(
+    filter: unknown,
+    lo: number,
+    hi: number,
+  ): Promise<ReadonlyArray<ethers.EventLog | ethers.Log>> {
+    const page = await this.execute(
+      filter,
+      lo,
+      hi,
+      this.scanProviders,
+      this.connected,
+      this.preferred,
+    );
+    this.preferred = page.provider;
+    return page.logs;
+  }
+}

--- a/packages/chain/test/context-graph-registry-scan-test-support.ts
+++ b/packages/chain/test/context-graph-registry-scan-test-support.ts
@@ -1,8 +1,7 @@
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
 import type {
   ContextGraphOnChain,
-  ContextGraphRegistryRoleAwareScanCursorKey,
-  ContextGraphRegistryRoleAwareScanCursorStore,
+  ContextGraphRegistryScanCursorKey,
   ContextGraphRegistryScanOptions,
 } from '../src/chain-adapter.js';
 
@@ -52,30 +51,48 @@ const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf
 const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
 export const REGISTRY = '0x3333333333333333333333333333333333333333';
 
-export class MemoryRegistryScanCursorStore implements ContextGraphRegistryRoleAwareScanCursorStore {
+type RoleAwareTestCursorKey = ContextGraphRegistryScanCursorKey & {
+  cursorKind: 'historical' | 'tip';
+};
+
+export class MemoryRegistryScanCursorStore {
   readonly values = new Map<string, number>();
   readonly loads: string[] = [];
   readonly saves: Array<{ key: string; nextBlock: number }> = [];
 
-  async load(key: ContextGraphRegistryRoleAwareScanCursorKey): Promise<number | undefined> {
+  async load(key: RoleAwareTestCursorKey): Promise<number | undefined> {
     const encoded = this.key(key);
     this.loads.push(encoded);
     return this.values.get(encoded);
   }
 
-  async save(key: ContextGraphRegistryRoleAwareScanCursorKey, nextBlock: number): Promise<void> {
+  async save(key: RoleAwareTestCursorKey, nextBlock: number): Promise<void> {
     const encoded = this.key(key);
     this.saves.push({ key: encoded, nextBlock });
     this.values.set(encoded, nextBlock);
   }
 
-  private key(key: ContextGraphRegistryRoleAwareScanCursorKey): string {
+  private key(key: RoleAwareTestCursorKey): string {
     return `${key.chainId}|${key.deploymentId}|${key.cursorKind}|${key.registryAddress.toLowerCase()}`;
   }
 }
 
-export function roleAwareRegistryCursorPersistence(store: ContextGraphRegistryRoleAwareScanCursorStore) {
-  return { kind: 'roleAware' as const, store };
+export function registryCursorStores(store: {
+  load(key: RoleAwareTestCursorKey): Promise<number | undefined>;
+  save(key: RoleAwareTestCursorKey, nextBlock: number): Promise<void>;
+}) {
+  return {
+    contextGraphRegistryScanCursorStore: {
+      load: (key: ContextGraphRegistryScanCursorKey) => store.load({ ...key, cursorKind: 'historical' }),
+      save: (key: ContextGraphRegistryScanCursorKey, nextBlock: number) =>
+        store.save({ ...key, cursorKind: 'historical' }, nextBlock),
+    },
+    contextGraphRegistryTipScanCursorStore: {
+      load: (key: ContextGraphRegistryScanCursorKey) => store.load({ ...key, cursorKind: 'tip' }),
+      save: (key: ContextGraphRegistryScanCursorKey, nextBlock: number) =>
+        store.save({ ...key, cursorKind: 'tip' }, nextBlock),
+    },
+  };
 }
 
 export function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterConfig {

--- a/packages/chain/test/context-graph-registry-scan-test-support.ts
+++ b/packages/chain/test/context-graph-registry-scan-test-support.ts
@@ -1,7 +1,8 @@
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
 import type {
   ContextGraphOnChain,
-  ContextGraphRegistryScanCursorKey,
+  ContextGraphRegistryRoleAwareScanCursorKey,
+  ContextGraphRegistryRoleAwareScanCursorStore,
   ContextGraphRegistryScanOptions,
 } from '../src/chain-adapter.js';
 
@@ -51,47 +52,38 @@ const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf
 const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
 export const REGISTRY = '0x3333333333333333333333333333333333333333';
 
-type RoleAwareTestCursorKey = ContextGraphRegistryScanCursorKey & {
-  cursorKind: 'historical' | 'tip';
-};
-
-export class MemoryRegistryScanCursorStore {
+export class MemoryRegistryScanCursorStore
+  implements ContextGraphRegistryRoleAwareScanCursorStore {
   readonly values = new Map<string, number>();
   readonly loads: string[] = [];
   readonly saves: Array<{ key: string; nextBlock: number }> = [];
 
-  async load(key: RoleAwareTestCursorKey): Promise<number | undefined> {
+  async load(key: ContextGraphRegistryRoleAwareScanCursorKey): Promise<number | undefined> {
     const encoded = this.key(key);
     this.loads.push(encoded);
     return this.values.get(encoded);
   }
 
-  async save(key: RoleAwareTestCursorKey, nextBlock: number): Promise<void> {
+  async save(
+    key: ContextGraphRegistryRoleAwareScanCursorKey,
+    nextBlock: number,
+  ): Promise<void> {
     const encoded = this.key(key);
     this.saves.push({ key: encoded, nextBlock });
     this.values.set(encoded, nextBlock);
   }
 
-  private key(key: RoleAwareTestCursorKey): string {
+  private key(key: ContextGraphRegistryRoleAwareScanCursorKey): string {
     return `${key.chainId}|${key.deploymentId}|${key.cursorKind}|${key.registryAddress.toLowerCase()}`;
   }
 }
 
 export function registryCursorStores(store: {
-  load(key: RoleAwareTestCursorKey): Promise<number | undefined>;
-  save(key: RoleAwareTestCursorKey, nextBlock: number): Promise<void>;
+  load(key: ContextGraphRegistryRoleAwareScanCursorKey): Promise<number | undefined>;
+  save(key: ContextGraphRegistryRoleAwareScanCursorKey, nextBlock: number): Promise<void>;
 }) {
   return {
-    contextGraphRegistryScanCursorStore: {
-      load: (key: ContextGraphRegistryScanCursorKey) => store.load({ ...key, cursorKind: 'historical' }),
-      save: (key: ContextGraphRegistryScanCursorKey, nextBlock: number) =>
-        store.save({ ...key, cursorKind: 'historical' }, nextBlock),
-    },
-    contextGraphRegistryTipScanCursorStore: {
-      load: (key: ContextGraphRegistryScanCursorKey) => store.load({ ...key, cursorKind: 'tip' }),
-      save: (key: ContextGraphRegistryScanCursorKey, nextBlock: number) =>
-        store.save({ ...key, cursorKind: 'tip' }, nextBlock),
-    },
+    contextGraphRegistryRoleAwareScanCursorStore: store,
   };
 }
 

--- a/packages/chain/test/context-graph-registry-scan-test-support.ts
+++ b/packages/chain/test/context-graph-registry-scan-test-support.ts
@@ -1,0 +1,144 @@
+import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
+import type {
+  ContextGraphOnChain,
+  ContextGraphRegistryRoleAwareScanCursorKey,
+  ContextGraphRegistryRoleAwareScanCursorStore,
+  ContextGraphRegistryScanOptions,
+} from '../src/chain-adapter.js';
+
+export function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
+  const calls: A[] = [];
+  const fn = (...args: A): R => {
+    calls.push(args);
+    return impl(...args);
+  };
+  return Object.assign(fn, { calls });
+}
+
+type OnceOutcome<R> = { type: 'return'; value: R } | { type: 'throw'; error: unknown };
+export function seam<A extends unknown[], R>(initialImpl: (...args: A) => R) {
+  const calls: A[] = [];
+  const queue: OnceOutcome<R>[] = [];
+  let impl = initialImpl;
+  const fn = (...args: A): R => {
+    calls.push(args);
+    if (queue.length > 0) {
+      const next = queue.shift() as OnceOutcome<R>;
+      if (next.type === 'throw') throw next.error;
+      return next.value;
+    }
+    return impl(...args);
+  };
+  return Object.assign(fn, {
+    calls,
+    setImpl(next: (...args: A) => R) {
+      impl = next;
+    },
+    queueOnce(outcome: OnceOutcome<R>) {
+      queue.push(outcome);
+    },
+    reset() {
+      calls.length = 0;
+      queue.length = 0;
+      impl = (() => undefined as unknown as R) as (...args: A) => R;
+    },
+    clear() {
+      calls.length = 0;
+    },
+  });
+}
+
+const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
+export const REGISTRY = '0x3333333333333333333333333333333333333333';
+
+export class MemoryRegistryScanCursorStore implements ContextGraphRegistryRoleAwareScanCursorStore {
+  readonly values = new Map<string, number>();
+  readonly loads: string[] = [];
+  readonly saves: Array<{ key: string; nextBlock: number }> = [];
+
+  async load(key: ContextGraphRegistryRoleAwareScanCursorKey): Promise<number | undefined> {
+    const encoded = this.key(key);
+    this.loads.push(encoded);
+    return this.values.get(encoded);
+  }
+
+  async save(key: ContextGraphRegistryRoleAwareScanCursorKey, nextBlock: number): Promise<void> {
+    const encoded = this.key(key);
+    this.saves.push({ key: encoded, nextBlock });
+    this.values.set(encoded, nextBlock);
+  }
+
+  private key(key: ContextGraphRegistryRoleAwareScanCursorKey): string {
+    return `${key.chainId}|${key.deploymentId}|${key.cursorKind}|${key.registryAddress.toLowerCase()}`;
+  }
+}
+
+export function roleAwareRegistryCursorPersistence(store: ContextGraphRegistryRoleAwareScanCursorStore) {
+  return { kind: 'roleAware' as const, store };
+}
+
+export function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterConfig {
+  return {
+    rpcUrl: 'http://127.0.0.1:59998',
+    privateKey: DEPLOYER_PK,
+    adminPrivateKey: ADMIN_PK,
+    hubAddress: '0x0000000000000000000000000000000000000001',
+    chainId: 'evm:31337',
+    staticNetwork: false,
+    ...overrides,
+  };
+}
+
+export function makeRegistry(overrides: Record<string, unknown> = {}) {
+  return {
+    getAddress: recorder(async () => REGISTRY),
+    filters: { NameClaimed: recorder(() => 'NameClaimedFilter') },
+    interface: {
+      parseLog: recorder(({ data }: { data: string }) => {
+        if (data === '0x01') {
+          return {
+            name: 'NameClaimed',
+            args: {
+              nameHash: '0xaaa0000000000000000000000000000000000000000000000000000000000001',
+              creator: '0x1111111111111111111111111111111111111111',
+              accessPolicy: 0,
+            },
+          };
+        }
+        return null;
+      }),
+    },
+    queryFilter: seam(async (_filter: unknown, _lo: number, _hi: number) => [] as unknown[]),
+    connect: recorder(() => undefined),
+    ...overrides,
+  } as any;
+}
+
+export function makeAdapter(registry: any, head = 0, config: Partial<EVMAdapterConfig> = {}) {
+  const adapter = new EVMChainAdapter(minimalConfig(config));
+  registry.connect = recorder(() => registry);
+  const provider = {
+    getBlockNumber: seam(async () => head),
+    getCode: seam(async (_address: string, block?: number) =>
+      block === undefined || block >= 0 ? '0x6000' : '0x',
+    ),
+  };
+  (adapter as any).contracts = { contextGraphNameRegistry: registry };
+  (adapter as any).initialized = true;
+  (adapter as any).provider = provider;
+  (adapter as any).providers = [provider];
+  return { adapter, provider };
+}
+
+export async function collectRegistryScan(
+  adapter: EVMChainAdapter,
+  options: ContextGraphRegistryScanOptions,
+): Promise<ContextGraphOnChain[]> {
+  const results: ContextGraphOnChain[] = [];
+  for await (const page of adapter.scanContextGraphRegistryPages(options)) {
+    results.push(...page.contextGraphs);
+    await page.ack();
+  }
+  return results;
+}

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -65,20 +65,20 @@ class MemoryRegistryScanCursorStore {
   readonly loads: string[] = [];
   readonly saves: Array<{ key: string; nextBlock: number }> = [];
 
-  async load(key: { chainId: string; deploymentId: string; registryAddress: string }): Promise<number | undefined> {
+  async load(key: { chainId: string; deploymentId: string; registryAddress: string; cursorKind: 'historical' | 'tip' }): Promise<number | undefined> {
     const encoded = this.key(key);
     this.loads.push(encoded);
     return this.values.get(encoded);
   }
 
-  async save(key: { chainId: string; deploymentId: string; registryAddress: string }, nextBlock: number): Promise<void> {
+  async save(key: { chainId: string; deploymentId: string; registryAddress: string; cursorKind: 'historical' | 'tip' }, nextBlock: number): Promise<void> {
     const encoded = this.key(key);
     this.saves.push({ key: encoded, nextBlock });
     this.values.set(encoded, nextBlock);
   }
 
-  private key(key: { chainId: string; deploymentId: string; registryAddress: string }): string {
-    return `${key.chainId}|${key.deploymentId}|${key.registryAddress.toLowerCase()}`;
+  private key(key: { chainId: string; deploymentId: string; registryAddress: string; cursorKind: 'historical' | 'tip' }): string {
+    return `${key.chainId}|${key.deploymentId}|${key.cursorKind}|${key.registryAddress.toLowerCase()}`;
   }
 }
 
@@ -306,6 +306,125 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
       [2_000, 3_999],
     ]);
     expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_000);
+  });
+
+  it('retains the first attempted tip range when its query fails before any acknowledgement', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    const registry = makeRegistry({
+      queryFilter: seam(async () => {
+        throw new Error('first tip page unavailable');
+      }),
+    });
+    const { adapter } = makeAdapter(registry, 10_000, {
+      contextGraphRegistryScanCursorStore: store,
+    });
+
+    await expect(collectRegistryScan(adapter, { mode: 'tip' }))
+      .rejects.toThrow('first tip page unavailable');
+    expect(store.saves.map((save) => save.nextBlock)).toEqual([8_001]);
+
+    const eventBlock = 10_001;
+    const head = 13_200;
+    registry.queryFilter.reset();
+    registry.queryFilter.setImpl(async (_filter: unknown, lo: number, hi: number) =>
+      lo <= eventBlock && eventBlock <= hi
+        ? [{ topics: [], data: '0x01', blockNumber: eventBlock }]
+        : [],
+    );
+    const { adapter: restarted } = makeAdapter(registry, head, {
+      contextGraphRegistryScanCursorStore: store,
+    });
+
+    const recovered = await collectRegistryScan(restarted, { mode: 'tip' });
+
+    expect(recovered.map((cg) => cg.blockNumber)).toEqual([eventBlock]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [7_951, 9_950],
+      [9_951, 11_950],
+      [11_951, 13_200],
+    ]);
+    expect(await restarted.hasContextGraphRegistryScanWatermark()).toBe(false);
+  });
+
+  it('retains the first tip lower bound in process when durable cursor persistence fails', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {
+        throw new Error('tip cursor save failed');
+      }),
+    };
+    let head = 10_000;
+    let firstQuery = true;
+    const eventBlock = 10_001;
+    const registry = makeRegistry({
+      queryFilter: seam(async (_filter: unknown, lo: number, hi: number) => {
+        if (firstQuery) {
+          firstQuery = false;
+          throw new Error('first tip page unavailable');
+        }
+        return lo <= eventBlock && eventBlock <= hi
+          ? [{ topics: [], data: '0x01', blockNumber: eventBlock }]
+          : [];
+      }),
+    });
+    const { adapter, provider } = makeAdapter(registry, head, {
+      contextGraphRegistryScanCursorStore: store,
+    });
+    provider.getBlockNumber.setImpl(async () => head);
+
+    try {
+      await expect(collectRegistryScan(adapter, { mode: 'tip' }))
+        .rejects.toThrow('first tip page unavailable');
+      expect((adapter as any).contextGraphRegistryTipScanCursor.getCachedWatermark(REGISTRY))
+        .toBe(8_001);
+
+      head = 13_200;
+      registry.queryFilter.clear();
+      const recovered = await collectRegistryScan(adapter, { mode: 'tip' });
+
+      expect(recovered.map((cg) => cg.blockNumber)).toEqual([eventBlock]);
+      expect(registry.queryFilter.calls[0]?.slice(1)).toEqual([7_951, 9_950]);
+      expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY))
+        .toBeUndefined();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('revisits a fetched tip page when local application never acknowledges it', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    const eventBlock = 9_999;
+    const registry = makeRegistry({
+      queryFilter: seam(async (_filter: unknown, lo: number, hi: number) =>
+        lo <= eventBlock && eventBlock <= hi
+          ? [{ topics: [], data: '0x01', blockNumber: eventBlock }]
+          : [],
+      ),
+    });
+    const { adapter } = makeAdapter(registry, 10_000, {
+      contextGraphRegistryScanCursorStore: store,
+    });
+    const iterator = adapter.scanContextGraphRegistryPages({ mode: 'tip' })[Symbol.asyncIterator]();
+
+    const fetched = await iterator.next();
+    expect(fetched.done).toBe(false);
+    expect(fetched.value?.contextGraphs.map((cg) => cg.blockNumber)).toEqual([eventBlock]);
+    await iterator.return?.();
+    expect(store.saves.map((save) => save.nextBlock)).toEqual([8_001]);
+
+    registry.queryFilter.clear();
+    const { adapter: restarted } = makeAdapter(registry, 10_000, {
+      contextGraphRegistryScanCursorStore: store,
+    });
+    const retried = await collectRegistryScan(restarted, { mode: 'tip' });
+
+    expect(retried.map((cg) => cg.blockNumber)).toEqual([eventBlock]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [7_951, 9_950],
+      [9_951, 10_000],
+    ]);
+    expect(await restarted.hasContextGraphRegistryScanWatermark()).toBe(false);
   });
 
   it('does not advance the incremental watermark when parsing a later page fails', async () => {
@@ -687,6 +806,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
       chainId: 'evm:31337',
       deploymentId: 'evm:31337:hub=0x0000000000000000000000000000000000000001',
       registryAddress: REGISTRY,
+      cursorKind: 'historical',
     }, 3_000);
 
     const registry = makeRegistry();
@@ -717,6 +837,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
       chainId: 'evm:31337',
       deploymentId: 'evm:31337:hub=0x0000000000000000000000000000000000000001',
       registryAddress: REGISTRY,
+      cursorKind: 'historical',
     }, 3_000);
     const registry = makeRegistry({
       queryFilter: seam(async (_filter: unknown, lo: number, hi: number) =>

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -87,7 +87,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const store = new MemoryRegistryScanCursorStore();
     const registry = makeRegistry();
     const { adapter } = makeAdapter(registry, 4_999, {
-      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
+      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
     });
     registry.queryFilter.queueOnce({
       type: 'return',
@@ -169,7 +169,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const registry = makeRegistry();
     const { adapter, provider } = makeAdapter(registry, 2_100, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
+      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
     });
     registry.queryFilter.setImpl(async () => []);
 
@@ -242,7 +242,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     });
     const { adapter } = makeAdapter(registry, 2_100, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
+      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
     });
 
     const seeded = await adapter.listContextGraphsFromChain(undefined, {
@@ -335,7 +335,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const registry = makeRegistry();
     const { adapter } = makeAdapter(registry, 5_000, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
+      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
     });
     registry.queryFilter.setImpl(async () => []);
 
@@ -353,7 +353,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const restartedRegistry = makeRegistry();
     const { adapter: restarted, provider } = makeAdapter(restartedRegistry, 5_000, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
+      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
     });
     provider.getCode = seam(async () => {
       throw new Error('deploy block probing should not run with persisted cursor');
@@ -380,7 +380,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     });
     const { adapter } = makeAdapter(registry, 2_100, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
+      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
     });
 
     const iterator = adapter.scanContextGraphRegistryPages({
@@ -397,7 +397,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const restartedRegistry = makeRegistry();
     const { adapter: restarted } = makeAdapter(restartedRegistry, 2_100, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
+      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
     });
     restartedRegistry.queryFilter.setImpl(async () => []);
 
@@ -492,7 +492,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const registry = makeRegistry();
     const { adapter, provider } = makeAdapter(registry, 5_000, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
+      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
     });
     provider.getCode = seam(async () => {
       throw new Error('deploy block probing should not run with persisted cursor');
@@ -528,7 +528,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     });
     const { adapter } = makeAdapter(registry, 3_500, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
+      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
     });
 
     const results = await collectRegistryScan(adapter, {
@@ -549,7 +549,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const store = new MemoryRegistryScanCursorStore();
     const seedRegistry = makeRegistry();
     const { adapter: seedAdapter } = makeAdapter(seedRegistry, 2_100, {
-      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
+      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
     });
     seedRegistry.queryFilter.setImpl(async () => []);
 
@@ -560,7 +560,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
 
     const publicRegistry = makeRegistry();
     const { adapter: publicAdapter } = makeAdapter(publicRegistry, 2_100, {
-      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
+      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
     });
     publicRegistry.queryFilter.setImpl(async () => []);
 
@@ -591,7 +591,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const store = new MemoryRegistryScanCursorStore();
     const registry = makeRegistry();
     const { adapter } = makeAdapter(registry, 4_000, {
-      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
+      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
     });
     registry.queryFilter.setImpl(async () => []);
 

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -61,6 +61,7 @@ const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab
 const REGISTRY = '0x3333333333333333333333333333333333333333';
 
 class MemoryRegistryScanCursorStore {
+  readonly cursorKeyVersion = 2 as const;
   readonly values = new Map<string, number>();
   readonly loads: string[] = [];
   readonly saves: Array<{ key: string; nextBlock: number }> = [];
@@ -79,6 +80,31 @@ class MemoryRegistryScanCursorStore {
 
   private key(key: { chainId: string; deploymentId: string; registryAddress: string; cursorKind: 'historical' | 'tip' }): string {
     return `${key.chainId}|${key.deploymentId}|${key.cursorKind}|${key.registryAddress.toLowerCase()}`;
+  }
+}
+
+class LegacyRolelessRegistryScanCursorStore {
+  readonly values = new Map<string, number>();
+  readonly loads: string[] = [];
+  readonly saves: Array<{ key: string; nextBlock: number }> = [];
+
+  async load(key: { chainId: string; deploymentId: string; registryAddress: string }): Promise<number | undefined> {
+    const encoded = this.key(key);
+    this.loads.push(encoded);
+    return this.values.get(encoded);
+  }
+
+  async save(
+    key: { chainId: string; deploymentId: string; registryAddress: string },
+    nextBlock: number,
+  ): Promise<void> {
+    const encoded = this.key(key);
+    this.saves.push({ key: encoded, nextBlock });
+    this.values.set(encoded, nextBlock);
+  }
+
+  private key(key: { chainId: string; deploymentId: string; registryAddress: string }): string {
+    return `${key.chainId}|${key.deploymentId}|${key.registryAddress.toLowerCase()}`;
   }
 }
 
@@ -305,7 +331,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
       [0, 1_999],
       [2_000, 3_999],
     ]);
-    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_000);
+    expect((restartedAdapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_000);
   });
 
   it('retains the first attempted tip range when its query fails before any acknowledgement', async () => {
@@ -346,9 +372,39 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     expect(await restarted.hasContextGraphRegistryScanWatermark()).toBe(false);
   });
 
+  it('never aliases tip progress through a legacy role-less historical cursor store', async () => {
+    const store = new LegacyRolelessRegistryScanCursorStore();
+    await store.save({
+      chainId: 'evm:31337',
+      deploymentId: 'evm:31337:hub=0x0000000000000000000000000000000000000001',
+      registryAddress: REGISTRY,
+    }, 2_000);
+    store.loads.length = 0;
+    store.saves.length = 0;
+    const registry = makeRegistry();
+    const { adapter } = makeAdapter(registry, 10_000, {
+      contextGraphRegistryScanCursorStore: store,
+    });
+    registry.queryFilter.setImpl(async () => []);
+
+    await collectRegistryScan(adapter, { mode: 'tip' });
+
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [8_001, 10_000],
+    ]);
+    expect(store.loads).toEqual([]);
+    expect(store.saves).toEqual([]);
+    expect((adapter as any).contextGraphRegistryTipScanCursor.getCachedWatermark(REGISTRY)).toBe(10_001);
+
+    await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(true);
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_000);
+    expect([...store.values.values()]).toEqual([2_000]);
+  });
+
   it('retains the first tip lower bound in process when durable cursor persistence fails', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const store = {
+      cursorKeyVersion: 2 as const,
       load: vi.fn(async () => undefined),
       save: vi.fn(async () => {
         throw new Error('tip cursor save failed');

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -640,7 +640,10 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
       throw new Error('eth_getCode should not be called');
     });
     registry.queryFilter.setImpl(async () => []);
-    await (adapter as any).contextGraphRegistryScanCursor.saveWatermark(REGISTRY, 2_050);
+    await (adapter as any).contextGraphRegistryScanCursor.saveBestEffortWatermark(
+      REGISTRY,
+      2_050,
+    );
 
     await collectRegistryScan(adapter, {
       mode: 'incremental',

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -1,177 +1,21 @@
 import { describe, it, expect, vi } from 'vitest';
-import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
-import { ContextGraphChainScanPartialError, type ContextGraphChainScanOptions, type ContextGraphOnChain, type ContextGraphRegistryScanOptions } from '../src/chain-adapter.js';
+import { EVMChainAdapter } from '../src/evm-adapter.js';
+import { ContextGraphChainScanPartialError, type ContextGraphChainScanOptions } from '../src/chain-adapter.js';
 import {
   CG_REGISTRY_MAX_SCAN_PAGES,
   CG_REGISTRY_REORG_BUFFER_BLOCKS,
 } from '../src/evm-adapter-base.js';
-
-function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
-  const calls: A[] = [];
-  const fn = (...args: A): R => {
-    calls.push(args);
-    return impl(...args);
-  };
-  return Object.assign(fn, { calls });
-}
-
-// A mutable di-seam double: records every call and runs the current `impl`.
-// `setImpl` swaps the steady-state behaviour (the no-mock analogue of
-// `mockResolvedValue`/`mockReturnValue`); `queueOnce` enqueues one-shot
-// outcomes consumed before the steady-state impl (the analogue of
-// `mockResolvedValueOnce`/`mockRejectedValueOnce`); `reset` clears both the
-// recorded calls and any queued/steady behaviour back to a returns-undefined
-// default (the analogue of `mockReset`); `clear` drops only recorded calls
-// (the analogue of `mockClear`).
-type OnceOutcome<R> = { type: 'return'; value: R } | { type: 'throw'; error: unknown };
-function seam<A extends unknown[], R>(initialImpl: (...args: A) => R) {
-  const calls: A[] = [];
-  const queue: OnceOutcome<R>[] = [];
-  let impl = initialImpl;
-  const fn = (...args: A): R => {
-    calls.push(args);
-    if (queue.length > 0) {
-      const next = queue.shift() as OnceOutcome<R>;
-      if (next.type === 'throw') throw next.error;
-      return next.value;
-    }
-    return impl(...args);
-  };
-  return Object.assign(fn, {
-    calls,
-    setImpl(next: (...args: A) => R) {
-      impl = next;
-    },
-    queueOnce(outcome: OnceOutcome<R>) {
-      queue.push(outcome);
-    },
-    reset() {
-      calls.length = 0;
-      queue.length = 0;
-      impl = (() => undefined as unknown as R) as (...args: A) => R;
-    },
-    clear() {
-      calls.length = 0;
-    },
-  });
-}
-
-const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
-const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
-const REGISTRY = '0x3333333333333333333333333333333333333333';
-
-class MemoryRegistryScanCursorStore {
-  readonly cursorKeyVersion = 2 as const;
-  readonly values = new Map<string, number>();
-  readonly loads: string[] = [];
-  readonly saves: Array<{ key: string; nextBlock: number }> = [];
-
-  async load(key: { chainId: string; deploymentId: string; registryAddress: string; cursorKind: 'historical' | 'tip' }): Promise<number | undefined> {
-    const encoded = this.key(key);
-    this.loads.push(encoded);
-    return this.values.get(encoded);
-  }
-
-  async save(key: { chainId: string; deploymentId: string; registryAddress: string; cursorKind: 'historical' | 'tip' }, nextBlock: number): Promise<void> {
-    const encoded = this.key(key);
-    this.saves.push({ key: encoded, nextBlock });
-    this.values.set(encoded, nextBlock);
-  }
-
-  private key(key: { chainId: string; deploymentId: string; registryAddress: string; cursorKind: 'historical' | 'tip' }): string {
-    return `${key.chainId}|${key.deploymentId}|${key.cursorKind}|${key.registryAddress.toLowerCase()}`;
-  }
-}
-
-class LegacyRolelessRegistryScanCursorStore {
-  readonly values = new Map<string, number>();
-  readonly loads: string[] = [];
-  readonly saves: Array<{ key: string; nextBlock: number }> = [];
-
-  async load(key: { chainId: string; deploymentId: string; registryAddress: string }): Promise<number | undefined> {
-    const encoded = this.key(key);
-    this.loads.push(encoded);
-    return this.values.get(encoded);
-  }
-
-  async save(
-    key: { chainId: string; deploymentId: string; registryAddress: string },
-    nextBlock: number,
-  ): Promise<void> {
-    const encoded = this.key(key);
-    this.saves.push({ key: encoded, nextBlock });
-    this.values.set(encoded, nextBlock);
-  }
-
-  private key(key: { chainId: string; deploymentId: string; registryAddress: string }): string {
-    return `${key.chainId}|${key.deploymentId}|${key.registryAddress.toLowerCase()}`;
-  }
-}
-
-function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterConfig {
-  return {
-    rpcUrl: 'http://127.0.0.1:59998',
-    privateKey: DEPLOYER_PK,
-    adminPrivateKey: ADMIN_PK,
-    hubAddress: '0x0000000000000000000000000000000000000001',
-    chainId: 'evm:31337',
-    staticNetwork: false,
-    ...overrides,
-  };
-}
-
-function makeRegistry(overrides: Record<string, unknown> = {}) {
-  return {
-    getAddress: recorder(async () => REGISTRY),
-    filters: { NameClaimed: recorder(() => 'NameClaimedFilter') },
-    interface: {
-      parseLog: recorder(({ data }: { data: string }) => {
-        if (data === '0x01') {
-          return {
-            name: 'NameClaimed',
-            args: {
-              nameHash: '0xaaa0000000000000000000000000000000000000000000000000000000000001',
-              creator: '0x1111111111111111111111111111111111111111',
-              accessPolicy: 0,
-            },
-          };
-        }
-        return null;
-      }),
-    },
-    queryFilter: seam(async (_filter: unknown, _lo: number, _hi: number) => [] as unknown[]),
-    connect: recorder(() => undefined),
-    ...overrides,
-  } as any;
-}
-
-function makeAdapter(registry: any, head = 0, config: Partial<EVMAdapterConfig> = {}) {
-  const adapter = new EVMChainAdapter(minimalConfig(config));
-  registry.connect = recorder(() => registry);
-  const provider = {
-    getBlockNumber: seam(async () => head),
-    getCode: seam(async (_address: string, block?: number) =>
-      block === undefined || block >= 0 ? '0x6000' : '0x',
-    ),
-  };
-  (adapter as any).contracts = { contextGraphNameRegistry: registry };
-  (adapter as any).initialized = true;
-  (adapter as any).provider = provider;
-  (adapter as any).providers = [provider];
-  return { adapter, provider };
-}
-
-async function collectRegistryScan(
-  adapter: EVMChainAdapter,
-  options: ContextGraphRegistryScanOptions,
-): Promise<ContextGraphOnChain[]> {
-  const results: ContextGraphOnChain[] = [];
-  for await (const page of adapter.scanContextGraphRegistryPages(options)) {
-    results.push(...page.contextGraphs);
-    await page.ack();
-  }
-  return results;
-}
+import {
+  MemoryRegistryScanCursorStore,
+  REGISTRY,
+  collectRegistryScan,
+  makeAdapter,
+  makeRegistry,
+  minimalConfig,
+  recorder,
+  roleAwareRegistryCursorPersistence,
+  seam,
+} from './context-graph-registry-scan-test-support.js';
 
 describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
   it('anchors at the registry deploy block and paginates with the 2,000-block default', async () => {
@@ -243,7 +87,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const store = new MemoryRegistryScanCursorStore();
     const registry = makeRegistry();
     const { adapter } = makeAdapter(registry, 4_999, {
-      contextGraphRegistryScanCursorStore: store,
+      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
     });
     registry.queryFilter.queueOnce({
       type: 'return',
@@ -261,226 +105,6 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     expect(partial.failedFromBlock).toBe(2_000);
     expect(partial.failedToBlock).toBe(3_999);
     expect(store.saves.map((s) => s.nextBlock)).toEqual([2_000]);
-  });
-
-  it('probes the current tip independently while a middle historical page remains unavailable', async () => {
-    let head = 4_999;
-    const store = new MemoryRegistryScanCursorStore();
-    const tipGraphBlock = 9_999;
-    const betweenTipProbesGraphBlock = 10_001;
-    const registry = makeRegistry({
-      queryFilter: seam(async (_filter: unknown, lo: number, hi: number) => {
-        if (lo >= 2_000 && lo < 4_000) throw new Error('archive range unavailable');
-        return [tipGraphBlock, betweenTipProbesGraphBlock]
-          .filter((blockNumber) => lo <= blockNumber && blockNumber <= hi)
-          .map((blockNumber) => ({ topics: [], data: '0x01', blockNumber }));
-      }),
-    });
-    const { adapter, provider } = makeAdapter(registry, head, {
-      contextGraphRegistryScanCursorStore: store,
-    });
-    provider.getBlockNumber.setImpl(async () => head);
-
-    const firstRecovery = await collectRegistryScan(adapter, {
-      mode: 'seedFull',
-    }).catch((err) => err);
-
-    expect(firstRecovery).toBeInstanceOf(ContextGraphChainScanPartialError);
-    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_000);
-
-    head = 10_000;
-    registry.queryFilter.clear();
-    const tipResults = await collectRegistryScan(adapter, { mode: 'tip' });
-
-    expect(tipResults.map((cg) => cg.blockNumber)).toEqual([tipGraphBlock]);
-    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
-      [8_001, 10_000],
-    ]);
-    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_000);
-
-    // More than one configured page elapses before the next tip probe. Its independent cursor,
-    // with reorg overlap, closes the interval instead of jumping to only the newest page and
-    // permanently skipping the event immediately after the prior head.
-    head = 13_200;
-    const { adapter: restartedAdapter, provider: restartedProvider } = makeAdapter(registry, head, {
-      contextGraphRegistryScanCursorStore: store,
-    });
-    restartedProvider.getBlockNumber.setImpl(async () => head);
-    registry.queryFilter.clear();
-    const nextTipResults = await collectRegistryScan(restartedAdapter, { mode: 'tip' });
-
-    expect(nextTipResults.map((cg) => cg.blockNumber)).toEqual([
-      tipGraphBlock,
-      betweenTipProbesGraphBlock,
-    ]);
-    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
-      [9_951, 11_950],
-      [11_951, 13_200],
-    ]);
-    expect((restartedAdapter as any).contextGraphRegistryTipScanCursor.getCachedWatermark(REGISTRY)).toBe(13_201);
-    expect(await restartedAdapter.hasContextGraphRegistryScanWatermark()).toBe(true);
-    expect((restartedAdapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_000);
-
-    registry.queryFilter.clear();
-    const secondRecovery = await collectRegistryScan(restartedAdapter, {
-      mode: 'seedFull',
-    }).catch((err) => err);
-
-    expect(secondRecovery).toBeInstanceOf(ContextGraphChainScanPartialError);
-    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
-      [0, 1_999],
-      [2_000, 3_999],
-    ]);
-    expect((restartedAdapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_000);
-  });
-
-  it('retains the first attempted tip range when its query fails before any acknowledgement', async () => {
-    const store = new MemoryRegistryScanCursorStore();
-    const registry = makeRegistry({
-      queryFilter: seam(async () => {
-        throw new Error('first tip page unavailable');
-      }),
-    });
-    const { adapter } = makeAdapter(registry, 10_000, {
-      contextGraphRegistryScanCursorStore: store,
-    });
-
-    await expect(collectRegistryScan(adapter, { mode: 'tip' }))
-      .rejects.toThrow('first tip page unavailable');
-    expect(store.saves.map((save) => save.nextBlock)).toEqual([8_001]);
-
-    const eventBlock = 10_001;
-    const head = 13_200;
-    registry.queryFilter.reset();
-    registry.queryFilter.setImpl(async (_filter: unknown, lo: number, hi: number) =>
-      lo <= eventBlock && eventBlock <= hi
-        ? [{ topics: [], data: '0x01', blockNumber: eventBlock }]
-        : [],
-    );
-    const { adapter: restarted } = makeAdapter(registry, head, {
-      contextGraphRegistryScanCursorStore: store,
-    });
-
-    const recovered = await collectRegistryScan(restarted, { mode: 'tip' });
-
-    expect(recovered.map((cg) => cg.blockNumber)).toEqual([eventBlock]);
-    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
-      [7_951, 9_950],
-      [9_951, 11_950],
-      [11_951, 13_200],
-    ]);
-    expect(await restarted.hasContextGraphRegistryScanWatermark()).toBe(false);
-  });
-
-  it('never aliases tip progress through a legacy role-less historical cursor store', async () => {
-    const store = new LegacyRolelessRegistryScanCursorStore();
-    await store.save({
-      chainId: 'evm:31337',
-      deploymentId: 'evm:31337:hub=0x0000000000000000000000000000000000000001',
-      registryAddress: REGISTRY,
-    }, 2_000);
-    store.loads.length = 0;
-    store.saves.length = 0;
-    const registry = makeRegistry();
-    const { adapter } = makeAdapter(registry, 10_000, {
-      contextGraphRegistryScanCursorStore: store,
-    });
-    registry.queryFilter.setImpl(async () => []);
-
-    await collectRegistryScan(adapter, { mode: 'tip' });
-
-    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
-      [8_001, 10_000],
-    ]);
-    expect(store.loads).toEqual([]);
-    expect(store.saves).toEqual([]);
-    expect((adapter as any).contextGraphRegistryTipScanCursor.getCachedWatermark(REGISTRY)).toBe(10_001);
-
-    await expect(adapter.hasContextGraphRegistryScanWatermark()).resolves.toBe(true);
-    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_000);
-    expect([...store.values.values()]).toEqual([2_000]);
-  });
-
-  it('retains the first tip lower bound in process when durable cursor persistence fails', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const store = {
-      cursorKeyVersion: 2 as const,
-      load: vi.fn(async () => undefined),
-      save: vi.fn(async () => {
-        throw new Error('tip cursor save failed');
-      }),
-    };
-    let head = 10_000;
-    let firstQuery = true;
-    const eventBlock = 10_001;
-    const registry = makeRegistry({
-      queryFilter: seam(async (_filter: unknown, lo: number, hi: number) => {
-        if (firstQuery) {
-          firstQuery = false;
-          throw new Error('first tip page unavailable');
-        }
-        return lo <= eventBlock && eventBlock <= hi
-          ? [{ topics: [], data: '0x01', blockNumber: eventBlock }]
-          : [];
-      }),
-    });
-    const { adapter, provider } = makeAdapter(registry, head, {
-      contextGraphRegistryScanCursorStore: store,
-    });
-    provider.getBlockNumber.setImpl(async () => head);
-
-    try {
-      await expect(collectRegistryScan(adapter, { mode: 'tip' }))
-        .rejects.toThrow('first tip page unavailable');
-      expect((adapter as any).contextGraphRegistryTipScanCursor.getCachedWatermark(REGISTRY))
-        .toBe(8_001);
-
-      head = 13_200;
-      registry.queryFilter.clear();
-      const recovered = await collectRegistryScan(adapter, { mode: 'tip' });
-
-      expect(recovered.map((cg) => cg.blockNumber)).toEqual([eventBlock]);
-      expect(registry.queryFilter.calls[0]?.slice(1)).toEqual([7_951, 9_950]);
-      expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY))
-        .toBeUndefined();
-    } finally {
-      warnSpy.mockRestore();
-    }
-  });
-
-  it('revisits a fetched tip page when local application never acknowledges it', async () => {
-    const store = new MemoryRegistryScanCursorStore();
-    const eventBlock = 9_999;
-    const registry = makeRegistry({
-      queryFilter: seam(async (_filter: unknown, lo: number, hi: number) =>
-        lo <= eventBlock && eventBlock <= hi
-          ? [{ topics: [], data: '0x01', blockNumber: eventBlock }]
-          : [],
-      ),
-    });
-    const { adapter } = makeAdapter(registry, 10_000, {
-      contextGraphRegistryScanCursorStore: store,
-    });
-    const iterator = adapter.scanContextGraphRegistryPages({ mode: 'tip' })[Symbol.asyncIterator]();
-
-    const fetched = await iterator.next();
-    expect(fetched.done).toBe(false);
-    expect(fetched.value?.contextGraphs.map((cg) => cg.blockNumber)).toEqual([eventBlock]);
-    await iterator.return?.();
-    expect(store.saves.map((save) => save.nextBlock)).toEqual([8_001]);
-
-    registry.queryFilter.clear();
-    const { adapter: restarted } = makeAdapter(registry, 10_000, {
-      contextGraphRegistryScanCursorStore: store,
-    });
-    const retried = await collectRegistryScan(restarted, { mode: 'tip' });
-
-    expect(retried.map((cg) => cg.blockNumber)).toEqual([eventBlock]);
-    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
-      [7_951, 9_950],
-      [9_951, 10_000],
-    ]);
-    expect(await restarted.hasContextGraphRegistryScanWatermark()).toBe(false);
   });
 
   it('does not advance the incremental watermark when parsing a later page fails', async () => {
@@ -545,7 +169,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const registry = makeRegistry();
     const { adapter, provider } = makeAdapter(registry, 2_100, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorStore: store,
+      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
     });
     registry.queryFilter.setImpl(async () => []);
 
@@ -618,7 +242,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     });
     const { adapter } = makeAdapter(registry, 2_100, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorStore: store,
+      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
     });
 
     const seeded = await adapter.listContextGraphsFromChain(undefined, {
@@ -711,7 +335,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const registry = makeRegistry();
     const { adapter } = makeAdapter(registry, 5_000, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorStore: store,
+      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
     });
     registry.queryFilter.setImpl(async () => []);
 
@@ -729,7 +353,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const restartedRegistry = makeRegistry();
     const { adapter: restarted, provider } = makeAdapter(restartedRegistry, 5_000, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorStore: store,
+      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
     });
     provider.getCode = seam(async () => {
       throw new Error('deploy block probing should not run with persisted cursor');
@@ -756,7 +380,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     });
     const { adapter } = makeAdapter(registry, 2_100, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorStore: store,
+      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
     });
 
     const iterator = adapter.scanContextGraphRegistryPages({
@@ -773,7 +397,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const restartedRegistry = makeRegistry();
     const { adapter: restarted } = makeAdapter(restartedRegistry, 2_100, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorStore: store,
+      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
     });
     restartedRegistry.queryFilter.setImpl(async () => []);
 
@@ -868,7 +492,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const registry = makeRegistry();
     const { adapter, provider } = makeAdapter(registry, 5_000, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorStore: store,
+      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
     });
     provider.getCode = seam(async () => {
       throw new Error('deploy block probing should not run with persisted cursor');
@@ -904,7 +528,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     });
     const { adapter } = makeAdapter(registry, 3_500, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorStore: store,
+      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
     });
 
     const results = await collectRegistryScan(adapter, {
@@ -925,7 +549,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const store = new MemoryRegistryScanCursorStore();
     const seedRegistry = makeRegistry();
     const { adapter: seedAdapter } = makeAdapter(seedRegistry, 2_100, {
-      contextGraphRegistryScanCursorStore: store,
+      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
     });
     seedRegistry.queryFilter.setImpl(async () => []);
 
@@ -936,7 +560,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
 
     const publicRegistry = makeRegistry();
     const { adapter: publicAdapter } = makeAdapter(publicRegistry, 2_100, {
-      contextGraphRegistryScanCursorStore: store,
+      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
     });
     publicRegistry.queryFilter.setImpl(async () => []);
 
@@ -967,7 +591,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const store = new MemoryRegistryScanCursorStore();
     const registry = makeRegistry();
     const { adapter } = makeAdapter(registry, 4_000, {
-      contextGraphRegistryScanCursorStore: store,
+      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
     });
     registry.queryFilter.setImpl(async () => []);
 

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -239,16 +239,20 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
 
   it('probes the current tip independently while a middle historical page remains unavailable', async () => {
     let head = 4_999;
+    const store = new MemoryRegistryScanCursorStore();
     const tipGraphBlock = 9_999;
+    const betweenTipProbesGraphBlock = 10_001;
     const registry = makeRegistry({
       queryFilter: seam(async (_filter: unknown, lo: number, hi: number) => {
         if (lo >= 2_000 && lo < 4_000) throw new Error('archive range unavailable');
-        return lo <= tipGraphBlock && tipGraphBlock <= hi
-          ? [{ topics: [], data: '0x01', blockNumber: tipGraphBlock }]
-          : [];
+        return [tipGraphBlock, betweenTipProbesGraphBlock]
+          .filter((blockNumber) => lo <= blockNumber && blockNumber <= hi)
+          .map((blockNumber) => ({ topics: [], data: '0x01', blockNumber }));
       }),
     });
-    const { adapter, provider } = makeAdapter(registry, head);
+    const { adapter, provider } = makeAdapter(registry, head, {
+      contextGraphRegistryScanCursorStore: store,
+    });
     provider.getBlockNumber.setImpl(async () => head);
 
     const firstRecovery = await collectRegistryScan(adapter, {
@@ -268,8 +272,31 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     ]);
     expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_000);
 
+    // More than one configured page elapses before the next tip probe. Its independent cursor,
+    // with reorg overlap, closes the interval instead of jumping to only the newest page and
+    // permanently skipping the event immediately after the prior head.
+    head = 13_200;
+    const { adapter: restartedAdapter, provider: restartedProvider } = makeAdapter(registry, head, {
+      contextGraphRegistryScanCursorStore: store,
+    });
+    restartedProvider.getBlockNumber.setImpl(async () => head);
     registry.queryFilter.clear();
-    const secondRecovery = await collectRegistryScan(adapter, {
+    const nextTipResults = await collectRegistryScan(restartedAdapter, { mode: 'tip' });
+
+    expect(nextTipResults.map((cg) => cg.blockNumber)).toEqual([
+      tipGraphBlock,
+      betweenTipProbesGraphBlock,
+    ]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [9_951, 11_950],
+      [11_951, 13_200],
+    ]);
+    expect((restartedAdapter as any).contextGraphRegistryTipScanCursor.getCachedWatermark(REGISTRY)).toBe(13_201);
+    expect(await restartedAdapter.hasContextGraphRegistryScanWatermark()).toBe(true);
+    expect((restartedAdapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_000);
+
+    registry.queryFilter.clear();
+    const secondRecovery = await collectRegistryScan(restartedAdapter, {
       mode: 'seedFull',
     }).catch((err) => err);
 

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -13,7 +13,7 @@ import {
   makeRegistry,
   minimalConfig,
   recorder,
-  roleAwareRegistryCursorPersistence,
+  registryCursorStores,
   seam,
 } from './context-graph-registry-scan-test-support.js';
 
@@ -87,7 +87,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const store = new MemoryRegistryScanCursorStore();
     const registry = makeRegistry();
     const { adapter } = makeAdapter(registry, 4_999, {
-      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
+      ...registryCursorStores(store),
     });
     registry.queryFilter.queueOnce({
       type: 'return',
@@ -169,7 +169,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const registry = makeRegistry();
     const { adapter, provider } = makeAdapter(registry, 2_100, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
+      ...registryCursorStores(store),
     });
     registry.queryFilter.setImpl(async () => []);
 
@@ -242,7 +242,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     });
     const { adapter } = makeAdapter(registry, 2_100, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
+      ...registryCursorStores(store),
     });
 
     const seeded = await adapter.listContextGraphsFromChain(undefined, {
@@ -335,7 +335,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const registry = makeRegistry();
     const { adapter } = makeAdapter(registry, 5_000, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
+      ...registryCursorStores(store),
     });
     registry.queryFilter.setImpl(async () => []);
 
@@ -353,7 +353,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const restartedRegistry = makeRegistry();
     const { adapter: restarted, provider } = makeAdapter(restartedRegistry, 5_000, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
+      ...registryCursorStores(store),
     });
     provider.getCode = seam(async () => {
       throw new Error('deploy block probing should not run with persisted cursor');
@@ -380,7 +380,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     });
     const { adapter } = makeAdapter(registry, 2_100, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
+      ...registryCursorStores(store),
     });
 
     const iterator = adapter.scanContextGraphRegistryPages({
@@ -397,7 +397,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const restartedRegistry = makeRegistry();
     const { adapter: restarted } = makeAdapter(restartedRegistry, 2_100, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
+      ...registryCursorStores(store),
     });
     restartedRegistry.queryFilter.setImpl(async () => []);
 
@@ -492,7 +492,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const registry = makeRegistry();
     const { adapter, provider } = makeAdapter(registry, 5_000, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
+      ...registryCursorStores(store),
     });
     provider.getCode = seam(async () => {
       throw new Error('deploy block probing should not run with persisted cursor');
@@ -528,7 +528,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     });
     const { adapter } = makeAdapter(registry, 3_500, {
       cgRegistryScanPageSize: 1_000,
-      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
+      ...registryCursorStores(store),
     });
 
     const results = await collectRegistryScan(adapter, {
@@ -549,7 +549,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const store = new MemoryRegistryScanCursorStore();
     const seedRegistry = makeRegistry();
     const { adapter: seedAdapter } = makeAdapter(seedRegistry, 2_100, {
-      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
+      ...registryCursorStores(store),
     });
     seedRegistry.queryFilter.setImpl(async () => []);
 
@@ -560,7 +560,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
 
     const publicRegistry = makeRegistry();
     const { adapter: publicAdapter } = makeAdapter(publicRegistry, 2_100, {
-      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
+      ...registryCursorStores(store),
     });
     publicRegistry.queryFilter.setImpl(async () => []);
 
@@ -591,7 +591,7 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     const store = new MemoryRegistryScanCursorStore();
     const registry = makeRegistry();
     const { adapter } = makeAdapter(registry, 4_000, {
-      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
+      ...registryCursorStores(store),
     });
     registry.queryFilter.setImpl(async () => []);
 

--- a/packages/chain/test/context-graph-registry-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-scan.unit.test.ts
@@ -237,6 +237,50 @@ describe('EVMChainAdapter.listContextGraphsFromChain registry scan', () => {
     expect(store.saves.map((s) => s.nextBlock)).toEqual([2_000]);
   });
 
+  it('probes the current tip independently while a middle historical page remains unavailable', async () => {
+    let head = 4_999;
+    const tipGraphBlock = 9_999;
+    const registry = makeRegistry({
+      queryFilter: seam(async (_filter: unknown, lo: number, hi: number) => {
+        if (lo >= 2_000 && lo < 4_000) throw new Error('archive range unavailable');
+        return lo <= tipGraphBlock && tipGraphBlock <= hi
+          ? [{ topics: [], data: '0x01', blockNumber: tipGraphBlock }]
+          : [];
+      }),
+    });
+    const { adapter, provider } = makeAdapter(registry, head);
+    provider.getBlockNumber.setImpl(async () => head);
+
+    const firstRecovery = await collectRegistryScan(adapter, {
+      mode: 'seedFull',
+    }).catch((err) => err);
+
+    expect(firstRecovery).toBeInstanceOf(ContextGraphChainScanPartialError);
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_000);
+
+    head = 10_000;
+    registry.queryFilter.clear();
+    const tipResults = await collectRegistryScan(adapter, { mode: 'tip' });
+
+    expect(tipResults.map((cg) => cg.blockNumber)).toEqual([tipGraphBlock]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [8_001, 10_000],
+    ]);
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_000);
+
+    registry.queryFilter.clear();
+    const secondRecovery = await collectRegistryScan(adapter, {
+      mode: 'seedFull',
+    }).catch((err) => err);
+
+    expect(secondRecovery).toBeInstanceOf(ContextGraphChainScanPartialError);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [0, 1_999],
+      [2_000, 3_999],
+    ]);
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_000);
+  });
+
   it('does not advance the incremental watermark when parsing a later page fails', async () => {
     const registry = makeRegistry({
       interface: {

--- a/packages/chain/test/context-graph-registry-tip-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-tip-scan.unit.test.ts
@@ -164,6 +164,38 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
     expect(await restarted.hasContextGraphRegistryScanWatermark()).toBe(false);
   });
 
+  it('probes the current tip without acknowledging an unavailable stale tip gap', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    await store.save({ ...LEGACY_KEY, cursorKind: 'historical' }, 2_000);
+    await store.save({ ...LEGACY_KEY, cursorKind: 'tip' }, 10_001);
+    const cursorStores = registryCursorStores(store);
+    const head = 1_000_000;
+    const currentTipStart = 998_001;
+    const currentEventBlock = 999_123;
+    const registry = makeRegistry({
+      queryFilter: seam(async (_filter: unknown, lo: number, hi: number) => {
+        if (lo < currentTipStart) throw new Error('stale tip gap unavailable');
+        return lo <= currentEventBlock && currentEventBlock <= hi
+          ? [{ topics: [], data: '0x01', blockNumber: currentEventBlock }]
+          : [];
+      }),
+    });
+    const { adapter } = makeAdapter(registry, head, { ...cursorStores });
+
+    const recovered = await collectRegistryScan(adapter, { mode: 'tip' });
+
+    expect(recovered.map((cg) => cg.blockNumber)).toEqual([currentEventBlock]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi]))
+      .toEqual([
+        [9_951, 11_950],
+        [currentTipStart, head],
+      ]);
+    expect(store.values.get(`${LEGACY_KEY.chainId}|${LEGACY_KEY.deploymentId}|tip|${REGISTRY}`))
+      .toBe(10_001);
+    expect(store.values.get(`${LEGACY_KEY.chainId}|${LEGACY_KEY.deploymentId}|historical|${REGISTRY}`))
+      .toBe(2_000);
+  });
+
   it('retains exact v1 read/write keys for a legacy store with unrelated kind metadata', async () => {
     const historical = new KindedJsonLegacyRegistryScanCursorStore();
     historical.seed(LEGACY_KEY, 2_000);

--- a/packages/chain/test/context-graph-registry-tip-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-tip-scan.unit.test.ts
@@ -212,6 +212,37 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
       .toBe(10_001);
   });
 
+  it('retains process-local tip progress across unrelated preflight invalidation', async () => {
+    let head = 10_000;
+    const eventBlock = 10_001;
+    const registry = makeRegistry();
+    const { adapter, provider } = makeAdapter(registry, head);
+    provider.getBlockNumber.setImpl(async () => head);
+    registry.queryFilter.setImpl(async () => []);
+
+    await collectRegistryScan(adapter, { mode: 'tip' });
+    expect((adapter as any).contextGraphRegistryTipScanCursor.getCachedWatermark(REGISTRY))
+      .toBe(10_001);
+
+    adapter.invalidatePublishPreflightCache();
+    head = 13_200;
+    registry.queryFilter.clear();
+    registry.queryFilter.setImpl(async (_filter: unknown, lo: number, hi: number) =>
+      lo <= eventBlock && eventBlock <= hi
+        ? [{ topics: [], data: '0x01', blockNumber: eventBlock }]
+        : [],
+    );
+
+    const recovered = await collectRegistryScan(adapter, { mode: 'tip' });
+
+    expect(recovered.map((cg) => cg.blockNumber)).toEqual([eventBlock]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi]))
+      .toEqual([
+        [9_951, 11_950],
+        [11_951, 13_200],
+      ]);
+  });
+
   it('persists independent tip progress across restart with split legacy stores', async () => {
     const historical = new JsonLegacyRegistryScanCursorStore();
     const tip = new JsonLegacyRegistryScanCursorStore();

--- a/packages/chain/test/context-graph-registry-tip-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-tip-scan.unit.test.ts
@@ -57,7 +57,7 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
       }),
     });
     const { adapter, provider } = makeAdapter(registry, head, {
-      contextGraphRegistryScanCursorPersistence: persistence,
+      contextGraphRegistryScanCursorStore: persistence,
     });
     provider.getBlockNumber.setImpl(async () => head);
 
@@ -78,7 +78,7 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
 
     head = 13_200;
     const { adapter: restartedAdapter, provider: restartedProvider } = makeAdapter(registry, head, {
-      contextGraphRegistryScanCursorPersistence: persistence,
+      contextGraphRegistryScanCursorStore: persistence,
     });
     restartedProvider.getBlockNumber.setImpl(async () => head);
     registry.queryFilter.clear();
@@ -117,7 +117,7 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
       }),
     });
     const { adapter } = makeAdapter(registry, 10_000, {
-      contextGraphRegistryScanCursorPersistence: persistence,
+      contextGraphRegistryScanCursorStore: persistence,
     });
 
     await expect(collectRegistryScan(adapter, { mode: 'tip' }))
@@ -133,7 +133,7 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
         : [],
     );
     const { adapter: restarted } = makeAdapter(registry, head, {
-      contextGraphRegistryScanCursorPersistence: persistence,
+      contextGraphRegistryScanCursorStore: persistence,
     });
 
     const recovered = await collectRegistryScan(restarted, { mode: 'tip' });
@@ -172,6 +172,27 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
     expect(registry.queryFilter.calls[0]?.slice(1)).toEqual([1_950, 2_949]);
   });
 
+  it('keeps tip progress in memory when only the original legacy store is configured', async () => {
+    const historical = new JsonLegacyRegistryScanCursorStore();
+    historical.seed(LEGACY_KEY, 2_000);
+    const registry = makeRegistry();
+    const { adapter } = makeAdapter(registry, 10_000, {
+      contextGraphRegistryScanCursorStore: historical,
+    });
+    registry.queryFilter.setImpl(async () => []);
+
+    await collectRegistryScan(adapter, { mode: 'tip' });
+
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [8_001, 10_000],
+    ]);
+    expect(historical.loads).toEqual([]);
+    expect(historical.saves).toEqual([]);
+    expect(historical.values.get(JSON.stringify(LEGACY_KEY))).toBe(2_000);
+    expect((adapter as any).contextGraphRegistryTipScanCursor.getCachedWatermark(REGISTRY))
+      .toBe(10_001);
+  });
+
   it('persists independent tip progress across restart with split legacy stores', async () => {
     const historical = new JsonLegacyRegistryScanCursorStore();
     const tip = new JsonLegacyRegistryScanCursorStore();
@@ -187,7 +208,7 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
       ),
     });
     const { adapter } = makeAdapter(registry, head, {
-      contextGraphRegistryScanCursorPersistence: persistence,
+      contextGraphRegistryScanCursorStore: persistence,
     });
 
     await collectRegistryScan(adapter, { mode: 'tip' });
@@ -199,7 +220,7 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
     head = 13_200;
     registry.queryFilter.clear();
     const { adapter: restarted, provider } = makeAdapter(registry, head, {
-      contextGraphRegistryScanCursorPersistence: persistence,
+      contextGraphRegistryScanCursorStore: persistence,
     });
     provider.getBlockNumber.setImpl(async () => head);
     const recovered = await collectRegistryScan(restarted, { mode: 'tip' });
@@ -238,7 +259,7 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
       }),
     });
     const { adapter, provider } = makeAdapter(registry, head, {
-      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
+      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
     });
     provider.getBlockNumber.setImpl(async () => head);
 
@@ -261,6 +282,50 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
     }
   });
 
+  it('fails closed when the first tip cursor read fails instead of overwriting older progress', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let persisted = 8_001;
+    let loadAttempts = 0;
+    const store = {
+      load: vi.fn(async () => {
+        loadAttempts += 1;
+        if (loadAttempts === 1) throw new Error('temporary cursor read failure');
+        return persisted;
+      }),
+      save: vi.fn(async (_key: unknown, nextBlock: number) => {
+        persisted = nextBlock;
+      }),
+    };
+    const eventBlock = 10_000;
+    const registry = makeRegistry({
+      queryFilter: seam(async (_filter: unknown, lo: number, hi: number) =>
+        lo <= eventBlock && eventBlock <= hi
+          ? [{ topics: [], data: '0x01', blockNumber: eventBlock }]
+          : [],
+      ),
+    });
+    const persistence = roleAwareRegistryCursorPersistence(store);
+    const { adapter } = makeAdapter(registry, 20_000, {
+      contextGraphRegistryScanCursorStore: persistence,
+    });
+
+    try {
+      await expect(collectRegistryScan(adapter, { mode: 'tip' }))
+        .rejects.toThrow('tip cursor load failed');
+      expect(registry.queryFilter.calls).toEqual([]);
+      expect(store.save).not.toHaveBeenCalled();
+      expect(persisted).toBe(8_001);
+
+      const recovered = await collectRegistryScan(adapter, { mode: 'tip' });
+
+      expect(recovered.map((cg) => cg.blockNumber)).toEqual([eventBlock]);
+      expect(registry.queryFilter.calls[0]?.slice(1)).toEqual([7_951, 9_950]);
+      expect(persisted).toBe(20_001);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('revisits a fetched tip page when local application never acknowledges it', async () => {
     const store = new MemoryRegistryScanCursorStore();
     const persistence = roleAwareRegistryCursorPersistence(store);
@@ -273,7 +338,7 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
       ),
     });
     const { adapter } = makeAdapter(registry, 10_000, {
-      contextGraphRegistryScanCursorPersistence: persistence,
+      contextGraphRegistryScanCursorStore: persistence,
     });
     const iterator = adapter.scanContextGraphRegistryPages({ mode: 'tip' })[Symbol.asyncIterator]();
 
@@ -285,7 +350,7 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
 
     registry.queryFilter.clear();
     const { adapter: restarted } = makeAdapter(registry, 10_000, {
-      contextGraphRegistryScanCursorPersistence: persistence,
+      contextGraphRegistryScanCursorStore: persistence,
     });
     const retried = await collectRegistryScan(restarted, { mode: 'tip' });
 

--- a/packages/chain/test/context-graph-registry-tip-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-tip-scan.unit.test.ts
@@ -46,6 +46,19 @@ class KindedJsonLegacyRegistryScanCursorStore extends JsonLegacyRegistryScanCurs
 }
 
 describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
+  it('exposes only the load policy owned by each cursor role', () => {
+    const { adapter } = makeAdapter(makeRegistry(), 10_000);
+    const historical = (adapter as any).contextGraphRegistryScanCursor;
+    const tip = (adapter as any).contextGraphRegistryTipScanCursor;
+
+    expect(historical.loadBestEffortWatermark).toEqual(expect.any(Function));
+    expect(historical.loadStrictWatermark).toBeUndefined();
+    expect(tip.loadStrictWatermark).toEqual(expect.any(Function));
+    expect(tip.loadBestEffortWatermark).toBeUndefined();
+    expect(historical.loadWatermark).toBeUndefined();
+    expect(tip.loadWatermarkResult).toBeUndefined();
+  });
+
   it('probes the current tip independently while a middle historical page remains unavailable', async () => {
     let head = 4_999;
     const store = new MemoryRegistryScanCursorStore();
@@ -243,14 +256,10 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
       ]);
   });
 
-  it('persists independent tip progress across restart with split legacy stores', async () => {
-    const historical = new JsonLegacyRegistryScanCursorStore();
-    const tip = new JsonLegacyRegistryScanCursorStore();
-    historical.seed(LEGACY_KEY, 2_000);
-    const cursorStores = {
-      contextGraphRegistryScanCursorStore: historical,
-      contextGraphRegistryTipScanCursorStore: tip,
-    };
+  it('persists independent historical and tip progress through one role-aware store', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    await store.save({ ...LEGACY_KEY, cursorKind: 'historical' }, 2_000);
+    const cursorStores = registryCursorStores(store);
     const eventBlock = 10_001;
     let head = 10_000;
     const registry = makeRegistry({
@@ -266,9 +275,10 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
 
     await collectRegistryScan(adapter, { mode: 'tip' });
 
-    expect(historical.values.get(JSON.stringify(LEGACY_KEY))).toBe(2_000);
-    expect(tip.values.get(JSON.stringify(LEGACY_KEY))).toBe(10_001);
-    expect(historical.loads).toEqual([]);
+    expect(store.values.get(`${LEGACY_KEY.chainId}|${LEGACY_KEY.deploymentId}|historical|${REGISTRY}`))
+      .toBe(2_000);
+    expect(store.values.get(`${LEGACY_KEY.chainId}|${LEGACY_KEY.deploymentId}|tip|${REGISTRY}`))
+      .toBe(10_001);
 
     head = 13_200;
     registry.queryFilter.clear();
@@ -283,10 +293,11 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
       [9_951, 11_950],
       [11_951, 13_200],
     ]);
-    expect(historical.values.get(JSON.stringify(LEGACY_KEY))).toBe(2_000);
-    expect(tip.values.get(JSON.stringify(LEGACY_KEY))).toBe(13_201);
-    expect(tip.loads).toHaveLength(2);
-    expect(tip.loads.every((key) => !('cursorKind' in key))).toBe(true);
+    expect(store.values.get(`${LEGACY_KEY.chainId}|${LEGACY_KEY.deploymentId}|historical|${REGISTRY}`))
+      .toBe(2_000);
+    expect(store.values.get(`${LEGACY_KEY.chainId}|${LEGACY_KEY.deploymentId}|tip|${REGISTRY}`))
+      .toBe(13_201);
+    expect(store.loads.filter((key) => key.includes('|tip|'))).toHaveLength(2);
   });
 
   it('fails closed on marker and acknowledgement saves without skipping the attempted tip range', async () => {

--- a/packages/chain/test/context-graph-registry-tip-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-tip-scan.unit.test.ts
@@ -13,6 +13,7 @@ import {
   registryCursorStores,
   seam,
 } from './context-graph-registry-scan-test-support.js';
+import { ContextGraphRegistryTipScanCursor } from '../src/context-graph-registry-scan-cursor.js';
 
 const DEPLOYMENT_ID = 'evm:31337:hub=0x0000000000000000000000000000000000000001';
 const LEGACY_KEY: ContextGraphRegistryScanCursorKey = {
@@ -20,6 +21,12 @@ const LEGACY_KEY: ContextGraphRegistryScanCursorKey = {
   deploymentId: DEPLOYMENT_ID,
   registryAddress: REGISTRY,
 };
+
+function deferred(): { promise: Promise<void>; resolve(): void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
+}
 
 class JsonLegacyRegistryScanCursorStore implements ContextGraphRegistryScanCursorStore {
   readonly values = new Map<string, number>();
@@ -46,6 +53,38 @@ class KindedJsonLegacyRegistryScanCursorStore extends JsonLegacyRegistryScanCurs
 }
 
 describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
+  it('serializes overlapping strict saves and leaves durable progress at the newest target', async () => {
+    const olderWrite = deferred();
+    const newerWrite = deferred();
+    const saves: number[] = [];
+    let durable: number | undefined;
+    const cursor = new ContextGraphRegistryTipScanCursor({
+      chainId: LEGACY_KEY.chainId,
+      deploymentId: LEGACY_KEY.deploymentId,
+      store: {
+        load: async () => durable,
+        save: async (_key, nextBlock) => {
+          saves.push(nextBlock);
+          await (nextBlock === 100 ? olderWrite.promise : newerWrite.promise);
+          durable = nextBlock;
+        },
+      },
+    });
+
+    const older = cursor.saveStrictWatermark(REGISTRY, 100);
+    await vi.waitFor(() => expect(saves).toEqual([100]));
+    const newer = cursor.saveStrictWatermark(REGISTRY, 200);
+    newerWrite.resolve();
+    await Promise.resolve();
+    expect(saves).toEqual([100]);
+
+    olderWrite.resolve();
+    await Promise.all([older, newer]);
+    expect(saves).toEqual([100, 200]);
+    expect(durable).toBe(200);
+    expect(cursor.getCachedWatermark(REGISTRY)).toBe(200);
+  });
+
   it('exposes only the load policy owned by each cursor role', () => {
     const { adapter } = makeAdapter(makeRegistry(), 10_000);
     const historical = (adapter as any).contextGraphRegistryScanCursor;
@@ -255,6 +294,13 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
     expect(historical.values.get(JSON.stringify(LEGACY_KEY))).toBe(2_000);
     expect((adapter as any).contextGraphRegistryTipScanCursor.getCachedWatermark(REGISTRY))
       .toBe(10_001);
+  });
+
+  it('rejects ambiguous legacy and role-aware cursor-store configuration', () => {
+    expect(() => makeAdapter(makeRegistry(), 10_000, {
+      contextGraphRegistryScanCursorStore: new JsonLegacyRegistryScanCursorStore(),
+      contextGraphRegistryRoleAwareScanCursorStore: new MemoryRegistryScanCursorStore(),
+    })).toThrow(/only one registry scan cursor store/u);
   });
 
   it('retains process-local tip progress across unrelated preflight invalidation', async () => {

--- a/packages/chain/test/context-graph-registry-tip-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-tip-scan.unit.test.ts
@@ -41,6 +41,10 @@ class JsonLegacyRegistryScanCursorStore implements ContextGraphRegistryScanCurso
   }
 }
 
+class KindedJsonLegacyRegistryScanCursorStore extends JsonLegacyRegistryScanCursorStore {
+  readonly kind = 'sqlite';
+}
+
 describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
   it('probes the current tip independently while a middle historical page remains unavailable', async () => {
     let head = 4_999;
@@ -147,8 +151,8 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
     expect(await restarted.hasContextGraphRegistryScanWatermark()).toBe(false);
   });
 
-  it('retains the exact v1 key shape when loading a legacy historical cursor', async () => {
-    const historical = new JsonLegacyRegistryScanCursorStore();
+  it('retains exact v1 read/write keys for a legacy store with unrelated kind metadata', async () => {
+    const historical = new KindedJsonLegacyRegistryScanCursorStore();
     historical.seed(LEGACY_KEY, 2_000);
     const registry = makeRegistry();
     const { adapter, provider } = makeAdapter(registry, 5_000, {
@@ -170,6 +174,21 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
       'registryAddress',
     ]);
     expect(registry.queryFilter.calls[0]?.slice(1)).toEqual([1_950, 2_949]);
+    expect(historical.saves).toEqual([{ key: LEGACY_KEY, nextBlock: 2_950 }]);
+    expect(Object.keys(historical.saves[0]?.key ?? {}).sort()).toEqual([
+      'chainId',
+      'deploymentId',
+      'registryAddress',
+    ]);
+
+    registry.queryFilter.clear();
+    const { adapter: restarted } = makeAdapter(registry, 5_000, {
+      cgRegistryScanPageSize: 1_000,
+      contextGraphRegistryScanCursorStore: historical,
+    });
+    await collectRegistryScan(restarted, { mode: 'seedFromCursor', pageBudget: 1 });
+
+    expect(registry.queryFilter.calls[0]?.slice(1)).toEqual([2_900, 3_899]);
   });
 
   it('keeps tip progress in memory when only the original legacy store is configured', async () => {
@@ -236,27 +255,27 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
     expect(tip.loads.every((key) => !('cursorKind' in key))).toBe(true);
   });
 
-  it('retains the first tip lower bound in process when durable cursor persistence fails', async () => {
+  it('fails closed on marker and acknowledgement saves without skipping the attempted tip range', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let persisted: number | undefined;
+    let saveAttempt = 0;
     const store = {
-      load: vi.fn(async () => undefined),
-      save: vi.fn(async () => {
-        throw new Error('tip cursor save failed');
+      load: vi.fn(async () => persisted),
+      save: vi.fn(async (_key: unknown, nextBlock: number) => {
+        saveAttempt += 1;
+        if (saveAttempt === 1) throw new Error('tip marker save failed');
+        if (saveAttempt === 3) throw new Error('tip acknowledgement save failed');
+        persisted = nextBlock;
       }),
     };
     let head = 10_000;
-    let firstQuery = true;
     const eventBlock = 10_001;
     const registry = makeRegistry({
-      queryFilter: seam(async (_filter: unknown, lo: number, hi: number) => {
-        if (firstQuery) {
-          firstQuery = false;
-          throw new Error('first tip page unavailable');
-        }
-        return lo <= eventBlock && eventBlock <= hi
+      queryFilter: seam(async (_filter: unknown, lo: number, hi: number) =>
+        lo <= eventBlock && eventBlock <= hi
           ? [{ topics: [], data: '0x01', blockNumber: eventBlock }]
-          : [];
-      }),
+          : [],
+      ),
     });
     const { adapter, provider } = makeAdapter(registry, head, {
       contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
@@ -265,17 +284,26 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
 
     try {
       await expect(collectRegistryScan(adapter, { mode: 'tip' }))
-        .rejects.toThrow('first tip page unavailable');
+        .rejects.toThrow('tip marker save failed');
+      expect(registry.queryFilter.calls).toEqual([]);
       expect((adapter as any).contextGraphRegistryTipScanCursor.getCachedWatermark(REGISTRY))
         .toBe(8_001);
 
+      await expect(collectRegistryScan(adapter, { mode: 'tip' }))
+        .rejects.toThrow('tip acknowledgement save failed');
+      expect(persisted).toBe(8_001);
+
       head = 13_200;
       registry.queryFilter.clear();
-      const recovered = await collectRegistryScan(adapter, { mode: 'tip' });
+      const { adapter: restarted, provider: restartedProvider } = makeAdapter(registry, head, {
+        contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
+      });
+      restartedProvider.getBlockNumber.setImpl(async () => head);
+      const recovered = await collectRegistryScan(restarted, { mode: 'tip' });
 
       expect(recovered.map((cg) => cg.blockNumber)).toEqual([eventBlock]);
       expect(registry.queryFilter.calls[0]?.slice(1)).toEqual([7_951, 9_950]);
-      expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY))
+      expect((restarted as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY))
         .toBeUndefined();
     } finally {
       warnSpy.mockRestore();

--- a/packages/chain/test/context-graph-registry-tip-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-tip-scan.unit.test.ts
@@ -10,7 +10,7 @@ import {
   collectRegistryScan,
   makeAdapter,
   makeRegistry,
-  roleAwareRegistryCursorPersistence,
+  registryCursorStores,
   seam,
 } from './context-graph-registry-scan-test-support.js';
 
@@ -49,7 +49,7 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
   it('probes the current tip independently while a middle historical page remains unavailable', async () => {
     let head = 4_999;
     const store = new MemoryRegistryScanCursorStore();
-    const persistence = roleAwareRegistryCursorPersistence(store);
+    const cursorStores = registryCursorStores(store);
     const tipGraphBlock = 9_999;
     const betweenTipProbesGraphBlock = 10_001;
     const registry = makeRegistry({
@@ -61,7 +61,7 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
       }),
     });
     const { adapter, provider } = makeAdapter(registry, head, {
-      contextGraphRegistryScanCursorStore: persistence,
+      ...cursorStores,
     });
     provider.getBlockNumber.setImpl(async () => head);
 
@@ -82,7 +82,7 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
 
     head = 13_200;
     const { adapter: restartedAdapter, provider: restartedProvider } = makeAdapter(registry, head, {
-      contextGraphRegistryScanCursorStore: persistence,
+      ...cursorStores,
     });
     restartedProvider.getBlockNumber.setImpl(async () => head);
     registry.queryFilter.clear();
@@ -114,14 +114,14 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
 
   it('retains the first attempted tip range when its query fails before any acknowledgement', async () => {
     const store = new MemoryRegistryScanCursorStore();
-    const persistence = roleAwareRegistryCursorPersistence(store);
+    const cursorStores = registryCursorStores(store);
     const registry = makeRegistry({
       queryFilter: seam(async () => {
         throw new Error('first tip page unavailable');
       }),
     });
     const { adapter } = makeAdapter(registry, 10_000, {
-      contextGraphRegistryScanCursorStore: persistence,
+      ...cursorStores,
     });
 
     await expect(collectRegistryScan(adapter, { mode: 'tip' }))
@@ -137,7 +137,7 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
         : [],
     );
     const { adapter: restarted } = makeAdapter(registry, head, {
-      contextGraphRegistryScanCursorStore: persistence,
+      ...cursorStores,
     });
 
     const recovered = await collectRegistryScan(restarted, { mode: 'tip' });
@@ -216,7 +216,10 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
     const historical = new JsonLegacyRegistryScanCursorStore();
     const tip = new JsonLegacyRegistryScanCursorStore();
     historical.seed(LEGACY_KEY, 2_000);
-    const persistence = { kind: 'legacy' as const, historical, tip };
+    const cursorStores = {
+      contextGraphRegistryScanCursorStore: historical,
+      contextGraphRegistryTipScanCursorStore: tip,
+    };
     const eventBlock = 10_001;
     let head = 10_000;
     const registry = makeRegistry({
@@ -227,7 +230,7 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
       ),
     });
     const { adapter } = makeAdapter(registry, head, {
-      contextGraphRegistryScanCursorStore: persistence,
+      ...cursorStores,
     });
 
     await collectRegistryScan(adapter, { mode: 'tip' });
@@ -239,7 +242,7 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
     head = 13_200;
     registry.queryFilter.clear();
     const { adapter: restarted, provider } = makeAdapter(registry, head, {
-      contextGraphRegistryScanCursorStore: persistence,
+      ...cursorStores,
     });
     provider.getBlockNumber.setImpl(async () => head);
     const recovered = await collectRegistryScan(restarted, { mode: 'tip' });
@@ -278,7 +281,7 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
       ),
     });
     const { adapter, provider } = makeAdapter(registry, head, {
-      contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
+      ...registryCursorStores(store),
     });
     provider.getBlockNumber.setImpl(async () => head);
 
@@ -289,14 +292,20 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
       expect((adapter as any).contextGraphRegistryTipScanCursor.getCachedWatermark(REGISTRY))
         .toBe(8_001);
 
+      adapter.invalidatePublishPreflightCache();
+      head = 13_000;
+      registry.queryFilter.clear();
+      expect((adapter as any).contextGraphRegistryTipScanCursor.getCachedWatermark(REGISTRY))
+        .toBe(8_001);
       await expect(collectRegistryScan(adapter, { mode: 'tip' }))
         .rejects.toThrow('tip acknowledgement save failed');
       expect(persisted).toBe(8_001);
+      expect(registry.queryFilter.calls[0]?.slice(1)).toEqual([7_951, 9_950]);
 
       head = 13_200;
       registry.queryFilter.clear();
       const { adapter: restarted, provider: restartedProvider } = makeAdapter(registry, head, {
-        contextGraphRegistryScanCursorStore: roleAwareRegistryCursorPersistence(store),
+        ...registryCursorStores(store),
       });
       restartedProvider.getBlockNumber.setImpl(async () => head);
       const recovered = await collectRegistryScan(restarted, { mode: 'tip' });
@@ -332,9 +341,9 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
           : [],
       ),
     });
-    const persistence = roleAwareRegistryCursorPersistence(store);
+    const cursorStores = registryCursorStores(store);
     const { adapter } = makeAdapter(registry, 20_000, {
-      contextGraphRegistryScanCursorStore: persistence,
+      ...cursorStores,
     });
 
     try {
@@ -356,7 +365,7 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
 
   it('revisits a fetched tip page when local application never acknowledges it', async () => {
     const store = new MemoryRegistryScanCursorStore();
-    const persistence = roleAwareRegistryCursorPersistence(store);
+    const cursorStores = registryCursorStores(store);
     const eventBlock = 9_999;
     const registry = makeRegistry({
       queryFilter: seam(async (_filter: unknown, lo: number, hi: number) =>
@@ -366,7 +375,7 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
       ),
     });
     const { adapter } = makeAdapter(registry, 10_000, {
-      contextGraphRegistryScanCursorStore: persistence,
+      ...cursorStores,
     });
     const iterator = adapter.scanContextGraphRegistryPages({ mode: 'tip' })[Symbol.asyncIterator]();
 
@@ -378,7 +387,7 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
 
     registry.queryFilter.clear();
     const { adapter: restarted } = makeAdapter(registry, 10_000, {
-      contextGraphRegistryScanCursorStore: persistence,
+      ...cursorStores,
     });
     const retried = await collectRegistryScan(restarted, { mode: 'tip' });
 

--- a/packages/chain/test/context-graph-registry-tip-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-tip-scan.unit.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ContextGraphChainScanPartialError,
+  type ContextGraphRegistryScanCursorKey,
+  type ContextGraphRegistryScanCursorStore,
+} from '../src/chain-adapter.js';
+import {
+  MemoryRegistryScanCursorStore,
+  REGISTRY,
+  collectRegistryScan,
+  makeAdapter,
+  makeRegistry,
+  roleAwareRegistryCursorPersistence,
+  seam,
+} from './context-graph-registry-scan-test-support.js';
+
+const DEPLOYMENT_ID = 'evm:31337:hub=0x0000000000000000000000000000000000000001';
+const LEGACY_KEY: ContextGraphRegistryScanCursorKey = {
+  chainId: 'evm:31337',
+  deploymentId: DEPLOYMENT_ID,
+  registryAddress: REGISTRY,
+};
+
+class JsonLegacyRegistryScanCursorStore implements ContextGraphRegistryScanCursorStore {
+  readonly values = new Map<string, number>();
+  readonly loads: ContextGraphRegistryScanCursorKey[] = [];
+  readonly saves: Array<{ key: ContextGraphRegistryScanCursorKey; nextBlock: number }> = [];
+
+  seed(key: ContextGraphRegistryScanCursorKey, nextBlock: number): void {
+    this.values.set(JSON.stringify(key), nextBlock);
+  }
+
+  async load(key: ContextGraphRegistryScanCursorKey): Promise<number | undefined> {
+    this.loads.push({ ...key });
+    return this.values.get(JSON.stringify(key));
+  }
+
+  async save(key: ContextGraphRegistryScanCursorKey, nextBlock: number): Promise<void> {
+    this.saves.push({ key: { ...key }, nextBlock });
+    this.values.set(JSON.stringify(key), nextBlock);
+  }
+}
+
+describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
+  it('probes the current tip independently while a middle historical page remains unavailable', async () => {
+    let head = 4_999;
+    const store = new MemoryRegistryScanCursorStore();
+    const persistence = roleAwareRegistryCursorPersistence(store);
+    const tipGraphBlock = 9_999;
+    const betweenTipProbesGraphBlock = 10_001;
+    const registry = makeRegistry({
+      queryFilter: seam(async (_filter: unknown, lo: number, hi: number) => {
+        if (lo >= 2_000 && lo < 4_000) throw new Error('archive range unavailable');
+        return [tipGraphBlock, betweenTipProbesGraphBlock]
+          .filter((blockNumber) => lo <= blockNumber && blockNumber <= hi)
+          .map((blockNumber) => ({ topics: [], data: '0x01', blockNumber }));
+      }),
+    });
+    const { adapter, provider } = makeAdapter(registry, head, {
+      contextGraphRegistryScanCursorPersistence: persistence,
+    });
+    provider.getBlockNumber.setImpl(async () => head);
+
+    const firstRecovery = await collectRegistryScan(adapter, { mode: 'seedFull' }).catch((err) => err);
+
+    expect(firstRecovery).toBeInstanceOf(ContextGraphChainScanPartialError);
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_000);
+
+    head = 10_000;
+    registry.queryFilter.clear();
+    const tipResults = await collectRegistryScan(adapter, { mode: 'tip' });
+
+    expect(tipResults.map((cg) => cg.blockNumber)).toEqual([tipGraphBlock]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [8_001, 10_000],
+    ]);
+    expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_000);
+
+    head = 13_200;
+    const { adapter: restartedAdapter, provider: restartedProvider } = makeAdapter(registry, head, {
+      contextGraphRegistryScanCursorPersistence: persistence,
+    });
+    restartedProvider.getBlockNumber.setImpl(async () => head);
+    registry.queryFilter.clear();
+    const nextTipResults = await collectRegistryScan(restartedAdapter, { mode: 'tip' });
+
+    expect(nextTipResults.map((cg) => cg.blockNumber)).toEqual([
+      tipGraphBlock,
+      betweenTipProbesGraphBlock,
+    ]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [9_951, 11_950],
+      [11_951, 13_200],
+    ]);
+    expect((restartedAdapter as any).contextGraphRegistryTipScanCursor.getCachedWatermark(REGISTRY)).toBe(13_201);
+    expect(await restartedAdapter.hasContextGraphRegistryScanWatermark()).toBe(true);
+    expect((restartedAdapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_000);
+
+    registry.queryFilter.clear();
+    const secondRecovery = await collectRegistryScan(restartedAdapter, { mode: 'seedFull' })
+      .catch((err) => err);
+
+    expect(secondRecovery).toBeInstanceOf(ContextGraphChainScanPartialError);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [0, 1_999],
+      [2_000, 3_999],
+    ]);
+    expect((restartedAdapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY)).toBe(2_000);
+  });
+
+  it('retains the first attempted tip range when its query fails before any acknowledgement', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    const persistence = roleAwareRegistryCursorPersistence(store);
+    const registry = makeRegistry({
+      queryFilter: seam(async () => {
+        throw new Error('first tip page unavailable');
+      }),
+    });
+    const { adapter } = makeAdapter(registry, 10_000, {
+      contextGraphRegistryScanCursorPersistence: persistence,
+    });
+
+    await expect(collectRegistryScan(adapter, { mode: 'tip' }))
+      .rejects.toThrow('first tip page unavailable');
+    expect(store.saves.map((save) => save.nextBlock)).toEqual([8_001]);
+
+    const eventBlock = 10_001;
+    const head = 13_200;
+    registry.queryFilter.reset();
+    registry.queryFilter.setImpl(async (_filter: unknown, lo: number, hi: number) =>
+      lo <= eventBlock && eventBlock <= hi
+        ? [{ topics: [], data: '0x01', blockNumber: eventBlock }]
+        : [],
+    );
+    const { adapter: restarted } = makeAdapter(registry, head, {
+      contextGraphRegistryScanCursorPersistence: persistence,
+    });
+
+    const recovered = await collectRegistryScan(restarted, { mode: 'tip' });
+
+    expect(recovered.map((cg) => cg.blockNumber)).toEqual([eventBlock]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [7_951, 9_950],
+      [9_951, 11_950],
+      [11_951, 13_200],
+    ]);
+    expect(await restarted.hasContextGraphRegistryScanWatermark()).toBe(false);
+  });
+
+  it('retains the exact v1 key shape when loading a legacy historical cursor', async () => {
+    const historical = new JsonLegacyRegistryScanCursorStore();
+    historical.seed(LEGACY_KEY, 2_000);
+    const registry = makeRegistry();
+    const { adapter, provider } = makeAdapter(registry, 5_000, {
+      cgRegistryScanPageSize: 1_000,
+      contextGraphRegistryScanCursorStore: historical,
+    });
+    provider.getCode = seam(async () => {
+      throw new Error('deploy probing must not run after loading the legacy cursor');
+    });
+    registry.queryFilter.setImpl(async () => []);
+
+    await collectRegistryScan(adapter, { mode: 'seedFromCursor', pageBudget: 1 });
+
+    expect(provider.getCode.calls).toEqual([]);
+    expect(historical.loads).toEqual([LEGACY_KEY]);
+    expect(Object.keys(historical.loads[0] ?? {}).sort()).toEqual([
+      'chainId',
+      'deploymentId',
+      'registryAddress',
+    ]);
+    expect(registry.queryFilter.calls[0]?.slice(1)).toEqual([1_950, 2_949]);
+  });
+
+  it('persists independent tip progress across restart with split legacy stores', async () => {
+    const historical = new JsonLegacyRegistryScanCursorStore();
+    const tip = new JsonLegacyRegistryScanCursorStore();
+    historical.seed(LEGACY_KEY, 2_000);
+    const persistence = { kind: 'legacy' as const, historical, tip };
+    const eventBlock = 10_001;
+    let head = 10_000;
+    const registry = makeRegistry({
+      queryFilter: seam(async (_filter: unknown, lo: number, hi: number) =>
+        lo <= eventBlock && eventBlock <= hi
+          ? [{ topics: [], data: '0x01', blockNumber: eventBlock }]
+          : [],
+      ),
+    });
+    const { adapter } = makeAdapter(registry, head, {
+      contextGraphRegistryScanCursorPersistence: persistence,
+    });
+
+    await collectRegistryScan(adapter, { mode: 'tip' });
+
+    expect(historical.values.get(JSON.stringify(LEGACY_KEY))).toBe(2_000);
+    expect(tip.values.get(JSON.stringify(LEGACY_KEY))).toBe(10_001);
+    expect(historical.loads).toEqual([]);
+
+    head = 13_200;
+    registry.queryFilter.clear();
+    const { adapter: restarted, provider } = makeAdapter(registry, head, {
+      contextGraphRegistryScanCursorPersistence: persistence,
+    });
+    provider.getBlockNumber.setImpl(async () => head);
+    const recovered = await collectRegistryScan(restarted, { mode: 'tip' });
+
+    expect(recovered.map((cg) => cg.blockNumber)).toEqual([eventBlock]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [9_951, 11_950],
+      [11_951, 13_200],
+    ]);
+    expect(historical.values.get(JSON.stringify(LEGACY_KEY))).toBe(2_000);
+    expect(tip.values.get(JSON.stringify(LEGACY_KEY))).toBe(13_201);
+    expect(tip.loads).toHaveLength(2);
+    expect(tip.loads.every((key) => !('cursorKind' in key))).toBe(true);
+  });
+
+  it('retains the first tip lower bound in process when durable cursor persistence fails', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {
+        throw new Error('tip cursor save failed');
+      }),
+    };
+    let head = 10_000;
+    let firstQuery = true;
+    const eventBlock = 10_001;
+    const registry = makeRegistry({
+      queryFilter: seam(async (_filter: unknown, lo: number, hi: number) => {
+        if (firstQuery) {
+          firstQuery = false;
+          throw new Error('first tip page unavailable');
+        }
+        return lo <= eventBlock && eventBlock <= hi
+          ? [{ topics: [], data: '0x01', blockNumber: eventBlock }]
+          : [];
+      }),
+    });
+    const { adapter, provider } = makeAdapter(registry, head, {
+      contextGraphRegistryScanCursorPersistence: roleAwareRegistryCursorPersistence(store),
+    });
+    provider.getBlockNumber.setImpl(async () => head);
+
+    try {
+      await expect(collectRegistryScan(adapter, { mode: 'tip' }))
+        .rejects.toThrow('first tip page unavailable');
+      expect((adapter as any).contextGraphRegistryTipScanCursor.getCachedWatermark(REGISTRY))
+        .toBe(8_001);
+
+      head = 13_200;
+      registry.queryFilter.clear();
+      const recovered = await collectRegistryScan(adapter, { mode: 'tip' });
+
+      expect(recovered.map((cg) => cg.blockNumber)).toEqual([eventBlock]);
+      expect(registry.queryFilter.calls[0]?.slice(1)).toEqual([7_951, 9_950]);
+      expect((adapter as any).contextGraphRegistryScanCursor.getCachedWatermark(REGISTRY))
+        .toBeUndefined();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('revisits a fetched tip page when local application never acknowledges it', async () => {
+    const store = new MemoryRegistryScanCursorStore();
+    const persistence = roleAwareRegistryCursorPersistence(store);
+    const eventBlock = 9_999;
+    const registry = makeRegistry({
+      queryFilter: seam(async (_filter: unknown, lo: number, hi: number) =>
+        lo <= eventBlock && eventBlock <= hi
+          ? [{ topics: [], data: '0x01', blockNumber: eventBlock }]
+          : [],
+      ),
+    });
+    const { adapter } = makeAdapter(registry, 10_000, {
+      contextGraphRegistryScanCursorPersistence: persistence,
+    });
+    const iterator = adapter.scanContextGraphRegistryPages({ mode: 'tip' })[Symbol.asyncIterator]();
+
+    const fetched = await iterator.next();
+    expect(fetched.done).toBe(false);
+    expect(fetched.value?.contextGraphs.map((cg) => cg.blockNumber)).toEqual([eventBlock]);
+    await iterator.return?.();
+    expect(store.saves.map((save) => save.nextBlock)).toEqual([8_001]);
+
+    registry.queryFilter.clear();
+    const { adapter: restarted } = makeAdapter(registry, 10_000, {
+      contextGraphRegistryScanCursorPersistence: persistence,
+    });
+    const retried = await collectRegistryScan(restarted, { mode: 'tip' });
+
+    expect(retried.map((cg) => cg.blockNumber)).toEqual([eventBlock]);
+    expect(registry.queryFilter.calls.map(([, lo, hi]: [unknown, number, number]) => [lo, hi])).toEqual([
+      [7_951, 9_950],
+      [9_951, 10_000],
+    ]);
+    expect(await restarted.hasContextGraphRegistryScanWatermark()).toBe(false);
+  });
+});

--- a/packages/chain/test/context-graph-registry-tip-scan.unit.test.ts
+++ b/packages/chain/test/context-graph-registry-tip-scan.unit.test.ts
@@ -405,6 +405,27 @@ describe('EVMChainAdapter ContextGraphNameRegistry tip recovery', () => {
     }
   });
 
+  it('fails closed when a store returns a present invalid tip cursor', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = {
+      load: vi.fn(async () => 0),
+      save: vi.fn(async () => undefined),
+    };
+    const registry = makeRegistry();
+    const { adapter } = makeAdapter(registry, 20_000, {
+      ...registryCursorStores(store),
+    });
+
+    try {
+      await expect(collectRegistryScan(adapter, { mode: 'tip' }))
+        .rejects.toThrow('tip cursor load failed');
+      expect(registry.queryFilter.calls).toEqual([]);
+      expect(store.save).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('revisits a fetched tip page when local application never acknowledges it', async () => {
     const store = new MemoryRegistryScanCursorStore();
     const cursorStores = registryCursorStores(store);

--- a/packages/chain/test/evm-event-log-page-session.unit.test.ts
+++ b/packages/chain/test/evm-event-log-page-session.unit.test.ts
@@ -1,0 +1,45 @@
+import type { Contract, JsonRpcProvider } from 'ethers';
+import { describe, expect, it } from 'vitest';
+import { EvmEventLogPageSession } from '../src/evm-event-log-page-session.js';
+
+describe('EvmEventLogPageSession', () => {
+  it('keeps provider affinity and contract bindings within one session only', async () => {
+    const providerA = {} as JsonRpcProvider;
+    const providerB = {} as JsonRpcProvider;
+    const binding = {} as Contract;
+    const connectedByCall: Array<Map<JsonRpcProvider, Contract>> = [];
+    const preferredByCall: Array<JsonRpcProvider | undefined> = [];
+    let call = 0;
+    const execute = async (
+      _filter: unknown,
+      _lo: number,
+      _hi: number,
+      _providers: ReadonlyArray<{ provider: JsonRpcProvider; backendHead: number }>,
+      connected: Map<JsonRpcProvider, Contract>,
+      preferred?: JsonRpcProvider,
+    ) => {
+      connectedByCall.push(connected);
+      preferredByCall.push(preferred);
+      if (call++ === 0) connected.set(providerB, binding);
+      return { logs: [], provider: providerB };
+    };
+    const providers = [
+      { provider: providerA, backendHead: 100 },
+      { provider: providerB, backendHead: 100 },
+    ];
+
+    const session = new EvmEventLogPageSession(providers, execute);
+    await session.query({}, 1, 50);
+    await session.query({}, 51, 100);
+
+    expect(preferredByCall).toEqual([undefined, providerB]);
+    expect(connectedByCall[1]).toBe(connectedByCall[0]);
+    expect(connectedByCall[1].get(providerB)).toBe(binding);
+
+    const isolated = new EvmEventLogPageSession(providers, execute);
+    await isolated.query({}, 1, 50);
+    expect(preferredByCall[2]).toBeUndefined();
+    expect(connectedByCall[2]).not.toBe(connectedByCall[0]);
+    expect(connectedByCall[2].size).toBe(0);
+  });
+});

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -19,6 +19,7 @@ export * from './daemon/openclaw.js';
 export * from './daemon/hermes.js';
 export * from './daemon/local-agents.js';
 export * from './daemon/lifecycle.js';
+export * from './daemon/chain-discovery-scan-runner.js';
 export * from './daemon/memory-tool-context.js';
 export * from './daemon/handle-request.js';
 export * from './daemon/shutdown.js';

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -1,7 +1,7 @@
 // Split-refactor barrel: every helper that used to live inline in
 // this 10.5k-line file now lives under `./daemon/*.ts`. External
-// consumers (cli.ts, tests) import from `./daemon.js`, so we re-
-// export every public symbol here. See `./daemon/index.ts` for the
+// consumers (cli.ts, tests) import from `./daemon.js`, so we preserve
+// the intended public surface here. See `./daemon/index.ts` for the
 // per-module barrel used inside the refactor.
 
 export {
@@ -19,7 +19,14 @@ export * from './daemon/openclaw.js';
 export * from './daemon/hermes.js';
 export * from './daemon/local-agents.js';
 export * from './daemon/lifecycle.js';
-export * from './daemon/chain-discovery-scan-runner.js';
+export {
+  CHAIN_FULL_SCAN_EVERY,
+  CHAIN_DISCOVERY_SCAN_PAGE_BUDGET,
+  chainDiscoveryScanOptions,
+  createChainDiscoveryScanRunner,
+  type LegacyChainDiscoveryScanOptionsInput,
+  type ChainDiscoveryScanOptions,
+} from './daemon/chain-discovery-scan-runner.js';
 export * from './daemon/memory-tool-context.js';
 export * from './daemon/handle-request.js';
 export * from './daemon/shutdown.js';

--- a/packages/cli/src/daemon/chain-discovery-scan-runner.ts
+++ b/packages/cli/src/daemon/chain-discovery-scan-runner.ts
@@ -20,22 +20,19 @@ export const CHAIN_DISCOVERY_SCAN_SCHEDULE = Object.freeze({
 export const CHAIN_FULL_SCAN_EVERY = CHAIN_DISCOVERY_SCAN_SCHEDULE.fullScanEvery;
 export const CHAIN_DISCOVERY_SCAN_PAGE_BUDGET = 30;
 
-export type ChainDiscoveryStartupPhase =
-  | 'undetermined'
-  | 'cursorSeed'
-  | 'startupFullRecovery'
-  | 'complete';
+export type ManagedChainDiscoveryScanState =
+  | { kind: 'undetermined' }
+  | { kind: 'cursorSeed'; failures: number }
+  | { kind: 'startupFullRecovery'; failures: number }
+  | { kind: 'steady'; successfulScansInCycle: number; cursorFailures: number }
+  | { kind: 'recoveryTip'; successfulScansInCycle: number }
+  | { kind: 'recoveryIncremental'; successfulScansInCycle: number }
+  | { kind: 'recoveryFull'; successfulScansInCycle: number };
 
-type ChainDiscoveryRecoveryStep = 'tip' | 'incremental' | 'full';
-
-type ManagedChainDiscoveryScanOptionsInput = {
-  watermarkSeeded: boolean;
-  startupPhase: ChainDiscoveryStartupPhase;
-  successfulScansInCycle: number;
-  recoveryStep?: ChainDiscoveryRecoveryStep;
-  fullScanEvery?: number;
-  pageBudget?: number;
-};
+type ActiveManagedChainDiscoveryScanState = Exclude<
+  ManagedChainDiscoveryScanState,
+  { kind: 'undetermined' }
+>;
 
 /** Input retained for callers of the original daemon lifecycle helper. */
 export type LegacyChainDiscoveryScanOptionsInput = {
@@ -91,41 +88,113 @@ export function chainDiscoveryScanOptions(
     : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
 }
 
-/** Outcome-aware policy used only by the managed daemon scan runner. */
-function managedChainDiscoveryScanOptions(
-  input: ManagedChainDiscoveryScanOptionsInput,
-): ChainDiscoveryScanOptions {
+export function resolveManagedChainDiscoveryScanAttempt(input: {
+  state: ManagedChainDiscoveryScanState;
+  watermarkSeeded: boolean;
+  fullScanEvery?: number;
+  pageBudget?: number;
+}): {
+  state: ActiveManagedChainDiscoveryScanState;
+  options: ChainDiscoveryScanOptions;
+} {
   const fullScanEvery = normalizeFullScanEvery(input.fullScanEvery);
   const pageBudget = normalizePageBudget(input.pageBudget);
+  const state: ActiveManagedChainDiscoveryScanState = input.state.kind === 'undetermined'
+    ? input.watermarkSeeded
+      ? { kind: 'startupFullRecovery', failures: 0 }
+      : { kind: 'cursorSeed', failures: 0 }
+    : input.state;
 
-  if (input.startupPhase === 'undetermined') {
-    return input.watermarkSeeded
-      ? { mode: 'seedFull', throwOnChainScanFailure: true }
-      : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
+  switch (state.kind) {
+    case 'startupFullRecovery':
+    case 'recoveryFull':
+      return { state, options: { mode: 'seedFull', throwOnChainScanFailure: true } };
+    case 'recoveryTip':
+      return { state, options: { mode: 'tip' } };
+    case 'cursorSeed':
+    case 'recoveryIncremental':
+      return {
+        state,
+        options: input.watermarkSeeded
+          ? { mode: 'incremental', throwOnChainScanFailure: true, pageBudget }
+          : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget },
+      };
+    case 'steady':
+      if (input.watermarkSeeded && state.successfulScansInCycle >= fullScanEvery) {
+        return { state, options: { mode: 'seedFull', throwOnChainScanFailure: true } };
+      }
+      return {
+        state,
+        options: input.watermarkSeeded
+          ? { mode: 'incremental', throwOnChainScanFailure: true, pageBudget }
+          : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget },
+      };
   }
-  if (input.startupPhase === 'cursorSeed') {
-    return input.watermarkSeeded
-      ? { mode: 'incremental', throwOnChainScanFailure: true, pageBudget }
-      : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
+}
+
+export function transitionManagedChainDiscoveryScanState(input: {
+  state: ActiveManagedChainDiscoveryScanState;
+  watermarkSeeded: boolean;
+  outcome: 'success' | 'failure';
+  fullScanEvery?: number;
+}): ManagedChainDiscoveryScanState {
+  const { state } = input;
+  const successes = 'successfulScansInCycle' in state
+    ? state.successfulScansInCycle
+    : 0;
+  const steadyFullAttempt = state.kind === 'steady'
+    && input.watermarkSeeded
+    && successes >= normalizeFullScanEvery(input.fullScanEvery);
+
+  if (input.outcome === 'failure') {
+    switch (state.kind) {
+      case 'startupFullRecovery':
+        return state.failures + 1 >= 2
+          ? { kind: 'recoveryTip', successfulScansInCycle: 0 }
+          : { ...state, failures: state.failures + 1 };
+      case 'cursorSeed':
+        return state.failures + 1 >= 2
+          ? { kind: 'recoveryTip', successfulScansInCycle: 0 }
+          : { ...state, failures: state.failures + 1 };
+      case 'recoveryTip':
+        return input.watermarkSeeded
+          ? { kind: 'recoveryIncremental', successfulScansInCycle: successes }
+          : { kind: 'recoveryFull', successfulScansInCycle: successes };
+      case 'recoveryIncremental':
+        return { kind: 'recoveryFull', successfulScansInCycle: successes };
+      case 'recoveryFull':
+        return { kind: 'recoveryTip', successfulScansInCycle: successes };
+      case 'steady':
+        if (steadyFullAttempt) {
+          return { kind: 'recoveryTip', successfulScansInCycle: successes };
+        }
+        return state.cursorFailures + 1 >= 2
+          ? { kind: 'recoveryTip', successfulScansInCycle: successes }
+          : { ...state, cursorFailures: state.cursorFailures + 1 };
+    }
   }
-  if (input.startupPhase === 'startupFullRecovery') {
-    return { mode: 'seedFull', throwOnChainScanFailure: true };
+
+  switch (state.kind) {
+    case 'startupFullRecovery':
+    case 'recoveryFull':
+      return { kind: 'steady', successfulScansInCycle: 1, cursorFailures: 0 };
+    case 'cursorSeed':
+      return { kind: 'steady', successfulScansInCycle: 1, cursorFailures: 0 };
+    case 'recoveryTip':
+      return input.watermarkSeeded
+        ? { kind: 'recoveryIncremental', successfulScansInCycle: successes }
+        : { kind: 'recoveryFull', successfulScansInCycle: successes };
+    case 'recoveryIncremental':
+      return { kind: 'recoveryFull', successfulScansInCycle: successes };
+    case 'steady':
+      return steadyFullAttempt
+        ? { kind: 'steady', successfulScansInCycle: 1, cursorFailures: 0 }
+        : {
+            kind: 'steady',
+            successfulScansInCycle: successes + 1,
+            cursorFailures: 0,
+          };
   }
-  if (input.recoveryStep === 'tip') return { mode: 'tip' };
-  if (input.recoveryStep === 'incremental') {
-    return input.watermarkSeeded
-      ? { mode: 'incremental', throwOnChainScanFailure: true, pageBudget }
-      : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
-  }
-  if (input.recoveryStep === 'full') {
-    return { mode: 'seedFull', throwOnChainScanFailure: true };
-  }
-  if (input.watermarkSeeded && input.successfulScansInCycle >= fullScanEvery) {
-    return { mode: 'seedFull', throwOnChainScanFailure: true };
-  }
-  return input.watermarkSeeded
-    ? { mode: 'incremental', throwOnChainScanFailure: true, pageBudget }
-    : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
 }
 
 function safeLog(log: (message: string) => void, message: string): void {
@@ -157,11 +226,7 @@ export function createChainDiscoveryScanRunner(input: {
   pageBudget?: number;
   fullScanEvery?: number;
 }): () => Promise<void> {
-  let startupPhase: ChainDiscoveryStartupPhase = 'undetermined';
-  let startupFullFailures = 0;
-  let successfulScansInCycle = 0;
-  let recoveryStep: ChainDiscoveryRecoveryStep | undefined;
-  let cursorBackedFailures = 0;
+  let state: ManagedChainDiscoveryScanState = { kind: 'undetermined' };
   let inFlight = false;
 
   return async () => {
@@ -180,19 +245,14 @@ export function createChainDiscoveryScanRunner(input: {
         return;
       }
 
-      if (startupPhase === 'undetermined') {
-        startupPhase = watermarkSeeded ? 'startupFullRecovery' : 'cursorSeed';
-      }
-
-      const scheduledRecoveryStep = recoveryStep;
-      const options = managedChainDiscoveryScanOptions({
+      const attempt = resolveManagedChainDiscoveryScanAttempt({
+        state,
         watermarkSeeded,
-        startupPhase,
-        successfulScansInCycle,
-        recoveryStep: scheduledRecoveryStep,
         pageBudget: input.pageBudget,
         fullScanEvery: input.fullScanEvery,
       });
+      state = attempt.state;
+      const { options } = attempt;
 
       let found: number;
       try {
@@ -202,63 +262,21 @@ export function createChainDiscoveryScanRunner(input: {
           input.log,
           `Chain scan: ${options.mode} scan failed: ${safeErrorMessage(error)}`,
         );
-
-        if (startupPhase === 'startupFullRecovery') {
-          startupFullFailures += 1;
-          // Retry startup recovery once immediately. If the historical range remains unavailable,
-          // enter steady state and interleave tip discovery before each later full retry.
-          if (startupFullFailures >= 2) {
-            startupPhase = 'complete';
-            recoveryStep = 'tip';
-          }
-        } else if (options.mode === 'seedFull') {
-          recoveryStep = 'tip';
-        } else if (scheduledRecoveryStep === 'tip' && options.mode === 'tip') {
-          // A tip probe cannot fill a multi-page cursor-to-tip gap by itself. Whether the probe
-          // succeeds or fails, give the usable historical cursor one bounded catch-up turn.
-          recoveryStep = watermarkSeeded ? 'incremental' : 'full';
-        } else if (
-          scheduledRecoveryStep === 'incremental' &&
-          (options.mode === 'seedFromCursor' || options.mode === 'incremental')
-        ) {
-          recoveryStep = 'full';
-        } else if (options.mode === 'seedFromCursor' || options.mode === 'incremental') {
-          cursorBackedFailures += 1;
-          // A bounded retry absorbs transient RPC failures. Persistent cursor-backed failure means
-          // historical progress is blocked, so preserve that cursor and enter the same tip/full
-          // recovery alternation used for failed full scans.
-          if (cursorBackedFailures >= 2) {
-            startupPhase = 'complete';
-            recoveryStep = 'tip';
-            cursorBackedFailures = 0;
-          }
-        }
+        state = transitionManagedChainDiscoveryScanState({
+          state: attempt.state,
+          watermarkSeeded,
+          outcome: 'failure',
+          fullScanEvery: input.fullScanEvery,
+        });
         return;
       }
 
-      if (options.mode === 'seedFull') {
-        startupPhase = 'complete';
-        startupFullFailures = 0;
-        successfulScansInCycle = 1;
-        recoveryStep = undefined;
-        cursorBackedFailures = 0;
-      } else {
-        if (startupPhase === 'cursorSeed') startupPhase = 'complete';
-        if (options.mode === 'seedFromCursor' || options.mode === 'incremental') {
-          cursorBackedFailures = 0;
-        }
-        if (scheduledRecoveryStep === 'tip' && options.mode === 'tip') {
-          recoveryStep = watermarkSeeded ? 'incremental' : 'full';
-        } else if (
-          scheduledRecoveryStep === 'incremental' &&
-          (options.mode === 'seedFromCursor' || options.mode === 'incremental')
-        ) {
-          recoveryStep = 'full';
-        }
-        if (scheduledRecoveryStep === undefined) {
-          successfulScansInCycle += 1;
-        }
-      }
+      state = transitionManagedChainDiscoveryScanState({
+        state: attempt.state,
+        watermarkSeeded,
+        outcome: 'success',
+        fullScanEvery: input.fullScanEvery,
+      });
 
       if (found > 0) {
         safeLog(input.log, `Chain scan: discovered ${found} new context graph(s)`);

--- a/packages/cli/src/daemon/chain-discovery-scan-runner.ts
+++ b/packages/cli/src/daemon/chain-discovery-scan-runner.ts
@@ -26,12 +26,13 @@ export type ChainDiscoveryStartupPhase =
   | 'startupFullRecovery'
   | 'complete';
 
-export type ManagedChainDiscoveryScanOptionsInput = {
+type ChainDiscoveryRecoveryStep = 'tip' | 'incremental' | 'full';
+
+type ManagedChainDiscoveryScanOptionsInput = {
   watermarkSeeded: boolean;
   startupPhase: ChainDiscoveryStartupPhase;
   successfulScansInCycle: number;
-  fullRecoveryPending?: boolean;
-  fullRecoveryRetryReady?: boolean;
+  recoveryStep?: ChainDiscoveryRecoveryStep;
   fullScanEvery?: number;
   pageBudget?: number;
 };
@@ -51,38 +52,51 @@ export type ChainDiscoveryScanOptions =
   | { mode: 'seedFromCursor'; throwOnChainScanFailure: true; pageBudget: number }
   | { mode: 'seedFull'; throwOnChainScanFailure: true };
 
-export function chainDiscoveryScanOptions(
-  input: ManagedChainDiscoveryScanOptionsInput | LegacyChainDiscoveryScanOptionsInput,
-): ChainDiscoveryScanOptions {
-  const configuredFullScanEvery = input.fullScanEvery;
+function normalizeFullScanEvery(configured: number | undefined): number {
   let fullScanEvery = CHAIN_DISCOVERY_SCAN_SCHEDULE.fullScanEvery;
   if (
-    typeof configuredFullScanEvery === 'number' &&
-    Number.isFinite(configuredFullScanEvery) &&
-    configuredFullScanEvery >= 1
+    typeof configured === 'number' &&
+    Number.isFinite(configured) &&
+    configured >= 1
   ) {
-    fullScanEvery = Math.floor(configuredFullScanEvery);
+    fullScanEvery = Math.floor(configured);
   }
-  const configuredPageBudget = input.pageBudget;
-  const pageBudget = (
-    typeof configuredPageBudget === 'number' &&
-    Number.isFinite(configuredPageBudget) &&
-    configuredPageBudget >= 1
-  )
-    ? Math.floor(configuredPageBudget)
-    : CHAIN_DISCOVERY_SCAN_PAGE_BUDGET;
+  return fullScanEvery;
+}
 
-  if (!('startupPhase' in input)) {
-    const run = input.run ?? 0;
-    const startupRecoveryScan = input.watermarkSeeded && run === 0;
-    const periodicFullResync = input.watermarkSeeded && run > 0 && run % fullScanEvery === 0;
-    if (startupRecoveryScan || periodicFullResync) {
-      return { mode: 'seedFull', throwOnChainScanFailure: true };
-    }
-    return input.watermarkSeeded
-      ? { mode: 'incremental', pageBudget }
-      : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
+function normalizePageBudget(configured: number | undefined): number {
+  return (
+    typeof configured === 'number' &&
+    Number.isFinite(configured) &&
+    configured >= 1
+  )
+    ? Math.floor(configured)
+    : CHAIN_DISCOVERY_SCAN_PAGE_BUDGET;
+}
+
+/** Original invocation-count policy retained for external daemon-barrel callers. */
+export function chainDiscoveryScanOptions(
+  input: LegacyChainDiscoveryScanOptionsInput,
+): ChainDiscoveryScanOptions {
+  const fullScanEvery = normalizeFullScanEvery(input.fullScanEvery);
+  const pageBudget = normalizePageBudget(input.pageBudget);
+  const run = input.run ?? 0;
+  const startupRecoveryScan = input.watermarkSeeded && run === 0;
+  const periodicFullResync = input.watermarkSeeded && run > 0 && run % fullScanEvery === 0;
+  if (startupRecoveryScan || periodicFullResync) {
+    return { mode: 'seedFull', throwOnChainScanFailure: true };
   }
+  return input.watermarkSeeded
+    ? { mode: 'incremental', pageBudget }
+    : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
+}
+
+/** Outcome-aware policy used only by the managed daemon scan runner. */
+function managedChainDiscoveryScanOptions(
+  input: ManagedChainDiscoveryScanOptionsInput,
+): ChainDiscoveryScanOptions {
+  const fullScanEvery = normalizeFullScanEvery(input.fullScanEvery);
+  const pageBudget = normalizePageBudget(input.pageBudget);
 
   if (input.startupPhase === 'undetermined') {
     return input.watermarkSeeded
@@ -97,10 +111,14 @@ export function chainDiscoveryScanOptions(
   if (input.startupPhase === 'startupFullRecovery') {
     return { mode: 'seedFull', throwOnChainScanFailure: true };
   }
-  if (input.fullRecoveryPending) {
-    return input.fullRecoveryRetryReady
-      ? { mode: 'seedFull', throwOnChainScanFailure: true }
-      : { mode: 'tip' };
+  if (input.recoveryStep === 'tip') return { mode: 'tip' };
+  if (input.recoveryStep === 'incremental') {
+    return input.watermarkSeeded
+      ? { mode: 'incremental', throwOnChainScanFailure: true, pageBudget }
+      : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
+  }
+  if (input.recoveryStep === 'full') {
+    return { mode: 'seedFull', throwOnChainScanFailure: true };
   }
   if (input.watermarkSeeded && input.successfulScansInCycle >= fullScanEvery) {
     return { mode: 'seedFull', throwOnChainScanFailure: true };
@@ -142,8 +160,7 @@ export function createChainDiscoveryScanRunner(input: {
   let startupPhase: ChainDiscoveryStartupPhase = 'undetermined';
   let startupFullFailures = 0;
   let successfulScansInCycle = 0;
-  let fullRecoveryPending = false;
-  let fullRecoveryRetryReady = false;
+  let recoveryStep: ChainDiscoveryRecoveryStep | undefined;
   let cursorBackedFailures = 0;
   let inFlight = false;
 
@@ -167,12 +184,12 @@ export function createChainDiscoveryScanRunner(input: {
         startupPhase = watermarkSeeded ? 'startupFullRecovery' : 'cursorSeed';
       }
 
-      const options = chainDiscoveryScanOptions({
+      const scheduledRecoveryStep = recoveryStep;
+      const options = managedChainDiscoveryScanOptions({
         watermarkSeeded,
         startupPhase,
         successfulScansInCycle,
-        fullRecoveryPending,
-        fullRecoveryRetryReady,
+        recoveryStep: scheduledRecoveryStep,
         pageBudget: input.pageBudget,
         fullScanEvery: input.fullScanEvery,
       });
@@ -192,12 +209,19 @@ export function createChainDiscoveryScanRunner(input: {
           // enter steady state and interleave tip discovery before each later full retry.
           if (startupFullFailures >= 2) {
             startupPhase = 'complete';
-            fullRecoveryPending = true;
-            fullRecoveryRetryReady = false;
+            recoveryStep = 'tip';
           }
         } else if (options.mode === 'seedFull') {
-          fullRecoveryPending = true;
-          fullRecoveryRetryReady = false;
+          recoveryStep = 'tip';
+        } else if (scheduledRecoveryStep === 'tip' && options.mode === 'tip') {
+          // A tip probe cannot fill a multi-page cursor-to-tip gap by itself. Whether the probe
+          // succeeds or fails, give the usable historical cursor one bounded catch-up turn.
+          recoveryStep = watermarkSeeded ? 'incremental' : 'full';
+        } else if (
+          scheduledRecoveryStep === 'incremental' &&
+          (options.mode === 'seedFromCursor' || options.mode === 'incremental')
+        ) {
+          recoveryStep = 'full';
         } else if (options.mode === 'seedFromCursor' || options.mode === 'incremental') {
           cursorBackedFailures += 1;
           // A bounded retry absorbs transient RPC failures. Persistent cursor-backed failure means
@@ -205,14 +229,9 @@ export function createChainDiscoveryScanRunner(input: {
           // recovery alternation used for failed full scans.
           if (cursorBackedFailures >= 2) {
             startupPhase = 'complete';
-            fullRecoveryPending = true;
-            fullRecoveryRetryReady = false;
+            recoveryStep = 'tip';
             cursorBackedFailures = 0;
           }
-        } else if (fullRecoveryPending && options.mode === 'tip') {
-          // One tip-discovery attempt, successful or not, prevents an unavailable historical range
-          // from monopolizing the scheduler. The next invocation may retry full recovery.
-          fullRecoveryRetryReady = true;
         }
         return;
       }
@@ -221,17 +240,23 @@ export function createChainDiscoveryScanRunner(input: {
         startupPhase = 'complete';
         startupFullFailures = 0;
         successfulScansInCycle = 1;
-        fullRecoveryPending = false;
-        fullRecoveryRetryReady = false;
+        recoveryStep = undefined;
         cursorBackedFailures = 0;
       } else {
         if (startupPhase === 'cursorSeed') startupPhase = 'complete';
         if (options.mode === 'seedFromCursor' || options.mode === 'incremental') {
           cursorBackedFailures = 0;
         }
-        successfulScansInCycle += 1;
-        if (fullRecoveryPending && options.mode === 'tip') {
-          fullRecoveryRetryReady = true;
+        if (scheduledRecoveryStep === 'tip' && options.mode === 'tip') {
+          recoveryStep = watermarkSeeded ? 'incremental' : 'full';
+        } else if (
+          scheduledRecoveryStep === 'incremental' &&
+          (options.mode === 'seedFromCursor' || options.mode === 'incremental')
+        ) {
+          recoveryStep = 'full';
+        }
+        if (scheduledRecoveryStep === undefined) {
+          successfulScansInCycle += 1;
         }
       }
 

--- a/packages/cli/src/daemon/chain-discovery-scan-runner.ts
+++ b/packages/cli/src/daemon/chain-discovery-scan-runner.ts
@@ -117,6 +117,7 @@ export function createChainDiscoveryScanRunner(input: {
   let successfulScansInCycle = 0;
   let fullRecoveryPending = false;
   let fullRecoveryRetryReady = false;
+  let cursorBackedFailures = 0;
   let inFlight = false;
 
   return async () => {
@@ -170,6 +171,17 @@ export function createChainDiscoveryScanRunner(input: {
         } else if (options.mode === 'seedFull') {
           fullRecoveryPending = true;
           fullRecoveryRetryReady = false;
+        } else if (options.mode === 'seedFromCursor' || options.mode === 'incremental') {
+          cursorBackedFailures += 1;
+          // A bounded retry absorbs transient RPC failures. Persistent cursor-backed failure means
+          // historical progress is blocked, so preserve that cursor and enter the same tip/full
+          // recovery alternation used for failed full scans.
+          if (cursorBackedFailures >= 2) {
+            startupPhase = 'complete';
+            fullRecoveryPending = true;
+            fullRecoveryRetryReady = false;
+            cursorBackedFailures = 0;
+          }
         } else if (fullRecoveryPending && options.mode === 'tip') {
           // One tip-discovery attempt, successful or not, prevents an unavailable historical range
           // from monopolizing the scheduler. The next invocation may retry full recovery.
@@ -184,8 +196,12 @@ export function createChainDiscoveryScanRunner(input: {
         successfulScansInCycle = 1;
         fullRecoveryPending = false;
         fullRecoveryRetryReady = false;
+        cursorBackedFailures = 0;
       } else {
         if (startupPhase === 'cursorSeed') startupPhase = 'complete';
+        if (options.mode === 'seedFromCursor' || options.mode === 'incremental') {
+          cursorBackedFailures = 0;
+        }
         successfulScansInCycle += 1;
         if (fullRecoveryPending && options.mode === 'tip') {
           fullRecoveryRetryReady = true;

--- a/packages/cli/src/daemon/chain-discovery-scan-runner.ts
+++ b/packages/cli/src/daemon/chain-discovery-scan-runner.ts
@@ -35,7 +35,7 @@ export function chainDiscoveryScanOptions(input: {
   fullScanEvery?: number;
   pageBudget?: number;
 }):
-  | { mode: 'incremental'; pageBudget: number }
+  | { mode: 'incremental'; throwOnChainScanFailure: true; pageBudget: number }
   | { mode: 'tip' }
   | { mode: 'seedFromCursor'; throwOnChainScanFailure: true; pageBudget: number }
   | { mode: 'seedFull'; throwOnChainScanFailure: true } {
@@ -64,7 +64,7 @@ export function chainDiscoveryScanOptions(input: {
   }
   if (input.startupPhase === 'cursorSeed') {
     return input.watermarkSeeded
-      ? { mode: 'incremental', pageBudget }
+      ? { mode: 'incremental', throwOnChainScanFailure: true, pageBudget }
       : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
   }
   if (input.startupPhase === 'startupFullRecovery') {
@@ -79,7 +79,7 @@ export function chainDiscoveryScanOptions(input: {
     return { mode: 'seedFull', throwOnChainScanFailure: true };
   }
   return input.watermarkSeeded
-    ? { mode: 'incremental', pageBudget }
+    ? { mode: 'incremental', throwOnChainScanFailure: true, pageBudget }
     : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
 }
 

--- a/packages/cli/src/daemon/chain-discovery-scan-runner.ts
+++ b/packages/cli/src/daemon/chain-discovery-scan-runner.ts
@@ -182,23 +182,6 @@ export function resolveManagedChainDiscoveryScanAttempt(input: {
   }
 }
 
-/** Compatibility wrapper over the attempt's co-located transition model. */
-export function transitionManagedChainDiscoveryScanState(input: {
-  state: ActiveManagedChainDiscoveryScanState;
-  watermarkSeeded: boolean;
-  outcome: 'success' | 'failure';
-  fullScanEvery?: number;
-}): ManagedChainDiscoveryScanState {
-  const attempt = resolveManagedChainDiscoveryScanAttempt({
-    state: input.state,
-    watermarkSeeded: input.watermarkSeeded,
-    fullScanEvery: input.fullScanEvery,
-  });
-  return input.outcome === 'success'
-    ? attempt.nextOnSuccess
-    : attempt.nextOnFailure;
-}
-
 function safeLog(log: (message: string) => void, message: string): void {
   try {
     log(message);

--- a/packages/cli/src/daemon/chain-discovery-scan-runner.ts
+++ b/packages/cli/src/daemon/chain-discovery-scan-runner.ts
@@ -26,7 +26,7 @@ export type ChainDiscoveryStartupPhase =
   | 'startupFullRecovery'
   | 'complete';
 
-export function chainDiscoveryScanOptions(input: {
+export type ManagedChainDiscoveryScanOptionsInput = {
   watermarkSeeded: boolean;
   startupPhase: ChainDiscoveryStartupPhase;
   successfulScansInCycle: number;
@@ -34,11 +34,26 @@ export function chainDiscoveryScanOptions(input: {
   fullRecoveryRetryReady?: boolean;
   fullScanEvery?: number;
   pageBudget?: number;
-}):
+};
+
+/** Input retained for callers of the original daemon lifecycle helper. */
+export type LegacyChainDiscoveryScanOptionsInput = {
+  watermarkSeeded: boolean;
+  run?: number;
+  fullScanEvery?: number;
+  pageBudget?: number;
+};
+
+export type ChainDiscoveryScanOptions =
   | { mode: 'incremental'; throwOnChainScanFailure: true; pageBudget: number }
+  | { mode: 'incremental'; pageBudget: number }
   | { mode: 'tip' }
   | { mode: 'seedFromCursor'; throwOnChainScanFailure: true; pageBudget: number }
-  | { mode: 'seedFull'; throwOnChainScanFailure: true } {
+  | { mode: 'seedFull'; throwOnChainScanFailure: true };
+
+export function chainDiscoveryScanOptions(
+  input: ManagedChainDiscoveryScanOptionsInput | LegacyChainDiscoveryScanOptionsInput,
+): ChainDiscoveryScanOptions {
   const configuredFullScanEvery = input.fullScanEvery;
   let fullScanEvery = CHAIN_DISCOVERY_SCAN_SCHEDULE.fullScanEvery;
   if (
@@ -56,6 +71,18 @@ export function chainDiscoveryScanOptions(input: {
   )
     ? Math.floor(configuredPageBudget)
     : CHAIN_DISCOVERY_SCAN_PAGE_BUDGET;
+
+  if (!('startupPhase' in input)) {
+    const run = input.run ?? 0;
+    const startupRecoveryScan = input.watermarkSeeded && run === 0;
+    const periodicFullResync = input.watermarkSeeded && run > 0 && run % fullScanEvery === 0;
+    if (startupRecoveryScan || periodicFullResync) {
+      return { mode: 'seedFull', throwOnChainScanFailure: true };
+    }
+    return input.watermarkSeeded
+      ? { mode: 'incremental', pageBudget }
+      : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
+  }
 
   if (input.startupPhase === 'undetermined') {
     return input.watermarkSeeded
@@ -105,7 +132,7 @@ export function createChainDiscoveryScanRunner(input: {
   agent: {
     hasContextGraphRegistryScanWatermark(): Promise<boolean>;
     discoverContextGraphsFromChain(
-      options: ReturnType<typeof chainDiscoveryScanOptions>,
+      options: ChainDiscoveryScanOptions,
     ): Promise<number>;
   };
   log: (msg: string) => void;

--- a/packages/cli/src/daemon/chain-discovery-scan-runner.ts
+++ b/packages/cli/src/daemon/chain-discovery-scan-runner.ts
@@ -36,6 +36,7 @@ export function chainDiscoveryScanOptions(input: {
   pageBudget?: number;
 }):
   | { mode: 'incremental'; pageBudget: number }
+  | { mode: 'tip' }
   | { mode: 'seedFromCursor'; throwOnChainScanFailure: true; pageBudget: number }
   | { mode: 'seedFull'; throwOnChainScanFailure: true } {
   const configuredFullScanEvery = input.fullScanEvery;
@@ -72,7 +73,7 @@ export function chainDiscoveryScanOptions(input: {
   if (input.fullRecoveryPending) {
     return input.fullRecoveryRetryReady
       ? { mode: 'seedFull', throwOnChainScanFailure: true }
-      : { mode: 'incremental', pageBudget };
+      : { mode: 'tip' };
   }
   if (input.watermarkSeeded && input.successfulScansInCycle >= fullScanEvery) {
     return { mode: 'seedFull', throwOnChainScanFailure: true };
@@ -169,7 +170,7 @@ export function createChainDiscoveryScanRunner(input: {
         } else if (options.mode === 'seedFull') {
           fullRecoveryPending = true;
           fullRecoveryRetryReady = false;
-        } else if (fullRecoveryPending && options.mode === 'incremental') {
+        } else if (fullRecoveryPending && options.mode === 'tip') {
           // One tip-discovery attempt, successful or not, prevents an unavailable historical range
           // from monopolizing the scheduler. The next invocation may retry full recovery.
           fullRecoveryRetryReady = true;
@@ -186,7 +187,7 @@ export function createChainDiscoveryScanRunner(input: {
       } else {
         if (startupPhase === 'cursorSeed') startupPhase = 'complete';
         successfulScansInCycle += 1;
-        if (fullRecoveryPending && options.mode === 'incremental') {
+        if (fullRecoveryPending && options.mode === 'tip') {
           fullRecoveryRetryReady = true;
         }
       }

--- a/packages/cli/src/daemon/chain-discovery-scan-runner.ts
+++ b/packages/cli/src/daemon/chain-discovery-scan-runner.ts
@@ -1,0 +1,116 @@
+export const CHAIN_FULL_SCAN_EVERY = 48; // about once per day at the 30-minute cadence
+export const CHAIN_DISCOVERY_SCAN_PAGE_BUDGET = 30;
+
+export function chainDiscoveryScanOptions(input: {
+  watermarkSeeded: boolean;
+  run?: number;
+  fullScanEvery?: number;
+  pageBudget?: number;
+}):
+  | { mode: 'incremental'; pageBudget: number }
+  | { mode: 'seedFromCursor'; throwOnChainScanFailure: true; pageBudget: number }
+  | { mode: 'seedFull'; throwOnChainScanFailure: true } {
+  const configuredFullScanEvery = input.fullScanEvery;
+  let fullScanEvery = CHAIN_FULL_SCAN_EVERY;
+  if (
+    typeof configuredFullScanEvery === 'number' &&
+    Number.isFinite(configuredFullScanEvery) &&
+    configuredFullScanEvery >= 1
+  ) {
+    fullScanEvery = Math.floor(configuredFullScanEvery);
+  }
+  const configuredPageBudget = input.pageBudget;
+  const pageBudget = (
+    typeof configuredPageBudget === 'number' &&
+    Number.isFinite(configuredPageBudget) &&
+    configuredPageBudget >= 1
+  )
+    ? Math.floor(configuredPageBudget)
+    : CHAIN_DISCOVERY_SCAN_PAGE_BUDGET;
+  const run = input.run ?? 0;
+  const startupRecoveryScan = input.watermarkSeeded && run === 0;
+  const periodicFullResync = input.watermarkSeeded && run > 0 && run % fullScanEvery === 0;
+  if (startupRecoveryScan || periodicFullResync) {
+    return { mode: 'seedFull', throwOnChainScanFailure: true };
+  }
+  return input.watermarkSeeded && !periodicFullResync
+    ? { mode: 'incremental', pageBudget }
+    : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
+}
+
+function safeLog(log: (message: string) => void, message: string): void {
+  try {
+    log(message);
+  } catch {
+    // Logging must not turn a non-critical scan or scan failure into a daemon failure.
+  }
+}
+
+export function createChainDiscoveryScanRunner(input: {
+  agent: {
+    hasContextGraphRegistryScanWatermark(): Promise<boolean>;
+    discoverContextGraphsFromChain(
+      options: ReturnType<typeof chainDiscoveryScanOptions>,
+    ): Promise<number>;
+  };
+  log: (msg: string) => void;
+  pageBudget?: number;
+  fullScanEvery?: number;
+}): () => Promise<void> {
+  let successfulRuns = 0;
+  let startupPath: 'undetermined' | 'seedFromCursor' | 'seedFull' = 'undetermined';
+  let inFlight = false;
+
+  return async () => {
+    if (inFlight) return;
+    inFlight = true;
+
+    try {
+      let watermarkSeeded: boolean;
+      try {
+        watermarkSeeded = await input.agent.hasContextGraphRegistryScanWatermark();
+      } catch (error) {
+        safeLog(
+          input.log,
+          `Chain scan: watermark probe failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        return;
+      }
+
+      if (startupPath === 'undetermined') {
+        startupPath = watermarkSeeded ? 'seedFull' : 'seedFromCursor';
+      }
+
+      // A failed initial cursor seed can still persist a watermark after applying a page.
+      // Once that bounded path has begun, a newly visible watermark must resume through the
+      // incremental cursor path rather than reclassifying the retry as run-0 seedFull.
+      const optionRun = successfulRuns === 0 && startupPath === 'seedFromCursor'
+        ? 1
+        : successfulRuns;
+      const options = chainDiscoveryScanOptions({
+        run: optionRun,
+        watermarkSeeded,
+        pageBudget: input.pageBudget,
+        fullScanEvery: input.fullScanEvery,
+      });
+
+      let found: number;
+      try {
+        found = await input.agent.discoverContextGraphsFromChain(options);
+      } catch (error) {
+        safeLog(
+          input.log,
+          `Chain scan: ${options.mode} scan failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        return;
+      }
+
+      successfulRuns += 1;
+      if (found > 0) {
+        safeLog(input.log, `Chain scan: discovered ${found} new context graph(s)`);
+      }
+    } finally {
+      inFlight = false;
+    }
+  };
+}

--- a/packages/cli/src/daemon/chain-discovery-scan-runner.ts
+++ b/packages/cli/src/daemon/chain-discovery-scan-runner.ts
@@ -22,12 +22,13 @@ export const CHAIN_DISCOVERY_SCAN_PAGE_BUDGET = 30;
 
 export type ManagedChainDiscoveryScanState =
   | { kind: 'undetermined' }
-  | { kind: 'cursorSeed'; failures: number }
-  | { kind: 'startupFullRecovery'; failures: number }
+  | { kind: 'initial'; strategy: 'cursor' | 'full'; failures: number }
   | { kind: 'steady'; successfulScansInCycle: number; cursorFailures: number }
-  | { kind: 'recoveryTip'; successfulScansInCycle: number }
-  | { kind: 'recoveryIncremental'; successfulScansInCycle: number }
-  | { kind: 'recoveryFull'; successfulScansInCycle: number };
+  | {
+      kind: 'recovery';
+      step: 'tip' | 'incremental' | 'full';
+      successfulScansInCycle: number;
+    };
 
 type ActiveManagedChainDiscoveryScanState = Exclude<
   ManagedChainDiscoveryScanState,
@@ -96,105 +97,106 @@ export function resolveManagedChainDiscoveryScanAttempt(input: {
 }): {
   state: ActiveManagedChainDiscoveryScanState;
   options: ChainDiscoveryScanOptions;
+  nextOnSuccess: ManagedChainDiscoveryScanState;
+  nextOnFailure: ManagedChainDiscoveryScanState;
 } {
   const fullScanEvery = normalizeFullScanEvery(input.fullScanEvery);
   const pageBudget = normalizePageBudget(input.pageBudget);
   const state: ActiveManagedChainDiscoveryScanState = input.state.kind === 'undetermined'
     ? input.watermarkSeeded
-      ? { kind: 'startupFullRecovery', failures: 0 }
-      : { kind: 'cursorSeed', failures: 0 }
+      ? { kind: 'initial', strategy: 'full', failures: 0 }
+      : { kind: 'initial', strategy: 'cursor', failures: 0 }
     : input.state;
+  const steady = (successfulScansInCycle: number): ManagedChainDiscoveryScanState => ({
+    kind: 'steady',
+    successfulScansInCycle,
+    cursorFailures: 0,
+  });
+  const recovery = (
+    step: 'tip' | 'incremental' | 'full',
+    successfulScansInCycle: number,
+  ): ManagedChainDiscoveryScanState => ({
+    kind: 'recovery',
+    step,
+    successfulScansInCycle,
+  });
 
   switch (state.kind) {
-    case 'startupFullRecovery':
-    case 'recoveryFull':
-      return { state, options: { mode: 'seedFull', throwOnChainScanFailure: true } };
-    case 'recoveryTip':
-      return { state, options: { mode: 'tip' } };
-    case 'cursorSeed':
-    case 'recoveryIncremental':
+    case 'initial': {
+      const options: ChainDiscoveryScanOptions = state.strategy === 'full'
+        ? { mode: 'seedFull', throwOnChainScanFailure: true }
+        : input.watermarkSeeded
+          ? { mode: 'incremental', throwOnChainScanFailure: true, pageBudget }
+          : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
       return {
         state,
-        options: input.watermarkSeeded
-          ? { mode: 'incremental', throwOnChainScanFailure: true, pageBudget }
-          : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget },
+        options,
+        nextOnSuccess: steady(1),
+        nextOnFailure: state.failures + 1 >= 2
+          ? recovery('tip', 0)
+          : { ...state, failures: state.failures + 1 },
       };
-    case 'steady':
-      if (input.watermarkSeeded && state.successfulScansInCycle >= fullScanEvery) {
-        return { state, options: { mode: 'seedFull', throwOnChainScanFailure: true } };
+    }
+    case 'recovery': {
+      const nextStep = state.step === 'tip'
+        ? input.watermarkSeeded ? 'incremental' : 'full'
+        : state.step === 'incremental' ? 'full' : 'tip';
+      const options: ChainDiscoveryScanOptions = state.step === 'tip'
+        ? { mode: 'tip' }
+        : state.step === 'full'
+          ? { mode: 'seedFull', throwOnChainScanFailure: true }
+          : input.watermarkSeeded
+            ? { mode: 'incremental', throwOnChainScanFailure: true, pageBudget }
+            : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
+      return {
+        state,
+        options,
+        nextOnSuccess: state.step === 'full'
+          ? steady(1)
+          : recovery(nextStep, state.successfulScansInCycle),
+        nextOnFailure: recovery(nextStep, state.successfulScansInCycle),
+      };
+    }
+    case 'steady': {
+      const fullAttempt = input.watermarkSeeded
+        && state.successfulScansInCycle >= fullScanEvery;
+      if (fullAttempt) {
+        return {
+          state,
+          options: { mode: 'seedFull', throwOnChainScanFailure: true },
+          nextOnSuccess: steady(1),
+          nextOnFailure: recovery('tip', state.successfulScansInCycle),
+        };
       }
       return {
         state,
         options: input.watermarkSeeded
           ? { mode: 'incremental', throwOnChainScanFailure: true, pageBudget }
           : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget },
+        nextOnSuccess: steady(state.successfulScansInCycle + 1),
+        nextOnFailure: state.cursorFailures + 1 >= 2
+          ? recovery('tip', state.successfulScansInCycle)
+          : { ...state, cursorFailures: state.cursorFailures + 1 },
       };
+    }
   }
 }
 
+/** Compatibility wrapper over the attempt's co-located transition model. */
 export function transitionManagedChainDiscoveryScanState(input: {
   state: ActiveManagedChainDiscoveryScanState;
   watermarkSeeded: boolean;
   outcome: 'success' | 'failure';
   fullScanEvery?: number;
 }): ManagedChainDiscoveryScanState {
-  const { state } = input;
-  const successes = 'successfulScansInCycle' in state
-    ? state.successfulScansInCycle
-    : 0;
-  const steadyFullAttempt = state.kind === 'steady'
-    && input.watermarkSeeded
-    && successes >= normalizeFullScanEvery(input.fullScanEvery);
-
-  if (input.outcome === 'failure') {
-    switch (state.kind) {
-      case 'startupFullRecovery':
-        return state.failures + 1 >= 2
-          ? { kind: 'recoveryTip', successfulScansInCycle: 0 }
-          : { ...state, failures: state.failures + 1 };
-      case 'cursorSeed':
-        return state.failures + 1 >= 2
-          ? { kind: 'recoveryTip', successfulScansInCycle: 0 }
-          : { ...state, failures: state.failures + 1 };
-      case 'recoveryTip':
-        return input.watermarkSeeded
-          ? { kind: 'recoveryIncremental', successfulScansInCycle: successes }
-          : { kind: 'recoveryFull', successfulScansInCycle: successes };
-      case 'recoveryIncremental':
-        return { kind: 'recoveryFull', successfulScansInCycle: successes };
-      case 'recoveryFull':
-        return { kind: 'recoveryTip', successfulScansInCycle: successes };
-      case 'steady':
-        if (steadyFullAttempt) {
-          return { kind: 'recoveryTip', successfulScansInCycle: successes };
-        }
-        return state.cursorFailures + 1 >= 2
-          ? { kind: 'recoveryTip', successfulScansInCycle: successes }
-          : { ...state, cursorFailures: state.cursorFailures + 1 };
-    }
-  }
-
-  switch (state.kind) {
-    case 'startupFullRecovery':
-    case 'recoveryFull':
-      return { kind: 'steady', successfulScansInCycle: 1, cursorFailures: 0 };
-    case 'cursorSeed':
-      return { kind: 'steady', successfulScansInCycle: 1, cursorFailures: 0 };
-    case 'recoveryTip':
-      return input.watermarkSeeded
-        ? { kind: 'recoveryIncremental', successfulScansInCycle: successes }
-        : { kind: 'recoveryFull', successfulScansInCycle: successes };
-    case 'recoveryIncremental':
-      return { kind: 'recoveryFull', successfulScansInCycle: successes };
-    case 'steady':
-      return steadyFullAttempt
-        ? { kind: 'steady', successfulScansInCycle: 1, cursorFailures: 0 }
-        : {
-            kind: 'steady',
-            successfulScansInCycle: successes + 1,
-            cursorFailures: 0,
-          };
-  }
+  const attempt = resolveManagedChainDiscoveryScanAttempt({
+    state: input.state,
+    watermarkSeeded: input.watermarkSeeded,
+    fullScanEvery: input.fullScanEvery,
+  });
+  return input.outcome === 'success'
+    ? attempt.nextOnSuccess
+    : attempt.nextOnFailure;
 }
 
 function safeLog(log: (message: string) => void, message: string): void {
@@ -262,21 +264,11 @@ export function createChainDiscoveryScanRunner(input: {
           input.log,
           `Chain scan: ${options.mode} scan failed: ${safeErrorMessage(error)}`,
         );
-        state = transitionManagedChainDiscoveryScanState({
-          state: attempt.state,
-          watermarkSeeded,
-          outcome: 'failure',
-          fullScanEvery: input.fullScanEvery,
-        });
+        state = attempt.nextOnFailure;
         return;
       }
 
-      state = transitionManagedChainDiscoveryScanState({
-        state: attempt.state,
-        watermarkSeeded,
-        outcome: 'success',
-        fullScanEvery: input.fullScanEvery,
-      });
+      state = attempt.nextOnSuccess;
 
       if (found > 0) {
         safeLog(input.log, `Chain scan: discovered ${found} new context graph(s)`);

--- a/packages/cli/src/daemon/chain-discovery-scan-runner.ts
+++ b/packages/cli/src/daemon/chain-discovery-scan-runner.ts
@@ -93,7 +93,7 @@ function safeLog(log: (message: string) => void, message: string): void {
 
 function safeErrorMessage(error: unknown): string {
   try {
-    return error instanceof Error ? error.message : String(error);
+    return error instanceof Error ? String(error.message) : String(error);
   } catch {
     // Promise rejection reasons are arbitrary values. Even property access or coercion can throw,
     // so error reporting must have a value-independent fallback inside the scan failure boundary.

--- a/packages/cli/src/daemon/chain-discovery-scan-runner.ts
+++ b/packages/cli/src/daemon/chain-discovery-scan-runner.ts
@@ -1,9 +1,37 @@
-export const CHAIN_FULL_SCAN_EVERY = 48; // about once per day at the 30-minute cadence
+export const CHAIN_DISCOVERY_SCAN_INTERVAL_MS = 30 * 60 * 1000;
+export const CHAIN_DISCOVERY_FULL_RESYNC_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+export function deriveChainFullScanEvery(input: {
+  intervalMs: number;
+  fullResyncIntervalMs: number;
+}): number {
+  return Math.max(1, Math.round(input.fullResyncIntervalMs / input.intervalMs));
+}
+
+export const CHAIN_DISCOVERY_SCAN_SCHEDULE = Object.freeze({
+  intervalMs: CHAIN_DISCOVERY_SCAN_INTERVAL_MS,
+  fullResyncIntervalMs: CHAIN_DISCOVERY_FULL_RESYNC_INTERVAL_MS,
+  fullScanEvery: deriveChainFullScanEvery({
+    intervalMs: CHAIN_DISCOVERY_SCAN_INTERVAL_MS,
+    fullResyncIntervalMs: CHAIN_DISCOVERY_FULL_RESYNC_INTERVAL_MS,
+  }),
+});
+
+export const CHAIN_FULL_SCAN_EVERY = CHAIN_DISCOVERY_SCAN_SCHEDULE.fullScanEvery;
 export const CHAIN_DISCOVERY_SCAN_PAGE_BUDGET = 30;
+
+export type ChainDiscoveryStartupPhase =
+  | 'undetermined'
+  | 'cursorSeed'
+  | 'startupFullRecovery'
+  | 'complete';
 
 export function chainDiscoveryScanOptions(input: {
   watermarkSeeded: boolean;
-  run?: number;
+  startupPhase: ChainDiscoveryStartupPhase;
+  successfulScansInCycle: number;
+  fullRecoveryPending?: boolean;
+  fullRecoveryRetryReady?: boolean;
   fullScanEvery?: number;
   pageBudget?: number;
 }):
@@ -11,7 +39,7 @@ export function chainDiscoveryScanOptions(input: {
   | { mode: 'seedFromCursor'; throwOnChainScanFailure: true; pageBudget: number }
   | { mode: 'seedFull'; throwOnChainScanFailure: true } {
   const configuredFullScanEvery = input.fullScanEvery;
-  let fullScanEvery = CHAIN_FULL_SCAN_EVERY;
+  let fullScanEvery = CHAIN_DISCOVERY_SCAN_SCHEDULE.fullScanEvery;
   if (
     typeof configuredFullScanEvery === 'number' &&
     Number.isFinite(configuredFullScanEvery) &&
@@ -27,13 +55,29 @@ export function chainDiscoveryScanOptions(input: {
   )
     ? Math.floor(configuredPageBudget)
     : CHAIN_DISCOVERY_SCAN_PAGE_BUDGET;
-  const run = input.run ?? 0;
-  const startupRecoveryScan = input.watermarkSeeded && run === 0;
-  const periodicFullResync = input.watermarkSeeded && run > 0 && run % fullScanEvery === 0;
-  if (startupRecoveryScan || periodicFullResync) {
+
+  if (input.startupPhase === 'undetermined') {
+    return input.watermarkSeeded
+      ? { mode: 'seedFull', throwOnChainScanFailure: true }
+      : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
+  }
+  if (input.startupPhase === 'cursorSeed') {
+    return input.watermarkSeeded
+      ? { mode: 'incremental', pageBudget }
+      : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
+  }
+  if (input.startupPhase === 'startupFullRecovery') {
     return { mode: 'seedFull', throwOnChainScanFailure: true };
   }
-  return input.watermarkSeeded && !periodicFullResync
+  if (input.fullRecoveryPending) {
+    return input.fullRecoveryRetryReady
+      ? { mode: 'seedFull', throwOnChainScanFailure: true }
+      : { mode: 'incremental', pageBudget };
+  }
+  if (input.watermarkSeeded && input.successfulScansInCycle >= fullScanEvery) {
+    return { mode: 'seedFull', throwOnChainScanFailure: true };
+  }
+  return input.watermarkSeeded
     ? { mode: 'incremental', pageBudget }
     : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
 }
@@ -57,8 +101,11 @@ export function createChainDiscoveryScanRunner(input: {
   pageBudget?: number;
   fullScanEvery?: number;
 }): () => Promise<void> {
-  let successfulRuns = 0;
-  let startupPath: 'undetermined' | 'seedFromCursor' | 'seedFull' = 'undetermined';
+  let startupPhase: ChainDiscoveryStartupPhase = 'undetermined';
+  let startupFullFailures = 0;
+  let successfulScansInCycle = 0;
+  let fullRecoveryPending = false;
+  let fullRecoveryRetryReady = false;
   let inFlight = false;
 
   return async () => {
@@ -77,19 +124,16 @@ export function createChainDiscoveryScanRunner(input: {
         return;
       }
 
-      if (startupPath === 'undetermined') {
-        startupPath = watermarkSeeded ? 'seedFull' : 'seedFromCursor';
+      if (startupPhase === 'undetermined') {
+        startupPhase = watermarkSeeded ? 'startupFullRecovery' : 'cursorSeed';
       }
 
-      // A failed initial cursor seed can still persist a watermark after applying a page.
-      // Once that bounded path has begun, a newly visible watermark must resume through the
-      // incremental cursor path rather than reclassifying the retry as run-0 seedFull.
-      const optionRun = successfulRuns === 0 && startupPath === 'seedFromCursor'
-        ? 1
-        : successfulRuns;
       const options = chainDiscoveryScanOptions({
-        run: optionRun,
         watermarkSeeded,
+        startupPhase,
+        successfulScansInCycle,
+        fullRecoveryPending,
+        fullRecoveryRetryReady,
         pageBudget: input.pageBudget,
         fullScanEvery: input.fullScanEvery,
       });
@@ -102,10 +146,41 @@ export function createChainDiscoveryScanRunner(input: {
           input.log,
           `Chain scan: ${options.mode} scan failed: ${error instanceof Error ? error.message : String(error)}`,
         );
+
+        if (startupPhase === 'startupFullRecovery') {
+          startupFullFailures += 1;
+          // Retry startup recovery once immediately. If the historical range remains unavailable,
+          // enter steady state and interleave tip discovery before each later full retry.
+          if (startupFullFailures >= 2) {
+            startupPhase = 'complete';
+            fullRecoveryPending = true;
+            fullRecoveryRetryReady = false;
+          }
+        } else if (options.mode === 'seedFull') {
+          fullRecoveryPending = true;
+          fullRecoveryRetryReady = false;
+        } else if (fullRecoveryPending && options.mode === 'incremental') {
+          // One tip-discovery attempt, successful or not, prevents an unavailable historical range
+          // from monopolizing the scheduler. The next invocation may retry full recovery.
+          fullRecoveryRetryReady = true;
+        }
         return;
       }
 
-      successfulRuns += 1;
+      if (options.mode === 'seedFull') {
+        startupPhase = 'complete';
+        startupFullFailures = 0;
+        successfulScansInCycle = 1;
+        fullRecoveryPending = false;
+        fullRecoveryRetryReady = false;
+      } else {
+        if (startupPhase === 'cursorSeed') startupPhase = 'complete';
+        successfulScansInCycle += 1;
+        if (fullRecoveryPending && options.mode === 'incremental') {
+          fullRecoveryRetryReady = true;
+        }
+      }
+
       if (found > 0) {
         safeLog(input.log, `Chain scan: discovered ${found} new context graph(s)`);
       }

--- a/packages/cli/src/daemon/chain-discovery-scan-runner.ts
+++ b/packages/cli/src/daemon/chain-discovery-scan-runner.ts
@@ -90,6 +90,16 @@ function safeLog(log: (message: string) => void, message: string): void {
   }
 }
 
+function safeErrorMessage(error: unknown): string {
+  try {
+    return error instanceof Error ? error.message : String(error);
+  } catch {
+    // Promise rejection reasons are arbitrary values. Even property access or coercion can throw,
+    // so error reporting must have a value-independent fallback inside the scan failure boundary.
+    return 'unformattable error';
+  }
+}
+
 export function createChainDiscoveryScanRunner(input: {
   agent: {
     hasContextGraphRegistryScanWatermark(): Promise<boolean>;
@@ -119,7 +129,7 @@ export function createChainDiscoveryScanRunner(input: {
       } catch (error) {
         safeLog(
           input.log,
-          `Chain scan: watermark probe failed: ${error instanceof Error ? error.message : String(error)}`,
+          `Chain scan: watermark probe failed: ${safeErrorMessage(error)}`,
         );
         return;
       }
@@ -144,7 +154,7 @@ export function createChainDiscoveryScanRunner(input: {
       } catch (error) {
         safeLog(
           input.log,
-          `Chain scan: ${options.mode} scan failed: ${error instanceof Error ? error.message : String(error)}`,
+          `Chain scan: ${options.mode} scan failed: ${safeErrorMessage(error)}`,
         );
 
         if (startupPhase === 'startupFullRecovery') {

--- a/packages/cli/src/daemon/index.ts
+++ b/packages/cli/src/daemon/index.ts
@@ -2,7 +2,7 @@
 //
 // The original `packages/cli/src/daemon.ts` became unmanageable at
 // ~10.5k lines. This directory hosts the sub-modules it was cut into;
-// the barrel re-exports every public symbol so consumers can import
+// the barrel re-exports the intended public surface so consumers can import
 // from `./daemon/index.js` without depending on the internal file
 // layout.
 //
@@ -19,6 +19,13 @@ export * from './auto-update.js';
 export * from './openclaw.js';
 export * from './local-agents.js';
 export * from './lifecycle.js';
-export * from './chain-discovery-scan-runner.js';
+export {
+  CHAIN_FULL_SCAN_EVERY,
+  CHAIN_DISCOVERY_SCAN_PAGE_BUDGET,
+  chainDiscoveryScanOptions,
+  createChainDiscoveryScanRunner,
+  type LegacyChainDiscoveryScanOptionsInput,
+  type ChainDiscoveryScanOptions,
+} from './chain-discovery-scan-runner.js';
 export * from './memory-tool-context.js';
 export * from './handle-request.js';

--- a/packages/cli/src/daemon/index.ts
+++ b/packages/cli/src/daemon/index.ts
@@ -19,5 +19,6 @@ export * from './auto-update.js';
 export * from './openclaw.js';
 export * from './local-agents.js';
 export * from './lifecycle.js';
+export * from './chain-discovery-scan-runner.js';
 export * from './memory-tool-context.js';
 export * from './handle-request.js';

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -52,14 +52,6 @@ import {
   CHAIN_DISCOVERY_SCAN_SCHEDULE,
   createChainDiscoveryScanRunner,
 } from './chain-discovery-scan-runner.js';
-export {
-  CHAIN_DISCOVERY_SCAN_PAGE_BUDGET,
-  CHAIN_DISCOVERY_SCAN_SCHEDULE,
-  CHAIN_FULL_SCAN_EVERY,
-  chainDiscoveryScanOptions,
-  createChainDiscoveryScanRunner,
-  deriveChainFullScanEvery,
-} from './chain-discovery-scan-runner.js';
 const { homedir } = osModule;
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1723,6 +1723,10 @@ async function runDaemonInnerWithStartupOwnership(
   const changelogEraGuard = config.store?.changelog ? new SqliteChangelogEraGuard(dashDb) : undefined;
   const chainEventCursorStore = new SqliteChainEventCursorStore(dashDb, { scope: chainCursorScope });
   const contextGraphRegistryScanCursorStore = new SqliteContextGraphRegistryScanCursorStore(dashDb);
+  const contextGraphRegistryTipScanCursorStore = new SqliteContextGraphRegistryScanCursorStore(
+    dashDb,
+    { cursorKind: 'tip' },
+  );
 
   // OT-RFC-43 Option-1 deterministic KA identity (B2 allocator core).
   // Durable per-author KA-number sequence backing the off-chain
@@ -1852,10 +1856,8 @@ async function runDaemonInnerWithStartupOwnership(
     syncCheckpointStore,
     changelogCursorStore,
     chainEventCursorStore,
-    contextGraphRegistryScanCursorStore: {
-      kind: 'roleAware',
-      store: contextGraphRegistryScanCursorStore,
-    },
+    contextGraphRegistryScanCursorStore,
+    contextGraphRegistryTipScanCursorStore,
     contextGraphSubscriptionStore: {
       loadAll: async () => dashDb.listContextGraphSubscriptions().map((row) => ({
         id: row.context_graph_id,

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1852,7 +1852,7 @@ async function runDaemonInnerWithStartupOwnership(
     syncCheckpointStore,
     changelogCursorStore,
     chainEventCursorStore,
-    contextGraphRegistryScanCursorPersistence: {
+    contextGraphRegistryScanCursorStore: {
       kind: 'roleAware',
       store: contextGraphRegistryScanCursorStore,
     },

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1852,7 +1852,10 @@ async function runDaemonInnerWithStartupOwnership(
     syncCheckpointStore,
     changelogCursorStore,
     chainEventCursorStore,
-    contextGraphRegistryScanCursorStore,
+    contextGraphRegistryScanCursorPersistence: {
+      kind: 'roleAware',
+      store: contextGraphRegistryScanCursorStore,
+    },
     contextGraphSubscriptionStore: {
       loadAll: async () => dashDb.listContextGraphSubscriptions().map((row) => ({
         id: row.context_graph_id,

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -753,21 +753,35 @@ export function createChainDiscoveryScanRunner(input: {
   return async () => {
     if (inFlight) return;
     inFlight = true;
+    let scanMode: ReturnType<typeof chainDiscoveryScanOptions>['mode'] | undefined;
     try {
-      const run = runs++;
+      const options = chainDiscoveryScanOptions({
+        run: runs,
+        watermarkSeeded: await input.agent.hasContextGraphRegistryScanWatermark(),
+        pageBudget: input.pageBudget,
+        fullScanEvery: input.fullScanEvery,
+      });
+      scanMode = options.mode;
       const found = await input.agent.discoverContextGraphsFromChain(
-        chainDiscoveryScanOptions({
-          run,
-          watermarkSeeded: await input.agent.hasContextGraphRegistryScanWatermark(),
-          pageBudget: input.pageBudget,
-          fullScanEvery: input.fullScanEvery,
-        }),
+        options,
       );
+      // A run number describes a settled scan, not an invocation. In particular, do not
+      // consume run 0 when the startup recovery scan (or its watermark probe) fails: the
+      // next scheduled invocation must retry seedFull instead of going incremental for ~24h.
+      runs += 1;
       if (found > 0) {
         input.log(`Chain scan: discovered ${found} new context graph(s)`);
       }
-    } catch {
-      /* non-critical */
+    } catch (error) {
+      // Discovery remains non-critical to daemon availability, but a failed full scan is
+      // operationally significant. Name the stage/mode so the retry is visible rather than
+      // leaving an unexplained discovery gap.
+      const stage = scanMode ? `${scanMode} scan` : 'watermark probe';
+      try {
+        input.log(`Chain scan: ${stage} failed: ${error instanceof Error ? error.message : String(error)}`);
+      } catch {
+        /* logging must not turn a non-critical scan failure into a daemon failure */
+      }
     } finally {
       inFlight = false;
     }

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1722,11 +1722,8 @@ async function runDaemonInnerWithStartupOwnership(
   // rotates the era and forces peers to full-resync instead of silently skipping.
   const changelogEraGuard = config.store?.changelog ? new SqliteChangelogEraGuard(dashDb) : undefined;
   const chainEventCursorStore = new SqliteChainEventCursorStore(dashDb, { scope: chainCursorScope });
-  const contextGraphRegistryScanCursorStore = new SqliteContextGraphRegistryScanCursorStore(dashDb);
-  const contextGraphRegistryTipScanCursorStore = new SqliteContextGraphRegistryScanCursorStore(
-    dashDb,
-    { cursorKind: 'tip' },
-  );
+  const contextGraphRegistryRoleAwareScanCursorStore =
+    new SqliteContextGraphRegistryScanCursorStore(dashDb);
 
   // OT-RFC-43 Option-1 deterministic KA identity (B2 allocator core).
   // Durable per-author KA-number sequence backing the off-chain
@@ -1856,8 +1853,7 @@ async function runDaemonInnerWithStartupOwnership(
     syncCheckpointStore,
     changelogCursorStore,
     chainEventCursorStore,
-    contextGraphRegistryScanCursorStore,
-    contextGraphRegistryTipScanCursorStore,
+    contextGraphRegistryRoleAwareScanCursorStore,
     contextGraphSubscriptionStore: {
       loadAll: async () => dashDb.listContextGraphSubscriptions().map((row) => ({
         id: row.context_graph_id,

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -47,6 +47,16 @@ import * as osModule from 'node:os';
 import type { NetworkInterfaceInfo } from 'node:os';
 import { checkCoreRelayPrereqs } from './core-prereq-check.js';
 import { rotateDaemonLogIfNeeded } from './log-rotation.js';
+import {
+  CHAIN_DISCOVERY_SCAN_PAGE_BUDGET,
+  createChainDiscoveryScanRunner,
+} from './chain-discovery-scan-runner.js';
+export {
+  CHAIN_DISCOVERY_SCAN_PAGE_BUDGET,
+  CHAIN_FULL_SCAN_EVERY,
+  chainDiscoveryScanOptions,
+  createChainDiscoveryScanRunner,
+} from './chain-discovery-scan-runner.js';
 const { homedir } = osModule;
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
@@ -695,97 +705,6 @@ export function orderACKCandidatePeerIds(input: {
     verifiedSameNetworkPeerIds: input.verifiedSameNetworkPeerIds,
     requiredACKs: Number.MAX_SAFE_INTEGER,
   });
-}
-
-export const CHAIN_FULL_SCAN_EVERY = 48; // about once per day at the 30-minute cadence
-export const CHAIN_DISCOVERY_SCAN_PAGE_BUDGET = 30;
-
-export function chainDiscoveryScanOptions(input: {
-  watermarkSeeded: boolean;
-  run?: number;
-  fullScanEvery?: number;
-  pageBudget?: number;
-}):
-  | { mode: 'incremental'; pageBudget: number }
-  | { mode: 'seedFromCursor'; throwOnChainScanFailure: true; pageBudget: number }
-  | { mode: 'seedFull'; throwOnChainScanFailure: true } {
-  const configuredFullScanEvery = input.fullScanEvery;
-  let fullScanEvery = CHAIN_FULL_SCAN_EVERY;
-  if (
-    typeof configuredFullScanEvery === 'number' &&
-    Number.isFinite(configuredFullScanEvery) &&
-    configuredFullScanEvery >= 1
-  ) {
-    fullScanEvery = Math.floor(configuredFullScanEvery);
-  }
-  const configuredPageBudget = input.pageBudget;
-  const pageBudget = (
-    typeof configuredPageBudget === 'number' &&
-    Number.isFinite(configuredPageBudget) &&
-    configuredPageBudget >= 1
-  )
-    ? Math.floor(configuredPageBudget)
-    : CHAIN_DISCOVERY_SCAN_PAGE_BUDGET;
-  const run = input.run ?? 0;
-  const startupRecoveryScan = input.watermarkSeeded && run === 0;
-  const periodicFullResync = input.watermarkSeeded && run > 0 && run % fullScanEvery === 0;
-  if (startupRecoveryScan || periodicFullResync) {
-    return { mode: 'seedFull', throwOnChainScanFailure: true };
-  }
-  return input.watermarkSeeded && !periodicFullResync
-    ? { mode: 'incremental', pageBudget }
-    : { mode: 'seedFromCursor', throwOnChainScanFailure: true, pageBudget };
-}
-
-export function createChainDiscoveryScanRunner(input: {
-  agent: {
-    hasContextGraphRegistryScanWatermark(): Promise<boolean>;
-    discoverContextGraphsFromChain(
-      options: ReturnType<typeof chainDiscoveryScanOptions>,
-    ): Promise<number>;
-  };
-  log: (msg: string) => void;
-  pageBudget?: number;
-  fullScanEvery?: number;
-}): () => Promise<void> {
-  let runs = 0;
-  let inFlight = false;
-  return async () => {
-    if (inFlight) return;
-    inFlight = true;
-    let scanMode: ReturnType<typeof chainDiscoveryScanOptions>['mode'] | undefined;
-    try {
-      const options = chainDiscoveryScanOptions({
-        run: runs,
-        watermarkSeeded: await input.agent.hasContextGraphRegistryScanWatermark(),
-        pageBudget: input.pageBudget,
-        fullScanEvery: input.fullScanEvery,
-      });
-      scanMode = options.mode;
-      const found = await input.agent.discoverContextGraphsFromChain(
-        options,
-      );
-      // A run number describes a settled scan, not an invocation. In particular, do not
-      // consume run 0 when the startup recovery scan (or its watermark probe) fails: the
-      // next scheduled invocation must retry seedFull instead of going incremental for ~24h.
-      runs += 1;
-      if (found > 0) {
-        input.log(`Chain scan: discovered ${found} new context graph(s)`);
-      }
-    } catch (error) {
-      // Discovery remains non-critical to daemon availability, but a failed full scan is
-      // operationally significant. Name the stage/mode so the retry is visible rather than
-      // leaving an unexplained discovery gap.
-      const stage = scanMode ? `${scanMode} scan` : 'watermark probe';
-      try {
-        input.log(`Chain scan: ${stage} failed: ${error instanceof Error ? error.message : String(error)}`);
-      } catch {
-        /* logging must not turn a non-critical scan failure into a daemon failure */
-      }
-    } finally {
-      inFlight = false;
-    }
-  };
 }
 
 export interface PromoteWorkerDaemonLifecycle {

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -49,13 +49,16 @@ import { checkCoreRelayPrereqs } from './core-prereq-check.js';
 import { rotateDaemonLogIfNeeded } from './log-rotation.js';
 import {
   CHAIN_DISCOVERY_SCAN_PAGE_BUDGET,
+  CHAIN_DISCOVERY_SCAN_SCHEDULE,
   createChainDiscoveryScanRunner,
 } from './chain-discovery-scan-runner.js';
 export {
   CHAIN_DISCOVERY_SCAN_PAGE_BUDGET,
+  CHAIN_DISCOVERY_SCAN_SCHEDULE,
   CHAIN_FULL_SCAN_EVERY,
   chainDiscoveryScanOptions,
   createChainDiscoveryScanRunner,
+  deriveChainFullScanEvery,
 } from './chain-discovery-scan-runner.js';
 const { homedir } = osModule;
 import { fileURLToPath } from 'node:url';
@@ -2426,14 +2429,17 @@ async function runDaemonInnerWithStartupOwnership(
 
   // Run an initial chain scan for context graphs we might not know about,
   // then repeat every 30 minutes as a fallback discovery mechanism.
-  const CHAIN_SCAN_INTERVAL_MS = 30 * 60 * 1000;
   const runChainDiscoveryScan = createChainDiscoveryScanRunner({
     agent,
     log,
     pageBudget: CHAIN_DISCOVERY_SCAN_PAGE_BUDGET,
+    fullScanEvery: CHAIN_DISCOVERY_SCAN_SCHEDULE.fullScanEvery,
   });
   setTimeout(runChainDiscoveryScan, 15_000);
-  const chainScanTimer = setInterval(runChainDiscoveryScan, CHAIN_SCAN_INTERVAL_MS);
+  const chainScanTimer = setInterval(
+    runChainDiscoveryScan,
+    CHAIN_DISCOVERY_SCAN_SCHEDULE.intervalMs,
+  );
   if (chainScanTimer.unref) chainScanTimer.unref();
 
   // Periodic peer health ping (every 2 minutes)

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -109,7 +109,7 @@ describe('chainDiscoveryScanOptions', () => {
 
     await expect(runner()).resolves.toBeUndefined();
     expect(agent.discoverContextGraphsFromChain).toHaveBeenCalledTimes(1);
-    expect(log).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith('Chain scan: seedFull scan failed: chain RPC unavailable');
 
     await runner();
 
@@ -121,22 +121,16 @@ describe('chainDiscoveryScanOptions', () => {
     // counts alone passes identically whether the retry recovers the missed
     // work or silently degrades (PR #2132 review).
     //
-    // `const run = runs++` sits at lifecycle.ts:740, BEFORE either await, so a
-    // rejection still consumes the run slot. Call 1 is run 0 with the
-    // watermark seeded => the `seedFull` startup-recovery scan. Call 2 is
-    // run 1, and 1 % CHAIN_FULL_SCAN_EVERY (48) !== 0, so it is `incremental`:
-    // the failed full-history scan is NOT re-attempted. The next `seedFull` is
-    // run 48, roughly 24h out at the 30-minute cadence.
-    //
-    // This documents current behaviour rather than endorsing it — whether the
-    // consumed run slot is a defect or intended backoff is tracked separately.
+    // A rejected scan does not consume run 0. The next scheduled invocation
+    // retries the startup-recovery seedFull instead of silently downgrading to
+    // incremental until the next full-scan cadence roughly 24 hours later.
     expect(agent.discoverContextGraphsFromChain).toHaveBeenNthCalledWith(1, {
       mode: 'seedFull',
       throwOnChainScanFailure: true,
     });
     expect(agent.discoverContextGraphsFromChain).toHaveBeenNthCalledWith(2, {
-      mode: 'incremental',
-      pageBudget: 30,
+      mode: 'seedFull',
+      throwOnChainScanFailure: true,
     });
   });
 
@@ -154,22 +148,23 @@ describe('chainDiscoveryScanOptions', () => {
           async () => 0,
         ),
     };
-    const runner = createChainDiscoveryScanRunner({ agent, log: vi.fn() });
+    const log = vi.fn();
+    const runner = createChainDiscoveryScanRunner({ agent, log });
 
     await expect(runner()).resolves.toBeUndefined();
     expect(agent.discoverContextGraphsFromChain).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith('Chain scan: watermark probe failed: watermark read failed');
 
     await runner();
 
     expect(agent.hasContextGraphRegistryScanWatermark).toHaveBeenCalledTimes(2);
     expect(agent.discoverContextGraphsFromChain).toHaveBeenCalledTimes(1);
 
-    // The probe rejection also consumed run 0, so the one scan that does reach
-    // the agent is run 1 => `incremental`, not the `seedFull` a fresh startup
-    // would have issued. Same run-slot accounting as the test above.
+    // The probe rejection does not consume run 0, so the first scan that reaches
+    // the agent still performs startup recovery.
     expect(agent.discoverContextGraphsFromChain).toHaveBeenNthCalledWith(1, {
-      mode: 'incremental',
-      pageBudget: 30,
+      mode: 'seedFull',
+      throwOnChainScanFailure: true,
     });
   });
 });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -352,4 +352,34 @@ describe('chainDiscoveryScanOptions', () => {
 
     expect(agent.discoverContextGraphsFromChain).toHaveBeenCalledTimes(2);
   });
+
+  it('contains unformattable rejection reasons and remains reusable across both failure paths', async () => {
+    const hostileReason = {
+      toString() {
+        throw new Error('format failed');
+      },
+    };
+    const agent = {
+      hasContextGraphRegistryScanWatermark: vi
+        .fn<() => Promise<boolean>>()
+        .mockRejectedValueOnce(hostileReason)
+        .mockResolvedValue(true),
+      discoverContextGraphsFromChain: vi
+        .fn<(options: ReturnType<typeof chainDiscoveryScanOptions>) => Promise<number>>()
+        .mockRejectedValueOnce(hostileReason)
+        .mockResolvedValueOnce(2),
+    };
+    const log = vi.fn();
+    const runner = createChainDiscoveryScanRunner({ agent, log });
+
+    await expect(runner()).resolves.toBeUndefined();
+    await expect(runner()).resolves.toBeUndefined();
+    await expect(runner()).resolves.toBeUndefined();
+
+    expect(log).toHaveBeenCalledWith('Chain scan: watermark probe failed: unformattable error');
+    expect(log).toHaveBeenCalledWith('Chain scan: seedFull scan failed: unformattable error');
+    expect(log).toHaveBeenCalledWith('Chain scan: discovered 2 new context graph(s)');
+    expect(agent.hasContextGraphRegistryScanWatermark).toHaveBeenCalledTimes(3);
+    expect(agent.discoverContextGraphsFromChain).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -167,4 +167,77 @@ describe('chainDiscoveryScanOptions', () => {
       throwOnChainScanFailure: true,
     });
   });
+
+  it('resumes a partially persisted cursor seed without reclassifying it as seedFull', async () => {
+    const agent = {
+      hasContextGraphRegistryScanWatermark: vi
+        .fn<() => Promise<boolean>>()
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true),
+      discoverContextGraphsFromChain: vi
+        .fn<(options: ReturnType<typeof chainDiscoveryScanOptions>) => Promise<number>>()
+        .mockRejectedValueOnce(new Error('page 2 failed after page 1 persisted'))
+        .mockResolvedValueOnce(0),
+    };
+    const runner = createChainDiscoveryScanRunner({ agent, log: vi.fn() });
+
+    await runner();
+    await runner();
+
+    expect(agent.discoverContextGraphsFromChain).toHaveBeenNthCalledWith(1, {
+      mode: 'seedFromCursor',
+      throwOnChainScanFailure: true,
+      pageBudget: 30,
+    });
+    expect(agent.discoverContextGraphsFromChain).toHaveBeenNthCalledWith(2, {
+      mode: 'incremental',
+      pageBudget: 30,
+    });
+  });
+
+  it('does not misclassify a successful scan when its progress log throws', async () => {
+    const agent = {
+      hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
+      discoverContextGraphsFromChain: vi
+        .fn<(options: ReturnType<typeof chainDiscoveryScanOptions>) => Promise<number>>()
+        .mockResolvedValueOnce(3)
+        .mockResolvedValueOnce(0),
+    };
+    const messages: string[] = [];
+    const log = vi.fn((message: string) => {
+      messages.push(message);
+      if (message.includes('discovered')) throw new Error('log sink unavailable');
+    });
+    const runner = createChainDiscoveryScanRunner({ agent, log });
+
+    await expect(runner()).resolves.toBeUndefined();
+    await expect(runner()).resolves.toBeUndefined();
+
+    expect(messages).toEqual(['Chain scan: discovered 3 new context graph(s)']);
+    expect(agent.discoverContextGraphsFromChain).toHaveBeenNthCalledWith(2, {
+      mode: 'incremental',
+      pageBudget: 30,
+    });
+  });
+
+  it('swallows a scan failure even when its failure logger throws', async () => {
+    const agent = {
+      hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
+      discoverContextGraphsFromChain: vi
+        .fn<(options: ReturnType<typeof chainDiscoveryScanOptions>) => Promise<number>>()
+        .mockRejectedValueOnce(new Error('chain RPC unavailable'))
+        .mockResolvedValueOnce(0),
+    };
+    const runner = createChainDiscoveryScanRunner({
+      agent,
+      log: vi.fn(() => {
+        throw new Error('log sink unavailable');
+      }),
+    });
+
+    await expect(runner()).resolves.toBeUndefined();
+    await expect(runner()).resolves.toBeUndefined();
+
+    expect(agent.discoverContextGraphsFromChain).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -256,6 +256,34 @@ describe('chainDiscoveryScanOptions', () => {
     ]);
   });
 
+  it('interleaves tip recovery when fresh cursor bootstrap remains blocked', async () => {
+    const agent = {
+      hasContextGraphRegistryScanWatermark: vi
+        .fn<() => Promise<boolean>>()
+        .mockResolvedValueOnce(false)
+        .mockResolvedValue(true),
+      discoverContextGraphsFromChain: vi
+        .fn<(options: ReturnType<typeof chainDiscoveryScanOptions>) => Promise<number>>()
+        .mockRejectedValueOnce(new Error('bootstrap page unavailable'))
+        .mockRejectedValueOnce(new Error('persisted historical page unavailable'))
+        .mockResolvedValueOnce(1)
+        .mockRejectedValueOnce(new Error('historical recovery remains pending')),
+    };
+    const runner = createChainDiscoveryScanRunner({ agent, log: vi.fn() });
+
+    await runner();
+    await runner();
+    await runner();
+    await runner();
+
+    expect(agent.discoverContextGraphsFromChain.mock.calls.map(([options]) => options.mode)).toEqual([
+      'seedFromCursor',
+      'incremental',
+      'tip',
+      'seedFull',
+    ]);
+  });
+
   it('interleaves a tip probe after a failed periodic full resync', async () => {
     const agent = {
       hasContextGraphRegistryScanWatermark: vi.fn(async () => true),

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -22,11 +22,9 @@ describe('chainDiscoveryScanOptions', () => {
     });
   });
 
-  it('uses bounded cursor-resumable watermark seeding before a seed exists', () => {
+  it('preserves bounded cursor seeding in the original helper', () => {
     expect(chainDiscoveryScanOptions({
       watermarkSeeded: false,
-      startupPhase: 'undetermined',
-      successfulScansInCycle: 0,
     })).toEqual({
       mode: 'seedFromCursor',
       throwOnChainScanFailure: true,
@@ -34,31 +32,26 @@ describe('chainDiscoveryScanOptions', () => {
     });
   });
 
-  it('uses a startup recovery scan even when the registry watermark already exists', () => {
+  it('preserves startup full recovery in the original helper', () => {
     expect(chainDiscoveryScanOptions({
       watermarkSeeded: true,
-      startupPhase: 'undetermined',
-      successfulScansInCycle: 0,
     })).toEqual({
       mode: 'seedFull',
       throwOnChainScanFailure: true,
     });
   });
 
-  it('keeps steady-state daemon scans incremental after startup recovery', () => {
+  it('preserves steady-state incremental scans in the original helper', () => {
     expect(chainDiscoveryScanOptions({
       watermarkSeeded: true,
-      startupPhase: 'complete',
-      successfulScansInCycle: 1,
-      fullScanEvery: 48,
-    })).toEqual({ mode: 'incremental', throwOnChainScanFailure: true, pageBudget: 30 });
+      run: 1,
+    })).toEqual({ mode: 'incremental', pageBudget: 30 });
   });
 
-  it('keeps a periodic full-history recovery path after the watermark is seeded', () => {
+  it('preserves periodic full-history recovery in the original helper', () => {
     expect(chainDiscoveryScanOptions({
       watermarkSeeded: true,
-      startupPhase: 'complete',
-      successfulScansInCycle: 48,
+      run: 48,
       fullScanEvery: 48,
     })).toEqual({
       mode: 'seedFull',
@@ -66,41 +59,28 @@ describe('chainDiscoveryScanOptions', () => {
     });
   });
 
-  it('uses a cursor-independent tip probe while full-history recovery is pending', () => {
+  it('does not force a full scan before the original helper cadence', () => {
     expect(chainDiscoveryScanOptions({
       watermarkSeeded: true,
-      startupPhase: 'complete',
-      successfulScansInCycle: 48,
-      fullRecoveryPending: true,
-      fullRecoveryRetryReady: false,
-    })).toEqual({ mode: 'tip' });
-  });
-
-  it('does not force a full scan before the configured recovery cadence', () => {
-    expect(chainDiscoveryScanOptions({
-      watermarkSeeded: true,
-      startupPhase: 'complete',
-      successfulScansInCycle: 47,
+      run: 47,
       fullScanEvery: 48,
-    })).toEqual({ mode: 'incremental', throwOnChainScanFailure: true, pageBudget: 30 });
+    })).toEqual({ mode: 'incremental', pageBudget: 30 });
   });
 
   it('ignores fractional full-scan cadence overrides below one', () => {
     expect(chainDiscoveryScanOptions({
       watermarkSeeded: true,
-      startupPhase: 'complete',
-      successfulScansInCycle: 1,
+      run: 1,
       fullScanEvery: 0.5,
-    })).toEqual({ mode: 'incremental', throwOnChainScanFailure: true, pageBudget: 30 });
+    })).toEqual({ mode: 'incremental', pageBudget: 30 });
   });
 
   it('honors a valid custom page budget', () => {
     expect(chainDiscoveryScanOptions({
       watermarkSeeded: true,
-      startupPhase: 'complete',
-      successfulScansInCycle: 1,
+      run: 1,
       pageBudget: 7.9,
-    })).toEqual({ mode: 'incremental', throwOnChainScanFailure: true, pageBudget: 7 });
+    })).toEqual({ mode: 'incremental', pageBudget: 7 });
   });
 
   it('derives the daily full-resync cadence from the same schedule as the interval', () => {
@@ -247,7 +227,7 @@ describe('chainDiscoveryScanOptions', () => {
     });
   });
 
-  it('interleaves tip discovery when startup full recovery keeps failing', async () => {
+  it('uses a valid historical cursor between tip probes and failed full retries', async () => {
     const agent = {
       hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
       discoverContextGraphsFromChain: vi
@@ -255,10 +235,12 @@ describe('chainDiscoveryScanOptions', () => {
         .mockRejectedValueOnce(new Error('old archive range unavailable'))
         .mockRejectedValueOnce(new Error('old archive range still unavailable'))
         .mockResolvedValueOnce(4)
+        .mockResolvedValueOnce(2)
         .mockRejectedValueOnce(new Error('full recovery remains pending')),
     };
     const runner = createChainDiscoveryScanRunner({ agent, log: vi.fn() });
 
+    await runner();
     await runner();
     await runner();
     await runner();
@@ -268,8 +250,14 @@ describe('chainDiscoveryScanOptions', () => {
       'seedFull',
       'seedFull',
       'tip',
+      'incremental',
       'seedFull',
     ]);
+    expect(agent.discoverContextGraphsFromChain).toHaveBeenNthCalledWith(4, {
+      mode: 'incremental',
+      throwOnChainScanFailure: true,
+      pageBudget: 30,
+    });
   });
 
   it('interleaves tip recovery when fresh cursor bootstrap remains blocked', async () => {
@@ -283,10 +271,12 @@ describe('chainDiscoveryScanOptions', () => {
         .mockRejectedValueOnce(new Error('bootstrap page unavailable'))
         .mockRejectedValueOnce(new Error('persisted historical page unavailable'))
         .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(0)
         .mockRejectedValueOnce(new Error('historical recovery remains pending')),
     };
     const runner = createChainDiscoveryScanRunner({ agent, log: vi.fn() });
 
+    await runner();
     await runner();
     await runner();
     await runner();
@@ -296,6 +286,7 @@ describe('chainDiscoveryScanOptions', () => {
       'seedFromCursor',
       'incremental',
       'tip',
+      'incremental',
       'seedFull',
     ]);
   });
@@ -345,6 +336,7 @@ describe('chainDiscoveryScanOptions', () => {
         .mockResolvedValueOnce(0)
         .mockRejectedValueOnce(new Error('historical page unavailable'))
         .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(0)
         .mockResolvedValueOnce(0),
     };
     const runner = createChainDiscoveryScanRunner({
@@ -358,12 +350,14 @@ describe('chainDiscoveryScanOptions', () => {
     await runner();
     await runner();
     await runner();
+    await runner();
 
     expect(agent.discoverContextGraphsFromChain.mock.calls.map(([options]) => options.mode)).toEqual([
       'seedFull',
       'incremental',
       'seedFull',
       'tip',
+      'incremental',
       'seedFull',
     ]);
   });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, it, vi } from 'vitest';
-import { chainDiscoveryScanOptions, createChainDiscoveryScanRunner } from '../src/daemon/lifecycle.js';
+import {
+  CHAIN_DISCOVERY_SCAN_SCHEDULE,
+  chainDiscoveryScanOptions,
+  createChainDiscoveryScanRunner,
+  deriveChainFullScanEvery,
+} from '../src/daemon/lifecycle.js';
 
 describe('chainDiscoveryScanOptions', () => {
   it('uses bounded cursor-resumable watermark seeding before a seed exists', () => {
-    expect(chainDiscoveryScanOptions({ watermarkSeeded: false })).toEqual({
+    expect(chainDiscoveryScanOptions({
+      watermarkSeeded: false,
+      startupPhase: 'undetermined',
+      successfulScansInCycle: 0,
+    })).toEqual({
       mode: 'seedFromCursor',
       throwOnChainScanFailure: true,
       pageBudget: 30,
@@ -11,7 +20,11 @@ describe('chainDiscoveryScanOptions', () => {
   });
 
   it('uses a startup recovery scan even when the registry watermark already exists', () => {
-    expect(chainDiscoveryScanOptions({ watermarkSeeded: true })).toEqual({
+    expect(chainDiscoveryScanOptions({
+      watermarkSeeded: true,
+      startupPhase: 'undetermined',
+      successfulScansInCycle: 0,
+    })).toEqual({
       mode: 'seedFull',
       throwOnChainScanFailure: true,
     });
@@ -20,7 +33,8 @@ describe('chainDiscoveryScanOptions', () => {
   it('keeps steady-state daemon scans incremental after startup recovery', () => {
     expect(chainDiscoveryScanOptions({
       watermarkSeeded: true,
-      run: 1,
+      startupPhase: 'complete',
+      successfulScansInCycle: 1,
       fullScanEvery: 48,
     })).toEqual({ mode: 'incremental', pageBudget: 30 });
   });
@@ -28,7 +42,8 @@ describe('chainDiscoveryScanOptions', () => {
   it('keeps a periodic full-history recovery path after the watermark is seeded', () => {
     expect(chainDiscoveryScanOptions({
       watermarkSeeded: true,
-      run: 48,
+      startupPhase: 'complete',
+      successfulScansInCycle: 48,
       fullScanEvery: 48,
     })).toEqual({
       mode: 'seedFull',
@@ -39,7 +54,8 @@ describe('chainDiscoveryScanOptions', () => {
   it('does not force a full scan before the configured recovery cadence', () => {
     expect(chainDiscoveryScanOptions({
       watermarkSeeded: true,
-      run: 47,
+      startupPhase: 'complete',
+      successfulScansInCycle: 47,
       fullScanEvery: 48,
     })).toEqual({ mode: 'incremental', pageBudget: 30 });
   });
@@ -47,7 +63,8 @@ describe('chainDiscoveryScanOptions', () => {
   it('ignores fractional full-scan cadence overrides below one', () => {
     expect(chainDiscoveryScanOptions({
       watermarkSeeded: true,
-      run: 1,
+      startupPhase: 'complete',
+      successfulScansInCycle: 1,
       fullScanEvery: 0.5,
     })).toEqual({ mode: 'incremental', pageBudget: 30 });
   });
@@ -55,9 +72,18 @@ describe('chainDiscoveryScanOptions', () => {
   it('honors a valid custom page budget', () => {
     expect(chainDiscoveryScanOptions({
       watermarkSeeded: true,
-      run: 1,
+      startupPhase: 'complete',
+      successfulScansInCycle: 1,
       pageBudget: 7.9,
     })).toEqual({ mode: 'incremental', pageBudget: 7 });
+  });
+
+  it('derives the daily full-resync cadence from the same schedule as the interval', () => {
+    expect(CHAIN_DISCOVERY_SCAN_SCHEDULE.intervalMs).toBe(30 * 60 * 1000);
+    expect(CHAIN_DISCOVERY_SCAN_SCHEDULE.fullScanEvery).toBe(48);
+    expect(deriveChainFullScanEvery(CHAIN_DISCOVERY_SCAN_SCHEDULE)).toBe(
+      CHAIN_DISCOVERY_SCAN_SCHEDULE.fullScanEvery,
+    );
   });
 
   it('serializes overlapping scheduled chain scans and resets after settle', async () => {
@@ -193,6 +219,92 @@ describe('chainDiscoveryScanOptions', () => {
       mode: 'incremental',
       pageBudget: 30,
     });
+  });
+
+  it('interleaves tip discovery when startup full recovery keeps failing', async () => {
+    const agent = {
+      hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
+      discoverContextGraphsFromChain: vi
+        .fn<(options: ReturnType<typeof chainDiscoveryScanOptions>) => Promise<number>>()
+        .mockRejectedValueOnce(new Error('old archive range unavailable'))
+        .mockRejectedValueOnce(new Error('old archive range still unavailable'))
+        .mockResolvedValueOnce(4)
+        .mockRejectedValueOnce(new Error('full recovery remains pending')),
+    };
+    const runner = createChainDiscoveryScanRunner({ agent, log: vi.fn() });
+
+    await runner();
+    await runner();
+    await runner();
+    await runner();
+
+    expect(agent.discoverContextGraphsFromChain.mock.calls.map(([options]) => options.mode)).toEqual([
+      'seedFull',
+      'seedFull',
+      'incremental',
+      'seedFull',
+    ]);
+  });
+
+  it('interleaves an incremental attempt after a failed periodic full resync', async () => {
+    const agent = {
+      hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
+      discoverContextGraphsFromChain: vi
+        .fn<(options: ReturnType<typeof chainDiscoveryScanOptions>) => Promise<number>>()
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(0)
+        .mockRejectedValueOnce(new Error('historical page unavailable'))
+        .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(0),
+    };
+    const runner = createChainDiscoveryScanRunner({
+      agent,
+      log: vi.fn(),
+      fullScanEvery: 2,
+    });
+
+    await runner();
+    await runner();
+    await runner();
+    await runner();
+    await runner();
+
+    expect(agent.discoverContextGraphsFromChain.mock.calls.map(([options]) => options.mode)).toEqual([
+      'seedFull',
+      'incremental',
+      'seedFull',
+      'incremental',
+      'seedFull',
+    ]);
+  });
+
+  it('does not advance the full-resync cadence on an incremental failure', async () => {
+    const agent = {
+      hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
+      discoverContextGraphsFromChain: vi
+        .fn<(options: ReturnType<typeof chainDiscoveryScanOptions>) => Promise<number>>()
+        .mockResolvedValueOnce(0)
+        .mockRejectedValueOnce(new Error('tip RPC unavailable'))
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(0),
+    };
+    const runner = createChainDiscoveryScanRunner({
+      agent,
+      log: vi.fn(),
+      fullScanEvery: 2,
+    });
+
+    await runner();
+    await runner();
+    await runner();
+    await runner();
+
+    expect(agent.discoverContextGraphsFromChain.mock.calls.map(([options]) => options.mode)).toEqual([
+      'seedFull',
+      'incremental',
+      'incremental',
+      'seedFull',
+    ]);
   });
 
   it('does not misclassify a successful scan when its progress log throws', async () => {

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -13,6 +13,8 @@ import {
   chainDiscoveryScanOptions as barrelChainDiscoveryScanOptions,
   createChainDiscoveryScanRunner as barrelCreateChainDiscoveryScanRunner,
 } from '../src/daemon.js';
+import * as daemonBarrel from '../src/daemon.js';
+import * as daemonIndexBarrel from '../src/daemon/index.js';
 
 describe('chainDiscoveryScanOptions', () => {
   it('preserves daemon barrel exports and the original run-based helper input', () => {
@@ -22,6 +24,13 @@ describe('chainDiscoveryScanOptions', () => {
       mode: 'incremental',
       pageBudget: 30,
     });
+  });
+
+  it('keeps scan state-machine reducers out of daemon barrels', () => {
+    for (const barrel of [daemonBarrel, daemonIndexBarrel]) {
+      expect(barrel).not.toHaveProperty('resolveManagedChainDiscoveryScanAttempt');
+      expect(barrel).not.toHaveProperty('transitionManagedChainDiscoveryScanState');
+    }
   });
 
   it('preserves bounded cursor seeding in the original helper', () => {

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { DKGAgent } from '@origintrail-official/dkg-agent';
 import {
   CHAIN_DISCOVERY_SCAN_SCHEDULE,
   chainDiscoveryScanOptions,
@@ -36,7 +37,7 @@ describe('chainDiscoveryScanOptions', () => {
       startupPhase: 'complete',
       successfulScansInCycle: 1,
       fullScanEvery: 48,
-    })).toEqual({ mode: 'incremental', pageBudget: 30 });
+    })).toEqual({ mode: 'incremental', throwOnChainScanFailure: true, pageBudget: 30 });
   });
 
   it('keeps a periodic full-history recovery path after the watermark is seeded', () => {
@@ -67,7 +68,7 @@ describe('chainDiscoveryScanOptions', () => {
       startupPhase: 'complete',
       successfulScansInCycle: 47,
       fullScanEvery: 48,
-    })).toEqual({ mode: 'incremental', pageBudget: 30 });
+    })).toEqual({ mode: 'incremental', throwOnChainScanFailure: true, pageBudget: 30 });
   });
 
   it('ignores fractional full-scan cadence overrides below one', () => {
@@ -76,7 +77,7 @@ describe('chainDiscoveryScanOptions', () => {
       startupPhase: 'complete',
       successfulScansInCycle: 1,
       fullScanEvery: 0.5,
-    })).toEqual({ mode: 'incremental', pageBudget: 30 });
+    })).toEqual({ mode: 'incremental', throwOnChainScanFailure: true, pageBudget: 30 });
   });
 
   it('honors a valid custom page budget', () => {
@@ -85,7 +86,7 @@ describe('chainDiscoveryScanOptions', () => {
       startupPhase: 'complete',
       successfulScansInCycle: 1,
       pageBudget: 7.9,
-    })).toEqual({ mode: 'incremental', pageBudget: 7 });
+    })).toEqual({ mode: 'incremental', throwOnChainScanFailure: true, pageBudget: 7 });
   });
 
   it('derives the daily full-resync cadence from the same schedule as the interval', () => {
@@ -227,6 +228,7 @@ describe('chainDiscoveryScanOptions', () => {
     });
     expect(agent.discoverContextGraphsFromChain).toHaveBeenNthCalledWith(2, {
       mode: 'incremental',
+      throwOnChainScanFailure: true,
       pageBudget: 30,
     });
   });
@@ -282,6 +284,42 @@ describe('chainDiscoveryScanOptions', () => {
       'tip',
       'seedFull',
     ]);
+  });
+
+  it('uses real DKGAgent failure propagation to escape a persistently failing incremental scan', async () => {
+    const attemptedModes: string[] = [];
+    const chain = {
+      scanContextGraphRegistryPages(options: { mode: string }) {
+        attemptedModes.push(options.mode);
+        return (async function* () {
+          if (options.mode === 'incremental') {
+            throw new Error('archive range unavailable');
+          }
+          yield* [];
+        })();
+      },
+    };
+    const harness = {
+      chain,
+      subscribedContextGraphs: new Map(),
+      log: { info: vi.fn(), warn: vi.fn() },
+    };
+    const realDiscover = DKGAgent.prototype.discoverContextGraphsFromChain.bind(harness as never);
+    const runner = createChainDiscoveryScanRunner({
+      agent: {
+        hasContextGraphRegistryScanWatermark: async () => true,
+        discoverContextGraphsFromChain: realDiscover,
+      },
+      log: vi.fn(),
+    });
+
+    await runner();
+    await runner();
+    await runner();
+    await runner();
+
+    expect(attemptedModes).toEqual(['seedFull', 'incremental', 'incremental', 'tip']);
+    expect(harness.log.warn).toHaveBeenCalledTimes(1);
   });
 
   it('interleaves a tip probe after a failed periodic full resync', async () => {
@@ -366,6 +404,7 @@ describe('chainDiscoveryScanOptions', () => {
     expect(messages).toEqual(['Chain scan: discovered 3 new context graph(s)']);
     expect(agent.discoverContextGraphsFromChain).toHaveBeenNthCalledWith(2, {
       mode: 'incremental',
+      throwOnChainScanFailure: true,
       pageBudget: 30,
     });
   });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -363,20 +363,22 @@ describe('chainDiscoveryScanOptions', () => {
     expect(agent.discoverContextGraphsFromChain).toHaveBeenCalledTimes(2);
   });
 
-  it('contains unformattable rejection reasons and remains reusable across both failure paths', async () => {
-    const hostileReason = {
+  it('contains errors with unformattable messages and remains reusable across both failure paths', async () => {
+    const hostileMessage = {
       toString() {
         throw new Error('format failed');
       },
     };
+    const hostileError = new Error('placeholder');
+    Object.defineProperty(hostileError, 'message', { value: hostileMessage });
     const agent = {
       hasContextGraphRegistryScanWatermark: vi
         .fn<() => Promise<boolean>>()
-        .mockRejectedValueOnce(hostileReason)
+        .mockRejectedValueOnce(hostileError)
         .mockResolvedValue(true),
       discoverContextGraphsFromChain: vi
         .fn<(options: ReturnType<typeof chainDiscoveryScanOptions>) => Promise<number>>()
-        .mockRejectedValueOnce(hostileReason)
+        .mockRejectedValueOnce(hostileError)
         .mockResolvedValueOnce(2),
     };
     const log = vi.fn();

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -4,7 +4,7 @@ import {
   chainDiscoveryScanOptions,
   createChainDiscoveryScanRunner,
   deriveChainFullScanEvery,
-} from '../src/daemon/lifecycle.js';
+} from '../src/daemon/chain-discovery-scan-runner.js';
 
 describe('chainDiscoveryScanOptions', () => {
   it('uses bounded cursor-resumable watermark seeding before a seed exists', () => {
@@ -49,6 +49,16 @@ describe('chainDiscoveryScanOptions', () => {
       mode: 'seedFull',
       throwOnChainScanFailure: true,
     });
+  });
+
+  it('uses a cursor-independent tip probe while full-history recovery is pending', () => {
+    expect(chainDiscoveryScanOptions({
+      watermarkSeeded: true,
+      startupPhase: 'complete',
+      successfulScansInCycle: 48,
+      fullRecoveryPending: true,
+      fullRecoveryRetryReady: false,
+    })).toEqual({ mode: 'tip' });
   });
 
   it('does not force a full scan before the configured recovery cadence', () => {
@@ -241,12 +251,12 @@ describe('chainDiscoveryScanOptions', () => {
     expect(agent.discoverContextGraphsFromChain.mock.calls.map(([options]) => options.mode)).toEqual([
       'seedFull',
       'seedFull',
-      'incremental',
+      'tip',
       'seedFull',
     ]);
   });
 
-  it('interleaves an incremental attempt after a failed periodic full resync', async () => {
+  it('interleaves a tip probe after a failed periodic full resync', async () => {
     const agent = {
       hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
       discoverContextGraphsFromChain: vi
@@ -273,7 +283,7 @@ describe('chainDiscoveryScanOptions', () => {
       'seedFull',
       'incremental',
       'seedFull',
-      'incremental',
+      'tip',
       'seedFull',
     ]);
   });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -6,7 +6,6 @@ import {
   createChainDiscoveryScanRunner,
   deriveChainFullScanEvery,
   resolveManagedChainDiscoveryScanAttempt,
-  transitionManagedChainDiscoveryScanState,
   type ManagedChainDiscoveryScanState,
 } from '../src/daemon/chain-discovery-scan-runner.js';
 import {
@@ -139,12 +138,9 @@ describe('chainDiscoveryScanOptions', () => {
         fullScanEvery,
       });
       actualModes.push(attempt.options.mode);
-      state = transitionManagedChainDiscoveryScanState({
-        state: attempt.state,
-        watermarkSeeded,
-        outcome: outcomes[index]!,
-        fullScanEvery,
-      });
+      state = outcomes[index] === 'success'
+        ? attempt.nextOnSuccess
+        : attempt.nextOnFailure;
     }
     expect(actualModes).toEqual(modes);
   });

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -29,7 +29,6 @@ describe('chainDiscoveryScanOptions', () => {
   it('keeps scan state-machine reducers out of daemon barrels', () => {
     for (const barrel of [daemonBarrel, daemonIndexBarrel]) {
       expect(barrel).not.toHaveProperty('resolveManagedChainDiscoveryScanAttempt');
-      expect(barrel).not.toHaveProperty('transitionManagedChainDiscoveryScanState');
     }
   });
 

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -6,8 +6,22 @@ import {
   createChainDiscoveryScanRunner,
   deriveChainFullScanEvery,
 } from '../src/daemon/chain-discovery-scan-runner.js';
+import {
+  CHAIN_FULL_SCAN_EVERY as BARREL_CHAIN_FULL_SCAN_EVERY,
+  chainDiscoveryScanOptions as barrelChainDiscoveryScanOptions,
+  createChainDiscoveryScanRunner as barrelCreateChainDiscoveryScanRunner,
+} from '../src/daemon.js';
 
 describe('chainDiscoveryScanOptions', () => {
+  it('preserves daemon barrel exports and the original run-based helper input', () => {
+    expect(BARREL_CHAIN_FULL_SCAN_EVERY).toBe(48);
+    expect(barrelCreateChainDiscoveryScanRunner).toBe(createChainDiscoveryScanRunner);
+    expect(barrelChainDiscoveryScanOptions({ watermarkSeeded: true, run: 1 })).toEqual({
+      mode: 'incremental',
+      pageBudget: 30,
+    });
+  });
+
   it('uses bounded cursor-resumable watermark seeding before a seed exists', () => {
     expect(chainDiscoveryScanOptions({
       watermarkSeeded: false,

--- a/packages/cli/test/chain-discovery-scan-mode.test.ts
+++ b/packages/cli/test/chain-discovery-scan-mode.test.ts
@@ -5,6 +5,9 @@ import {
   chainDiscoveryScanOptions,
   createChainDiscoveryScanRunner,
   deriveChainFullScanEvery,
+  resolveManagedChainDiscoveryScanAttempt,
+  transitionManagedChainDiscoveryScanState,
+  type ManagedChainDiscoveryScanState,
 } from '../src/daemon/chain-discovery-scan-runner.js';
 import {
   CHAIN_FULL_SCAN_EVERY as BARREL_CHAIN_FULL_SCAN_EVERY,
@@ -89,6 +92,61 @@ describe('chainDiscoveryScanOptions', () => {
     expect(deriveChainFullScanEvery(CHAIN_DISCOVERY_SCAN_SCHEDULE)).toBe(
       CHAIN_DISCOVERY_SCAN_SCHEDULE.fullScanEvery,
     );
+  });
+
+  it.each([
+    {
+      label: 'resumes a partially persisted cursor seed',
+      watermarks: [false, true],
+      outcomes: ['failure', 'success'] as const,
+      fullScanEvery: 48,
+      modes: ['seedFromCursor', 'incremental'],
+    },
+    {
+      label: 'interleaves tip and cursor recovery after two startup full failures',
+      watermarks: [true, true, true, true, true],
+      outcomes: ['failure', 'failure', 'success', 'success', 'success'] as const,
+      fullScanEvery: 48,
+      modes: ['seedFull', 'seedFull', 'tip', 'incremental', 'seedFull'],
+    },
+    {
+      label: 'interleaves recovery after a periodic full failure',
+      watermarks: [true, true, true, true, true, true],
+      outcomes: ['success', 'success', 'failure', 'success', 'success', 'success'] as const,
+      fullScanEvery: 2,
+      modes: ['seedFull', 'incremental', 'seedFull', 'tip', 'incremental', 'seedFull'],
+    },
+    {
+      label: 'retries full recovery after the interleaved incremental attempt fails',
+      watermarks: [true, true, true, true, true],
+      outcomes: ['failure', 'failure', 'success', 'failure', 'success'] as const,
+      fullScanEvery: 48,
+      modes: ['seedFull', 'seedFull', 'tip', 'incremental', 'seedFull'],
+    },
+  ])('$label through pure state transitions', ({
+    watermarks,
+    outcomes,
+    fullScanEvery,
+    modes,
+  }) => {
+    let state: ManagedChainDiscoveryScanState = { kind: 'undetermined' };
+    const actualModes: string[] = [];
+    for (let index = 0; index < outcomes.length; index += 1) {
+      const watermarkSeeded = watermarks[index]!;
+      const attempt = resolveManagedChainDiscoveryScanAttempt({
+        state,
+        watermarkSeeded,
+        fullScanEvery,
+      });
+      actualModes.push(attempt.options.mode);
+      state = transitionManagedChainDiscoveryScanState({
+        state: attempt.state,
+        watermarkSeeded,
+        outcome: outcomes[index]!,
+        fullScanEvery,
+      });
+    }
+    expect(actualModes).toEqual(modes);
   });
 
   it('serializes overlapping scheduled chain scans and resets after settle', async () => {
@@ -258,6 +316,34 @@ describe('chainDiscoveryScanOptions', () => {
       throwOnChainScanFailure: true,
       pageBudget: 30,
     });
+  });
+
+  it('retries full recovery after the interleaved incremental recovery attempt fails', async () => {
+    const agent = {
+      hasContextGraphRegistryScanWatermark: vi.fn(async () => true),
+      discoverContextGraphsFromChain: vi
+        .fn<(options: ReturnType<typeof chainDiscoveryScanOptions>) => Promise<number>>()
+        .mockRejectedValueOnce(new Error('old archive range unavailable'))
+        .mockRejectedValueOnce(new Error('old archive range still unavailable'))
+        .mockResolvedValueOnce(0)
+        .mockRejectedValueOnce(new Error('bounded cursor recovery failed'))
+        .mockResolvedValueOnce(0),
+    };
+    const runner = createChainDiscoveryScanRunner({ agent, log: vi.fn() });
+
+    await runner();
+    await runner();
+    await runner();
+    await runner();
+    await runner();
+
+    expect(agent.discoverContextGraphsFromChain.mock.calls.map(([options]) => options.mode)).toEqual([
+      'seedFull',
+      'seedFull',
+      'tip',
+      'incremental',
+      'seedFull',
+    ]);
   });
 
   it('interleaves tip recovery when fresh cursor bootstrap remains blocked', async () => {

--- a/packages/cli/test/daemon-snapshot-page-index-wiring.test.ts
+++ b/packages/cli/test/daemon-snapshot-page-index-wiring.test.ts
@@ -107,7 +107,7 @@ function createFakeAgent() {
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db
-    ?? createArg?.contextGraphRegistryScanCursorStore?.store?.cursors?.db;
+    ?? createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
   db?.close?.();
 }
 

--- a/packages/cli/test/daemon-snapshot-page-index-wiring.test.ts
+++ b/packages/cli/test/daemon-snapshot-page-index-wiring.test.ts
@@ -107,7 +107,7 @@ function createFakeAgent() {
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db
-    ?? createArg?.contextGraphRegistryScanCursorPersistence?.store?.cursors?.db;
+    ?? createArg?.contextGraphRegistryScanCursorStore?.store?.cursors?.db;
   db?.close?.();
 }
 

--- a/packages/cli/test/daemon-snapshot-page-index-wiring.test.ts
+++ b/packages/cli/test/daemon-snapshot-page-index-wiring.test.ts
@@ -107,7 +107,7 @@ function createFakeAgent() {
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db
-    ?? createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
+    ?? createArg?.contextGraphRegistryScanCursorPersistence?.store?.cursors?.db;
   db?.close?.();
 }
 

--- a/packages/cli/test/daemon-snapshot-page-index-wiring.test.ts
+++ b/packages/cli/test/daemon-snapshot-page-index-wiring.test.ts
@@ -107,7 +107,7 @@ function createFakeAgent() {
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db
-    ?? createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
+    ?? createArg?.contextGraphRegistryRoleAwareScanCursorStore?.cursors?.db;
   db?.close?.();
 }
 

--- a/packages/cli/test/daemon-startup-validation.test.ts
+++ b/packages/cli/test/daemon-startup-validation.test.ts
@@ -37,7 +37,7 @@ const { runDaemonInner } = await import('../src/daemon/lifecycle.js');
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db ??
-    createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
+    createArg?.contextGraphRegistryRoleAwareScanCursorStore?.cursors?.db;
   db?.close?.();
 }
 
@@ -242,11 +242,7 @@ describe('daemon startup network validation', () => {
         loadLane: expect.any(Function),
         saveLane: expect.any(Function),
       },
-      contextGraphRegistryScanCursorStore: {
-        load: expect.any(Function),
-        save: expect.any(Function),
-      },
-      contextGraphRegistryTipScanCursorStore: {
+      contextGraphRegistryRoleAwareScanCursorStore: {
         load: expect.any(Function),
         save: expect.any(Function),
       },
@@ -259,11 +255,12 @@ describe('daemon startup network validation', () => {
       }),
       registryAddress: '0x3333333333333333333333333333333333333333',
     };
-    await createArg.contextGraphRegistryScanCursorStore.save(registryCursorKey, 111);
-    await createArg.contextGraphRegistryTipScanCursorStore.save(registryCursorKey, 222);
-    await expect(createArg.contextGraphRegistryScanCursorStore.load(registryCursorKey))
+    const cursorStore = createArg.contextGraphRegistryRoleAwareScanCursorStore;
+    await cursorStore.save({ ...registryCursorKey, cursorKind: 'historical' }, 111);
+    await cursorStore.save({ ...registryCursorKey, cursorKind: 'tip' }, 222);
+    await expect(cursorStore.load({ ...registryCursorKey, cursorKind: 'historical' }))
       .resolves.toBe(111);
-    await expect(createArg.contextGraphRegistryTipScanCursorStore.load(registryCursorKey))
+    await expect(cursorStore.load({ ...registryCursorKey, cursorKind: 'tip' }))
       .resolves.toBe(222);
     expect((createArg.chainEventCursorStore as any).scope).toBe(buildEvmDeploymentId({
       chainId: 'gnosis:100',

--- a/packages/cli/test/daemon-startup-validation.test.ts
+++ b/packages/cli/test/daemon-startup-validation.test.ts
@@ -37,7 +37,7 @@ const { runDaemonInner } = await import('../src/daemon/lifecycle.js');
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db ??
-    createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
+    createArg?.contextGraphRegistryScanCursorPersistence?.store?.cursors?.db;
   db?.close?.();
 }
 
@@ -242,9 +242,12 @@ describe('daemon startup network validation', () => {
         loadLane: expect.any(Function),
         saveLane: expect.any(Function),
       },
-      contextGraphRegistryScanCursorStore: {
-        load: expect.any(Function),
-        save: expect.any(Function),
+      contextGraphRegistryScanCursorPersistence: {
+        kind: 'roleAware',
+        store: {
+          load: expect.any(Function),
+          save: expect.any(Function),
+        },
       },
     });
     expect((createArg.chainEventCursorStore as any).scope).toBe(buildEvmDeploymentId({

--- a/packages/cli/test/daemon-startup-validation.test.ts
+++ b/packages/cli/test/daemon-startup-validation.test.ts
@@ -37,7 +37,7 @@ const { runDaemonInner } = await import('../src/daemon/lifecycle.js');
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db ??
-    createArg?.contextGraphRegistryScanCursorPersistence?.store?.cursors?.db;
+    createArg?.contextGraphRegistryScanCursorStore?.store?.cursors?.db;
   db?.close?.();
 }
 
@@ -242,7 +242,7 @@ describe('daemon startup network validation', () => {
         loadLane: expect.any(Function),
         saveLane: expect.any(Function),
       },
-      contextGraphRegistryScanCursorPersistence: {
+      contextGraphRegistryScanCursorStore: {
         kind: 'roleAware',
         store: {
           load: expect.any(Function),

--- a/packages/cli/test/daemon-startup-validation.test.ts
+++ b/packages/cli/test/daemon-startup-validation.test.ts
@@ -37,7 +37,7 @@ const { runDaemonInner } = await import('../src/daemon/lifecycle.js');
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db ??
-    createArg?.contextGraphRegistryScanCursorStore?.store?.cursors?.db;
+    createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
   db?.close?.();
 }
 
@@ -243,11 +243,12 @@ describe('daemon startup network validation', () => {
         saveLane: expect.any(Function),
       },
       contextGraphRegistryScanCursorStore: {
-        kind: 'roleAware',
-        store: {
-          load: expect.any(Function),
-          save: expect.any(Function),
-        },
+        load: expect.any(Function),
+        save: expect.any(Function),
+      },
+      contextGraphRegistryTipScanCursorStore: {
+        load: expect.any(Function),
+        save: expect.any(Function),
       },
     });
     expect((createArg.chainEventCursorStore as any).scope).toBe(buildEvmDeploymentId({

--- a/packages/cli/test/daemon-startup-validation.test.ts
+++ b/packages/cli/test/daemon-startup-validation.test.ts
@@ -251,6 +251,20 @@ describe('daemon startup network validation', () => {
         save: expect.any(Function),
       },
     });
+    const registryCursorKey = {
+      chainId: 'gnosis:100',
+      deploymentId: buildEvmDeploymentId({
+        chainId: 'gnosis:100',
+        hubAddress: '0x1234567890123456789012345678901234567890',
+      }),
+      registryAddress: '0x3333333333333333333333333333333333333333',
+    };
+    await createArg.contextGraphRegistryScanCursorStore.save(registryCursorKey, 111);
+    await createArg.contextGraphRegistryTipScanCursorStore.save(registryCursorKey, 222);
+    await expect(createArg.contextGraphRegistryScanCursorStore.load(registryCursorKey))
+      .resolves.toBe(111);
+    await expect(createArg.contextGraphRegistryTipScanCursorStore.load(registryCursorKey))
+      .resolves.toBe(222);
     expect((createArg.chainEventCursorStore as any).scope).toBe(buildEvmDeploymentId({
       chainId: 'gnosis:100',
       hubAddress: '0x1234567890123456789012345678901234567890',

--- a/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
+++ b/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
@@ -159,7 +159,7 @@ function createFakeServer() {
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db ??
-    createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
+    createArg?.contextGraphRegistryScanCursorPersistence?.store?.cursors?.db;
   db?.close?.();
 }
 

--- a/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
+++ b/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
@@ -159,7 +159,7 @@ function createFakeServer() {
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db ??
-    createArg?.contextGraphRegistryScanCursorPersistence?.store?.cursors?.db;
+    createArg?.contextGraphRegistryScanCursorStore?.store?.cursors?.db;
   db?.close?.();
 }
 

--- a/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
+++ b/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
@@ -159,7 +159,7 @@ function createFakeServer() {
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db ??
-    createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
+    createArg?.contextGraphRegistryRoleAwareScanCursorStore?.cursors?.db;
   db?.close?.();
 }
 

--- a/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
+++ b/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
@@ -159,7 +159,7 @@ function createFakeServer() {
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db ??
-    createArg?.contextGraphRegistryScanCursorStore?.store?.cursors?.db;
+    createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
   db?.close?.();
 }
 

--- a/packages/cli/test/daemon-sync-agents-meta-wiring.test.ts
+++ b/packages/cli/test/daemon-sync-agents-meta-wiring.test.ts
@@ -49,7 +49,7 @@ const { runDaemonInner } = await import('../src/daemon/lifecycle.js');
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db ??
-    createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
+    createArg?.contextGraphRegistryRoleAwareScanCursorStore?.cursors?.db;
   db?.close?.();
 }
 

--- a/packages/cli/test/daemon-sync-agents-meta-wiring.test.ts
+++ b/packages/cli/test/daemon-sync-agents-meta-wiring.test.ts
@@ -49,7 +49,7 @@ const { runDaemonInner } = await import('../src/daemon/lifecycle.js');
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db ??
-    createArg?.contextGraphRegistryScanCursorPersistence?.store?.cursors?.db;
+    createArg?.contextGraphRegistryScanCursorStore?.store?.cursors?.db;
   db?.close?.();
 }
 

--- a/packages/cli/test/daemon-sync-agents-meta-wiring.test.ts
+++ b/packages/cli/test/daemon-sync-agents-meta-wiring.test.ts
@@ -49,7 +49,7 @@ const { runDaemonInner } = await import('../src/daemon/lifecycle.js');
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db ??
-    createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
+    createArg?.contextGraphRegistryScanCursorPersistence?.store?.cursors?.db;
   db?.close?.();
 }
 

--- a/packages/cli/test/daemon-sync-agents-meta-wiring.test.ts
+++ b/packages/cli/test/daemon-sync-agents-meta-wiring.test.ts
@@ -49,7 +49,7 @@ const { runDaemonInner } = await import('../src/daemon/lifecycle.js');
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db ??
-    createArg?.contextGraphRegistryScanCursorStore?.store?.cursors?.db;
+    createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
   db?.close?.();
 }
 

--- a/packages/cli/test/publisher-backfill-wiring-1828.test.ts
+++ b/packages/cli/test/publisher-backfill-wiring-1828.test.ts
@@ -74,7 +74,7 @@ function createFakeServer() {
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db ??
-    createArg?.contextGraphRegistryScanCursorPersistence?.store?.cursors?.db;
+    createArg?.contextGraphRegistryScanCursorStore?.store?.cursors?.db;
   db?.close?.();
 }
 

--- a/packages/cli/test/publisher-backfill-wiring-1828.test.ts
+++ b/packages/cli/test/publisher-backfill-wiring-1828.test.ts
@@ -74,7 +74,7 @@ function createFakeServer() {
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db ??
-    createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
+    createArg?.contextGraphRegistryScanCursorPersistence?.store?.cursors?.db;
   db?.close?.();
 }
 

--- a/packages/cli/test/publisher-backfill-wiring-1828.test.ts
+++ b/packages/cli/test/publisher-backfill-wiring-1828.test.ts
@@ -74,7 +74,7 @@ function createFakeServer() {
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db ??
-    createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
+    createArg?.contextGraphRegistryRoleAwareScanCursorStore?.cursors?.db;
   db?.close?.();
 }
 

--- a/packages/cli/test/publisher-backfill-wiring-1828.test.ts
+++ b/packages/cli/test/publisher-backfill-wiring-1828.test.ts
@@ -74,7 +74,7 @@ function createFakeServer() {
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db ??
-    createArg?.contextGraphRegistryScanCursorStore?.store?.cursors?.db;
+    createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
   db?.close?.();
 }
 

--- a/packages/cli/test/publisher-maxretries-wiring-1836.test.ts
+++ b/packages/cli/test/publisher-maxretries-wiring-1836.test.ts
@@ -70,7 +70,7 @@ function createFakeServer() {
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db ??
-    createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
+    createArg?.contextGraphRegistryRoleAwareScanCursorStore?.cursors?.db;
   db?.close?.();
 }
 

--- a/packages/cli/test/publisher-maxretries-wiring-1836.test.ts
+++ b/packages/cli/test/publisher-maxretries-wiring-1836.test.ts
@@ -70,7 +70,7 @@ function createFakeServer() {
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db ??
-    createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
+    createArg?.contextGraphRegistryScanCursorPersistence?.store?.cursors?.db;
   db?.close?.();
 }
 

--- a/packages/cli/test/publisher-maxretries-wiring-1836.test.ts
+++ b/packages/cli/test/publisher-maxretries-wiring-1836.test.ts
@@ -70,7 +70,7 @@ function createFakeServer() {
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db ??
-    createArg?.contextGraphRegistryScanCursorPersistence?.store?.cursors?.db;
+    createArg?.contextGraphRegistryScanCursorStore?.store?.cursors?.db;
   db?.close?.();
 }
 

--- a/packages/cli/test/publisher-maxretries-wiring-1836.test.ts
+++ b/packages/cli/test/publisher-maxretries-wiring-1836.test.ts
@@ -70,7 +70,7 @@ function createFakeServer() {
 function closeDashboardDbFromAgentCreateArg(createArg: any): void {
   const db =
     createArg?.chainEventCursorStore?.cursors?.db ??
-    createArg?.contextGraphRegistryScanCursorStore?.store?.cursors?.db;
+    createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
   db?.close?.();
 }
 

--- a/packages/cli/test/publisher-retry-tuning-boot-validation-2270.test.ts
+++ b/packages/cli/test/publisher-retry-tuning-boot-validation-2270.test.ts
@@ -165,7 +165,7 @@ describe('runDaemonInner publisher retry-knob config validation (#2270)', () => 
   function closeAgentCreateDb(): void {
     const createArg = mocks.agentCreate.mock.calls[0]?.[0] as any;
     const db = createArg?.chainEventCursorStore?.cursors?.db
-      ?? createArg?.contextGraphRegistryScanCursorPersistence?.store?.cursors?.db;
+      ?? createArg?.contextGraphRegistryScanCursorStore?.store?.cursors?.db;
     db?.close?.();
   }
 

--- a/packages/cli/test/publisher-retry-tuning-boot-validation-2270.test.ts
+++ b/packages/cli/test/publisher-retry-tuning-boot-validation-2270.test.ts
@@ -165,7 +165,7 @@ describe('runDaemonInner publisher retry-knob config validation (#2270)', () => 
   function closeAgentCreateDb(): void {
     const createArg = mocks.agentCreate.mock.calls[0]?.[0] as any;
     const db = createArg?.chainEventCursorStore?.cursors?.db
-      ?? createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
+      ?? createArg?.contextGraphRegistryScanCursorPersistence?.store?.cursors?.db;
     db?.close?.();
   }
 

--- a/packages/cli/test/publisher-retry-tuning-boot-validation-2270.test.ts
+++ b/packages/cli/test/publisher-retry-tuning-boot-validation-2270.test.ts
@@ -165,7 +165,7 @@ describe('runDaemonInner publisher retry-knob config validation (#2270)', () => 
   function closeAgentCreateDb(): void {
     const createArg = mocks.agentCreate.mock.calls[0]?.[0] as any;
     const db = createArg?.chainEventCursorStore?.cursors?.db
-      ?? createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
+      ?? createArg?.contextGraphRegistryRoleAwareScanCursorStore?.cursors?.db;
     db?.close?.();
   }
 

--- a/packages/cli/test/publisher-retry-tuning-boot-validation-2270.test.ts
+++ b/packages/cli/test/publisher-retry-tuning-boot-validation-2270.test.ts
@@ -165,7 +165,7 @@ describe('runDaemonInner publisher retry-knob config validation (#2270)', () => 
   function closeAgentCreateDb(): void {
     const createArg = mocks.agentCreate.mock.calls[0]?.[0] as any;
     const db = createArg?.chainEventCursorStore?.cursors?.db
-      ?? createArg?.contextGraphRegistryScanCursorStore?.store?.cursors?.db;
+      ?? createArg?.contextGraphRegistryScanCursorStore?.cursors?.db;
     db?.close?.();
   }
 

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -30,6 +30,7 @@
     "@opentelemetry/sdk-trace-node": "^2.8.0",
     "@opentelemetry/semantic-conventions": "^1.41.1",
     "@openuidev/react-lang": "^0.2.3",
+    "@origintrail-official/dkg-chain": "workspace:*",
     "@origintrail-official/dkg-core": "workspace:*",
     "@origintrail-official/dkg-graph-viz": "workspace:*",
     "better-sqlite3": "12.11.1",

--- a/packages/node-ui/src/chain-cursor-stores.ts
+++ b/packages/node-ui/src/chain-cursor-stores.ts
@@ -89,7 +89,6 @@ export class SqliteChainEventCursorStore {
  * fallbacks for role-less runtime rows and the original settings representation.
  */
 export class SqliteContextGraphRegistryScanCursorStore {
-  readonly cursorKeyVersion = 2 as const;
   private readonly cursors: RuntimePositiveIntegerCursorStore;
   private readonly legacyCursors: SettingsPositiveIntegerCursorStore;
 

--- a/packages/node-ui/src/chain-cursor-stores.ts
+++ b/packages/node-ui/src/chain-cursor-stores.ts
@@ -1,12 +1,14 @@
 import Database from 'better-sqlite3';
 import type { DashboardDB } from './db.js';
 
-type RegistryScanCursorKey = {
+type LegacyRegistryScanCursorKey = {
   chainId: string;
   deploymentId: string;
   registryAddress: string;
-  /** Missing only for the original historical-store compatibility surface. */
-  cursorKind?: 'historical' | 'tip';
+};
+
+type RegistryScanCursorKey = LegacyRegistryScanCursorKey & {
+  cursorKind: 'historical' | 'tip';
 };
 
 function parsePositiveSafeInteger(value: number | string | undefined): number | undefined {
@@ -112,13 +114,12 @@ export class SqliteContextGraphRegistryScanCursorStore {
   }
 
   async load(key: RegistryScanCursorKey): Promise<number | undefined> {
-    const cursorKind = this.cursorKind(key);
     const current = this.cursors.load(
       this.scope(key),
       this.registryKey(key),
-      cursorKind === 'tip',
+      key.cursorKind === 'tip',
     );
-    if (current !== undefined || cursorKind === 'tip') return current;
+    if (current !== undefined || key.cursorKind === 'tip') return current;
     return this.cursors.load(this.scope(key), this.legacyRegistryKey(key))
       ?? this.legacyCursors.load(this.legacyKey(key));
   }
@@ -132,11 +133,7 @@ export class SqliteContextGraphRegistryScanCursorStore {
   }
 
   private registryKey(key: RegistryScanCursorKey): string {
-    return `${this.cursorKind(key)}:${key.registryAddress.toLowerCase()}`;
-  }
-
-  private cursorKind(key: RegistryScanCursorKey): 'historical' | 'tip' {
-    return key.cursorKind ?? 'historical';
+    return `${key.cursorKind}:${key.registryAddress.toLowerCase()}`;
   }
 
   private legacyRegistryKey(key: { registryAddress: string }): string {
@@ -150,5 +147,22 @@ export class SqliteContextGraphRegistryScanCursorStore {
       key.deploymentId,
       key.registryAddress.toLowerCase(),
     ].join(':');
+  }
+}
+
+/** Compatibility adapter that confines the original role-less API to historical progress. */
+export class SqliteLegacyContextGraphRegistryScanCursorStore {
+  private readonly roleAware: SqliteContextGraphRegistryScanCursorStore;
+
+  constructor(dashboard: DashboardDB) {
+    this.roleAware = new SqliteContextGraphRegistryScanCursorStore(dashboard);
+  }
+
+  async load(key: LegacyRegistryScanCursorKey): Promise<number | undefined> {
+    return this.roleAware.load({ ...key, cursorKind: 'historical' });
+  }
+
+  async save(key: LegacyRegistryScanCursorKey, nextBlock: number): Promise<void> {
+    await this.roleAware.save({ ...key, cursorKind: 'historical' }, nextBlock);
   }
 }

--- a/packages/node-ui/src/chain-cursor-stores.ts
+++ b/packages/node-ui/src/chain-cursor-stores.ts
@@ -39,11 +39,17 @@ class RuntimePositiveIntegerCursorStore {
     private readonly namespace: string,
   ) {}
 
-  load(scope: string, key: string): number | undefined {
+  load(scope: string, key: string, rejectInvalid = false): number | undefined {
     const row = this.db.prepare(
       `SELECT value FROM runtime_cursors WHERE namespace = ? AND scope = ? AND key = ?`,
-    ).get(this.namespace, scope, key) as { value: number } | undefined;
-    return parsePositiveSafeInteger(row?.value);
+    ).get(this.namespace, scope, key) as { value: number | string } | undefined;
+    const parsed = parsePositiveSafeInteger(row?.value);
+    if (row !== undefined && parsed === undefined && rejectInvalid) {
+      throw new Error(
+        `Invalid ${this.namespace} value for ${scope}/${key}: expected a positive safe integer`,
+      );
+    }
+    return parsed;
   }
 
   save(scope: string, key: string, value: number): void {
@@ -93,8 +99,8 @@ export class SqliteChainEventCursorStore {
  *
  * The value is the next unbuffered block after a successfully scanned
  * contiguous prefix. It is keyed by chain/deployment/registry address/cursor role;
- * corrupt values are ignored by returning `undefined`. Historical loads retain
- * fallbacks for role-less runtime rows and the original settings representation.
+ * Historical corrupt values retain best-effort fallback behavior. A present
+ * corrupt tip value throws so strict recovery cannot confuse it with a missing row.
  */
 export class SqliteContextGraphRegistryScanCursorStore {
   private readonly cursors: RuntimePositiveIntegerCursorStore;
@@ -106,8 +112,13 @@ export class SqliteContextGraphRegistryScanCursorStore {
   }
 
   async load(key: RegistryScanCursorKey): Promise<number | undefined> {
-    const current = this.cursors.load(this.scope(key), this.registryKey(key));
-    if (current !== undefined || this.cursorKind(key) === 'tip') return current;
+    const cursorKind = this.cursorKind(key);
+    const current = this.cursors.load(
+      this.scope(key),
+      this.registryKey(key),
+      cursorKind === 'tip',
+    );
+    if (current !== undefined || cursorKind === 'tip') return current;
     return this.cursors.load(this.scope(key), this.legacyRegistryKey(key))
       ?? this.legacyCursors.load(this.legacyKey(key));
   }

--- a/packages/node-ui/src/chain-cursor-stores.ts
+++ b/packages/node-ui/src/chain-cursor-stores.ts
@@ -1,6 +1,15 @@
 import Database from 'better-sqlite3';
 import type { DashboardDB } from './db.js';
 
+type RegistryScanCursorKey = {
+  chainId: string;
+  deploymentId: string;
+  registryAddress: string;
+};
+type RoleAwareRegistryScanCursorKey = RegistryScanCursorKey & {
+  cursorKind: 'historical' | 'tip';
+};
+
 function parsePositiveSafeInteger(value: number | string | undefined): number | undefined {
   if (value == null) return undefined;
   const parsed = Number(value);
@@ -97,23 +106,38 @@ export class SqliteContextGraphRegistryScanCursorStore {
     this.legacyCursors = new SettingsPositiveIntegerCursorStore(dashboard.db);
   }
 
-  async load(key: { chainId: string; deploymentId: string; registryAddress: string; cursorKind: 'historical' | 'tip' }): Promise<number | undefined> {
-    const current = this.cursors.load(this.scope(key), this.registryKey(key));
-    if (current !== undefined || key.cursorKind === 'tip') return current;
+  async load(
+    key: RegistryScanCursorKey | RoleAwareRegistryScanCursorKey,
+  ): Promise<number | undefined> {
+    const cursorKind = this.cursorKind(key);
+    const current = this.cursors.load(this.scope(key), this.registryKey(key, cursorKind));
+    if (current !== undefined || cursorKind === 'tip') return current;
     return this.cursors.load(this.scope(key), this.legacyRegistryKey(key))
       ?? this.legacyCursors.load(this.legacyKey(key));
   }
 
-  async save(key: { chainId: string; deploymentId: string; registryAddress: string; cursorKind: 'historical' | 'tip' }, nextBlock: number): Promise<void> {
-    this.cursors.save(this.scope(key), this.registryKey(key), nextBlock);
+  async save(
+    key: RegistryScanCursorKey | RoleAwareRegistryScanCursorKey,
+    nextBlock: number,
+  ): Promise<void> {
+    this.cursors.save(this.scope(key), this.registryKey(key, this.cursorKind(key)), nextBlock);
   }
 
   private scope(key: { chainId: string; deploymentId: string }): string {
     return `${key.chainId}:${key.deploymentId}`;
   }
 
-  private registryKey(key: { registryAddress: string; cursorKind: 'historical' | 'tip' }): string {
-    return `${key.cursorKind}:${key.registryAddress.toLowerCase()}`;
+  private cursorKind(
+    key: RegistryScanCursorKey | RoleAwareRegistryScanCursorKey,
+  ): 'historical' | 'tip' {
+    return 'cursorKind' in key ? key.cursorKind : 'historical';
+  }
+
+  private registryKey(
+    key: { registryAddress: string },
+    cursorKind: 'historical' | 'tip',
+  ): string {
+    return `${cursorKind}:${key.registryAddress.toLowerCase()}`;
   }
 
   private legacyRegistryKey(key: { registryAddress: string }): string {

--- a/packages/node-ui/src/chain-cursor-stores.ts
+++ b/packages/node-ui/src/chain-cursor-stores.ts
@@ -1,15 +1,11 @@
 import Database from 'better-sqlite3';
+import type {
+  ContextGraphRegistryRoleAwareScanCursorKey,
+  ContextGraphRegistryRoleAwareScanCursorStore,
+  ContextGraphRegistryScanCursorKey,
+  ContextGraphRegistryScanCursorStore,
+} from '@origintrail-official/dkg-chain';
 import type { DashboardDB } from './db.js';
-
-type LegacyRegistryScanCursorKey = {
-  chainId: string;
-  deploymentId: string;
-  registryAddress: string;
-};
-
-type RegistryScanCursorKey = LegacyRegistryScanCursorKey & {
-  cursorKind: 'historical' | 'tip';
-};
 
 function parsePositiveSafeInteger(value: number | string | undefined): number | undefined {
   if (value == null) return undefined;
@@ -104,7 +100,8 @@ export class SqliteChainEventCursorStore {
  * Historical corrupt values retain best-effort fallback behavior. A present
  * corrupt tip value throws so strict recovery cannot confuse it with a missing row.
  */
-export class SqliteContextGraphRegistryScanCursorStore {
+export class SqliteContextGraphRegistryScanCursorStore
+  implements ContextGraphRegistryRoleAwareScanCursorStore {
   private readonly cursors: RuntimePositiveIntegerCursorStore;
   private readonly legacyCursors: SettingsPositiveIntegerCursorStore;
 
@@ -113,7 +110,7 @@ export class SqliteContextGraphRegistryScanCursorStore {
     this.legacyCursors = new SettingsPositiveIntegerCursorStore(dashboard.db);
   }
 
-  async load(key: RegistryScanCursorKey): Promise<number | undefined> {
+  async load(key: ContextGraphRegistryRoleAwareScanCursorKey): Promise<number | undefined> {
     const current = this.cursors.load(
       this.scope(key),
       this.registryKey(key),
@@ -124,7 +121,7 @@ export class SqliteContextGraphRegistryScanCursorStore {
       ?? this.legacyCursors.load(this.legacyKey(key));
   }
 
-  async save(key: RegistryScanCursorKey, nextBlock: number): Promise<void> {
+  async save(key: ContextGraphRegistryRoleAwareScanCursorKey, nextBlock: number): Promise<void> {
     this.cursors.save(this.scope(key), this.registryKey(key), nextBlock);
   }
 
@@ -132,7 +129,7 @@ export class SqliteContextGraphRegistryScanCursorStore {
     return `${key.chainId}:${key.deploymentId}`;
   }
 
-  private registryKey(key: RegistryScanCursorKey): string {
+  private registryKey(key: ContextGraphRegistryRoleAwareScanCursorKey): string {
     return `${key.cursorKind}:${key.registryAddress.toLowerCase()}`;
   }
 
@@ -151,18 +148,19 @@ export class SqliteContextGraphRegistryScanCursorStore {
 }
 
 /** Compatibility adapter that confines the original role-less API to historical progress. */
-export class SqliteLegacyContextGraphRegistryScanCursorStore {
+export class SqliteLegacyContextGraphRegistryScanCursorStore
+  implements ContextGraphRegistryScanCursorStore {
   private readonly roleAware: SqliteContextGraphRegistryScanCursorStore;
 
   constructor(dashboard: DashboardDB) {
     this.roleAware = new SqliteContextGraphRegistryScanCursorStore(dashboard);
   }
 
-  async load(key: LegacyRegistryScanCursorKey): Promise<number | undefined> {
+  async load(key: ContextGraphRegistryScanCursorKey): Promise<number | undefined> {
     return this.roleAware.load({ ...key, cursorKind: 'historical' });
   }
 
-  async save(key: LegacyRegistryScanCursorKey, nextBlock: number): Promise<void> {
+  async save(key: ContextGraphRegistryScanCursorKey, nextBlock: number): Promise<void> {
     await this.roleAware.save({ ...key, cursorKind: 'historical' }, nextBlock);
   }
 }

--- a/packages/node-ui/src/chain-cursor-stores.ts
+++ b/packages/node-ui/src/chain-cursor-stores.ts
@@ -84,9 +84,9 @@ export class SqliteChainEventCursorStore {
  * SQLite-backed ContextGraphNameRegistry scan cursor.
  *
  * The value is the next unbuffered block after a successfully scanned
- * contiguous prefix. It is keyed by chain/deployment/registry address; corrupt
- * values are ignored by returning `undefined`, which fails closed to the
- * historical scan path.
+ * contiguous prefix. It is keyed by chain/deployment/registry address/cursor role;
+ * corrupt values are ignored by returning `undefined`. Historical loads retain
+ * fallbacks for role-less runtime rows and the original settings representation.
  */
 export class SqliteContextGraphRegistryScanCursorStore {
   private readonly cursors: RuntimePositiveIntegerCursorStore;
@@ -97,12 +97,14 @@ export class SqliteContextGraphRegistryScanCursorStore {
     this.legacyCursors = new SettingsPositiveIntegerCursorStore(dashboard.db);
   }
 
-  async load(key: { chainId: string; deploymentId: string; registryAddress: string }): Promise<number | undefined> {
-    return this.cursors.load(this.scope(key), this.registryKey(key))
+  async load(key: { chainId: string; deploymentId: string; registryAddress: string; cursorKind: 'historical' | 'tip' }): Promise<number | undefined> {
+    const current = this.cursors.load(this.scope(key), this.registryKey(key));
+    if (current !== undefined || key.cursorKind === 'tip') return current;
+    return this.cursors.load(this.scope(key), this.legacyRegistryKey(key))
       ?? this.legacyCursors.load(this.legacyKey(key));
   }
 
-  async save(key: { chainId: string; deploymentId: string; registryAddress: string }, nextBlock: number): Promise<void> {
+  async save(key: { chainId: string; deploymentId: string; registryAddress: string; cursorKind: 'historical' | 'tip' }, nextBlock: number): Promise<void> {
     this.cursors.save(this.scope(key), this.registryKey(key), nextBlock);
   }
 
@@ -110,7 +112,11 @@ export class SqliteContextGraphRegistryScanCursorStore {
     return `${key.chainId}:${key.deploymentId}`;
   }
 
-  private registryKey(key: { registryAddress: string }): string {
+  private registryKey(key: { registryAddress: string; cursorKind: 'historical' | 'tip' }): string {
+    return `${key.cursorKind}:${key.registryAddress.toLowerCase()}`;
+  }
+
+  private legacyRegistryKey(key: { registryAddress: string }): string {
     return key.registryAddress.toLowerCase();
   }
 

--- a/packages/node-ui/src/chain-cursor-stores.ts
+++ b/packages/node-ui/src/chain-cursor-stores.ts
@@ -5,6 +5,8 @@ type RegistryScanCursorKey = {
   chainId: string;
   deploymentId: string;
   registryAddress: string;
+  /** Missing only for the original historical-store compatibility surface. */
+  cursorKind?: 'historical' | 'tip';
 };
 
 function parsePositiveSafeInteger(value: number | string | undefined): number | undefined {
@@ -97,20 +99,15 @@ export class SqliteChainEventCursorStore {
 export class SqliteContextGraphRegistryScanCursorStore {
   private readonly cursors: RuntimePositiveIntegerCursorStore;
   private readonly legacyCursors: SettingsPositiveIntegerCursorStore;
-  private readonly cursorKind: 'historical' | 'tip';
 
-  constructor(
-    dashboard: DashboardDB,
-    options: { cursorKind?: 'historical' | 'tip' } = {},
-  ) {
+  constructor(dashboard: DashboardDB) {
     this.cursors = new RuntimePositiveIntegerCursorStore(dashboard.db, 'contextGraphRegistryScan.cursor');
     this.legacyCursors = new SettingsPositiveIntegerCursorStore(dashboard.db);
-    this.cursorKind = options.cursorKind ?? 'historical';
   }
 
   async load(key: RegistryScanCursorKey): Promise<number | undefined> {
     const current = this.cursors.load(this.scope(key), this.registryKey(key));
-    if (current !== undefined || this.cursorKind === 'tip') return current;
+    if (current !== undefined || this.cursorKind(key) === 'tip') return current;
     return this.cursors.load(this.scope(key), this.legacyRegistryKey(key))
       ?? this.legacyCursors.load(this.legacyKey(key));
   }
@@ -123,8 +120,12 @@ export class SqliteContextGraphRegistryScanCursorStore {
     return `${key.chainId}:${key.deploymentId}`;
   }
 
-  private registryKey(key: { registryAddress: string }): string {
-    return `${this.cursorKind}:${key.registryAddress.toLowerCase()}`;
+  private registryKey(key: RegistryScanCursorKey): string {
+    return `${this.cursorKind(key)}:${key.registryAddress.toLowerCase()}`;
+  }
+
+  private cursorKind(key: RegistryScanCursorKey): 'historical' | 'tip' {
+    return key.cursorKind ?? 'historical';
   }
 
   private legacyRegistryKey(key: { registryAddress: string }): string {

--- a/packages/node-ui/src/chain-cursor-stores.ts
+++ b/packages/node-ui/src/chain-cursor-stores.ts
@@ -6,9 +6,6 @@ type RegistryScanCursorKey = {
   deploymentId: string;
   registryAddress: string;
 };
-type RoleAwareRegistryScanCursorKey = RegistryScanCursorKey & {
-  cursorKind: 'historical' | 'tip';
-};
 
 function parsePositiveSafeInteger(value: number | string | undefined): number | undefined {
   if (value == null) return undefined;
@@ -100,44 +97,34 @@ export class SqliteChainEventCursorStore {
 export class SqliteContextGraphRegistryScanCursorStore {
   private readonly cursors: RuntimePositiveIntegerCursorStore;
   private readonly legacyCursors: SettingsPositiveIntegerCursorStore;
+  private readonly cursorKind: 'historical' | 'tip';
 
-  constructor(dashboard: DashboardDB) {
+  constructor(
+    dashboard: DashboardDB,
+    options: { cursorKind?: 'historical' | 'tip' } = {},
+  ) {
     this.cursors = new RuntimePositiveIntegerCursorStore(dashboard.db, 'contextGraphRegistryScan.cursor');
     this.legacyCursors = new SettingsPositiveIntegerCursorStore(dashboard.db);
+    this.cursorKind = options.cursorKind ?? 'historical';
   }
 
-  async load(
-    key: RegistryScanCursorKey | RoleAwareRegistryScanCursorKey,
-  ): Promise<number | undefined> {
-    const cursorKind = this.cursorKind(key);
-    const current = this.cursors.load(this.scope(key), this.registryKey(key, cursorKind));
-    if (current !== undefined || cursorKind === 'tip') return current;
+  async load(key: RegistryScanCursorKey): Promise<number | undefined> {
+    const current = this.cursors.load(this.scope(key), this.registryKey(key));
+    if (current !== undefined || this.cursorKind === 'tip') return current;
     return this.cursors.load(this.scope(key), this.legacyRegistryKey(key))
       ?? this.legacyCursors.load(this.legacyKey(key));
   }
 
-  async save(
-    key: RegistryScanCursorKey | RoleAwareRegistryScanCursorKey,
-    nextBlock: number,
-  ): Promise<void> {
-    this.cursors.save(this.scope(key), this.registryKey(key, this.cursorKind(key)), nextBlock);
+  async save(key: RegistryScanCursorKey, nextBlock: number): Promise<void> {
+    this.cursors.save(this.scope(key), this.registryKey(key), nextBlock);
   }
 
   private scope(key: { chainId: string; deploymentId: string }): string {
     return `${key.chainId}:${key.deploymentId}`;
   }
 
-  private cursorKind(
-    key: RegistryScanCursorKey | RoleAwareRegistryScanCursorKey,
-  ): 'historical' | 'tip' {
-    return 'cursorKind' in key ? key.cursorKind : 'historical';
-  }
-
-  private registryKey(
-    key: { registryAddress: string },
-    cursorKind: 'historical' | 'tip',
-  ): string {
-    return `${cursorKind}:${key.registryAddress.toLowerCase()}`;
+  private registryKey(key: { registryAddress: string }): string {
+    return `${this.cursorKind}:${key.registryAddress.toLowerCase()}`;
   }
 
   private legacyRegistryKey(key: { registryAddress: string }): string {

--- a/packages/node-ui/src/chain-cursor-stores.ts
+++ b/packages/node-ui/src/chain-cursor-stores.ts
@@ -89,6 +89,7 @@ export class SqliteChainEventCursorStore {
  * fallbacks for role-less runtime rows and the original settings representation.
  */
 export class SqliteContextGraphRegistryScanCursorStore {
+  readonly cursorKeyVersion = 2 as const;
   private readonly cursors: RuntimePositiveIntegerCursorStore;
   private readonly legacyCursors: SettingsPositiveIntegerCursorStore;
 

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -24,6 +24,7 @@ import { RoutineLogRetention } from './routine-log-retention.js';
 export {
   SqliteChainEventCursorStore,
   SqliteContextGraphRegistryScanCursorStore,
+  SqliteLegacyContextGraphRegistryScanCursorStore,
 } from './chain-cursor-stores.js';
 
 export const SCHEMA_VERSION = 34;

--- a/packages/node-ui/src/index.ts
+++ b/packages/node-ui/src/index.ts
@@ -18,6 +18,7 @@ export {
 export {
   SqliteChainEventCursorStore,
   SqliteContextGraphRegistryScanCursorStore,
+  SqliteLegacyContextGraphRegistryScanCursorStore,
 } from './chain-cursor-stores.js';
 export type {
   DashboardDBOptions,

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -2214,17 +2214,17 @@ describe('DashboardDB — chain RPC cursor stores', () => {
 
   it('persists registry scan cursors by deployment key and ignores corrupt values', async () => {
     const store = new SqliteContextGraphRegistryScanCursorStore(db);
+    const tipStore = new SqliteContextGraphRegistryScanCursorStore(db, { cursorKind: 'tip' });
     const key = {
       chainId: 'evm:1',
       deploymentId: 'evm:1:hub=0xabc',
       registryAddress: '0x3333333333333333333333333333333333333333',
-      cursorKind: 'historical' as const,
     };
 
     await store.save(key, 5000);
-    await store.save({ ...key, cursorKind: 'tip' }, 9000);
+    await tipStore.save(key, 9000);
     expect(await store.load(key)).toBe(5000);
-    expect(await store.load({ ...key, cursorKind: 'tip' })).toBe(9000);
+    expect(await tipStore.load(key)).toBe(9000);
     const originalKey = {
       chainId: key.chainId,
       deploymentId: key.deploymentId,
@@ -2232,8 +2232,7 @@ describe('DashboardDB — chain RPC cursor stores', () => {
     };
     await store.save(originalKey, 4000);
     expect(await store.load(originalKey)).toBe(4000);
-    expect(await store.load({ ...originalKey, cursorKind: 'historical' })).toBe(4000);
-    expect(await store.load({ ...originalKey, cursorKind: 'tip' })).toBeUndefined();
+    expect(await tipStore.load(originalKey)).toBeUndefined();
     expect(db.db.prepare(
       `SELECT value FROM runtime_cursors
        WHERE namespace = 'contextGraphRegistryScan.cursor'
@@ -2280,17 +2279,14 @@ describe('DashboardDB — chain RPC cursor stores', () => {
       Date.now(),
     );
     expect(await store.load({ ...key, registryAddress: legacyRuntimeAddress })).toBe(7000);
-    expect(await store.load({
-      ...key,
-      registryAddress: legacyRuntimeAddress,
-      cursorKind: 'tip',
-    })).toBeUndefined();
+    expect(await tipStore.load({ ...key, registryAddress: legacyRuntimeAddress })).toBeUndefined();
 
     db.close();
     db = new DashboardDB({ dataDir: dir });
     const reopened = new SqliteContextGraphRegistryScanCursorStore(db);
+    const reopenedTip = new SqliteContextGraphRegistryScanCursorStore(db, { cursorKind: 'tip' });
     expect(await reopened.load(key)).toBe(5000);
-    expect(await reopened.load({ ...key, cursorKind: 'tip' })).toBe(9000);
+    expect(await reopenedTip.load(key)).toBe(9000);
     expect(await reopened.load({ ...key, registryAddress: '0x6666666666666666666666666666666666666666' })).toBe(6000);
     expect(await reopened.load({ ...key, registryAddress: legacyRuntimeAddress })).toBe(7000);
   });

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -2218,16 +2218,25 @@ describe('DashboardDB — chain RPC cursor stores', () => {
       chainId: 'evm:1',
       deploymentId: 'evm:1:hub=0xabc',
       registryAddress: '0x3333333333333333333333333333333333333333',
+      cursorKind: 'historical' as const,
     };
 
     await store.save(key, 5000);
+    await store.save({ ...key, cursorKind: 'tip' }, 9000);
     expect(await store.load(key)).toBe(5000);
+    expect(await store.load({ ...key, cursorKind: 'tip' })).toBe(9000);
     expect(db.db.prepare(
       `SELECT value FROM runtime_cursors
        WHERE namespace = 'contextGraphRegistryScan.cursor'
          AND scope = ?
          AND key = ?`,
-    ).get(`${key.chainId}:${key.deploymentId}`, key.registryAddress.toLowerCase())).toEqual({ value: 5000 });
+    ).get(`${key.chainId}:${key.deploymentId}`, `historical:${key.registryAddress.toLowerCase()}`)).toEqual({ value: 5000 });
+    expect(db.db.prepare(
+      `SELECT value FROM runtime_cursors
+       WHERE namespace = 'contextGraphRegistryScan.cursor'
+         AND scope = ?
+         AND key = ?`,
+    ).get(`${key.chainId}:${key.deploymentId}`, `tip:${key.registryAddress.toLowerCase()}`)).toEqual({ value: 9000 });
     await store.save(key, 0);
     await store.save(key, -1);
     await store.save(key, 1.5);
@@ -2250,11 +2259,31 @@ describe('DashboardDB — chain RPC cursor stores', () => {
     );
     expect(await store.load({ ...key, registryAddress: '0x6666666666666666666666666666666666666666' })).toBe(6000);
 
+    const legacyRuntimeAddress = '0x7777777777777777777777777777777777777777';
+    db.db.prepare(`
+      INSERT INTO runtime_cursors (namespace, scope, key, value, updated_at)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(
+      'contextGraphRegistryScan.cursor',
+      `${key.chainId}:${key.deploymentId}`,
+      legacyRuntimeAddress,
+      7000,
+      Date.now(),
+    );
+    expect(await store.load({ ...key, registryAddress: legacyRuntimeAddress })).toBe(7000);
+    expect(await store.load({
+      ...key,
+      registryAddress: legacyRuntimeAddress,
+      cursorKind: 'tip',
+    })).toBeUndefined();
+
     db.close();
     db = new DashboardDB({ dataDir: dir });
     const reopened = new SqliteContextGraphRegistryScanCursorStore(db);
     expect(await reopened.load(key)).toBe(5000);
+    expect(await reopened.load({ ...key, cursorKind: 'tip' })).toBe(9000);
     expect(await reopened.load({ ...key, registryAddress: '0x6666666666666666666666666666666666666666' })).toBe(6000);
+    expect(await reopened.load({ ...key, registryAddress: legacyRuntimeAddress })).toBe(7000);
   });
 });
 

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -2212,7 +2212,7 @@ describe('DashboardDB — chain RPC cursor stores', () => {
     expect(await reopened.loadLane('legacyLane')).toBe(2468);
   });
 
-  it('persists registry scan cursors by deployment key and ignores corrupt values', async () => {
+  it('persists registry scan cursors and rejects corrupt strict tip rows', async () => {
     const store = new SqliteContextGraphRegistryScanCursorStore(db);
     const key = {
       chainId: 'evm:1',
@@ -2250,6 +2250,28 @@ describe('DashboardDB — chain RPC cursor stores', () => {
     await store.save(key, Number.MAX_SAFE_INTEGER + 1);
     expect(await store.load(key)).toBe(5000);
     expect(await store.load({ ...key, registryAddress: '0x4444444444444444444444444444444444444444' })).toBeUndefined();
+
+    const corruptTipAddress = '0x8888888888888888888888888888888888888888';
+    db.db.pragma('ignore_check_constraints = ON');
+    try {
+      db.db.prepare(`
+        INSERT INTO runtime_cursors (namespace, scope, key, value, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+      `).run(
+        'contextGraphRegistryScan.cursor',
+        `${key.chainId}:${key.deploymentId}`,
+        `tip:${corruptTipAddress}`,
+        0,
+        Date.now(),
+      );
+    } finally {
+      db.db.pragma('ignore_check_constraints = OFF');
+    }
+    await expect(store.load({
+      ...key,
+      registryAddress: corruptTipAddress,
+      cursorKind: 'tip',
+    })).rejects.toThrow(/expected a positive safe integer/);
 
     db.db.prepare(
       `INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`,

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import Database from 'better-sqlite3';
-import { DashboardDB, SqliteChainEventCursorStore, SqliteContextGraphRegistryScanCursorStore, SqliteKaNumberStore, SqliteSyncCheckpointStore, SqliteChangelogCursorStore, SqliteChangelogEraGuard, buildActivityDigestKey, ACTIVITY_DIGEST_WINDOW_MS, ASSERTION_ACTIVITY_TYPE, SCHEMA_VERSION } from '../src/db.js';
+import { DashboardDB, SqliteChainEventCursorStore, SqliteContextGraphRegistryScanCursorStore, SqliteLegacyContextGraphRegistryScanCursorStore, SqliteKaNumberStore, SqliteSyncCheckpointStore, SqliteChangelogCursorStore, SqliteChangelogEraGuard, buildActivityDigestKey, ACTIVITY_DIGEST_WINDOW_MS, ASSERTION_ACTIVITY_TYPE, SCHEMA_VERSION } from '../src/db.js';
 
 let db: DashboardDB;
 let dir: string;
@@ -2214,6 +2214,7 @@ describe('DashboardDB — chain RPC cursor stores', () => {
 
   it('persists registry scan cursors and rejects corrupt strict tip rows', async () => {
     const store = new SqliteContextGraphRegistryScanCursorStore(db);
+    const legacyStore = new SqliteLegacyContextGraphRegistryScanCursorStore(db);
     const key = {
       chainId: 'evm:1',
       deploymentId: 'evm:1:hub=0xabc',
@@ -2229,8 +2230,8 @@ describe('DashboardDB — chain RPC cursor stores', () => {
       deploymentId: key.deploymentId,
       registryAddress: '0x2222222222222222222222222222222222222222',
     };
-    await store.save(originalKey, 4000);
-    expect(await store.load(originalKey)).toBe(4000);
+    await legacyStore.save(originalKey, 4000);
+    expect(await legacyStore.load(originalKey)).toBe(4000);
     expect(await store.load({ ...originalKey, cursorKind: 'tip' })).toBeUndefined();
     expect(db.db.prepare(
       `SELECT value FROM runtime_cursors
@@ -2244,12 +2245,12 @@ describe('DashboardDB — chain RPC cursor stores', () => {
          AND scope = ?
          AND key = ?`,
     ).get(`${key.chainId}:${key.deploymentId}`, `tip:${key.registryAddress.toLowerCase()}`)).toEqual({ value: 9000 });
-    await store.save(key, 0);
-    await store.save(key, -1);
-    await store.save(key, 1.5);
-    await store.save(key, Number.MAX_SAFE_INTEGER + 1);
-    expect(await store.load(key)).toBe(5000);
-    expect(await store.load({ ...key, registryAddress: '0x4444444444444444444444444444444444444444' })).toBeUndefined();
+    await legacyStore.save(key, 0);
+    await legacyStore.save(key, -1);
+    await legacyStore.save(key, 1.5);
+    await legacyStore.save(key, Number.MAX_SAFE_INTEGER + 1);
+    expect(await legacyStore.load(key)).toBe(5000);
+    expect(await legacyStore.load({ ...key, registryAddress: '0x4444444444444444444444444444444444444444' })).toBeUndefined();
 
     const corruptTipAddress = '0x8888888888888888888888888888888888888888';
     db.db.pragma('ignore_check_constraints = ON');
@@ -2279,14 +2280,14 @@ describe('DashboardDB — chain RPC cursor stores', () => {
       `contextGraphRegistryScan.cursor:${key.chainId}:${key.deploymentId}:0x5555555555555555555555555555555555555555`,
       'not-a-number',
     );
-    expect(await store.load({ ...key, registryAddress: '0x5555555555555555555555555555555555555555' })).toBeUndefined();
+    expect(await legacyStore.load({ ...key, registryAddress: '0x5555555555555555555555555555555555555555' })).toBeUndefined();
     db.db.prepare(
       `INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`,
     ).run(
       `contextGraphRegistryScan.cursor:${key.chainId}:${key.deploymentId}:0x6666666666666666666666666666666666666666`,
       '6000',
     );
-    expect(await store.load({ ...key, registryAddress: '0x6666666666666666666666666666666666666666' })).toBe(6000);
+    expect(await legacyStore.load({ ...key, registryAddress: '0x6666666666666666666666666666666666666666' })).toBe(6000);
 
     const legacyRuntimeAddress = '0x7777777777777777777777777777777777777777';
     db.db.prepare(`
@@ -2299,7 +2300,7 @@ describe('DashboardDB — chain RPC cursor stores', () => {
       7000,
       Date.now(),
     );
-    expect(await store.load({ ...key, registryAddress: legacyRuntimeAddress })).toBe(7000);
+    expect(await legacyStore.load({ ...key, registryAddress: legacyRuntimeAddress })).toBe(7000);
     expect(await store.load({
       ...key,
       registryAddress: legacyRuntimeAddress,
@@ -2309,10 +2310,11 @@ describe('DashboardDB — chain RPC cursor stores', () => {
     db.close();
     db = new DashboardDB({ dataDir: dir });
     const reopened = new SqliteContextGraphRegistryScanCursorStore(db);
+    const reopenedLegacy = new SqliteLegacyContextGraphRegistryScanCursorStore(db);
     expect(await reopened.load({ ...key, cursorKind: 'historical' })).toBe(5000);
     expect(await reopened.load({ ...key, cursorKind: 'tip' })).toBe(9000);
-    expect(await reopened.load({ ...key, registryAddress: '0x6666666666666666666666666666666666666666' })).toBe(6000);
-    expect(await reopened.load({ ...key, registryAddress: legacyRuntimeAddress })).toBe(7000);
+    expect(await reopenedLegacy.load({ ...key, registryAddress: '0x6666666666666666666666666666666666666666' })).toBe(6000);
+    expect(await reopenedLegacy.load({ ...key, registryAddress: legacyRuntimeAddress })).toBe(7000);
   });
 });
 

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -2214,17 +2214,16 @@ describe('DashboardDB — chain RPC cursor stores', () => {
 
   it('persists registry scan cursors by deployment key and ignores corrupt values', async () => {
     const store = new SqliteContextGraphRegistryScanCursorStore(db);
-    const tipStore = new SqliteContextGraphRegistryScanCursorStore(db, { cursorKind: 'tip' });
     const key = {
       chainId: 'evm:1',
       deploymentId: 'evm:1:hub=0xabc',
       registryAddress: '0x3333333333333333333333333333333333333333',
     };
 
-    await store.save(key, 5000);
-    await tipStore.save(key, 9000);
-    expect(await store.load(key)).toBe(5000);
-    expect(await tipStore.load(key)).toBe(9000);
+    await store.save({ ...key, cursorKind: 'historical' }, 5000);
+    await store.save({ ...key, cursorKind: 'tip' }, 9000);
+    expect(await store.load({ ...key, cursorKind: 'historical' })).toBe(5000);
+    expect(await store.load({ ...key, cursorKind: 'tip' })).toBe(9000);
     const originalKey = {
       chainId: key.chainId,
       deploymentId: key.deploymentId,
@@ -2232,7 +2231,7 @@ describe('DashboardDB — chain RPC cursor stores', () => {
     };
     await store.save(originalKey, 4000);
     expect(await store.load(originalKey)).toBe(4000);
-    expect(await tipStore.load(originalKey)).toBeUndefined();
+    expect(await store.load({ ...originalKey, cursorKind: 'tip' })).toBeUndefined();
     expect(db.db.prepare(
       `SELECT value FROM runtime_cursors
        WHERE namespace = 'contextGraphRegistryScan.cursor'
@@ -2279,14 +2278,17 @@ describe('DashboardDB — chain RPC cursor stores', () => {
       Date.now(),
     );
     expect(await store.load({ ...key, registryAddress: legacyRuntimeAddress })).toBe(7000);
-    expect(await tipStore.load({ ...key, registryAddress: legacyRuntimeAddress })).toBeUndefined();
+    expect(await store.load({
+      ...key,
+      registryAddress: legacyRuntimeAddress,
+      cursorKind: 'tip',
+    })).toBeUndefined();
 
     db.close();
     db = new DashboardDB({ dataDir: dir });
     const reopened = new SqliteContextGraphRegistryScanCursorStore(db);
-    const reopenedTip = new SqliteContextGraphRegistryScanCursorStore(db, { cursorKind: 'tip' });
-    expect(await reopened.load(key)).toBe(5000);
-    expect(await reopenedTip.load(key)).toBe(9000);
+    expect(await reopened.load({ ...key, cursorKind: 'historical' })).toBe(5000);
+    expect(await reopened.load({ ...key, cursorKind: 'tip' })).toBe(9000);
     expect(await reopened.load({ ...key, registryAddress: '0x6666666666666666666666666666666666666666' })).toBe(6000);
     expect(await reopened.load({ ...key, registryAddress: legacyRuntimeAddress })).toBe(7000);
   });

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -2225,6 +2225,15 @@ describe('DashboardDB — chain RPC cursor stores', () => {
     await store.save({ ...key, cursorKind: 'tip' }, 9000);
     expect(await store.load(key)).toBe(5000);
     expect(await store.load({ ...key, cursorKind: 'tip' })).toBe(9000);
+    const originalKey = {
+      chainId: key.chainId,
+      deploymentId: key.deploymentId,
+      registryAddress: '0x2222222222222222222222222222222222222222',
+    };
+    await store.save(originalKey, 4000);
+    expect(await store.load(originalKey)).toBe(4000);
+    expect(await store.load({ ...originalKey, cursorKind: 'historical' })).toBe(4000);
+    expect(await store.load({ ...originalKey, cursorKind: 'tip' })).toBeUndefined();
     expect(db.db.prepare(
       `SELECT value FROM runtime_cursors
        WHERE namespace = 'contextGraphRegistryScan.cursor'

--- a/packages/node-ui/tsconfig.json
+++ b/packages/node-ui/tsconfig.json
@@ -8,6 +8,7 @@
   "include": ["src"],
   "exclude": ["src/ui"],
   "references": [
-    { "path": "../core" }
+    { "path": "../core" },
+    { "path": "../chain" }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1082,6 +1082,9 @@ importers:
       '@openuidev/react-lang':
         specifier: ^0.2.3
         version: 0.2.3(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))(react@19.2.4)(zod@3.25.76)
+      '@origintrail-official/dkg-chain':
+        specifier: workspace:*
+        version: link:../chain
       '@origintrail-official/dkg-core':
         specifier: workspace:*
         version: link:../core

--- a/scripts/lib/ci-delta.mjs
+++ b/scripts/lib/ci-delta.mjs
@@ -69,6 +69,7 @@ export const WORKSPACE_RULES = Object.freeze({
       'tornado_publisher',
       'tornado_agent',
       'bura_cli',
+      'kosava_node_ui',
       'kosava_node_ui_e2e',
       'kosava_supporting',
       'kosava_hardhat_plugins',


### PR DESCRIPTION
## Summary

- use explicit startup, cursor-seed, and pending-full-recovery state for chain discovery
- resume partial cursor seeding without restarting unbounded history scans
- retry startup full recovery immediately once, then interleave incremental tip discovery before later full retries
- derive the daily full-resync cadence from the same 30-minute schedule used by lifecycle
- keep probe, scan, logging, and even rejection-reason formatting failures non-critical and serialized

## Verification

- 18 focused chain-discovery runner tests
- CLI build and typecheck
- repository lint

Closes #2323