### PR TITLE
fix(publisher): restore node-operator clear authority

### DIFF
--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -47,13 +47,33 @@ type HttpCredentialDecision =
     readonly acceptedToken: string;
   };
 
+type AcceptedHttpIdentity =
+  | {
+    readonly acceptedToken: string;
+    readonly principal: Extract<RequestPrincipal, { kind: 'agent' }>;
+  }
+  | {
+    readonly acceptedToken: string;
+    readonly principal: Extract<RequestPrincipal, { kind: 'nodeOperator' }>;
+  };
+
+type AnonymousHttpIdentity = {
+  readonly acceptedToken: undefined;
+  readonly principal: Extract<RequestPrincipal, { kind: 'anonymous' }>;
+};
+
+/**
+ * One correlated allow decision. Authenticated mode always carries an accepted credential, while
+ * an absent credential can only be anonymous. Public/disabled requests may still carry a valid
+ * optional bearer, but that bearer is classified at the same boundary before this value exists.
+ */
 export type AllowedHttpAuthentication = {
   readonly allowed: true;
-  readonly mode: 'disabled' | 'public' | 'authenticated';
   readonly presentedToken: string | undefined;
-  readonly acceptedToken: string | undefined;
-  readonly principal: RequestPrincipal;
-};
+} & (
+  | ({ readonly mode: 'authenticated' } & AcceptedHttpIdentity)
+  | ({ readonly mode: 'disabled' | 'public' } & (AcceptedHttpIdentity | AnonymousHttpIdentity))
+);
 
 export type HttpAuthenticationResult =
   | { readonly allowed: false }
@@ -64,31 +84,69 @@ export type HttpAuthenticationResult =
  * Tests use the same factory so impossible principal/capability combinations cannot be assembled
  * by independently mutating fixture fields.
  */
-export function createAllowedHttpAuthentication(input: {
-  readonly mode: AllowedHttpAuthentication['mode'];
-  readonly presentedToken?: string;
-  readonly acceptedToken?: string;
-  readonly resolveAgentByToken?: (token: string) => string | undefined;
-}): AllowedHttpAuthentication {
-  if (input.mode === 'authenticated' && !input.acceptedToken) {
-    throw new Error('Authenticated HTTP requests require an accepted token');
+type CreateAllowedHttpAuthenticationInput =
+  | {
+    readonly mode: 'disabled' | 'public';
+    readonly presentedToken?: string;
+    readonly acceptedToken?: undefined;
+    readonly resolveAgentByToken?: never;
   }
-  const agentAddress = input.acceptedToken
-    ? input.resolveAgentByToken?.(input.acceptedToken)
-    : undefined;
-  const principal: RequestPrincipal = agentAddress
-    ? { kind: 'agent', agentAddress }
-    : input.acceptedToken
-      ? { kind: 'nodeOperator' }
-      : { kind: 'anonymous' };
+  | {
+    readonly mode: AllowedHttpAuthentication['mode'];
+    readonly presentedToken?: string;
+    readonly acceptedToken: string;
+    readonly resolveAgentByToken: (token: string) => string | undefined;
+  };
+
+export function createAllowedHttpAuthentication(
+  input: CreateAllowedHttpAuthenticationInput,
+): AllowedHttpAuthentication {
+  if (input.acceptedToken !== undefined) {
+    const agentAddress = input.resolveAgentByToken(input.acceptedToken);
+    const identity: AcceptedHttpIdentity = agentAddress
+      ? { acceptedToken: input.acceptedToken, principal: { kind: 'agent', agentAddress } }
+      : { acceptedToken: input.acceptedToken, principal: { kind: 'nodeOperator' } };
+    return input.mode === 'authenticated'
+      ? {
+        allowed: true,
+        mode: 'authenticated',
+        presentedToken: input.presentedToken,
+        ...identity,
+      }
+      : {
+        allowed: true,
+        mode: input.mode,
+        presentedToken: input.presentedToken,
+        ...identity,
+      };
+  }
   return {
     allowed: true,
     mode: input.mode,
     presentedToken: input.presentedToken,
-    acceptedToken: input.acceptedToken,
-    principal,
+    acceptedToken: undefined,
+    principal: { kind: 'anonymous' },
   };
 }
+
+// Compile-time-only invariant assertions; deliberately never called.
+function assertAllowedHttpAuthenticationTypeInvariants(): void {
+  // @ts-expect-error authenticated mode cannot be anonymous or omit an accepted credential
+  const anonymousAuthenticated: AllowedHttpAuthentication = {
+    allowed: true, mode: 'authenticated', presentedToken: undefined,
+    acceptedToken: undefined, principal: { kind: 'anonymous' },
+  };
+  // @ts-expect-error an accepted credential cannot carry an anonymous principal
+  const acceptedAnonymous: AllowedHttpAuthentication = {
+    allowed: true, mode: 'public', presentedToken: 'token',
+    acceptedToken: 'token', principal: { kind: 'anonymous' },
+  };
+  // @ts-expect-error accepted credentials must be classified by a resolver
+  createAllowedHttpAuthentication({ mode: 'public', acceptedToken: 'token' });
+  void anonymousAuthenticated;
+  void acceptedAnonymous;
+}
+void assertAllowedHttpAuthenticationTypeInvariants;
 
 /** Node administration is a projection of the correlated authentication decision, never state. */
 export function canAdministerNode(authentication: AllowedHttpAuthentication): boolean {
@@ -1257,12 +1315,25 @@ export async function authenticateHttpRequest(input: {
   );
   if (!credential.allowed) return credential;
 
-  return createAllowedHttpAuthentication({
-    mode: credential.mode,
-    presentedToken: credential.presentedToken,
-    acceptedToken: credential.acceptedToken,
-    resolveAgentByToken: input.resolveAgentByToken,
-  });
+  if (credential.mode === 'authenticated') {
+    return createAllowedHttpAuthentication({
+      mode: credential.mode,
+      presentedToken: credential.presentedToken,
+      acceptedToken: credential.acceptedToken,
+      resolveAgentByToken: input.resolveAgentByToken,
+    });
+  }
+  return credential.acceptedToken === undefined
+    ? createAllowedHttpAuthentication({
+      mode: credential.mode,
+      presentedToken: credential.presentedToken,
+    })
+    : createAllowedHttpAuthentication({
+      mode: credential.mode,
+      presentedToken: credential.presentedToken,
+      acceptedToken: credential.acceptedToken,
+      resolveAgentByToken: input.resolveAgentByToken,
+    });
 }
 
 /**

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -11,6 +11,7 @@ import { readFileSync, statSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { existsSync } from 'node:fs';
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { RequestPrincipal } from '@origintrail-official/dkg-core';
 import { dkgDir } from './config.js';
 
 // ---------------------------------------------------------------------------
@@ -23,6 +24,23 @@ export interface AuthConfig {
   /** Pre-configured tokens. If empty, one is auto-generated on first start. */
   tokens?: string[];
 }
+
+export type HttpAuthenticationResult =
+  | { readonly allowed: false }
+  | {
+    readonly allowed: true;
+    readonly requestToken: string | undefined;
+    readonly requestPrincipal: RequestPrincipal;
+    readonly requestCredentialAuthenticated: boolean;
+  };
+
+type AcceptedHttpCredential = {
+  readonly mode: 'disabled' | 'public' | 'authenticated';
+  readonly requestToken: string | undefined;
+  readonly acceptedToken: string | undefined;
+};
+
+const acceptedHttpCredentials = new WeakMap<IncomingMessage, AcceptedHttpCredential>();
 
 // ---------------------------------------------------------------------------
 // Token file management
@@ -828,13 +846,32 @@ export function httpAuthGuard(
   validTokens: Set<string>,
   corsOrigin?: string | null,
 ): boolean | Promise<boolean> {
-  if (!authEnabled) return true;
-  if (req.method === 'OPTIONS') return true;
+  acceptedHttpCredentials.delete(req);
+  const headerToken = extractBearerToken(req.headers.authorization);
+  if (!authEnabled) {
+    const acceptedToken = verifyToken(headerToken, validTokens) ? headerToken : undefined;
+    acceptedHttpCredentials.set(req, {
+      mode: 'disabled', requestToken: headerToken, acceptedToken,
+    });
+    return true;
+  }
+  if (req.method === 'OPTIONS') {
+    acceptedHttpCredentials.set(req, {
+      mode: 'public', requestToken: headerToken, acceptedToken: undefined,
+    });
+    return true;
+  }
 
   const pathname = new URL(req.url ?? '/', `http://${req.headers.host}`).pathname;
-  if (isPublicPath(req.method ?? '', pathname)) return true;
+  if (isPublicPath(req.method ?? '', pathname)) {
+    const acceptedToken = verifyToken(headerToken, validTokens) ? headerToken : undefined;
+    acceptedHttpCredentials.set(req, {
+      mode: 'public', requestToken: headerToken, acceptedToken,
+    });
+    return true;
+  }
 
-  const token = extractBearerToken(req.headers.authorization);
+  const token = headerToken;
   let acceptedToken: string | undefined;
   if (verifyToken(token, validTokens)) {
     acceptedToken = token;
@@ -849,6 +886,9 @@ export function httpAuthGuard(
   }
 
   if (acceptedToken) {
+    acceptedHttpCredentials.set(req, {
+      mode: 'authenticated', requestToken: acceptedToken, acceptedToken,
+    });
     const now = Date.now();
 
     // CLI-10: stale-timestamp gate. If the client opted into the
@@ -1115,6 +1155,59 @@ export function httpAuthGuard(
   });
   res.end(JSON.stringify({ error: 'Unauthorized — provide a valid Bearer token in the Authorization header' }));
   return false;
+}
+
+/**
+ * Canonical daemon authentication boundary. The guard decides credential acceptance once; this
+ * adapter turns that accepted credential into the principal passed to every route.
+ */
+export async function authenticateHttpRequest(input: {
+  readonly req: IncomingMessage;
+  readonly res: ServerResponse;
+  readonly authEnabled: boolean;
+  readonly validTokens: Set<string>;
+  readonly resolveAgentByToken: (token: string) => string | undefined;
+  readonly corsOrigin?: string | null;
+}): Promise<HttpAuthenticationResult> {
+  const allowed = await httpAuthGuard(
+    input.req,
+    input.res,
+    input.authEnabled,
+    input.validTokens,
+    input.corsOrigin,
+  );
+  if (!allowed) return { allowed: false };
+
+  const credential = acceptedHttpCredentials.get(input.req);
+  if (!credential) {
+    throw new Error('HTTP authentication succeeded without an accepted credential decision');
+  }
+  if (credential.mode === 'disabled' && !credential.acceptedToken) {
+    return {
+      allowed: true,
+      requestToken: credential.requestToken,
+      requestPrincipal: { kind: 'nodeOperator' },
+      requestCredentialAuthenticated: false,
+    };
+  }
+  if (!credential.acceptedToken) {
+    return {
+      allowed: true,
+      requestToken: credential.requestToken,
+      requestPrincipal: { kind: 'anonymous' },
+      requestCredentialAuthenticated: false,
+    };
+  }
+
+  const agentAddress = input.resolveAgentByToken(credential.acceptedToken);
+  return {
+    allowed: true,
+    requestToken: credential.requestToken,
+    requestPrincipal: agentAddress
+      ? { kind: 'agent', agentAddress }
+      : { kind: 'nodeOperator' },
+    requestCredentialAuthenticated: true,
+  };
 }
 
 /**

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -11,7 +11,6 @@ import { readFileSync, statSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { existsSync } from 'node:fs';
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import type { RequestPrincipal } from '@origintrail-official/dkg-core';
 import { dkgDir } from './config.js';
 
 // ---------------------------------------------------------------------------
@@ -25,22 +24,43 @@ export interface AuthConfig {
   tokens?: string[];
 }
 
-export type HttpAuthenticationResult =
+/** HTTP identity established by the CLI daemon's authentication boundary. */
+export type RequestPrincipal =
+  | { readonly kind: 'agent'; readonly agentAddress: string }
+  | { readonly kind: 'nodeOperator' }
+  | { readonly kind: 'anonymous' };
+
+/** Capabilities are independent from identity (notably when authentication is disabled). */
+export interface RequestAuthorization {
+  readonly nodeOperator: boolean;
+}
+
+type HttpCredentialDecision =
   | { readonly allowed: false }
   | {
     readonly allowed: true;
+    readonly mode: 'disabled' | 'public';
     readonly requestToken: string | undefined;
-    readonly requestPrincipal: RequestPrincipal;
-    readonly requestCredentialAuthenticated: boolean;
+    readonly acceptedToken: string | undefined;
+  }
+  | {
+    readonly allowed: true;
+    readonly mode: 'authenticated';
+    readonly requestToken: string;
+    readonly acceptedToken: string;
   };
 
-type AcceptedHttpCredential = {
+export type AllowedHttpAuthentication = {
+  readonly allowed: true;
   readonly mode: 'disabled' | 'public' | 'authenticated';
   readonly requestToken: string | undefined;
-  readonly acceptedToken: string | undefined;
+  readonly requestPrincipal: RequestPrincipal;
+  readonly requestAuthorization: RequestAuthorization;
 };
 
-const acceptedHttpCredentials = new WeakMap<IncomingMessage, AcceptedHttpCredential>();
+export type HttpAuthenticationResult =
+  | { readonly allowed: false }
+  | AllowedHttpAuthentication;
 
 // ---------------------------------------------------------------------------
 // Token file management
@@ -839,36 +859,35 @@ function isPublicPath(method: string, pathname: string): boolean {
  * synchronously to a bare `boolean` so existing fast-path callers do
  * not pay an awaiting cost on hot routes.
  */
-export function httpAuthGuard(
+function evaluateHttpCredential(
   req: IncomingMessage,
   res: ServerResponse,
   authEnabled: boolean,
   validTokens: Set<string>,
   corsOrigin?: string | null,
-): boolean | Promise<boolean> {
-  acceptedHttpCredentials.delete(req);
+): HttpCredentialDecision | Promise<HttpCredentialDecision> {
   const headerToken = extractBearerToken(req.headers.authorization);
   if (!authEnabled) {
     const acceptedToken = verifyToken(headerToken, validTokens) ? headerToken : undefined;
-    acceptedHttpCredentials.set(req, {
+    return {
+      allowed: true,
       mode: 'disabled', requestToken: headerToken, acceptedToken,
-    });
-    return true;
+    };
   }
   if (req.method === 'OPTIONS') {
-    acceptedHttpCredentials.set(req, {
+    return {
+      allowed: true,
       mode: 'public', requestToken: headerToken, acceptedToken: undefined,
-    });
-    return true;
+    };
   }
 
   const pathname = new URL(req.url ?? '/', `http://${req.headers.host}`).pathname;
   if (isPublicPath(req.method ?? '', pathname)) {
     const acceptedToken = verifyToken(headerToken, validTokens) ? headerToken : undefined;
-    acceptedHttpCredentials.set(req, {
+    return {
+      allowed: true,
       mode: 'public', requestToken: headerToken, acceptedToken,
-    });
-    return true;
+    };
   }
 
   const token = headerToken;
@@ -886,9 +905,10 @@ export function httpAuthGuard(
   }
 
   if (acceptedToken) {
-    acceptedHttpCredentials.set(req, {
+    const accepted: HttpCredentialDecision = {
+      allowed: true,
       mode: 'authenticated', requestToken: acceptedToken, acceptedToken,
-    });
+    };
     const now = Date.now();
 
     // CLI-10: stale-timestamp gate. If the client opted into the
@@ -912,7 +932,7 @@ export function httpAuthGuard(
         res.end(
           JSON.stringify({ error: 'Stale or unparseable x-dkg-timestamp' }),
         );
-        return false;
+        return { allowed: false };
       }
     }
 
@@ -948,7 +968,7 @@ export function httpAuthGuard(
         res.end(JSON.stringify({
           error: 'Signed-request mode requires x-dkg-timestamp, x-dkg-nonce, and x-dkg-signature.',
         }));
-        return false;
+        return { allowed: false };
       }
       // Pre-body replay rejection: an attacker swapping in a fresh
       // nonce still fails the post-body HMAC (nonce is bound), but
@@ -974,7 +994,7 @@ export function httpAuthGuard(
           'Access-Control-Allow-Origin': corsOrigin ?? '*',
         });
         res.end(JSON.stringify({ error: 'Replayed nonce' }));
-        return false;
+        return { allowed: false };
       }
       // Stash the auth context so route handlers can call
       // verifyHttpSignedRequestAfterBody(req, rawBody) after
@@ -1084,7 +1104,7 @@ export function httpAuthGuard(
               error: `Signed request rejected: ${outcome.reason}`,
             }),
           );
-          return false;
+          return { allowed: false };
         }
         pending.verified = true;
       } else {
@@ -1122,10 +1142,10 @@ export function httpAuthGuard(
           req,
           res,
           corsOrigin ?? undefined,
-        );
+        ).then((allowed) => (allowed ? accepted : { allowed: false }));
       }
 
-      return true;
+      return accepted;
     }
 
     // the previous revision of this
@@ -1144,7 +1164,7 @@ export function httpAuthGuard(
     // responsible for whatever replay semantics they need at the
     // application layer.
 
-    return true;
+    return accepted;
   }
 
   res.writeHead(401, {
@@ -1154,12 +1174,29 @@ export function httpAuthGuard(
     'Access-Control-Allow-Headers': 'Content-Type, Authorization',
   });
   res.end(JSON.stringify({ error: 'Unauthorized — provide a valid Bearer token in the Authorization header' }));
-  return false;
+  return { allowed: false };
 }
 
 /**
- * Canonical daemon authentication boundary. The guard decides credential acceptance once; this
- * adapter turns that accepted credential into the principal passed to every route.
+ * Compatibility adapter for callers that only need an allow/deny result. The canonical evaluator
+ * still returns one explicit credential decision; this wrapper projects that decision to boolean.
+ */
+export function httpAuthGuard(
+  req: IncomingMessage,
+  res: ServerResponse,
+  authEnabled: boolean,
+  validTokens: Set<string>,
+  corsOrigin?: string | null,
+): boolean | Promise<boolean> {
+  const decision = evaluateHttpCredential(req, res, authEnabled, validTokens, corsOrigin);
+  return decision instanceof Promise
+    ? decision.then((resolved) => resolved.allowed)
+    : decision.allowed;
+}
+
+/**
+ * Canonical daemon authentication boundary. Credential acceptance, identity and authority all
+ * derive from the same explicit decision; route code never re-authenticates the request.
  */
 export async function authenticateHttpRequest(input: {
   readonly req: IncomingMessage;
@@ -1169,44 +1206,31 @@ export async function authenticateHttpRequest(input: {
   readonly resolveAgentByToken: (token: string) => string | undefined;
   readonly corsOrigin?: string | null;
 }): Promise<HttpAuthenticationResult> {
-  const allowed = await httpAuthGuard(
+  const credential = await evaluateHttpCredential(
     input.req,
     input.res,
     input.authEnabled,
     input.validTokens,
     input.corsOrigin,
   );
-  if (!allowed) return { allowed: false };
+  if (!credential.allowed) return credential;
 
-  const credential = acceptedHttpCredentials.get(input.req);
-  if (!credential) {
-    throw new Error('HTTP authentication succeeded without an accepted credential decision');
-  }
-  if (credential.mode === 'disabled' && !credential.acceptedToken) {
-    return {
-      allowed: true,
-      requestToken: credential.requestToken,
-      requestPrincipal: { kind: 'nodeOperator' },
-      requestCredentialAuthenticated: false,
-    };
-  }
-  if (!credential.acceptedToken) {
-    return {
-      allowed: true,
-      requestToken: credential.requestToken,
-      requestPrincipal: { kind: 'anonymous' },
-      requestCredentialAuthenticated: false,
-    };
-  }
-
-  const agentAddress = input.resolveAgentByToken(credential.acceptedToken);
+  const agentAddress = credential.acceptedToken
+    ? input.resolveAgentByToken(credential.acceptedToken)
+    : undefined;
+  const requestPrincipal: RequestPrincipal = agentAddress
+    ? { kind: 'agent', agentAddress }
+    : credential.acceptedToken
+      ? { kind: 'nodeOperator' }
+      : { kind: 'anonymous' };
   return {
     allowed: true,
+    mode: credential.mode,
     requestToken: credential.requestToken,
-    requestPrincipal: agentAddress
-      ? { kind: 'agent', agentAddress }
-      : { kind: 'nodeOperator' },
-    requestCredentialAuthenticated: true,
+    requestPrincipal,
+    requestAuthorization: {
+      nodeOperator: credential.mode === 'disabled' || requestPrincipal.kind === 'nodeOperator',
+    },
   };
 }
 

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -30,37 +30,79 @@ export type RequestPrincipal =
   | { readonly kind: 'nodeOperator' }
   | { readonly kind: 'anonymous' };
 
-/** Capabilities are independent from identity (notably when authentication is disabled). */
-export interface RequestAuthorization {
-  readonly nodeOperator: boolean;
-}
-
 type HttpCredentialDecision =
   | { readonly allowed: false }
   | {
     readonly allowed: true;
     readonly mode: 'disabled' | 'public';
-    readonly requestToken: string | undefined;
+    /** Raw bearer header, whether accepted or not. Never use this as an authenticated credential. */
+    readonly presentedToken: string | undefined;
     readonly acceptedToken: string | undefined;
   }
   | {
     readonly allowed: true;
     readonly mode: 'authenticated';
-    readonly requestToken: string;
+    /** Raw bearer header; SSE query authentication may leave this undefined. */
+    readonly presentedToken: string | undefined;
     readonly acceptedToken: string;
   };
 
 export type AllowedHttpAuthentication = {
   readonly allowed: true;
   readonly mode: 'disabled' | 'public' | 'authenticated';
-  readonly requestToken: string | undefined;
-  readonly requestPrincipal: RequestPrincipal;
-  readonly requestAuthorization: RequestAuthorization;
+  readonly presentedToken: string | undefined;
+  readonly acceptedToken: string | undefined;
+  readonly principal: RequestPrincipal;
 };
 
 export type HttpAuthenticationResult =
   | { readonly allowed: false }
   | AllowedHttpAuthentication;
+
+/**
+ * Build the one correlated authentication value carried by request context.
+ * Tests use the same factory so impossible principal/capability combinations cannot be assembled
+ * by independently mutating fixture fields.
+ */
+export function createAllowedHttpAuthentication(input: {
+  readonly mode: AllowedHttpAuthentication['mode'];
+  readonly presentedToken?: string;
+  readonly acceptedToken?: string;
+  readonly resolveAgentByToken?: (token: string) => string | undefined;
+}): AllowedHttpAuthentication {
+  if (input.mode === 'authenticated' && !input.acceptedToken) {
+    throw new Error('Authenticated HTTP requests require an accepted token');
+  }
+  const agentAddress = input.acceptedToken
+    ? input.resolveAgentByToken?.(input.acceptedToken)
+    : undefined;
+  const principal: RequestPrincipal = agentAddress
+    ? { kind: 'agent', agentAddress }
+    : input.acceptedToken
+      ? { kind: 'nodeOperator' }
+      : { kind: 'anonymous' };
+  return {
+    allowed: true,
+    mode: input.mode,
+    presentedToken: input.presentedToken,
+    acceptedToken: input.acceptedToken,
+    principal,
+  };
+}
+
+/** Node administration is a projection of the correlated authentication decision, never state. */
+export function canAdministerNode(authentication: AllowedHttpAuthentication): boolean {
+  return authentication.mode === 'disabled' || authentication.principal.kind === 'nodeOperator';
+}
+
+/** Authenticated agent identity projection shared by every route. */
+export function authenticatedAgentAddress(
+  authentication: AllowedHttpAuthentication,
+): string | undefined {
+  return authentication.principal.kind === 'agent'
+    ? authentication.principal.agentAddress
+    : undefined;
+}
 
 // ---------------------------------------------------------------------------
 // Token file management
@@ -871,13 +913,13 @@ function evaluateHttpCredential(
     const acceptedToken = verifyToken(headerToken, validTokens) ? headerToken : undefined;
     return {
       allowed: true,
-      mode: 'disabled', requestToken: headerToken, acceptedToken,
+      mode: 'disabled', presentedToken: headerToken, acceptedToken,
     };
   }
   if (req.method === 'OPTIONS') {
     return {
       allowed: true,
-      mode: 'public', requestToken: headerToken, acceptedToken: undefined,
+      mode: 'public', presentedToken: headerToken, acceptedToken: undefined,
     };
   }
 
@@ -886,7 +928,7 @@ function evaluateHttpCredential(
     const acceptedToken = verifyToken(headerToken, validTokens) ? headerToken : undefined;
     return {
       allowed: true,
-      mode: 'public', requestToken: headerToken, acceptedToken,
+      mode: 'public', presentedToken: headerToken, acceptedToken,
     };
   }
 
@@ -907,7 +949,7 @@ function evaluateHttpCredential(
   if (acceptedToken) {
     const accepted: HttpCredentialDecision = {
       allowed: true,
-      mode: 'authenticated', requestToken: acceptedToken, acceptedToken,
+      mode: 'authenticated', presentedToken: headerToken, acceptedToken,
     };
     const now = Date.now();
 
@@ -1215,23 +1257,12 @@ export async function authenticateHttpRequest(input: {
   );
   if (!credential.allowed) return credential;
 
-  const agentAddress = credential.acceptedToken
-    ? input.resolveAgentByToken(credential.acceptedToken)
-    : undefined;
-  const requestPrincipal: RequestPrincipal = agentAddress
-    ? { kind: 'agent', agentAddress }
-    : credential.acceptedToken
-      ? { kind: 'nodeOperator' }
-      : { kind: 'anonymous' };
-  return {
-    allowed: true,
+  return createAllowedHttpAuthentication({
     mode: credential.mode,
-    requestToken: credential.requestToken,
-    requestPrincipal,
-    requestAuthorization: {
-      nodeOperator: credential.mode === 'disabled' || requestPrincipal.kind === 'nodeOperator',
-    },
-  };
+    presentedToken: credential.presentedToken,
+    acceptedToken: credential.acceptedToken,
+    resolveAgentByToken: input.resolveAgentByToken,
+  });
 }
 
 /**

--- a/packages/cli/src/daemon/CONTEXT.md
+++ b/packages/cli/src/daemon/CONTEXT.md
@@ -38,8 +38,10 @@ See `packages/adapter-elizaos/`.
 **RequestContext**:
 The bag of per-request state passed to every route group and route plugin.
 Holds the live agent, publisher, config, dashDb, vectorStore, file store,
-and the derived per-request fields (`url`, `path`, `requestToken`,
-`requestAgentAddress`). Defined in `routes/context.ts`.
+and the derived per-request fields (`url`, `path`, `actor`). The actor is one
+correlated authentication/identity value. Route plugins retain deprecated
+`requestToken` and `requestAgentAddress` read-only projections. Defined in
+`routes/context.ts` and `plugin-api.ts`.
 
 **httpAuthGuard**:
 The single global authentication gate at `lifecycle.ts:1865`. Runs **before**
@@ -50,7 +52,8 @@ narrower `PUBLIC_HEAD_PATHS` (HEAD on `/api/status`, `/api/chain/rpc-health`,
 `/.well-known/skill.md` only — the three paths where `routes/status.ts`
 explicitly claims HEAD so liveness probes never reach plugins). Other methods
 go through auth. Plugins do not get a per-plugin auth surface — finer-grained
-policy reads `ctx.requestToken` / `ctx.requestAgentAddress`. See
+policy reads `ctx.actor.authentication` / `ctx.actor.effectiveAgentAddress`
+(or the deprecated plugin projections while migrating). See
 `ARCHITECTURE.md` "Auth boundary — `httpAuthGuard`" for the full breakdown.
 
 **Operator state**:

--- a/packages/cli/src/daemon/handle-request.ts
+++ b/packages/cli/src/daemon/handle-request.ts
@@ -313,6 +313,7 @@ import type {
   NotificationSseEvent,
   RequestContext,
 } from './routes/context.js';
+import { authenticatedAgentAddress } from '../auth.js';
 import { handleStatusRoutes } from './routes/status.js';
 import { handleBackpressureRoutes } from './routes/backpressure.js';
 import { handleAgentChatRoutes } from './routes/agent-chat.js';
@@ -348,11 +349,10 @@ export async function handleRequest(input: HandleRequestInput): Promise<void> {
   const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
   const path = url.pathname;
 
-  // Authentication already established both the accepted credential and its principal. Routing
-  // only derives the compatibility address projection; it never re-authenticates the header.
-  const requestAgentAddress = input.requestPrincipal.kind === 'agent'
-    ? input.requestPrincipal.agentAddress
-    : agent.resolveAgentAddress(input.requestToken);
+  // Routing derives compatibility identity only from the accepted authentication. A raw invalid
+  // bearer is observable as presentedToken but can never participate in identity resolution.
+  const requestAgentAddress = authenticatedAgentAddress(input.authentication)
+    ?? agent.resolveAgentAddress(input.authentication.acceptedToken);
 
   const ctx: RequestContext = {
     ...input,

--- a/packages/cli/src/daemon/handle-request.ts
+++ b/packages/cli/src/daemon/handle-request.ts
@@ -312,8 +312,10 @@ import type {
   MemoryGraphChangedEvent,
   NotificationSseEvent,
   RequestContext,
+  RequestContextInputFields,
 } from './routes/context.js';
-import { authenticatedAgentAddress } from '../auth.js';
+import { createRequestActor } from './routes/context.js';
+import type { AllowedHttpAuthentication } from '../auth.js';
 import { handleStatusRoutes } from './routes/status.js';
 import { handleBackpressureRoutes } from './routes/backpressure.js';
 import { handleAgentChatRoutes } from './routes/agent-chat.js';
@@ -338,28 +340,44 @@ import type { RoutePlugin } from './plugin-api.js';
 
 
 export type HandleRequestInput = Omit<
-  RequestContext,
+  RequestContextInputFields,
   | 'url'
   | 'path'
+  | 'actor'
+  | 'authentication'
   | 'requestAgentAddress'
->;
+> & { readonly authentication: AllowedHttpAuthentication };
 
 export async function handleRequest(input: HandleRequestInput): Promise<void> {
-  const { req, res, agent } = input;
+  const { req, res, agent, authentication, ...contextInput } = input;
   const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
   const path = url.pathname;
 
-  // Routing derives compatibility identity only from the accepted authentication. A raw invalid
-  // bearer is observable as presentedToken but can never participate in identity resolution.
-  const requestAgentAddress = authenticatedAgentAddress(input.authentication)
-    ?? agent.resolveAgentAddress(input.authentication.acceptedToken);
-
-  const ctx: RequestContext = {
-    ...input,
+  // Build one actor from the accepted authentication decision. Compatibility properties are
+  // read-only getters over this value, never independently stored request state.
+  const actor = createRequestActor(
+    authentication,
+    (acceptedToken) => agent.resolveAgentAddress(acceptedToken),
+  );
+  const ctxBase = {
+    ...contextInput,
+    req,
+    res,
+    agent,
     url,
     path,
-    requestAgentAddress,
+    actor,
   };
+  const ctx = Object.defineProperties(ctxBase, {
+    authentication: {
+      enumerable: true,
+      get: () => actor.authentication,
+    },
+    requestAgentAddress: {
+      enumerable: true,
+      get: () => actor.effectiveAgentAddress,
+    },
+  }) as RequestContext;
 
   await handleStatusRoutes(ctx);
   if (res.writableEnded) return;

--- a/packages/cli/src/daemon/handle-request.ts
+++ b/packages/cli/src/daemon/handle-request.ts
@@ -100,7 +100,6 @@ import {
   CLI_NPM_PACKAGE,
 } from '../config.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../catchup-runner.js';
-import { loadTokens, httpAuthGuard, extractBearerToken } from '../auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
 import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown, extractWithLlm } from '../extraction/index.js';
 import {
@@ -313,7 +312,6 @@ import type {
   MemoryGraphChangedEvent,
   NotificationSseEvent,
   RequestContext,
-  RequestPrincipal,
 } from './routes/context.js';
 import { handleStatusRoutes } from './routes/status.js';
 import { handleBackpressureRoutes } from './routes/backpressure.js';
@@ -342,53 +340,25 @@ export type HandleRequestInput = Omit<
   RequestContext,
   | 'url'
   | 'path'
-  | 'requestToken'
   | 'requestAgentAddress'
-  | 'requestPrincipal'
 >;
-
-export function resolveRequestPrincipal(input: {
-  readonly authEnabled: boolean;
-  readonly requestToken: string | undefined;
-  readonly validTokens: ReadonlySet<string>;
-  readonly resolveAgentByToken: (token: string) => string | undefined;
-}): RequestPrincipal {
-  if (!input.authEnabled) return { kind: 'nodeOperator' };
-  if (!input.requestToken || !input.validTokens.has(input.requestToken)) {
-    return { kind: 'anonymous' };
-  }
-  const agentAddress = input.resolveAgentByToken(input.requestToken);
-  return agentAddress
-    ? { kind: 'agent', agentAddress }
-    : { kind: 'nodeOperator' };
-}
 
 export async function handleRequest(input: HandleRequestInput): Promise<void> {
   const { req, res, agent } = input;
   const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
   const path = url.pathname;
 
-  // Resolve the requesting agent's address from the Bearer token.
-  // Agent tokens (dkg_at_...) resolve to their specific agent; node-level tokens
-  // fall back to the default owner agent.
-  const requestToken = extractBearerToken(req.headers.authorization);
-  const requestPrincipal = resolveRequestPrincipal({
-    authEnabled: input.config.auth?.enabled !== false,
-    requestToken,
-    validTokens: input.validTokens,
-    resolveAgentByToken: (token) => agent.resolveAgentByToken(token),
-  });
-  const requestAgentAddress = requestPrincipal.kind === 'agent'
-    ? requestPrincipal.agentAddress
-    : agent.resolveAgentAddress(requestToken);
+  // Authentication already established both the accepted credential and its principal. Routing
+  // only derives the compatibility address projection; it never re-authenticates the header.
+  const requestAgentAddress = input.requestPrincipal.kind === 'agent'
+    ? input.requestPrincipal.agentAddress
+    : agent.resolveAgentAddress(input.requestToken);
 
   const ctx: RequestContext = {
     ...input,
     url,
     path,
-    requestToken,
     requestAgentAddress,
-    requestPrincipal,
   };
 
   await handleStatusRoutes(ctx);

--- a/packages/cli/src/daemon/handle-request.ts
+++ b/packages/cli/src/daemon/handle-request.ts
@@ -309,7 +309,12 @@ import {
   reverseLocalAgentSetupForUi,
   refreshLocalAgentIntegrationFromUi,
 } from './local-agents.js';
-import type { MemoryGraphChangedEvent, NotificationSseEvent, RequestContext } from './routes/context.js';
+import type {
+  MemoryGraphChangedEvent,
+  NotificationSseEvent,
+  RequestContext,
+  RequestPrincipal,
+} from './routes/context.js';
 import { handleStatusRoutes } from './routes/status.js';
 import { handleBackpressureRoutes } from './routes/backpressure.js';
 import { handleAgentChatRoutes } from './routes/agent-chat.js';
@@ -339,7 +344,24 @@ export type HandleRequestInput = Omit<
   | 'path'
   | 'requestToken'
   | 'requestAgentAddress'
+  | 'requestPrincipal'
 >;
+
+export function resolveRequestPrincipal(input: {
+  readonly authEnabled: boolean;
+  readonly requestToken: string | undefined;
+  readonly validTokens: ReadonlySet<string>;
+  readonly resolveAgentByToken: (token: string) => string | undefined;
+}): RequestPrincipal {
+  if (!input.authEnabled) return { kind: 'nodeOperator' };
+  if (!input.requestToken || !input.validTokens.has(input.requestToken)) {
+    return { kind: 'anonymous' };
+  }
+  const agentAddress = input.resolveAgentByToken(input.requestToken);
+  return agentAddress
+    ? { kind: 'agent', agentAddress }
+    : { kind: 'nodeOperator' };
+}
 
 export async function handleRequest(input: HandleRequestInput): Promise<void> {
   const { req, res, agent } = input;
@@ -350,7 +372,15 @@ export async function handleRequest(input: HandleRequestInput): Promise<void> {
   // Agent tokens (dkg_at_...) resolve to their specific agent; node-level tokens
   // fall back to the default owner agent.
   const requestToken = extractBearerToken(req.headers.authorization);
-  const requestAgentAddress = agent.resolveAgentAddress(requestToken);
+  const requestPrincipal = resolveRequestPrincipal({
+    authEnabled: input.config.auth?.enabled !== false,
+    requestToken,
+    validTokens: input.validTokens,
+    resolveAgentByToken: (token) => agent.resolveAgentByToken(token),
+  });
+  const requestAgentAddress = requestPrincipal.kind === 'agent'
+    ? requestPrincipal.agentAddress
+    : agent.resolveAgentAddress(requestToken);
 
   const ctx: RequestContext = {
     ...input,
@@ -358,6 +388,7 @@ export async function handleRequest(input: HandleRequestInput): Promise<void> {
     path,
     requestToken,
     requestAgentAddress,
+    requestPrincipal,
   };
 
   await handleStatusRoutes(ctx);

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -3662,7 +3662,7 @@ async function runDaemonInnerWithStartupOwnership(
         req,
         res,
         requestToken: authentication.requestToken,
-        requestCredentialAuthenticated: authentication.requestCredentialAuthenticated,
+        requestAuthorization: authentication.requestAuthorization,
         requestPrincipal: authentication.requestPrincipal,
         agent,
         publisherControl,

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -187,7 +187,7 @@ import {
   writeContextGraphReadiness,
   type ContextGraphReadinessStore,
 } from '../context-graph-readiness.js';
-import { loadTokens, httpAuthGuard } from '../auth.js';
+import { authenticateHttpRequest, loadTokens } from '../auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
 import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown, extractWithLlm } from '../extraction/index.js';
 import {
@@ -3534,14 +3534,15 @@ async function runDaemonInnerWithStartupOwnership(
       }
 
       // Auth guard — rejects with 401 if token is invalid/missing
-      const authAllowed = await httpAuthGuard(
+      const authentication = await authenticateHttpRequest({
         req,
         res,
         authEnabled,
         validTokens,
-        resolveCorsOrigin(req, corsAllowed),
-      );
-      if (!authAllowed) return;
+        resolveAgentByToken: (token) => agent.resolveAgentByToken(token),
+        corsOrigin: resolveCorsOrigin(req, corsAllowed),
+      });
+      if (!authentication.allowed) return;
 
       // Retired installable apps framework (V9): respond with 410 Gone so upgraded
       // nodes give a clear migration hint for both the JSON API and any bookmarked
@@ -3660,6 +3661,9 @@ async function runDaemonInnerWithStartupOwnership(
       await handleRequest({
         req,
         res,
+        requestToken: authentication.requestToken,
+        requestCredentialAuthenticated: authentication.requestCredentialAuthenticated,
+        requestPrincipal: authentication.requestPrincipal,
         agent,
         publisherControl,
         publisherState,

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -3661,9 +3661,7 @@ async function runDaemonInnerWithStartupOwnership(
       await handleRequest({
         req,
         res,
-        requestToken: authentication.requestToken,
-        requestAuthorization: authentication.requestAuthorization,
-        requestPrincipal: authentication.requestPrincipal,
+        authentication,
         agent,
         publisherControl,
         publisherState,

--- a/packages/cli/src/daemon/plugin-api.ts
+++ b/packages/cli/src/daemon/plugin-api.ts
@@ -20,6 +20,8 @@ import type { RequestContext as DaemonRequestContext } from './routes/context.js
  * treat them as independent lifecycle state.
  */
 export type RequestContext = DaemonRequestContext & {
+  /** @deprecated Use `actor.authentication.acceptedToken`. */
+  readonly requestToken: string | undefined;
   /** @deprecated Use publisherState.runtime. */
   publisherRuntime: PublisherRuntime | null;
   /** @deprecated Use publisherState.availability. */

--- a/packages/cli/src/daemon/routes/agent-chat.ts
+++ b/packages/cli/src/daemon/routes/agent-chat.ts
@@ -441,9 +441,12 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
     apiPortRef,
     url,
     path,
-    requestToken,
     requestAgentAddress,
+    requestPrincipal,
   } = ctx;
+  const authenticatedAgentAddress = requestPrincipal.kind === 'agent'
+    ? requestPrincipal.agentAddress
+    : undefined;
 
 
   // POST /api/agent/register — register a new agent on this node
@@ -481,14 +484,13 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
   // routes (e.g. memory.ts, query.ts) already use for caller-vs-target
   // gating.
   function authorizeKeyManagementOnAddress(targetAddress: string): { ok: true } | { ok: false; status: number; body: Record<string, unknown> } {
-    const tokenAgentAddress = requestToken ? agent.resolveAgentByToken(requestToken) : undefined;
-    if (!tokenAgentAddress) return { ok: true };
-    if (tokenAgentAddress.toLowerCase() === targetAddress.toLowerCase()) return { ok: true };
+    if (!authenticatedAgentAddress) return { ok: true };
+    if (authenticatedAgentAddress.toLowerCase() === targetAddress.toLowerCase()) return { ok: true };
     return {
       ok: false,
       status: 403,
       body: {
-        error: `Agent token for ${tokenAgentAddress} cannot manage encryption keys for ${targetAddress}. ` +
+        error: `Agent token for ${authenticatedAgentAddress} cannot manage encryption keys for ${targetAddress}. ` +
           'Use a node-level admin token (~/.dkg/auth.token) to manage other agents on this node.',
       },
     };
@@ -601,8 +603,7 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
   // agent's; gating to admin avoids a non-default-agent token tricking
   // the daemon into republishing on demand for spam.
   if (req.method === "POST" && path === "/api/agent/publish-profile") {
-    const tokenAgentAddress = requestToken ? agent.resolveAgentByToken(requestToken) : undefined;
-    if (tokenAgentAddress) {
+    if (requestPrincipal.kind !== 'nodeOperator') {
       return jsonResponse(res, 403, {
         error: 'POST /api/agent/publish-profile requires a node-level admin token; agent-scoped tokens cannot trigger a profile republish.',
       });
@@ -942,10 +943,9 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
     if (parsed.precomputedUpdateAttestation !== undefined && !precomputedUpdateAttestation) {
       return;
     }
-    const tokenAgentAddress = requestToken ? agent.resolveAgentByToken(requestToken) : undefined;
     if (!authorizeAgentScopedAuthorClaim(
       res,
-      tokenAgentAddress,
+      authenticatedAgentAddress,
       precomputedUpdateAttestation?.authorAddress,
       "precomputedUpdateAttestation.authorAddress",
     )) {

--- a/packages/cli/src/daemon/routes/agent-chat.ts
+++ b/packages/cli/src/daemon/routes/agent-chat.ts
@@ -442,6 +442,7 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
     url,
     path,
     requestAgentAddress,
+    requestAuthorization,
     requestPrincipal,
   } = ctx;
   const authenticatedAgentAddress = requestPrincipal.kind === 'agent'
@@ -603,7 +604,7 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
   // agent's; gating to admin avoids a non-default-agent token tricking
   // the daemon into republishing on demand for spam.
   if (req.method === "POST" && path === "/api/agent/publish-profile") {
-    if (requestPrincipal.kind !== 'nodeOperator') {
+    if (!requestAuthorization.nodeOperator) {
       return jsonResponse(res, 403, {
         error: 'POST /api/agent/publish-profile requires a node-level admin token; agent-scoped tokens cannot trigger a profile republish.',
       });

--- a/packages/cli/src/daemon/routes/agent-chat.ts
+++ b/packages/cli/src/daemon/routes/agent-chat.ts
@@ -118,7 +118,7 @@ import {
 } from '../../config.js';
 import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type PublisherRuntime } from '../../publisher-runner.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../../catchup-runner.js';
-import { authenticatedAgentAddress as agentAddressFromAuthentication, canAdministerNode, loadTokens, httpAuthGuard, extractBearerToken } from '../../auth.js';
+import { authenticatedAgentAddress as agentAddressFromAuthentication, canAdministerNode, loadTokens, httpAuthGuard } from '../../auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
 import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown, extractWithLlm } from '../../extraction/index.js';
 import {
@@ -616,8 +616,7 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
 
   // GET /api/agent/identity — current agent identity for the requesting token
   if (req.method === "GET" && path === "/api/agent/identity") {
-    const token = extractBearerToken(req.headers.authorization);
-    const agentAddress = agent.resolveAgentAddress(token);
+    const agentAddress = requestAgentAddress;
     const localAgents = agent.listLocalAgents();
     const current = localAgents.find((a) => a.agentAddress === agentAddress);
     return jsonResponse(res, 200, {

--- a/packages/cli/src/daemon/routes/agent-chat.ts
+++ b/packages/cli/src/daemon/routes/agent-chat.ts
@@ -118,7 +118,7 @@ import {
 } from '../../config.js';
 import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type PublisherRuntime } from '../../publisher-runner.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../../catchup-runner.js';
-import { authenticatedAgentAddress as agentAddressFromAuthentication, canAdministerNode, loadTokens, httpAuthGuard } from '../../auth.js';
+import { canAdministerNode, loadTokens, httpAuthGuard } from '../../auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
 import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown, extractWithLlm } from '../../extraction/index.js';
 import {
@@ -333,6 +333,7 @@ import {
 import { authorizeAgentScopedAuthorClaim } from './shared-assertion-helpers.js';
 import { classifyAgentConnectError } from './agent-connect-error.js';
 import type { RequestContext } from './context.js';
+import { actorFromRequestContext } from './context.js';
 import { handleAgentsListRoute } from './agents-list.js';
 import type { PublishOptions } from '@origintrail-official/dkg-publisher';
 
@@ -441,10 +442,13 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
     apiPortRef,
     url,
     path,
-    requestAgentAddress,
-    authentication,
   } = ctx;
-  const authenticatedAgentAddress = agentAddressFromAuthentication(authentication);
+  const actor = actorFromRequestContext(ctx);
+  const {
+    authentication,
+    authenticatedAgentAddress,
+    effectiveAgentAddress: requestAgentAddress,
+  } = actor;
 
 
   // POST /api/agent/register — register a new agent on this node

--- a/packages/cli/src/daemon/routes/agent-chat.ts
+++ b/packages/cli/src/daemon/routes/agent-chat.ts
@@ -118,7 +118,7 @@ import {
 } from '../../config.js';
 import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type PublisherRuntime } from '../../publisher-runner.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../../catchup-runner.js';
-import { loadTokens, httpAuthGuard, extractBearerToken } from '../../auth.js';
+import { authenticatedAgentAddress as agentAddressFromAuthentication, canAdministerNode, loadTokens, httpAuthGuard, extractBearerToken } from '../../auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
 import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown, extractWithLlm } from '../../extraction/index.js';
 import {
@@ -442,12 +442,9 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
     url,
     path,
     requestAgentAddress,
-    requestAuthorization,
-    requestPrincipal,
+    authentication,
   } = ctx;
-  const authenticatedAgentAddress = requestPrincipal.kind === 'agent'
-    ? requestPrincipal.agentAddress
-    : undefined;
+  const authenticatedAgentAddress = agentAddressFromAuthentication(authentication);
 
 
   // POST /api/agent/register — register a new agent on this node
@@ -604,7 +601,7 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
   // agent's; gating to admin avoids a non-default-agent token tricking
   // the daemon into republishing on demand for spam.
   if (req.method === "POST" && path === "/api/agent/publish-profile") {
-    if (!requestAuthorization.nodeOperator) {
+    if (!canAdministerNode(authentication)) {
       return jsonResponse(res, 403, {
         error: 'POST /api/agent/publish-profile requires a node-level admin token; agent-scoped tokens cannot trigger a profile republish.',
       });

--- a/packages/cli/src/daemon/routes/backpressure.ts
+++ b/packages/cli/src/daemon/routes/backpressure.ts
@@ -14,12 +14,12 @@ export async function handleBackpressureRoutes(ctx: RequestContext): Promise<voi
     req,
     res,
     path,
-    requestPrincipal,
+    requestAuthorization,
   } = ctx;
 
   if (req.method !== 'GET' || path !== '/api/diagnostics/backpressure') return;
 
-  const isNodeAdminCaller = requestPrincipal.kind === 'nodeOperator';
+  const isNodeAdminCaller = requestAuthorization.nodeOperator;
   if (!isNodeAdminCaller) {
     return jsonResponse(res, 403, {
       error:

--- a/packages/cli/src/daemon/routes/backpressure.ts
+++ b/packages/cli/src/daemon/routes/backpressure.ts
@@ -1,6 +1,7 @@
 import { backpressureRegistry } from '@origintrail-official/dkg-core';
 import { jsonResponse } from '../http-utils.js';
 import type { RequestContext } from './context.js';
+import { canAdministerNode } from '../../auth.js';
 
 /**
  * Node-admin diagnostics for every registered scheduler/backlog source.
@@ -14,12 +15,12 @@ export async function handleBackpressureRoutes(ctx: RequestContext): Promise<voi
     req,
     res,
     path,
-    requestAuthorization,
+    authentication,
   } = ctx;
 
   if (req.method !== 'GET' || path !== '/api/diagnostics/backpressure') return;
 
-  const isNodeAdminCaller = requestAuthorization.nodeOperator;
+  const isNodeAdminCaller = canAdministerNode(authentication);
   if (!isNodeAdminCaller) {
     return jsonResponse(res, 403, {
       error:

--- a/packages/cli/src/daemon/routes/backpressure.ts
+++ b/packages/cli/src/daemon/routes/backpressure.ts
@@ -13,23 +13,13 @@ export async function handleBackpressureRoutes(ctx: RequestContext): Promise<voi
   const {
     req,
     res,
-    agent,
-    config,
-    validTokens,
     path,
-    requestToken,
+    requestPrincipal,
   } = ctx;
 
   if (req.method !== 'GET' || path !== '/api/diagnostics/backpressure') return;
 
-  const authEnabled = config.auth?.enabled !== false;
-  const isNodeAdminCaller =
-    !authEnabled
-    || (
-      !!requestToken
-      && validTokens.has(requestToken)
-      && !agent.resolveAgentByToken(requestToken)
-    );
+  const isNodeAdminCaller = requestPrincipal.kind === 'nodeOperator';
   if (!isNodeAdminCaller) {
     return jsonResponse(res, 403, {
       error:

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -605,7 +605,6 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
     res,
     agent,
     publisherControl,
-    config,
     startedAt,
     dashDb,
     opWallets,
@@ -622,26 +621,20 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
     assertionImportLocks,
     vectorStore,
     embeddingProvider,
-    validTokens,
     apiHost,
     apiPortRef,
     url,
     path,
     requestToken,
     requestAgentAddress,
+    requestPrincipal,
     emitMemoryGraphChanged,
   } = ctx;
-  // Operator gate for the node-wide subscription endpoints. When auth is ENABLED,
-  // require a node-level admin token — a recognised token (in validTokens) that
-  // resolves to no agent (agent-scoped tokens resolve to an address; a
-  // missing/unrecognised token isn't in validTokens). When auth is DISABLED the
-  // daemon runs admin maintenance routes tokenless (trusted local), so don't 403.
-  const authEnabled = config.auth?.enabled !== false;
-  const isNodeAdminCaller = (): boolean =>
-    !authEnabled ||
-    (!!requestToken && validTokens.has(requestToken) && !agent.resolveAgentByToken(requestToken));
-  const writePreflightCallerAgentAddress = requestToken
-    ? agent.resolveAgentByToken(requestToken)
+  // Node-wide gates consume the principal established by authentication; route code must not
+  // reinterpret token storage or agent-token resolution.
+  const isNodeAdminCaller = (): boolean => requestPrincipal.kind === 'nodeOperator';
+  const writePreflightCallerAgentAddress = requestPrincipal.kind === 'agent'
+    ? requestPrincipal.agentAddress
     : undefined;
   const writePreflightContextGraphOpts = {
     callerAgentAddress: writePreflightCallerAgentAddress,

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -123,7 +123,7 @@ import {
   readContextGraphReadiness,
   writeContextGraphReadiness,
 } from '../../context-graph-readiness.js';
-import { loadTokens, httpAuthGuard, extractBearerToken } from '../../auth.js';
+import { authenticatedAgentAddress, canAdministerNode, loadTokens, httpAuthGuard, extractBearerToken } from '../../auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
 import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown, extractWithLlm } from '../../extraction/index.js';
 import {
@@ -625,18 +625,15 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
     apiPortRef,
     url,
     path,
-    requestToken,
+    authentication,
     requestAgentAddress,
-    requestAuthorization,
-    requestPrincipal,
     emitMemoryGraphChanged,
   } = ctx;
   // Node-wide gates consume the principal established by authentication; route code must not
   // reinterpret token storage or agent-token resolution.
-  const isNodeAdminCaller = (): boolean => requestAuthorization.nodeOperator;
-  const writePreflightCallerAgentAddress = requestPrincipal.kind === 'agent'
-    ? requestPrincipal.agentAddress
-    : undefined;
+  const isNodeAdminCaller = (): boolean => canAdministerNode(authentication);
+  const writePreflightCallerAgentAddress = authenticatedAgentAddress(authentication);
+  const requestToken = authentication.acceptedToken;
   const writePreflightContextGraphOpts = {
     callerAgentAddress: writePreflightCallerAgentAddress,
     allowLocalExactFallback: !writePreflightCallerAgentAddress,

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -123,7 +123,7 @@ import {
   readContextGraphReadiness,
   writeContextGraphReadiness,
 } from '../../context-graph-readiness.js';
-import { authenticatedAgentAddress, canAdministerNode, loadTokens, httpAuthGuard, extractBearerToken } from '../../auth.js';
+import { authenticatedAgentAddress, canAdministerNode, loadTokens, httpAuthGuard } from '../../auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
 import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown, extractWithLlm } from '../../extraction/index.js';
 import {
@@ -1439,13 +1439,10 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
   if (req.method === "POST" && signJoinMatch) {
     const contextGraphId = decodeURIComponent(signJoinMatch[1]);
     try {
-      const callerAddress = agent.resolveAgentAddress(
-        extractBearerToken(req.headers.authorization),
-      );
       // Body is intentionally ignored — sign-only. Drain it so a JSON body
       // sent by older clients doesn't sit on the socket.
       try { await readBody(req, SMALL_BODY_BYTES); } catch { /* ignored */ }
-      const delegation = await agent.signJoinRequest(contextGraphId, callerAddress);
+      const delegation = await agent.signJoinRequest(contextGraphId, requestAgentAddress);
       return jsonResponse(res, 200, {
         ok: true,
         contextGraphId,

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -123,7 +123,7 @@ import {
   readContextGraphReadiness,
   writeContextGraphReadiness,
 } from '../../context-graph-readiness.js';
-import { authenticatedAgentAddress, canAdministerNode, loadTokens, httpAuthGuard } from '../../auth.js';
+import { canAdministerNode, loadTokens, httpAuthGuard } from '../../auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
 import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown, extractWithLlm } from '../../extraction/index.js';
 import {
@@ -344,6 +344,7 @@ import {
 } from '../local-agents.js';
 
 import type { RequestContext } from './context.js';
+import { actorFromRequestContext } from './context.js';
 
 /**
  * Map a `registerContextGraph` failure to an HTTP status +
@@ -625,14 +626,17 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
     apiPortRef,
     url,
     path,
-    authentication,
-    requestAgentAddress,
     emitMemoryGraphChanged,
   } = ctx;
+  const actor = actorFromRequestContext(ctx);
+  const {
+    authentication,
+    effectiveAgentAddress: requestAgentAddress,
+  } = actor;
   // Node-wide gates consume the principal established by authentication; route code must not
   // reinterpret token storage or agent-token resolution.
   const isNodeAdminCaller = (): boolean => canAdministerNode(authentication);
-  const writePreflightCallerAgentAddress = authenticatedAgentAddress(authentication);
+  const writePreflightCallerAgentAddress = actor.authenticatedAgentAddress;
   const requestToken = authentication.acceptedToken;
   const writePreflightContextGraphOpts = {
     callerAgentAddress: writePreflightCallerAgentAddress,

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -627,12 +627,13 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
     path,
     requestToken,
     requestAgentAddress,
+    requestAuthorization,
     requestPrincipal,
     emitMemoryGraphChanged,
   } = ctx;
   // Node-wide gates consume the principal established by authentication; route code must not
   // reinterpret token storage or agent-token resolution.
-  const isNodeAdminCaller = (): boolean => requestPrincipal.kind === 'nodeOperator';
+  const isNodeAdminCaller = (): boolean => requestAuthorization.nodeOperator;
   const writePreflightCallerAgentAddress = requestPrincipal.kind === 'agent'
     ? requestPrincipal.agentAddress
     : undefined;

--- a/packages/cli/src/daemon/routes/context.ts
+++ b/packages/cli/src/daemon/routes/context.ts
@@ -9,7 +9,11 @@
 
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { DKGAgent, OpWalletsConfig } from '@origintrail-official/dkg-agent';
-import type { ExtractionPipelineRegistry, RequestPrincipal } from '@origintrail-official/dkg-core';
+import type { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
+import type {
+  RequestAuthorization,
+  RequestPrincipal,
+} from '../../auth.js';
 import type {
   ChatMemoryManager,
   DashboardDB,
@@ -109,8 +113,8 @@ export interface RequestContext {
   url: URL;
   path: string;
   requestToken: string | undefined;
-  /** True only when the canonical auth boundary accepted a real credential. */
-  requestCredentialAuthenticated: boolean;
+  /** Capabilities established independently from caller identity. */
+  requestAuthorization: RequestAuthorization;
   requestAgentAddress: string;
   requestPrincipal: RequestPrincipal;
   emitMemoryGraphChanged?: (event: MemoryGraphChangedEvent) => void;

--- a/packages/cli/src/daemon/routes/context.ts
+++ b/packages/cli/src/daemon/routes/context.ts
@@ -10,7 +10,10 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { DKGAgent, OpWalletsConfig } from '@origintrail-official/dkg-agent';
 import type { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
-import type { AllowedHttpAuthentication } from '../../auth.js';
+import {
+  authenticatedAgentAddress,
+  type AllowedHttpAuthentication,
+} from '../../auth.js';
 import type {
   ChatMemoryManager,
   DashboardDB,
@@ -62,7 +65,51 @@ export interface NotificationSseEvent {
   type: string;
 }
 
+declare const REQUEST_ACTOR_BRAND: unique symbol;
+declare const REQUEST_CONTEXT_BRAND: unique symbol;
+
+/**
+ * The identity and authority used by one routed request. Constructed once by `handleRequest` so
+ * routes cannot combine authentication from one credential with an operational identity derived
+ * from another.
+ */
+export interface RequestActor {
+  readonly [REQUEST_ACTOR_BRAND]: true;
+  readonly authentication: AllowedHttpAuthentication;
+  readonly authenticatedAgentAddress: string | undefined;
+  readonly effectiveAgentAddress: string;
+}
+
+export function createRequestActor(
+  authentication: AllowedHttpAuthentication,
+  resolveEffectiveAgentAddress: (acceptedToken: string | undefined) => string,
+): RequestActor {
+  const agentAddress = authenticatedAgentAddress(authentication);
+  return Object.freeze({
+    authentication,
+    authenticatedAgentAddress: agentAddress,
+    effectiveAgentAddress: agentAddress
+      ?? resolveEffectiveAgentAddress(authentication.acceptedToken),
+  }) as RequestActor;
+}
+
+/**
+ * Compatibility boundary for isolated route-handler embedders created before `RequestActor`.
+ * Real daemon requests always take the first branch. In the fallback, credential identity still
+ * wins over the legacy effective-address projection, so contradictory agent authority cannot be
+ * assembled even by an untyped older caller.
+ */
+export function actorFromRequestContext(ctx: RequestContext): RequestActor {
+  const actor = (ctx as RequestContext & { actor?: RequestActor }).actor;
+  return actor ?? createRequestActor(
+    ctx.authentication,
+    () => ctx.requestAgentAddress,
+  );
+}
+
 export interface RequestContext {
+  /** Opaque: daemon request contexts are assembled only by the dispatch boundary. */
+  readonly [REQUEST_CONTEXT_BRAND]: true;
   req: IncomingMessage;
   res: ServerResponse;
   agent: DKGAgent;
@@ -108,10 +155,15 @@ export interface RequestContext {
   // and capabilities are pure projections from it rather than separately mutable context fields.
   url: URL;
   path: string;
-  authentication: AllowedHttpAuthentication;
-  /** Compatibility operational identity derived once from the accepted authentication. */
-  requestAgentAddress: string;
+  actor: RequestActor;
+  /** @deprecated Built-in routes should use `actor.authentication`. Runtime getter only. */
+  readonly authentication: AllowedHttpAuthentication;
+  /** @deprecated Built-in routes should use `actor.effectiveAgentAddress`. Runtime getter only. */
+  readonly requestAgentAddress: string;
   emitMemoryGraphChanged?: (event: MemoryGraphChangedEvent) => void;
   /** A5: broadcast a generic `notification` SSE refresh for the bell pane. */
   emitNotification?: (event: NotificationSseEvent) => void;
 }
+
+/** Unbranded input fields accepted only by the daemon's request-context factory. */
+export type RequestContextInputFields = Omit<RequestContext, typeof REQUEST_CONTEXT_BRAND>;

--- a/packages/cli/src/daemon/routes/context.ts
+++ b/packages/cli/src/daemon/routes/context.ts
@@ -9,7 +9,7 @@
 
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { DKGAgent, OpWalletsConfig } from '@origintrail-official/dkg-agent';
-import type { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
+import type { ExtractionPipelineRegistry, RequestPrincipal } from '@origintrail-official/dkg-core';
 import type {
   ChatMemoryManager,
   DashboardDB,
@@ -61,12 +61,6 @@ export interface NotificationSseEvent {
   type: string;
 }
 
-/** Authenticated request identity derived once before route dispatch. */
-export type RequestPrincipal =
-  | { readonly kind: 'agent'; readonly agentAddress: string }
-  | { readonly kind: 'nodeOperator' }
-  | { readonly kind: 'anonymous' };
-
 export interface RequestContext {
   req: IncomingMessage;
   res: ServerResponse;
@@ -115,6 +109,8 @@ export interface RequestContext {
   url: URL;
   path: string;
   requestToken: string | undefined;
+  /** True only when the canonical auth boundary accepted a real credential. */
+  requestCredentialAuthenticated: boolean;
   requestAgentAddress: string;
   requestPrincipal: RequestPrincipal;
   emitMemoryGraphChanged?: (event: MemoryGraphChangedEvent) => void;

--- a/packages/cli/src/daemon/routes/context.ts
+++ b/packages/cli/src/daemon/routes/context.ts
@@ -2,7 +2,7 @@
 //
 // Per-request context bag passed to every route-group handler.
 // Bundles the 24 parameters `handleRequest` used to take plus the 4
-// derived locals (url, path, requestToken, requestAgentAddress) so
+// derived locals (url, path, authentication, requestAgentAddress) so
 // route-group modules destructure exactly once on entry and route
 // bodies can keep referring to bare names — identical to how they
 // looked inside the monolithic `handleRequest`.
@@ -10,10 +10,7 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { DKGAgent, OpWalletsConfig } from '@origintrail-official/dkg-agent';
 import type { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
-import type {
-  RequestAuthorization,
-  RequestPrincipal,
-} from '../../auth.js';
+import type { AllowedHttpAuthentication } from '../../auth.js';
 import type {
   ChatMemoryManager,
   DashboardDB,
@@ -107,16 +104,13 @@ export interface RequestContext {
   admission: AdmissionStatsView;
   /** Daemon-owned, read-only local LLM session used by the Node UI. */
   localLlm?: DaemonLocalLlmService;
-  // Derived per-request (from req.url + headers + token). Routes read
-  // `path`, `url`, `requestAgentAddress` extensively; pre-computing
-  // here keeps every group on the same fast path.
+  // Derived per-request. The correlated authentication decision is carried unchanged; identity
+  // and capabilities are pure projections from it rather than separately mutable context fields.
   url: URL;
   path: string;
-  requestToken: string | undefined;
-  /** Capabilities established independently from caller identity. */
-  requestAuthorization: RequestAuthorization;
+  authentication: AllowedHttpAuthentication;
+  /** Compatibility operational identity derived once from the accepted authentication. */
   requestAgentAddress: string;
-  requestPrincipal: RequestPrincipal;
   emitMemoryGraphChanged?: (event: MemoryGraphChangedEvent) => void;
   /** A5: broadcast a generic `notification` SSE refresh for the bell pane. */
   emitNotification?: (event: NotificationSseEvent) => void;

--- a/packages/cli/src/daemon/routes/context.ts
+++ b/packages/cli/src/daemon/routes/context.ts
@@ -61,6 +61,12 @@ export interface NotificationSseEvent {
   type: string;
 }
 
+/** Authenticated request identity derived once before route dispatch. */
+export type RequestPrincipal =
+  | { readonly kind: 'agent'; readonly agentAddress: string }
+  | { readonly kind: 'nodeOperator' }
+  | { readonly kind: 'anonymous' };
+
 export interface RequestContext {
   req: IncomingMessage;
   res: ServerResponse;
@@ -110,6 +116,7 @@ export interface RequestContext {
   path: string;
   requestToken: string | undefined;
   requestAgentAddress: string;
+  requestPrincipal: RequestPrincipal;
   emitMemoryGraphChanged?: (event: MemoryGraphChangedEvent) => void;
   /** A5: broadcast a generic `notification` SSE refresh for the bell pane. */
   emitNotification?: (event: NotificationSseEvent) => void;

--- a/packages/cli/src/daemon/routes/epcis.ts
+++ b/packages/cli/src/daemon/routes/epcis.ts
@@ -418,7 +418,6 @@ export async function handleEpcisRoutes(ctx: RequestContext): Promise<void> {
     apiPortRef,
     url,
     path,
-    requestToken,
     requestAgentAddress,
   } = ctx;
 

--- a/packages/cli/src/daemon/routes/knowledge-assets-async-share.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets-async-share.ts
@@ -23,6 +23,7 @@
 // Shared logic lives in `./shared-assertion-helpers.js`.
 
 import type { RequestContext } from "./context.js";
+import { authenticatedAgentAddress } from '../../auth.js';
 import { respondTerminalClearOutcome } from "./terminal-clear-response.js";
 import {
   jsonResponse,
@@ -60,10 +61,8 @@ import {
 // serves swm/share-async inline; this standalone faithful-port handler is kept in
 // lockstep so either entry point behaves identically.)
 export async function handleKaShareAsyncEnqueue(ctx: RequestContext, name: string): Promise<void> {
-  const { req, res, agent, requestPrincipal } = ctx;
-  const writePreflightCallerAgentAddress = requestPrincipal.kind === 'agent'
-    ? requestPrincipal.agentAddress
-    : undefined;
+  const { req, res, agent, authentication } = ctx;
+  const writePreflightCallerAgentAddress = authenticatedAgentAddress(authentication);
   const writePreflightContextGraphOpts = {
     callerAgentAddress: writePreflightCallerAgentAddress,
     allowLocalExactFallback: !writePreflightCallerAgentAddress,

--- a/packages/cli/src/daemon/routes/knowledge-assets-async-share.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets-async-share.ts
@@ -60,9 +60,9 @@ import {
 // serves swm/share-async inline; this standalone faithful-port handler is kept in
 // lockstep so either entry point behaves identically.)
 export async function handleKaShareAsyncEnqueue(ctx: RequestContext, name: string): Promise<void> {
-  const { req, res, agent, requestToken } = ctx;
-  const writePreflightCallerAgentAddress = requestToken
-    ? agent.resolveAgentByToken(requestToken)
+  const { req, res, agent, requestPrincipal } = ctx;
+  const writePreflightCallerAgentAddress = requestPrincipal.kind === 'agent'
+    ? requestPrincipal.agentAddress
     : undefined;
   const writePreflightContextGraphOpts = {
     callerAgentAddress: writePreflightCallerAgentAddress,

--- a/packages/cli/src/daemon/routes/knowledge-assets-import.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets-import.ts
@@ -71,7 +71,7 @@ import {
   getExtractionStatusRecord,
   setExtractionStatusRecord,
 } from "../../extraction-status.js";
-import { SignedRequestRejectedError } from "../../auth.js";
+import { authenticatedAgentAddress, SignedRequestRejectedError } from "../../auth.js";
 
 type AssertionArtifactKind = 'source' | 'markdown' | 'original';
 
@@ -590,15 +590,13 @@ export async function handleKaSemanticEnrichmentWrite(ctx: RequestContext): Prom
     res,
     agent,
     requestAgentAddress,
-    requestPrincipal,
+    authentication,
     emitMemoryGraphChanged,
   } = ctx;
   // Mirror the legacy assertion-route preflight: resolve the caller agent
   // from the bearer token so `resolveRequiredWriteContextGraphId` validates
   // the write CG against the caller's known graphs before any mutation.
-  const writePreflightCallerAgentAddress = requestPrincipal.kind === 'agent'
-    ? requestPrincipal.agentAddress
-    : undefined;
+  const writePreflightCallerAgentAddress = authenticatedAgentAddress(authentication);
   const writePreflightContextGraphOpts = {
     callerAgentAddress: writePreflightCallerAgentAddress,
     allowLocalExactFallback: !writePreflightCallerAgentAddress,
@@ -717,15 +715,13 @@ export async function handleKaImportFile(ctx: RequestContext, name: string): Pro
     extractionStatus,
     assertionImportLocks,
     requestAgentAddress,
-    requestPrincipal,
+    authentication,
     emitMemoryGraphChanged,
   } = ctx;
   // Mirror the legacy assertion-route preflight: resolve the caller agent from
   // the bearer token so `resolveRequiredWriteContextGraphId` validates the write
   // CG against the caller's known graphs before any mutation.
-  const writePreflightCallerAgentAddress = requestPrincipal.kind === 'agent'
-    ? requestPrincipal.agentAddress
-    : undefined;
+  const writePreflightCallerAgentAddress = authenticatedAgentAddress(authentication);
   const writePreflightContextGraphOpts = {
     callerAgentAddress: writePreflightCallerAgentAddress,
     allowLocalExactFallback: !writePreflightCallerAgentAddress,

--- a/packages/cli/src/daemon/routes/knowledge-assets-import.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets-import.ts
@@ -585,12 +585,19 @@ export async function handleKaImportArtifactReadMarkdown(ctx: RequestContext): P
 // POST /api/knowledge-assets/semantic-enrichment/write
 // Write model-derived semantic triples into the completed imported assertion with provenance.
 export async function handleKaSemanticEnrichmentWrite(ctx: RequestContext): Promise<void> {
-  const { req, res, agent, requestToken, requestAgentAddress, emitMemoryGraphChanged } = ctx;
+  const {
+    req,
+    res,
+    agent,
+    requestAgentAddress,
+    requestPrincipal,
+    emitMemoryGraphChanged,
+  } = ctx;
   // Mirror the legacy assertion-route preflight: resolve the caller agent
   // from the bearer token so `resolveRequiredWriteContextGraphId` validates
   // the write CG against the caller's known graphs before any mutation.
-  const writePreflightCallerAgentAddress = requestToken
-    ? agent.resolveAgentByToken(requestToken)
+  const writePreflightCallerAgentAddress = requestPrincipal.kind === 'agent'
+    ? requestPrincipal.agentAddress
     : undefined;
   const writePreflightContextGraphOpts = {
     callerAgentAddress: writePreflightCallerAgentAddress,
@@ -709,15 +716,15 @@ export async function handleKaImportFile(ctx: RequestContext, name: string): Pro
     fileStore,
     extractionStatus,
     assertionImportLocks,
-    requestToken,
     requestAgentAddress,
+    requestPrincipal,
     emitMemoryGraphChanged,
   } = ctx;
   // Mirror the legacy assertion-route preflight: resolve the caller agent from
   // the bearer token so `resolveRequiredWriteContextGraphId` validates the write
   // CG against the caller's known graphs before any mutation.
-  const writePreflightCallerAgentAddress = requestToken
-    ? agent.resolveAgentByToken(requestToken)
+  const writePreflightCallerAgentAddress = requestPrincipal.kind === 'agent'
+    ? requestPrincipal.agentAddress
     : undefined;
   const writePreflightContextGraphOpts = {
     callerAgentAddress: writePreflightCallerAgentAddress,

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -731,7 +731,17 @@ function rejectSelectedAuthorOnCreate(
 }
 
 export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<void> {
-  const { req, res, agent, publisherControl, path, url, requestToken, requestAgentAddress, emitMemoryGraphChanged } = ctx;
+  const {
+    req,
+    res,
+    agent,
+    publisherControl,
+    path,
+    url,
+    requestAgentAddress,
+    requestPrincipal,
+    emitMemoryGraphChanged,
+  } = ctx;
   if (path !== PREFIX && !path.startsWith(`${PREFIX}/`)) return;
   const method = req.method ?? "GET";
 
@@ -814,7 +824,9 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
   // Parity with the legacy assertion routes: resolve/validate the write
   // contextGraphId against the caller's known graphs before any mutation, so a
   // bad/foreign id is a 400 here rather than an opaque 500 from the engine.
-  const writePreflightCallerAgentAddress = requestToken ? agent.resolveAgentByToken(requestToken) : undefined;
+  const writePreflightCallerAgentAddress = requestPrincipal.kind === 'agent'
+    ? requestPrincipal.agentAddress
+    : undefined;
   const writePreflightContextGraphOpts = {
     callerAgentAddress: writePreflightCallerAgentAddress,
     allowLocalExactFallback: !writePreflightCallerAgentAddress,

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -90,6 +90,7 @@ import {
   type NormalizedFinalizedPublishOptions,
 } from "../../finalized-publish-options.js";
 import { storageAckPeerIdsFromPublishResult } from "./storage-ack-peers.js";
+import { authenticatedAgentAddress } from '../../auth.js';
 
 const PREFIX = "/api/knowledge-assets";
 type FinalizedPublishResult = Awaited<
@@ -739,7 +740,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
     path,
     url,
     requestAgentAddress,
-    requestPrincipal,
+    authentication,
     emitMemoryGraphChanged,
   } = ctx;
   if (path !== PREFIX && !path.startsWith(`${PREFIX}/`)) return;
@@ -824,9 +825,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
   // Parity with the legacy assertion routes: resolve/validate the write
   // contextGraphId against the caller's known graphs before any mutation, so a
   // bad/foreign id is a 400 here rather than an opaque 500 from the engine.
-  const writePreflightCallerAgentAddress = requestPrincipal.kind === 'agent'
-    ? requestPrincipal.agentAddress
-    : undefined;
+  const writePreflightCallerAgentAddress = authenticatedAgentAddress(authentication);
   const writePreflightContextGraphOpts = {
     callerAgentAddress: writePreflightCallerAgentAddress,
     allowLocalExactFallback: !writePreflightCallerAgentAddress,

--- a/packages/cli/src/daemon/routes/local-agents.ts
+++ b/packages/cli/src/daemon/routes/local-agents.ts
@@ -402,7 +402,6 @@ export async function handleLocalAgentsRoutes(ctx: RequestContext): Promise<void
     apiPortRef,
     url,
     path,
-    requestToken,
     requestAgentAddress,
   } = ctx;
 

--- a/packages/cli/src/daemon/routes/local-llm.ts
+++ b/packages/cli/src/daemon/routes/local-llm.ts
@@ -6,6 +6,7 @@ import {
   DKG_LOCAL_LLM_UI_SESSION_ID,
 } from '../local-llm-service.js';
 import { createStoreQueryRequestLifecycle } from '../store-query-lifecycle.js';
+import { canAdministerNode } from '../../auth.js';
 
 export const LOCAL_LLM_CHAT_BODY_BYTES = 64 * 1024;
 export const LOCAL_LLM_MAX_MESSAGE_CHARS = 16_000;
@@ -29,7 +30,7 @@ function serviceErrorResponse(
 }
 
 function isNodeAdminCaller(ctx: RequestContext): boolean {
-  return ctx.requestAuthorization.nodeOperator;
+  return canAdministerNode(ctx.authentication);
 }
 
 async function readJsonObject(ctx: RequestContext): Promise<Record<string, unknown> | null> {

--- a/packages/cli/src/daemon/routes/local-llm.ts
+++ b/packages/cli/src/daemon/routes/local-llm.ts
@@ -29,7 +29,7 @@ function serviceErrorResponse(
 }
 
 function isNodeAdminCaller(ctx: RequestContext): boolean {
-  return ctx.requestPrincipal.kind === 'nodeOperator';
+  return ctx.requestAuthorization.nodeOperator;
 }
 
 async function readJsonObject(ctx: RequestContext): Promise<Record<string, unknown> | null> {

--- a/packages/cli/src/daemon/routes/local-llm.ts
+++ b/packages/cli/src/daemon/routes/local-llm.ts
@@ -29,12 +29,7 @@ function serviceErrorResponse(
 }
 
 function isNodeAdminCaller(ctx: RequestContext): boolean {
-  if (ctx.config.auth?.enabled === false) return true;
-  return Boolean(
-    ctx.requestToken
-    && ctx.validTokens.has(ctx.requestToken)
-    && !ctx.agent.resolveAgentByToken(ctx.requestToken),
-  );
+  return ctx.requestPrincipal.kind === 'nodeOperator';
 }
 
 async function readJsonObject(ctx: RequestContext): Promise<Record<string, unknown> | null> {

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -123,7 +123,7 @@ import {
   type DurableCatchupLegState,
   type DurableLegDiagnostics,
 } from '../../catchup-runner.js';
-import { loadTokens, httpAuthGuard } from '../../auth.js';
+import { authenticatedAgentAddress, loadTokens, httpAuthGuard } from '../../auth.js';
 import { recordAssertionActivity } from '../activity-notification.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
 import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown, extractWithLlm } from '../../extraction/index.js';
@@ -510,13 +510,11 @@ export async function handleMemoryRoutes(ctx: RequestContext): Promise<void> {
     url,
     path,
     requestAgentAddress,
-    requestPrincipal,
+    authentication,
     emitMemoryGraphChanged,
     emitNotification,
   } = ctx;
-  const writePreflightCallerAgentAddress = requestPrincipal.kind === 'agent'
-    ? requestPrincipal.agentAddress
-    : undefined;
+  const writePreflightCallerAgentAddress = authenticatedAgentAddress(authentication);
   const writePreflightContextGraphOpts = {
     callerAgentAddress: writePreflightCallerAgentAddress,
     allowLocalExactFallback: !writePreflightCallerAgentAddress,

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -509,13 +509,13 @@ export async function handleMemoryRoutes(ctx: RequestContext): Promise<void> {
     apiPortRef,
     url,
     path,
-    requestToken,
     requestAgentAddress,
+    requestPrincipal,
     emitMemoryGraphChanged,
     emitNotification,
   } = ctx;
-  const writePreflightCallerAgentAddress = requestToken
-    ? agent.resolveAgentByToken(requestToken)
+  const writePreflightCallerAgentAddress = requestPrincipal.kind === 'agent'
+    ? requestPrincipal.agentAddress
     : undefined;
   const writePreflightContextGraphOpts = {
     callerAgentAddress: writePreflightCallerAgentAddress,

--- a/packages/cli/src/daemon/routes/notifications.ts
+++ b/packages/cli/src/daemon/routes/notifications.ts
@@ -52,7 +52,7 @@ function resolveScopedCaller(ctx: RequestContext): string | undefined {
   // anonymous loopback caller the node default agent's feed). When auth is
   // enabled, httpAuthGuard already 401s tokenless requests before dispatch, so
   // this only guards the loopback-no-auth case.
-  if (!ctx.requestToken) return undefined;
+  if (!ctx.authentication.acceptedToken) return undefined;
   // A token IS present (valid). Resolve it to the caller's agent: a per-agent
   // delegation token → that agent; the node's own API token (the owner's
   // normal UI token, which is NOT in the per-agent index → resolveAgentByToken
@@ -60,8 +60,9 @@ function resolveScopedCaller(ctx: RequestContext): string | undefined {
   // default for a present node token is REQUIRED: the original B1 fix
   // over-corrected by failing closed for it too, so the owner saw "Verifying
   // access…" on their own node.
-  const resolved = ctx.agent.resolveAgentByToken(ctx.requestToken)
-    ?? ctx.agent.getDefaultAgentAddress();
+  const resolved = ctx.authentication.principal.kind === 'agent'
+    ? ctx.authentication.principal.agentAddress
+    : ctx.agent.getDefaultAgentAddress();
   return addressFromAgentDid(resolved);
 }
 

--- a/packages/cli/src/daemon/routes/openclaw.ts
+++ b/packages/cli/src/daemon/routes/openclaw.ts
@@ -448,7 +448,6 @@ export async function handleOpenclawRoutes(ctx: RequestContext): Promise<void> {
     apiPortRef,
     url,
     path,
-    requestToken,
     requestAgentAddress,
   } = ctx;
 

--- a/packages/cli/src/daemon/routes/operational-wallets.ts
+++ b/packages/cli/src/daemon/routes/operational-wallets.ts
@@ -89,7 +89,7 @@ function respondKeyError(res: ServerResponse, err: unknown, address: string): vo
 }
 
 export async function handleOperationalWalletRoutes(ctx: RequestContext): Promise<void> {
-  const { req, res, agent, path, opWallets, requestPrincipal } = ctx;
+  const { req, res, agent, path, opWallets, requestAuthorization } = ctx;
 
   if (!path.startsWith('/api/operational-wallets')) return;
 
@@ -99,7 +99,7 @@ export async function handleOperationalWalletRoutes(ctx: RequestContext): Promis
   // identity is an operator action: require a node-level admin token, not a
   // per-agent (dkg_at_) token (which the global guard would otherwise accept).
   // Mirrors isNodeAdminCaller in context-graph.ts. Reads are not gated here.
-  const isNodeAdmin = (): boolean => requestPrincipal.kind === 'nodeOperator';
+  const isNodeAdmin = (): boolean => requestAuthorization.nodeOperator;
   const requireNodeAdmin = (): boolean => {
     if (isNodeAdmin()) return true;
     jsonResponse(res, 403, {

--- a/packages/cli/src/daemon/routes/operational-wallets.ts
+++ b/packages/cli/src/daemon/routes/operational-wallets.ts
@@ -89,7 +89,7 @@ function respondKeyError(res: ServerResponse, err: unknown, address: string): vo
 }
 
 export async function handleOperationalWalletRoutes(ctx: RequestContext): Promise<void> {
-  const { req, res, agent, path, opWallets, config, requestToken, validTokens } = ctx;
+  const { req, res, agent, path, opWallets, requestPrincipal } = ctx;
 
   if (!path.startsWith('/api/operational-wallets')) return;
 
@@ -99,10 +99,7 @@ export async function handleOperationalWalletRoutes(ctx: RequestContext): Promis
   // identity is an operator action: require a node-level admin token, not a
   // per-agent (dkg_at_) token (which the global guard would otherwise accept).
   // Mirrors isNodeAdminCaller in context-graph.ts. Reads are not gated here.
-  const authEnabled = config.auth?.enabled !== false;
-  const isNodeAdmin = (): boolean =>
-    !authEnabled ||
-    (!!requestToken && validTokens.has(requestToken) && !agent.resolveAgentByToken(requestToken));
+  const isNodeAdmin = (): boolean => requestPrincipal.kind === 'nodeOperator';
   const requireNodeAdmin = (): boolean => {
     if (isNodeAdmin()) return true;
     jsonResponse(res, 403, {

--- a/packages/cli/src/daemon/routes/operational-wallets.ts
+++ b/packages/cli/src/daemon/routes/operational-wallets.ts
@@ -19,6 +19,7 @@ import { ethers } from 'ethers';
 import { jsonResponse, readBody, SMALL_BODY_BYTES, respondIfChainRpcTransportError } from '../http-utils.js';
 import type { ServerResponse } from 'node:http';
 import type { RequestContext } from './context.js';
+import { canAdministerNode } from '../../auth.js';
 
 const FEATURE_UNAVAILABLE_503 = {
   error:
@@ -89,7 +90,7 @@ function respondKeyError(res: ServerResponse, err: unknown, address: string): vo
 }
 
 export async function handleOperationalWalletRoutes(ctx: RequestContext): Promise<void> {
-  const { req, res, agent, path, opWallets, requestAuthorization } = ctx;
+  const { req, res, agent, path, opWallets, authentication } = ctx;
 
   if (!path.startsWith('/api/operational-wallets')) return;
 
@@ -99,7 +100,7 @@ export async function handleOperationalWalletRoutes(ctx: RequestContext): Promis
   // identity is an operator action: require a node-level admin token, not a
   // per-agent (dkg_at_) token (which the global guard would otherwise accept).
   // Mirrors isNodeAdminCaller in context-graph.ts. Reads are not gated here.
-  const isNodeAdmin = (): boolean => requestAuthorization.nodeOperator;
+  const isNodeAdmin = (): boolean => canAdministerNode(authentication);
   const requireNodeAdmin = (): boolean => {
     if (isNodeAdmin()) return true;
     jsonResponse(res, 403, {

--- a/packages/cli/src/daemon/routes/pca.ts
+++ b/packages/cli/src/daemon/routes/pca.ts
@@ -393,7 +393,7 @@ function serializeAccountInfo(
 }
 
 export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
-  const { req, res, agent, path, config, requestToken, validTokens, opWallets } = ctx;
+  const { req, res, agent, path, requestPrincipal, opWallets } = ctx;
 
   if (!path.startsWith('/api/pca')) return;
 
@@ -415,10 +415,7 @@ export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
   // or attaching a publishing agent are operator actions: require a node-level
   // admin token, not a per-agent (dkg_at_) token. Mirrors isNodeAdminCaller in
   // context-graph.ts. Reads and the permissionless `settle` are NOT gated.
-  const authEnabled = config.auth?.enabled !== false;
-  const isNodeAdmin = (): boolean =>
-    !authEnabled ||
-    (!!requestToken && validTokens.has(requestToken) && !agent.resolveAgentByToken(requestToken));
+  const isNodeAdmin = (): boolean => requestPrincipal.kind === 'nodeOperator';
   const requireNodeAdmin = (): boolean => {
     if (isNodeAdmin()) return true;
     jsonResponse(res, 403, {

--- a/packages/cli/src/daemon/routes/pca.ts
+++ b/packages/cli/src/daemon/routes/pca.ts
@@ -393,7 +393,7 @@ function serializeAccountInfo(
 }
 
 export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
-  const { req, res, agent, path, requestPrincipal, opWallets } = ctx;
+  const { req, res, agent, path, requestAuthorization, opWallets } = ctx;
 
   if (!path.startsWith('/api/pca')) return;
 
@@ -415,7 +415,7 @@ export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
   // or attaching a publishing agent are operator actions: require a node-level
   // admin token, not a per-agent (dkg_at_) token. Mirrors isNodeAdminCaller in
   // context-graph.ts. Reads and the permissionless `settle` are NOT gated.
-  const isNodeAdmin = (): boolean => requestPrincipal.kind === 'nodeOperator';
+  const isNodeAdmin = (): boolean => requestAuthorization.nodeOperator;
   const requireNodeAdmin = (): boolean => {
     if (isNodeAdmin()) return true;
     jsonResponse(res, 403, {

--- a/packages/cli/src/daemon/routes/pca.ts
+++ b/packages/cli/src/daemon/routes/pca.ts
@@ -19,6 +19,7 @@ import {
 import type { RequestContext } from './context.js';
 import { parseUint72Decimal } from '@origintrail-official/dkg-core';
 import { pcaConfirmationToWire, type RegisterPcaAgentResponse } from '../../pca-confirmation-wire.js';
+import { canAdministerNode } from '../../auth.js';
 
 const ZERO = '0x0000000000000000000000000000000000000000';
 const PCA_RPC_PROXY_PATH = '/api/pca/rpc';
@@ -393,7 +394,7 @@ function serializeAccountInfo(
 }
 
 export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
-  const { req, res, agent, path, requestAuthorization, opWallets } = ctx;
+  const { req, res, agent, path, authentication, opWallets } = ctx;
 
   if (!path.startsWith('/api/pca')) return;
 
@@ -415,7 +416,7 @@ export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
   // or attaching a publishing agent are operator actions: require a node-level
   // admin token, not a per-agent (dkg_at_) token. Mirrors isNodeAdminCaller in
   // context-graph.ts. Reads and the permissionless `settle` are NOT gated.
-  const isNodeAdmin = (): boolean => requestAuthorization.nodeOperator;
+  const isNodeAdmin = (): boolean => canAdministerNode(authentication);
   const requireNodeAdmin = (): boolean => {
     if (isNodeAdmin()) return true;
     jsonResponse(res, 403, {

--- a/packages/cli/src/daemon/routes/plugins.ts
+++ b/packages/cli/src/daemon/routes/plugins.ts
@@ -12,6 +12,7 @@ function responseStarted(res: RequestContext['res']): boolean {
 export async function handlePluginRoutes(ctx: RequestContext): Promise<void> {
   const pluginContext: PluginRequestContext = {
     ...ctx,
+    requestToken: ctx.actor.authentication.acceptedToken,
     publisherRuntime: ctx.publisherState.runtime,
     publisherAvailability: ctx.publisherState.availability,
   };

--- a/packages/cli/src/daemon/routes/publisher.ts
+++ b/packages/cli/src/daemon/routes/publisher.ts
@@ -65,7 +65,12 @@ import {
   isSkolemizedUri,
   SAFE_JOB_ID_ERROR,
 } from '@origintrail-official/dkg-publisher';
-import type { AsyncPreparedPublishPayload, LiftJobRetryProjection, PersistedLiftJob } from '@origintrail-official/dkg-publisher';
+import type {
+  AsyncPreparedPublishPayload,
+  LiftJobRetryProjection,
+  PendingTransactionClearOverride,
+  PersistedLiftJob,
+} from '@origintrail-official/dkg-publisher';
 import {
   DashboardDB,
   MetricsCollector,
@@ -504,6 +509,7 @@ export async function handlePublisherRoutes(ctx: RequestContext): Promise<void> 
     path,
     requestToken,
     requestAgentAddress,
+    requestPrincipal,
   } = ctx;
 
 
@@ -674,21 +680,32 @@ export async function handlePublisherRoutes(ctx: RequestContext): Promise<void> 
     // query before `clearTerminalJob`'s safe-id guard ran, and decided ownership outside the claim
     // lock the clear then takes. Validation, the ownership decision and the delete now happen on
     // one record behind one boundary.
-    const isNodeOperatorCaller = config.auth?.enabled === false
-      || (
-        !!requestToken
-        && validTokens.has(requestToken)
-        && !agent.resolveAgentByToken(requestToken)
-      );
+    let pendingTransactionOverride: PendingTransactionClearOverride | undefined;
+    if (parsed.allowPendingTransaction === true) {
+      switch (requestPrincipal.kind) {
+        case 'agent':
+          pendingTransactionOverride = {
+            kind: 'agent',
+            requestedBy: requestPrincipal.agentAddress,
+          };
+          break;
+        case 'nodeOperator':
+          pendingTransactionOverride = { kind: 'nodeOperator' };
+          break;
+        case 'anonymous':
+          break;
+        default: {
+          const unhandledPrincipal: never = requestPrincipal;
+          return unhandledPrincipal;
+        }
+      }
+    }
     return respondTerminalClearOutcome(
       res,
-      await publisherControl.clearTerminalJob(jobId, parsed.allowPendingTransaction === true
-        ? {
-          pendingTransactionOverride: isNodeOperatorCaller
-            ? { requestedByNodeOperator: true }
-            : { requestedBy: requestAgentAddress },
-        }
-        : {}),
+      await publisherControl.clearTerminalJob(
+        jobId,
+        pendingTransactionOverride ? { pendingTransactionOverride } : {},
+      ),
       jobId,
     );
   }

--- a/packages/cli/src/daemon/routes/publisher.ts
+++ b/packages/cli/src/daemon/routes/publisher.ts
@@ -509,6 +509,7 @@ export async function handlePublisherRoutes(ctx: RequestContext): Promise<void> 
     path,
     requestToken,
     requestAgentAddress,
+    requestAuthorization,
     requestPrincipal,
   } = ctx;
 
@@ -680,10 +681,17 @@ export async function handlePublisherRoutes(ctx: RequestContext): Promise<void> 
     // query before `clearTerminalJob`'s safe-id guard ran, and decided ownership outside the claim
     // lock the clear then takes. Validation, the ownership decision and the delete now happen on
     // one record behind one boundary.
-    const pendingTransactionOverride: PendingTransactionClearOverride | undefined =
-      parsed.allowPendingTransaction === true && requestPrincipal.kind !== 'anonymous'
-        ? requestPrincipal
-        : undefined;
+    let pendingTransactionOverride: PendingTransactionClearOverride | undefined;
+    if (parsed.allowPendingTransaction === true) {
+      if (requestAuthorization.nodeOperator) {
+        pendingTransactionOverride = { kind: 'nodeOperator' };
+      } else if (requestPrincipal.kind === 'agent') {
+        pendingTransactionOverride = {
+          kind: 'agent',
+          agentAddress: requestPrincipal.agentAddress,
+        };
+      }
+    }
     return respondTerminalClearOutcome(
       res,
       await publisherControl.clearTerminalJob(

--- a/packages/cli/src/daemon/routes/publisher.ts
+++ b/packages/cli/src/daemon/routes/publisher.ts
@@ -117,7 +117,7 @@ import {
 } from '../../config.js';
 import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type AsyncPublisherAvailability, type PublisherRuntime } from '../../publisher-runner.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../../catchup-runner.js';
-import { loadTokens, httpAuthGuard, extractBearerToken } from '../../auth.js';
+import { authenticatedAgentAddress, canAdministerNode, loadTokens, httpAuthGuard, extractBearerToken } from '../../auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
 import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown, extractWithLlm } from '../../extraction/index.js';
 import {
@@ -507,10 +507,8 @@ export async function handlePublisherRoutes(ctx: RequestContext): Promise<void> 
     apiPortRef,
     url,
     path,
-    requestToken,
+    authentication,
     requestAgentAddress,
-    requestAuthorization,
-    requestPrincipal,
   } = ctx;
 
 
@@ -683,13 +681,16 @@ export async function handlePublisherRoutes(ctx: RequestContext): Promise<void> 
     // one record behind one boundary.
     let pendingTransactionOverride: PendingTransactionClearOverride | undefined;
     if (parsed.allowPendingTransaction === true) {
-      if (requestAuthorization.nodeOperator) {
+      if (canAdministerNode(authentication)) {
         pendingTransactionOverride = { kind: 'nodeOperator' };
-      } else if (requestPrincipal.kind === 'agent') {
-        pendingTransactionOverride = {
-          kind: 'agent',
-          agentAddress: requestPrincipal.agentAddress,
-        };
+      } else {
+        const agentAddress = authenticatedAgentAddress(authentication);
+        if (agentAddress) {
+          pendingTransactionOverride = {
+            kind: 'agent',
+            agentAddress,
+          };
+        }
       }
     }
     return respondTerminalClearOutcome(

--- a/packages/cli/src/daemon/routes/publisher.ts
+++ b/packages/cli/src/daemon/routes/publisher.ts
@@ -117,7 +117,7 @@ import {
 } from '../../config.js';
 import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type AsyncPublisherAvailability, type PublisherRuntime } from '../../publisher-runner.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../../catchup-runner.js';
-import { authenticatedAgentAddress, canAdministerNode, loadTokens, httpAuthGuard, extractBearerToken } from '../../auth.js';
+import { authenticatedAgentAddress, canAdministerNode, loadTokens, httpAuthGuard } from '../../auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
 import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown, extractWithLlm } from '../../extraction/index.js';
 import {
@@ -331,6 +331,7 @@ import {
 } from '../local-agents.js';
 
 import type { RequestContext } from './context.js';
+import { actorFromRequestContext } from './context.js';
 
 
 interface PublisherLifecycleFacts {
@@ -507,9 +508,12 @@ export async function handlePublisherRoutes(ctx: RequestContext): Promise<void> 
     apiPortRef,
     url,
     path,
-    authentication,
-    requestAgentAddress,
   } = ctx;
+  const actor = actorFromRequestContext(ctx);
+  const {
+    authentication,
+    effectiveAgentAddress: requestAgentAddress,
+  } = actor;
 
 
   // GET /api/publisher/jobs?status=...

--- a/packages/cli/src/daemon/routes/publisher.ts
+++ b/packages/cli/src/daemon/routes/publisher.ts
@@ -680,26 +680,10 @@ export async function handlePublisherRoutes(ctx: RequestContext): Promise<void> 
     // query before `clearTerminalJob`'s safe-id guard ran, and decided ownership outside the claim
     // lock the clear then takes. Validation, the ownership decision and the delete now happen on
     // one record behind one boundary.
-    let pendingTransactionOverride: PendingTransactionClearOverride | undefined;
-    if (parsed.allowPendingTransaction === true) {
-      switch (requestPrincipal.kind) {
-        case 'agent':
-          pendingTransactionOverride = {
-            kind: 'agent',
-            requestedBy: requestPrincipal.agentAddress,
-          };
-          break;
-        case 'nodeOperator':
-          pendingTransactionOverride = { kind: 'nodeOperator' };
-          break;
-        case 'anonymous':
-          break;
-        default: {
-          const unhandledPrincipal: never = requestPrincipal;
-          return unhandledPrincipal;
-        }
-      }
-    }
+    const pendingTransactionOverride: PendingTransactionClearOverride | undefined =
+      parsed.allowPendingTransaction === true && requestPrincipal.kind !== 'anonymous'
+        ? requestPrincipal
+        : undefined;
     return respondTerminalClearOutcome(
       res,
       await publisherControl.clearTerminalJob(

--- a/packages/cli/src/daemon/routes/publisher.ts
+++ b/packages/cli/src/daemon/routes/publisher.ts
@@ -666,18 +666,28 @@ export async function handlePublisherRoutes(ctx: RequestContext): Promise<void> 
       return jsonResponse(res, 400, { outcome: "rejected", reason: "malformed", error: "Missing jobId" });
     }
     // GH#2270 follow-up (🔴 3823952704, 🔴 3824098476) — clearing a job whose transaction may
-    // still land is a DESTRUCTIVE override, and this route is open to every registered agent token
-    // with no ownership check of its own. The route therefore states WHO is asking and WHAT they
-    // asked for; it does not look the job up itself.
+    // still land is a DESTRUCTIVE override, and this route is open to both agent and node tokens.
+    // The route authenticates WHICH principal tier is asking and WHAT it asked for; it does not
+    // look the job up or decide agent ownership itself.
     //
     // That matters: an earlier version read the job here, which put an unvalidated jobId into a
     // query before `clearTerminalJob`'s safe-id guard ran, and decided ownership outside the claim
     // lock the clear then takes. Validation, the ownership decision and the delete now happen on
     // one record behind one boundary.
+    const isNodeOperatorCaller = config.auth?.enabled === false
+      || (
+        !!requestToken
+        && validTokens.has(requestToken)
+        && !agent.resolveAgentByToken(requestToken)
+      );
     return respondTerminalClearOutcome(
       res,
       await publisherControl.clearTerminalJob(jobId, parsed.allowPendingTransaction === true
-        ? { pendingTransactionOverride: { requestedBy: requestAgentAddress } }
+        ? {
+          pendingTransactionOverride: isNodeOperatorCaller
+            ? { requestedByNodeOperator: true }
+            : { requestedBy: requestAgentAddress },
+        }
         : {}),
       jobId,
     );

--- a/packages/cli/src/daemon/routes/query-catalog.ts
+++ b/packages/cli/src/daemon/routes/query-catalog.ts
@@ -45,6 +45,7 @@ export async function handleQueryCatalogRoutes(ctx: RequestContext): Promise<boo
     res,
     agent,
     path,
+    requestAuthorization,
     requestPrincipal,
     emitMemoryGraphChanged,
   } = ctx;
@@ -159,7 +160,7 @@ export async function handleQueryCatalogRoutes(ctx: RequestContext): Promise<boo
     const callerAgentAddress = requestPrincipal.kind === 'agent'
       ? requestPrincipal.agentAddress
       : undefined;
-    const isNodeAdmin = requestPrincipal.kind === 'nodeOperator';
+    const isNodeAdmin = requestAuthorization.nodeOperator;
     if (
       !isNodeAdmin
       && !(await agent.canReadContextGraph(contextGraphId, { callerAgentAddress }))

--- a/packages/cli/src/daemon/routes/query-catalog.ts
+++ b/packages/cli/src/daemon/routes/query-catalog.ts
@@ -30,6 +30,7 @@ import {
   readContextGraphQueryCatalogBindings,
   writeContextGraphQueryCatalog,
 } from '../query-catalog-service.js';
+import { authenticatedAgentAddress, canAdministerNode } from '../../auth.js';
 
 const QUERY_CATALOG_RESULT_LIMIT = 5_000;
 const QUERY_CATALOG_RESPONSE_BYTES = 1024 * 1024;
@@ -45,8 +46,7 @@ export async function handleQueryCatalogRoutes(ctx: RequestContext): Promise<boo
     res,
     agent,
     path,
-    requestAuthorization,
-    requestPrincipal,
+    authentication,
     emitMemoryGraphChanged,
   } = ctx;
 
@@ -62,9 +62,7 @@ export async function handleQueryCatalogRoutes(ctx: RequestContext): Promise<boo
       return true;
     }
 
-    const callerAgentAddress = requestPrincipal.kind === 'agent'
-      ? requestPrincipal.agentAddress
-      : undefined;
+    const callerAgentAddress = authenticatedAgentAddress(authentication);
     const resolvedContextGraphId = await resolveRequiredWriteContextGraphId(
       agent,
       parsed.contextGraphId,
@@ -157,10 +155,8 @@ export async function handleQueryCatalogRoutes(ctx: RequestContext): Promise<boo
     const contextGraphId = parsed.contextGraphId;
     if (!validateRequiredContextGraphId(contextGraphId, res)) return true;
 
-    const callerAgentAddress = requestPrincipal.kind === 'agent'
-      ? requestPrincipal.agentAddress
-      : undefined;
-    const isNodeAdmin = requestAuthorization.nodeOperator;
+    const callerAgentAddress = authenticatedAgentAddress(authentication);
+    const isNodeAdmin = canAdministerNode(authentication);
     if (
       !isNodeAdmin
       && !(await agent.canReadContextGraph(contextGraphId, { callerAgentAddress }))

--- a/packages/cli/src/daemon/routes/query-catalog.ts
+++ b/packages/cli/src/daemon/routes/query-catalog.ts
@@ -30,7 +30,7 @@ import {
   readContextGraphQueryCatalogBindings,
   writeContextGraphQueryCatalog,
 } from '../query-catalog-service.js';
-import { authenticatedAgentAddress, canAdministerNode } from '../../auth.js';
+import { authenticatedAgentAddress } from '../../auth.js';
 
 const QUERY_CATALOG_RESULT_LIMIT = 5_000;
 const QUERY_CATALOG_RESPONSE_BYTES = 1024 * 1024;
@@ -156,7 +156,7 @@ export async function handleQueryCatalogRoutes(ctx: RequestContext): Promise<boo
     if (!validateRequiredContextGraphId(contextGraphId, res)) return true;
 
     const callerAgentAddress = authenticatedAgentAddress(authentication);
-    const isNodeAdmin = canAdministerNode(authentication);
+    const isNodeAdmin = authentication.principal.kind === 'nodeOperator';
     if (
       !isNodeAdmin
       && !(await agent.canReadContextGraph(contextGraphId, { callerAgentAddress }))

--- a/packages/cli/src/daemon/routes/query-catalog.ts
+++ b/packages/cli/src/daemon/routes/query-catalog.ts
@@ -45,8 +45,7 @@ export async function handleQueryCatalogRoutes(ctx: RequestContext): Promise<boo
     res,
     agent,
     path,
-    requestToken,
-    validTokens,
+    requestPrincipal,
     emitMemoryGraphChanged,
   } = ctx;
 
@@ -62,8 +61,8 @@ export async function handleQueryCatalogRoutes(ctx: RequestContext): Promise<boo
       return true;
     }
 
-    const callerAgentAddress = requestToken
-      ? agent.resolveAgentByToken(requestToken)
+    const callerAgentAddress = requestPrincipal.kind === 'agent'
+      ? requestPrincipal.agentAddress
       : undefined;
     const resolvedContextGraphId = await resolveRequiredWriteContextGraphId(
       agent,
@@ -157,12 +156,10 @@ export async function handleQueryCatalogRoutes(ctx: RequestContext): Promise<boo
     const contextGraphId = parsed.contextGraphId;
     if (!validateRequiredContextGraphId(contextGraphId, res)) return true;
 
-    const callerAgentAddress = requestToken
-      ? agent.resolveAgentByToken(requestToken)
+    const callerAgentAddress = requestPrincipal.kind === 'agent'
+      ? requestPrincipal.agentAddress
       : undefined;
-    const isNodeAdmin = !!requestToken
-      && validTokens.has(requestToken)
-      && callerAgentAddress === undefined;
+    const isNodeAdmin = requestPrincipal.kind === 'nodeOperator';
     if (
       !isNodeAdmin
       && !(await agent.canReadContextGraph(contextGraphId, { callerAgentAddress }))

--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -437,13 +437,13 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
     assertionImportLocks,
     vectorStore,
     embeddingProvider,
-    validTokens,
     apiHost,
     apiPortRef,
     url,
     path,
-    requestToken,
     requestAgentAddress,
+    requestCredentialAuthenticated,
+    requestPrincipal,
     emitMemoryGraphChanged,
   } = ctx;
 
@@ -550,63 +550,16 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
       // in the body). `resolveAgentByToken` returns `undefined` for
       // node-level tokens, so only genuine agent-scoped identities
       // ever reach the A-1 guard.
-      const callerAgentAddress = requestToken
-        ? agent.resolveAgentByToken(requestToken)
+      const callerAgentAddress = requestPrincipal.kind === 'agent'
+        ? requestPrincipal.agentAddress
         : undefined;
-      // A-1 follow-up review (iteration 2): close the auth-disabled WM
-      // hole WITHOUT regressing existing node-token clients.
-      //
-      // When we reach this line with `callerAgentAddress === undefined`,
-      // the caller is one of:
-      //
-      //   (a) node-level admin (`~/.dkg/auth.token`, a token present in
-      //       `validTokens`). Admin is already trusted to run as any
-      //       local agent — `packages/adapter-openclaw` relies on this
-      //       by passing a session-specific `agentAddress` alongside the
-      //       admin token. Keep the legacy "skip the A-1 guard" here.
-      //
-      //   (b) unauthenticated (auth disabled at daemon level, OR no
-      //       Authorization header, OR a bogus / mismatched bearer that
-      //       the auth middleware never validated because `authEnabled`
-      //       is false). This is the hole Codex flagged: a raw
-      //       `Authorization: Bearer junk` used to set `requestToken`
-      //       truthy, sliding past a `!requestToken` check and letting
-      //       foreign WM reads through.
-      //
-      //   (c) auth-enabled + rejected — we never reach this line
-      //       because `httpAuthGuard` has already 401'd the request.
-      //
-      // Gate the 403 on "not a known admin token" (i.e. the caller is
-      // not in `validTokens`), which fails closed for (b) regardless of
-      // what garbage they put in the header, and leaves (a) alone.
-      //
-      // Codex PR #242 iter-8: `validTokens` contains BOTH the
-      // node-level admin token (`~/.dkg/auth.token`) AND any
-      // per-agent tokens the node has issued. Treating every
-      // validToken as "admin" means an authenticated agent could
-      // use its OWN token to skip the A-1 guard and read another
-      // local agent's WM via `agentAddress`. Restrict the admin
-      // bypass to tokens that are NOT bound to a specific agent
-      // (`resolveAgentByToken(token) === undefined`), which is the
-      // current signal for "node-level / admin-scoped".
-      //
-      // Codex PR #242 iter-8 re-review: the A-1 fallback 403 must
-      // also NOT fire for authenticated agent callers. An agent
-      // querying its OWN WM (`callerAgentAddress === agentAddress`)
-      // was previously being rejected here unless the target happened
-      // to be the node default / peerId alias, and genuine cross-agent
-      // reads were surfacing as a 403 (leaking existence) instead of
-      // the intended silent empty-per-kind result from
-      // `DKGAgent.query`. Only gate the self-alias fallback when the
-      // caller has no recognised identity at all — neither a
-      // node-level admin token nor an agent-scoped bearer. Authenticated
-      // agent callers flow straight into `agent.query()` below, which
-      // enforces the isolation invariant by returning an empty-per-kind
-      // result for any target that is not `callerAgentAddress`.
+      // The authentication boundary distinguishes agent, node-operator, and anonymous callers.
+      // Node operators retain the cross-agent OpenClaw use case; authenticated agents flow into
+      // DKGAgent.query's isolation check; only anonymous working-memory requests need this local
+      // self-alias fallback gate.
       const isAdminToken =
-        !!requestToken
-        && validTokens.has(requestToken)
-        && callerAgentAddress === undefined;
+        requestPrincipal.kind === 'nodeOperator'
+        && requestCredentialAuthenticated;
       const hasRecognisedIdentity = isAdminToken || callerAgentAddress !== undefined;
       if (
         !hasRecognisedIdentity &&

--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -442,7 +442,7 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
     url,
     path,
     requestAgentAddress,
-    requestCredentialAuthenticated,
+    requestAuthorization,
     requestPrincipal,
     emitMemoryGraphChanged,
   } = ctx;
@@ -558,8 +558,8 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
       // DKGAgent.query's isolation check; only anonymous working-memory requests need this local
       // self-alias fallback gate.
       const isAdminToken =
-        requestPrincipal.kind === 'nodeOperator'
-        && requestCredentialAuthenticated;
+        requestAuthorization.nodeOperator
+        && requestPrincipal.kind === 'nodeOperator';
       const hasRecognisedIdentity = isAdminToken || callerAgentAddress !== undefined;
       if (
         !hasRecognisedIdentity &&

--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -117,7 +117,7 @@ export {
 export type { ApiQueryPriority } from '../api-query-priority.js';
 import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type PublisherRuntime } from '../../publisher-runner.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../../catchup-runner.js';
-import { loadTokens, httpAuthGuard, extractBearerToken } from '../../auth.js';
+import { authenticatedAgentAddress, canAdministerNode, loadTokens, httpAuthGuard, extractBearerToken } from '../../auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
 import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown, extractWithLlm } from '../../extraction/index.js';
 import {
@@ -442,8 +442,7 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
     url,
     path,
     requestAgentAddress,
-    requestAuthorization,
-    requestPrincipal,
+    authentication,
     emitMemoryGraphChanged,
   } = ctx;
 
@@ -550,16 +549,14 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
       // in the body). `resolveAgentByToken` returns `undefined` for
       // node-level tokens, so only genuine agent-scoped identities
       // ever reach the A-1 guard.
-      const callerAgentAddress = requestPrincipal.kind === 'agent'
-        ? requestPrincipal.agentAddress
-        : undefined;
+      const callerAgentAddress = authenticatedAgentAddress(authentication);
       // The authentication boundary distinguishes agent, node-operator, and anonymous callers.
       // Node operators retain the cross-agent OpenClaw use case; authenticated agents flow into
       // DKGAgent.query's isolation check; only anonymous working-memory requests need this local
       // self-alias fallback gate.
       const isAdminToken =
-        requestAuthorization.nodeOperator
-        && requestPrincipal.kind === 'nodeOperator';
+        canAdministerNode(authentication)
+        && authentication.principal.kind === 'nodeOperator';
       const hasRecognisedIdentity = isAdminToken || callerAgentAddress !== undefined;
       if (
         !hasRecognisedIdentity &&

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -629,7 +629,6 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
     admission,
     url,
     path,
-    requestToken,
     requestAgentAddress,
   } = ctx;
 

--- a/packages/cli/test/_helpers/request-authentication.ts
+++ b/packages/cli/test/_helpers/request-authentication.ts
@@ -36,8 +36,8 @@ export function requestAuthentication(input: FixtureAuthentication): AllowedHttp
     mode: input.mode ?? 'authenticated',
     presentedToken: token,
     acceptedToken: token,
-    ...(input.kind === 'agent'
-      ? { resolveAgentByToken: () => input.agentAddress }
-      : {}),
+    resolveAgentByToken: input.kind === 'agent'
+      ? () => input.agentAddress
+      : () => undefined,
   });
 }

--- a/packages/cli/test/_helpers/request-authentication.ts
+++ b/packages/cli/test/_helpers/request-authentication.ts
@@ -1,0 +1,43 @@
+import {
+  createAllowedHttpAuthentication,
+  type AllowedHttpAuthentication,
+} from '../../src/auth.js';
+
+type FixtureAuthentication =
+  | {
+      readonly kind: 'agent';
+      readonly agentAddress: string;
+      readonly mode?: AllowedHttpAuthentication['mode'];
+      readonly token?: string;
+    }
+  | {
+      readonly kind: 'nodeOperator';
+      readonly mode?: AllowedHttpAuthentication['mode'];
+      readonly token?: string;
+    }
+  | {
+      readonly kind: 'anonymous';
+      readonly mode?: 'disabled' | 'public';
+      readonly presentedToken?: string;
+    };
+
+/** Correlated RequestContext authentication fixture built through the production factory. */
+export function requestAuthentication(input: FixtureAuthentication): AllowedHttpAuthentication {
+  if (input.kind === 'anonymous') {
+    return createAllowedHttpAuthentication({
+      mode: input.mode ?? 'public',
+      presentedToken: input.presentedToken,
+    });
+  }
+  const token = input.token ?? (
+    input.kind === 'agent' ? 'fixture-agent-token' : 'fixture-node-operator-token'
+  );
+  return createAllowedHttpAuthentication({
+    mode: input.mode ?? 'authenticated',
+    presentedToken: token,
+    acceptedToken: token,
+    ...(input.kind === 'agent'
+      ? { resolveAgentByToken: () => input.agentAddress }
+      : {}),
+  });
+}

--- a/packages/cli/test/agent-connect-routes.test.ts
+++ b/packages/cli/test/agent-connect-routes.test.ts
@@ -29,6 +29,7 @@ function runConnect(agent: any, body: unknown) {
     validTokens: new Set<string>(),
     requestToken: undefined,
     requestAgentAddress: '',
+    requestPrincipal: { kind: 'nodeOperator' },
   } as unknown as RequestContext;
   return { res, done: handleAgentChatRoutes(ctx) };
 }

--- a/packages/cli/test/agent-connect-routes.test.ts
+++ b/packages/cli/test/agent-connect-routes.test.ts
@@ -30,6 +30,7 @@ function runConnect(agent: any, body: unknown) {
     requestToken: undefined,
     requestAgentAddress: '',
     requestPrincipal: { kind: 'nodeOperator' },
+    requestAuthorization: { nodeOperator: true },
   } as unknown as RequestContext;
   return { res, done: handleAgentChatRoutes(ctx) };
 }

--- a/packages/cli/test/agent-connect-routes.test.ts
+++ b/packages/cli/test/agent-connect-routes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { classifyAgentConnectError } from '../src/daemon/routes/agent-connect-error.js';
 import { handleAgentChatRoutes } from '../src/daemon/routes/agent-chat.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 function fakeRes() {
   const res: any = { statusCode: 0, body: '' };
@@ -27,10 +28,8 @@ function runConnect(agent: any, body: unknown) {
     path,
     url,
     validTokens: new Set<string>(),
-    requestToken: undefined,
     requestAgentAddress: '',
-    requestPrincipal: { kind: 'nodeOperator' },
-    requestAuthorization: { nodeOperator: true },
+    authentication: requestAuthentication({ kind: 'nodeOperator' }),
   } as unknown as RequestContext;
   return { res, done: handleAgentChatRoutes(ctx) };
 }

--- a/packages/cli/test/agent-encryption-key-routes.test.ts
+++ b/packages/cli/test/agent-encryption-key-routes.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect } from 'vitest';
 import { handleAgentChatRoutes } from '../src/daemon/routes/agent-chat.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 function fakeRes() {
   const res: any = { statusCode: 0, body: '' };
@@ -48,12 +49,10 @@ function runCtx(
     agent,
     path: url.pathname,
     url,
-    requestToken,
     requestAgentAddress,
-    requestPrincipal: tokenAgentAddress
-      ? { kind: 'agent', agentAddress: tokenAgentAddress }
-      : { kind: 'nodeOperator' },
-    requestAuthorization: { nodeOperator: !tokenAgentAddress },
+    authentication: tokenAgentAddress
+      ? requestAuthentication({ kind: 'agent', agentAddress: tokenAgentAddress, token: requestToken })
+      : requestAuthentication({ kind: 'nodeOperator', token: requestToken }),
     validTokens: new Set<string>(),
   } as unknown as RequestContext;
   return { res, done: handleAgentChatRoutes(ctx) };

--- a/packages/cli/test/agent-encryption-key-routes.test.ts
+++ b/packages/cli/test/agent-encryption-key-routes.test.ts
@@ -41,6 +41,7 @@ function runCtx(
   // sees the same bearer the test passed in.
   const requestToken = opts?.bearer;
   const requestAgentAddress = opts?.requestAgentAddress ?? '';
+  const tokenAgentAddress = requestToken ? agent.resolveAgentByToken(requestToken) : undefined;
   const ctx = {
     req: fakeReq(method, rawPath, opts),
     res,
@@ -49,6 +50,9 @@ function runCtx(
     url,
     requestToken,
     requestAgentAddress,
+    requestPrincipal: tokenAgentAddress
+      ? { kind: 'agent', agentAddress: tokenAgentAddress }
+      : { kind: 'nodeOperator' },
     validTokens: new Set<string>(),
   } as unknown as RequestContext;
   return { res, done: handleAgentChatRoutes(ctx) };

--- a/packages/cli/test/agent-encryption-key-routes.test.ts
+++ b/packages/cli/test/agent-encryption-key-routes.test.ts
@@ -53,6 +53,7 @@ function runCtx(
     requestPrincipal: tokenAgentAddress
       ? { kind: 'agent', agentAddress: tokenAgentAddress }
       : { kind: 'nodeOperator' },
+    requestAuthorization: { nodeOperator: !tokenAgentAddress },
     validTokens: new Set<string>(),
   } as unknown as RequestContext;
   return { res, done: handleAgentChatRoutes(ctx) };

--- a/packages/cli/test/agents-list-routes.test.ts
+++ b/packages/cli/test/agents-list-routes.test.ts
@@ -393,6 +393,7 @@ async function getAgents(agent: any, qs = '') {
     requestToken: undefined,
     requestAgentAddress: '',
     requestPrincipal: { kind: 'nodeOperator' },
+    requestAuthorization: { nodeOperator: true },
   } as unknown as RequestContext;
   await handleAgentChatRoutes(ctx);
   return { status: res.statusCode, body: JSON.parse(res.body) };

--- a/packages/cli/test/agents-list-routes.test.ts
+++ b/packages/cli/test/agents-list-routes.test.ts
@@ -5,6 +5,7 @@ import {
 } from '../src/daemon/routes/agents-list.js';
 import { handleAgentChatRoutes } from '../src/daemon/routes/agent-chat.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 import {
   discoveredAgentIdentityKey,
 } from '@origintrail-official/dkg-agent';
@@ -390,10 +391,8 @@ async function getAgents(agent: any, qs = '') {
     path,
     url,
     validTokens: new Set<string>(),
-    requestToken: undefined,
     requestAgentAddress: '',
-    requestPrincipal: { kind: 'nodeOperator' },
-    requestAuthorization: { nodeOperator: true },
+    authentication: requestAuthentication({ kind: 'nodeOperator' }),
   } as unknown as RequestContext;
   await handleAgentChatRoutes(ctx);
   return { status: res.statusCode, body: JSON.parse(res.body) };

--- a/packages/cli/test/agents-list-routes.test.ts
+++ b/packages/cli/test/agents-list-routes.test.ts
@@ -392,6 +392,7 @@ async function getAgents(agent: any, qs = '') {
     validTokens: new Set<string>(),
     requestToken: undefined,
     requestAgentAddress: '',
+    requestPrincipal: { kind: 'nodeOperator' },
   } as unknown as RequestContext;
   await handleAgentChatRoutes(ctx);
   return { status: res.statusCode, body: JSON.parse(res.body) };

--- a/packages/cli/test/async-promote-queue-e2e.test.ts
+++ b/packages/cli/test/async-promote-queue-e2e.test.ts
@@ -43,6 +43,7 @@ import {
   type PromoteRequest,
 } from '@origintrail-official/dkg-publisher';
 import { handleKnowledgeAssetsRoutes } from '../src/daemon/routes/knowledge-assets.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 import { daemonState } from '../src/daemon/state.js';
 import {
   createPromoteWorkerSupervisor,
@@ -217,12 +218,10 @@ describe('async-promote queue — end-to-end (routes + worker + queue)', () => {
           apiPortRef: { value: 0 },
           url,
           path: url.pathname,
-          requestToken,
           requestAgentAddress: 'did:dkg:agent:test',
-          requestPrincipal: tokenAgentAddress
-            ? { kind: 'agent', agentAddress: tokenAgentAddress }
-            : { kind: 'anonymous' },
-          requestAuthorization: { nodeOperator: false },
+          authentication: tokenAgentAddress
+            ? requestAuthentication({ kind: 'agent', agentAddress: tokenAgentAddress, token: requestToken })
+            : requestAuthentication({ kind: 'anonymous' }),
           emitMemoryGraphChanged: () => {},
           emitNotification: () => {},
         } as any);

--- a/packages/cli/test/async-promote-queue-e2e.test.ts
+++ b/packages/cli/test/async-promote-queue-e2e.test.ts
@@ -219,6 +219,9 @@ describe('async-promote queue — end-to-end (routes + worker + queue)', () => {
           path: url.pathname,
           requestToken,
           requestAgentAddress: 'did:dkg:agent:test',
+          requestPrincipal: tokenAgentAddress
+            ? { kind: 'agent', agentAddress: tokenAgentAddress }
+            : { kind: 'anonymous' },
           emitMemoryGraphChanged: () => {},
           emitNotification: () => {},
         } as any);

--- a/packages/cli/test/async-promote-queue-e2e.test.ts
+++ b/packages/cli/test/async-promote-queue-e2e.test.ts
@@ -222,6 +222,7 @@ describe('async-promote queue — end-to-end (routes + worker + queue)', () => {
           requestPrincipal: tokenAgentAddress
             ? { kind: 'agent', agentAddress: tokenAgentAddress }
             : { kind: 'anonymous' },
+          requestAuthorization: { nodeOperator: false },
           emitMemoryGraphChanged: () => {},
           emitNotification: () => {},
         } as any);

--- a/packages/cli/test/backfill-rs-percgid-meta-route.test.ts
+++ b/packages/cli/test/backfill-rs-percgid-meta-route.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createServer, type Server } from 'node:http';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 /**
  * Endpoint test for `POST /api/random-sampling/backfill-percgid-meta`.
@@ -152,7 +153,7 @@ function makeCtx(path: string, agent: ReturnType<typeof makeAgentMock>) {
     apiPortRef: { value: 0 },
     url,
     path: url.pathname,
-    requestToken: undefined,
+    authentication: requestAuthentication({ kind: 'anonymous' }),
     requestAgentAddress: 'did:dkg:agent:test',
     emitMemoryGraphChanged: () => {},
   };

--- a/packages/cli/test/backpressure-route.test.ts
+++ b/packages/cli/test/backpressure-route.test.ts
@@ -68,9 +68,7 @@ describe('backpressure diagnostics route', () => {
         validTokens,
         url,
         path: url.pathname,
-        requestToken: authentication.requestToken,
-        requestAuthorization: authentication.requestAuthorization,
-        requestPrincipal: authentication.requestPrincipal,
+        authentication,
       } as any);
       if (!res.writableEnded) {
         res.statusCode = 404;

--- a/packages/cli/test/backpressure-route.test.ts
+++ b/packages/cli/test/backpressure-route.test.ts
@@ -58,6 +58,11 @@ describe('backpressure diagnostics route', () => {
         url,
         path: url.pathname,
         requestToken: options.requestToken,
+        requestPrincipal: options.authEnabled === false
+          ? { kind: 'nodeOperator' }
+          : (options.tokenAgentAddress
+            ? { kind: 'agent', agentAddress: options.tokenAgentAddress }
+            : { kind: 'nodeOperator' }),
       } as any);
       if (!res.writableEnded) {
         res.statusCode = 404;

--- a/packages/cli/test/backpressure-route.test.ts
+++ b/packages/cli/test/backpressure-route.test.ts
@@ -4,6 +4,7 @@ import {
   backpressureRegistry,
   type BackpressureSource,
 } from '@origintrail-official/dkg-core';
+import { authenticateHttpRequest } from '../src/auth.js';
 import { handleBackpressureRoutes } from '../src/daemon/routes/backpressure.js';
 
 describe('backpressure diagnostics route', () => {
@@ -47,22 +48,29 @@ describe('backpressure diagnostics route', () => {
       resolveAgentByToken: (token: string) =>
         token === options.requestToken ? options.tokenAgentAddress : undefined,
     };
+    const authEnabled = options.authEnabled ?? true;
+    const validTokens = new Set(options.requestToken ? [options.requestToken] : []);
     server = createServer(async (req, res) => {
       const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+      const authentication = await authenticateHttpRequest({
+        req,
+        res,
+        authEnabled,
+        validTokens,
+        resolveAgentByToken: agent.resolveAgentByToken,
+      });
+      if (!authentication.allowed) return;
       await handleBackpressureRoutes({
         req,
         res,
         agent,
-        config: { auth: { enabled: options.authEnabled ?? true } },
-        validTokens: new Set(options.requestToken ? [options.requestToken] : []),
+        config: { auth: { enabled: authEnabled } },
+        validTokens,
         url,
         path: url.pathname,
-        requestToken: options.requestToken,
-        requestPrincipal: options.authEnabled === false
-          ? { kind: 'nodeOperator' }
-          : (options.tokenAgentAddress
-            ? { kind: 'agent', agentAddress: options.tokenAgentAddress }
-            : { kind: 'nodeOperator' }),
+        requestToken: authentication.requestToken,
+        requestAuthorization: authentication.requestAuthorization,
+        requestPrincipal: authentication.requestPrincipal,
       } as any);
       if (!res.writableEnded) {
         res.statusCode = 404;
@@ -74,6 +82,9 @@ describe('backpressure diagnostics route', () => {
     if (!address || typeof address === 'string') throw new Error('route test server did not bind');
     const response = await fetch(
       `http://127.0.0.1:${address.port}/api/diagnostics/backpressure`,
+      options.requestToken
+        ? { headers: { authorization: `Bearer ${options.requestToken}` } }
+        : undefined,
     );
     return { status: response.status, body: await response.json() };
   }
@@ -103,6 +114,15 @@ describe('backpressure diagnostics route', () => {
 
   it('allows tokenless diagnostics when daemon auth is disabled', async () => {
     const result = await request({ authEnabled: false });
+    expect(result.status).toBe(200);
+  });
+
+  it('retains node-operator capability for a valid agent bearer when auth is disabled', async () => {
+    const result = await request({
+      authEnabled: false,
+      requestToken: 'agent-token',
+      tokenAgentAddress: '0xagent',
+    });
     expect(result.status).toBe(200);
   });
 });

--- a/packages/cli/test/context-graph-join-policy-route.test.ts
+++ b/packages/cli/test/context-graph-join-policy-route.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createServer, type Server } from 'node:http';
 import { handleContextGraphRoutes } from '../src/daemon/routes/context-graph.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 const CONTEXT_GRAPH_ID = '0x1234567890123456789012345678901234567890/private-graph';
 const OWNER_ADDRESS = '0x1111111111111111111111111111111111111111';
@@ -101,12 +102,10 @@ describe('GET/PUT /api/context-graph/{id}/join-policy', () => {
         routePlugins: [],
         url,
         path: url.pathname,
-        requestToken,
         requestAgentAddress: agent.resolveAgentAddress(requestToken),
-        requestPrincipal: agent.resolveAgentByToken(requestToken)
-          ? { kind: 'agent', agentAddress: agent.resolveAgentByToken(requestToken)! }
-          : { kind: 'nodeOperator' },
-        requestAuthorization: { nodeOperator: !agent.resolveAgentByToken(requestToken) },
+        authentication: agent.resolveAgentByToken(requestToken)
+          ? requestAuthentication({ kind: 'agent', agentAddress: agent.resolveAgentByToken(requestToken)!, token: requestToken })
+          : requestAuthentication({ kind: 'nodeOperator', token: requestToken }),
       } as any);
       if (!res.writableEnded) {
         res.writeHead(404, { 'content-type': 'application/json' });

--- a/packages/cli/test/context-graph-join-policy-route.test.ts
+++ b/packages/cli/test/context-graph-join-policy-route.test.ts
@@ -103,6 +103,9 @@ describe('GET/PUT /api/context-graph/{id}/join-policy', () => {
         path: url.pathname,
         requestToken,
         requestAgentAddress: agent.resolveAgentAddress(requestToken),
+        requestPrincipal: agent.resolveAgentByToken(requestToken)
+          ? { kind: 'agent', agentAddress: agent.resolveAgentByToken(requestToken)! }
+          : { kind: 'nodeOperator' },
       } as any);
       if (!res.writableEnded) {
         res.writeHead(404, { 'content-type': 'application/json' });

--- a/packages/cli/test/context-graph-join-policy-route.test.ts
+++ b/packages/cli/test/context-graph-join-policy-route.test.ts
@@ -106,6 +106,7 @@ describe('GET/PUT /api/context-graph/{id}/join-policy', () => {
         requestPrincipal: agent.resolveAgentByToken(requestToken)
           ? { kind: 'agent', agentAddress: agent.resolveAgentByToken(requestToken)! }
           : { kind: 'nodeOperator' },
+        requestAuthorization: { nodeOperator: !agent.resolveAgentByToken(requestToken) },
       } as any);
       if (!res.writableEnded) {
         res.writeHead(404, { 'content-type': 'application/json' });

--- a/packages/cli/test/context-graph-join-request-route.test.ts
+++ b/packages/cli/test/context-graph-join-request-route.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createServer, type Server } from 'node:http';
 import { handleContextGraphRoutes } from '../src/daemon/routes/context-graph.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 async function startRouteServer(agent: Record<string, unknown>): Promise<Server> {
   const server = createServer(async (req, res) => {
@@ -34,10 +35,8 @@ async function startRouteServer(agent: Record<string, unknown>): Promise<Server>
       routePlugins: [],
       url,
       path: url.pathname,
-      requestToken: undefined,
       requestAgentAddress: undefined,
-      requestPrincipal: { kind: 'nodeOperator' },
-      requestAuthorization: { nodeOperator: true },
+      authentication: requestAuthentication({ kind: 'nodeOperator' }),
     } as any);
     if (!res.writableEnded) {
       res.writeHead(404, { 'content-type': 'application/json' });
@@ -124,10 +123,8 @@ describe('POST /api/context-graph/{id}/request-join', () => {
         routePlugins: [],
         url,
         path: url.pathname,
-        requestToken: undefined,
         requestAgentAddress: undefined,
-        requestPrincipal: { kind: 'nodeOperator' },
-        requestAuthorization: { nodeOperator: true },
+        authentication: requestAuthentication({ kind: 'nodeOperator' }),
       } as any);
       if (!res.writableEnded) {
         res.writeHead(404, { 'content-type': 'application/json' });

--- a/packages/cli/test/context-graph-join-request-route.test.ts
+++ b/packages/cli/test/context-graph-join-request-route.test.ts
@@ -36,6 +36,7 @@ async function startRouteServer(agent: Record<string, unknown>): Promise<Server>
       path: url.pathname,
       requestToken: undefined,
       requestAgentAddress: undefined,
+      requestPrincipal: { kind: 'nodeOperator' },
     } as any);
     if (!res.writableEnded) {
       res.writeHead(404, { 'content-type': 'application/json' });
@@ -124,6 +125,7 @@ describe('POST /api/context-graph/{id}/request-join', () => {
         path: url.pathname,
         requestToken: undefined,
         requestAgentAddress: undefined,
+        requestPrincipal: { kind: 'nodeOperator' },
       } as any);
       if (!res.writableEnded) {
         res.writeHead(404, { 'content-type': 'application/json' });

--- a/packages/cli/test/context-graph-join-request-route.test.ts
+++ b/packages/cli/test/context-graph-join-request-route.test.ts
@@ -37,6 +37,7 @@ async function startRouteServer(agent: Record<string, unknown>): Promise<Server>
       requestToken: undefined,
       requestAgentAddress: undefined,
       requestPrincipal: { kind: 'nodeOperator' },
+      requestAuthorization: { nodeOperator: true },
     } as any);
     if (!res.writableEnded) {
       res.writeHead(404, { 'content-type': 'application/json' });
@@ -126,6 +127,7 @@ describe('POST /api/context-graph/{id}/request-join', () => {
         requestToken: undefined,
         requestAgentAddress: undefined,
         requestPrincipal: { kind: 'nodeOperator' },
+        requestAuthorization: { nodeOperator: true },
       } as any);
       if (!res.writableEnded) {
         res.writeHead(404, { 'content-type': 'application/json' });

--- a/packages/cli/test/context-graph-reconcile-route.test.ts
+++ b/packages/cli/test/context-graph-reconcile-route.test.ts
@@ -76,6 +76,9 @@ describe('context graph targeted reconcile route', () => {
         path: url.pathname,
         requestToken: options.requestToken,
         requestAgentAddress: options.agentAddress,
+        requestPrincipal: options.agentAddress
+          ? { kind: 'agent', agentAddress: options.agentAddress }
+          : { kind: 'nodeOperator' },
       } as any);
       if (!res.writableEnded) {
         res.statusCode = 404;

--- a/packages/cli/test/context-graph-reconcile-route.test.ts
+++ b/packages/cli/test/context-graph-reconcile-route.test.ts
@@ -79,6 +79,7 @@ describe('context graph targeted reconcile route', () => {
         requestPrincipal: options.agentAddress
           ? { kind: 'agent', agentAddress: options.agentAddress }
           : { kind: 'nodeOperator' },
+        requestAuthorization: { nodeOperator: !options.agentAddress },
       } as any);
       if (!res.writableEnded) {
         res.statusCode = 404;

--- a/packages/cli/test/context-graph-reconcile-route.test.ts
+++ b/packages/cli/test/context-graph-reconcile-route.test.ts
@@ -10,6 +10,7 @@ import {
   VmReconcileUnavailableError,
 } from '@origintrail-official/dkg-agent';
 import { handleContextGraphRoutes } from '../src/daemon/routes/context-graph.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 describe('context graph targeted reconcile route', () => {
   let server: Server | undefined;
@@ -74,12 +75,10 @@ describe('context graph targeted reconcile route', () => {
         routePlugins: [],
         url,
         path: url.pathname,
-        requestToken: options.requestToken,
         requestAgentAddress: options.agentAddress,
-        requestPrincipal: options.agentAddress
-          ? { kind: 'agent', agentAddress: options.agentAddress }
-          : { kind: 'nodeOperator' },
-        requestAuthorization: { nodeOperator: !options.agentAddress },
+        authentication: options.agentAddress
+          ? requestAuthentication({ kind: 'agent', agentAddress: options.agentAddress, token: options.requestToken })
+          : requestAuthentication({ kind: 'nodeOperator', token: options.requestToken }),
       } as any);
       if (!res.writableEnded) {
         res.statusCode = 404;

--- a/packages/cli/test/context-graph-subscribe-readiness.test.ts
+++ b/packages/cli/test/context-graph-subscribe-readiness.test.ts
@@ -276,6 +276,7 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
         requestToken: undefined,
         requestAgentAddress: undefined,
         requestPrincipal: { kind: 'nodeOperator' },
+        requestAuthorization: { nodeOperator: true },
       } as any;
       await handleContextGraphRoutes(routeContext);
       if (!res.writableEnded) await handleQueryRoutes(routeContext);

--- a/packages/cli/test/context-graph-subscribe-readiness.test.ts
+++ b/packages/cli/test/context-graph-subscribe-readiness.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { createServer, type Server } from 'node:http';
 import type { CatchupJobResult, CatchupRunRequest } from '../src/catchup-runner.js';
 import { handleContextGraphRoutes } from '../src/daemon/routes/context-graph.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 import { handleQueryRoutes } from '../src/daemon/routes/query.js';
 import { daemonState } from '../src/daemon/state.js';
 
@@ -273,10 +274,8 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
         routePlugins: [],
         url,
         path: url.pathname,
-        requestToken: undefined,
         requestAgentAddress: undefined,
-        requestPrincipal: { kind: 'nodeOperator' },
-        requestAuthorization: { nodeOperator: true },
+        authentication: requestAuthentication({ kind: 'nodeOperator' }),
       } as any;
       await handleContextGraphRoutes(routeContext);
       if (!res.writableEnded) await handleQueryRoutes(routeContext);

--- a/packages/cli/test/context-graph-subscribe-readiness.test.ts
+++ b/packages/cli/test/context-graph-subscribe-readiness.test.ts
@@ -275,6 +275,7 @@ describe('context graph subscribe readiness requires authoritative metadata', ()
         path: url.pathname,
         requestToken: undefined,
         requestAgentAddress: undefined,
+        requestPrincipal: { kind: 'nodeOperator' },
       } as any;
       await handleContextGraphRoutes(routeContext);
       if (!res.writableEnded) await handleQueryRoutes(routeContext);

--- a/packages/cli/test/context-graph-subscriptions-route.test.ts
+++ b/packages/cli/test/context-graph-subscriptions-route.test.ts
@@ -92,6 +92,9 @@ describe('context graph subscription diagnostics route', () => {
         path: url.pathname,
         requestToken,
         requestAgentAddress: agent.resolveAgentByToken(requestToken),
+        requestPrincipal: agent.resolveAgentByToken(requestToken)
+          ? { kind: 'agent', agentAddress: agent.resolveAgentByToken(requestToken)! }
+          : { kind: 'nodeOperator' },
       } as any);
       if (!res.writableEnded) {
         res.writeHead(404, { 'content-type': 'application/json' });

--- a/packages/cli/test/context-graph-subscriptions-route.test.ts
+++ b/packages/cli/test/context-graph-subscriptions-route.test.ts
@@ -95,6 +95,7 @@ describe('context graph subscription diagnostics route', () => {
         requestPrincipal: agent.resolveAgentByToken(requestToken)
           ? { kind: 'agent', agentAddress: agent.resolveAgentByToken(requestToken)! }
           : { kind: 'nodeOperator' },
+        requestAuthorization: { nodeOperator: !agent.resolveAgentByToken(requestToken) },
       } as any);
       if (!res.writableEnded) {
         res.writeHead(404, { 'content-type': 'application/json' });

--- a/packages/cli/test/context-graph-subscriptions-route.test.ts
+++ b/packages/cli/test/context-graph-subscriptions-route.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createServer, type Server } from 'node:http';
 import { SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
 import { handleContextGraphRoutes } from '../src/daemon/routes/context-graph.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 describe('context graph subscription diagnostics route', () => {
   let server: Server | undefined;
@@ -90,12 +91,10 @@ describe('context graph subscription diagnostics route', () => {
         routePlugins: [],
         url,
         path: url.pathname,
-        requestToken,
         requestAgentAddress: agent.resolveAgentByToken(requestToken),
-        requestPrincipal: agent.resolveAgentByToken(requestToken)
-          ? { kind: 'agent', agentAddress: agent.resolveAgentByToken(requestToken)! }
-          : { kind: 'nodeOperator' },
-        requestAuthorization: { nodeOperator: !agent.resolveAgentByToken(requestToken) },
+        authentication: agent.resolveAgentByToken(requestToken)
+          ? requestAuthentication({ kind: 'agent', agentAddress: agent.resolveAgentByToken(requestToken)!, token: requestToken })
+          : requestAuthentication({ kind: 'nodeOperator', token: requestToken }),
       } as any);
       if (!res.writableEnded) {
         res.writeHead(404, { 'content-type': 'application/json' });

--- a/packages/cli/test/daemon-catchup-telemetry-shutdown.test.ts
+++ b/packages/cli/test/daemon-catchup-telemetry-shutdown.test.ts
@@ -14,6 +14,7 @@ import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import type { DKGAgent } from '@origintrail-official/dkg-agent';
 import type { CatchupJobResult } from '../src/catchup-runner.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 type Listener = (...args: unknown[]) => void;
 
@@ -281,9 +282,8 @@ async function createHarness(opts: HarnessOptions = {}) {
       assertionImportLocks: new Map(), vectorStore: {}, embeddingProvider: null,
       validTokens: new Set(), apiHost: '127.0.0.1', apiPortRef: { value: 0 },
       routePlugins: [], url, path: url.pathname,
-      requestToken: undefined, requestAgentAddress: undefined,
-      requestPrincipal: { kind: 'nodeOperator' },
-      requestAuthorization: { nodeOperator: true },
+      requestAgentAddress: undefined,
+      authentication: requestAuthentication({ kind: 'nodeOperator' }),
     } as any;
     await handleContextGraphRoutes(routeContext);
     if (!res.writableEnded) await handleQueryRoutes(routeContext);

--- a/packages/cli/test/daemon-catchup-telemetry-shutdown.test.ts
+++ b/packages/cli/test/daemon-catchup-telemetry-shutdown.test.ts
@@ -282,6 +282,7 @@ async function createHarness(opts: HarnessOptions = {}) {
       validTokens: new Set(), apiHost: '127.0.0.1', apiPortRef: { value: 0 },
       routePlugins: [], url, path: url.pathname,
       requestToken: undefined, requestAgentAddress: undefined,
+      requestPrincipal: { kind: 'nodeOperator' },
     } as any;
     await handleContextGraphRoutes(routeContext);
     if (!res.writableEnded) await handleQueryRoutes(routeContext);

--- a/packages/cli/test/daemon-catchup-telemetry-shutdown.test.ts
+++ b/packages/cli/test/daemon-catchup-telemetry-shutdown.test.ts
@@ -283,6 +283,7 @@ async function createHarness(opts: HarnessOptions = {}) {
       routePlugins: [], url, path: url.pathname,
       requestToken: undefined, requestAgentAddress: undefined,
       requestPrincipal: { kind: 'nodeOperator' },
+      requestAuthorization: { nodeOperator: true },
     } as any;
     await handleContextGraphRoutes(routeContext);
     if (!res.writableEnded) await handleQueryRoutes(routeContext);

--- a/packages/cli/test/daemon-context-graph-register.test.ts
+++ b/packages/cli/test/daemon-context-graph-register.test.ts
@@ -70,6 +70,7 @@ describe('POST /api/context-graph/register — effective publishPolicy resolutio
         validTokens: new Set(), apiHost: '127.0.0.1', apiPortRef: { value: 0 },
         routePlugins: [], url, path: url.pathname, requestToken: undefined,
         requestAgentAddress: '0x0000000000000000000000000000000000000001',
+        requestPrincipal: { kind: 'nodeOperator' },
       } as any);
       if (!res.writableEnded) { res.statusCode = 404; res.end(); }
     });

--- a/packages/cli/test/daemon-context-graph-register.test.ts
+++ b/packages/cli/test/daemon-context-graph-register.test.ts
@@ -15,6 +15,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createServer } from 'node:http';
 import { handleContextGraphRoutes } from '../src/daemon/routes/context-graph.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 describe('POST /api/context-graph/register — effective publishPolicy resolution (#1085)', () => {
   async function runRegisterRouteCaptureOpts(
@@ -68,10 +69,9 @@ describe('POST /api/context-graph/register — effective publishPolicy resolutio
         extractionRegistry: {}, fileStore: {}, extractionStatus: new Map(),
         assertionImportLocks: new Map(), vectorStore: {}, embeddingProvider: null,
         validTokens: new Set(), apiHost: '127.0.0.1', apiPortRef: { value: 0 },
-        routePlugins: [], url, path: url.pathname, requestToken: undefined,
+        routePlugins: [], url, path: url.pathname,
         requestAgentAddress: '0x0000000000000000000000000000000000000001',
-        requestPrincipal: { kind: 'nodeOperator' },
-        requestAuthorization: { nodeOperator: true },
+        authentication: requestAuthentication({ kind: 'nodeOperator' }),
       } as any);
       if (!res.writableEnded) { res.statusCode = 404; res.end(); }
     });

--- a/packages/cli/test/daemon-context-graph-register.test.ts
+++ b/packages/cli/test/daemon-context-graph-register.test.ts
@@ -71,6 +71,7 @@ describe('POST /api/context-graph/register — effective publishPolicy resolutio
         routePlugins: [], url, path: url.pathname, requestToken: undefined,
         requestAgentAddress: '0x0000000000000000000000000000000000000001',
         requestPrincipal: { kind: 'nodeOperator' },
+        requestAuthorization: { nodeOperator: true },
       } as any);
       if (!res.writableEnded) { res.statusCode = 404; res.end(); }
     });

--- a/packages/cli/test/daemon-http-behavior-extra.test.ts
+++ b/packages/cli/test/daemon-http-behavior-extra.test.ts
@@ -56,6 +56,7 @@ import { ethers } from 'ethers';
 import { getSharedContext, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
 import { ApiClient } from '../src/api-client.js';
 import { handleContextGraphRoutes } from '../src/daemon/routes/context-graph.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 import { daemonState } from '../src/daemon/state.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -884,10 +885,8 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
           routePlugins: [],
           url,
           path: url.pathname,
-          requestToken: undefined,
           requestAgentAddress: '0x0000000000000000000000000000000000000001',
-          requestPrincipal: { kind: 'nodeOperator' },
-          requestAuthorization: { nodeOperator: true },
+          authentication: requestAuthentication({ kind: 'nodeOperator' }),
         } as any);
         if (!res.writableEnded) {
           res.statusCode = 404;
@@ -976,10 +975,8 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
           routePlugins: [],
           url,
           path: url.pathname,
-          requestToken: undefined,
           requestAgentAddress: '0x0000000000000000000000000000000000000001',
-          requestPrincipal: { kind: 'nodeOperator' },
-          requestAuthorization: { nodeOperator: true },
+          authentication: requestAuthentication({ kind: 'nodeOperator' }),
         } as any);
         if (!res.writableEnded) {
           res.statusCode = 404;
@@ -1114,10 +1111,8 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
           routePlugins: [],
           url,
           path: url.pathname,
-          requestToken: undefined,
           requestAgentAddress: '0x0000000000000000000000000000000000000001',
-          requestPrincipal: { kind: 'nodeOperator' },
-          requestAuthorization: { nodeOperator: true },
+          authentication: requestAuthentication({ kind: 'nodeOperator' }),
         } as any);
         if (!res.writableEnded) {
           res.statusCode = 404;
@@ -1233,10 +1228,8 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
           routePlugins: [],
           url,
           path: url.pathname,
-          requestToken: undefined,
           requestAgentAddress: '0x0000000000000000000000000000000000000001',
-          requestPrincipal: { kind: 'nodeOperator' },
-          requestAuthorization: { nodeOperator: true },
+          authentication: requestAuthentication({ kind: 'nodeOperator' }),
         } as any);
         if (!res.writableEnded) {
           res.statusCode = 404;
@@ -1352,10 +1345,8 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
           routePlugins: [],
           url,
           path: url.pathname,
-          requestToken: undefined,
           requestAgentAddress: '0x0000000000000000000000000000000000000001',
-          requestPrincipal: { kind: 'nodeOperator' },
-          requestAuthorization: { nodeOperator: true },
+          authentication: requestAuthentication({ kind: 'nodeOperator' }),
         } as any);
         if (!res.writableEnded) {
           res.statusCode = 404;
@@ -2508,10 +2499,8 @@ describe('#1596 — subscribe allowlist gate respects explicit public accessPoli
           routePlugins: [],
           url,
           path: url.pathname,
-          requestToken: undefined,
           requestAgentAddress: CALLER,
-          requestPrincipal: { kind: 'nodeOperator' },
-          requestAuthorization: { nodeOperator: true },
+          authentication: requestAuthentication({ kind: 'nodeOperator' }),
         } as any);
         if (!res.writableEnded) {
           res.statusCode = 404;

--- a/packages/cli/test/daemon-http-behavior-extra.test.ts
+++ b/packages/cli/test/daemon-http-behavior-extra.test.ts
@@ -887,6 +887,7 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
           requestToken: undefined,
           requestAgentAddress: '0x0000000000000000000000000000000000000001',
           requestPrincipal: { kind: 'nodeOperator' },
+          requestAuthorization: { nodeOperator: true },
         } as any);
         if (!res.writableEnded) {
           res.statusCode = 404;
@@ -978,6 +979,7 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
           requestToken: undefined,
           requestAgentAddress: '0x0000000000000000000000000000000000000001',
           requestPrincipal: { kind: 'nodeOperator' },
+          requestAuthorization: { nodeOperator: true },
         } as any);
         if (!res.writableEnded) {
           res.statusCode = 404;
@@ -1115,6 +1117,7 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
           requestToken: undefined,
           requestAgentAddress: '0x0000000000000000000000000000000000000001',
           requestPrincipal: { kind: 'nodeOperator' },
+          requestAuthorization: { nodeOperator: true },
         } as any);
         if (!res.writableEnded) {
           res.statusCode = 404;
@@ -1233,6 +1236,7 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
           requestToken: undefined,
           requestAgentAddress: '0x0000000000000000000000000000000000000001',
           requestPrincipal: { kind: 'nodeOperator' },
+          requestAuthorization: { nodeOperator: true },
         } as any);
         if (!res.writableEnded) {
           res.statusCode = 404;
@@ -1351,6 +1355,7 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
           requestToken: undefined,
           requestAgentAddress: '0x0000000000000000000000000000000000000001',
           requestPrincipal: { kind: 'nodeOperator' },
+          requestAuthorization: { nodeOperator: true },
         } as any);
         if (!res.writableEnded) {
           res.statusCode = 404;
@@ -2506,6 +2511,7 @@ describe('#1596 — subscribe allowlist gate respects explicit public accessPoli
           requestToken: undefined,
           requestAgentAddress: CALLER,
           requestPrincipal: { kind: 'nodeOperator' },
+          requestAuthorization: { nodeOperator: true },
         } as any);
         if (!res.writableEnded) {
           res.statusCode = 404;

--- a/packages/cli/test/daemon-http-behavior-extra.test.ts
+++ b/packages/cli/test/daemon-http-behavior-extra.test.ts
@@ -886,6 +886,7 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
           path: url.pathname,
           requestToken: undefined,
           requestAgentAddress: '0x0000000000000000000000000000000000000001',
+          requestPrincipal: { kind: 'nodeOperator' },
         } as any);
         if (!res.writableEnded) {
           res.statusCode = 404;
@@ -976,6 +977,7 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
           path: url.pathname,
           requestToken: undefined,
           requestAgentAddress: '0x0000000000000000000000000000000000000001',
+          requestPrincipal: { kind: 'nodeOperator' },
         } as any);
         if (!res.writableEnded) {
           res.statusCode = 404;
@@ -1112,6 +1114,7 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
           path: url.pathname,
           requestToken: undefined,
           requestAgentAddress: '0x0000000000000000000000000000000000000001',
+          requestPrincipal: { kind: 'nodeOperator' },
         } as any);
         if (!res.writableEnded) {
           res.statusCode = 404;
@@ -1229,6 +1232,7 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
           path: url.pathname,
           requestToken: undefined,
           requestAgentAddress: '0x0000000000000000000000000000000000000001',
+          requestPrincipal: { kind: 'nodeOperator' },
         } as any);
         if (!res.writableEnded) {
           res.statusCode = 404;
@@ -1346,6 +1350,7 @@ describe('CLI-7 — SPARQL endpoint 4xx matrix', () => {
           path: url.pathname,
           requestToken: undefined,
           requestAgentAddress: '0x0000000000000000000000000000000000000001',
+          requestPrincipal: { kind: 'nodeOperator' },
         } as any);
         if (!res.writableEnded) {
           res.statusCode = 404;
@@ -2500,6 +2505,7 @@ describe('#1596 — subscribe allowlist gate respects explicit public accessPoli
           path: url.pathname,
           requestToken: undefined,
           requestAgentAddress: CALLER,
+          requestPrincipal: { kind: 'nodeOperator' },
         } as any);
         if (!res.writableEnded) {
           res.statusCode = 404;

--- a/packages/cli/test/daemon-ka-transport.test.ts
+++ b/packages/cli/test/daemon-ka-transport.test.ts
@@ -47,6 +47,7 @@ function runKaCtx(
     requestPrincipal: tokenAgentAddress
       ? { kind: 'agent', agentAddress: tokenAgentAddress }
       : { kind: 'anonymous' },
+    requestAuthorization: { nodeOperator: false },
     ...ctxOverrides,
   } as unknown as RequestContext;
   return { res, done: handleKnowledgeAssetsRoutes(ctx) };
@@ -58,7 +59,9 @@ function runMemoryCtx(method: string, rawPath: string, agent: any, body?: unknow
   if (body !== undefined) req.__dkgPrebufferedBody = Buffer.from(JSON.stringify(body));
   const url = new URL(`http://127.0.0.1${rawPath}`);
   const ctx = {
-    req, res, agent, path: url.pathname, url, requestPrincipal: { kind: 'anonymous' },
+    req, res, agent, path: url.pathname, url,
+    requestPrincipal: { kind: 'anonymous' },
+    requestAuthorization: { nodeOperator: false },
   } as unknown as RequestContext;
   return { res, done: handleMemoryRoutes(ctx) };
 }

--- a/packages/cli/test/daemon-ka-transport.test.ts
+++ b/packages/cli/test/daemon-ka-transport.test.ts
@@ -35,7 +35,20 @@ function runKaCtx(
   const req: any = { method, url: rawPath };
   if (body !== undefined) req.__dkgPrebufferedBody = Buffer.from(JSON.stringify(body));
   const url = new URL(`http://127.0.0.1${rawPath}`);
-  const ctx = { req, res, agent, path: url.pathname, url, ...ctxOverrides } as unknown as RequestContext;
+  const tokenAgentAddress = ctxOverrides.requestToken
+    ? agent.resolveAgentByToken?.(ctxOverrides.requestToken)
+    : undefined;
+  const ctx = {
+    req,
+    res,
+    agent,
+    path: url.pathname,
+    url,
+    requestPrincipal: tokenAgentAddress
+      ? { kind: 'agent', agentAddress: tokenAgentAddress }
+      : { kind: 'anonymous' },
+    ...ctxOverrides,
+  } as unknown as RequestContext;
   return { res, done: handleKnowledgeAssetsRoutes(ctx) };
 }
 
@@ -44,7 +57,9 @@ function runMemoryCtx(method: string, rawPath: string, agent: any, body?: unknow
   const req: any = { method, url: rawPath };
   if (body !== undefined) req.__dkgPrebufferedBody = Buffer.from(JSON.stringify(body));
   const url = new URL(`http://127.0.0.1${rawPath}`);
-  const ctx = { req, res, agent, path: url.pathname, url } as unknown as RequestContext;
+  const ctx = {
+    req, res, agent, path: url.pathname, url, requestPrincipal: { kind: 'anonymous' },
+  } as unknown as RequestContext;
   return { res, done: handleMemoryRoutes(ctx) };
 }
 

--- a/packages/cli/test/daemon-ka-transport.test.ts
+++ b/packages/cli/test/daemon-ka-transport.test.ts
@@ -14,6 +14,7 @@ import {
 import { handleKnowledgeAssetsRoutes } from '../src/daemon/routes/knowledge-assets.js';
 import { handleMemoryRoutes } from '../src/daemon/routes/memory.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 function fakeRes() {
   const res: any = { statusCode: 0, body: '', headers: {} };
@@ -44,10 +45,9 @@ function runKaCtx(
     agent,
     path: url.pathname,
     url,
-    requestPrincipal: tokenAgentAddress
-      ? { kind: 'agent', agentAddress: tokenAgentAddress }
-      : { kind: 'anonymous' },
-    requestAuthorization: { nodeOperator: false },
+    authentication: tokenAgentAddress
+      ? requestAuthentication({ kind: 'agent', agentAddress: tokenAgentAddress })
+      : requestAuthentication({ kind: 'anonymous' }),
     ...ctxOverrides,
   } as unknown as RequestContext;
   return { res, done: handleKnowledgeAssetsRoutes(ctx) };
@@ -60,8 +60,7 @@ function runMemoryCtx(method: string, rawPath: string, agent: any, body?: unknow
   const url = new URL(`http://127.0.0.1${rawPath}`);
   const ctx = {
     req, res, agent, path: url.pathname, url,
-    requestPrincipal: { kind: 'anonymous' },
-    requestAuthorization: { nodeOperator: false },
+    authentication: requestAuthentication({ kind: 'anonymous' }),
   } as unknown as RequestContext;
   return { res, done: handleMemoryRoutes(ctx) };
 }

--- a/packages/cli/test/daemon-local-llm-route.test.ts
+++ b/packages/cli/test/daemon-local-llm-route.test.ts
@@ -2,6 +2,7 @@ import { createServer, request as httpRequest, type Server } from 'node:http';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { handleLocalLlmRoutes } from '../src/daemon/routes/local-llm.js';
 import { DaemonLocalLlmError } from '../src/daemon/local-llm-service.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 describe('daemon local LLM routes', () => {
   let server: Server | undefined;
@@ -33,19 +34,16 @@ describe('daemon local LLM routes', () => {
         localLlm: service,
         config: { auth: { enabled: auth.enabled ?? false } },
         validTokens: new Set(auth.validTokens ?? []),
-        requestToken: auth.requestToken,
-        requestPrincipal: auth.enabled === false
-          ? (auth.requestToken && auth.agentTokens?.[auth.requestToken]
-            ? { kind: 'agent', agentAddress: auth.agentTokens[auth.requestToken] }
-            : { kind: 'anonymous' })
-          : (auth.requestToken && auth.agentTokens?.[auth.requestToken]
-            ? { kind: 'agent', agentAddress: auth.agentTokens[auth.requestToken] }
-            : { kind: 'nodeOperator' }),
-        requestAuthorization: {
-          nodeOperator: auth.enabled === false
-            || !auth.requestToken
-            || !auth.agentTokens?.[auth.requestToken],
-        },
+        authentication: auth.requestToken && auth.agentTokens?.[auth.requestToken]
+          ? requestAuthentication({
+              kind: 'agent',
+              agentAddress: auth.agentTokens[auth.requestToken],
+              token: auth.requestToken,
+              mode: auth.enabled === true ? 'authenticated' : 'disabled',
+            })
+          : auth.enabled === true
+            ? requestAuthentication({ kind: 'nodeOperator', token: auth.requestToken })
+            : requestAuthentication({ kind: 'anonymous', mode: 'disabled', presentedToken: auth.requestToken }),
         agent: {
           resolveAgentByToken: (token: string) => auth.agentTokens?.[token],
         },
@@ -162,9 +160,7 @@ describe('daemon local LLM routes', () => {
         localLlm: fake,
         config: { auth: { enabled: false } },
         validTokens: new Set(),
-        requestToken: undefined,
-        requestPrincipal: { kind: 'nodeOperator' },
-        requestAuthorization: { nodeOperator: true },
+        authentication: requestAuthentication({ kind: 'anonymous', mode: 'disabled' }),
         agent: { resolveAgentByToken: () => undefined },
       } as any);
     });

--- a/packages/cli/test/daemon-local-llm-route.test.ts
+++ b/packages/cli/test/daemon-local-llm-route.test.ts
@@ -35,10 +35,17 @@ describe('daemon local LLM routes', () => {
         validTokens: new Set(auth.validTokens ?? []),
         requestToken: auth.requestToken,
         requestPrincipal: auth.enabled === false
-          ? { kind: 'nodeOperator' }
+          ? (auth.requestToken && auth.agentTokens?.[auth.requestToken]
+            ? { kind: 'agent', agentAddress: auth.agentTokens[auth.requestToken] }
+            : { kind: 'anonymous' })
           : (auth.requestToken && auth.agentTokens?.[auth.requestToken]
             ? { kind: 'agent', agentAddress: auth.agentTokens[auth.requestToken] }
             : { kind: 'nodeOperator' }),
+        requestAuthorization: {
+          nodeOperator: auth.enabled === false
+            || !auth.requestToken
+            || !auth.agentTokens?.[auth.requestToken],
+        },
         agent: {
           resolveAgentByToken: (token: string) => auth.agentTokens?.[token],
         },
@@ -157,6 +164,7 @@ describe('daemon local LLM routes', () => {
         validTokens: new Set(),
         requestToken: undefined,
         requestPrincipal: { kind: 'nodeOperator' },
+        requestAuthorization: { nodeOperator: true },
         agent: { resolveAgentByToken: () => undefined },
       } as any);
     });

--- a/packages/cli/test/daemon-local-llm-route.test.ts
+++ b/packages/cli/test/daemon-local-llm-route.test.ts
@@ -34,6 +34,11 @@ describe('daemon local LLM routes', () => {
         config: { auth: { enabled: auth.enabled ?? false } },
         validTokens: new Set(auth.validTokens ?? []),
         requestToken: auth.requestToken,
+        requestPrincipal: auth.enabled === false
+          ? { kind: 'nodeOperator' }
+          : (auth.requestToken && auth.agentTokens?.[auth.requestToken]
+            ? { kind: 'agent', agentAddress: auth.agentTokens[auth.requestToken] }
+            : { kind: 'nodeOperator' }),
         agent: {
           resolveAgentByToken: (token: string) => auth.agentTokens?.[token],
         },
@@ -151,6 +156,7 @@ describe('daemon local LLM routes', () => {
         config: { auth: { enabled: false } },
         validTokens: new Set(),
         requestToken: undefined,
+        requestPrincipal: { kind: 'nodeOperator' },
         agent: { resolveAgentByToken: () => undefined },
       } as any);
     });

--- a/packages/cli/test/daemon-operational-wallet-routes.test.ts
+++ b/packages/cli/test/daemon-operational-wallet-routes.test.ts
@@ -51,7 +51,12 @@ function runCtx(
       ? (auth.requestToken && agent.resolveAgentByToken?.(auth.requestToken)
         ? { kind: 'agent', agentAddress: agent.resolveAgentByToken(auth.requestToken) }
         : { kind: 'nodeOperator' })
-      : { kind: 'nodeOperator' },
+      : { kind: 'anonymous' },
+    requestAuthorization: {
+      nodeOperator: !auth?.authEnabled
+        || !auth.requestToken
+        || !agent.resolveAgentByToken?.(auth.requestToken),
+    },
   } as unknown as RequestContext;
   return { res, done: handleOperationalWalletRoutes(ctx) };
 }

--- a/packages/cli/test/daemon-operational-wallet-routes.test.ts
+++ b/packages/cli/test/daemon-operational-wallet-routes.test.ts
@@ -47,6 +47,11 @@ function runCtx(
     config: { auth: { enabled: auth?.authEnabled ?? false } },
     requestToken: auth?.requestToken,
     validTokens: auth?.validTokens ?? new Set<string>(),
+    requestPrincipal: auth?.authEnabled
+      ? (auth.requestToken && agent.resolveAgentByToken?.(auth.requestToken)
+        ? { kind: 'agent', agentAddress: agent.resolveAgentByToken(auth.requestToken) }
+        : { kind: 'nodeOperator' })
+      : { kind: 'nodeOperator' },
   } as unknown as RequestContext;
   return { res, done: handleOperationalWalletRoutes(ctx) };
 }

--- a/packages/cli/test/daemon-operational-wallet-routes.test.ts
+++ b/packages/cli/test/daemon-operational-wallet-routes.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from 'vitest';
 import { handleOperationalWalletRoutes } from '../src/daemon/routes/operational-wallets.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 const PRIMARY = '0x' + '1'.repeat(40);
 const SECOND = '0x' + '2'.repeat(40);
@@ -45,18 +46,12 @@ function runCtx(
     // Default auth disabled → node-admin gate short-circuits true; route-logic
     // tests below run without a token. Gating is covered in its own block.
     config: { auth: { enabled: auth?.authEnabled ?? false } },
-    requestToken: auth?.requestToken,
     validTokens: auth?.validTokens ?? new Set<string>(),
-    requestPrincipal: auth?.authEnabled
+    authentication: auth?.authEnabled
       ? (auth.requestToken && agent.resolveAgentByToken?.(auth.requestToken)
-        ? { kind: 'agent', agentAddress: agent.resolveAgentByToken(auth.requestToken) }
-        : { kind: 'nodeOperator' })
-      : { kind: 'anonymous' },
-    requestAuthorization: {
-      nodeOperator: !auth?.authEnabled
-        || !auth.requestToken
-        || !agent.resolveAgentByToken?.(auth.requestToken),
-    },
+        ? requestAuthentication({ kind: 'agent', agentAddress: agent.resolveAgentByToken(auth.requestToken), token: auth.requestToken })
+        : requestAuthentication({ kind: 'nodeOperator', token: auth.requestToken }))
+      : requestAuthentication({ kind: 'anonymous', mode: 'disabled', presentedToken: auth?.requestToken }),
   } as unknown as RequestContext;
   return { res, done: handleOperationalWalletRoutes(ctx) };
 }

--- a/packages/cli/test/daemon-pca-routes.test.ts
+++ b/packages/cli/test/daemon-pca-routes.test.ts
@@ -50,7 +50,12 @@ function runCtx(
       ? (auth.requestToken && agent.resolveAgentByToken?.(auth.requestToken)
         ? { kind: 'agent', agentAddress: agent.resolveAgentByToken(auth.requestToken) }
         : { kind: 'nodeOperator' })
-      : { kind: 'nodeOperator' },
+      : { kind: 'anonymous' },
+    requestAuthorization: {
+      nodeOperator: !auth?.authEnabled
+        || !auth.requestToken
+        || !agent.resolveAgentByToken?.(auth.requestToken),
+    },
   } as unknown as RequestContext;
   return { res, done: handlePcaRoutes(ctx) };
 }

--- a/packages/cli/test/daemon-pca-routes.test.ts
+++ b/packages/cli/test/daemon-pca-routes.test.ts
@@ -46,6 +46,11 @@ function runCtx(
     config: { auth: { enabled: auth?.authEnabled ?? false } },
     requestToken: auth?.requestToken,
     validTokens: auth?.validTokens ?? new Set<string>(),
+    requestPrincipal: auth?.authEnabled
+      ? (auth.requestToken && agent.resolveAgentByToken?.(auth.requestToken)
+        ? { kind: 'agent', agentAddress: agent.resolveAgentByToken(auth.requestToken) }
+        : { kind: 'nodeOperator' })
+      : { kind: 'nodeOperator' },
   } as unknown as RequestContext;
   return { res, done: handlePcaRoutes(ctx) };
 }

--- a/packages/cli/test/daemon-pca-routes.test.ts
+++ b/packages/cli/test/daemon-pca-routes.test.ts
@@ -3,6 +3,7 @@ import { ethers } from 'ethers';
 import { NoChainAdapter, ChainRpcTransportError } from '@origintrail-official/dkg-chain';
 import { handlePcaRoutes } from '../src/daemon/routes/pca.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 function fakeRes() {
   const res: any = { statusCode: 0, body: '' };
@@ -44,18 +45,12 @@ function runCtx(
     // existing route-logic tests below exercise the handler without an admin
     // token. The node-admin gating itself is covered by its own describe block.
     config: { auth: { enabled: auth?.authEnabled ?? false } },
-    requestToken: auth?.requestToken,
     validTokens: auth?.validTokens ?? new Set<string>(),
-    requestPrincipal: auth?.authEnabled
+    authentication: auth?.authEnabled
       ? (auth.requestToken && agent.resolveAgentByToken?.(auth.requestToken)
-        ? { kind: 'agent', agentAddress: agent.resolveAgentByToken(auth.requestToken) }
-        : { kind: 'nodeOperator' })
-      : { kind: 'anonymous' },
-    requestAuthorization: {
-      nodeOperator: !auth?.authEnabled
-        || !auth.requestToken
-        || !agent.resolveAgentByToken?.(auth.requestToken),
-    },
+        ? requestAuthentication({ kind: 'agent', agentAddress: agent.resolveAgentByToken(auth.requestToken), token: auth.requestToken })
+        : requestAuthentication({ kind: 'nodeOperator', token: auth.requestToken }))
+      : requestAuthentication({ kind: 'anonymous', mode: 'disabled', presentedToken: auth?.requestToken }),
   } as unknown as RequestContext;
   return { res, done: handlePcaRoutes(ctx) };
 }

--- a/packages/cli/test/daemon/routes/plugins.test.ts
+++ b/packages/cli/test/daemon/routes/plugins.test.ts
@@ -3,6 +3,8 @@ import type { ServerResponse } from 'node:http';
 import type { RequestContext } from '../../../src/daemon/routes/context.js';
 import type { RoutePlugin } from '../../../src/daemon/plugin-api.js';
 import { handlePluginRoutes } from '../../../src/daemon/routes/plugins.js';
+import { createRequestActor } from '../../../src/daemon/routes/context.js';
+import { requestAuthentication } from '../../_helpers/request-authentication.js';
 import {
   createInitialPublisherState,
   type PublisherRuntime,
@@ -76,6 +78,10 @@ function makeCtx(
     routePlugins,
     path: '/api/test',
     publisherState,
+    actor: createRequestActor(
+      requestAuthentication({ kind: 'anonymous' }),
+      () => 'did:dkg:agent:default',
+    ),
   } as unknown as RequestContext;
   return { ctx, res };
 }
@@ -96,6 +102,25 @@ describe('handlePluginRoutes', () => {
   });
   afterEach(() => {
     console.error = originalConsoleError;
+  });
+
+  it('keeps the deprecated plugin requestToken alias tied to the accepted credential', async () => {
+    const seen: Array<string | undefined> = [];
+    const plugin: RoutePlugin = {
+      name: 'compat-request-token',
+      handle(ctx) {
+        seen.push(ctx.requestToken);
+      },
+    };
+    const { ctx } = makeCtx([plugin]);
+    (ctx as { actor: RequestContext['actor'] }).actor = createRequestActor(
+      requestAuthentication({ kind: 'agent', agentAddress: 'did:dkg:agent:alice', token: 'accepted-agent-token' }),
+      () => 'did:dkg:agent:default',
+    );
+
+    await handlePluginRoutes(ctx);
+
+    expect(seen).toEqual(['accepted-agent-token']);
   });
 
   it('returns without writing when routePlugins is empty', async () => {

--- a/packages/cli/test/epcis-route-readiness.test.ts
+++ b/packages/cli/test/epcis-route-readiness.test.ts
@@ -3,6 +3,7 @@ import type { ServerResponse } from 'node:http';
 import { Readable } from 'node:stream';
 import { handleEpcisRoutes } from '../src/daemon/routes/epcis.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 const VALID_OBJECT_EVENT_DOC = {
   '@context': {
@@ -141,7 +142,7 @@ function createContext(overrides: Partial<RequestContext> = {}): RequestContext 
     apiPortRef: { value: 0 },
     url,
     path: url.pathname,
-    requestToken: undefined,
+    authentication: requestAuthentication({ kind: 'anonymous' }),
     requestAgentAddress: '0x0',
     ...overrides,
   };

--- a/packages/cli/test/import-artifact-routes.test.ts
+++ b/packages/cli/test/import-artifact-routes.test.ts
@@ -14,6 +14,7 @@ import {
 import { FileStore } from '../src/file-store.js';
 import type { ExtractionStatusRecord } from '../src/extraction-status.js';
 import { handleKnowledgeAssetsRoutes } from '../src/daemon/routes/knowledge-assets.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 const DKG = 'http://dkg.io/ontology/';
 const PROV = 'http://www.w3.org/ns/prov#';
@@ -82,10 +83,8 @@ describe('import artifact daemon routes', () => {
           apiPortRef: { value: 0 },
           url,
           path: url.pathname,
-          requestToken: undefined,
           requestAgentAddress: 'did:dkg:agent:test',
-          requestPrincipal: { kind: 'anonymous' },
-          requestAuthorization: { nodeOperator: false },
+          authentication: requestAuthentication({ kind: 'anonymous' }),
           emitMemoryGraphChanged: (event) => events.push(event),
         } as any);
         if (!res.writableEnded) {

--- a/packages/cli/test/import-artifact-routes.test.ts
+++ b/packages/cli/test/import-artifact-routes.test.ts
@@ -84,6 +84,7 @@ describe('import artifact daemon routes', () => {
           path: url.pathname,
           requestToken: undefined,
           requestAgentAddress: 'did:dkg:agent:test',
+          requestPrincipal: { kind: 'anonymous' },
           emitMemoryGraphChanged: (event) => events.push(event),
         } as any);
         if (!res.writableEnded) {

--- a/packages/cli/test/import-artifact-routes.test.ts
+++ b/packages/cli/test/import-artifact-routes.test.ts
@@ -85,6 +85,7 @@ describe('import artifact daemon routes', () => {
           requestToken: undefined,
           requestAgentAddress: 'did:dkg:agent:test',
           requestPrincipal: { kind: 'anonymous' },
+          requestAuthorization: { nodeOperator: false },
           emitMemoryGraphChanged: (event) => events.push(event),
         } as any);
         if (!res.writableEnded) {

--- a/packages/cli/test/kc-author-route.e2e.test.ts
+++ b/packages/cli/test/kc-author-route.e2e.test.ts
@@ -35,6 +35,7 @@ import {
 import { buildAuthorAttestationTypedData } from '@origintrail-official/dkg-core';
 import { handleKcChainMetadataRoutes } from '../src/daemon/routes/kc-chain-metadata.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 const TEST_KAV10_ADDR = '0x000000000000000000000000000000000000c10a';
 const ZERO = '0x0000000000000000000000000000000000000000';
@@ -122,7 +123,7 @@ function createContext(args: {
     apiPortRef: { value: 0 },
     url,
     path: url.pathname,
-    requestToken: undefined,
+    authentication: requestAuthentication({ kind: 'anonymous' }),
     requestAgentAddress: '0x0',
   };
 }

--- a/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
+++ b/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
@@ -171,6 +171,9 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
           path: url.pathname,
           requestToken: routeOverrides.requestToken,
           requestAgentAddress: routeOverrides.requestAgentAddress ?? 'did:dkg:agent:test',
+          requestPrincipal: routeOverrides.requestToken && agent.resolveAgentByToken(routeOverrides.requestToken)
+            ? { kind: 'agent', agentAddress: agent.resolveAgentByToken(routeOverrides.requestToken) }
+            : { kind: 'anonymous' },
           emitMemoryGraphChanged: () => {},
           emitNotification: () => {},
         } as any);

--- a/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
+++ b/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
@@ -174,6 +174,7 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
           requestPrincipal: routeOverrides.requestToken && agent.resolveAgentByToken(routeOverrides.requestToken)
             ? { kind: 'agent', agentAddress: agent.resolveAgentByToken(routeOverrides.requestToken) }
             : { kind: 'anonymous' },
+          requestAuthorization: { nodeOperator: false },
           emitMemoryGraphChanged: () => {},
           emitNotification: () => {},
         } as any);

--- a/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
+++ b/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
@@ -45,6 +45,7 @@ import { daemonState } from '../src/daemon/state.js';
 import { addPublisherWallet } from '../src/publisher-wallets.js';
 import { createPublisherRuntimeFromAgent, type AsyncPublisherAvailability } from '../src/publisher-runner.js';
 import { createKnowledgeAssetVmPublishHandler } from '../src/daemon/lifecycle.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 const CG_ID = 'issue-1116-cg';
 const ASSERTION_NAME = 'seal-asset';
@@ -169,12 +170,14 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
           apiPortRef: { value: 0 },
           url,
           path: url.pathname,
-          requestToken: routeOverrides.requestToken,
           requestAgentAddress: routeOverrides.requestAgentAddress ?? 'did:dkg:agent:test',
-          requestPrincipal: routeOverrides.requestToken && agent.resolveAgentByToken(routeOverrides.requestToken)
-            ? { kind: 'agent', agentAddress: agent.resolveAgentByToken(routeOverrides.requestToken) }
-            : { kind: 'anonymous' },
-          requestAuthorization: { nodeOperator: false },
+          authentication: routeOverrides.requestToken && agent.resolveAgentByToken(routeOverrides.requestToken)
+            ? requestAuthentication({
+                kind: 'agent',
+                agentAddress: agent.resolveAgentByToken(routeOverrides.requestToken),
+                token: routeOverrides.requestToken,
+              })
+            : requestAuthentication({ kind: 'anonymous' }),
           emitMemoryGraphChanged: () => {},
           emitNotification: () => {},
         } as any);

--- a/packages/cli/test/knowledge-assets-no-funded-wallet-route.test.ts
+++ b/packages/cli/test/knowledge-assets-no-funded-wallet-route.test.ts
@@ -63,6 +63,7 @@ describe('POST /api/knowledge-assets/:name/vm/publish — NO_FUNDED_PUBLISHER_WA
           extractionRegistry: {}, fileStore: {}, extractionStatus: new Map(), assertionImportLocks: new Map(),
           vectorStore: {}, embeddingProvider: null, validTokens: new Set(), apiHost: '127.0.0.1', apiPortRef: { value: 0 },
           url, path: url.pathname, requestToken: undefined, requestAgentAddress: 'did:dkg:agent:test',
+          requestPrincipal: { kind: 'anonymous' },
           emitMemoryGraphChanged: () => {}, emitNotification: () => {},
         } as any);
         if (!res.writableEnded) { res.statusCode = 404; res.end(); }

--- a/packages/cli/test/knowledge-assets-no-funded-wallet-route.test.ts
+++ b/packages/cli/test/knowledge-assets-no-funded-wallet-route.test.ts
@@ -18,6 +18,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { createServer, type Server } from 'node:http';
 import { handleKnowledgeAssetsRoutes } from '../src/daemon/routes/knowledge-assets.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 const CG_ID = 'no-funded-wallet-cg';
 const ASSERTION_NAME = 'paid-asset';
@@ -62,9 +63,8 @@ describe('POST /api/knowledge-assets/:name/vm/publish — NO_FUNDED_PUBLISHER_WA
           catchupTracker: { jobs: new Map(), latestByContextGraph: new Map() },
           extractionRegistry: {}, fileStore: {}, extractionStatus: new Map(), assertionImportLocks: new Map(),
           vectorStore: {}, embeddingProvider: null, validTokens: new Set(), apiHost: '127.0.0.1', apiPortRef: { value: 0 },
-          url, path: url.pathname, requestToken: undefined, requestAgentAddress: 'did:dkg:agent:test',
-          requestPrincipal: { kind: 'anonymous' },
-          requestAuthorization: { nodeOperator: false },
+          url, path: url.pathname, requestAgentAddress: 'did:dkg:agent:test',
+          authentication: requestAuthentication({ kind: 'anonymous' }),
           emitMemoryGraphChanged: () => {}, emitNotification: () => {},
         } as any);
         if (!res.writableEnded) { res.statusCode = 404; res.end(); }

--- a/packages/cli/test/knowledge-assets-no-funded-wallet-route.test.ts
+++ b/packages/cli/test/knowledge-assets-no-funded-wallet-route.test.ts
@@ -64,6 +64,7 @@ describe('POST /api/knowledge-assets/:name/vm/publish — NO_FUNDED_PUBLISHER_WA
           vectorStore: {}, embeddingProvider: null, validTokens: new Set(), apiHost: '127.0.0.1', apiPortRef: { value: 0 },
           url, path: url.pathname, requestToken: undefined, requestAgentAddress: 'did:dkg:agent:test',
           requestPrincipal: { kind: 'anonymous' },
+          requestAuthorization: { nodeOperator: false },
           emitMemoryGraphChanged: () => {}, emitNotification: () => {},
         } as any);
         if (!res.writableEnded) { res.statusCode = 404; res.end(); }

--- a/packages/cli/test/memory-search-sparql-injection.test.ts
+++ b/packages/cli/test/memory-search-sparql-injection.test.ts
@@ -43,6 +43,7 @@ function buildCtx(body: unknown, captureSparql: (s: string) => void) {
     path: url.pathname,
     url,
     requestPrincipal: { kind: 'anonymous' },
+    requestAuthorization: { nodeOperator: false },
   } as unknown as RequestContext;
   return { ctx, res };
 }

--- a/packages/cli/test/memory-search-sparql-injection.test.ts
+++ b/packages/cli/test/memory-search-sparql-injection.test.ts
@@ -42,6 +42,7 @@ function buildCtx(body: unknown, captureSparql: (s: string) => void) {
     vectorStore: { search: async () => [] },
     path: url.pathname,
     url,
+    requestPrincipal: { kind: 'anonymous' },
   } as unknown as RequestContext;
   return { ctx, res };
 }

--- a/packages/cli/test/memory-search-sparql-injection.test.ts
+++ b/packages/cli/test/memory-search-sparql-injection.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { escapeSparqlLiteral } from '@origintrail-official/dkg-core';
 import { handleMemoryRoutes } from '../src/daemon/routes/memory.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 function fakeRes() {
   const res: any = { statusCode: 0, body: '', headers: {} as Record<string, string> };
@@ -42,8 +43,7 @@ function buildCtx(body: unknown, captureSparql: (s: string) => void) {
     vectorStore: { search: async () => [] },
     path: url.pathname,
     url,
-    requestPrincipal: { kind: 'anonymous' },
-    requestAuthorization: { nodeOperator: false },
+    authentication: requestAuthentication({ kind: 'anonymous' }),
   } as unknown as RequestContext;
   return { ctx, res };
 }

--- a/packages/cli/test/memory-turn-route.test.ts
+++ b/packages/cli/test/memory-turn-route.test.ts
@@ -60,6 +60,7 @@ function buildTurnCtx(body: unknown, agent: Record<string, any>, requestAgentAdd
     path: url.pathname,
     requestToken: 'agent-token',
     requestAgentAddress,
+    requestPrincipal: { kind: 'agent', agentAddress: requestAgentAddress },
     emitMemoryGraphChanged: vi.fn(),
     emitNotification: vi.fn(),
   } as unknown as RequestContext;

--- a/packages/cli/test/memory-turn-route.test.ts
+++ b/packages/cli/test/memory-turn-route.test.ts
@@ -61,6 +61,7 @@ function buildTurnCtx(body: unknown, agent: Record<string, any>, requestAgentAdd
     requestToken: 'agent-token',
     requestAgentAddress,
     requestPrincipal: { kind: 'agent', agentAddress: requestAgentAddress },
+    requestAuthorization: { nodeOperator: false },
     emitMemoryGraphChanged: vi.fn(),
     emitNotification: vi.fn(),
   } as unknown as RequestContext;

--- a/packages/cli/test/memory-turn-route.test.ts
+++ b/packages/cli/test/memory-turn-route.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { handleMemoryRoutes } from '../src/daemon/routes/memory.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 function fakeRes() {
   const res: any = { statusCode: 0, body: '', headers: {} as Record<string, string>, writableEnded: false };
@@ -58,10 +59,8 @@ function buildTurnCtx(body: unknown, agent: Record<string, any>, requestAgentAdd
     apiPortRef: { value: 0 },
     url,
     path: url.pathname,
-    requestToken: 'agent-token',
     requestAgentAddress,
-    requestPrincipal: { kind: 'agent', agentAddress: requestAgentAddress },
-    requestAuthorization: { nodeOperator: false },
+    authentication: requestAuthentication({ kind: 'agent', agentAddress: requestAgentAddress, token: 'agent-token' }),
     emitMemoryGraphChanged: vi.fn(),
     emitNotification: vi.fn(),
   } as unknown as RequestContext;

--- a/packages/cli/test/notifications-route-pca.test.ts
+++ b/packages/cli/test/notifications-route-pca.test.ts
@@ -14,6 +14,7 @@
 import { describe, it, expect } from 'vitest';
 import { handleNotificationRoutes } from '../src/daemon/routes/notifications.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 const CALLER = '0xaaaa000000000000000000000000000000000001';
 const OTHER = '0xbbbb000000000000000000000000000000000002';
@@ -80,7 +81,8 @@ function makeCtx(
   };
   const ctx = {
     req: fakeReq(method, path, body), res, agent, dashDb,
-    path: url.pathname, url, requestToken: TOKEN,
+    path: url.pathname, url,
+    authentication: requestAuthentication({ kind: 'agent', agentAddress: CALLER, token: TOKEN }),
   } as unknown as RequestContext;
   return { ctx, res };
 }

--- a/packages/cli/test/promote-async-daemon-lifecycle.test.ts
+++ b/packages/cli/test/promote-async-daemon-lifecycle.test.ts
@@ -18,6 +18,7 @@ import {
   type PromoteListFilter,
 } from '@origintrail-official/dkg-publisher';
 import { handleKnowledgeAssetsRoutes } from '../src/daemon/routes/knowledge-assets.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 import { daemonState, startPromoteWorkerDaemonLifecycle, type PromoteWorkerDaemonLifecycle } from '../src/daemon.js';
 
 describe('promote-async daemon lifecycle wiring', () => {
@@ -154,10 +155,8 @@ describe('promote-async daemon lifecycle wiring', () => {
           apiPortRef: { value: 0 },
           url,
           path: url.pathname,
-          requestToken: undefined,
           requestAgentAddress: 'did:dkg:agent:test',
-          requestPrincipal: { kind: 'anonymous' },
-          requestAuthorization: { nodeOperator: false },
+          authentication: requestAuthentication({ kind: 'anonymous' }),
           emitMemoryGraphChanged: () => {},
           emitNotification: () => {},
         } as any);

--- a/packages/cli/test/promote-async-daemon-lifecycle.test.ts
+++ b/packages/cli/test/promote-async-daemon-lifecycle.test.ts
@@ -157,6 +157,7 @@ describe('promote-async daemon lifecycle wiring', () => {
           requestToken: undefined,
           requestAgentAddress: 'did:dkg:agent:test',
           requestPrincipal: { kind: 'anonymous' },
+          requestAuthorization: { nodeOperator: false },
           emitMemoryGraphChanged: () => {},
           emitNotification: () => {},
         } as any);

--- a/packages/cli/test/promote-async-daemon-lifecycle.test.ts
+++ b/packages/cli/test/promote-async-daemon-lifecycle.test.ts
@@ -156,6 +156,7 @@ describe('promote-async daemon lifecycle wiring', () => {
           path: url.pathname,
           requestToken: undefined,
           requestAgentAddress: 'did:dkg:agent:test',
+          requestPrincipal: { kind: 'anonymous' },
           emitMemoryGraphChanged: () => {},
           emitNotification: () => {},
         } as any);

--- a/packages/cli/test/promote-async-routes.test.ts
+++ b/packages/cli/test/promote-async-routes.test.ts
@@ -164,6 +164,7 @@ describe('async SWM-share queue daemon routes', () => {
           requestPrincipal: agent.resolveAgentByToken(requestToken)
             ? { kind: 'agent', agentAddress: agent.resolveAgentByToken(requestToken) }
             : { kind: 'anonymous' },
+          requestAuthorization: { nodeOperator: false },
           emitMemoryGraphChanged: () => {},
           emitNotification: () => {},
         } as any);

--- a/packages/cli/test/promote-async-routes.test.ts
+++ b/packages/cli/test/promote-async-routes.test.ts
@@ -34,6 +34,7 @@ import {
   type PromoteListFilter,
 } from '@origintrail-official/dkg-publisher';
 import { handleKnowledgeAssetsRoutes } from '../src/daemon/routes/knowledge-assets.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 import { daemonState } from '../src/daemon/state.js';
 
 describe('async SWM-share queue daemon routes', () => {
@@ -159,12 +160,10 @@ describe('async SWM-share queue daemon routes', () => {
           apiPortRef: { value: 0 },
           url,
           path: url.pathname,
-          requestToken,
           requestAgentAddress: agent.resolveAgentByToken(requestToken) ?? 'did:dkg:agent:test',
-          requestPrincipal: agent.resolveAgentByToken(requestToken)
-            ? { kind: 'agent', agentAddress: agent.resolveAgentByToken(requestToken) }
-            : { kind: 'anonymous' },
-          requestAuthorization: { nodeOperator: false },
+          authentication: agent.resolveAgentByToken(requestToken)
+            ? requestAuthentication({ kind: 'agent', agentAddress: agent.resolveAgentByToken(requestToken), token: requestToken })
+            : requestAuthentication({ kind: 'anonymous' }),
           emitMemoryGraphChanged: () => {},
           emitNotification: () => {},
         } as any);

--- a/packages/cli/test/promote-async-routes.test.ts
+++ b/packages/cli/test/promote-async-routes.test.ts
@@ -161,6 +161,9 @@ describe('async SWM-share queue daemon routes', () => {
           path: url.pathname,
           requestToken,
           requestAgentAddress: agent.resolveAgentByToken(requestToken) ?? 'did:dkg:agent:test',
+          requestPrincipal: agent.resolveAgentByToken(requestToken)
+            ? { kind: 'agent', agentAddress: agent.resolveAgentByToken(requestToken) }
+            : { kind: 'anonymous' },
           emitMemoryGraphChanged: () => {},
           emitNotification: () => {},
         } as any);

--- a/packages/cli/test/promote-route-not-persisted.test.ts
+++ b/packages/cli/test/promote-route-not-persisted.test.ts
@@ -121,6 +121,7 @@ describe('POST /api/knowledge-assets/:name/swm/share — issue #864 not-persiste
           path: url.pathname,
           requestToken: undefined,
           requestAgentAddress: 'did:dkg:agent:test',
+          requestPrincipal: { kind: 'anonymous' },
           emitMemoryGraphChanged: () => {},
           emitNotification: () => {},
         } as any);

--- a/packages/cli/test/promote-route-not-persisted.test.ts
+++ b/packages/cli/test/promote-route-not-persisted.test.ts
@@ -122,6 +122,7 @@ describe('POST /api/knowledge-assets/:name/swm/share — issue #864 not-persiste
           requestToken: undefined,
           requestAgentAddress: 'did:dkg:agent:test',
           requestPrincipal: { kind: 'anonymous' },
+          requestAuthorization: { nodeOperator: false },
           emitMemoryGraphChanged: () => {},
           emitNotification: () => {},
         } as any);

--- a/packages/cli/test/promote-route-not-persisted.test.ts
+++ b/packages/cli/test/promote-route-not-persisted.test.ts
@@ -25,6 +25,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createServer, type Server } from 'node:http';
 import { handleKnowledgeAssetsRoutes } from '../src/daemon/routes/knowledge-assets.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 const CG_ID = 'issue-864-cg';
 const ASSERTION_NAME = 'orphan-assertion';
@@ -119,10 +120,8 @@ describe('POST /api/knowledge-assets/:name/swm/share — issue #864 not-persiste
           apiPortRef: { value: 0 },
           url,
           path: url.pathname,
-          requestToken: undefined,
           requestAgentAddress: 'did:dkg:agent:test',
-          requestPrincipal: { kind: 'anonymous' },
-          requestAuthorization: { nodeOperator: false },
+          authentication: requestAuthentication({ kind: 'anonymous' }),
           emitMemoryGraphChanged: () => {},
           emitNotification: () => {},
         } as any);

--- a/packages/cli/test/publisher-admin-body-boundary.test.ts
+++ b/packages/cli/test/publisher-admin-body-boundary.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { handlePublisherRoutes } from '../src/daemon/routes/publisher.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
 import { SAFE_JOB_ID_ERROR } from '@origintrail-official/dkg-publisher';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 // #1890 — the four publisher admin POST routes now share one request-body boundary
 // (readSmallJsonObject). This pins each route's body handling — importantly the previously
@@ -71,7 +72,7 @@ describe('#1890 publisher admin POST body boundary', () => {
       validTokens: new Set<string>(),
       apiHost: '127.0.0.1', apiPortRef: { value: 0 },
       url, path: url.pathname,
-      requestToken: undefined, requestAgentAddress: '0x0',
+      authentication: requestAuthentication({ kind: 'anonymous' }), requestAgentAddress: '0x0',
     } as unknown as RequestContext;
     await handlePublisherRoutes(ctx);
     return { status: res.statusCode, body: res.body ? JSON.parse(res.body) as Record<string, unknown> : {} };

--- a/packages/cli/test/publisher-clear-job-override-authz.test.ts
+++ b/packages/cli/test/publisher-clear-job-override-authz.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { Readable } from 'node:stream';
 import type { ServerResponse } from 'node:http';
 import { handlePublisherRoutes } from '../src/daemon/routes/publisher.js';
-import { authenticateHttpRequest } from '../src/auth.js';
+import { authenticateHttpRequest, canAdministerNode } from '../src/auth.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
 import type {
   PendingTransactionClearOverride,
@@ -93,10 +93,8 @@ describe('clear-job pending-transaction override authorization', () => {
           res: res as unknown as ServerResponse,
           url: new URL(`http://127.0.0.1${path}`),
           path,
-          requestToken: authentication.requestToken,
-          requestAuthorization: authentication.requestAuthorization,
+          authentication,
           requestAgentAddress: caller.requestAgentAddress,
-          requestPrincipal: authentication.requestPrincipal,
           agent,
           config: { auth: { enabled: authEnabled } },
           validTokens,
@@ -185,9 +183,10 @@ describe('clear-job pending-transaction override authorization', () => {
     expect(authentication).toMatchObject({
       allowed: true,
       mode: 'disabled',
-      requestPrincipal: { kind: 'agent', agentAddress: OWNER },
-      requestAuthorization: { nodeOperator: true },
+      acceptedToken: 'dkg_at_owner',
+      principal: { kind: 'agent', agentAddress: OWNER },
     });
+    expect(authentication.allowed && canAdministerNode(authentication)).toBe(true);
     expect(calls).toEqual([{
       jobId: 'legacy-agent-job',
       authority: { kind: 'nodeOperator' },
@@ -209,9 +208,11 @@ describe('clear-job pending-transaction override authorization', () => {
     expect(authentication).toMatchObject({
       allowed: true,
       mode: 'disabled',
-      requestPrincipal: { kind: 'anonymous' },
-      requestAuthorization: { nodeOperator: true },
+      presentedToken: 'junk-token',
+      acceptedToken: undefined,
+      principal: { kind: 'anonymous' },
     });
+    expect(authentication.allowed && canAdministerNode(authentication)).toBe(true);
     expect(calls[0]?.authority).toEqual({ kind: 'nodeOperator' });
   });
 
@@ -229,9 +230,10 @@ describe('clear-job pending-transaction override authorization', () => {
     expect(authentication).toMatchObject({
       allowed: true,
       mode: 'disabled',
-      requestPrincipal: { kind: 'nodeOperator' },
-      requestAuthorization: { nodeOperator: true },
+      acceptedToken: 'node-admin-token',
+      principal: { kind: 'nodeOperator' },
     });
+    expect(authentication.allowed && canAdministerNode(authentication)).toBe(true);
     expect(calls[0]?.authority).toEqual({ kind: 'nodeOperator' });
   });
 

--- a/packages/cli/test/publisher-clear-job-override-authz.test.ts
+++ b/packages/cli/test/publisher-clear-job-override-authz.test.ts
@@ -4,6 +4,7 @@ import type { ServerResponse } from 'node:http';
 import { handlePublisherRoutes } from '../src/daemon/routes/publisher.js';
 import { authenticateHttpRequest, canAdministerNode } from '../src/auth.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
+import { createRequestActor } from '../src/daemon/routes/context.js';
 import type {
   PendingTransactionClearOverride,
   TargetedLiftJobClearOptions,
@@ -93,8 +94,7 @@ describe('clear-job pending-transaction override authorization', () => {
           res: res as unknown as ServerResponse,
           url: new URL(`http://127.0.0.1${path}`),
           path,
-          authentication,
-          requestAgentAddress: caller.requestAgentAddress,
+          actor: createRequestActor(authentication, () => caller.requestAgentAddress),
           agent,
           config: { auth: { enabled: authEnabled } },
           validTokens,

--- a/packages/cli/test/publisher-clear-job-override-authz.test.ts
+++ b/packages/cli/test/publisher-clear-job-override-authz.test.ts
@@ -216,6 +216,30 @@ describe('clear-job pending-transaction override authorization', () => {
     expect(calls[0]?.authority).toEqual({ kind: 'nodeOperator' });
   });
 
+  it('ignores a resolver-known token that is no longer accepted', async () => {
+    const { run, calls } = post(
+      { jobId: 'legacy-revoked-token-job', allowPendingTransaction: true },
+      {
+        requestAgentAddress: DEFAULT_AGENT,
+        requestToken: 'revoked-agent-token',
+        tokenAgentAddress: OWNER,
+        validTokens: new Set(),
+        authEnabled: false,
+      },
+    );
+    const authentication = await run();
+
+    expect(authentication).toMatchObject({
+      allowed: true,
+      mode: 'disabled',
+      presentedToken: 'revoked-agent-token',
+      acceptedToken: undefined,
+      principal: { kind: 'anonymous' },
+    });
+    expect(authentication.allowed && canAdministerNode(authentication)).toBe(true);
+    expect(calls[0]?.authority).toEqual({ kind: 'nodeOperator' });
+  });
+
   it('keeps a valid node token identified as the operator when auth is disabled', async () => {
     const { run, calls } = post(
       { jobId: 'legacy-node-token-job', allowPendingTransaction: true },

--- a/packages/cli/test/publisher-clear-job-override-authz.test.ts
+++ b/packages/cli/test/publisher-clear-job-override-authz.test.ts
@@ -87,14 +87,14 @@ describe('clear-job pending-transaction override authorization', () => {
           validTokens,
           resolveAgentByToken: (token) => agent.resolveAgentByToken(token),
         });
-        if (!authentication.allowed) return;
+        if (!authentication.allowed) return authentication;
         const ctx = {
           req: req as RequestContext['req'],
           res: res as unknown as ServerResponse,
           url: new URL(`http://127.0.0.1${path}`),
           path,
           requestToken: authentication.requestToken,
-          requestCredentialAuthenticated: authentication.requestCredentialAuthenticated,
+          requestAuthorization: authentication.requestAuthorization,
           requestAgentAddress: caller.requestAgentAddress,
           requestPrincipal: authentication.requestPrincipal,
           agent,
@@ -103,6 +103,7 @@ describe('clear-job pending-transaction override authorization', () => {
           publisherControl,
         } as unknown as RequestContext;
         await handlePublisherRoutes(ctx);
+        return authentication;
       },
       calls,
       res,
@@ -167,6 +168,71 @@ describe('clear-job pending-transaction override authorization', () => {
       jobId: 'legacy-job',
       authority: { kind: 'nodeOperator' },
     }]);
+  });
+
+  it('preserves agent identity and operator authority for a valid bearer when auth is disabled', async () => {
+    const { run, calls } = post(
+      { jobId: 'legacy-agent-job', allowPendingTransaction: true },
+      {
+        requestAgentAddress: OWNER,
+        requestToken: 'dkg_at_owner',
+        tokenAgentAddress: OWNER,
+        authEnabled: false,
+      },
+    );
+    const authentication = await run();
+
+    expect(authentication).toMatchObject({
+      allowed: true,
+      mode: 'disabled',
+      requestPrincipal: { kind: 'agent', agentAddress: OWNER },
+      requestAuthorization: { nodeOperator: true },
+    });
+    expect(calls).toEqual([{
+      jobId: 'legacy-agent-job',
+      authority: { kind: 'nodeOperator' },
+    }]);
+  });
+
+  it('keeps an invalid optional bearer anonymous without removing auth-disabled operator authority', async () => {
+    const { run, calls } = post(
+      { jobId: 'legacy-junk-token-job', allowPendingTransaction: true },
+      {
+        requestAgentAddress: DEFAULT_AGENT,
+        requestToken: 'junk-token',
+        validTokens: new Set(),
+        authEnabled: false,
+      },
+    );
+    const authentication = await run();
+
+    expect(authentication).toMatchObject({
+      allowed: true,
+      mode: 'disabled',
+      requestPrincipal: { kind: 'anonymous' },
+      requestAuthorization: { nodeOperator: true },
+    });
+    expect(calls[0]?.authority).toEqual({ kind: 'nodeOperator' });
+  });
+
+  it('keeps a valid node token identified as the operator when auth is disabled', async () => {
+    const { run, calls } = post(
+      { jobId: 'legacy-node-token-job', allowPendingTransaction: true },
+      {
+        requestAgentAddress: DEFAULT_AGENT,
+        requestToken: 'node-admin-token',
+        authEnabled: false,
+      },
+    );
+    const authentication = await run();
+
+    expect(authentication).toMatchObject({
+      allowed: true,
+      mode: 'disabled',
+      requestPrincipal: { kind: 'nodeOperator' },
+      requestAuthorization: { nodeOperator: true },
+    });
+    expect(calls[0]?.authority).toEqual({ kind: 'nodeOperator' });
   });
 
   it('does NOT grant it to the owner who did not ask for it', async () => {

--- a/packages/cli/test/publisher-clear-job-override-authz.test.ts
+++ b/packages/cli/test/publisher-clear-job-override-authz.test.ts
@@ -8,18 +8,29 @@ import type { RequestContext } from '../src/daemon/handle-request.js';
  * GH#2270 follow-up (🔴 3823952704) — who may force-clear a job whose transaction may still land.
  *
  * The by-id clear is the stated exit for a held UPDATE, but `/api/publisher/clear-job` is reachable
- * by every registered agent token and does no ownership check of its own. Widening the predicate
- * for all callers therefore let one agent delete another lifecycle's only chain-recovery record —
- * and if that transaction later landed, or the owner resubmitted, the node could publish twice.
+ * by every registered agent token. Widening the predicate for all callers therefore let one agent
+ * delete another lifecycle's only chain-recovery record — and if that transaction later landed,
+ * or the owner resubmitted, the node could publish twice. The node token is a distinct operator
+ * tier: it owns the queue and must not be collapsed into the default agent identity.
  *
- * Two conditions are required, and these rows pin each one independently.
+ * These rows pin the three tiers: owning agent, node operator, and unrelated agent.
  */
 describe('clear-job pending-transaction override authorization', () => {
   const OWNER = '0xAAaAAa00000000000000000000000000000000Aa';
   const OTHER = '0xBBbBBb00000000000000000000000000000000Bb';
+  const DEFAULT_AGENT = '0xCCcCCc00000000000000000000000000000000Cc';
 
-  function post(body: unknown, requestAgentAddress: string) {
-    const calls: Array<{ jobId: string; requestedBy?: string }> = [];
+  function post(body: unknown, caller: {
+    requestAgentAddress: string;
+    requestToken?: string;
+    tokenAgentAddress?: string;
+    authEnabled?: boolean;
+  }) {
+    const calls: Array<{
+      jobId: string;
+      requestedBy?: string;
+      requestedByNodeOperator?: true;
+    }> = [];
     const path = '/api/publisher/clear-job';
     const req = Readable.from([]);
     Object.assign(req, {
@@ -38,20 +49,40 @@ describe('clear-job pending-transaction override authorization', () => {
       getStatus: async () => { throw new Error('route must not query the job'); },
       clearTerminalJob: async (
         jobId: string,
-        options?: { pendingTransactionOverride?: { requestedBy: string } },
+        options?: {
+          pendingTransactionOverride?: {
+            requestedBy?: string;
+            requestedByNodeOperator?: true;
+          };
+        },
       ) => {
-        calls.push({ jobId, requestedBy: options?.pendingTransactionOverride?.requestedBy });
+        calls.push({
+          jobId,
+          requestedBy: options?.pendingTransactionOverride?.requestedBy,
+          requestedByNodeOperator:
+            options?.pendingTransactionOverride?.requestedByNodeOperator,
+        });
         return { outcome: 'cleared' as const };
       },
     } as unknown as RequestContext['publisherControl'];
+
+    const requestToken = caller.requestToken;
+    const agent = {
+      resolveAgentByToken: (token: string) => (
+        token === requestToken ? caller.tokenAgentAddress : undefined
+      ),
+    } as unknown as RequestContext['agent'];
 
     const ctx = {
       req: req as RequestContext['req'],
       res: res as unknown as ServerResponse,
       url: new URL(`http://127.0.0.1${path}`),
       path,
-      requestToken: 'dkg_at_test',
-      requestAgentAddress,
+      requestToken,
+      requestAgentAddress: caller.requestAgentAddress,
+      agent,
+      config: { auth: { enabled: caller.authEnabled ?? true } },
+      validTokens: new Set(requestToken ? [requestToken] : []),
       publisherControl,
     } as unknown as RequestContext;
 
@@ -60,26 +91,85 @@ describe('clear-job pending-transaction override authorization', () => {
 
   it('does NOT grant the override to an agent that does not own the job', async () => {
     // The reviewer's scenario: agent B force-clearing agent A's held job.
-    const { run, calls } = post({ jobId: 'job-1', allowPendingTransaction: true }, OTHER);
+    const { run, calls } = post(
+      { jobId: 'job-1', allowPendingTransaction: true },
+      {
+        requestAgentAddress: OTHER,
+        requestToken: 'dkg_at_other',
+        tokenAgentAddress: OTHER,
+      },
+    );
     await run();
     // The route forwards WHO is asking; the publisher decides, atomically, on the record it is
     // about to delete. What matters here is that the caller's identity is not lost on the way.
-    expect(calls).toEqual([{ jobId: 'job-1', requestedBy: OTHER }]);
+    expect(calls).toEqual([{
+      jobId: 'job-1',
+      requestedBy: OTHER,
+      requestedByNodeOperator: undefined,
+    }]);
   });
 
   it('grants it to the owning agent that explicitly asks', async () => {
     // The discriminating half — without it, refusing everyone would pass the row above.
-    const { run, calls } = post({ jobId: 'job-1', allowPendingTransaction: true }, OWNER);
+    const { run, calls } = post(
+      { jobId: 'job-1', allowPendingTransaction: true },
+      {
+        requestAgentAddress: OWNER,
+        requestToken: 'dkg_at_owner',
+        tokenAgentAddress: OWNER,
+      },
+    );
     await run();
-    expect(calls).toEqual([{ jobId: 'job-1', requestedBy: OWNER }]);
+    expect(calls).toEqual([{
+      jobId: 'job-1',
+      requestedBy: OWNER,
+      requestedByNodeOperator: undefined,
+    }]);
+  });
+
+  it('grants a distinct node-operator override instead of impersonating the default agent', async () => {
+    const { run, calls } = post(
+      { jobId: 'job-1', allowPendingTransaction: true },
+      { requestAgentAddress: DEFAULT_AGENT, requestToken: 'node-admin-token' },
+    );
+    await run();
+    expect(calls).toEqual([{
+      jobId: 'job-1',
+      requestedBy: undefined,
+      requestedByNodeOperator: true,
+    }]);
+  });
+
+  it('treats the tokenless auth-disabled daemon as the node operator', async () => {
+    const { run, calls } = post(
+      { jobId: 'legacy-job', allowPendingTransaction: true },
+      { requestAgentAddress: DEFAULT_AGENT, authEnabled: false },
+    );
+    await run();
+    expect(calls).toEqual([{
+      jobId: 'legacy-job',
+      requestedBy: undefined,
+      requestedByNodeOperator: true,
+    }]);
   });
 
   it('does NOT grant it to the owner who did not ask for it', async () => {
     // Ownership alone is not consent: an ordinary terminal clear must stay ordinary.
-    const { run, calls } = post({ jobId: 'job-1' }, OWNER);
+    const { run, calls } = post(
+      { jobId: 'job-1' },
+      {
+        requestAgentAddress: OWNER,
+        requestToken: 'dkg_at_owner',
+        tokenAgentAddress: OWNER,
+      },
+    );
     await run();
     // No override asked for: the value is absent entirely, not a false flag beside an identity.
-    expect(calls).toEqual([{ jobId: 'job-1', requestedBy: undefined }]);
+    expect(calls).toEqual([{
+      jobId: 'job-1',
+      requestedBy: undefined,
+      requestedByNodeOperator: undefined,
+    }]);
   });
 });
 

--- a/packages/cli/test/publisher-clear-job-override-authz.test.ts
+++ b/packages/cli/test/publisher-clear-job-override-authz.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { Readable } from 'node:stream';
 import type { ServerResponse } from 'node:http';
 import { handlePublisherRoutes } from '../src/daemon/routes/publisher.js';
-import type { RequestContext } from '../src/daemon/handle-request.js';
+import { resolveRequestPrincipal } from '../src/daemon/handle-request.js';
+import type { RequestContext } from '../src/daemon/routes/context.js';
+import type {
+  PendingTransactionClearOverride,
+  TargetedLiftJobClearOptions,
+} from '@origintrail-official/dkg-publisher';
 
 /**
  * GH#2270 follow-up (🔴 3823952704) — who may force-clear a job whose transaction may still land.
@@ -28,8 +33,7 @@ describe('clear-job pending-transaction override authorization', () => {
   }) {
     const calls: Array<{
       jobId: string;
-      requestedBy?: string;
-      requestedByNodeOperator?: true;
+      authority?: PendingTransactionClearOverride;
     }> = [];
     const path = '/api/publisher/clear-job';
     const req = Readable.from([]);
@@ -49,18 +53,11 @@ describe('clear-job pending-transaction override authorization', () => {
       getStatus: async () => { throw new Error('route must not query the job'); },
       clearTerminalJob: async (
         jobId: string,
-        options?: {
-          pendingTransactionOverride?: {
-            requestedBy?: string;
-            requestedByNodeOperator?: true;
-          };
-        },
+        options?: TargetedLiftJobClearOptions,
       ) => {
         calls.push({
           jobId,
-          requestedBy: options?.pendingTransactionOverride?.requestedBy,
-          requestedByNodeOperator:
-            options?.pendingTransactionOverride?.requestedByNodeOperator,
+          authority: options?.pendingTransactionOverride,
         });
         return { outcome: 'cleared' as const };
       },
@@ -72,6 +69,14 @@ describe('clear-job pending-transaction override authorization', () => {
         token === requestToken ? caller.tokenAgentAddress : undefined
       ),
     } as unknown as RequestContext['agent'];
+    const validTokens = new Set(requestToken ? [requestToken] : []);
+    const authEnabled = caller.authEnabled ?? true;
+    const requestPrincipal = resolveRequestPrincipal({
+      authEnabled,
+      requestToken,
+      validTokens,
+      resolveAgentByToken: (token) => agent.resolveAgentByToken(token),
+    });
 
     const ctx = {
       req: req as RequestContext['req'],
@@ -80,9 +85,10 @@ describe('clear-job pending-transaction override authorization', () => {
       path,
       requestToken,
       requestAgentAddress: caller.requestAgentAddress,
+      requestPrincipal,
       agent,
-      config: { auth: { enabled: caller.authEnabled ?? true } },
-      validTokens: new Set(requestToken ? [requestToken] : []),
+      config: { auth: { enabled: authEnabled } },
+      validTokens,
       publisherControl,
     } as unknown as RequestContext;
 
@@ -104,8 +110,7 @@ describe('clear-job pending-transaction override authorization', () => {
     // about to delete. What matters here is that the caller's identity is not lost on the way.
     expect(calls).toEqual([{
       jobId: 'job-1',
-      requestedBy: OTHER,
-      requestedByNodeOperator: undefined,
+      authority: { kind: 'agent', requestedBy: OTHER },
     }]);
   });
 
@@ -122,8 +127,7 @@ describe('clear-job pending-transaction override authorization', () => {
     await run();
     expect(calls).toEqual([{
       jobId: 'job-1',
-      requestedBy: OWNER,
-      requestedByNodeOperator: undefined,
+      authority: { kind: 'agent', requestedBy: OWNER },
     }]);
   });
 
@@ -135,8 +139,7 @@ describe('clear-job pending-transaction override authorization', () => {
     await run();
     expect(calls).toEqual([{
       jobId: 'job-1',
-      requestedBy: undefined,
-      requestedByNodeOperator: true,
+      authority: { kind: 'nodeOperator' },
     }]);
   });
 
@@ -148,8 +151,7 @@ describe('clear-job pending-transaction override authorization', () => {
     await run();
     expect(calls).toEqual([{
       jobId: 'legacy-job',
-      requestedBy: undefined,
-      requestedByNodeOperator: true,
+      authority: { kind: 'nodeOperator' },
     }]);
   });
 
@@ -167,9 +169,52 @@ describe('clear-job pending-transaction override authorization', () => {
     // No override asked for: the value is absent entirely, not a false flag beside an identity.
     expect(calls).toEqual([{
       jobId: 'job-1',
-      requestedBy: undefined,
-      requestedByNodeOperator: undefined,
+      authority: undefined,
     }]);
+  });
+});
+
+describe('shared request-principal boundary', () => {
+  const AGENT_TOKEN = 'dkg_at_owner';
+  const NODE_TOKEN = 'node-admin-token';
+  const OWNER = '0xAAaAAa00000000000000000000000000000000Aa';
+  const validTokens = new Set([AGENT_TOKEN, NODE_TOKEN]);
+  const resolveAgentByToken = (token: string) => token === AGENT_TOKEN ? OWNER : undefined;
+
+  it('classifies a registered agent token as its agent principal', () => {
+    expect(resolveRequestPrincipal({
+      authEnabled: true,
+      requestToken: AGENT_TOKEN,
+      validTokens,
+      resolveAgentByToken,
+    })).toEqual({ kind: 'agent', agentAddress: OWNER });
+  });
+
+  it('classifies a valid non-agent token as the node operator', () => {
+    expect(resolveRequestPrincipal({
+      authEnabled: true,
+      requestToken: NODE_TOKEN,
+      validTokens,
+      resolveAgentByToken,
+    })).toEqual({ kind: 'nodeOperator' });
+  });
+
+  it('classifies a tokenless auth-disabled request as the node operator', () => {
+    expect(resolveRequestPrincipal({
+      authEnabled: false,
+      requestToken: undefined,
+      validTokens,
+      resolveAgentByToken,
+    })).toEqual({ kind: 'nodeOperator' });
+  });
+
+  it('fails closed for a request that has no authenticated principal', () => {
+    expect(resolveRequestPrincipal({
+      authEnabled: true,
+      requestToken: undefined,
+      validTokens,
+      resolveAgentByToken,
+    })).toEqual({ kind: 'anonymous' });
   });
 });
 

--- a/packages/cli/test/publisher-clear-job-override-authz.test.ts
+++ b/packages/cli/test/publisher-clear-job-override-authz.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { Readable } from 'node:stream';
 import type { ServerResponse } from 'node:http';
 import { handlePublisherRoutes } from '../src/daemon/routes/publisher.js';
-import { resolveRequestPrincipal } from '../src/daemon/handle-request.js';
+import { authenticateHttpRequest } from '../src/auth.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
 import type {
   PendingTransactionClearOverride,
@@ -30,6 +30,7 @@ describe('clear-job pending-transaction override authorization', () => {
     requestToken?: string;
     tokenAgentAddress?: string;
     authEnabled?: boolean;
+    validTokens?: Set<string>;
   }) {
     const calls: Array<{
       jobId: string;
@@ -38,7 +39,12 @@ describe('clear-job pending-transaction override authorization', () => {
     const path = '/api/publisher/clear-job';
     const req = Readable.from([]);
     Object.assign(req, {
-      method: 'POST', url: path, headers: { host: '127.0.0.1' },
+      method: 'POST',
+      url: path,
+      headers: {
+        host: '127.0.0.1',
+        ...(caller.requestToken ? { authorization: `Bearer ${caller.requestToken}` } : {}),
+      },
       __dkgPrebufferedBody: Buffer.from(JSON.stringify(body), 'utf8'),
     });
     const res = {
@@ -69,30 +75,38 @@ describe('clear-job pending-transaction override authorization', () => {
         token === requestToken ? caller.tokenAgentAddress : undefined
       ),
     } as unknown as RequestContext['agent'];
-    const validTokens = new Set(requestToken ? [requestToken] : []);
+    const validTokens = caller.validTokens ?? new Set(requestToken ? [requestToken] : []);
     const authEnabled = caller.authEnabled ?? true;
-    const requestPrincipal = resolveRequestPrincipal({
-      authEnabled,
-      requestToken,
-      validTokens,
-      resolveAgentByToken: (token) => agent.resolveAgentByToken(token),
-    });
 
-    const ctx = {
-      req: req as RequestContext['req'],
-      res: res as unknown as ServerResponse,
-      url: new URL(`http://127.0.0.1${path}`),
-      path,
-      requestToken,
-      requestAgentAddress: caller.requestAgentAddress,
-      requestPrincipal,
-      agent,
-      config: { auth: { enabled: authEnabled } },
-      validTokens,
-      publisherControl,
-    } as unknown as RequestContext;
-
-    return { run: () => handlePublisherRoutes(ctx), calls, res };
+    return {
+      run: async () => {
+        const authentication = await authenticateHttpRequest({
+          req: req as RequestContext['req'],
+          res: res as unknown as ServerResponse,
+          authEnabled,
+          validTokens,
+          resolveAgentByToken: (token) => agent.resolveAgentByToken(token),
+        });
+        if (!authentication.allowed) return;
+        const ctx = {
+          req: req as RequestContext['req'],
+          res: res as unknown as ServerResponse,
+          url: new URL(`http://127.0.0.1${path}`),
+          path,
+          requestToken: authentication.requestToken,
+          requestCredentialAuthenticated: authentication.requestCredentialAuthenticated,
+          requestAgentAddress: caller.requestAgentAddress,
+          requestPrincipal: authentication.requestPrincipal,
+          agent,
+          config: { auth: { enabled: authEnabled } },
+          validTokens,
+          publisherControl,
+        } as unknown as RequestContext;
+        await handlePublisherRoutes(ctx);
+      },
+      calls,
+      res,
+    };
   }
 
   it('does NOT grant the override to an agent that does not own the job', async () => {
@@ -110,7 +124,7 @@ describe('clear-job pending-transaction override authorization', () => {
     // about to delete. What matters here is that the caller's identity is not lost on the way.
     expect(calls).toEqual([{
       jobId: 'job-1',
-      authority: { kind: 'agent', requestedBy: OTHER },
+      authority: { kind: 'agent', agentAddress: OTHER },
     }]);
   });
 
@@ -127,7 +141,7 @@ describe('clear-job pending-transaction override authorization', () => {
     await run();
     expect(calls).toEqual([{
       jobId: 'job-1',
-      authority: { kind: 'agent', requestedBy: OWNER },
+      authority: { kind: 'agent', agentAddress: OWNER },
     }]);
   });
 
@@ -172,49 +186,19 @@ describe('clear-job pending-transaction override authorization', () => {
       authority: undefined,
     }]);
   });
-});
 
-describe('shared request-principal boundary', () => {
-  const AGENT_TOKEN = 'dkg_at_owner';
-  const NODE_TOKEN = 'node-admin-token';
-  const OWNER = '0xAAaAAa00000000000000000000000000000000Aa';
-  const validTokens = new Set([AGENT_TOKEN, NODE_TOKEN]);
-  const resolveAgentByToken = (token: string) => token === AGENT_TOKEN ? OWNER : undefined;
-
-  it('classifies a registered agent token as its agent principal', () => {
-    expect(resolveRequestPrincipal({
-      authEnabled: true,
-      requestToken: AGENT_TOKEN,
-      validTokens,
-      resolveAgentByToken,
-    })).toEqual({ kind: 'agent', agentAddress: OWNER });
-  });
-
-  it('classifies a valid non-agent token as the node operator', () => {
-    expect(resolveRequestPrincipal({
-      authEnabled: true,
-      requestToken: NODE_TOKEN,
-      validTokens,
-      resolveAgentByToken,
-    })).toEqual({ kind: 'nodeOperator' });
-  });
-
-  it('classifies a tokenless auth-disabled request as the node operator', () => {
-    expect(resolveRequestPrincipal({
-      authEnabled: false,
-      requestToken: undefined,
-      validTokens,
-      resolveAgentByToken,
-    })).toEqual({ kind: 'nodeOperator' });
-  });
-
-  it('fails closed for a request that has no authenticated principal', () => {
-    expect(resolveRequestPrincipal({
-      authEnabled: true,
-      requestToken: undefined,
-      validTokens,
-      resolveAgentByToken,
-    })).toEqual({ kind: 'anonymous' });
+  it('rejects an unrecognized bearer before routing any override authority', async () => {
+    const { run, calls, res } = post(
+      { jobId: 'job-1', allowPendingTransaction: true },
+      {
+        requestAgentAddress: DEFAULT_AGENT,
+        requestToken: 'forged-token',
+        validTokens: new Set(),
+      },
+    );
+    await run();
+    expect(res.statusCode).toBe(401);
+    expect(calls).toEqual([]);
   });
 });
 

--- a/packages/cli/test/publisher-clear-job-route.test.ts
+++ b/packages/cli/test/publisher-clear-job-route.test.ts
@@ -5,6 +5,7 @@ import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import { createPublisherControlFromStore } from '../src/publisher-runner.js';
 import { handlePublisherRoutes } from '../src/daemon/routes/publisher.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 // #1837 — POST /api/publisher/clear-job outcome → HTTP mapping.
 describe('#1837 POST /api/publisher/clear-job', () => {
@@ -142,7 +143,7 @@ describe('#1837 POST /api/publisher/clear-job', () => {
       apiPortRef: { value: 0 },
       url,
       path: url.pathname,
-      requestToken: undefined,
+      authentication: requestAuthentication({ kind: 'anonymous' }),
       requestAgentAddress: '0x0',
     };
   }

--- a/packages/cli/test/publisher-job-by-intent-route.test.ts
+++ b/packages/cli/test/publisher-job-by-intent-route.test.ts
@@ -5,6 +5,7 @@ import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import { createPublisherControlFromStore } from '../src/publisher-runner.js';
 import { handlePublisherRoutes } from '../src/daemon/routes/publisher.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 // #1828 — GET /api/publisher/job-by-intent route: read-only durable-admission
 // recovery keyed on the lifecycle facts the client retains.
@@ -227,7 +228,7 @@ function createContext(
     apiPortRef: { value: 0 },
     url,
     path: url.pathname,
-    requestToken: undefined,
+    authentication: requestAuthentication({ kind: 'anonymous' }),
     requestAgentAddress,
   };
 }

--- a/packages/cli/test/publisher-journal-route.test.ts
+++ b/packages/cli/test/publisher-journal-route.test.ts
@@ -5,6 +5,7 @@ import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import { createPublisherControlFromStore } from '../src/publisher-runner.js';
 import { handlePublisherRoutes } from '../src/daemon/routes/publisher.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 // #1829 — GET /api/publisher/journal route: read-only append-only journal, by jobId
 // or facts-pure by lifecycle identity. createPublisherControlFromStore enables
@@ -140,7 +141,7 @@ function createContext(path: string, publisherControl: RequestContext['publisher
     apiPortRef: { value: 0 },
     url,
     path: url.pathname,
-    requestToken: undefined,
+    authentication: requestAuthentication({ kind: 'anonymous' }),
     requestAgentAddress,
   };
 }

--- a/packages/cli/test/publisher-retry-surfacing-2270.test.ts
+++ b/packages/cli/test/publisher-retry-surfacing-2270.test.ts
@@ -6,6 +6,7 @@ import { QuorumUnmetError, type LiftJob } from '@origintrail-official/dkg-publis
 import { createPublisherControlFromStore, type AsyncPublisherAvailability } from '../src/publisher-runner.js';
 import { handlePublisherRoutes } from '../src/daemon/routes/publisher.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 /**
  * GH#2270 — what the daemon TELLS an operator about retries.
@@ -417,7 +418,7 @@ describe('GH#2270 publisher retry surfacing (routes over a real publisher)', () 
       validTokens: new Set<string>(),
       apiHost: '127.0.0.1', apiPortRef: { value: 0 },
       url, path: url.pathname,
-      requestToken: undefined, requestAgentAddress: '0x0',
+      authentication: requestAuthentication({ kind: 'anonymous' }), requestAgentAddress: '0x0',
     } as unknown as RequestContext);
     return { status: res.statusCode, body: res.body ? JSON.parse(res.body) : {} };
   }

--- a/packages/cli/test/publisher-route-snapshot.test.ts
+++ b/packages/cli/test/publisher-route-snapshot.test.ts
@@ -15,6 +15,7 @@ import { seedLegacyRawLiftTestJob } from '../../publisher/test/_helpers/legacy-r
 import { createPublisherControlFromStore } from '../src/publisher-runner.js';
 import { handlePublisherRoutes } from '../src/daemon/routes/publisher.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 const CONTEXT_GRAPH = 'publisher-route-snapshot';
 const ENTITY = 'urn:publisher-route:snapshot:entity';
@@ -126,7 +127,7 @@ function createContext(
     apiPortRef: { value: 0 },
     url,
     path: url.pathname,
-    requestToken: undefined,
+    authentication: requestAuthentication({ kind: 'anonymous' }),
     requestAgentAddress: '0x0',
   };
 }

--- a/packages/cli/test/query-catalog-profile-route.test.ts
+++ b/packages/cli/test/query-catalog-profile-route.test.ts
@@ -8,6 +8,7 @@ import {
 import { StoreSchedulerBusyError, type Quad } from '@origintrail-official/dkg-storage';
 import { handleMemoryRoutes } from '../src/daemon/routes/memory.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 const CONTEXT_GRAPH_ID = 'kamstrup-testnet';
 const PROFILE_NS = 'http://dkg.io/ontology/profile/';
@@ -119,10 +120,8 @@ function requestContext(
       agent,
       url,
       path: url.pathname,
-      requestToken: undefined,
       requestAgentAddress: '',
-      requestPrincipal: { kind: 'nodeOperator' },
-      requestAuthorization: { nodeOperator: true },
+      authentication: requestAuthentication({ kind: 'nodeOperator' }),
       validTokens: new Set<string>(),
     } as unknown as RequestContext,
     response,
@@ -196,13 +195,12 @@ describe('/api/profile/query-catalog/read', () => {
     agent.resolveAgentByToken.mockReturnValue('0x1111111111111111111111111111111111111111');
     agent.canReadContextGraph.mockResolvedValue(false);
     const { context, response } = readContext(agent);
-    context.requestToken = 'agent-token';
     context.requestAgentAddress = '0x1111111111111111111111111111111111111111';
-    context.requestPrincipal = {
+    context.authentication = requestAuthentication({
       kind: 'agent',
       agentAddress: '0x1111111111111111111111111111111111111111',
-    };
-    context.requestAuthorization = { nodeOperator: false };
+      token: 'agent-token',
+    });
     context.validTokens = new Set(['agent-token']);
 
     await handleMemoryRoutes(context);
@@ -219,9 +217,7 @@ describe('/api/profile/query-catalog/read', () => {
     const agent = fakeCatalogAgent();
     agent.canReadContextGraph.mockResolvedValue(false);
     const { context, response } = readContext(agent);
-    context.requestToken = 'node-admin-token';
-    context.requestPrincipal = { kind: 'nodeOperator' };
-    context.requestAuthorization = { nodeOperator: true };
+    context.authentication = requestAuthentication({ kind: 'nodeOperator', token: 'node-admin-token' });
     context.validTokens = new Set(['node-admin-token']);
 
     await handleMemoryRoutes(context);

--- a/packages/cli/test/query-catalog-profile-route.test.ts
+++ b/packages/cli/test/query-catalog-profile-route.test.ts
@@ -213,6 +213,28 @@ describe('/api/profile/query-catalog/read', () => {
     expect(agent.store.query).not.toHaveBeenCalled();
   });
 
+  it('keeps an auth-disabled agent principal behind the private-graph ACL', async () => {
+    const agentAddress = '0x1111111111111111111111111111111111111111';
+    const agent = fakeCatalogAgent();
+    agent.canReadContextGraph.mockResolvedValue(false);
+    const { context, response } = readContext(agent);
+    context.authentication = requestAuthentication({
+      kind: 'agent',
+      agentAddress,
+      mode: 'disabled',
+      token: 'agent-token',
+    });
+
+    await handleMemoryRoutes(context);
+
+    expect(response.statusCode).toBe(403);
+    expect(agent.canReadContextGraph).toHaveBeenCalledWith(CONTEXT_GRAPH_ID, {
+      callerAgentAddress: agentAddress,
+    });
+    expect(agent.query).not.toHaveBeenCalled();
+    expect(agent.store.query).not.toHaveBeenCalled();
+  });
+
   it('reads the registered meta subgraph through all Context Graph layers', async () => {
     const agent = fakeCatalogAgent();
     agent.canReadContextGraph.mockResolvedValue(false);

--- a/packages/cli/test/query-catalog-profile-route.test.ts
+++ b/packages/cli/test/query-catalog-profile-route.test.ts
@@ -122,6 +122,7 @@ function requestContext(
       requestToken: undefined,
       requestAgentAddress: '',
       requestPrincipal: { kind: 'nodeOperator' },
+      requestAuthorization: { nodeOperator: true },
       validTokens: new Set<string>(),
     } as unknown as RequestContext,
     response,
@@ -201,6 +202,7 @@ describe('/api/profile/query-catalog/read', () => {
       kind: 'agent',
       agentAddress: '0x1111111111111111111111111111111111111111',
     };
+    context.requestAuthorization = { nodeOperator: false };
     context.validTokens = new Set(['agent-token']);
 
     await handleMemoryRoutes(context);
@@ -219,6 +221,7 @@ describe('/api/profile/query-catalog/read', () => {
     const { context, response } = readContext(agent);
     context.requestToken = 'node-admin-token';
     context.requestPrincipal = { kind: 'nodeOperator' };
+    context.requestAuthorization = { nodeOperator: true };
     context.validTokens = new Set(['node-admin-token']);
 
     await handleMemoryRoutes(context);

--- a/packages/cli/test/query-catalog-profile-route.test.ts
+++ b/packages/cli/test/query-catalog-profile-route.test.ts
@@ -121,6 +121,7 @@ function requestContext(
       path: url.pathname,
       requestToken: undefined,
       requestAgentAddress: '',
+      requestPrincipal: { kind: 'nodeOperator' },
       validTokens: new Set<string>(),
     } as unknown as RequestContext,
     response,
@@ -196,6 +197,10 @@ describe('/api/profile/query-catalog/read', () => {
     const { context, response } = readContext(agent);
     context.requestToken = 'agent-token';
     context.requestAgentAddress = '0x1111111111111111111111111111111111111111';
+    context.requestPrincipal = {
+      kind: 'agent',
+      agentAddress: '0x1111111111111111111111111111111111111111',
+    };
     context.validTokens = new Set(['agent-token']);
 
     await handleMemoryRoutes(context);
@@ -213,6 +218,7 @@ describe('/api/profile/query-catalog/read', () => {
     agent.canReadContextGraph.mockResolvedValue(false);
     const { context, response } = readContext(agent);
     context.requestToken = 'node-admin-token';
+    context.requestPrincipal = { kind: 'nodeOperator' };
     context.validTokens = new Set(['node-admin-token']);
 
     await handleMemoryRoutes(context);

--- a/packages/cli/test/query-route-lifecycle.test.ts
+++ b/packages/cli/test/query-route-lifecycle.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../src/daemon/routes/query.js';
 import { respondIfStoreUnavailable } from '../src/daemon/http-utils.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 class RequestStub extends EventEmitter {
   aborted = false;
@@ -65,10 +66,8 @@ function queryRouteContext(
     validTokens: new Set<string>(),
     url: new URL('http://127.0.0.1/api/query'),
     path: '/api/query',
-    requestToken: undefined,
     requestAgentAddress: '',
-    requestPrincipal: { kind: 'anonymous' },
-    requestAuthorization: { nodeOperator: false },
+    authentication: requestAuthentication({ kind: 'anonymous' }),
   } as unknown as RequestContext;
 }
 

--- a/packages/cli/test/query-route-lifecycle.test.ts
+++ b/packages/cli/test/query-route-lifecycle.test.ts
@@ -67,6 +67,7 @@ function queryRouteContext(
     path: '/api/query',
     requestToken: undefined,
     requestAgentAddress: '',
+    requestPrincipal: { kind: 'anonymous' },
   } as unknown as RequestContext;
 }
 

--- a/packages/cli/test/query-route-lifecycle.test.ts
+++ b/packages/cli/test/query-route-lifecycle.test.ts
@@ -68,6 +68,7 @@ function queryRouteContext(
     requestToken: undefined,
     requestAgentAddress: '',
     requestPrincipal: { kind: 'anonymous' },
+    requestAuthorization: { nodeOperator: false },
   } as unknown as RequestContext;
 }
 

--- a/packages/cli/test/request-actor-authentication.test.ts
+++ b/packages/cli/test/request-actor-authentication.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createAllowedHttpAuthentication,
+} from '../src/auth.js';
+
+describe('request authentication invariants', () => {
+  it.each([
+    { mode: 'public' as const, presentedToken: 'agent-token' },
+    { mode: 'disabled' as const, presentedToken: 'agent-token' },
+    { mode: 'authenticated' as const, presentedToken: undefined },
+  ])('classifies an accepted agent bearer in $mode mode', ({ mode, presentedToken }) => {
+    const authentication = createAllowedHttpAuthentication({
+      mode,
+      presentedToken,
+      acceptedToken: 'agent-token',
+      resolveAgentByToken: () => 'did:dkg:agent:alice',
+    });
+
+    expect(authentication).toMatchObject({
+      mode,
+      acceptedToken: 'agent-token',
+      principal: { kind: 'agent', agentAddress: 'did:dkg:agent:alice' },
+    });
+  });
+
+  it('classifies an accepted bearer with no agent binding as the node operator', () => {
+    expect(createAllowedHttpAuthentication({
+      mode: 'authenticated',
+      acceptedToken: 'node-token',
+      resolveAgentByToken: () => undefined,
+    })).toMatchObject({
+      acceptedToken: 'node-token',
+      principal: { kind: 'nodeOperator' },
+    });
+  });
+});

--- a/packages/cli/test/request-actor-route-identity.test.ts
+++ b/packages/cli/test/request-actor-route-identity.test.ts
@@ -1,0 +1,111 @@
+import { Readable } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+import { createAllowedHttpAuthentication } from '../src/auth.js';
+import { handleAgentChatRoutes } from '../src/daemon/routes/agent-chat.js';
+import { handleContextGraphRoutes } from '../src/daemon/routes/context-graph.js';
+import type { RequestContext } from '../src/daemon/routes/context.js';
+
+const TRUSTED_ADDRESS = '0x1111111111111111111111111111111111111111';
+const REVOKED_ADDRESS = '0x2222222222222222222222222222222222222222';
+const REVOKED_TOKEN = 'revoked-agent-token';
+
+function request(method: string, path: string) {
+  return Object.assign(Readable.from([]), {
+    method,
+    url: path,
+    headers: {
+      host: '127.0.0.1',
+      authorization: `Bearer ${REVOKED_TOKEN}`,
+    },
+    __dkgPrebufferedBody: Buffer.from('{}', 'utf8'),
+  });
+}
+
+function response() {
+  return {
+    statusCode: 0,
+    body: '',
+    writableEnded: false,
+    writeHead(status: number) {
+      this.statusCode = status;
+      return this;
+    },
+    end(body?: string) {
+      this.body = body ?? '';
+      this.writableEnded = true;
+      return this;
+    },
+  };
+}
+
+function authentication() {
+  return createAllowedHttpAuthentication({
+    mode: 'disabled',
+    presentedToken: REVOKED_TOKEN,
+  });
+}
+
+describe('canonical request actor route identity', () => {
+  it('does not let an unaccepted bearer alter /api/agent/identity', async () => {
+    const req = request('GET', '/api/agent/identity');
+    const res = response();
+    const resolveAgentAddress = vi.fn((token?: string) => (
+      token === REVOKED_TOKEN ? REVOKED_ADDRESS : TRUSTED_ADDRESS
+    ));
+    const agent = {
+      resolveAgentAddress,
+      listLocalAgents: () => [{ agentAddress: TRUSTED_ADDRESS, name: 'trusted-agent', framework: 'test' }],
+      nodeName: 'node',
+      nodeFramework: 'node-framework',
+      peerId: '12D3KooWTrusted',
+      publisher: { getIdentityId: () => 7n },
+    };
+
+    await handleAgentChatRoutes({
+      req,
+      res,
+      agent,
+      path: '/api/agent/identity',
+      url: new URL('http://127.0.0.1/api/agent/identity'),
+      requestAgentAddress: TRUSTED_ADDRESS,
+      authentication: authentication(),
+    } as unknown as RequestContext);
+
+    expect(resolveAgentAddress).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toMatchObject({
+      agentAddress: TRUSTED_ADDRESS,
+      name: 'trusted-agent',
+    });
+  });
+
+  it('does not let an unaccepted bearer alter sign-join identity', async () => {
+    const contextGraphId = 'private-cg';
+    const path = `/api/context-graph/${contextGraphId}/sign-join`;
+    const req = request('POST', path);
+    const res = response();
+    const resolveAgentAddress = vi.fn((token?: string) => (
+      token === REVOKED_TOKEN ? REVOKED_ADDRESS : TRUSTED_ADDRESS
+    ));
+    const signJoinRequest = vi.fn(async (_cg: string, agentAddress: string) => ({
+      agentAddress,
+      signature: '0xsigned',
+    }));
+    const agent = { resolveAgentAddress, signJoinRequest };
+
+    await handleContextGraphRoutes({
+      req,
+      res,
+      agent,
+      path,
+      url: new URL(`http://127.0.0.1${path}`),
+      requestAgentAddress: TRUSTED_ADDRESS,
+      authentication: authentication(),
+    } as unknown as RequestContext);
+
+    expect(resolveAgentAddress).not.toHaveBeenCalled();
+    expect(signJoinRequest).toHaveBeenCalledWith(contextGraphId, TRUSTED_ADDRESS);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).agentAddress).toBe(TRUSTED_ADDRESS);
+  });
+});

--- a/packages/cli/test/request-actor-route-identity.test.ts
+++ b/packages/cli/test/request-actor-route-identity.test.ts
@@ -1,9 +1,10 @@
 import { Readable } from 'node:stream';
 import { describe, expect, it, vi } from 'vitest';
 import { createAllowedHttpAuthentication } from '../src/auth.js';
-import { handleAgentChatRoutes } from '../src/daemon/routes/agent-chat.js';
-import { handleContextGraphRoutes } from '../src/daemon/routes/context-graph.js';
-import type { RequestContext } from '../src/daemon/routes/context.js';
+import {
+  handleRequest,
+  type HandleRequestInput,
+} from '../src/daemon/handle-request.js';
 
 const TRUSTED_ADDRESS = '0x1111111111111111111111111111111111111111';
 const REVOKED_ADDRESS = '0x2222222222222222222222222222222222222222';
@@ -61,17 +62,15 @@ describe('canonical request actor route identity', () => {
       publisher: { getIdentityId: () => 7n },
     };
 
-    await handleAgentChatRoutes({
+    await handleRequest({
       req,
       res,
       agent,
-      path: '/api/agent/identity',
-      url: new URL('http://127.0.0.1/api/agent/identity'),
-      requestAgentAddress: TRUSTED_ADDRESS,
       authentication: authentication(),
-    } as unknown as RequestContext);
+    } as unknown as HandleRequestInput);
 
-    expect(resolveAgentAddress).not.toHaveBeenCalled();
+    expect(resolveAgentAddress).toHaveBeenCalledTimes(1);
+    expect(resolveAgentAddress).toHaveBeenCalledWith(undefined);
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toMatchObject({
       agentAddress: TRUSTED_ADDRESS,
@@ -93,17 +92,15 @@ describe('canonical request actor route identity', () => {
     }));
     const agent = { resolveAgentAddress, signJoinRequest };
 
-    await handleContextGraphRoutes({
+    await handleRequest({
       req,
       res,
       agent,
-      path,
-      url: new URL(`http://127.0.0.1${path}`),
-      requestAgentAddress: TRUSTED_ADDRESS,
       authentication: authentication(),
-    } as unknown as RequestContext);
+    } as unknown as HandleRequestInput);
 
-    expect(resolveAgentAddress).not.toHaveBeenCalled();
+    expect(resolveAgentAddress).toHaveBeenCalledTimes(1);
+    expect(resolveAgentAddress).toHaveBeenCalledWith(undefined);
     expect(signJoinRequest).toHaveBeenCalledWith(contextGraphId, TRUSTED_ADDRESS);
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body).agentAddress).toBe(TRUSTED_ADDRESS);

--- a/packages/cli/test/shared-memory-catchup-durable.test.ts
+++ b/packages/cli/test/shared-memory-catchup-durable.test.ts
@@ -35,6 +35,7 @@ function buildCatchupCtx(body: unknown, agent: Record<string, any>) {
     agent,
     path: url.pathname,
     url,
+    requestPrincipal: { kind: 'anonymous' },
   } as unknown as RequestContext;
   return { ctx, res };
 }

--- a/packages/cli/test/shared-memory-catchup-durable.test.ts
+++ b/packages/cli/test/shared-memory-catchup-durable.test.ts
@@ -36,6 +36,7 @@ function buildCatchupCtx(body: unknown, agent: Record<string, any>) {
     path: url.pathname,
     url,
     requestPrincipal: { kind: 'anonymous' },
+    requestAuthorization: { nodeOperator: false },
   } as unknown as RequestContext;
   return { ctx, res };
 }

--- a/packages/cli/test/shared-memory-catchup-durable.test.ts
+++ b/packages/cli/test/shared-memory-catchup-durable.test.ts
@@ -3,6 +3,7 @@ import { PROTOCOL_SYNC } from '@origintrail-official/dkg-core';
 import { handleMemoryRoutes } from '../src/daemon/routes/memory.js';
 import type { RequestContext } from '../src/daemon/routes/context.js';
 import type { DurableSyncResult } from '@origintrail-official/dkg-agent';
+import { requestAuthentication } from './_helpers/request-authentication.js';
 
 function fakeRes() {
   const res: any = { statusCode: 0, body: '', headers: {} as Record<string, string>, writableEnded: false };
@@ -35,8 +36,7 @@ function buildCatchupCtx(body: unknown, agent: Record<string, any>) {
     agent,
     path: url.pathname,
     url,
-    requestPrincipal: { kind: 'anonymous' },
-    requestAuthorization: { nodeOperator: false },
+    authentication: requestAuthentication({ kind: 'anonymous' }),
   } as unknown as RequestContext;
   return { ctx, res };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,6 +73,7 @@ export * from './author-catalog-directory.js';
 export * from './swm-author-inventory-v1.js';
 export * from './event-bus.js';
 export * from './backpressure-observability.js';
+export * from './request-principal.js';
 export {
   Logger,
   createOperationContext,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,7 +73,6 @@ export * from './author-catalog-directory.js';
 export * from './swm-author-inventory-v1.js';
 export * from './event-bus.js';
 export * from './backpressure-observability.js';
-export * from './request-principal.js';
 export {
   Logger,
   createOperationContext,

--- a/packages/core/src/request-principal.ts
+++ b/packages/core/src/request-principal.ts
@@ -1,0 +1,9 @@
+/** Authenticated HTTP identity established by the daemon authentication boundary. */
+export type AuthenticatedRequestPrincipal =
+  | { readonly kind: 'agent'; readonly agentAddress: string }
+  | { readonly kind: 'nodeOperator' };
+
+/** Request identity routes may consume without re-reading credentials. */
+export type RequestPrincipal =
+  | AuthenticatedRequestPrincipal
+  | { readonly kind: 'anonymous' };

--- a/packages/core/src/request-principal.ts
+++ b/packages/core/src/request-principal.ts
@@ -1,9 +1,0 @@
-/** Authenticated HTTP identity established by the daemon authentication boundary. */
-export type AuthenticatedRequestPrincipal =
-  | { readonly kind: 'agent'; readonly agentAddress: string }
-  | { readonly kind: 'nodeOperator' };
-
-/** Request identity routes may consume without re-reading credentials. */
-export type RequestPrincipal =
-  | AuthenticatedRequestPrincipal
-  | { readonly kind: 'anonymous' };

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -92,6 +92,7 @@ import {
   isHeldForChainProof,
   selectLifecycleBindingJobs,
   type LiftJobRetryProjection,
+  type TargetedLiftJobClearOptions,
 } from './async-lift-retry-disposition.js';
 import { type TerminalJobClearOutcome } from './terminal-job-clear.js';
 import { isSafeJobId } from './job-id.js';
@@ -2835,7 +2836,7 @@ export class TripleStoreAsyncLiftPublisher
    */
   async clearTerminalJob(
     jobId: string,
-    options: { readonly pendingTransactionOverride?: { readonly requestedBy: string } } = {},
+    options: TargetedLiftJobClearOptions = {},
   ): Promise<TerminalJobClearOutcome> {
     // Reject an empty OR SPARQL-unsafe jobId as malformed BEFORE building the jobSubject
     // IRI — otherwise an attacker-controlled jobId (from the clear-job HTTP body) with a
@@ -2853,14 +2854,16 @@ export class TripleStoreAsyncLiftPublisher
       }
       if (transaction.kind === 'unknown') return { outcome: 'rejected', reason: 'unknown' };
       const { current: job, scope } = transaction;
-      // GH#2270 follow-up (🔴 3824098476, 🟡 3824098494) — ownership is resolved HERE, not at
-      // the route. Doing it at the route meant an unsafe jobId reached a `getStatus` query before
-      // this method's `isSafeJobId` guard ran, and the ownership read happened outside the claim
-      // lock the clear itself takes — a TOCTOU on the record the decision is about.
+      // GH#2270 follow-up (🔴 3824098476, 🟡 3824098494) — authorization against the job is
+      // resolved HERE, not at the route. Doing it at the route meant an unsafe jobId reached a
+      // `getStatus` query before this method's `isSafeJobId` guard ran, and the ownership read
+      // happened outside the claim lock the clear itself takes — a TOCTOU on the record the
+      // decision is about. The route only authenticates which principal tier made the request.
       //
       // Inside, the job has already been validated and read under that lock, so the check is on
-      // the same record that is about to be deleted. A caller that cannot be matched to the job's
-      // admission lane simply does not get the override; the ordinary terminal clear is untouched.
+      // the same record that is about to be deleted. An agent that cannot be matched to the job's
+      // admission lane gets no override; an authenticated node operator has explicit queue-wide
+      // authority. The ordinary terminal clear is untouched.
       // 3825162663 — ONE decision: the policy takes the override as the caller made it and
       // settles authority and state eligibility together, so a call site cannot read the
       // canonical predicate while forgetting the ownership half.

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -92,9 +92,11 @@ import {
   isHeldForChainProof,
   selectLifecycleBindingJobs,
   type LiftJobRetryProjection,
-  type TargetedLiftJobClearOptions,
 } from './async-lift-retry-disposition.js';
-import { type TerminalJobClearOutcome } from './terminal-job-clear.js';
+import {
+  type TargetedLiftJobClearOptions,
+  type TerminalJobClearOutcome,
+} from './terminal-job-clear.js';
 import { isSafeJobId } from './job-id.js';
 import { replaceSubjectAtomicallyOrFallback } from './subject-atomic-write.js';
 import {

--- a/packages/publisher/src/async-lift-publisher-types.ts
+++ b/packages/publisher/src/async-lift-publisher-types.ts
@@ -15,7 +15,10 @@ import type {
   LiftPublishRequestMetadata,
   LiftPublishSnapshotRequest,
 } from './lift-job.js';
-import type { LiftJobRetryProjection } from './async-lift-retry-disposition.js';
+import type {
+  LiftJobRetryProjection,
+  TargetedLiftJobClearOptions,
+} from './async-lift-retry-disposition.js';
 import type { DKGPublisher } from './dkg-publisher.js';
 import type { PublishOptions, PublishResult } from './publisher.js';
 import type { AsyncLiftPublishFailureInput } from './async-lift-publish-result.js';
@@ -386,24 +389,12 @@ export interface VmPublishAdmissionJournalReader {
 export interface VmPublishTerminalJobClearer {
   /**
    * GH#2270 follow-up (🔴 3823952704) — `allowPendingTransaction` opts in to clearing a job whose
-   * transaction may still land. It is OFF by default: the caller must have established the right
-   * to take that risk for this specific job, because the route this is reached through is open to
-   * every registered agent token.
+   * transaction may still land. It is OFF by default: an agent must own this job's admission lane,
+   * while an authenticated node operator may accept the risk for any job in the node's queue.
    */
   clearTerminalJob(
     jobId: string,
-    options?: {
-      /**
-       * GH#2270 follow-up — opt in to clearing a job whose transaction may still land.
-       *
-       * ONE value rather than a flag beside an identity: the request and the authority to make it
-       * are the same fact, and splitting them let `{ allowPendingTransaction: true }` and
-       * `{ requireOwnerAgentAddress: x }` each compile while silently behaving like an ordinary
-       * clear. Present means "this caller asks"; the publisher grants it only for a job that
-       * caller enqueued.
-       */
-      readonly pendingTransactionOverride?: { readonly requestedBy: string };
-    },
+    options?: TargetedLiftJobClearOptions,
   ): Promise<TerminalJobClearOutcome>;
 }
 

--- a/packages/publisher/src/async-lift-publisher-types.ts
+++ b/packages/publisher/src/async-lift-publisher-types.ts
@@ -17,7 +17,6 @@ import type {
 } from './lift-job.js';
 import type {
   LiftJobRetryProjection,
-  TargetedLiftJobClearOptions,
 } from './async-lift-retry-disposition.js';
 import type { DKGPublisher } from './dkg-publisher.js';
 import type { PublishOptions, PublishResult } from './publisher.js';
@@ -25,7 +24,7 @@ import type { AsyncLiftPublishFailureInput } from './async-lift-publish-result.j
 import type { AsyncPreparedPublishPayload, LiftResolvedPublishSlice } from './async-lift-publish-options.js';
 import type { WorkspacePublicSnapshotStore } from './workspace-snapshot-store.js';
 import type { PublishTransactionObservation } from '@origintrail-official/dkg-chain';
-import type { TerminalJobClearOutcome } from './terminal-job-clear.js';
+import type { TargetedLiftJobClearOptions, TerminalJobClearOutcome } from './terminal-job-clear.js';
 
 export class AsyncLiftJobConflictError extends Error {
   readonly code = 'ASYNC_LIFT_JOB_CONFLICT';

--- a/packages/publisher/src/async-lift-retry-disposition.ts
+++ b/packages/publisher/src/async-lift-retry-disposition.ts
@@ -31,7 +31,10 @@ import {
 import { knowledgeAssetAgentAddressesEqual } from '@origintrail-official/dkg-core';
 import { getLiftJobFailurePolicy, isTerminalLiftJobState } from './lift-job.js';
 import type { LiftJobFailureCode, PersistedLiftJob } from './lift-job.js';
-import type { TargetedLiftJobClearOptions } from './terminal-job-clear.js';
+import type {
+  PendingTransactionClearOverride,
+  TargetedLiftJobClearOptions,
+} from './terminal-job-clear.js';
 // Type-only, and erased at emit — the reverse edge (types importing `LiftJobRetryProjection`
 // from here) is type-only too, so nothing circular survives into the JavaScript. The verdict
 // vocabulary stays defined once, beside the resolver contract that produces it.
@@ -397,14 +400,27 @@ export function isTargetedClearableLiftJob(
   options: TargetedLiftJobClearOptions = {},
 ): boolean {
   if (isClearableTerminalLiftJob(job)) return true;
-  const override = options.pendingTransactionOverride;
+  const rawOverride = options.pendingTransactionOverride;
+  if (!rawOverride || typeof rawOverride !== 'object') return false;
+  // Backward compatibility for the original public options shape. Legacy `requestedBy` is
+  // deliberately normalized to AGENT authority only: it can clear its own admission lane but
+  // can never acquire the node-wide capability introduced later.
+  const override: PendingTransactionClearOverride | null = 'requestedBy' in rawOverride
+    && !('kind' in rawOverride)
+    && typeof rawOverride.requestedBy === 'string'
+    && rawOverride.requestedBy.trim().length > 0
+    ? { kind: 'agent' as const, agentAddress: rawOverride.requestedBy }
+    : 'kind' in rawOverride
+      ? rawOverride
+      : null;
   if (!override) return false;
   // Authority and state eligibility are decided together, under the same job lock. An agent may
   // accept risk only for the lane it admitted; a node operator owns the queue and may accept it
   // for any job, including an unstamped pre-upgrade record.
   switch (override.kind) {
     case 'agent':
-      if (!ownsLiftJobAdmissionLane(job, override.agentAddress)) return false;
+      if (typeof override.agentAddress !== 'string'
+        || !ownsLiftJobAdmissionLane(job, override.agentAddress)) return false;
       break;
     case 'nodeOperator':
       break;

--- a/packages/publisher/src/async-lift-retry-disposition.ts
+++ b/packages/publisher/src/async-lift-retry-disposition.ts
@@ -256,13 +256,30 @@ export function selectLifecycleBindingJobs(
  * {@link isBulkClearableTerminalLiftJob}) and `clearTerminalJob(jobId)` so they cannot drift. A job
  * is clearable iff it is in a native terminal state (finalized|failed) AND is not a
  * `retry_recovery`-failed job — those may still carry a pending on-chain tx that periodic recovery
- * will finalize, so NEITHER clear lane removes them (they leave the queue when `recover()`
- * finalizes them from chain). A `retry_recovery`-failed job is therefore treated as
- * NONTERMINAL-for-cleanup.
+ * will finalize, so ordinary and bulk cleanup do not remove them. The separately authorized,
+ * exact-job override below is their deliberate operator/owner exit. A `retry_recovery`-failed job
+ * is therefore treated as NONTERMINAL-for-routine-cleanup.
  */
 export function isClearableTerminalLiftJob(job: PersistedLiftJob): boolean {
   return isTerminalLiftJobState(job.status)
     && !(isFailedJob(job) && job.failure.resolution === 'retry_recovery');
+}
+
+/**
+ * Authenticated authority accompanying an explicit pending-transaction clear request.
+ *
+ * `requestedBy` preserves the agent-scoped, owner-only lane. The node-operator bit is set only
+ * by the daemon after it distinguishes the node token from an agent token; it deliberately does
+ * not impersonate the default agent, because an operator may clear any job on the node (including
+ * records created before admission ownership was persisted).
+ */
+export interface PendingTransactionClearOverride {
+  readonly requestedBy?: string;
+  readonly requestedByNodeOperator?: true;
+}
+
+export interface TargetedLiftJobClearOptions {
+  readonly pendingTransactionOverride?: PendingTransactionClearOverride;
 }
 
 /**
@@ -343,13 +360,14 @@ export function resolveHeldJobSettlementCapability(wiring: {
  * Does this caller own the job's admission lane?
  *
  * The pending-transaction override below is destructive and `/api/publisher/clear-job` is open to
- * every registered agent token, so the right to accept that risk is per JOB, not per node.
+ * every registered agent token, so an AGENT'S right to accept that risk is per job. The separately
+ * authenticated node operator owns the queue and is authorized independently.
  *
  * The owner is the AUTHENTICATED ENQUEUER, not the resolved author: curated publishing lets those
  * differ (GH#1778), so a curator may submit for another author and it is the curator who admitted
- * the job. A record with no admission has nobody to match and is denied — falling back to the
- * author would grant the override to an identity that did not enqueue anything, and the risk being
- * accepted is a double publish.
+ * the job. A record with no admission has no agent to match — falling back to the author would
+ * grant the override to an identity that did not enqueue anything. Only the node-operator lane may
+ * clear such a legacy record.
  *
  * This boundary is generic over job kind on purpose (3824743779): it reads one typed job-level
  * field and never inspects an operation payload, so a new job variant needs no case here.
@@ -377,7 +395,7 @@ function ownsLiftJobAdmissionLane(job: PersistedLiftJob, agentAddress: string | 
  *
  * #1837's base predicate treats transaction-bearing jobs as nonterminal-for-cleanup, because
  * periodic recovery may still finalize them from chain. That is right for bulk cleanup. The
- * explicit owner override is also the exit when an operator abandons one exact closed-run record:
+ * explicit agent-owner/node-operator override is the exit for one exact closed-run record:
  * it accepts a pre-broadcast `validated` record, a `retry_recovery` failure, or a live
  * `broadcast`/`included` record. The append-only journal remains, and no broad clear receives this
  * authority. A `claimed` record stays denied because it can still be running before validation;
@@ -387,25 +405,23 @@ function ownsLiftJobAdmissionLane(job: PersistedLiftJob, agentAddress: string | 
  * way it would silently absorb every future reason a terminal job becomes protected. Additions to
  * the base policy stay denied here until someone allows them on purpose.
  *
- * The caller must also be entitled to it — see {@link ownsLiftJobAdmissionLane}.
+ * The caller must also be entitled to it: either the admission owner (see
+ * {@link ownsLiftJobAdmissionLane}) or the authenticated node operator.
  */
 export function isTargetedClearableLiftJob(
   job: PersistedLiftJob,
-  options: {
-    /**
-     * The override as the CALLER made it: who requested it, not whether someone decided they
-     * may have it (3825162663). Taking a boolean here reduced authenticated authority to a flag at
-     * the call site and left the ownership check as a separate step a future targeted-clear
-     * could forget while still reading the apparently canonical predicate.
-     */
-    readonly pendingTransactionOverride?: { readonly requestedBy?: string };
-  } = {},
+  options: TargetedLiftJobClearOptions = {},
 ): boolean {
   if (isClearableTerminalLiftJob(job)) return true;
   const override = options.pendingTransactionOverride;
   if (!override) return false;
-  // Authority and state eligibility are decided together, so neither can be granted alone.
-  if (!ownsLiftJobAdmissionLane(job, override.requestedBy)) return false;
+  // Authority and state eligibility are decided together, under the same job lock. An agent may
+  // accept risk only for the lane it admitted; a node operator owns the queue and may accept it
+  // for any job, including an unstamped pre-upgrade record.
+  if (
+    override.requestedByNodeOperator !== true
+    && !ownsLiftJobAdmissionLane(job, override.requestedBy)
+  ) return false;
   if (job.status === 'validated' || job.status === 'broadcast' || job.status === 'included') return true;
   return isTerminalLiftJobState(job.status)
     && isFailedJob(job)

--- a/packages/publisher/src/async-lift-retry-disposition.ts
+++ b/packages/publisher/src/async-lift-retry-disposition.ts
@@ -31,6 +31,7 @@ import {
 import { knowledgeAssetAgentAddressesEqual } from '@origintrail-official/dkg-core';
 import { getLiftJobFailurePolicy, isTerminalLiftJobState } from './lift-job.js';
 import type { LiftJobFailureCode, PersistedLiftJob } from './lift-job.js';
+import type { TargetedLiftJobClearOptions } from './terminal-job-clear.js';
 // Type-only, and erased at emit — the reverse edge (types importing `LiftJobRetryProjection`
 // from here) is type-only too, so nothing circular survives into the JavaScript. The verdict
 // vocabulary stays defined once, beside the resolver contract that produces it.
@@ -266,23 +267,6 @@ export function isClearableTerminalLiftJob(job: PersistedLiftJob): boolean {
 }
 
 /**
- * Authenticated authority accompanying an explicit pending-transaction clear request.
- *
- * `requestedBy` preserves the agent-scoped, owner-only lane. The node-operator bit is set only
- * by the daemon after it distinguishes the node token from an agent token; it deliberately does
- * not impersonate the default agent, because an operator may clear any job on the node (including
- * records created before admission ownership was persisted).
- */
-export interface PendingTransactionClearOverride {
-  readonly requestedBy?: string;
-  readonly requestedByNodeOperator?: true;
-}
-
-export interface TargetedLiftJobClearOptions {
-  readonly pendingTransactionOverride?: PendingTransactionClearOverride;
-}
-
-/**
  * Can THIS node settle a held job itself — the CAPABILITY half of "does an automatic exit exist"?
  *
  * {@link hasAutomaticRecoveryExit} answers from the record alone (is there a question the chain
@@ -418,10 +402,17 @@ export function isTargetedClearableLiftJob(
   // Authority and state eligibility are decided together, under the same job lock. An agent may
   // accept risk only for the lane it admitted; a node operator owns the queue and may accept it
   // for any job, including an unstamped pre-upgrade record.
-  if (
-    override.requestedByNodeOperator !== true
-    && !ownsLiftJobAdmissionLane(job, override.requestedBy)
-  ) return false;
+  switch (override.kind) {
+    case 'agent':
+      if (!ownsLiftJobAdmissionLane(job, override.requestedBy)) return false;
+      break;
+    case 'nodeOperator':
+      break;
+    default: {
+      const unhandledAuthority: never = override;
+      return unhandledAuthority;
+    }
+  }
   if (job.status === 'validated' || job.status === 'broadcast' || job.status === 'included') return true;
   return isTerminalLiftJobState(job.status)
     && isFailedJob(job)

--- a/packages/publisher/src/async-lift-retry-disposition.ts
+++ b/packages/publisher/src/async-lift-retry-disposition.ts
@@ -408,10 +408,10 @@ export function isTargetedClearableLiftJob(
       break;
     case 'nodeOperator':
       break;
-    default: {
-      const unhandledAuthority: never = override;
-      return unhandledAuthority;
-    }
+    default:
+      // Persisted/API inputs exist at runtime independently of this TypeScript union. Unknown
+      // legacy or malformed authority variants must never become a truthy destructive override.
+      return false;
   }
   if (job.status === 'validated' || job.status === 'broadcast' || job.status === 'included') return true;
   return isTerminalLiftJobState(job.status)

--- a/packages/publisher/src/async-lift-retry-disposition.ts
+++ b/packages/publisher/src/async-lift-retry-disposition.ts
@@ -404,7 +404,7 @@ export function isTargetedClearableLiftJob(
   // for any job, including an unstamped pre-upgrade record.
   switch (override.kind) {
     case 'agent':
-      if (!ownsLiftJobAdmissionLane(job, override.requestedBy)) return false;
+      if (!ownsLiftJobAdmissionLane(job, override.agentAddress)) return false;
       break;
     case 'nodeOperator':
       break;

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -302,7 +302,7 @@ export {
 export {
   type PendingTransactionClearOverride,
   type TargetedLiftJobClearOptions,
-} from './async-lift-retry-disposition.js';
+} from './terminal-job-clear.js';
 export {
   AsyncLiftJobConflictError,
   LiftJobPendingChainProofError,

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -300,6 +300,7 @@ export {
 } from './async-lift-retry-disposition.js';
 // Public option types for the narrow terminal-job administrative capability.
 export {
+  type LegacyPendingTransactionClearOverride,
   type PendingTransactionClearOverride,
   type TargetedLiftJobClearOptions,
 } from './terminal-job-clear.js';

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -298,6 +298,11 @@ export {
   type LiftJobRetryProjection,
   type LiftJobRetryWaitingReason,
 } from './async-lift-retry-disposition.js';
+// Public option types for the narrow terminal-job administrative capability.
+export {
+  type PendingTransactionClearOverride,
+  type TargetedLiftJobClearOptions,
+} from './async-lift-retry-disposition.js';
 export {
   AsyncLiftJobConflictError,
   LiftJobPendingChainProofError,

--- a/packages/publisher/src/terminal-job-clear.ts
+++ b/packages/publisher/src/terminal-job-clear.ts
@@ -1,3 +1,5 @@
+import type { AuthenticatedRequestPrincipal } from '@origintrail-official/dkg-core';
+
 // #1837 — shared contract for the atomic by-exact-jobId TERMINAL clear OUTCOME, owned by
 // NEITHER queue (lift nor promote) so a generic admin-clear result is not coupled to one
 // implementation family's type module. (The job-id grammar guard lives in `./job-id.ts`.)
@@ -20,9 +22,7 @@ export type TerminalJobClearOutcome =
  * The variants are deliberately mutually exclusive: an agent accepts risk only for its own
  * admission lane, while the node operator owns the queue and needs no agent identity.
  */
-export type PendingTransactionClearOverride =
-  | { readonly kind: 'agent'; readonly requestedBy: string }
-  | { readonly kind: 'nodeOperator' };
+export type PendingTransactionClearOverride = AuthenticatedRequestPrincipal;
 
 export interface TargetedLiftJobClearOptions {
   readonly pendingTransactionOverride?: PendingTransactionClearOverride;

--- a/packages/publisher/src/terminal-job-clear.ts
+++ b/packages/publisher/src/terminal-job-clear.ts
@@ -24,6 +24,16 @@ export type PendingTransactionClearOverride =
   | { readonly kind: 'agent'; readonly agentAddress: string }
   | { readonly kind: 'nodeOperator' };
 
+/**
+ * @deprecated Use `{ kind: 'agent', agentAddress }`. Kept as an agent-only compatibility shape
+ * for callers compiled against the original targeted-clear API; it never grants node authority.
+ */
+export interface LegacyPendingTransactionClearOverride {
+  readonly requestedBy: string;
+}
+
 export interface TargetedLiftJobClearOptions {
-  readonly pendingTransactionOverride?: PendingTransactionClearOverride;
+  readonly pendingTransactionOverride?:
+    | PendingTransactionClearOverride
+    | LegacyPendingTransactionClearOverride;
 }

--- a/packages/publisher/src/terminal-job-clear.ts
+++ b/packages/publisher/src/terminal-job-clear.ts
@@ -13,3 +13,17 @@ export type TerminalJobClearOutcome =
   | { readonly outcome: 'cleared' }
   | { readonly outcome: 'already_absent' }
   | { readonly outcome: 'rejected'; readonly reason: 'nonterminal' | 'unknown' | 'malformed' };
+
+/**
+ * Authenticated authority for the destructive, exact-job pending-transaction override.
+ *
+ * The variants are deliberately mutually exclusive: an agent accepts risk only for its own
+ * admission lane, while the node operator owns the queue and needs no agent identity.
+ */
+export type PendingTransactionClearOverride =
+  | { readonly kind: 'agent'; readonly requestedBy: string }
+  | { readonly kind: 'nodeOperator' };
+
+export interface TargetedLiftJobClearOptions {
+  readonly pendingTransactionOverride?: PendingTransactionClearOverride;
+}

--- a/packages/publisher/src/terminal-job-clear.ts
+++ b/packages/publisher/src/terminal-job-clear.ts
@@ -1,5 +1,3 @@
-import type { AuthenticatedRequestPrincipal } from '@origintrail-official/dkg-core';
-
 // #1837 — shared contract for the atomic by-exact-jobId TERMINAL clear OUTCOME, owned by
 // NEITHER queue (lift nor promote) so a generic admin-clear result is not coupled to one
 // implementation family's type module. (The job-id grammar guard lives in `./job-id.ts`.)
@@ -22,7 +20,9 @@ export type TerminalJobClearOutcome =
  * The variants are deliberately mutually exclusive: an agent accepts risk only for its own
  * admission lane, while the node operator owns the queue and needs no agent identity.
  */
-export type PendingTransactionClearOverride = AuthenticatedRequestPrincipal;
+export type PendingTransactionClearOverride =
+  | { readonly kind: 'agent'; readonly agentAddress: string }
+  | { readonly kind: 'nodeOperator' };
 
 export interface TargetedLiftJobClearOptions {
   readonly pendingTransactionOverride?: PendingTransactionClearOverride;

--- a/packages/publisher/test/_helpers/claim-fencing-types.ts
+++ b/packages/publisher/test/_helpers/claim-fencing-types.ts
@@ -14,6 +14,7 @@ import type {
   TripleStoreAsyncLiftPublisher,
 } from '../../src/index.js';
 import type { LiftJobTransaction } from '../../src/async-lift-claim-session.js';
+import type { RequestPrincipal } from '@origintrail-official/dkg-core';
 import {
   canonicalLiftJobPayload,
   type LiftJobPayloadDecodeResult,
@@ -27,7 +28,7 @@ declare const activeClaim: ActiveLiftJobClaim;
 
 const agentClearAuthority: PendingTransactionClearOverride = {
   kind: 'agent',
-  requestedBy: 'did:dkg:agent:owner',
+  agentAddress: 'did:dkg:agent:owner',
 };
 const nodeOperatorClearAuthority: PendingTransactionClearOverride = { kind: 'nodeOperator' };
 void agentClearAuthority;
@@ -36,12 +37,16 @@ void nodeOperatorClearAuthority;
 const emptyClearAuthority: PendingTransactionClearOverride = {};
 const contradictoryClearAuthority: PendingTransactionClearOverride = {
   kind: 'agent',
-  requestedBy: 'did:dkg:agent:owner',
+  agentAddress: 'did:dkg:agent:owner',
   // @ts-expect-error Agent and node-operator authority cannot coexist in one request.
-  requestedByNodeOperator: true,
+  nodeOperator: true,
 };
 void emptyClearAuthority;
 void contradictoryClearAuthority;
+const anonymousPrincipal: RequestPrincipal = { kind: 'anonymous' };
+// @ts-expect-error Anonymous requests cannot become a pending-transaction override.
+const anonymousClearAuthority: PendingTransactionClearOverride = anonymousPrincipal;
+void anonymousClearAuthority;
 
 const concreteCapability: ClaimSessionAsyncLiftPublisher = publisher;
 void concreteCapability;

--- a/packages/publisher/test/_helpers/claim-fencing-types.ts
+++ b/packages/publisher/test/_helpers/claim-fencing-types.ts
@@ -10,6 +10,7 @@ import type {
   LiftJobLegacyEvidenceFreeBroadcast,
   LiftJobPersistedFailure,
   PersistedLiftJob,
+  PendingTransactionClearOverride,
   TripleStoreAsyncLiftPublisher,
 } from '../../src/index.js';
 import type { LiftJobTransaction } from '../../src/async-lift-claim-session.js';
@@ -23,6 +24,24 @@ declare const publisher: TripleStoreAsyncLiftPublisher;
 declare const accepted: LiftJobAccepted;
 declare const legacyClaimedWithoutFence: LiftJobClaimed;
 declare const activeClaim: ActiveLiftJobClaim;
+
+const agentClearAuthority: PendingTransactionClearOverride = {
+  kind: 'agent',
+  requestedBy: 'did:dkg:agent:owner',
+};
+const nodeOperatorClearAuthority: PendingTransactionClearOverride = { kind: 'nodeOperator' };
+void agentClearAuthority;
+void nodeOperatorClearAuthority;
+// @ts-expect-error A pending-transaction override must name an authority variant.
+const emptyClearAuthority: PendingTransactionClearOverride = {};
+const contradictoryClearAuthority: PendingTransactionClearOverride = {
+  kind: 'agent',
+  requestedBy: 'did:dkg:agent:owner',
+  // @ts-expect-error Agent and node-operator authority cannot coexist in one request.
+  requestedByNodeOperator: true,
+};
+void emptyClearAuthority;
+void contradictoryClearAuthority;
 
 const concreteCapability: ClaimSessionAsyncLiftPublisher = publisher;
 void concreteCapability;

--- a/packages/publisher/test/_helpers/claim-fencing-types.ts
+++ b/packages/publisher/test/_helpers/claim-fencing-types.ts
@@ -14,7 +14,6 @@ import type {
   TripleStoreAsyncLiftPublisher,
 } from '../../src/index.js';
 import type { LiftJobTransaction } from '../../src/async-lift-claim-session.js';
-import type { RequestPrincipal } from '@origintrail-official/dkg-core';
 import {
   canonicalLiftJobPayload,
   type LiftJobPayloadDecodeResult,
@@ -43,7 +42,7 @@ const contradictoryClearAuthority: PendingTransactionClearOverride = {
 };
 void emptyClearAuthority;
 void contradictoryClearAuthority;
-const anonymousPrincipal: RequestPrincipal = { kind: 'anonymous' };
+const anonymousPrincipal = { kind: 'anonymous' } as const;
 // @ts-expect-error Anonymous requests cannot become a pending-transaction override.
 const anonymousClearAuthority: PendingTransactionClearOverride = anonymousPrincipal;
 void anonymousClearAuthority;

--- a/packages/publisher/test/async-lift-chain-proof-cadence.test.ts
+++ b/packages/publisher/test/async-lift-chain-proof-cadence.test.ts
@@ -679,7 +679,7 @@ describe('GH#2270 chain-proof cadence', () => {
       await publisher.recover(); // observed + installed, batch 0: never dispatched
       expect(schedule.retainedEntryCount()).toBe(1);
 
-      await publisher.clearTerminalJob(jobId, { pendingTransactionOverride: { kind: 'agent', requestedBy: 'operator' } });
+      await publisher.clearTerminalJob(jobId, { pendingTransactionOverride: { kind: 'agent', agentAddress: 'operator' } });
       await publisher.recover(); // empty held population: the sweep collects the residue
       expect(schedule.retainedEntryCount()).toBe(0);
     });
@@ -795,7 +795,7 @@ describe('GH#2270 chain-proof cadence', () => {
       while (asks === 0) await new Promise((resolve) => setTimeout(resolve, 5));
 
       // The real operator exit, serialized on the same claim lock the disposition uses.
-      await publisher.clearTerminalJob(jobId, { pendingTransactionOverride: { kind: 'agent', requestedBy: 'operator' } });
+      await publisher.clearTerminalJob(jobId, { pendingTransactionOverride: { kind: 'agent', agentAddress: 'operator' } });
 
       release();
       await firstPass;

--- a/packages/publisher/test/async-lift-chain-proof-cadence.test.ts
+++ b/packages/publisher/test/async-lift-chain-proof-cadence.test.ts
@@ -679,7 +679,7 @@ describe('GH#2270 chain-proof cadence', () => {
       await publisher.recover(); // observed + installed, batch 0: never dispatched
       expect(schedule.retainedEntryCount()).toBe(1);
 
-      await publisher.clearTerminalJob(jobId, { pendingTransactionOverride: { requestedBy: 'operator' } });
+      await publisher.clearTerminalJob(jobId, { pendingTransactionOverride: { kind: 'agent', requestedBy: 'operator' } });
       await publisher.recover(); // empty held population: the sweep collects the residue
       expect(schedule.retainedEntryCount()).toBe(0);
     });
@@ -795,7 +795,7 @@ describe('GH#2270 chain-proof cadence', () => {
       while (asks === 0) await new Promise((resolve) => setTimeout(resolve, 5));
 
       // The real operator exit, serialized on the same claim lock the disposition uses.
-      await publisher.clearTerminalJob(jobId, { pendingTransactionOverride: { requestedBy: 'operator' } });
+      await publisher.clearTerminalJob(jobId, { pendingTransactionOverride: { kind: 'agent', requestedBy: 'operator' } });
 
       release();
       await firstPass;

--- a/packages/publisher/test/async-lift-retry-disposition-2270.test.ts
+++ b/packages/publisher/test/async-lift-retry-disposition-2270.test.ts
@@ -241,7 +241,9 @@ describe('GH#2270 failed-job retry disposition', () => {
       admission: { byAgentAddress: owner },
       request: { jobType: 'lift', lift: {} },
     } as unknown as LiftJob);
-    const override = (requestedBy: string) => ({ pendingTransactionOverride: { requestedBy } });
+    const override = (requestedBy: string) => ({
+      pendingTransactionOverride: { kind: 'agent' as const, requestedBy },
+    });
 
     // EVM: case-insensitive, both directions.
     const EVM = '0xAbCdEf0000000000000000000000000000001234';
@@ -333,10 +335,10 @@ describe('GH#2270 failed-job retry disposition', () => {
       failure: { ...admitted.failure, resolution: 'retry_recovery' },
     } as PersistedFailedJob;
     expect(isTargetedClearableLiftJob(heldAfterReset, {
-      pendingTransactionOverride: { requestedBy: ADMITTED_BY },
+      pendingTransactionOverride: { kind: 'agent', requestedBy: ADMITTED_BY },
     })).toBe(true);
     expect(isTargetedClearableLiftJob(heldAfterReset, {
-      pendingTransactionOverride: { requestedBy: '0xBBbBBb00000000000000000000000000000000Bb' },
+      pendingTransactionOverride: { kind: 'agent', requestedBy: '0xBBbBBb00000000000000000000000000000000Bb' },
     })).toBe(false);
     // ...and with no override at all, ownership alone never grants the clear.
     expect(isTargetedClearableLiftJob(heldAfterReset)).toBe(false);

--- a/packages/publisher/test/async-lift-retry-disposition-2270.test.ts
+++ b/packages/publisher/test/async-lift-retry-disposition-2270.test.ts
@@ -256,6 +256,27 @@ describe('GH#2270 failed-job retry disposition', () => {
     expect(isTargetedClearableLiftJob(held(PEER), override(PEER.toLowerCase()))).toBe(false);
   });
 
+  it('fails closed for unknown and malformed runtime clear-authority variants', () => {
+    const heldJob = {
+      status: 'failed',
+      failure: { resolution: 'retry_recovery' },
+      admission: { byAgentAddress: '0xAbCdEf0000000000000000000000000000001234' },
+      request: { jobType: 'lift', lift: {} },
+    } as unknown as LiftJob;
+    const runtimeOptions = (pendingTransactionOverride: unknown) => ({
+      pendingTransactionOverride,
+    }) as unknown as Parameters<typeof isTargetedClearableLiftJob>[1];
+
+    expect(isTargetedClearableLiftJob(heldJob, runtimeOptions({
+      requestedBy: '0xAbCdEf0000000000000000000000000000001234',
+    }))).toBe(false);
+    expect(isTargetedClearableLiftJob(heldJob, runtimeOptions({
+      kind: 'legacyOwner',
+      agentAddress: '0xAbCdEf0000000000000000000000000000001234',
+    }))).toBe(false);
+    expect(isTargetedClearableLiftJob(heldJob, runtimeOptions({ kind: 'agent' }))).toBe(false);
+  });
+
   it('names the two settlement ROLES explicitly, without inferring either from wiring [3825614002]', () => {
     // 3825614002 — the role used to be re-derived inside the decision method from which
     // collaborators happened to be installed, so the same oracle meant different things depending

--- a/packages/publisher/test/async-lift-retry-disposition-2270.test.ts
+++ b/packages/publisher/test/async-lift-retry-disposition-2270.test.ts
@@ -256,7 +256,7 @@ describe('GH#2270 failed-job retry disposition', () => {
     expect(isTargetedClearableLiftJob(held(PEER), override(PEER.toLowerCase()))).toBe(false);
   });
 
-  it('fails closed for unknown and malformed runtime clear-authority variants', () => {
+  it('accepts the exact legacy owner shape but fails closed for non-owner and malformed variants', () => {
     const heldJob = {
       status: 'failed',
       failure: { resolution: 'retry_recovery' },
@@ -269,6 +269,9 @@ describe('GH#2270 failed-job retry disposition', () => {
 
     expect(isTargetedClearableLiftJob(heldJob, runtimeOptions({
       requestedBy: '0xAbCdEf0000000000000000000000000000001234',
+    }))).toBe(true);
+    expect(isTargetedClearableLiftJob(heldJob, runtimeOptions({
+      requestedBy: '0x0000000000000000000000000000000000000001',
     }))).toBe(false);
     expect(isTargetedClearableLiftJob(heldJob, runtimeOptions({
       kind: 'legacyOwner',

--- a/packages/publisher/test/async-lift-retry-disposition-2270.test.ts
+++ b/packages/publisher/test/async-lift-retry-disposition-2270.test.ts
@@ -241,8 +241,8 @@ describe('GH#2270 failed-job retry disposition', () => {
       admission: { byAgentAddress: owner },
       request: { jobType: 'lift', lift: {} },
     } as unknown as LiftJob);
-    const override = (requestedBy: string) => ({
-      pendingTransactionOverride: { kind: 'agent' as const, requestedBy },
+    const override = (agentAddress: string) => ({
+      pendingTransactionOverride: { kind: 'agent' as const, agentAddress },
     });
 
     // EVM: case-insensitive, both directions.
@@ -335,10 +335,10 @@ describe('GH#2270 failed-job retry disposition', () => {
       failure: { ...admitted.failure, resolution: 'retry_recovery' },
     } as PersistedFailedJob;
     expect(isTargetedClearableLiftJob(heldAfterReset, {
-      pendingTransactionOverride: { kind: 'agent', requestedBy: ADMITTED_BY },
+      pendingTransactionOverride: { kind: 'agent', agentAddress: ADMITTED_BY },
     })).toBe(true);
     expect(isTargetedClearableLiftJob(heldAfterReset, {
-      pendingTransactionOverride: { kind: 'agent', requestedBy: '0xBBbBBb00000000000000000000000000000000Bb' },
+      pendingTransactionOverride: { kind: 'agent', agentAddress: '0xBBbBBb00000000000000000000000000000000Bb' },
     })).toBe(false);
     // ...and with no override at all, ownership alone never grants the clear.
     expect(isTargetedClearableLiftJob(heldAfterReset)).toBe(false);

--- a/packages/publisher/test/async-lift-terminal-clear.test.ts
+++ b/packages/publisher/test/async-lift-terminal-clear.test.ts
@@ -224,7 +224,7 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     }) as unknown as Parameters<typeof p.clearTerminalJob>[1];
 
     for (const malformedAuthority of [
-      { requestedBy: '0xCCcCCc00000000000000000000000000000000Cc' },
+      { requestedBy: 42 },
       { kind: 'legacyOwner', agentAddress: '0xCCcCCc00000000000000000000000000000000Cc' },
       { kind: 'agent' },
     ]) {
@@ -232,6 +232,26 @@ describe('#1837 lift publisher clearTerminalJob', () => {
         .toEqual({ outcome: 'rejected', reason: 'nonterminal' });
       expect((await p.getStatus(validated))?.status).toBe('validated');
     }
+  });
+
+  it('keeps the deprecated requestedBy override agent-scoped', async () => {
+    const OWNER = '0xCCcCCc00000000000000000000000000000000Cc';
+    const OTHER = '0xBBbBBb00000000000000000000000000000000Bb';
+    const p = createPublisher();
+    const jobId = await driveToValidated(
+      p,
+      { name: 'legacy-shape' },
+      { admittedByAgentAddress: OWNER },
+    );
+    expect(await p.clearTerminalJob(jobId, {
+      pendingTransactionOverride: { requestedBy: OTHER },
+    })).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
+    expect(await p.getStatus(jobId)).not.toBeNull();
+
+    expect(await p.clearTerminalJob(jobId, {
+      pendingTransactionOverride: { requestedBy: OWNER },
+    })).toEqual({ outcome: 'cleared' });
+    expect(await p.getStatus(jobId)).toBeNull();
   });
 
   it('lets only the admission owner explicitly clear one pre-broadcast validated job', async () => {

--- a/packages/publisher/test/async-lift-terminal-clear.test.ts
+++ b/packages/publisher/test/async-lift-terminal-clear.test.ts
@@ -212,6 +212,28 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     expect((await p.getStatus(validated))?.status).toBe('validated');
   });
 
+  it('rejects malformed runtime clear authorities as nonterminal without mutation', async () => {
+    const p = createPublisher();
+    const validated = await driveToValidated(
+      p,
+      {},
+      { admittedByAgentAddress: '0xCCcCCc00000000000000000000000000000000Cc' },
+    );
+    const runtimeOptions = (pendingTransactionOverride: unknown) => ({
+      pendingTransactionOverride,
+    }) as unknown as Parameters<typeof p.clearTerminalJob>[1];
+
+    for (const malformedAuthority of [
+      { requestedBy: '0xCCcCCc00000000000000000000000000000000Cc' },
+      { kind: 'legacyOwner', agentAddress: '0xCCcCCc00000000000000000000000000000000Cc' },
+      { kind: 'agent' },
+    ]) {
+      expect(await p.clearTerminalJob(validated, runtimeOptions(malformedAuthority)))
+        .toEqual({ outcome: 'rejected', reason: 'nonterminal' });
+      expect((await p.getStatus(validated))?.status).toBe('validated');
+    }
+  });
+
   it('lets only the admission owner explicitly clear one pre-broadcast validated job', async () => {
     const OWNER = '0xCCcCCc00000000000000000000000000000000Cc';
     const OTHER = '0xBBbBBb00000000000000000000000000000000Bb';

--- a/packages/publisher/test/async-lift-terminal-clear.test.ts
+++ b/packages/publisher/test/async-lift-terminal-clear.test.ts
@@ -219,12 +219,12 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     const validated = await driveToValidated(p, {}, { admittedByAgentAddress: OWNER });
 
     expect(await p.clearTerminalJob(validated, {
-      pendingTransactionOverride: { kind: 'agent', requestedBy: OTHER },
+      pendingTransactionOverride: { kind: 'agent', agentAddress: OTHER },
     })).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
     expect((await p.getStatus(validated))?.status).toBe('validated');
 
     expect(await p.clearTerminalJob(validated, {
-      pendingTransactionOverride: { kind: 'agent', requestedBy: OWNER },
+      pendingTransactionOverride: { kind: 'agent', agentAddress: OWNER },
     })).toEqual({ outcome: 'cleared' });
     expect(await p.getStatus(validated)).toBeNull();
   });
@@ -270,12 +270,12 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     await p.update(broadcast, 'broadcast', { broadcast: bx });
 
     expect(await p.clearTerminalJob(broadcast, {
-      pendingTransactionOverride: { kind: 'agent', requestedBy: OTHER },
+      pendingTransactionOverride: { kind: 'agent', agentAddress: OTHER },
     })).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
     expect((await p.getStatus(broadcast))?.status).toBe('broadcast');
 
     expect(await p.clearTerminalJob(broadcast, {
-      pendingTransactionOverride: { kind: 'agent', requestedBy: OWNER },
+      pendingTransactionOverride: { kind: 'agent', agentAddress: OWNER },
     })).toEqual({ outcome: 'cleared' });
     expect(await p.getStatus(broadcast)).toBeNull();
   });
@@ -300,7 +300,7 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     await resolverEntered;
     let clearSettled = false;
     const clearing = p.clearTerminalJob(broadcast, {
-      pendingTransactionOverride: { kind: 'agent', requestedBy: OWNER },
+      pendingTransactionOverride: { kind: 'agent', agentAddress: OWNER },
     }).then((outcome) => {
       clearSettled = true;
       return outcome;
@@ -359,7 +359,7 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     // The AUTHOR is not the enqueuer, so the author's token gets nothing — this is the exact
     // confusion the previous version had backwards.
     expect(await p.clearTerminalJob(jobId, {
-      pendingTransactionOverride: { kind: 'agent', requestedBy: AUTHOR },
+      pendingTransactionOverride: { kind: 'agent', agentAddress: AUTHOR },
     })).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
     expect((await p.getStatus(jobId))?.status).toBe('failed');
 
@@ -367,12 +367,12 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     // sole entitlement, so the GH#1778 hint sitting in the request grants nothing — this is
     // what fails if ownership ever falls back to reading the payload.
     expect(await p.clearTerminalJob(jobId, {
-      pendingTransactionOverride: { kind: 'agent', requestedBy: PAYLOAD_CALLER },
+      pendingTransactionOverride: { kind: 'agent', agentAddress: PAYLOAD_CALLER },
     })).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
     expect((await p.getStatus(jobId))?.status).toBe('failed');
 
     expect(await p.clearTerminalJob(jobId, {
-      pendingTransactionOverride: { kind: 'agent', requestedBy: OWNER },
+      pendingTransactionOverride: { kind: 'agent', agentAddress: OWNER },
     })).toEqual({ outcome: 'cleared' });
     expect(await p.getStatus(jobId)).toBeNull();
   });
@@ -390,7 +390,7 @@ describe('#1837 lift publisher clearTerminalJob', () => {
 
     // An unrelated agent token is still refused...
     expect(await p.clearTerminalJob(jobId, {
-      pendingTransactionOverride: { kind: 'agent', requestedBy: OTHER },
+      pendingTransactionOverride: { kind: 'agent', agentAddress: OTHER },
     })).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
 
     // ...while the explicit node-operator principal may clear any job in this node's queue.
@@ -413,7 +413,7 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     await store.insert(serializeJob(mutated as typeof job, DEFAULT_CONTROL_GRAPH_URI));
 
     expect(await p.clearTerminalJob(jobId, {
-      pendingTransactionOverride: { kind: 'agent', requestedBy: PAYLOAD_CALLER },
+      pendingTransactionOverride: { kind: 'agent', agentAddress: PAYLOAD_CALLER },
     })).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
     expect((await p.getStatus(jobId))?.status).toBe('failed');
 

--- a/packages/publisher/test/async-lift-terminal-clear.test.ts
+++ b/packages/publisher/test/async-lift-terminal-clear.test.ts
@@ -377,43 +377,31 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     expect(await p.getStatus(jobId)).toBeNull();
   });
 
-  it('a NODE-TOKEN job can be force-cleared by that node token [followup]', async () => {
-    // 🔴 3824484639 — a node-level API token is the ordinary client, and it resolves to no
-    // `callerAgentAddress` at all: that field is an author RESOLUTION HINT and is deliberately
-    // absent for node tokens. Authorizing on it therefore denied the force-clear to the most
-    // common caller, reproducing the exact dead end this PR set out to remove — the daemon handed
-    // back a command that could never work.
-    //
-    // Job-level admission metadata records the authenticated enqueuer instead, for every
-    // admission, and carries no author-selection meaning.
-    const NODE = '0xNNnNNn00000000000000000000000000000000Nn';
+  it('lets the node operator force-clear a job admitted by another agent', async () => {
+    const OWNER = '0xAAaAAa00000000000000000000000000000000Aa';
     const OTHER = '0xBBbBBb00000000000000000000000000000000Bb';
     const p = createPublisher();
-    // No callerAgentAddress in the REQUEST: the node-token shape. The principal travels
-    // beside it, as admission metadata.
-    const jobId = await driveToTerminalFailed(p, {}, { admittedByAgentAddress: NODE });
+    const jobId = await driveToTerminalFailed(p, {}, { admittedByAgentAddress: OWNER });
     const job = await p.getStatus(jobId);
     if (!job || !('failure' in job)) throw new Error('expected a failed job');
     const mutated = { ...job, failure: { ...job.failure, resolution: 'retry_recovery' } };
     await store.deleteByPattern({ subject: jobSubject(jobId), graph: DEFAULT_CONTROL_GRAPH_URI });
     await store.insert(serializeJob(mutated as typeof job, DEFAULT_CONTROL_GRAPH_URI));
 
-    // An unrelated token is still refused...
+    // An unrelated agent token is still refused...
     expect(await p.clearTerminalJob(jobId, {
       pendingTransactionOverride: { requestedBy: OTHER },
     })).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
 
-    // ...and the token that admitted it can clear it, which is what the daemon advertises.
+    // ...while the explicit node-operator principal may clear any job in this node's queue.
     expect(await p.clearTerminalJob(jobId, {
-      pendingTransactionOverride: { requestedBy: NODE },
+      pendingTransactionOverride: { requestedByNodeOperator: true },
     })).toEqual({ outcome: 'cleared' });
   });
 
-  it('an UNOWNED job grants the override to nobody, including its payload caller [3825861808]', async () => {
-    // Fail-closed half. A record with no admission stamp (one admitted before ownership existed,
-    // or by a path that never stamped) has nobody to match. If ownership ever fell back to the
-    // payload's `callerAgentAddress`, this is the row that catches it: that identity is present,
-    // and it must still be refused.
+  it('lets only the node operator force-clear an unowned legacy job', async () => {
+    // A record admitted before ownership stamps existed has no agent owner. Its payload caller
+    // must not gain the right by fallback, but the operator still needs an upgrade escape hatch.
     const PAYLOAD_CALLER = '0xDDdDDd00000000000000000000000000000000Dd';
     const p = createPublisher();
     const jobId = await driveToTerminalFailed(p, { callerAgentAddress: PAYLOAD_CALLER });
@@ -428,6 +416,11 @@ describe('#1837 lift publisher clearTerminalJob', () => {
       pendingTransactionOverride: { requestedBy: PAYLOAD_CALLER },
     })).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
     expect((await p.getStatus(jobId))?.status).toBe('failed');
+
+    expect(await p.clearTerminalJob(jobId, {
+      pendingTransactionOverride: { requestedByNodeOperator: true },
+    })).toEqual({ outcome: 'cleared' });
+    expect(await p.getStatus(jobId)).toBeNull();
   });
 
   it('refuses to REASSIGN the admission owner through a transition [3825861806]', async () => {
@@ -455,7 +448,7 @@ describe('#1837 lift publisher clearTerminalJob', () => {
   it('refuses an explicit `undefined` for an immutable field, which would ERASE it', async () => {
     // The merge spreads the patch, so an explicit `undefined` overwrites rather than being skipped.
     // Treating it as "nothing supplied" let a transition delete the owner outright — worse than
-    // reassigning it, because the job is then held with nobody able to clear it at all.
+    // reassigning it, because the job is then held with no agent able to clear it.
     const OWNER = '0xCCcCCc00000000000000000000000000000000Cc';
     const p = createPublisher();
     const jobId = await driveToValidated(p, {}, { admittedByAgentAddress: OWNER });

--- a/packages/publisher/test/async-lift-terminal-clear.test.ts
+++ b/packages/publisher/test/async-lift-terminal-clear.test.ts
@@ -219,12 +219,12 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     const validated = await driveToValidated(p, {}, { admittedByAgentAddress: OWNER });
 
     expect(await p.clearTerminalJob(validated, {
-      pendingTransactionOverride: { requestedBy: OTHER },
+      pendingTransactionOverride: { kind: 'agent', requestedBy: OTHER },
     })).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
     expect((await p.getStatus(validated))?.status).toBe('validated');
 
     expect(await p.clearTerminalJob(validated, {
-      pendingTransactionOverride: { requestedBy: OWNER },
+      pendingTransactionOverride: { kind: 'agent', requestedBy: OWNER },
     })).toEqual({ outcome: 'cleared' });
     expect(await p.getStatus(validated)).toBeNull();
   });
@@ -270,12 +270,12 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     await p.update(broadcast, 'broadcast', { broadcast: bx });
 
     expect(await p.clearTerminalJob(broadcast, {
-      pendingTransactionOverride: { requestedBy: OTHER },
+      pendingTransactionOverride: { kind: 'agent', requestedBy: OTHER },
     })).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
     expect((await p.getStatus(broadcast))?.status).toBe('broadcast');
 
     expect(await p.clearTerminalJob(broadcast, {
-      pendingTransactionOverride: { requestedBy: OWNER },
+      pendingTransactionOverride: { kind: 'agent', requestedBy: OWNER },
     })).toEqual({ outcome: 'cleared' });
     expect(await p.getStatus(broadcast)).toBeNull();
   });
@@ -300,7 +300,7 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     await resolverEntered;
     let clearSettled = false;
     const clearing = p.clearTerminalJob(broadcast, {
-      pendingTransactionOverride: { requestedBy: OWNER },
+      pendingTransactionOverride: { kind: 'agent', requestedBy: OWNER },
     }).then((outcome) => {
       clearSettled = true;
       return outcome;
@@ -359,7 +359,7 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     // The AUTHOR is not the enqueuer, so the author's token gets nothing — this is the exact
     // confusion the previous version had backwards.
     expect(await p.clearTerminalJob(jobId, {
-      pendingTransactionOverride: { requestedBy: AUTHOR },
+      pendingTransactionOverride: { kind: 'agent', requestedBy: AUTHOR },
     })).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
     expect((await p.getStatus(jobId))?.status).toBe('failed');
 
@@ -367,12 +367,12 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     // sole entitlement, so the GH#1778 hint sitting in the request grants nothing — this is
     // what fails if ownership ever falls back to reading the payload.
     expect(await p.clearTerminalJob(jobId, {
-      pendingTransactionOverride: { requestedBy: PAYLOAD_CALLER },
+      pendingTransactionOverride: { kind: 'agent', requestedBy: PAYLOAD_CALLER },
     })).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
     expect((await p.getStatus(jobId))?.status).toBe('failed');
 
     expect(await p.clearTerminalJob(jobId, {
-      pendingTransactionOverride: { requestedBy: OWNER },
+      pendingTransactionOverride: { kind: 'agent', requestedBy: OWNER },
     })).toEqual({ outcome: 'cleared' });
     expect(await p.getStatus(jobId)).toBeNull();
   });
@@ -390,12 +390,12 @@ describe('#1837 lift publisher clearTerminalJob', () => {
 
     // An unrelated agent token is still refused...
     expect(await p.clearTerminalJob(jobId, {
-      pendingTransactionOverride: { requestedBy: OTHER },
+      pendingTransactionOverride: { kind: 'agent', requestedBy: OTHER },
     })).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
 
     // ...while the explicit node-operator principal may clear any job in this node's queue.
     expect(await p.clearTerminalJob(jobId, {
-      pendingTransactionOverride: { requestedByNodeOperator: true },
+      pendingTransactionOverride: { kind: 'nodeOperator' },
     })).toEqual({ outcome: 'cleared' });
   });
 
@@ -413,12 +413,12 @@ describe('#1837 lift publisher clearTerminalJob', () => {
     await store.insert(serializeJob(mutated as typeof job, DEFAULT_CONTROL_GRAPH_URI));
 
     expect(await p.clearTerminalJob(jobId, {
-      pendingTransactionOverride: { requestedBy: PAYLOAD_CALLER },
+      pendingTransactionOverride: { kind: 'agent', requestedBy: PAYLOAD_CALLER },
     })).toEqual({ outcome: 'rejected', reason: 'nonterminal' });
     expect((await p.getStatus(jobId))?.status).toBe('failed');
 
     expect(await p.clearTerminalJob(jobId, {
-      pendingTransactionOverride: { requestedByNodeOperator: true },
+      pendingTransactionOverride: { kind: 'nodeOperator' },
     })).toEqual({ outcome: 'cleared' });
     expect(await p.getStatus(jobId)).toBeNull();
   });


### PR DESCRIPTION
## Summary

- derive one explicit HTTP authentication decision without a WeakMap side channel
- keep request identity in the CLI daemon and model node-operator capability separately
- preserve auth-disabled operator behavior for tokenless, invalid-token, valid node-token, and valid agent-token requests while retaining any recognized agent identity
- map CLI request identity and capability explicitly into the publisher-owned terminal-clear authority
- let an admitting agent clear only its own pending-transaction job and let the node operator clear any job in the node queue
- continue denying cross-agent and forged-bearer force-clears when authentication is enabled

The job authorization decision remains inside the publisher claim lock.

## Verification

- complete CLI suite: 3,790 passed, 14 skipped, 0 failed
- focused authentication and admin-route matrix: 207/207
- publisher terminal-clear, retry-disposition, and chain-proof tests: 87/87
- CLI and publisher build/typecheck
- repository lint
- rerun of the unrelated two-node gossip timing failure passed

Closes #2308