### PR TITLE
fix(query): return structured P2P store busy responses

### DIFF
--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -96,7 +96,7 @@ import {
   SUBSCRIPTION_SOURCES,
   pickNetworkTunables,
 } from '@origintrail-official/dkg-core';
-import { GraphManager, PrivateContentStore, StoreSchedulerBusyError, asChangelogReader, asGraphWriteRevisionSource, createTripleStore, tryUpdateWithTouchedGraphs, type TripleStore, type TripleStoreConfig, type QueryOptions, type Quad, type LargeLiteralStorageConfig, type SelectResult } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, isStoreSchedulerBusyError, asChangelogReader, asGraphWriteRevisionSource, createTripleStore, tryUpdateWithTouchedGraphs, type TripleStore, type TripleStoreConfig, type QueryOptions, type Quad, type LargeLiteralStorageConfig, type SelectResult } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
@@ -281,13 +281,6 @@ function rsHealStoreOptions(operation: string, signal?: AbortSignal): QueryOptio
     source: `agent.swm.rsHeal.${operation}`,
     ...(signal ? { signal } : {}),
   };
-}
-
-function isStoreSchedulerBusyError(err: unknown): boolean {
-  return err instanceof StoreSchedulerBusyError || (
-    typeof err === 'object' && err !== null &&
-    (err as { code?: unknown }).code === 'STORE_SCHEDULER_BUSY'
-  );
 }
 
 export type RsHealPassResult =

--- a/packages/agent/test/rs-heal-stranded-kc.test.ts
+++ b/packages/agent/test/rs-heal-stranded-kc.test.ts
@@ -402,6 +402,43 @@ describe('healStrandedScopedKCs — content-binding gate', () => {
     expect(options.every((entry) => entry.source?.startsWith('agent.swm.rsHeal.'))).toBe(true);
   });
 
+  it('does not treat an incomplete busy-shaped failure as retry-safe admission rejection', async () => {
+    let queryCalls = 0;
+    const cursorKey = 'incomplete-busy-cg\u000029';
+    const cursorMap = new Map<string, string>([[cursorKey, 'did:dkg:hardhat:31337/0xbefore/1']]);
+    const agentLike = {
+      store: {
+        update: async () => undefined,
+        query: async () => {
+          queryCalls += 1;
+          if (queryCalls === 1) return { type: 'boolean', value: true } as const;
+          if (queryCalls === 2) {
+            return {
+              type: 'bindings',
+              bindings: [{
+                ual: 'did:dkg:hardhat:31337/0xincomplete/1',
+                b: `"1"^^<${XSD}integer>`,
+              }],
+            } as const;
+          }
+          throw { code: 'STORE_SCHEDULER_BUSY' };
+        },
+      },
+      contextGraphBindingState: new ContextGraphBindingState(),
+      rsHealCursorByCg: cursorMap,
+      log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+    };
+
+    await expect(SwmHostModeMethods.prototype.healStrandedScopedKCs.call(
+      agentLike as never,
+      'incomplete-busy-cg',
+      authoritativeTarget('29') as never,
+    )).resolves.toEqual({ status: 'completed', inspected: 1 });
+
+    expect(queryCalls).toBe(3);
+    expect(cursorMap.has(cursorKey)).toBe(false);
+  });
+
   it('cancels a queued legacy-version read through the scheduler before teardown completes', async () => {
     const scheduler = new StorePriorityScheduler({
       maxConcurrent: 1,

--- a/packages/query/src/query-handler.ts
+++ b/packages/query/src/query-handler.ts
@@ -1,6 +1,6 @@
 import type { PeerId } from '@origintrail-official/dkg-core';
 import { contextGraphDataUri, assertSafeIri, escapeSparqlLiteral } from '@origintrail-official/dkg-core';
-import { quadsToNQuads } from '@origintrail-official/dkg-storage';
+import { quadsToNQuads, StoreSchedulerBusyError } from '@origintrail-official/dkg-storage';
 import { stripLiteralsAndComments } from './sparql-utils.js';
 import { validateReadOnlySparql } from './sparql-guard.js';
 import type { DKGQueryEngine } from './dkg-query-engine.js';
@@ -18,6 +18,7 @@ const MAX_LIMIT = 1000;
 const DEFAULT_TIMEOUT_MS = 5000;
 const MAX_TIMEOUT_MS = 30000;
 const MAX_RESULT_BYTES = 1_048_576; // 1 MB
+const STORE_BUSY_RETRY_AFTER_MS = 1_000;
 // PR #1107 review (🔴): cache isContextGraphPublic verdicts so repeated
 // remote queries against the same CG don't each burn an RPC round-trip on
 // the chain adapter. Short TTL keeps policy flips (public → private)
@@ -145,6 +146,7 @@ export class QueryHandler {
 
       return this.enforceResultSize(response);
     } catch (err) {
+      if (isStoreSchedulerBusyError(err)) return storeBusyResponse(opId, err);
       return errorResponse(opId, 'ERROR', 'Internal error processing query');
     }
   }
@@ -308,7 +310,8 @@ export class QueryHandler {
         truncated: false,
         resultCount: resolved.quads.length,
       };
-    } catch {
+    } catch (err) {
+      if (isStoreSchedulerBusyError(err)) throw err;
       return errorResponse(opId, 'ERROR', `Failed to resolve UAL: ${ual}`);
     }
   }
@@ -460,6 +463,36 @@ function errorResponse(opId: string, status: QueryStatus, error: string): QueryR
     truncated: false,
     resultCount: 0,
     error,
+  };
+}
+
+function isStoreSchedulerBusyError(
+  error: unknown,
+): error is StoreSchedulerBusyError {
+  return error instanceof StoreSchedulerBusyError || (
+    typeof error === 'object'
+    && error !== null
+    && (error as { code?: unknown }).code === 'STORE_SCHEDULER_BUSY'
+  );
+}
+
+function storeBusyResponse(
+  opId: string,
+  error: StoreSchedulerBusyError,
+): QueryResponse {
+  const reason = error.reason === 'queue_full' || error.reason === 'queue_wait_timeout'
+    ? error.reason
+    : undefined;
+  return {
+    operationId: opId,
+    status: 'BUSY',
+    truncated: false,
+    resultCount: 0,
+    error: 'Node storage is temporarily busy. Retry later.',
+    code: 'STORE_BUSY',
+    retryable: true,
+    retryAfterMs: STORE_BUSY_RETRY_AFTER_MS,
+    ...(reason ? { reason } : {}),
   };
 }
 

--- a/packages/query/src/query-handler.ts
+++ b/packages/query/src/query-handler.ts
@@ -1,6 +1,10 @@
 import type { PeerId } from '@origintrail-official/dkg-core';
 import { contextGraphDataUri, assertSafeIri, escapeSparqlLiteral } from '@origintrail-official/dkg-core';
-import { quadsToNQuads, StoreSchedulerBusyError } from '@origintrail-official/dkg-storage';
+import {
+  isStoreSchedulerBusyError,
+  quadsToNQuads,
+  type StoreSchedulerBusyErrorLike,
+} from '@origintrail-official/dkg-storage';
 import { stripLiteralsAndComments } from './sparql-utils.js';
 import { validateReadOnlySparql } from './sparql-guard.js';
 import type { DKGQueryEngine } from './dkg-query-engine.js';
@@ -10,7 +14,8 @@ import type {
   QueryAccessConfig,
   ContextGraphQueryPolicy,
   LookupType,
-  QueryStatus,
+  NonBusyQueryStatus,
+  QueryBusyResponse,
 } from './query-types.js';
 
 const DEFAULT_LIMIT = 100;
@@ -30,6 +35,13 @@ const PUBLIC_CG_CACHE_MAX_ENTRIES = 1000;
 interface RateBucket {
   count: number;
   resetAt: number;
+}
+
+class UalResolutionError extends Error {
+  constructor(readonly ual: string, cause: unknown) {
+    super(`Failed to resolve UAL: ${ual}`, { cause });
+    this.name = 'UalResolutionError';
+  }
 }
 
 /**
@@ -146,7 +158,11 @@ export class QueryHandler {
 
       return this.enforceResultSize(response);
     } catch (err) {
-      if (isStoreSchedulerBusyError(err)) return storeBusyResponse(opId, err);
+      const busyError = storeSchedulerBusyCause(err);
+      if (busyError) return storeBusyResponse(opId, busyError);
+      if (err instanceof UalResolutionError) {
+        return errorResponse(opId, 'ERROR', err.message);
+      }
       return errorResponse(opId, 'ERROR', 'Internal error processing query');
     }
   }
@@ -287,33 +303,34 @@ export class QueryHandler {
       return errorResponse(opId, 'ERROR', 'Invalid request: missing ual');
     }
 
+    let resolved;
     try {
-      const resolved = this.queryEngine.resolveKnowledgeAsset
+      resolved = this.queryEngine.resolveKnowledgeAsset
         ? await this.queryEngine.resolveKnowledgeAsset(ual)
         : await this.queryEngine.resolveKA(ual);
-      // PR #1107 review (🔴): enforce the RESOLVED context graph's access
-      // policy — config entry first (operator override), then the #1105
-      // on-chain public resolver. Pre-fix, UAL lookups bypassed per-CG
-      // evaluation entirely: they were denied for on-chain-public CGs on
-      // default configs, yet allowed THROUGH explicitly denied CGs whenever
-      // any other public CG existed on the node.
-      const denied = await this.checkContextGraphAccess('ENTITY_BY_UAL', resolved.contextGraphId, peerId);
-      if (denied) return { ...denied, operationId: opId };
-      const ntriples = quadsToNQuads(
-        resolved.quads.map((quad) => ({ ...quad, graph: '' })),
-      );
-
-      return {
-        operationId: opId,
-        status: 'OK',
-        ntriples,
-        truncated: false,
-        resultCount: resolved.quads.length,
-      };
-    } catch (err) {
-      if (isStoreSchedulerBusyError(err)) throw err;
-      return errorResponse(opId, 'ERROR', `Failed to resolve UAL: ${ual}`);
+    } catch (cause) {
+      throw new UalResolutionError(ual, cause);
     }
+
+    // PR #1107 review (🔴): enforce the RESOLVED context graph's access
+    // policy — config entry first (operator override), then the #1105
+    // on-chain public resolver. Pre-fix, UAL lookups bypassed per-CG
+    // evaluation entirely: they were denied for on-chain-public CGs on
+    // default configs, yet allowed THROUGH explicitly denied CGs whenever
+    // any other public CG existed on the node.
+    const denied = await this.checkContextGraphAccess('ENTITY_BY_UAL', resolved.contextGraphId, peerId);
+    if (denied) return { ...denied, operationId: opId };
+    const ntriples = quadsToNQuads(
+      resolved.quads.map((quad) => ({ ...quad, graph: '' })),
+    );
+
+    return {
+      operationId: opId,
+      status: 'OK',
+      ntriples,
+      truncated: false,
+      resultCount: resolved.quads.length,
+    };
   }
 
   private async lookupByType(
@@ -445,7 +462,7 @@ export class QueryHandler {
 
   private enforceResultSize(response: QueryResponse): QueryResponse {
     const serialized = JSON.stringify(response);
-    if (serialized.length <= MAX_RESULT_BYTES) return response;
+    if (serialized.length <= MAX_RESULT_BYTES || response.status === 'BUSY') return response;
 
     return {
       ...response,
@@ -456,7 +473,11 @@ export class QueryHandler {
   }
 }
 
-function errorResponse(opId: string, status: QueryStatus, error: string): QueryResponse {
+function errorResponse(
+  opId: string,
+  status: NonBusyQueryStatus,
+  error: string,
+): QueryResponse {
   return {
     operationId: opId,
     status,
@@ -466,23 +487,20 @@ function errorResponse(opId: string, status: QueryStatus, error: string): QueryR
   };
 }
 
-function isStoreSchedulerBusyError(
+function storeSchedulerBusyCause(
   error: unknown,
-): error is StoreSchedulerBusyError {
-  return error instanceof StoreSchedulerBusyError || (
-    typeof error === 'object'
-    && error !== null
-    && (error as { code?: unknown }).code === 'STORE_SCHEDULER_BUSY'
-  );
+): StoreSchedulerBusyErrorLike | null {
+  if (isStoreSchedulerBusyError(error)) return error;
+  if (error instanceof UalResolutionError && isStoreSchedulerBusyError(error.cause)) {
+    return error.cause;
+  }
+  return null;
 }
 
 function storeBusyResponse(
   opId: string,
-  error: StoreSchedulerBusyError,
-): QueryResponse {
-  const reason = error.reason === 'queue_full' || error.reason === 'queue_wait_timeout'
-    ? error.reason
-    : undefined;
+  error: StoreSchedulerBusyErrorLike,
+): QueryBusyResponse {
   return {
     operationId: opId,
     status: 'BUSY',
@@ -492,7 +510,7 @@ function storeBusyResponse(
     code: 'STORE_BUSY',
     retryable: true,
     retryAfterMs: STORE_BUSY_RETRY_AFTER_MS,
-    ...(reason ? { reason } : {}),
+    reason: error.reason,
   };
 }
 

--- a/packages/query/src/query-handler.ts
+++ b/packages/query/src/query-handler.ts
@@ -16,6 +16,7 @@ import type {
   LookupType,
   NonBusyQueryStatus,
   QueryBusyResponse,
+  QueryNonBusyResponse,
 } from './query-types.js';
 
 const DEFAULT_LIMIT = 100;
@@ -131,7 +132,7 @@ export class QueryHandler {
       const timeout = Math.min(request.timeout ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
       const contextGraphPolicy = this.contextGraphPolicy(contextGraphId);
 
-      let response: QueryResponse;
+      let response: QueryNonBusyResponse;
 
       switch (request.lookupType) {
         case 'ENTITY_BY_UAL':
@@ -171,7 +172,7 @@ export class QueryHandler {
     lookupType: LookupType,
     contextGraphId: string | undefined,
     peerId: string,
-  ): Promise<QueryResponse | null> {
+  ): Promise<QueryNonBusyResponse | null> {
     const defaultPolicy = this.config.defaultPolicy ?? 'deny';
 
     // ENTITY_BY_UAL: the target CG is only known AFTER the UAL resolves, so
@@ -199,7 +200,7 @@ export class QueryHandler {
     lookupType: LookupType,
     contextGraphId: string,
     peerId: string,
-  ): Promise<QueryResponse | null> {
+  ): Promise<QueryNonBusyResponse | null> {
     const defaultPolicy = this.config.defaultPolicy ?? 'deny';
     const cgConfig = this.config.contextGraphs?.[contextGraphId];
     if (!cgConfig) {
@@ -276,7 +277,7 @@ export class QueryHandler {
     return this.config.contextGraphs?.[contextGraphId];
   }
 
-  private checkRateLimit(peerId: string): QueryResponse | null {
+  private checkRateLimit(peerId: string): QueryNonBusyResponse | null {
     const now = Date.now();
     let bucket = this.rateBuckets.get(peerId);
 
@@ -298,7 +299,7 @@ export class QueryHandler {
     return null;
   }
 
-  private async lookupByUAL(opId: string, ual: string, peerId: string): Promise<QueryResponse> {
+  private async lookupByUAL(opId: string, ual: string, peerId: string): Promise<QueryNonBusyResponse> {
     if (!ual) {
       return errorResponse(opId, 'ERROR', 'Invalid request: missing ual');
     }
@@ -338,7 +339,7 @@ export class QueryHandler {
     contextGraphId: string,
     rdfType: string,
     limit: number,
-  ): Promise<QueryResponse> {
+  ): Promise<QueryNonBusyResponse> {
     if (!rdfType) {
       return errorResponse(opId, 'ERROR', 'Invalid request: missing rdfType');
     }
@@ -363,7 +364,7 @@ export class QueryHandler {
     opId: string,
     contextGraphId: string,
     entityUri: string,
-  ): Promise<QueryResponse> {
+  ): Promise<QueryNonBusyResponse> {
     if (!entityUri) {
       return errorResponse(opId, 'ERROR', 'Invalid request: missing entityUri');
     }
@@ -392,7 +393,7 @@ export class QueryHandler {
     sparql: string,
     limit: number,
     timeout: number,
-  ): Promise<QueryResponse> {
+  ): Promise<QueryNonBusyResponse> {
     if (!sparql) {
       return errorResponse(opId, 'ERROR', 'Invalid request: missing sparql');
     }
@@ -460,9 +461,9 @@ export class QueryHandler {
     };
   }
 
-  private enforceResultSize(response: QueryResponse): QueryResponse {
+  private enforceResultSize(response: QueryNonBusyResponse): QueryNonBusyResponse {
     const serialized = JSON.stringify(response);
-    if (serialized.length <= MAX_RESULT_BYTES || response.status === 'BUSY') return response;
+    if (serialized.length <= MAX_RESULT_BYTES) return response;
 
     return {
       ...response,
@@ -477,7 +478,7 @@ function errorResponse(
   opId: string,
   status: NonBusyQueryStatus,
   error: string,
-): QueryResponse {
+): QueryNonBusyResponse {
   return {
     operationId: opId,
     status,

--- a/packages/query/src/query-types.ts
+++ b/packages/query/src/query-types.ts
@@ -7,6 +7,7 @@ export type LookupType =
 export type QueryStatus =
   | 'OK'
   | 'ERROR'
+  | 'BUSY'
   | 'ACCESS_DENIED'
   | 'RATE_LIMITED'
   | 'NOT_FOUND'
@@ -35,6 +36,14 @@ export interface QueryResponse {
   resultCount: number;
   gasConsumed?: number;
   error?: string;
+  /** Stable machine-readable code for retryable protocol outcomes. */
+  code?: string;
+  /** True only when repeating the same request is safe. */
+  retryable?: boolean;
+  /** Bounded delay suggested by the responding node. */
+  retryAfterMs?: number;
+  /** Bounded scheduler reason when the request was rejected before dispatch. */
+  reason?: 'queue_full' | 'queue_wait_timeout';
 }
 
 export interface ContextGraphQueryPolicy {

--- a/packages/query/src/query-types.ts
+++ b/packages/query/src/query-types.ts
@@ -69,7 +69,9 @@ type ContradictoryOkResponse = QueryResponseBase & {
   code: 'STORE_BUSY';
   retryable: true;
 };
-export type QueryResponseTypeAssertions = [
+// Compile-only contract: intentionally private so fixture types do not enter the public API.
+// eslint-disable-next-line no-unused-vars
+type QueryResponseTypeAssertions = [
   AssertFalse<IncompleteBusyResponse extends QueryResponse ? true : false>,
   AssertFalse<ContradictoryOkResponse extends QueryResponse ? true : false>,
 ];

--- a/packages/query/src/query-types.ts
+++ b/packages/query/src/query-types.ts
@@ -1,3 +1,5 @@
+import type { StoreSchedulerBusyReason } from '@origintrail-official/dkg-storage';
+
 export type LookupType =
   | 'ENTITY_BY_UAL'
   | 'ENTITIES_BY_TYPE'
@@ -53,7 +55,7 @@ export interface QueryBusyResponse extends QueryResponseBase {
   code: 'STORE_BUSY';
   retryable: true;
   retryAfterMs: number;
-  reason?: 'queue_full' | 'queue_wait_timeout';
+  reason: StoreSchedulerBusyReason;
   ntriples?: never;
   bindings?: never;
   entityUris?: never;

--- a/packages/query/src/query-types.ts
+++ b/packages/query/src/query-types.ts
@@ -14,6 +14,8 @@ export type QueryStatus =
   | 'GAS_LIMIT_EXCEEDED'
   | 'UNSUPPORTED_LOOKUP';
 
+export type NonBusyQueryStatus = Exclude<QueryStatus, 'BUSY'>;
+
 export interface QueryRequest {
   operationId: string;
   lookupType: LookupType;
@@ -26,25 +28,51 @@ export interface QueryRequest {
   timeout?: number;
 }
 
-export interface QueryResponse {
+interface QueryResponseBase {
   operationId: string;
-  status: QueryStatus;
+  truncated: boolean;
+  resultCount: number;
+}
+
+export interface QueryNonBusyResponse extends QueryResponseBase {
+  status: NonBusyQueryStatus;
   ntriples?: string;
   bindings?: string;
   entityUris?: string[];
-  truncated: boolean;
-  resultCount: number;
   gasConsumed?: number;
   error?: string;
-  /** Stable machine-readable code for retryable protocol outcomes. */
-  code?: string;
-  /** True only when repeating the same request is safe. */
-  retryable?: boolean;
-  /** Bounded delay suggested by the responding node. */
-  retryAfterMs?: number;
-  /** Bounded scheduler reason when the request was rejected before dispatch. */
-  reason?: 'queue_full' | 'queue_wait_timeout';
+  code?: never;
+  retryable?: never;
+  retryAfterMs?: never;
+  reason?: never;
 }
+
+export interface QueryBusyResponse extends QueryResponseBase {
+  status: 'BUSY';
+  error: string;
+  code: 'STORE_BUSY';
+  retryable: true;
+  retryAfterMs: number;
+  reason?: 'queue_full' | 'queue_wait_timeout';
+  ntriples?: never;
+  bindings?: never;
+  entityUris?: never;
+  gasConsumed?: never;
+}
+
+export type QueryResponse = QueryNonBusyResponse | QueryBusyResponse;
+
+type AssertFalse<T extends false> = T;
+type IncompleteBusyResponse = QueryResponseBase & { status: 'BUSY' };
+type ContradictoryOkResponse = QueryResponseBase & {
+  status: 'OK';
+  code: 'STORE_BUSY';
+  retryable: true;
+};
+export type QueryResponseTypeAssertions = [
+  AssertFalse<IncompleteBusyResponse extends QueryResponse ? true : false>,
+  AssertFalse<ContradictoryOkResponse extends QueryResponse ? true : false>,
+];
 
 export interface ContextGraphQueryPolicy {
   policy: 'deny' | 'public' | 'allowList';

--- a/packages/query/test/query-extra.test.ts
+++ b/packages/query/test/query-extra.test.ts
@@ -1168,6 +1168,52 @@ describe('[Q-6] QueryHandler error taxonomy', () => {
       retryAfterMs: 1_000,
     });
   });
+
+  it('preserves the structured busy response through UAL resolution', async () => {
+    const busy = new StoreSchedulerBusyError(
+      'queue_full',
+      'normal',
+      'remote-query.resolveKnowledgeAsset',
+    );
+    const queryEngine = {
+      resolveKnowledgeAsset: async () => { throw busy; },
+    } as unknown as DKGQueryEngine;
+    const handler = new QueryHandler(queryEngine, { defaultPolicy: 'public' });
+
+    const response = await handler.handle({
+      operationId: 'busy-ual',
+      lookupType: 'ENTITY_BY_UAL',
+      ual: 'did:dkg:testnet:31337/0xabc/1',
+    }, 'peer-busy');
+
+    expect(response).toMatchObject({
+      operationId: 'busy-ual',
+      status: 'BUSY',
+      code: 'STORE_BUSY',
+      retryable: true,
+      retryAfterMs: 1_000,
+      reason: 'queue_full',
+    });
+  });
+
+  it('preserves the ordinary UAL resolution failure text at the outer boundary', async () => {
+    const queryEngine = {
+      resolveKnowledgeAsset: async () => { throw new Error('resolver failed'); },
+    } as unknown as DKGQueryEngine;
+    const handler = new QueryHandler(queryEngine, { defaultPolicy: 'public' });
+
+    const response = await handler.handle({
+      operationId: 'failed-ual',
+      lookupType: 'ENTITY_BY_UAL',
+      ual: 'did:dkg:testnet:31337/0xabc/1',
+    }, 'peer');
+
+    expect(response).toMatchObject({
+      operationId: 'failed-ual',
+      status: 'ERROR',
+      error: 'Failed to resolve UAL: did:dkg:testnet:31337/0xabc/1',
+    });
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/query/test/query-extra.test.ts
+++ b/packages/query/test/query-extra.test.ts
@@ -41,6 +41,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   OxigraphStore,
+  StoreSchedulerBusyError,
   type TripleStore,
   type Quad,
   type QueryResult as StoreQueryResult,
@@ -1109,6 +1110,63 @@ describe('[Q-6] QueryHandler error taxonomy', () => {
     }, 'p');
     expect(resp.status).toBe('ERROR');
     expect(resp.error).toBe('Internal error processing query');
+  });
+
+  it('returns a structured retryable P2P response when storage rejects before dispatch', async () => {
+    class BusyStore implements TripleStore {
+      async insert() { /* noop */ }
+      async delete() { /* noop */ }
+      async deleteByPattern() { return 0; }
+      async hasGraph() { return false; }
+      async createGraph() { /* noop */ }
+      async dropGraph() { /* noop */ }
+      async listGraphs() { return []; }
+      async deleteBySubjectPrefix() { return 0; }
+      async countQuads() { return 0; }
+      async close() { /* noop */ }
+      async query(): Promise<StoreQueryResult> {
+        throw new StoreSchedulerBusyError(
+          'queue_wait_timeout',
+          'normal',
+          'remote-query.read',
+        );
+      }
+    }
+
+    const handler = new QueryHandler(new DKGQueryEngine(new BusyStore()), {
+      defaultPolicy: 'public',
+      contextGraphs: { [CG]: { policy: 'public', sparqlEnabled: true } },
+    });
+    const request = {
+      operationId: 'busy-op',
+      lookupType: 'SPARQL_QUERY' as const,
+      contextGraphId: CG,
+      sparql: 'SELECT ?s WHERE { ?s ?p ?o }',
+    };
+    const response = await handler.handle(request, 'peer-busy');
+
+    expect(response).toEqual({
+      operationId: 'busy-op',
+      status: 'BUSY',
+      truncated: false,
+      resultCount: 0,
+      error: 'Node storage is temporarily busy. Retry later.',
+      code: 'STORE_BUSY',
+      retryable: true,
+      retryAfterMs: 1_000,
+      reason: 'queue_wait_timeout',
+    });
+
+    const wireResponse = await handler.handler(
+      new TextEncoder().encode(JSON.stringify(request)),
+      { toString: () => 'peer-busy', toBytes: () => new Uint8Array() },
+    );
+    expect(JSON.parse(new TextDecoder().decode(wireResponse))).toMatchObject({
+      status: 'BUSY',
+      code: 'STORE_BUSY',
+      retryable: true,
+      retryAfterMs: 1_000,
+    });
   });
 });
 

--- a/packages/query/test/query-extra.test.ts
+++ b/packages/query/test/query-extra.test.ts
@@ -41,7 +41,6 @@
 import { describe, it, expect } from 'vitest';
 import {
   OxigraphStore,
-  StoreSchedulerBusyError,
   type TripleStore,
   type Quad,
   type QueryResult as StoreQueryResult,
@@ -1110,90 +1109,6 @@ describe('[Q-6] QueryHandler error taxonomy', () => {
     }, 'p');
     expect(resp.status).toBe('ERROR');
     expect(resp.error).toBe('Internal error processing query');
-  });
-
-  it('returns a structured retryable P2P response when storage rejects before dispatch', async () => {
-    class BusyStore implements TripleStore {
-      async insert() { /* noop */ }
-      async delete() { /* noop */ }
-      async deleteByPattern() { return 0; }
-      async hasGraph() { return false; }
-      async createGraph() { /* noop */ }
-      async dropGraph() { /* noop */ }
-      async listGraphs() { return []; }
-      async deleteBySubjectPrefix() { return 0; }
-      async countQuads() { return 0; }
-      async close() { /* noop */ }
-      async query(): Promise<StoreQueryResult> {
-        throw new StoreSchedulerBusyError(
-          'queue_wait_timeout',
-          'normal',
-          'remote-query.read',
-        );
-      }
-    }
-
-    const handler = new QueryHandler(new DKGQueryEngine(new BusyStore()), {
-      defaultPolicy: 'public',
-      contextGraphs: { [CG]: { policy: 'public', sparqlEnabled: true } },
-    });
-    const request = {
-      operationId: 'busy-op',
-      lookupType: 'SPARQL_QUERY' as const,
-      contextGraphId: CG,
-      sparql: 'SELECT ?s WHERE { ?s ?p ?o }',
-    };
-    const response = await handler.handle(request, 'peer-busy');
-
-    expect(response).toEqual({
-      operationId: 'busy-op',
-      status: 'BUSY',
-      truncated: false,
-      resultCount: 0,
-      error: 'Node storage is temporarily busy. Retry later.',
-      code: 'STORE_BUSY',
-      retryable: true,
-      retryAfterMs: 1_000,
-      reason: 'queue_wait_timeout',
-    });
-
-    const wireResponse = await handler.handler(
-      new TextEncoder().encode(JSON.stringify(request)),
-      { toString: () => 'peer-busy', toBytes: () => new Uint8Array() },
-    );
-    expect(JSON.parse(new TextDecoder().decode(wireResponse))).toMatchObject({
-      status: 'BUSY',
-      code: 'STORE_BUSY',
-      retryable: true,
-      retryAfterMs: 1_000,
-    });
-  });
-
-  it('preserves the structured busy response through UAL resolution', async () => {
-    const busy = new StoreSchedulerBusyError(
-      'queue_full',
-      'normal',
-      'remote-query.resolveKnowledgeAsset',
-    );
-    const queryEngine = {
-      resolveKnowledgeAsset: async () => { throw busy; },
-    } as unknown as DKGQueryEngine;
-    const handler = new QueryHandler(queryEngine, { defaultPolicy: 'public' });
-
-    const response = await handler.handle({
-      operationId: 'busy-ual',
-      lookupType: 'ENTITY_BY_UAL',
-      ual: 'did:dkg:testnet:31337/0xabc/1',
-    }, 'peer-busy');
-
-    expect(response).toMatchObject({
-      operationId: 'busy-ual',
-      status: 'BUSY',
-      code: 'STORE_BUSY',
-      retryable: true,
-      retryAfterMs: 1_000,
-      reason: 'queue_full',
-    });
   });
 
   it('preserves the ordinary UAL resolution failure text at the outer boundary', async () => {

--- a/packages/query/test/query-store-busy.test.ts
+++ b/packages/query/test/query-store-busy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   StoreSchedulerBusyError,
   type QueryResult as StoreQueryResult,
+  type StoreSchedulerBusyErrorLike,
   type StoreSchedulerBusyReason,
   type TripleStore,
 } from '@origintrail-official/dkg-storage';
@@ -29,6 +30,22 @@ function queryOnlyStore(query: TripleStore['query']): TripleStore {
 
 function busyError(reason: StoreSchedulerBusyReason, operation: string) {
   return new StoreSchedulerBusyError(reason, 'normal', operation);
+}
+
+function structuralBusyError(
+  reason: StoreSchedulerBusyReason,
+  operation: string,
+): StoreSchedulerBusyErrorLike {
+  return {
+    code: 'STORE_SCHEDULER_BUSY',
+    retryable: true,
+    outcome: 'not_started',
+    storeOperationOutcomeTag: 'dkg.store-operation-outcome.v1',
+    reason,
+    priority: 'normal',
+    operation,
+    storeOperation: 'query',
+  };
 }
 
 function expectedBusyResponse(
@@ -63,7 +80,9 @@ class BusyUalQueryEngine extends DKGQueryEngine {
 
 describe('QueryHandler store-busy responses', () => {
   it('preserves queue-wait admission failure through direct and encoded SPARQL responses', async () => {
-    const failure = busyError('queue_wait_timeout', 'remote-query.read');
+    // Deliberately use a plain structural value to exercise the package
+    // boundary rather than relying on shared Error-class identity.
+    const failure = structuralBusyError('queue_wait_timeout', 'remote-query.read');
     const store = queryOnlyStore(async (): Promise<StoreQueryResult> => { throw failure; });
     const handler = new QueryHandler(new DKGQueryEngine(store), {
       defaultPolicy: 'public',

--- a/packages/query/test/query-store-busy.test.ts
+++ b/packages/query/test/query-store-busy.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+  StoreSchedulerBusyError,
+  type QueryResult as StoreQueryResult,
+  type StoreSchedulerBusyReason,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
+import { DKGQueryEngine } from '../src/dkg-query-engine.js';
+import { QueryHandler } from '../src/query-handler.js';
+import type { QueryBusyResponse } from '../src/query-types.js';
+
+const CONTEXT_GRAPH_ID = 'busy-query-cg';
+
+function queryOnlyStore(query: TripleStore['query']): TripleStore {
+  return {
+    insert: async () => undefined,
+    delete: async () => undefined,
+    deleteByPattern: async () => 0,
+    query,
+    hasGraph: async () => false,
+    createGraph: async () => undefined,
+    dropGraph: async () => undefined,
+    listGraphs: async () => [],
+    deleteBySubjectPrefix: async () => 0,
+    countQuads: async () => 0,
+    close: async () => undefined,
+  };
+}
+
+function busyError(reason: StoreSchedulerBusyReason, operation: string) {
+  return new StoreSchedulerBusyError(reason, 'normal', operation);
+}
+
+function expectedBusyResponse(
+  operationId: string,
+  reason: StoreSchedulerBusyReason,
+): QueryBusyResponse {
+  return {
+    operationId,
+    status: 'BUSY',
+    truncated: false,
+    resultCount: 0,
+    error: 'Node storage is temporarily busy. Retry later.',
+    code: 'STORE_BUSY',
+    retryable: true,
+    retryAfterMs: 1_000,
+    reason,
+  };
+}
+
+class BusyUalQueryEngine extends DKGQueryEngine {
+  constructor(private readonly failure: StoreSchedulerBusyError) {
+    super(queryOnlyStore(async (): Promise<StoreQueryResult> => ({
+      type: 'bindings',
+      bindings: [],
+    })));
+  }
+
+  override async resolveKnowledgeAsset(): Promise<never> {
+    throw this.failure;
+  }
+}
+
+describe('QueryHandler store-busy responses', () => {
+  it('preserves queue-wait admission failure through direct and encoded SPARQL responses', async () => {
+    const failure = busyError('queue_wait_timeout', 'remote-query.read');
+    const store = queryOnlyStore(async (): Promise<StoreQueryResult> => { throw failure; });
+    const handler = new QueryHandler(new DKGQueryEngine(store), {
+      defaultPolicy: 'public',
+      contextGraphs: {
+        [CONTEXT_GRAPH_ID]: { policy: 'public', sparqlEnabled: true },
+      },
+    });
+    const request = {
+      operationId: 'busy-op',
+      lookupType: 'SPARQL_QUERY' as const,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      sparql: 'SELECT ?s WHERE { ?s ?p ?o }',
+    };
+    const expected = expectedBusyResponse('busy-op', 'queue_wait_timeout');
+
+    await expect(handler.handle(request, 'peer-busy')).resolves.toEqual(expected);
+
+    const wireResponse = await handler.handler(
+      new TextEncoder().encode(JSON.stringify(request)),
+      {
+        toString: () => 'peer-busy',
+        toBytes: () => new Uint8Array(),
+      } as Parameters<QueryHandler['handler']>[1],
+    );
+    expect(JSON.parse(new TextDecoder().decode(wireResponse))).toEqual(expected);
+  });
+
+  it('preserves queue-full admission failure through UAL resolution', async () => {
+    const handler = new QueryHandler(
+      new BusyUalQueryEngine(
+        busyError('queue_full', 'remote-query.resolveKnowledgeAsset'),
+      ),
+      { defaultPolicy: 'public' },
+    );
+
+    await expect(handler.handle({
+      operationId: 'busy-ual',
+      lookupType: 'ENTITY_BY_UAL',
+      ual: 'did:dkg:testnet:31337/0xabc/1',
+    }, 'peer-busy')).resolves.toEqual(expectedBusyResponse('busy-ual', 'queue_full'));
+  });
+});

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -14,6 +14,8 @@ export {
   type TripleStoreQueryOptions,
   type UpdateOptions,
   type LargeLiteralStorageConfig,
+  STORE_WORK_PRIORITIES,
+  isStoreWorkPriority,
   registerTripleStoreAdapter,
   findTripleStoreCapability,
   deleteByPatternWithoutCount,

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -46,6 +46,7 @@ export {
 export {
   StorePriorityScheduler,
   StoreSchedulerBusyError,
+  isStoreSchedulerBusyError,
   externalStorePriorityScheduler,
   getExternalStorePrioritySchedulerSnapshot,
   DEFAULT_STORE_QUEUE_LIMIT,
@@ -56,6 +57,7 @@ export {
   type StoreSchedulerBusyReason,
   type StoreSchedulerOperationMetadata,
   type StoreSchedulerBusyErrorOptions,
+  type StoreSchedulerBusyErrorLike,
 } from './store-priority-scheduler.js';
 export {
   STORE_OPERATION_TIMEOUT_CODE,

--- a/packages/storage/src/store-priority-scheduler.ts
+++ b/packages/storage/src/store-priority-scheduler.ts
@@ -10,6 +10,7 @@ import {
 import type { StorePressureSnapshot, StoreWorkPriority } from './triple-store.js';
 import {
   STORE_OPERATION_OUTCOME_TAG,
+  isStoreOperation,
   type StoreOperation,
   type StoreOperationOutcomeTagged,
 } from './store-operation-outcome.js';
@@ -70,6 +71,39 @@ export class StoreSchedulerBusyError extends Error implements StoreOperationOutc
     this.name = 'StoreSchedulerBusyError';
     this.storeOperation = options?.storeOperation;
   }
+}
+
+export interface StoreSchedulerBusyErrorLike extends StoreOperationOutcomeTagged {
+  readonly code: 'STORE_SCHEDULER_BUSY';
+  readonly retryable: true;
+  readonly outcome: 'not_started';
+  readonly reason: StoreSchedulerBusyReason;
+  readonly priority: StoreWorkPriority;
+  readonly operation: string;
+}
+
+const STORE_WORK_PRIORITIES: ReadonlySet<string> = new Set([
+  'ack',
+  'health',
+  'normal',
+  'background',
+]);
+
+/** Canonical cross-package guard for retry-safe scheduler admission errors. */
+export function isStoreSchedulerBusyError(
+  error: unknown,
+): error is StoreSchedulerBusyErrorLike {
+  if (!error || typeof error !== 'object') return false;
+  const shaped = error as Partial<StoreSchedulerBusyErrorLike>;
+  return shaped.code === 'STORE_SCHEDULER_BUSY'
+    && shaped.retryable === true
+    && shaped.outcome === 'not_started'
+    && shaped.storeOperationOutcomeTag === STORE_OPERATION_OUTCOME_TAG
+    && (shaped.reason === 'queue_full' || shaped.reason === 'queue_wait_timeout')
+    && typeof shaped.priority === 'string'
+    && STORE_WORK_PRIORITIES.has(shaped.priority)
+    && typeof shaped.operation === 'string'
+    && (shaped.storeOperation === undefined || isStoreOperation(shaped.storeOperation));
 }
 
 export type StorePriorityQueueLimits = Record<StoreWorkPriority, number>;

--- a/packages/storage/src/store-priority-scheduler.ts
+++ b/packages/storage/src/store-priority-scheduler.ts
@@ -7,7 +7,12 @@ import {
   type SchedulerPressureOutcome,
   type SchedulerPressureTicket,
 } from '@origintrail-official/dkg-core';
-import type { StorePressureSnapshot, StoreWorkPriority } from './triple-store.js';
+import {
+  isStoreWorkPriority,
+  STORE_WORK_PRIORITIES,
+  type StorePressureSnapshot,
+  type StoreWorkPriority,
+} from './triple-store.js';
 import {
   STORE_OPERATION_OUTCOME_TAG,
   isStoreOperation,
@@ -82,13 +87,6 @@ export interface StoreSchedulerBusyErrorLike extends StoreOperationOutcomeTagged
   readonly operation: string;
 }
 
-const STORE_WORK_PRIORITIES: ReadonlySet<string> = new Set([
-  'ack',
-  'health',
-  'normal',
-  'background',
-]);
-
 /** Canonical cross-package guard for retry-safe scheduler admission errors. */
 export function isStoreSchedulerBusyError(
   error: unknown,
@@ -100,8 +98,7 @@ export function isStoreSchedulerBusyError(
     && shaped.outcome === 'not_started'
     && shaped.storeOperationOutcomeTag === STORE_OPERATION_OUTCOME_TAG
     && (shaped.reason === 'queue_full' || shaped.reason === 'queue_wait_timeout')
-    && typeof shaped.priority === 'string'
-    && STORE_WORK_PRIORITIES.has(shaped.priority)
+    && isStoreWorkPriority(shaped.priority)
     && typeof shaped.operation === 'string'
     && (shaped.storeOperation === undefined || isStoreOperation(shaped.storeOperation));
 }
@@ -288,10 +285,7 @@ function metricOperation(operation: string): string {
 }
 
 export function storeWorkPriorityRank(priority: StoreWorkPriority): number {
-  if (priority === 'ack') return 0;
-  if (priority === 'health') return 1;
-  if (priority === 'normal') return 2;
-  return 3;
+  return STORE_WORK_PRIORITIES.indexOf(priority);
 }
 
 export class StorePriorityScheduler extends ObservableScheduler {
@@ -524,9 +518,7 @@ export class StorePriorityScheduler extends ObservableScheduler {
   }
 
   private nextRunnable(): QueueEntry<unknown> | undefined {
-    const priorities: StoreWorkPriority[] = ['ack', 'health', 'normal', 'background'];
-    priorities.sort((a, b) => storeWorkPriorityRank(a) - storeWorkPriorityRank(b));
-    for (const priority of priorities) {
+    for (const priority of STORE_WORK_PRIORITIES) {
       const queue = this.queues[priority];
       if (queue.length === 0) continue;
       if (!this.canStart(priority)) continue;

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -43,7 +43,12 @@ export interface AskResult {
 
 export type QueryResult = SelectResult | ConstructResult | AskResult;
 export type QueryCancellationMode = 'interruptible' | 'pre-dispatch';
-export const STORE_WORK_PRIORITIES = ['ack', 'health', 'normal', 'background'] as const;
+export const STORE_WORK_PRIORITIES = Object.freeze([
+  'ack',
+  'health',
+  'normal',
+  'background',
+] as const);
 export type StoreWorkPriority = (typeof STORE_WORK_PRIORITIES)[number];
 
 export function isStoreWorkPriority(value: unknown): value is StoreWorkPriority {

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -43,7 +43,13 @@ export interface AskResult {
 
 export type QueryResult = SelectResult | ConstructResult | AskResult;
 export type QueryCancellationMode = 'interruptible' | 'pre-dispatch';
-export type StoreWorkPriority = 'ack' | 'health' | 'normal' | 'background';
+export const STORE_WORK_PRIORITIES = ['ack', 'health', 'normal', 'background'] as const;
+export type StoreWorkPriority = (typeof STORE_WORK_PRIORITIES)[number];
+
+export function isStoreWorkPriority(value: unknown): value is StoreWorkPriority {
+  return typeof value === 'string'
+    && (STORE_WORK_PRIORITIES as readonly string[]).includes(value);
+}
 
 export interface StorePressureSnapshot {
   ackInflight: number;

--- a/packages/storage/test/store-priority-scheduler.test.ts
+++ b/packages/storage/test/store-priority-scheduler.test.ts
@@ -21,6 +21,46 @@ const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 const mockedAvailableParallelism = vi.mocked(availableParallelism);
 
 describe('StorePriorityScheduler', () => {
+  it('keeps the exported canonical priority collection runtime-immutable', () => {
+    expect(Object.isFrozen(STORE_WORK_PRIORITIES)).toBe(true);
+    expect(() => {
+      (STORE_WORK_PRIORITIES as unknown as string[]).sort();
+    }).toThrow(TypeError);
+    expect(STORE_WORK_PRIORITIES).toEqual(['ack', 'health', 'normal', 'background']);
+  });
+
+  it('dispatches contending lanes in the stable canonical order', async () => {
+    const scheduler = new StorePriorityScheduler({
+      maxConcurrent: 1,
+      ackReservedSlots: 0,
+      healthReservedSlots: 0,
+      backgroundReservedSlots: 0,
+      queueWaitTimeoutMs: 1_000,
+    });
+    let release!: () => void;
+    const blocker = scheduler.run('normal', 'priority-order.blocker', async () => {
+      await new Promise<void>((resolve) => { release = resolve; });
+    });
+    const dispatched: string[] = [];
+    const background = scheduler.run('background', 'priority-order.background', async () => {
+      dispatched.push('background');
+    });
+    const normal = scheduler.run('normal', 'priority-order.normal', async () => {
+      dispatched.push('normal');
+    });
+    const health = scheduler.run('health', 'priority-order.health', async () => {
+      dispatched.push('health');
+    });
+    const ack = scheduler.run('ack', 'priority-order.ack', async () => {
+      dispatched.push('ack');
+    });
+
+    release();
+    await Promise.all([blocker, background, normal, health, ack]);
+
+    expect(dispatched).toEqual(['ack', 'health', 'normal', 'background']);
+  });
+
   it('caps only oversized process settings while preserving lower values and constructor overrides', () => {
     const previous = process.env.DKG_STORE_MAX_CONCURRENT;
     mockedAvailableParallelism.mockReturnValue(4);

--- a/packages/storage/test/store-priority-scheduler.test.ts
+++ b/packages/storage/test/store-priority-scheduler.test.ts
@@ -5,7 +5,9 @@ import {
   StoreSchedulerBusyError,
   isStoreSchedulerBusyError,
 } from '../src/store-priority-scheduler.js';
-import type { StoreWorkPriority } from '../src/triple-store.js';
+import {
+  STORE_WORK_PRIORITIES,
+} from '../src/triple-store.js';
 
 vi.mock('node:os', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:os')>();
@@ -78,7 +80,7 @@ describe('StorePriorityScheduler', () => {
     }
   });
 
-  for (const priority of ['ack', 'health', 'normal', 'background'] as const satisfies readonly StoreWorkPriority[]) {
+  for (const priority of STORE_WORK_PRIORITIES) {
     it(`bounds the ${priority} queue and returns a typed retryable rejection`, async () => {
       const scheduler = new StorePriorityScheduler({
         maxConcurrent: 1,
@@ -256,7 +258,9 @@ describe('StorePriorityScheduler', () => {
       storeOperation: 'query',
     };
 
-    expect(isStoreSchedulerBusyError(structural)).toBe(true);
+    for (const priority of STORE_WORK_PRIORITIES) {
+      expect(isStoreSchedulerBusyError({ ...structural, priority })).toBe(true);
+    }
     expect(isStoreSchedulerBusyError({ ...structural, reason: undefined })).toBe(false);
     expect(isStoreSchedulerBusyError({ ...structural, priority: 'urgent' })).toBe(false);
     expect(isStoreSchedulerBusyError({ ...structural, operation: undefined })).toBe(false);

--- a/packages/storage/test/store-priority-scheduler.test.ts
+++ b/packages/storage/test/store-priority-scheduler.test.ts
@@ -301,6 +301,13 @@ describe('StorePriorityScheduler', () => {
     for (const priority of STORE_WORK_PRIORITIES) {
       expect(isStoreSchedulerBusyError({ ...structural, priority })).toBe(true);
     }
+    expect(isStoreSchedulerBusyError({ ...structural, retryable: false })).toBe(false);
+    expect(isStoreSchedulerBusyError({ ...structural, outcome: 'indeterminate' })).toBe(false);
+    expect(isStoreSchedulerBusyError({
+      ...structural,
+      storeOperationOutcomeTag: 'dkg.store-operation-outcome.v2',
+    })).toBe(false);
+    expect(isStoreSchedulerBusyError({ ...structural, storeOperation: 'unknown' })).toBe(false);
     expect(isStoreSchedulerBusyError({ ...structural, reason: undefined })).toBe(false);
     expect(isStoreSchedulerBusyError({ ...structural, priority: 'urgent' })).toBe(false);
     expect(isStoreSchedulerBusyError({ ...structural, operation: undefined })).toBe(false);

--- a/packages/storage/test/store-priority-scheduler.test.ts
+++ b/packages/storage/test/store-priority-scheduler.test.ts
@@ -3,6 +3,7 @@ import { availableParallelism } from 'node:os';
 import {
   StorePriorityScheduler,
   StoreSchedulerBusyError,
+  isStoreSchedulerBusyError,
 } from '../src/store-priority-scheduler.js';
 import type { StoreWorkPriority } from '../src/triple-store.js';
 
@@ -240,6 +241,26 @@ describe('StorePriorityScheduler', () => {
       retryable: true,
       reason: 'queue_full',
     });
+    expect(isStoreSchedulerBusyError(error)).toBe(true);
+  });
+
+  it('recognizes only complete structural busy errors across package boundaries', () => {
+    const structural = {
+      code: 'STORE_SCHEDULER_BUSY',
+      retryable: true,
+      outcome: 'not_started',
+      storeOperationOutcomeTag: 'dkg.store-operation-outcome.v1',
+      reason: 'queue_wait_timeout',
+      priority: 'normal',
+      operation: 'remote-query.read',
+      storeOperation: 'query',
+    };
+
+    expect(isStoreSchedulerBusyError(structural)).toBe(true);
+    expect(isStoreSchedulerBusyError({ ...structural, reason: undefined })).toBe(false);
+    expect(isStoreSchedulerBusyError({ ...structural, priority: 'urgent' })).toBe(false);
+    expect(isStoreSchedulerBusyError({ ...structural, operation: undefined })).toBe(false);
+    expect(isStoreSchedulerBusyError({ code: 'STORE_SCHEDULER_BUSY' })).toBe(false);
   });
 
   it('binds canonical operations at both scheduler-owned admission rejection sites', async () => {


### PR DESCRIPTION
## Summary
- preserve the existing HTTP 503 and Retry-After mapping already present on testnet-canary
- map pre-dispatch store scheduler rejections to a structured remote-query `BUSY` response
- include stable `STORE_BUSY`, `retryable`, bounded `retryAfterMs`, and bounded scheduler reason fields
- keep unrelated internal query failures generic

## Verification
- `pnpm exec vitest run test/query-handler.test.ts test/query-extra.test.ts` (115 passed)
- `pnpm --filter @origintrail-official/dkg-query build`
- `pnpm lint`

Closes #1643