### PR TITLE
perf(sync): coalesce reconcile and on-connect attempts

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -1417,6 +1417,26 @@ interface RecoverContextGraphSwmFromPeerDependencies {
 
 type SyncReconcilerAttemptOutcome = SyncOnConnectOutcome | 'not-started' | 'deferred-backpressure';
 
+// The connection listener and periodic reconciler can both clear their
+// freshness checks before runSyncOnConnect marks the peer active. Share the
+// complete ordinary attempt (including its accounting) across that window so
+// one peer cannot consume two sync admission slots or grow backoff twice.
+const ordinarySyncAttemptFlights = new WeakMap<
+  DKGAgent,
+  Map<string, Promise<SyncReconcilerAttemptOutcome>>
+>();
+
+function ordinarySyncFlightsFor(
+  agent: DKGAgent,
+): Map<string, Promise<SyncReconcilerAttemptOutcome>> {
+  let flights = ordinarySyncAttemptFlights.get(agent);
+  if (!flights) {
+    flights = new Map();
+    ordinarySyncAttemptFlights.set(agent, flights);
+  }
+  return flights;
+}
+
 export interface ContextGraphCatchupOptions {
   includeSharedMemory?: boolean;
   maxPeers?: number;
@@ -4767,7 +4787,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     mode: OrdinarySyncOnConnectMode = 'ordinary',
   ): Promise<SyncReconcilerAttemptOutcome> {
     if (!syncOnConnectEnabled(this.config)) return 'not-started';
-    return this.accountSyncAttemptWithReconciler(
+    const flights = ordinarySyncFlightsFor(this);
+    // Keep the post-selected ordinary lane distinct: it is intentionally
+    // sequenced after selected recovery and must not join a pre-selected sweep.
+    const flightKey = `${remotePeer}\u0000${mode}`;
+    const existing = flights.get(flightKey);
+    if (existing) return existing;
+
+    const attempt = this.accountSyncAttemptWithReconciler(
       remotePeer,
       probe,
       (onSyncAccounting) => this.trySyncFromPeer(
@@ -4777,6 +4804,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         mode,
       ),
     );
+    flights.set(flightKey, attempt);
+    try {
+      return await attempt;
+    } finally {
+      if (flights.get(flightKey) === attempt) flights.delete(flightKey);
+      if (flights.size === 0) ordinarySyncAttemptFlights.delete(this);
+    }
   }
 
   async attemptSelectedSwmRetryWithReconcilerAccounting(

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -871,6 +871,33 @@ describe('sync-on-connect churn gates', () => {
     expect(sources).toEqual(['on-connect']);
   });
 
+  it('coalesces a reconcile race with the same ordinary on-connect attempt', async () => {
+    const agent = await createUnstartedAgent('SyncAttemptRaceCoalescing');
+    (agent as any).started = true;
+    let release!: (outcome: 'synced') => void;
+    const gate = new Promise<'synced'>((resolve) => { release = resolve; });
+    const trySyncFromPeer = recorder(async () => gate);
+    (agent as any).trySyncFromPeer = trySyncFromPeer;
+    const probe = { connected: true, hasSyncProtocol: true };
+
+    const onConnect = (agent as any).attemptSyncFromPeerWithReconcilerAccounting(
+      PEER_A,
+      probe,
+      'on-connect',
+    );
+    const reconcile = (agent as any).attemptSyncFromPeerWithReconcilerAccounting(
+      PEER_A,
+      probe,
+      'reconcile',
+    );
+    await Promise.resolve();
+
+    expect(trySyncFromPeer.calls).toHaveLength(1);
+    release('synced');
+    await expect(Promise.all([onConnect, reconcile])).resolves.toEqual(['synced', 'synced']);
+    expect(trySyncFromPeer.calls).toHaveLength(1);
+  });
+
   it('reconciler still retries stale connected peers', async () => {
     const agent = await createUnstartedAgent('SyncReconcilerStillRetries');
     (agent as any).started = true;


### PR DESCRIPTION
## Summary

- add one per-agent single-flight for ordinary peer sync attempts
- coalesce the race where connection-open and the periodic reconciler both pass freshness checks before `runSyncOnConnect` marks the peer active
- share the complete attempt and reconciler accounting so one race cannot consume two admission slots or grow backoff twice
- keep `ordinary-after-selected` isolated so selected recovery ordering remains intact

## Profiler motivation

All five transient degraded samples in the latest load run coincided with sync-on-connect pressure, and on-connect activity increased versus the preceding profile. Existing scheduler and freshness gates cover most duplication, but the reconciler bypasses the peer scheduler and could race in the preflight window.

## Correctness

- selected SWM recovery is unchanged
- post-selected ordinary work has a distinct flight key
- failures and backpressure still flow through the existing accounting path
- flights are removed on both resolution and rejection and are weakly owned by the agent

## Verification

- `pnpm --filter @origintrail-official/dkg-agent build`
- `pnpm --dir packages/agent exec vitest run test/sync-on-connect-churn.test.ts` (41/41)
- `pnpm lint`