### PR TITLE
perf(node-ui): make routine log retention probes constant-time

### DIFF
--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -20,7 +20,10 @@ import {
   type DurableManifestPrefixDigest,
   type SyncCheckpointEntry,
 } from '@origintrail-official/dkg-core';
-import { RoutineLogRetention } from './routine-log-retention.js';
+import {
+  RoutineLogRetention,
+  installRoutineLogRetentionSchema,
+} from './routine-log-retention.js';
 export {
   SqliteChainEventCursorStore,
   SqliteContextGraphRegistryScanCursorStore,
@@ -341,96 +344,6 @@ export class DashboardDB {
         this.db.exec(`ALTER TABLE sync_checkpoints ADD COLUMN terminal INTEGER NOT NULL DEFAULT 0 CHECK (terminal IN (0, 1));`);
       }
     };
-    const ensureRoutineLogRetentionIndex = () => {
-      const logsTable = this.db.prepare(`
-        SELECT 1 AS found FROM sqlite_master
-        WHERE type = 'table' AND name = 'logs'
-      `).get() as { found: number } | undefined;
-      if (!logsTable) return;
-
-      const expectedTriggers = [
-        'track_routine_log_insert',
-        'track_routine_log_delete',
-        'track_routine_log_level_to_protected',
-        'track_routine_log_level_to_routine',
-      ];
-      const existingTriggers = new Set(
-        (this.db.prepare(`
-          SELECT name FROM sqlite_master
-          WHERE type = 'trigger'
-            AND name IN (${expectedTriggers.map(() => '?').join(', ')})
-        `).all(...expectedTriggers) as Array<{ name: string }>).map(({ name }) => name),
-      );
-      const stateTable = this.db.prepare(`
-        SELECT 1 AS found FROM sqlite_master
-        WHERE type = 'table' AND name = 'log_retention_state'
-      `).get() as { found: number } | undefined;
-      const stateRow = stateTable
-        ? this.db.prepare(`
-          SELECT 1 AS found FROM log_retention_state WHERE singleton_id = 1
-        `).get() as { found: number } | undefined
-        : undefined;
-      const needsReseed = !stateTable
-        || !stateRow
-        || expectedTriggers.some((name) => !existingTriggers.has(name));
-
-      this.db.exec(`
-        CREATE INDEX IF NOT EXISTS idx_logs_routine_id
-          ON logs(id) WHERE level NOT IN ('warn', 'error');
-        CREATE TABLE IF NOT EXISTS log_retention_state (
-          singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
-          routine_count INTEGER NOT NULL CHECK (routine_count >= 0)
-        );
-      `);
-      if (needsReseed) {
-        this.db.prepare(`
-          INSERT INTO log_retention_state(singleton_id, routine_count)
-          SELECT 1, COUNT(*) FROM logs
-          WHERE level NOT IN ('warn', 'error')
-          ON CONFLICT(singleton_id) DO UPDATE
-            SET routine_count = excluded.routine_count
-        `).run();
-      }
-      this.db.exec(`
-        CREATE TRIGGER IF NOT EXISTS track_routine_log_insert
-        AFTER INSERT ON logs
-        WHEN NEW.level NOT IN ('warn', 'error')
-        BEGIN
-          UPDATE log_retention_state
-          SET routine_count = routine_count + 1
-          WHERE singleton_id = 1;
-        END;
-
-        CREATE TRIGGER IF NOT EXISTS track_routine_log_delete
-        AFTER DELETE ON logs
-        WHEN OLD.level NOT IN ('warn', 'error')
-        BEGIN
-          UPDATE log_retention_state
-          SET routine_count = routine_count - 1
-          WHERE singleton_id = 1;
-        END;
-
-        CREATE TRIGGER IF NOT EXISTS track_routine_log_level_to_protected
-        AFTER UPDATE OF level ON logs
-        WHEN OLD.level NOT IN ('warn', 'error')
-          AND NEW.level IN ('warn', 'error')
-        BEGIN
-          UPDATE log_retention_state
-          SET routine_count = routine_count - 1
-          WHERE singleton_id = 1;
-        END;
-
-        CREATE TRIGGER IF NOT EXISTS track_routine_log_level_to_routine
-        AFTER UPDATE OF level ON logs
-        WHEN OLD.level IN ('warn', 'error')
-          AND NEW.level NOT IN ('warn', 'error')
-        BEGIN
-          UPDATE log_retention_state
-          SET routine_count = routine_count + 1
-          WHERE singleton_id = 1;
-        END;
-      `);
-    };
     if (version > SCHEMA_VERSION) return;
     if (version === SCHEMA_VERSION) {
       // Repair restored/development databases that carry the current version
@@ -438,7 +351,7 @@ export class DashboardDB {
       ensureJoinApprovalRepairMarker();
       ensureSyncCheckpointResumeColumns();
       ensureJoinPolicyAuditCapTrigger();
-      ensureRoutineLogRetentionIndex();
+      installRoutineLogRetentionSchema(this.db);
       return;
     }
 
@@ -1374,7 +1287,7 @@ export class DashboardDB {
       // tick. Maintain the exact count transactionally and index only routine
       // row ids, so overflow checks are O(1) and each prune touches at most one
       // configured batch.
-      ensureRoutineLogRetentionIndex();
+      installRoutineLogRetentionSchema(this.db);
     }
     this.db.pragma(`user_version = ${SCHEMA_VERSION}`);
     if (upgradedExistingDb && !this.explicitRetentionDays) {

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -26,7 +26,7 @@ export {
   SqliteContextGraphRegistryScanCursorStore,
 } from './chain-cursor-stores.js';
 
-export const SCHEMA_VERSION = 34;
+export const SCHEMA_VERSION = 35;
 // Default operator retention. Lowered from 90 → 14 days on V15 (2026-05) after
 // a production incident in which the `logs` table + its FTS5 shadow tables
 // grew to ~9 GB on a 12-day-old node and corrupted the SQLite page (header
@@ -341,6 +341,96 @@ export class DashboardDB {
         this.db.exec(`ALTER TABLE sync_checkpoints ADD COLUMN terminal INTEGER NOT NULL DEFAULT 0 CHECK (terminal IN (0, 1));`);
       }
     };
+    const ensureRoutineLogRetentionIndex = () => {
+      const logsTable = this.db.prepare(`
+        SELECT 1 AS found FROM sqlite_master
+        WHERE type = 'table' AND name = 'logs'
+      `).get() as { found: number } | undefined;
+      if (!logsTable) return;
+
+      const expectedTriggers = [
+        'track_routine_log_insert',
+        'track_routine_log_delete',
+        'track_routine_log_level_to_protected',
+        'track_routine_log_level_to_routine',
+      ];
+      const existingTriggers = new Set(
+        (this.db.prepare(`
+          SELECT name FROM sqlite_master
+          WHERE type = 'trigger'
+            AND name IN (${expectedTriggers.map(() => '?').join(', ')})
+        `).all(...expectedTriggers) as Array<{ name: string }>).map(({ name }) => name),
+      );
+      const stateTable = this.db.prepare(`
+        SELECT 1 AS found FROM sqlite_master
+        WHERE type = 'table' AND name = 'log_retention_state'
+      `).get() as { found: number } | undefined;
+      const stateRow = stateTable
+        ? this.db.prepare(`
+          SELECT 1 AS found FROM log_retention_state WHERE singleton_id = 1
+        `).get() as { found: number } | undefined
+        : undefined;
+      const needsReseed = !stateTable
+        || !stateRow
+        || expectedTriggers.some((name) => !existingTriggers.has(name));
+
+      this.db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_logs_routine_id
+          ON logs(id) WHERE level NOT IN ('warn', 'error');
+        CREATE TABLE IF NOT EXISTS log_retention_state (
+          singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+          routine_count INTEGER NOT NULL CHECK (routine_count >= 0)
+        );
+      `);
+      if (needsReseed) {
+        this.db.prepare(`
+          INSERT INTO log_retention_state(singleton_id, routine_count)
+          SELECT 1, COUNT(*) FROM logs
+          WHERE level NOT IN ('warn', 'error')
+          ON CONFLICT(singleton_id) DO UPDATE
+            SET routine_count = excluded.routine_count
+        `).run();
+      }
+      this.db.exec(`
+        CREATE TRIGGER IF NOT EXISTS track_routine_log_insert
+        AFTER INSERT ON logs
+        WHEN NEW.level NOT IN ('warn', 'error')
+        BEGIN
+          UPDATE log_retention_state
+          SET routine_count = routine_count + 1
+          WHERE singleton_id = 1;
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS track_routine_log_delete
+        AFTER DELETE ON logs
+        WHEN OLD.level NOT IN ('warn', 'error')
+        BEGIN
+          UPDATE log_retention_state
+          SET routine_count = routine_count - 1
+          WHERE singleton_id = 1;
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS track_routine_log_level_to_protected
+        AFTER UPDATE OF level ON logs
+        WHEN OLD.level NOT IN ('warn', 'error')
+          AND NEW.level IN ('warn', 'error')
+        BEGIN
+          UPDATE log_retention_state
+          SET routine_count = routine_count - 1
+          WHERE singleton_id = 1;
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS track_routine_log_level_to_routine
+        AFTER UPDATE OF level ON logs
+        WHEN OLD.level IN ('warn', 'error')
+          AND NEW.level NOT IN ('warn', 'error')
+        BEGIN
+          UPDATE log_retention_state
+          SET routine_count = routine_count + 1
+          WHERE singleton_id = 1;
+        END;
+      `);
+    };
     if (version > SCHEMA_VERSION) return;
     if (version === SCHEMA_VERSION) {
       // Repair restored/development databases that carry the current version
@@ -348,6 +438,7 @@ export class DashboardDB {
       ensureJoinApprovalRepairMarker();
       ensureSyncCheckpointResumeColumns();
       ensureJoinPolicyAuditCapTrigger();
+      ensureRoutineLogRetentionIndex();
       return;
     }
 
@@ -1276,6 +1367,14 @@ export class DashboardDB {
          WHERE key LIKE '%|durable|data%'
            AND key NOT LIKE '%|durable|data|checkpoint:v2%'
       `).run();
+    }
+    if (version < 35) {
+      // Retention probes used to find the (cap + 1)th newest routine row via
+      // OFFSET, synchronously scanning the million-row cap on every cleanup
+      // tick. Maintain the exact count transactionally and index only routine
+      // row ids, so overflow checks are O(1) and each prune touches at most one
+      // configured batch.
+      ensureRoutineLogRetentionIndex();
     }
     this.db.pragma(`user_version = ${SCHEMA_VERSION}`);
     if (upgradedExistingDb && !this.explicitRetentionDays) {

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -1382,10 +1382,7 @@ export class DashboardDB {
       };
     }
 
-    // If the batch filled, conservatively schedule another tick. An exact-size
-    // final batch costs one extra cheap probe before compaction, which is safer
-    // than running a second million-row count after every deletion.
-    const { deleted, filledBatch: hasMore } = batch;
+    const { deleted, hasMore } = batch;
     const reclaim = hasMore
       ? { compacted: false, reclaimPending: false }
       : this.reclaimFreePagesIfNeeded(deleted > LOGS_VACUUM_DELETE_THRESHOLD);

--- a/packages/node-ui/src/routine-log-retention.ts
+++ b/packages/node-ui/src/routine-log-retention.ts
@@ -235,7 +235,7 @@ export class RoutineLogRetention {
   private writesSinceGuard = 0;
 
   constructor(
-    private readonly db: Pick<Database.Database, 'prepare'>,
+    private readonly db: Pick<Database.Database, 'prepare' | 'transaction'>,
     private readonly rowCap: number,
     private readonly batchRows: number,
   ) {}
@@ -267,6 +267,13 @@ export class RoutineLogRetention {
   }
 
   pruneOverflowBatch(): RoutineLogPruneBatch {
+    // Hold a write reservation from the counter read through deletion. Without
+    // it, two connections can both observe the same overflow and the second
+    // pruner can delete routine rows below the configured cap.
+    return this.db.transaction(() => this.pruneOverflowBatchLocked()).immediate();
+  }
+
+  private pruneOverflowBatchLocked(): RoutineLogPruneBatch {
     const overflowRows = this.routineCount() - this.rowCap;
     if (overflowRows <= 0) {
       return { deleted: 0, hadOverflow: false, hasMore: false };

--- a/packages/node-ui/src/routine-log-retention.ts
+++ b/packages/node-ui/src/routine-log-retention.ts
@@ -1,17 +1,13 @@
 import type Database from 'better-sqlite3';
 
 const PROTECTED_LOG_LEVELS = ['warn', 'error'] as const;
+// Bump when the persisted index/trigger policy changes. Definition validation
+// still repairs unexpected drift within a version (restores, dev databases).
+export const ROUTINE_LOG_RETENTION_SCHEMA_VERSION = 1;
 const protectedLogLevels = new Set<string>(PROTECTED_LOG_LEVELS);
 const PROTECTED_LOG_LEVELS_SQL = PROTECTED_LOG_LEVELS
   .map((level) => `'${level.replaceAll("'", "''")}'`)
   .join(', ');
-const RETENTION_TRIGGER_NAMES = [
-  'track_routine_log_insert',
-  'track_routine_log_delete',
-  'track_routine_log_level_to_protected',
-  'track_routine_log_level_to_routine',
-] as const;
-
 function routineLevelSql(column: string): string {
   return `${column} NOT IN (${PROTECTED_LOG_LEVELS_SQL})`;
 }
@@ -22,6 +18,84 @@ function protectedLevelSql(column: string): string {
 
 type RoutineLogRetentionSchemaDatabase = Pick<Database.Database, 'exec' | 'prepare'>;
 
+const ROUTINE_LOG_INDEX_NAME = 'idx_logs_routine_id';
+const ROUTINE_LOG_INDEX_SQL = `
+  CREATE INDEX ${ROUTINE_LOG_INDEX_NAME}
+  ON logs(id) WHERE ${routineLevelSql('level')}
+`;
+const RETENTION_TRIGGER_DEFINITIONS = [
+  {
+    name: 'track_routine_log_insert',
+    sql: `
+      CREATE TRIGGER track_routine_log_insert
+      AFTER INSERT ON logs
+      WHEN ${routineLevelSql('NEW.level')}
+      BEGIN
+        UPDATE log_retention_state
+        SET routine_count = routine_count + 1
+        WHERE singleton_id = 1;
+      END
+    `,
+  },
+  {
+    name: 'track_routine_log_delete',
+    sql: `
+      CREATE TRIGGER track_routine_log_delete
+      AFTER DELETE ON logs
+      WHEN ${routineLevelSql('OLD.level')}
+      BEGIN
+        UPDATE log_retention_state
+        SET routine_count = routine_count - 1
+        WHERE singleton_id = 1;
+      END
+    `,
+  },
+  {
+    name: 'track_routine_log_level_to_protected',
+    sql: `
+      CREATE TRIGGER track_routine_log_level_to_protected
+      AFTER UPDATE OF level ON logs
+      WHEN ${routineLevelSql('OLD.level')}
+        AND ${protectedLevelSql('NEW.level')}
+      BEGIN
+        UPDATE log_retention_state
+        SET routine_count = routine_count - 1
+        WHERE singleton_id = 1;
+      END
+    `,
+  },
+  {
+    name: 'track_routine_log_level_to_routine',
+    sql: `
+      CREATE TRIGGER track_routine_log_level_to_routine
+      AFTER UPDATE OF level ON logs
+      WHEN ${protectedLevelSql('OLD.level')}
+        AND ${routineLevelSql('NEW.level')}
+      BEGIN
+        UPDATE log_retention_state
+        SET routine_count = routine_count + 1
+        WHERE singleton_id = 1;
+      END
+    `,
+  },
+] as const;
+const RETENTION_SCHEMA_DEFINITIONS = [
+  { name: ROUTINE_LOG_INDEX_NAME, sql: ROUTINE_LOG_INDEX_SQL },
+  ...RETENTION_TRIGGER_DEFINITIONS,
+];
+
+/** Exact production statement used for bounded oldest-row deletion. */
+export const ROUTINE_LOG_PRUNE_SQL = `
+  DELETE FROM logs
+  WHERE id IN (
+    SELECT id
+    FROM logs
+    WHERE ${routineLevelSql('level')}
+    ORDER BY id ASC
+    LIMIT @deleteRows
+  )
+`;
+
 /**
  * Install or repair every SQLite adjunct owned by routine-log retention.
  * Missing state or triggers force a reseed from existing rows before triggers
@@ -30,88 +104,94 @@ type RoutineLogRetentionSchemaDatabase = Pick<Database.Database, 'exec' | 'prepa
 export function installRoutineLogRetentionSchema(
   db: RoutineLogRetentionSchemaDatabase,
 ): void {
-  const logsTable = db.prepare(`
-    SELECT 1 AS found FROM sqlite_master
-    WHERE type = 'table' AND name = 'logs'
-  `).get() as { found: number } | undefined;
-  if (!logsTable) return;
+  // BEGIN IMMEDIATE acquires the write reservation before counting. Another
+  // connection can only commit after the canonical triggers are active, so no
+  // write can fall between the seed and its maintenance boundary.
+  db.exec('BEGIN IMMEDIATE');
+  try {
+    const logsTable = db.prepare(`
+      SELECT 1 AS found FROM sqlite_master
+      WHERE type = 'table' AND name = 'logs'
+    `).get() as { found: number } | undefined;
+    if (!logsTable) {
+      db.exec('COMMIT');
+      return;
+    }
 
-  const existingTriggers = new Set(
-    (db.prepare(`
-      SELECT name FROM sqlite_master
-      WHERE type = 'trigger'
-        AND name IN (${RETENTION_TRIGGER_NAMES.map(() => '?').join(', ')})
-    `).all(...RETENTION_TRIGGER_NAMES) as Array<{ name: string }>).map(({ name }) => name),
-  );
-  const stateTable = db.prepare(`
-    SELECT 1 AS found FROM sqlite_master
-    WHERE type = 'table' AND name = 'log_retention_state'
-  `).get() as { found: number } | undefined;
-  const stateRow = stateTable
-    ? db.prepare(`
-      SELECT 1 AS found FROM log_retention_state WHERE singleton_id = 1
-    `).get() as { found: number } | undefined
-    : undefined;
-  const needsReseed = !stateTable
-    || !stateRow
-    || RETENTION_TRIGGER_NAMES.some((name) => !existingTriggers.has(name));
-
-  db.exec(`
-    CREATE INDEX IF NOT EXISTS idx_logs_routine_id
-      ON logs(id) WHERE ${routineLevelSql('level')};
-    CREATE TABLE IF NOT EXISTS log_retention_state (
-      singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
-      routine_count INTEGER NOT NULL CHECK (routine_count >= 0)
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS log_retention_state (
+        singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+        schema_version INTEGER NOT NULL CHECK (schema_version > 0),
+        routine_count INTEGER NOT NULL CHECK (routine_count >= 0)
+      )
+    `);
+    const stateColumns = new Set(
+      (db.prepare('PRAGMA table_info(log_retention_state)').all() as Array<{ name: string }>)
+        .map(({ name }) => name),
     );
-  `);
-  if (needsReseed) {
-    db.prepare(`
-      INSERT INTO log_retention_state(singleton_id, routine_count)
-      SELECT 1, COUNT(*) FROM logs
-      WHERE ${routineLevelSql('level')}
-      ON CONFLICT(singleton_id) DO UPDATE
-        SET routine_count = excluded.routine_count
-    `).run();
+    if (!stateColumns.has('schema_version')) {
+      // Repairs databases created by an earlier development revision of V35.
+      db.exec(`
+        ALTER TABLE log_retention_state
+        ADD COLUMN schema_version INTEGER NOT NULL DEFAULT 0
+      `);
+    }
+
+    const stateRow = db.prepare(`
+      SELECT schema_version FROM log_retention_state WHERE singleton_id = 1
+    `).get() as { schema_version: number } | undefined;
+    const canonicalSchema = hasCanonicalRetentionDefinitions(db);
+    const needsReseed = !stateRow
+      || stateRow.schema_version !== ROUTINE_LOG_RETENTION_SCHEMA_VERSION
+      || !canonicalSchema;
+
+    // Recreate every owned object from immutable versioned SQL. Comparing the
+    // persisted definitions above decides whether counter drift is possible;
+    // rebuilding is cheap and prevents same-name stale objects from surviving.
+    db.exec([
+      ...RETENTION_TRIGGER_DEFINITIONS.map(({ name }) => `DROP TRIGGER IF EXISTS ${name}`),
+      `DROP INDEX IF EXISTS ${ROUTINE_LOG_INDEX_NAME}`,
+      ROUTINE_LOG_INDEX_SQL,
+      ...RETENTION_TRIGGER_DEFINITIONS.map(({ sql }) => sql),
+    ].join(';\n'));
+
+    if (needsReseed) {
+      db.prepare(`
+        INSERT INTO log_retention_state(singleton_id, schema_version, routine_count)
+        SELECT 1, @schemaVersion, COUNT(*) FROM logs
+        WHERE ${routineLevelSql('level')}
+        ON CONFLICT(singleton_id) DO UPDATE SET
+          schema_version = excluded.schema_version,
+          routine_count = excluded.routine_count
+      `).run({ schemaVersion: ROUTINE_LOG_RETENTION_SCHEMA_VERSION });
+    }
+    db.exec('COMMIT');
+  } catch (error: unknown) {
+    try {
+      db.exec('ROLLBACK');
+    } catch {
+      // BEGIN IMMEDIATE itself may have failed before a transaction existed.
+    }
+    throw error;
   }
-  db.exec(`
-    CREATE TRIGGER IF NOT EXISTS track_routine_log_insert
-    AFTER INSERT ON logs
-    WHEN ${routineLevelSql('NEW.level')}
-    BEGIN
-      UPDATE log_retention_state
-      SET routine_count = routine_count + 1
-      WHERE singleton_id = 1;
-    END;
+}
 
-    CREATE TRIGGER IF NOT EXISTS track_routine_log_delete
-    AFTER DELETE ON logs
-    WHEN ${routineLevelSql('OLD.level')}
-    BEGIN
-      UPDATE log_retention_state
-      SET routine_count = routine_count - 1
-      WHERE singleton_id = 1;
-    END;
+function hasCanonicalRetentionDefinitions(db: RoutineLogRetentionSchemaDatabase): boolean {
+  const names = RETENTION_SCHEMA_DEFINITIONS.map(({ name }) => name);
+  const persisted = new Map(
+    (db.prepare(`
+      SELECT name, sql FROM sqlite_master
+      WHERE name IN (${names.map(() => '?').join(', ')})
+    `).all(...names) as Array<{ name: string; sql: string | null }>)
+      .map(({ name, sql }) => [name, normalizeSchemaSql(sql ?? '')]),
+  );
+  return RETENTION_SCHEMA_DEFINITIONS.every(({ name, sql }) => (
+    persisted.get(name) === normalizeSchemaSql(sql)
+  ));
+}
 
-    CREATE TRIGGER IF NOT EXISTS track_routine_log_level_to_protected
-    AFTER UPDATE OF level ON logs
-    WHEN ${routineLevelSql('OLD.level')}
-      AND ${protectedLevelSql('NEW.level')}
-    BEGIN
-      UPDATE log_retention_state
-      SET routine_count = routine_count - 1
-      WHERE singleton_id = 1;
-    END;
-
-    CREATE TRIGGER IF NOT EXISTS track_routine_log_level_to_routine
-    AFTER UPDATE OF level ON logs
-    WHEN ${protectedLevelSql('OLD.level')}
-      AND ${routineLevelSql('NEW.level')}
-    BEGIN
-      UPDATE log_retention_state
-      SET routine_count = routine_count + 1
-      WHERE singleton_id = 1;
-    END;
-  `);
+function normalizeSchemaSql(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim().replace(/;$/, '');
 }
 
 export class RoutineLogRetentionInvariantError extends Error {
@@ -176,16 +256,7 @@ export class RoutineLogRetention {
       return { deleted: 0, hadOverflow: false, filledBatch: false };
     }
     const deleteRows = Math.min(this.batchRows, overflowRows);
-    const deleted = this.db.prepare(`
-      DELETE FROM logs
-      WHERE id IN (
-        SELECT id
-        FROM logs
-        WHERE ${routineLevelSql('level')}
-        ORDER BY id ASC
-        LIMIT @deleteRows
-      )
-    `).run({ deleteRows }).changes;
+    const deleted = this.db.prepare(ROUTINE_LOG_PRUNE_SQL).run({ deleteRows }).changes;
     return {
       deleted,
       hadOverflow: true,
@@ -197,8 +268,8 @@ export class RoutineLogRetention {
     const row = this.db.prepare(`
       SELECT routine_count AS count
       FROM log_retention_state
-      WHERE singleton_id = 1
-    `).get() as { count: number } | undefined;
+      WHERE singleton_id = 1 AND schema_version = ?
+    `).get(ROUTINE_LOG_RETENTION_SCHEMA_VERSION) as { count: number } | undefined;
     if (!row) throw new RoutineLogRetentionInvariantError();
     return row.count;
   }

--- a/packages/node-ui/src/routine-log-retention.ts
+++ b/packages/node-ui/src/routine-log-retention.ts
@@ -1,5 +1,128 @@
 import type Database from 'better-sqlite3';
 
+const PROTECTED_LOG_LEVELS = ['warn', 'error'] as const;
+const protectedLogLevels = new Set<string>(PROTECTED_LOG_LEVELS);
+const PROTECTED_LOG_LEVELS_SQL = PROTECTED_LOG_LEVELS
+  .map((level) => `'${level.replaceAll("'", "''")}'`)
+  .join(', ');
+const RETENTION_TRIGGER_NAMES = [
+  'track_routine_log_insert',
+  'track_routine_log_delete',
+  'track_routine_log_level_to_protected',
+  'track_routine_log_level_to_routine',
+] as const;
+
+function routineLevelSql(column: string): string {
+  return `${column} NOT IN (${PROTECTED_LOG_LEVELS_SQL})`;
+}
+
+function protectedLevelSql(column: string): string {
+  return `${column} IN (${PROTECTED_LOG_LEVELS_SQL})`;
+}
+
+type RoutineLogRetentionSchemaDatabase = Pick<Database.Database, 'exec' | 'prepare'>;
+
+/**
+ * Install or repair every SQLite adjunct owned by routine-log retention.
+ * Missing state or triggers force a reseed from existing rows before triggers
+ * are installed, so upgraded/restored databases regain an exact counter.
+ */
+export function installRoutineLogRetentionSchema(
+  db: RoutineLogRetentionSchemaDatabase,
+): void {
+  const logsTable = db.prepare(`
+    SELECT 1 AS found FROM sqlite_master
+    WHERE type = 'table' AND name = 'logs'
+  `).get() as { found: number } | undefined;
+  if (!logsTable) return;
+
+  const existingTriggers = new Set(
+    (db.prepare(`
+      SELECT name FROM sqlite_master
+      WHERE type = 'trigger'
+        AND name IN (${RETENTION_TRIGGER_NAMES.map(() => '?').join(', ')})
+    `).all(...RETENTION_TRIGGER_NAMES) as Array<{ name: string }>).map(({ name }) => name),
+  );
+  const stateTable = db.prepare(`
+    SELECT 1 AS found FROM sqlite_master
+    WHERE type = 'table' AND name = 'log_retention_state'
+  `).get() as { found: number } | undefined;
+  const stateRow = stateTable
+    ? db.prepare(`
+      SELECT 1 AS found FROM log_retention_state WHERE singleton_id = 1
+    `).get() as { found: number } | undefined
+    : undefined;
+  const needsReseed = !stateTable
+    || !stateRow
+    || RETENTION_TRIGGER_NAMES.some((name) => !existingTriggers.has(name));
+
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_logs_routine_id
+      ON logs(id) WHERE ${routineLevelSql('level')};
+    CREATE TABLE IF NOT EXISTS log_retention_state (
+      singleton_id INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+      routine_count INTEGER NOT NULL CHECK (routine_count >= 0)
+    );
+  `);
+  if (needsReseed) {
+    db.prepare(`
+      INSERT INTO log_retention_state(singleton_id, routine_count)
+      SELECT 1, COUNT(*) FROM logs
+      WHERE ${routineLevelSql('level')}
+      ON CONFLICT(singleton_id) DO UPDATE
+        SET routine_count = excluded.routine_count
+    `).run();
+  }
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS track_routine_log_insert
+    AFTER INSERT ON logs
+    WHEN ${routineLevelSql('NEW.level')}
+    BEGIN
+      UPDATE log_retention_state
+      SET routine_count = routine_count + 1
+      WHERE singleton_id = 1;
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS track_routine_log_delete
+    AFTER DELETE ON logs
+    WHEN ${routineLevelSql('OLD.level')}
+    BEGIN
+      UPDATE log_retention_state
+      SET routine_count = routine_count - 1
+      WHERE singleton_id = 1;
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS track_routine_log_level_to_protected
+    AFTER UPDATE OF level ON logs
+    WHEN ${routineLevelSql('OLD.level')}
+      AND ${protectedLevelSql('NEW.level')}
+    BEGIN
+      UPDATE log_retention_state
+      SET routine_count = routine_count - 1
+      WHERE singleton_id = 1;
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS track_routine_log_level_to_routine
+    AFTER UPDATE OF level ON logs
+    WHEN ${protectedLevelSql('OLD.level')}
+      AND ${routineLevelSql('NEW.level')}
+    BEGIN
+      UPDATE log_retention_state
+      SET routine_count = routine_count + 1
+      WHERE singleton_id = 1;
+    END;
+  `);
+}
+
+export class RoutineLogRetentionInvariantError extends Error {
+  constructor() {
+    super(
+      'Routine log retention state is missing its singleton row; reopen the database to repair it',
+    );
+    this.name = 'RoutineLogRetentionInvariantError';
+  }
+}
+
 export interface RoutineLogPruneBatch {
   deleted: number;
   hadOverflow: boolean;
@@ -58,7 +181,7 @@ export class RoutineLogRetention {
       WHERE id IN (
         SELECT id
         FROM logs
-        WHERE level NOT IN ('warn', 'error')
+        WHERE ${routineLevelSql('level')}
         ORDER BY id ASC
         LIMIT @deleteRows
       )
@@ -76,10 +199,11 @@ export class RoutineLogRetention {
       FROM log_retention_state
       WHERE singleton_id = 1
     `).get() as { count: number } | undefined;
-    return row?.count ?? 0;
+    if (!row) throw new RoutineLogRetentionInvariantError();
+    return row.count;
   }
 
   private isRoutineLevel(level: string): boolean {
-    return level !== 'warn' && level !== 'error';
+    return !protectedLogLevels.has(level);
   }
 }

--- a/packages/node-ui/src/routine-log-retention.ts
+++ b/packages/node-ui/src/routine-log-retention.ts
@@ -44,25 +44,25 @@ export class RoutineLogRetention {
   }
 
   hasOverflow(): boolean {
-    return this.overflowCutoff() !== null;
+    return this.routineCount() > this.rowCap;
   }
 
   pruneOverflowBatch(): RoutineLogPruneBatch {
-    const cutoff = this.overflowCutoff();
-    if (cutoff === null) {
+    const overflowRows = this.routineCount() - this.rowCap;
+    if (overflowRows <= 0) {
       return { deleted: 0, hadOverflow: false, filledBatch: false };
     }
+    const deleteRows = Math.min(this.batchRows, overflowRows);
     const deleted = this.db.prepare(`
       DELETE FROM logs
       WHERE id IN (
         SELECT id
         FROM logs
-        WHERE id <= @cutoff
-          AND level NOT IN ('warn', 'error')
+        WHERE level NOT IN ('warn', 'error')
         ORDER BY id ASC
-        LIMIT @batchRows
+        LIMIT @deleteRows
       )
-    `).run({ cutoff, batchRows: this.batchRows }).changes;
+    `).run({ deleteRows }).changes;
     return {
       deleted,
       hadOverflow: true,
@@ -70,15 +70,13 @@ export class RoutineLogRetention {
     };
   }
 
-  private overflowCutoff(): number | null {
+  private routineCount(): number {
     const row = this.db.prepare(`
-      SELECT id
-      FROM logs
-      WHERE level NOT IN ('warn', 'error')
-      ORDER BY id DESC
-      LIMIT 1 OFFSET ?
-    `).get(this.rowCap) as { id: number } | undefined;
-    return row?.id ?? null;
+      SELECT routine_count AS count
+      FROM log_retention_state
+      WHERE singleton_id = 1
+    `).get() as { count: number } | undefined;
+    return row?.count ?? 0;
   }
 
   private isRoutineLevel(level: string): boolean {

--- a/packages/node-ui/src/routine-log-retention.ts
+++ b/packages/node-ui/src/routine-log-retention.ts
@@ -16,7 +16,10 @@ function protectedLevelSql(column: string): string {
   return `${column} IN (${PROTECTED_LOG_LEVELS_SQL})`;
 }
 
-type RoutineLogRetentionSchemaDatabase = Pick<Database.Database, 'exec' | 'prepare'>;
+type RoutineLogRetentionSchemaDatabase = Pick<
+  Database.Database,
+  'exec' | 'prepare' | 'transaction'
+>;
 
 const ROUTINE_LOG_INDEX_NAME = 'idx_logs_routine_id';
 const ROUTINE_LOG_INDEX_SQL = `
@@ -104,19 +107,37 @@ export const ROUTINE_LOG_PRUNE_SQL = `
 export function installRoutineLogRetentionSchema(
   db: RoutineLogRetentionSchemaDatabase,
 ): void {
-  // BEGIN IMMEDIATE acquires the write reservation before counting. Another
-  // connection can only commit after the canonical triggers are active, so no
-  // write can fall between the seed and its maintenance boundary.
-  db.exec('BEGIN IMMEDIATE');
-  try {
+  const install = db.transaction(() => {
     const logsTable = db.prepare(`
       SELECT 1 AS found FROM sqlite_master
       WHERE type = 'table' AND name = 'logs'
     `).get() as { found: number } | undefined;
-    if (!logsTable) {
-      db.exec('COMMIT');
-      return;
-    }
+    if (!logsTable) return;
+
+    const stateTable = db.prepare(`
+      SELECT 1 AS found FROM sqlite_master
+      WHERE type = 'table' AND name = 'log_retention_state'
+    `).get() as { found: number } | undefined;
+    const initialStateColumns = stateTable
+      ? new Set(
+        (db.prepare('PRAGMA table_info(log_retention_state)').all() as Array<{ name: string }>)
+          .map(({ name }) => name),
+      )
+      : new Set<string>();
+    const stateRow = initialStateColumns.has('schema_version')
+      ? db.prepare(`
+        SELECT schema_version FROM log_retention_state WHERE singleton_id = 1
+      `).get() as { schema_version: number } | undefined
+      : undefined;
+    const canonicalSchema = hasCanonicalRetentionDefinitions(db);
+
+    // Reopening a canonical database must not mutate the schema. In
+    // particular, recreating the partial index scans every routine log row and
+    // defeats the constant-time startup path this state table provides.
+    if (
+      stateRow?.schema_version === ROUTINE_LOG_RETENTION_SCHEMA_VERSION
+      && canonicalSchema
+    ) return;
 
     db.exec(`
       CREATE TABLE IF NOT EXISTS log_retention_state (
@@ -125,11 +146,7 @@ export function installRoutineLogRetentionSchema(
         routine_count INTEGER NOT NULL CHECK (routine_count >= 0)
       )
     `);
-    const stateColumns = new Set(
-      (db.prepare('PRAGMA table_info(log_retention_state)').all() as Array<{ name: string }>)
-        .map(({ name }) => name),
-    );
-    if (!stateColumns.has('schema_version')) {
+    if (!initialStateColumns.has('schema_version') && stateTable) {
       // Repairs databases created by an earlier development revision of V35.
       db.exec(`
         ALTER TABLE log_retention_state
@@ -137,23 +154,25 @@ export function installRoutineLogRetentionSchema(
       `);
     }
 
-    const stateRow = db.prepare(`
+    const repairedStateRow = db.prepare(`
       SELECT schema_version FROM log_retention_state WHERE singleton_id = 1
     `).get() as { schema_version: number } | undefined;
-    const canonicalSchema = hasCanonicalRetentionDefinitions(db);
-    const needsReseed = !stateRow
-      || stateRow.schema_version !== ROUTINE_LOG_RETENTION_SCHEMA_VERSION
+    const needsSchemaRepair = !canonicalSchema;
+    const needsReseed = !repairedStateRow
+      || repairedStateRow.schema_version !== ROUTINE_LOG_RETENTION_SCHEMA_VERSION
       || !canonicalSchema;
 
-    // Recreate every owned object from immutable versioned SQL. Comparing the
-    // persisted definitions above decides whether counter drift is possible;
-    // rebuilding is cheap and prevents same-name stale objects from surviving.
-    db.exec([
-      ...RETENTION_TRIGGER_DEFINITIONS.map(({ name }) => `DROP TRIGGER IF EXISTS ${name}`),
-      `DROP INDEX IF EXISTS ${ROUTINE_LOG_INDEX_NAME}`,
-      ROUTINE_LOG_INDEX_SQL,
-      ...RETENTION_TRIGGER_DEFINITIONS.map(({ sql }) => sql),
-    ].join(';\n'));
+    if (needsSchemaRepair) {
+      // Recreate every owned object from immutable versioned SQL only when
+      // validation found drift. Rebuilding the partial index is intentionally
+      // reserved for this repair path because it scans the logs table.
+      db.exec([
+        ...RETENTION_TRIGGER_DEFINITIONS.map(({ name }) => `DROP TRIGGER IF EXISTS ${name}`),
+        `DROP INDEX IF EXISTS ${ROUTINE_LOG_INDEX_NAME}`,
+        ROUTINE_LOG_INDEX_SQL,
+        ...RETENTION_TRIGGER_DEFINITIONS.map(({ sql }) => sql),
+      ].join(';\n'));
+    }
 
     if (needsReseed) {
       db.prepare(`
@@ -165,15 +184,12 @@ export function installRoutineLogRetentionSchema(
           routine_count = excluded.routine_count
       `).run({ schemaVersion: ROUTINE_LOG_RETENTION_SCHEMA_VERSION });
     }
-    db.exec('COMMIT');
-  } catch (error: unknown) {
-    try {
-      db.exec('ROLLBACK');
-    } catch {
-      // BEGIN IMMEDIATE itself may have failed before a transaction existed.
-    }
-    throw error;
-  }
+  });
+
+  // IMMEDIATE acquires the write reservation before validation/counting.
+  // Another connection can only commit after canonical triggers are active,
+  // so no write can fall between the seed and its maintenance boundary.
+  install.immediate();
 }
 
 function hasCanonicalRetentionDefinitions(db: RoutineLogRetentionSchemaDatabase): boolean {
@@ -206,7 +222,7 @@ export class RoutineLogRetentionInvariantError extends Error {
 export interface RoutineLogPruneBatch {
   deleted: number;
   hadOverflow: boolean;
-  filledBatch: boolean;
+  hasMore: boolean;
 }
 
 /**
@@ -253,14 +269,14 @@ export class RoutineLogRetention {
   pruneOverflowBatch(): RoutineLogPruneBatch {
     const overflowRows = this.routineCount() - this.rowCap;
     if (overflowRows <= 0) {
-      return { deleted: 0, hadOverflow: false, filledBatch: false };
+      return { deleted: 0, hadOverflow: false, hasMore: false };
     }
     const deleteRows = Math.min(this.batchRows, overflowRows);
     const deleted = this.db.prepare(ROUTINE_LOG_PRUNE_SQL).run({ deleteRows }).changes;
     return {
       deleted,
       hadOverflow: true,
-      filledBatch: deleted === this.batchRows,
+      hasMore: overflowRows > deleteRows,
     };
   }
 

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -408,45 +408,6 @@ describe('DashboardDB — retention', () => {
     }
   });
 
-  it('tracks routine-log retention state transactionally and uses the partial id index', () => {
-    const volumeDir = mkdtempSync(join(tmpdir(), 'dkg-db-log-retention-index-'));
-    const volumeDb = new DashboardDB({
-      dataDir: volumeDir,
-      retentionDays: 365,
-      routineLogRowCap: 10,
-      logVolumePruneBatchRows: 2,
-    });
-    try {
-      const insert = volumeDb.db.prepare(
-        `INSERT INTO logs (ts, level, module, message) VALUES (?, ?, 'test', ?)`,
-      );
-      insert.run(1, 'info', 'routine-a');
-      insert.run(2, 'debug', 'routine-b');
-      insert.run(3, 'warn', 'protected');
-      expect(volumeDb.db.prepare(`
-        SELECT routine_count FROM log_retention_state WHERE singleton_id = 1
-      `).get()).toEqual({ routine_count: 2 });
-
-      volumeDb.db.prepare(`UPDATE logs SET level = 'error' WHERE message = 'routine-a'`).run();
-      volumeDb.db.prepare(`UPDATE logs SET level = 'info' WHERE message = 'protected'`).run();
-      volumeDb.db.prepare(`DELETE FROM logs WHERE message = 'routine-b'`).run();
-      expect(volumeDb.db.prepare(`
-        SELECT routine_count FROM log_retention_state WHERE singleton_id = 1
-      `).get()).toEqual({ routine_count: 1 });
-
-      const plan = volumeDb.db.prepare(`
-        EXPLAIN QUERY PLAN
-        SELECT id FROM logs
-        WHERE level NOT IN ('warn', 'error')
-        ORDER BY id ASC LIMIT 2
-      `).all() as Array<{ detail: string }>;
-      expect(plan.some(({ detail }) => detail.includes('idx_logs_routine_id'))).toBe(true);
-    } finally {
-      volumeDb.close();
-      rmSync(volumeDir, { recursive: true, force: true });
-    }
-  });
-
   it('seeds and prunes populated pre-V35 routine logs during a V34 upgrade', () => {
     const dbPath = join(dir, 'node-ui.db');
     db.close();
@@ -496,30 +457,30 @@ describe('DashboardDB — retention', () => {
     `).get()).toEqual({ routine_count: 2 });
   });
 
-  it('fails loudly on missing retention state and repairs it on reopen', () => {
-    db.insertLog({
-      ts: Date.now(),
-      level: 'info',
-      module: 'retention-invariant',
-      message: 'routine-row',
-    });
-    db.db.exec('DELETE FROM log_retention_state WHERE singleton_id = 1');
-
-    expect(() => db.pruneLogVolumeBatch()).toThrow(
-      /retention state is missing its singleton row/,
-    );
+  it('repairs a lost V35 retention trigger when DashboardDB reopens', () => {
+    db.db.exec('DROP TRIGGER track_routine_log_insert');
+    db.db.prepare(`
+      INSERT INTO logs (ts, level, module, message)
+      VALUES (?, 'info', 'restore-test', 'untracked-before-reopen')
+    `).run(Date.now());
+    expect(db.db.prepare(`
+      SELECT routine_count FROM log_retention_state WHERE singleton_id = 1
+    `).get()).toEqual({ routine_count: 0 });
 
     db.close();
-    db = new DashboardDB({
-      dataDir: dir,
-      retentionDays: 365,
-      routineLogRowCap: 0,
-      logVolumePruneBatchRows: 1,
-    });
+    db = new DashboardDB({ dataDir: dir, retentionDays: 365 });
+    expect(db.db.pragma('user_version', { simple: true })).toBe(SCHEMA_VERSION);
     expect(db.db.prepare(`
       SELECT routine_count FROM log_retention_state WHERE singleton_id = 1
     `).get()).toEqual({ routine_count: 1 });
-    expect(db.pruneLogVolumeBatch()).toMatchObject({ deleted: 1 });
+
+    db.db.prepare(`
+      INSERT INTO logs (ts, level, module, message)
+      VALUES (?, 'debug', 'restore-test', 'tracked-after-reopen')
+    `).run(Date.now() + 1);
+    expect(db.db.prepare(`
+      SELECT routine_count FROM log_retention_state WHERE singleton_id = 1
+    `).get()).toEqual({ routine_count: 2 });
   });
 
   it('preserves ambiguous pre-upgrade compatibility rows below the public cap', () => {

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -408,6 +408,45 @@ describe('DashboardDB — retention', () => {
     }
   });
 
+  it('tracks routine-log retention state transactionally and uses the partial id index', () => {
+    const volumeDir = mkdtempSync(join(tmpdir(), 'dkg-db-log-retention-index-'));
+    const volumeDb = new DashboardDB({
+      dataDir: volumeDir,
+      retentionDays: 365,
+      routineLogRowCap: 10,
+      logVolumePruneBatchRows: 2,
+    });
+    try {
+      const insert = volumeDb.db.prepare(
+        `INSERT INTO logs (ts, level, module, message) VALUES (?, ?, 'test', ?)`,
+      );
+      insert.run(1, 'info', 'routine-a');
+      insert.run(2, 'debug', 'routine-b');
+      insert.run(3, 'warn', 'protected');
+      expect(volumeDb.db.prepare(`
+        SELECT routine_count FROM log_retention_state WHERE singleton_id = 1
+      `).get()).toEqual({ routine_count: 2 });
+
+      volumeDb.db.prepare(`UPDATE logs SET level = 'error' WHERE message = 'routine-a'`).run();
+      volumeDb.db.prepare(`UPDATE logs SET level = 'info' WHERE message = 'protected'`).run();
+      volumeDb.db.prepare(`DELETE FROM logs WHERE message = 'routine-b'`).run();
+      expect(volumeDb.db.prepare(`
+        SELECT routine_count FROM log_retention_state WHERE singleton_id = 1
+      `).get()).toEqual({ routine_count: 1 });
+
+      const plan = volumeDb.db.prepare(`
+        EXPLAIN QUERY PLAN
+        SELECT id FROM logs
+        WHERE level NOT IN ('warn', 'error')
+        ORDER BY id ASC LIMIT 2
+      `).all() as Array<{ detail: string }>;
+      expect(plan.some(({ detail }) => detail.includes('idx_logs_routine_id'))).toBe(true);
+    } finally {
+      volumeDb.close();
+      rmSync(volumeDir, { recursive: true, force: true });
+    }
+  });
+
   it('preserves ambiguous pre-upgrade compatibility rows below the public cap', () => {
     const volumeDir = mkdtempSync(join(tmpdir(), 'dkg-db-log-legacy-compat-'));
     const dbPath = join(volumeDir, 'node-ui.db');

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -389,8 +389,7 @@ describe('DashboardDB — retention', () => {
       insert.run(2_001, 'error', 'keep-error');
 
       expect(volumeDb.pruneLogVolumeBatch()).toEqual({ deleted: 2, status: 'more' });
-      expect(volumeDb.pruneLogVolumeBatch()).toEqual({ deleted: 2, status: 'more' });
-      expect(volumeDb.pruneLogVolumeBatch()).toEqual({ deleted: 0, status: 'done' });
+      expect(volumeDb.pruneLogVolumeBatch()).toEqual({ deleted: 2, status: 'done' });
 
       const rows = volumeDb.db.prepare(
         `SELECT level, message FROM logs ORDER BY id ASC`,
@@ -635,8 +634,7 @@ describe('DashboardDB — retention', () => {
       ]);
 
       volumeDb.db.exec('DROP TRIGGER fail_inline_log_retention');
-      expect(volumeDb.pruneLogVolumeBatch()).toEqual({ deleted: 1, status: 'more' });
-      expect(volumeDb.pruneLogVolumeBatch()).toEqual({ deleted: 0, status: 'done' });
+      expect(volumeDb.pruneLogVolumeBatch()).toEqual({ deleted: 1, status: 'done' });
     } finally {
       volumeDb.close();
       rmSync(volumeDir, { recursive: true, force: true });

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -447,6 +447,81 @@ describe('DashboardDB — retention', () => {
     }
   });
 
+  it('seeds and prunes populated pre-V35 routine logs during a V34 upgrade', () => {
+    const dbPath = join(dir, 'node-ui.db');
+    db.close();
+    const raw = new Database(dbPath);
+    raw.exec(`
+      DROP TRIGGER IF EXISTS track_routine_log_insert;
+      DROP TRIGGER IF EXISTS track_routine_log_delete;
+      DROP TRIGGER IF EXISTS track_routine_log_level_to_protected;
+      DROP TRIGGER IF EXISTS track_routine_log_level_to_routine;
+      DROP INDEX IF EXISTS idx_logs_routine_id;
+      DROP TABLE IF EXISTS log_retention_state;
+    `);
+    const insert = raw.prepare(
+      `INSERT INTO logs (ts, level, module, message) VALUES (?, ?, 'pre-v35', ?)`,
+    );
+    insert.run(Date.now(), 'info', 'routine-0');
+    insert.run(Date.now() + 1, 'debug', 'routine-1');
+    insert.run(Date.now() + 2, 'info', 'routine-2');
+    insert.run(Date.now() + 3, 'debug', 'routine-3');
+    insert.run(Date.now() + 4, 'warn', 'keep-warn');
+    insert.run(Date.now() + 5, 'error', 'keep-error');
+    raw.pragma('user_version = 34');
+    raw.close();
+
+    db = new DashboardDB({
+      dataDir: dir,
+      retentionDays: 365,
+      routineLogRowCap: 2,
+      logVolumePruneBatchRows: 10,
+    });
+    expect(db.db.pragma('user_version', { simple: true })).toBe(SCHEMA_VERSION);
+    expect(db.db.prepare(`
+      SELECT routine_count FROM log_retention_state WHERE singleton_id = 1
+    `).get()).toEqual({ routine_count: 4 });
+
+    expect(db.pruneLogVolumeBatch()).toMatchObject({ deleted: 2 });
+    expect(db.db.prepare(`
+      SELECT level, message FROM logs ORDER BY id ASC
+    `).all()).toEqual([
+      { level: 'info', message: 'routine-2' },
+      { level: 'debug', message: 'routine-3' },
+      { level: 'warn', message: 'keep-warn' },
+      { level: 'error', message: 'keep-error' },
+    ]);
+    expect(db.db.prepare(`
+      SELECT routine_count FROM log_retention_state WHERE singleton_id = 1
+    `).get()).toEqual({ routine_count: 2 });
+  });
+
+  it('fails loudly on missing retention state and repairs it on reopen', () => {
+    db.insertLog({
+      ts: Date.now(),
+      level: 'info',
+      module: 'retention-invariant',
+      message: 'routine-row',
+    });
+    db.db.exec('DELETE FROM log_retention_state WHERE singleton_id = 1');
+
+    expect(() => db.pruneLogVolumeBatch()).toThrow(
+      /retention state is missing its singleton row/,
+    );
+
+    db.close();
+    db = new DashboardDB({
+      dataDir: dir,
+      retentionDays: 365,
+      routineLogRowCap: 0,
+      logVolumePruneBatchRows: 1,
+    });
+    expect(db.db.prepare(`
+      SELECT routine_count FROM log_retention_state WHERE singleton_id = 1
+    `).get()).toEqual({ routine_count: 1 });
+    expect(db.pruneLogVolumeBatch()).toMatchObject({ deleted: 1 });
+  });
+
   it('preserves ambiguous pre-upgrade compatibility rows below the public cap', () => {
     const volumeDir = mkdtempSync(join(tmpdir(), 'dkg-db-log-legacy-compat-'));
     const dbPath = join(volumeDir, 'node-ui.db');

--- a/packages/node-ui/test/routine-log-retention.test.ts
+++ b/packages/node-ui/test/routine-log-retention.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import Database from 'better-sqlite3';
+import {
+  ROUTINE_LOG_PRUNE_SQL,
+  ROUTINE_LOG_RETENTION_SCHEMA_VERSION,
+  RoutineLogRetention,
+  installRoutineLogRetentionSchema,
+} from '../src/routine-log-retention.js';
+
+function createLogsTable(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE logs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      ts INTEGER NOT NULL,
+      level TEXT NOT NULL,
+      module TEXT NOT NULL,
+      message TEXT NOT NULL
+    )
+  `);
+}
+
+function retentionState(db: Database.Database): {
+  schema_version: number;
+  routine_count: number;
+} {
+  return db.prepare(`
+    SELECT schema_version, routine_count
+    FROM log_retention_state
+    WHERE singleton_id = 1
+  `).get() as { schema_version: number; routine_count: number };
+}
+
+describe('RoutineLogRetention', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createLogsTable(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('tracks every level transition and the production prune uses the partial index', () => {
+    installRoutineLogRetentionSchema(db);
+    const insert = db.prepare(
+      `INSERT INTO logs (ts, level, module, message) VALUES (?, ?, 'test', ?)`,
+    );
+    insert.run(1, 'info', 'routine-a');
+    insert.run(2, 'debug', 'routine-b');
+    insert.run(3, 'warn', 'protected');
+    expect(retentionState(db)).toEqual({
+      schema_version: ROUTINE_LOG_RETENTION_SCHEMA_VERSION,
+      routine_count: 2,
+    });
+
+    db.prepare(`UPDATE logs SET level = 'error' WHERE message = 'routine-a'`).run();
+    db.prepare(`UPDATE logs SET level = 'info' WHERE message = 'protected'`).run();
+    db.prepare(`DELETE FROM logs WHERE message = 'routine-b'`).run();
+    expect(retentionState(db).routine_count).toBe(1);
+
+    const plan = db.prepare(`EXPLAIN QUERY PLAN ${ROUTINE_LOG_PRUNE_SQL}`)
+      .all({ deleteRows: 2 }) as Array<{ detail: string }>;
+    expect(plan.some(({ detail }) => detail.includes('idx_logs_routine_id'))).toBe(true);
+
+    const retention = new RoutineLogRetention(db, 0, 1);
+    expect(retention.pruneOverflowBatch()).toEqual({
+      deleted: 1,
+      hadOverflow: true,
+      filledBatch: true,
+    });
+    expect(db.prepare(`SELECT level, message FROM logs ORDER BY id`).all()).toEqual([
+      { level: 'error', message: 'routine-a' },
+    ]);
+  });
+
+  it('fails loudly on a missing singleton and repairs its count on reinstall', () => {
+    installRoutineLogRetentionSchema(db);
+    db.prepare(`
+      INSERT INTO logs (ts, level, module, message)
+      VALUES (1, 'info', 'test', 'routine-row')
+    `).run();
+    db.exec('DELETE FROM log_retention_state WHERE singleton_id = 1');
+
+    const retention = new RoutineLogRetention(db, 10, 2);
+    expect(() => retention.hasOverflow()).toThrow(
+      /retention state is missing its singleton row/,
+    );
+
+    installRoutineLogRetentionSchema(db);
+    expect(retentionState(db).routine_count).toBe(1);
+  });
+
+  it('repairs stale same-name schema objects and reseeds possible counter drift', () => {
+    installRoutineLogRetentionSchema(db);
+    db.exec(`
+      DROP TRIGGER track_routine_log_insert;
+      CREATE TRIGGER track_routine_log_insert
+      AFTER INSERT ON logs
+      BEGIN
+        UPDATE log_retention_state SET routine_count = routine_count;
+      END;
+      DROP INDEX idx_logs_routine_id;
+      CREATE INDEX idx_logs_routine_id ON logs(level, id);
+    `);
+    db.prepare(`
+      INSERT INTO logs (ts, level, module, message)
+      VALUES (1, 'info', 'test', 'untracked')
+    `).run();
+    expect(retentionState(db).routine_count).toBe(0);
+
+    installRoutineLogRetentionSchema(db);
+    expect(retentionState(db).routine_count).toBe(1);
+    const definitions = db.prepare(`
+      SELECT name, sql FROM sqlite_master
+      WHERE name IN ('track_routine_log_insert', 'idx_logs_routine_id')
+      ORDER BY name
+    `).all() as Array<{ name: string; sql: string }>;
+    expect(definitions.find(({ name }) => name === 'track_routine_log_insert')?.sql)
+      .toContain('routine_count = routine_count + 1');
+    expect(definitions.find(({ name }) => name === 'idx_logs_routine_id')?.sql)
+      .toContain("WHERE level NOT IN ('warn', 'error')");
+
+    db.prepare(`
+      INSERT INTO logs (ts, level, module, message)
+      VALUES (2, 'debug', 'test', 'tracked')
+    `).run();
+    expect(retentionState(db).routine_count).toBe(2);
+  });
+
+  it('repairs a missing current-version trigger and tracks subsequent writes', () => {
+    installRoutineLogRetentionSchema(db);
+    db.exec('DROP TRIGGER track_routine_log_insert');
+    db.prepare(`
+      INSERT INTO logs (ts, level, module, message)
+      VALUES (1, 'info', 'test', 'drifted')
+    `).run();
+    expect(retentionState(db).routine_count).toBe(0);
+
+    installRoutineLogRetentionSchema(db);
+    expect(retentionState(db).routine_count).toBe(1);
+    db.prepare(`
+      INSERT INTO logs (ts, level, module, message)
+      VALUES (2, 'debug', 'test', 'tracked')
+    `).run();
+    expect(retentionState(db).routine_count).toBe(2);
+  });
+
+  it('does not rescan logs when the installed versioned definitions are canonical', () => {
+    installRoutineLogRetentionSchema(db);
+    db.prepare(`
+      INSERT INTO logs (ts, level, module, message)
+      VALUES (1, 'info', 'test', 'already-tracked')
+    `).run();
+    let reseedStatements = 0;
+    const observedDb = new Proxy(db, {
+      get(target, property) {
+        if (property === 'prepare') {
+          return (sql: string) => {
+            if (sql.includes('SELECT 1, @schemaVersion, COUNT(*) FROM logs')) {
+              reseedStatements += 1;
+            }
+            return target.prepare(sql);
+          };
+        }
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+
+    installRoutineLogRetentionSchema(observedDb);
+    expect(reseedStatements).toBe(0);
+    expect(retentionState(db).routine_count).toBe(1);
+  });
+});
+
+describe('installRoutineLogRetentionSchema locking', () => {
+  it('holds a write lock from before seeding until canonical triggers are active', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dkg-routine-retention-lock-'));
+    const path = join(dir, 'retention.db');
+    const installerConnection = new Database(path);
+    const racingConnection = new Database(path);
+    try {
+      createLogsTable(installerConnection);
+      racingConnection.pragma('busy_timeout = 0');
+      let racingWriteBlocked = false;
+      const installingDb = new Proxy(installerConnection, {
+        get(target, property) {
+          if (property === 'exec') {
+            return (sql: string) => {
+              const result = target.exec(sql);
+              if (sql === 'BEGIN IMMEDIATE') {
+                expect(() => racingConnection.prepare(`
+                  INSERT INTO logs (ts, level, module, message)
+                  VALUES (1, 'info', 'racer', 'blocked')
+                `).run()).toThrow(/locked/);
+                racingWriteBlocked = true;
+              }
+              return result;
+            };
+          }
+          const value = Reflect.get(target, property, target) as unknown;
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+      });
+
+      installRoutineLogRetentionSchema(installingDb);
+      expect(racingWriteBlocked).toBe(true);
+
+      racingConnection.prepare(`
+        INSERT INTO logs (ts, level, module, message)
+        VALUES (2, 'info', 'racer', 'tracked-after-commit')
+      `).run();
+      expect(retentionState(installerConnection).routine_count).toBe(1);
+    } finally {
+      racingConnection.close();
+      installerConnection.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/node-ui/test/routine-log-retention.test.ts
+++ b/packages/node-ui/test/routine-log-retention.test.ts
@@ -71,11 +71,38 @@ describe('RoutineLogRetention', () => {
     expect(retention.pruneOverflowBatch()).toEqual({
       deleted: 1,
       hadOverflow: true,
-      filledBatch: true,
+      hasMore: false,
     });
     expect(db.prepare(`SELECT level, message FROM logs ORDER BY id`).all()).toEqual([
       { level: 'error', message: 'routine-a' },
     ]);
+  });
+
+  it('reports remaining overflow exactly at and above the batch boundary', () => {
+    installRoutineLogRetentionSchema(db);
+    const insert = db.prepare(`
+      INSERT INTO logs (ts, level, module, message)
+      VALUES (?, 'info', 'test', ?)
+    `);
+    insert.run(1, 'one');
+    insert.run(2, 'two');
+
+    const exactBatch = new RoutineLogRetention(db, 0, 2);
+    expect(exactBatch.pruneOverflowBatch()).toEqual({
+      deleted: 2,
+      hadOverflow: true,
+      hasMore: false,
+    });
+
+    insert.run(3, 'one');
+    insert.run(4, 'two');
+    insert.run(5, 'three');
+    const batchPlusOne = new RoutineLogRetention(db, 0, 2);
+    expect(batchPlusOne.pruneOverflowBatch()).toEqual({
+      deleted: 2,
+      hadOverflow: true,
+      hasMore: true,
+    });
   });
 
   it('fails loudly on a missing singleton and repairs its count on reinstall', () => {
@@ -156,15 +183,21 @@ describe('RoutineLogRetention', () => {
       INSERT INTO logs (ts, level, module, message)
       VALUES (1, 'info', 'test', 'already-tracked')
     `).run();
-    let reseedStatements = 0;
+    const scannedOrMutatingSql: string[] = [];
     const observedDb = new Proxy(db, {
       get(target, property) {
         if (property === 'prepare') {
           return (sql: string) => {
             if (sql.includes('SELECT 1, @schemaVersion, COUNT(*) FROM logs')) {
-              reseedStatements += 1;
+              scannedOrMutatingSql.push(sql);
             }
             return target.prepare(sql);
+          };
+        }
+        if (property === 'exec') {
+          return (sql: string) => {
+            if (/\b(?:CREATE|DROP|ALTER)\b/i.test(sql)) scannedOrMutatingSql.push(sql);
+            return target.exec(sql);
           };
         }
         const value = Reflect.get(target, property, target) as unknown;
@@ -173,7 +206,7 @@ describe('RoutineLogRetention', () => {
     });
 
     installRoutineLogRetentionSchema(observedDb);
-    expect(reseedStatements).toBe(0);
+    expect(scannedOrMutatingSql).toEqual([]);
     expect(retentionState(db).routine_count).toBe(1);
   });
 });
@@ -190,17 +223,16 @@ describe('installRoutineLogRetentionSchema locking', () => {
       let racingWriteBlocked = false;
       const installingDb = new Proxy(installerConnection, {
         get(target, property) {
-          if (property === 'exec') {
+          if (property === 'prepare') {
             return (sql: string) => {
-              const result = target.exec(sql);
-              if (sql === 'BEGIN IMMEDIATE') {
+              if (!racingWriteBlocked && sql.includes("name = 'logs'")) {
                 expect(() => racingConnection.prepare(`
                   INSERT INTO logs (ts, level, module, message)
                   VALUES (1, 'info', 'racer', 'blocked')
                 `).run()).toThrow(/locked/);
                 racingWriteBlocked = true;
               }
-              return result;
+              return target.prepare(sql);
             };
           }
           const value = Reflect.get(target, property, target) as unknown;

--- a/packages/node-ui/test/routine-log-retention.test.ts
+++ b/packages/node-ui/test/routine-log-retention.test.ts
@@ -255,3 +255,58 @@ describe('installRoutineLogRetentionSchema locking', () => {
     }
   });
 });
+
+describe('RoutineLogRetention pruning locks', () => {
+  it('prevents concurrent pruners from acting on the same overflow count', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dkg-routine-retention-prune-lock-'));
+    const path = join(dir, 'retention.db');
+    const firstConnection = new Database(path);
+    const secondConnection = new Database(path);
+    try {
+      createLogsTable(firstConnection);
+      installRoutineLogRetentionSchema(firstConnection);
+      const insert = firstConnection.prepare(`
+        INSERT INTO logs (ts, level, module, message)
+        VALUES (?, 'info', 'test', ?)
+      `);
+      for (let index = 1; index <= 5; index += 1) insert.run(index, `row-${index}`);
+      secondConnection.pragma('busy_timeout = 0');
+
+      const competingPruner = new RoutineLogRetention(secondConnection, 3, 2);
+      let competingPrunerBlocked = false;
+      const observedFirst = new Proxy(firstConnection, {
+        get(target, property) {
+          if (property === 'prepare') {
+            return (sql: string) => {
+              if (!competingPrunerBlocked && sql === ROUTINE_LOG_PRUNE_SQL) {
+                expect(() => competingPruner.pruneOverflowBatch()).toThrow(/locked/);
+                competingPrunerBlocked = true;
+              }
+              return target.prepare(sql);
+            };
+          }
+          const value = Reflect.get(target, property, target) as unknown;
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+      });
+
+      const firstPruner = new RoutineLogRetention(observedFirst, 3, 2);
+      expect(firstPruner.pruneOverflowBatch()).toEqual({
+        deleted: 2,
+        hadOverflow: true,
+        hasMore: false,
+      });
+      expect(competingPrunerBlocked).toBe(true);
+      expect(competingPruner.pruneOverflowBatch()).toEqual({
+        deleted: 0,
+        hadOverflow: false,
+        hasMore: false,
+      });
+      expect(retentionState(firstConnection).routine_count).toBe(3);
+    } finally {
+      secondConnection.close();
+      firstConnection.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- replace the million-row OFFSET overflow probe with a singleton routine-row count maintained by SQLite triggers
- add a partial `logs(id)` index for routine rows so each prune deletes only the oldest bounded batch
- add the V35 migration and current-version repair path, including one exact seed count
- keep warning/error retention behavior and best-effort inline cleanup unchanged

## Profiler motivation

The latest load profile attributed about 48.9s of self CPU to `RoutineLogRetention.overflowCutoff()`. That work ran synchronously in better-sqlite3 and repeatedly walked toward the one-million-row cap. After this change steady-state overflow checks are O(1); cleanup work is bounded by `logVolumePruneBatchRows`.

The upgrade performs one intentional count/index build. Subsequent inserts, deletes, and level transitions maintain the count transactionally.

## Correctness

- direct compatibility inserts/deletes are covered by triggers
- updates between routine and protected levels adjust the count in the same transaction
- warning and error rows remain outside the count cap
- missing schema adjuncts are repaired and reseeded on open

## Verification

- `pnpm --filter @origintrail-official/dkg-node-ui... build`
- `pnpm --dir packages/node-ui exec vitest run test/db.test.ts` (118/118)
- `pnpm lint`