### PR TITLE
test(cli): cover detectable installed integrations

### DIFF
--- a/packages/cli/src/integrations/commands.ts
+++ b/packages/cli/src/integrations/commands.ts
@@ -16,7 +16,7 @@
 // failing generically.
 
 import type { Command } from 'commander';
-import { detectInstalled } from './detect-installed.js';
+import { detectInstalled, type DetectDeps } from './detect-installed.js';
 import { installCli } from './install-cli.js';
 import { installMcp } from './install-mcp.js';
 import { installService } from './install-service.js';
@@ -31,7 +31,15 @@ function matchesKeyword(e: IntegrationEntry, needle: string): boolean {
 
 const TIER_RANK: Record<TrustTier, number> = { community: 0, verified: 1, featured: 2 };
 
-export function registerIntegrationCommands(program: Command): void {
+export interface IntegrationCommandDependencies {
+  /** Detection probes; injectable so the command layer can be tested without host I/O. */
+  detection?: DetectDeps;
+}
+
+export function registerIntegrationCommands(
+  program: Command,
+  deps: IntegrationCommandDependencies = {},
+): void {
   const integrationCmd = program
     .command('integration')
     .description('Install and inspect community DKG integrations from the registry');
@@ -129,7 +137,7 @@ export function registerIntegrationCommands(program: Command): void {
         const { entries, failures } = await fetchAllEntries(cfg);
         const min = parseTier(opts.tier);
         const candidates = entries.filter((e) => TIER_RANK[e.trustTier] >= TIER_RANK[min]);
-        const rows = await detectInstalled(candidates);
+        const rows = await detectInstalled(candidates, deps.detection);
 
         if (opts.json) {
           console.log(JSON.stringify({ installed: rows, failures }, null, 2));

--- a/packages/cli/src/integrations/commands.ts
+++ b/packages/cli/src/integrations/commands.ts
@@ -16,7 +16,7 @@
 // failing generically.
 
 import type { Command } from 'commander';
-import { detectInstalled, type DetectDeps } from './detect-installed.js';
+import { detectInstalled } from './detect-installed.js';
 import { installCli } from './install-cli.js';
 import { installMcp } from './install-mcp.js';
 import { installService } from './install-service.js';
@@ -32,8 +32,8 @@ function matchesKeyword(e: IntegrationEntry, needle: string): boolean {
 const TIER_RANK: Record<TrustTier, number> = { community: 0, verified: 1, featured: 2 };
 
 export interface IntegrationCommandDependencies {
-  /** Detection probes; injectable so the command layer can be tested without host I/O. */
-  detection?: DetectDeps;
+  /** Command-level detector operation; production defaults to real host detection. */
+  detectInstalled?: typeof detectInstalled;
 }
 
 export function registerIntegrationCommands(
@@ -137,7 +137,7 @@ export function registerIntegrationCommands(
         const { entries, failures } = await fetchAllEntries(cfg);
         const min = parseTier(opts.tier);
         const candidates = entries.filter((e) => TIER_RANK[e.trustTier] >= TIER_RANK[min]);
-        const rows = await detectInstalled(candidates, deps.detection);
+        const rows = await (deps.detectInstalled ?? detectInstalled)(candidates);
 
         if (opts.json) {
           console.log(JSON.stringify({ installed: rows, failures }, null, 2));

--- a/packages/cli/test/_helpers/integration-entry-fixtures.ts
+++ b/packages/cli/test/_helpers/integration-entry-fixtures.ts
@@ -1,0 +1,36 @@
+import type { IntegrationEntry } from '../../src/integrations/schema.js';
+
+export const baseIntegrationEntry = {
+  slug: 'dkg-hello-world',
+  name: 'DKG Hello World',
+  description: 'Test fixture',
+  maintainer: { github: '@OriginTrail/core-developers' },
+  repo: 'https://github.com/OriginTrail/dkg-hello-world',
+  commit: '0000000000000000000000000000000000000000',
+  license: 'Apache-2.0',
+  memoryLayers: ['WM'],
+  v10PrimitivesUsed: ['ContextGraph', 'Assertion'],
+  publicInterfacesUsed: ['http-api'],
+  install: {
+    kind: 'cli',
+    package: '@origintrail/dkg-hello-world',
+    version: '0.1.0',
+    binary: 'dkg-hello-world',
+    envRequired: ['DKG_API_URL', 'DKG_AUTH_TOKEN'],
+    usageHint: 'dkg-hello-world greet "first post"\ndkg-hello-world list',
+  },
+  security: {},
+  trustTier: 'featured',
+} satisfies IntegrationEntry;
+
+export const argsLessMcpEntry = {
+  ...baseIntegrationEntry,
+  slug: 'mcp-no-args',
+  name: 'MCP No Args',
+  install: {
+    kind: 'mcp',
+    command: 'my-mcp-server',
+    supportedClients: ['cursor'],
+  },
+  trustTier: 'verified',
+} satisfies IntegrationEntry;

--- a/packages/cli/test/_helpers/local-registry-stub.ts
+++ b/packages/cli/test/_helpers/local-registry-stub.ts
@@ -1,0 +1,69 @@
+import { createServer, type Server } from 'node:http';
+
+export interface RegistryRoute {
+  status: number;
+  body: string;
+}
+
+/** A real, resettable HTTP registry shared by integration tests. */
+export interface LocalRegistryStub {
+  readonly routes: Map<string, RegistryRoute>;
+  readonly seenAuthorizationHeaders: Array<string | null>;
+  readonly baseUrl: string;
+  start(): Promise<void>;
+  close(): Promise<void>;
+  reset(): void;
+}
+
+export function createLocalRegistryStub(): LocalRegistryStub {
+  const routes = new Map<string, RegistryRoute>();
+  const seenAuthorizationHeaders: Array<string | null> = [];
+  let server: Server | undefined;
+  let baseUrl = '';
+
+  return {
+    routes,
+    seenAuthorizationHeaders,
+    get baseUrl(): string {
+      if (!baseUrl) throw new Error('Local registry stub has not been started');
+      return baseUrl;
+    },
+    async start(): Promise<void> {
+      if (server) return;
+      server = createServer((req, res) => {
+        seenAuthorizationHeaders.push(req.headers.authorization ?? null);
+        const route = routes.get(req.url ?? '');
+        if (!route) {
+          res.writeHead(500);
+          res.end('unconfigured route');
+          return;
+        }
+        res.writeHead(route.status, { 'Content-Type': 'application/json' });
+        res.end(route.body);
+      });
+      await new Promise<void>((resolve, reject) => {
+        server?.once('error', reject);
+        server?.listen(0, '127.0.0.1', () => {
+          server?.off('error', reject);
+          resolve();
+        });
+      });
+      const address = server.address();
+      if (!address || typeof address === 'string') throw new Error('Local registry has no TCP address');
+      baseUrl = `http://127.0.0.1:${address.port}`;
+    },
+    async close(): Promise<void> {
+      if (!server) return;
+      const activeServer = server;
+      server = undefined;
+      baseUrl = '';
+      await new Promise<void>((resolve, reject) => {
+        activeServer.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+    reset(): void {
+      routes.clear();
+      seenAuthorizationHeaders.length = 0;
+    },
+  };
+}

--- a/packages/cli/test/integrations-commands.test.ts
+++ b/packages/cli/test/integrations-commands.test.ts
@@ -1,0 +1,409 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import { Command } from 'commander';
+import { createServer as createHttpServer, type Server as HttpServer } from 'node:http';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+
+import { registerIntegrationCommands } from '../src/integrations/commands.js';
+import type { IntegrationEntry } from '../src/integrations/schema.js';
+import {
+  argsLessMcpEntry,
+  baseIntegrationEntry,
+} from './_helpers/integration-entry-fixtures.js';
+
+const baseEntry: IntegrationEntry = baseIntegrationEntry;
+const registryRoutes = new Map<string, { status: number; body: string }>();
+let registryServer: HttpServer;
+let registryBase = '';
+
+beforeAll(async () => {
+  registryServer = createHttpServer((req, res) => {
+    const route = registryRoutes.get(req.url ?? '');
+    if (!route) {
+      res.writeHead(500);
+      res.end('unconfigured route');
+      return;
+    }
+    res.writeHead(route.status, { 'Content-Type': 'application/json' });
+    res.end(route.body);
+  });
+  await new Promise<void>((resolve) => registryServer.listen(0, '127.0.0.1', resolve));
+  const address = registryServer.address();
+  if (!address || typeof address === 'string') throw new Error('no addr');
+  registryBase = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => registryServer.close(() => resolve()));
+});
+
+// ── Commander layer: the public `dkg integration …` contracts ──────────────
+// Everything above tests helpers. The wiring between them — argument parsing,
+// tier defaults, which envelope key each verb prints — lives only in
+// commands.ts, so a regression there (a `search` that ignores its keyword, an
+// `installed` that prints `{ entries }`) would leave every helper test green.
+// These drive the real Commander tree against the real local registry server.
+describe('integration commands (Commander layer, real wire)', () => {
+  const manualEntry = (slug: string, name: string, tier: 'community' | 'verified'): IntegrationEntry =>
+    ({
+      ...baseEntry,
+      slug,
+      name,
+      description: `${name} integration for testing`,
+      install: { kind: 'manual', docsUrl: 'https://example.com/README.md' },
+      trustTier: tier,
+    }) as unknown as IntegrationEntry;
+
+  // `manual` entries keep detectInstalled off the network and off npm: with no
+  // cli/mcp/npm-global candidates it performs no I/O at all, so `installed`
+  // stays deterministic here and still exercises the real command path.
+  const alpha = manualEntry('alpha-chat', 'Alpha Chat', 'verified');
+  const beta = manualEntry('beta-graph', 'Beta Graph', 'verified');
+  const communityOnly = manualEntry('gamma-tool', 'Gamma Tool', 'community');
+
+  // npm-global service WITHOUT `npmGlobal.binary` — schema-valid, and the shape
+  // resolveBinary's package-name fallback exists for.
+  const svcEntry = {
+    ...baseEntry,
+    slug: 'svc-ok',
+    name: 'Service OK',
+    install: {
+      kind: 'service',
+      runtime: 'npm-global',
+      npmGlobal: { package: '@acme/svc', version: '2.0.0' },
+      // Declared so the DKG_API_URL guidance renders — that line is where an
+      // ignored --api-url becomes visible to an operator.
+      envRequired: ['DKG_API_URL'],
+    },
+    trustTier: 'verified',
+  } as unknown as IntegrationEntry;
+
+  // Schema-valid (only kind + runtime are required) but NOT automatable.
+  const svcNoMeta = {
+    ...baseEntry,
+    slug: 'svc-bare',
+    name: 'Service Bare',
+    install: { kind: 'service', runtime: 'npm-global' },
+    trustTier: 'verified',
+  } as unknown as IntegrationEntry;
+
+  // Registry-valid, but the package is whitespace. The dispatcher used to gate
+  // on truthiness while the installer trimmed, so this passed the gate, threw
+  // inside installService, and surfaced as a generic "Install failed".
+  const svcBlankPkg = {
+    ...baseEntry,
+    slug: 'svc-blank',
+    name: 'Service Blank',
+    install: {
+      kind: 'service',
+      runtime: 'npm-global',
+      npmGlobal: { package: '   ', version: '1.0.0' },
+    },
+    trustTier: 'verified',
+  } as unknown as IntegrationEntry;
+
+  // A runtime the CLI does not automate at all. Readable, and this branch is now
+  // its public install behaviour.
+  const svcBinary = {
+    ...baseEntry,
+    slug: 'svc-binary',
+    name: 'Service Binary',
+    install: {
+      kind: 'service',
+      runtime: 'binary',
+      binary: { url: 'https://example.com/svc' },
+    },
+    trustTier: 'verified',
+  } as unknown as IntegrationEntry;
+
+  let savedIndex: string | undefined;
+  let savedRaw: string | undefined;
+
+  beforeEach(() => {
+    savedIndex = process.env.DKG_REGISTRY_INDEX_URL;
+    savedRaw = process.env.DKG_REGISTRY_RAW_BASE;
+    // commands.ts calls resolveRegistryConfig() with no argument, so the
+    // redirect has to happen through the real environment.
+    process.env.DKG_REGISTRY_INDEX_URL = `${registryBase}/index`;
+    process.env.DKG_REGISTRY_RAW_BASE = `${registryBase}/raw`;
+
+    for (const e of [
+      alpha,
+      beta,
+      communityOnly,
+      argsLessMcpEntry,
+      svcEntry,
+      svcNoMeta,
+      svcBinary,
+      svcBlankPkg,
+    ]) {
+      registryRoutes.set(`/raw/${e.slug}.json`, { status: 200, body: JSON.stringify(e) });
+    }
+    // Only the manual entries are indexed: `installed` runs detectInstalled over
+    // everything the index returns, and keeping npm-backed kinds out of it means
+    // no test here ever shells out to npm. `install <slug>` fetches by slug, so
+    // the service entries are still reachable by the install tests below.
+    registryRoutes.set('/index', {
+      status: 200,
+      body: JSON.stringify([alpha, beta, communityOnly].map((e) => ({ name: `${e.slug}.json` }))),
+    });
+  });
+
+  afterEach(() => {
+    if (savedIndex === undefined) delete process.env.DKG_REGISTRY_INDEX_URL;
+    else process.env.DKG_REGISTRY_INDEX_URL = savedIndex;
+    if (savedRaw === undefined) delete process.env.DKG_REGISTRY_RAW_BASE;
+    else process.env.DKG_REGISTRY_RAW_BASE = savedRaw;
+  });
+
+  /** Runs the real command tree and returns whatever it printed to stdout. */
+  async function runCli(argv: string[]): Promise<string> {
+    const program = new Command();
+    program.exitOverride(); // never let a parse error kill the test runner
+    registerIntegrationCommands(program);
+    const out: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      out.push(args.map(String).join(' '));
+    });
+    try {
+      await program.parseAsync(['node', 'dkg', ...argv]);
+    } finally {
+      spy.mockRestore();
+    }
+    return out.join('\n');
+  }
+
+  it('`search <keyword> --json` filters by the keyword', async () => {
+    const parsed = JSON.parse(await runCli(['integration', 'search', 'alpha', '--json']));
+    expect(parsed.entries.map((e: IntegrationEntry) => e.slug)).toEqual(['alpha-chat']);
+  });
+
+  // The control for the test above: without it, a `search` that dropped its
+  // keyword and returned everything would still need the filtered case to fail,
+  // but a `search` that returned NOTHING would pass it vacuously.
+  it('`search --json` with no keyword returns every entry at the tier', async () => {
+    const parsed = JSON.parse(await runCli(['integration', 'search', '--json']));
+    expect(parsed.entries.map((e: IntegrationEntry) => e.slug).sort()).toEqual([
+      'alpha-chat',
+      'beta-graph',
+    ]);
+  });
+
+  it('`list --json` keeps its shipped { entries, failures } envelope', async () => {
+    const parsed = JSON.parse(await runCli(['integration', 'list', '--json']));
+    expect(Object.keys(parsed).sort()).toEqual(['entries', 'failures']);
+    expect(parsed.entries.map((e: IntegrationEntry) => e.slug).sort()).toEqual([
+      'alpha-chat',
+      'beta-graph',
+    ]);
+  });
+
+  // `installed` reports something different from `list`/`search`, so it prints a
+  // different key. Printing `{ entries }` here would silently look like a
+  // registry listing to any script consuming it.
+  it('`installed --json` prints { installed, failures }, never { entries }', async () => {
+    const parsed = JSON.parse(await runCli(['integration', 'installed', '--json']));
+    expect(Object.keys(parsed).sort()).toEqual(['failures', 'installed']);
+    expect(parsed.entries).toBeUndefined();
+    expect(Array.isArray(parsed.installed)).toBe(true);
+  });
+
+  // The two verbs deliberately default to different tiers: browsing surfaces
+  // vetted entries, while "what is on my machine" must not hide a
+  // community-tier install the user actually has.
+  it('defaults `search` to verified but `installed` to community', async () => {
+    const searched = JSON.parse(await runCli(['integration', 'search', '--json']));
+    expect(searched.entries.map((e: IntegrationEntry) => e.slug)).not.toContain('gamma-tool');
+
+    const inst = JSON.parse(await runCli(['integration', 'installed', '--json']));
+    expect(inst.installed.map((r: { slug: string }) => r.slug)).toContain('gamma-tool');
+  });
+
+  it('routes a detectable registry entry through real installed detection', async () => {
+    const fakeBin = await mkdtemp(join(tmpdir(), 'dkg-integration-npm-'));
+    const originalPath = process.env.PATH;
+    const npmResult = JSON.stringify({
+      dependencies: { '@acme/svc': { version: '2.0.0' } },
+    });
+    await writeFile(
+      join(fakeBin, 'npm'),
+      `#!/usr/bin/env node\nconst expected = ['ls', '--global', '--json', '--depth=0'];\nif (JSON.stringify(process.argv.slice(2)) !== JSON.stringify(expected)) process.exit(64);\nprocess.stdout.write(${JSON.stringify(npmResult)});\n`,
+      'utf8',
+    );
+    await chmod(join(fakeBin, 'npm'), 0o755);
+    await writeFile(
+      join(fakeBin, 'npm.cmd'),
+      `@echo off\r\nif not "%*"=="ls --global --json --depth=0" exit /b 64\r\necho ${npmResult}\r\n`,
+      'utf8',
+    );
+    process.env.PATH = [fakeBin, originalPath].filter(Boolean).join(delimiter);
+    registryRoutes.set('/index', {
+      status: 200,
+      body: JSON.stringify([alpha, svcEntry].map((entry) => ({ name: `${entry.slug}.json` }))),
+    });
+
+    try {
+      const parsed = JSON.parse(await runCli(['integration', 'installed', '--json']));
+      expect(parsed.installed).toContainEqual({
+        slug: 'svc-ok',
+        kind: 'service',
+        state: 'installed',
+        detail: '@acme/svc@2.0.0',
+      });
+    } finally {
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+      await rm(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  it('prints schema-valid MCP entries with no args through `info`', async () => {
+    const output = await runCli(['integration', 'info', argsLessMcpEntry.slug]);
+    expect(output).toContain('MCP No Args  [verified]');
+    expect(output).toContain('command:    my-mcp-server (no args declared)');
+  });
+
+  it('`search --tier community --json` widens to community entries', async () => {
+    const parsed = JSON.parse(await runCli(['integration', 'search', '--tier', 'community', '--json']));
+    expect(parsed.entries.map((e: IntegrationEntry) => e.slug).sort()).toEqual([
+      'alpha-chat',
+      'beta-graph',
+      'gamma-tool',
+    ]);
+  });
+
+  // ── install dispatch ────────────────────────────────────────────────────
+  // The branches below are reachable only through the command; the helpers
+  // cannot tell you whether the dispatcher picked the right one or forwarded
+  // its options. Exit codes are captured rather than allowed to run, or a
+  // process.exit would take the test runner with it.
+  async function runInstall(
+    argv: string[],
+  ): Promise<{ out: string; err: string; exit: number | null; exits: number[] }> {
+    const program = new Command();
+    program.exitOverride();
+    registerIntegrationCommands(program);
+    const out: string[] = [];
+    const err: string[] = [];
+    const exits: number[] = [];
+    let exit: number | null = null;
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+      out.push(a.map(String).join(' '));
+    });
+    const errSpy = vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
+      err.push(a.map(String).join(' '));
+    });
+    // Records rather than throws. Throwing would be caught by the command's own
+    // try/catch, which then calls process.exit(1) — turning every asserted exit
+    // code into 1 and hiding which branch actually ran. Only the FIRST code is
+    // kept for the same reason: it is the one the real process would have used.
+    // The spy RECORDS rather than throws, because throwing is caught by the
+    // command's own try/catch and converted into exit(1) — which collapses
+    // every asserted exit code to 1 and hides which branch ran.
+    //
+    // The cost of not throwing is that execution CONTINUES past a simulated
+    // exit, so a missing `break` would let a branch fall through into the
+    // generic failure path while `exit` still reports the first code. Every
+    // code is therefore recorded: `exits` having more than one entry means the
+    // real process would already have terminated, and the test is observing
+    // code that could never run.
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      exits.push(code ?? 0);
+      if (exit === null) exit = code ?? 0;
+      return undefined;
+    }) as never);
+    try {
+      await program.parseAsync(['node', 'dkg', ...argv]);
+    } finally {
+      logSpy.mockRestore();
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+    return { out: out.join('\n'), err: err.join('\n'), exit, exits };
+  }
+
+  it('`install <manual>` prints the docs link and does not exit non-zero', async () => {
+    const r = await runInstall(['integration', 'install', 'alpha-chat']);
+    expect(r.exit).toBeNull();
+    expect(r.out).toContain('https://example.com/README.md');
+  });
+
+  it('`install <npm-global service> --dry-run` reaches the service installer with the pin', async () => {
+    const r = await runInstall(['integration', 'install', 'svc-ok', '--dry-run']);
+    expect(r.exit).toBeNull();
+    // Proves dispatch reached installService AND that --dry-run was forwarded.
+    expect(r.out).toContain('@acme/svc@2.0.0');
+    expect(r.out).toContain('Dry-run');
+  });
+
+  // A schema-valid npm-global service with no npmGlobal block cannot be
+  // automated. It must take the same graceful path docker/binary take, not
+  // throw out of installService into the generic "install failed".
+  it('`install` falls back gracefully for an npm-global service with no package metadata', async () => {
+    const r = await runInstall(['integration', 'install', 'svc-bare']);
+    expect(r.err).toContain('no npmGlobal.package/version');
+    expect(r.err).not.toMatch(/undefined/);
+    // Exactly one exit. Asserting only the FIRST code would still pass if the
+    // branch lost its `break` and fell through into installService, printing
+    // the graceful message and then the generic failure — the regression this
+    // test exists to catch.
+    expect(r.exits).toEqual([2]);
+    expect(r.err).not.toContain('Install failed');
+  });
+
+  // Regression guard for a fix that was previously verified only BELOW this
+  // boundary. `installService` accepted and rendered `apiUrl` correctly, and its
+  // unit test passed — while the command never passed the flag through, so the
+  // real CLI still printed the default node. Only a test that drives the actual
+  // command can catch a missing property on the call.
+  it('`install --api-url` reaches the service post-install guidance', async () => {
+    const r = await runInstall([
+      'integration',
+      'install',
+      'svc-ok',
+      '--dry-run',
+      '--api-url',
+      'http://10.0.0.5:9200',
+    ]);
+    expect(r.exits).toEqual([]);
+    expect(r.out).toContain('http://10.0.0.5:9200');
+    expect(r.out).not.toContain('default http://127.0.0.1:9200');
+  });
+
+  // Control: without the flag the guidance still renders, showing the effective
+  // node — so the test above cannot pass by never printing the DKG_API_URL line.
+  // Commander gives --api-url a default, so opts.apiUrl is always populated and
+  // the command path always echoes the URL actually in effect; the literal
+  // "default …" wording only appears for direct installService callers that
+  // pass no apiUrl at all.
+  it('`install --dry-run` shows the effective node when no --api-url is given', async () => {
+    const r = await runInstall(['integration', 'install', 'svc-ok', '--dry-run']);
+    expect(r.out).toContain('DKG_API_URL');
+    expect(r.out).toContain('http://127.0.0.1:9200');
+    expect(r.out).not.toContain('10.0.0.5');
+  });
+
+  // The gap between the two gates: registry-valid, whitespace package. It must
+  // take the same graceful path as missing metadata, not fall through to the
+  // generic failure because one layer checked truthiness and the other trimmed.
+  it('`install` treats a whitespace-only package as not automatable, not a hard failure', async () => {
+    const r = await runInstall(['integration', 'install', 'svc-blank']);
+    expect(r.exits).toEqual([2]);
+    expect(r.err).toContain('no npmGlobal.package/version');
+    expect(r.err).not.toContain('Install failed');
+  });
+
+  // Making docker/binary services readable also made this branch their public
+  // install behaviour. A regression routing them into installService would
+  // surface a generic "Install failed" (exit 1) instead of the graceful
+  // runtime-not-automated message — and no helper test would notice.
+  it('`install` gives a non-automated runtime the graceful path, not a generic failure', async () => {
+    const r = await runInstall(['integration', 'install', 'svc-binary']);
+    expect(r.exits).toEqual([2]);
+    expect(r.err).toContain('binary');
+    expect(r.err).toContain('not yet');
+    // The generic catch-all path would say this instead.
+    expect(r.err).not.toContain('Install failed');
+  });
+});

--- a/packages/cli/test/integrations-commands.test.ts
+++ b/packages/cli/test/integrations-commands.test.ts
@@ -205,22 +205,32 @@ describe('integration commands (Commander layer, real wire)', () => {
     expect(inst.installed.map((r: { slug: string }) => r.slug)).toContain('gamma-tool');
   });
 
-  it('routes a detectable registry entry through real installed detection', async () => {
+  it('passes tier-filtered candidates to the command-level detector and renders its rows', async () => {
     registryRoutes.set('/index', {
       status: 200,
       body: JSON.stringify([alpha, svcEntry].map((entry) => ({ name: `${entry.slug}.json` }))),
     });
 
-    const parsed = JSON.parse(
-      await runCli(['integration', 'installed', '--json'], {
-        detection: { listGlobalNpm: async () => ({ '@acme/svc': '2.0.0' }) },
-      }),
-    );
+    const detectInstalled = vi.fn(async () => [{
+      slug: 'detector-marker',
+      kind: 'service',
+      state: 'installed' as const,
+      detail: 'recorded command boundary',
+    }]);
+    const parsed = JSON.parse(await runCli(
+      ['integration', 'installed', '--tier', 'verified', '--json'],
+      { detectInstalled },
+    ));
+    expect(detectInstalled).toHaveBeenCalledOnce();
+    expect(detectInstalled.mock.calls[0]?.[0].map((entry) => entry.slug)).toEqual([
+      'alpha-chat',
+      'svc-ok',
+    ]);
     expect(parsed.installed).toContainEqual({
-      slug: 'svc-ok',
+      slug: 'detector-marker',
       kind: 'service',
       state: 'installed',
-      detail: '@acme/svc@2.0.0',
+      detail: 'recorded command boundary',
     });
   });
 

--- a/packages/cli/test/integrations-commands.test.ts
+++ b/packages/cli/test/integrations-commands.test.ts
@@ -1,42 +1,23 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
 import { Command } from 'commander';
-import { createServer as createHttpServer, type Server as HttpServer } from 'node:http';
-import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { delimiter, join } from 'node:path';
 
-import { registerIntegrationCommands } from '../src/integrations/commands.js';
+import {
+  registerIntegrationCommands,
+  type IntegrationCommandDependencies,
+} from '../src/integrations/commands.js';
 import type { IntegrationEntry } from '../src/integrations/schema.js';
 import {
   argsLessMcpEntry,
   baseIntegrationEntry,
 } from './_helpers/integration-entry-fixtures.js';
+import { createLocalRegistryStub } from './_helpers/local-registry-stub.js';
 
 const baseEntry: IntegrationEntry = baseIntegrationEntry;
-const registryRoutes = new Map<string, { status: number; body: string }>();
-let registryServer: HttpServer;
-let registryBase = '';
+const registry = createLocalRegistryStub();
+const registryRoutes = registry.routes;
 
-beforeAll(async () => {
-  registryServer = createHttpServer((req, res) => {
-    const route = registryRoutes.get(req.url ?? '');
-    if (!route) {
-      res.writeHead(500);
-      res.end('unconfigured route');
-      return;
-    }
-    res.writeHead(route.status, { 'Content-Type': 'application/json' });
-    res.end(route.body);
-  });
-  await new Promise<void>((resolve) => registryServer.listen(0, '127.0.0.1', resolve));
-  const address = registryServer.address();
-  if (!address || typeof address === 'string') throw new Error('no addr');
-  registryBase = `http://127.0.0.1:${address.port}`;
-});
-
-afterAll(async () => {
-  await new Promise<void>((resolve) => registryServer.close(() => resolve()));
-});
+beforeAll(() => registry.start());
+afterAll(() => registry.close());
 
 // ── Commander layer: the public `dkg integration …` contracts ──────────────
 // Everything above tests helpers. The wiring between them — argument parsing,
@@ -121,12 +102,13 @@ describe('integration commands (Commander layer, real wire)', () => {
   let savedRaw: string | undefined;
 
   beforeEach(() => {
+    registry.reset();
     savedIndex = process.env.DKG_REGISTRY_INDEX_URL;
     savedRaw = process.env.DKG_REGISTRY_RAW_BASE;
     // commands.ts calls resolveRegistryConfig() with no argument, so the
     // redirect has to happen through the real environment.
-    process.env.DKG_REGISTRY_INDEX_URL = `${registryBase}/index`;
-    process.env.DKG_REGISTRY_RAW_BASE = `${registryBase}/raw`;
+    process.env.DKG_REGISTRY_INDEX_URL = `${registry.baseUrl}/index`;
+    process.env.DKG_REGISTRY_RAW_BASE = `${registry.baseUrl}/raw`;
 
     for (const e of [
       alpha,
@@ -158,10 +140,13 @@ describe('integration commands (Commander layer, real wire)', () => {
   });
 
   /** Runs the real command tree and returns whatever it printed to stdout. */
-  async function runCli(argv: string[]): Promise<string> {
+  async function runCli(
+    argv: string[],
+    deps: IntegrationCommandDependencies = {},
+  ): Promise<string> {
     const program = new Command();
     program.exitOverride(); // never let a parse error kill the test runner
-    registerIntegrationCommands(program);
+    registerIntegrationCommands(program, deps);
     const out: string[] = [];
     const spy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
       out.push(args.map(String).join(' '));
@@ -221,41 +206,22 @@ describe('integration commands (Commander layer, real wire)', () => {
   });
 
   it('routes a detectable registry entry through real installed detection', async () => {
-    const fakeBin = await mkdtemp(join(tmpdir(), 'dkg-integration-npm-'));
-    const originalPath = process.env.PATH;
-    const npmResult = JSON.stringify({
-      dependencies: { '@acme/svc': { version: '2.0.0' } },
-    });
-    await writeFile(
-      join(fakeBin, 'npm'),
-      `#!/usr/bin/env node\nconst expected = ['ls', '--global', '--json', '--depth=0'];\nif (JSON.stringify(process.argv.slice(2)) !== JSON.stringify(expected)) process.exit(64);\nprocess.stdout.write(${JSON.stringify(npmResult)});\n`,
-      'utf8',
-    );
-    await chmod(join(fakeBin, 'npm'), 0o755);
-    await writeFile(
-      join(fakeBin, 'npm.cmd'),
-      `@echo off\r\nif not "%*"=="ls --global --json --depth=0" exit /b 64\r\necho ${npmResult}\r\n`,
-      'utf8',
-    );
-    process.env.PATH = [fakeBin, originalPath].filter(Boolean).join(delimiter);
     registryRoutes.set('/index', {
       status: 200,
       body: JSON.stringify([alpha, svcEntry].map((entry) => ({ name: `${entry.slug}.json` }))),
     });
 
-    try {
-      const parsed = JSON.parse(await runCli(['integration', 'installed', '--json']));
-      expect(parsed.installed).toContainEqual({
-        slug: 'svc-ok',
-        kind: 'service',
-        state: 'installed',
-        detail: '@acme/svc@2.0.0',
-      });
-    } finally {
-      if (originalPath === undefined) delete process.env.PATH;
-      else process.env.PATH = originalPath;
-      await rm(fakeBin, { recursive: true, force: true });
-    }
+    const parsed = JSON.parse(
+      await runCli(['integration', 'installed', '--json'], {
+        detection: { listGlobalNpm: async () => ({ '@acme/svc': '2.0.0' }) },
+      }),
+    );
+    expect(parsed.installed).toContainEqual({
+      slug: 'svc-ok',
+      kind: 'service',
+      state: 'installed',
+      detail: '@acme/svc@2.0.0',
+    });
   });
 
   it('prints schema-valid MCP entries with no args through `info`', async () => {

--- a/packages/cli/test/integrations.test.ts
+++ b/packages/cli/test/integrations.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
 import { Command } from 'commander';
 import { createServer as createHttpServer, type Server as HttpServer } from 'node:http';
-import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile, mkdir, chmod } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { delimiter, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 // This package is `"type": "module"`. Vitest's transform happens to supply
@@ -805,6 +805,14 @@ describe('integration commands (Commander layer, real wire)', () => {
   const beta = manualEntry('beta-graph', 'Beta Graph', 'verified');
   const communityOnly = manualEntry('gamma-tool', 'Gamma Tool', 'community');
 
+  const mcpNoArgs = {
+    ...baseEntry,
+    slug: 'mcp-no-args',
+    name: 'MCP No Args',
+    install: { kind: 'mcp', command: 'my-mcp-server' },
+    trustTier: 'verified',
+  } as unknown as IntegrationEntry;
+
   // npm-global service WITHOUT `npmGlobal.binary` — schema-valid, and the shape
   // resolveBinary's package-name fallback exists for.
   const svcEntry = {
@@ -871,7 +879,16 @@ describe('integration commands (Commander layer, real wire)', () => {
     process.env.DKG_REGISTRY_INDEX_URL = `${registryBase}/index`;
     process.env.DKG_REGISTRY_RAW_BASE = `${registryBase}/raw`;
 
-    for (const e of [alpha, beta, communityOnly, svcEntry, svcNoMeta, svcBinary, svcBlankPkg]) {
+    for (const e of [
+      alpha,
+      beta,
+      communityOnly,
+      mcpNoArgs,
+      svcEntry,
+      svcNoMeta,
+      svcBinary,
+      svcBlankPkg,
+    ]) {
       registryRoutes.set(`/raw/${e.slug}.json`, { status: 200, body: JSON.stringify(e) });
     }
     // Only the manual entries are indexed: `installed` runs detectInstalled over
@@ -952,6 +969,50 @@ describe('integration commands (Commander layer, real wire)', () => {
 
     const inst = JSON.parse(await runCli(['integration', 'installed', '--json']));
     expect(inst.installed.map((r: { slug: string }) => r.slug)).toContain('gamma-tool');
+  });
+
+  it('routes a detectable registry entry through real installed detection', async () => {
+    const fakeBin = await mkdtemp(join(tmpdir(), 'dkg-integration-npm-'));
+    const originalPath = process.env.PATH;
+    const npmResult = JSON.stringify({
+      dependencies: { '@acme/svc': { version: '2.0.0' } },
+    });
+    await writeFile(
+      join(fakeBin, 'npm'),
+      `#!/usr/bin/env node\nprocess.stdout.write(${JSON.stringify(npmResult)});\n`,
+      'utf8',
+    );
+    await chmod(join(fakeBin, 'npm'), 0o755);
+    await writeFile(
+      join(fakeBin, 'npm.cmd'),
+      `@echo off\r\necho ${npmResult}\r\n`,
+      'utf8',
+    );
+    process.env.PATH = [fakeBin, originalPath].filter(Boolean).join(delimiter);
+    registryRoutes.set('/index', {
+      status: 200,
+      body: JSON.stringify([alpha, svcEntry].map((entry) => ({ name: `${entry.slug}.json` }))),
+    });
+
+    try {
+      const parsed = JSON.parse(await runCli(['integration', 'installed', '--json']));
+      expect(parsed.installed).toContainEqual({
+        slug: 'svc-ok',
+        kind: 'service',
+        state: 'installed',
+        detail: '@acme/svc@2.0.0',
+      });
+    } finally {
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+      await rm(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  it('prints schema-valid MCP entries with no args through `info`', async () => {
+    const output = await runCli(['integration', 'info', mcpNoArgs.slug]);
+    expect(output).toContain('MCP No Args  [verified]');
+    expect(output).toContain('command:    my-mcp-server (no args declared)');
   });
 
   it('`search --tier community --json` widens to community entries', async () => {

--- a/packages/cli/test/integrations.test.ts
+++ b/packages/cli/test/integrations.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
-import { createServer as createHttpServer, type Server as HttpServer } from 'node:http';
 import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -28,6 +27,7 @@ import {
   argsLessMcpEntry,
   baseIntegrationEntry,
 } from './_helpers/integration-entry-fixtures.js';
+import { createLocalRegistryStub } from './_helpers/local-registry-stub.js';
 
 // ── Fixtures ──────────────────────────────────────────────────────────────
 
@@ -199,42 +199,21 @@ describe('isGithubHost', () => {
 // is fixture DATA on a real wire; `seenAuth` records the Authorization header
 // the server REALLY received (the token-leak contract is proven on the
 // receiving end, not by inspecting an intercepted call).
-const registryRoutes = new Map<string, { status: number; body: string }>();
-const seenAuth: Array<string | null> = [];
-let registryServer: HttpServer;
-let registryBase = '';
+const registry = createLocalRegistryStub();
+const registryRoutes = registry.routes;
+const seenAuth = registry.seenAuthorizationHeaders;
 
-beforeAll(async () => {
-  registryServer = createHttpServer((req, res) => {
-    seenAuth.push(req.headers.authorization ?? null);
-    const route = registryRoutes.get(req.url ?? '');
-    if (!route) {
-      res.writeHead(500);
-      res.end('unconfigured route');
-      return;
-    }
-    res.writeHead(route.status, { 'Content-Type': 'application/json' });
-    res.end(route.body);
-  });
-  await new Promise<void>((resolve) => registryServer.listen(0, '127.0.0.1', resolve));
-  const addr = registryServer.address();
-  if (!addr || typeof addr === 'string') throw new Error('no addr');
-  registryBase = `http://127.0.0.1:${addr.port}`;
-});
-
-afterAll(async () => {
-  await new Promise<void>((resolve) => registryServer.close(() => resolve()));
-});
+beforeAll(() => registry.start());
+afterAll(() => registry.close());
 
 beforeEach(() => {
-  registryRoutes.clear();
-  seenAuth.length = 0;
+  registry.reset();
 });
 
 function localRegistryCfg(extraEnv: Record<string, string> = {}) {
   return resolveRegistryConfig({
-    DKG_REGISTRY_INDEX_URL: `${registryBase}/index`,
-    DKG_REGISTRY_RAW_BASE: `${registryBase}/raw`,
+    DKG_REGISTRY_INDEX_URL: `${registry.baseUrl}/index`,
+    DKG_REGISTRY_RAW_BASE: `${registry.baseUrl}/raw`,
     ...extraEnv,
   });
 }

--- a/packages/cli/test/integrations.test.ts
+++ b/packages/cli/test/integrations.test.ts
@@ -1,9 +1,8 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
-import { Command } from 'commander';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import { createServer as createHttpServer, type Server as HttpServer } from 'node:http';
-import { mkdtemp, rm, writeFile, mkdir, chmod } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { delimiter, dirname, join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 // This package is `"type": "module"`. Vitest's transform happens to supply
@@ -20,37 +19,19 @@ import {
   isGithubHost,
 } from '../src/integrations/registry-client.js';
 import { isIntegrationEntry } from '../src/integrations/schema.js';
-import { registerIntegrationCommands } from '../src/integrations/commands.js';
 import { installCli } from '../src/integrations/install-cli.js';
 import { installMcp } from '../src/integrations/install-mcp.js';
 import { normalizeRepoUrl } from '../src/integrations/verify-npm-provenance.js';
 import type { IntegrationEntry } from '../src/integrations/schema.js';
 import type { ProvenanceCheckResult } from '../src/integrations/verify-npm-provenance.js';
+import {
+  argsLessMcpEntry,
+  baseIntegrationEntry,
+} from './_helpers/integration-entry-fixtures.js';
 
 // ── Fixtures ──────────────────────────────────────────────────────────────
 
-const baseEntry: IntegrationEntry = {
-  slug: 'dkg-hello-world',
-  name: 'DKG Hello World',
-  description: 'Test fixture',
-  maintainer: { github: '@OriginTrail/core-developers' },
-  repo: 'https://github.com/OriginTrail/dkg-hello-world',
-  commit: '0000000000000000000000000000000000000000',
-  license: 'Apache-2.0',
-  memoryLayers: ['WM'],
-  v10PrimitivesUsed: ['ContextGraph', 'Assertion'],
-  publicInterfacesUsed: ['http-api'],
-  install: {
-    kind: 'cli',
-    package: '@origintrail/dkg-hello-world',
-    version: '0.1.0',
-    binary: 'dkg-hello-world',
-    envRequired: ['DKG_API_URL', 'DKG_AUTH_TOKEN'],
-    usageHint: 'dkg-hello-world greet "first post"\ndkg-hello-world list',
-  },
-  security: {},
-  trustTier: 'featured',
-};
+const baseEntry: IntegrationEntry = baseIntegrationEntry;
 
 const mcpEntry: IntegrationEntry = {
   ...baseEntry,
@@ -742,22 +723,16 @@ describe('installMcp with an args-less entry', () => {
   // block rather than dropping the key (JSON.stringify discards `undefined`)
   // or refusing the entry — judging whether a given command needs args is the
   // entry author's call, not the installer's.
-  const mcpNoArgs: IntegrationEntry = {
-    ...baseEntry,
-    slug: 'no-args',
-    install: { kind: 'mcp', command: 'my-mcp-server', supportedClients: ['cursor'] },
-  };
-
   it('emits args: [] rather than omitting the key', async () => {
     const res = await installMcp({
-      entry: mcpNoArgs,
+      entry: argsLessMcpEntry,
       apiUrl: 'http://127.0.0.1:9200',
       logger: () => {},
     });
     const parsed = JSON.parse(res.mcpJson) as {
       mcpServers: Record<string, { command: string; args: unknown }>;
     };
-    const block = parsed.mcpServers['no-args']!;
+    const block = parsed.mcpServers[argsLessMcpEntry.slug]!;
     expect(block.command).toBe('my-mcp-server');
     expect(block.args).toEqual([]);
     expect(res.mcpJson).toContain('"args"');
@@ -765,7 +740,7 @@ describe('installMcp with an args-less entry', () => {
 
   it('preserves declared args when present', async () => {
     const withArgs: IntegrationEntry = {
-      ...mcpNoArgs,
+      ...argsLessMcpEntry,
       slug: 'with-args',
       install: { kind: 'mcp', command: 'npx', args: ['-y', 'pkg@1.0.0'] },
     };
@@ -778,383 +753,5 @@ describe('installMcp with an args-less entry', () => {
       mcpServers: Record<string, { args: string[] }>;
     };
     expect(parsed.mcpServers['with-args']!.args).toEqual(['-y', 'pkg@1.0.0']);
-  });
-});
-
-// ── Commander layer: the public `dkg integration …` contracts ──────────────
-// Everything above tests helpers. The wiring between them — argument parsing,
-// tier defaults, which envelope key each verb prints — lives only in
-// commands.ts, so a regression there (a `search` that ignores its keyword, an
-// `installed` that prints `{ entries }`) would leave every helper test green.
-// These drive the real Commander tree against the real local registry server.
-describe('integration commands (Commander layer, real wire)', () => {
-  const manualEntry = (slug: string, name: string, tier: 'community' | 'verified'): IntegrationEntry =>
-    ({
-      ...baseEntry,
-      slug,
-      name,
-      description: `${name} integration for testing`,
-      install: { kind: 'manual', docsUrl: 'https://example.com/README.md' },
-      trustTier: tier,
-    }) as unknown as IntegrationEntry;
-
-  // `manual` entries keep detectInstalled off the network and off npm: with no
-  // cli/mcp/npm-global candidates it performs no I/O at all, so `installed`
-  // stays deterministic here and still exercises the real command path.
-  const alpha = manualEntry('alpha-chat', 'Alpha Chat', 'verified');
-  const beta = manualEntry('beta-graph', 'Beta Graph', 'verified');
-  const communityOnly = manualEntry('gamma-tool', 'Gamma Tool', 'community');
-
-  const mcpNoArgs = {
-    ...baseEntry,
-    slug: 'mcp-no-args',
-    name: 'MCP No Args',
-    install: { kind: 'mcp', command: 'my-mcp-server' },
-    trustTier: 'verified',
-  } as unknown as IntegrationEntry;
-
-  // npm-global service WITHOUT `npmGlobal.binary` — schema-valid, and the shape
-  // resolveBinary's package-name fallback exists for.
-  const svcEntry = {
-    ...baseEntry,
-    slug: 'svc-ok',
-    name: 'Service OK',
-    install: {
-      kind: 'service',
-      runtime: 'npm-global',
-      npmGlobal: { package: '@acme/svc', version: '2.0.0' },
-      // Declared so the DKG_API_URL guidance renders — that line is where an
-      // ignored --api-url becomes visible to an operator.
-      envRequired: ['DKG_API_URL'],
-    },
-    trustTier: 'verified',
-  } as unknown as IntegrationEntry;
-
-  // Schema-valid (only kind + runtime are required) but NOT automatable.
-  const svcNoMeta = {
-    ...baseEntry,
-    slug: 'svc-bare',
-    name: 'Service Bare',
-    install: { kind: 'service', runtime: 'npm-global' },
-    trustTier: 'verified',
-  } as unknown as IntegrationEntry;
-
-  // Registry-valid, but the package is whitespace. The dispatcher used to gate
-  // on truthiness while the installer trimmed, so this passed the gate, threw
-  // inside installService, and surfaced as a generic "Install failed".
-  const svcBlankPkg = {
-    ...baseEntry,
-    slug: 'svc-blank',
-    name: 'Service Blank',
-    install: {
-      kind: 'service',
-      runtime: 'npm-global',
-      npmGlobal: { package: '   ', version: '1.0.0' },
-    },
-    trustTier: 'verified',
-  } as unknown as IntegrationEntry;
-
-  // A runtime the CLI does not automate at all. Readable, and this branch is now
-  // its public install behaviour.
-  const svcBinary = {
-    ...baseEntry,
-    slug: 'svc-binary',
-    name: 'Service Binary',
-    install: {
-      kind: 'service',
-      runtime: 'binary',
-      binary: { url: 'https://example.com/svc' },
-    },
-    trustTier: 'verified',
-  } as unknown as IntegrationEntry;
-
-  let savedIndex: string | undefined;
-  let savedRaw: string | undefined;
-
-  beforeEach(() => {
-    savedIndex = process.env.DKG_REGISTRY_INDEX_URL;
-    savedRaw = process.env.DKG_REGISTRY_RAW_BASE;
-    // commands.ts calls resolveRegistryConfig() with no argument, so the
-    // redirect has to happen through the real environment.
-    process.env.DKG_REGISTRY_INDEX_URL = `${registryBase}/index`;
-    process.env.DKG_REGISTRY_RAW_BASE = `${registryBase}/raw`;
-
-    for (const e of [
-      alpha,
-      beta,
-      communityOnly,
-      mcpNoArgs,
-      svcEntry,
-      svcNoMeta,
-      svcBinary,
-      svcBlankPkg,
-    ]) {
-      registryRoutes.set(`/raw/${e.slug}.json`, { status: 200, body: JSON.stringify(e) });
-    }
-    // Only the manual entries are indexed: `installed` runs detectInstalled over
-    // everything the index returns, and keeping npm-backed kinds out of it means
-    // no test here ever shells out to npm. `install <slug>` fetches by slug, so
-    // the service entries are still reachable by the install tests below.
-    registryRoutes.set('/index', {
-      status: 200,
-      body: JSON.stringify([alpha, beta, communityOnly].map((e) => ({ name: `${e.slug}.json` }))),
-    });
-  });
-
-  afterEach(() => {
-    if (savedIndex === undefined) delete process.env.DKG_REGISTRY_INDEX_URL;
-    else process.env.DKG_REGISTRY_INDEX_URL = savedIndex;
-    if (savedRaw === undefined) delete process.env.DKG_REGISTRY_RAW_BASE;
-    else process.env.DKG_REGISTRY_RAW_BASE = savedRaw;
-  });
-
-  /** Runs the real command tree and returns whatever it printed to stdout. */
-  async function runCli(argv: string[]): Promise<string> {
-    const program = new Command();
-    program.exitOverride(); // never let a parse error kill the test runner
-    registerIntegrationCommands(program);
-    const out: string[] = [];
-    const spy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
-      out.push(args.map(String).join(' '));
-    });
-    try {
-      await program.parseAsync(['node', 'dkg', ...argv]);
-    } finally {
-      spy.mockRestore();
-    }
-    return out.join('\n');
-  }
-
-  it('`search <keyword> --json` filters by the keyword', async () => {
-    const parsed = JSON.parse(await runCli(['integration', 'search', 'alpha', '--json']));
-    expect(parsed.entries.map((e: IntegrationEntry) => e.slug)).toEqual(['alpha-chat']);
-  });
-
-  // The control for the test above: without it, a `search` that dropped its
-  // keyword and returned everything would still need the filtered case to fail,
-  // but a `search` that returned NOTHING would pass it vacuously.
-  it('`search --json` with no keyword returns every entry at the tier', async () => {
-    const parsed = JSON.parse(await runCli(['integration', 'search', '--json']));
-    expect(parsed.entries.map((e: IntegrationEntry) => e.slug).sort()).toEqual([
-      'alpha-chat',
-      'beta-graph',
-    ]);
-  });
-
-  it('`list --json` keeps its shipped { entries, failures } envelope', async () => {
-    const parsed = JSON.parse(await runCli(['integration', 'list', '--json']));
-    expect(Object.keys(parsed).sort()).toEqual(['entries', 'failures']);
-    expect(parsed.entries.map((e: IntegrationEntry) => e.slug).sort()).toEqual([
-      'alpha-chat',
-      'beta-graph',
-    ]);
-  });
-
-  // `installed` reports something different from `list`/`search`, so it prints a
-  // different key. Printing `{ entries }` here would silently look like a
-  // registry listing to any script consuming it.
-  it('`installed --json` prints { installed, failures }, never { entries }', async () => {
-    const parsed = JSON.parse(await runCli(['integration', 'installed', '--json']));
-    expect(Object.keys(parsed).sort()).toEqual(['failures', 'installed']);
-    expect(parsed.entries).toBeUndefined();
-    expect(Array.isArray(parsed.installed)).toBe(true);
-  });
-
-  // The two verbs deliberately default to different tiers: browsing surfaces
-  // vetted entries, while "what is on my machine" must not hide a
-  // community-tier install the user actually has.
-  it('defaults `search` to verified but `installed` to community', async () => {
-    const searched = JSON.parse(await runCli(['integration', 'search', '--json']));
-    expect(searched.entries.map((e: IntegrationEntry) => e.slug)).not.toContain('gamma-tool');
-
-    const inst = JSON.parse(await runCli(['integration', 'installed', '--json']));
-    expect(inst.installed.map((r: { slug: string }) => r.slug)).toContain('gamma-tool');
-  });
-
-  it('routes a detectable registry entry through real installed detection', async () => {
-    const fakeBin = await mkdtemp(join(tmpdir(), 'dkg-integration-npm-'));
-    const originalPath = process.env.PATH;
-    const npmResult = JSON.stringify({
-      dependencies: { '@acme/svc': { version: '2.0.0' } },
-    });
-    await writeFile(
-      join(fakeBin, 'npm'),
-      `#!/usr/bin/env node\nprocess.stdout.write(${JSON.stringify(npmResult)});\n`,
-      'utf8',
-    );
-    await chmod(join(fakeBin, 'npm'), 0o755);
-    await writeFile(
-      join(fakeBin, 'npm.cmd'),
-      `@echo off\r\necho ${npmResult}\r\n`,
-      'utf8',
-    );
-    process.env.PATH = [fakeBin, originalPath].filter(Boolean).join(delimiter);
-    registryRoutes.set('/index', {
-      status: 200,
-      body: JSON.stringify([alpha, svcEntry].map((entry) => ({ name: `${entry.slug}.json` }))),
-    });
-
-    try {
-      const parsed = JSON.parse(await runCli(['integration', 'installed', '--json']));
-      expect(parsed.installed).toContainEqual({
-        slug: 'svc-ok',
-        kind: 'service',
-        state: 'installed',
-        detail: '@acme/svc@2.0.0',
-      });
-    } finally {
-      if (originalPath === undefined) delete process.env.PATH;
-      else process.env.PATH = originalPath;
-      await rm(fakeBin, { recursive: true, force: true });
-    }
-  });
-
-  it('prints schema-valid MCP entries with no args through `info`', async () => {
-    const output = await runCli(['integration', 'info', mcpNoArgs.slug]);
-    expect(output).toContain('MCP No Args  [verified]');
-    expect(output).toContain('command:    my-mcp-server (no args declared)');
-  });
-
-  it('`search --tier community --json` widens to community entries', async () => {
-    const parsed = JSON.parse(await runCli(['integration', 'search', '--tier', 'community', '--json']));
-    expect(parsed.entries.map((e: IntegrationEntry) => e.slug).sort()).toEqual([
-      'alpha-chat',
-      'beta-graph',
-      'gamma-tool',
-    ]);
-  });
-
-  // ── install dispatch ────────────────────────────────────────────────────
-  // The branches below are reachable only through the command; the helpers
-  // cannot tell you whether the dispatcher picked the right one or forwarded
-  // its options. Exit codes are captured rather than allowed to run, or a
-  // process.exit would take the test runner with it.
-  async function runInstall(
-    argv: string[],
-  ): Promise<{ out: string; err: string; exit: number | null; exits: number[] }> {
-    const program = new Command();
-    program.exitOverride();
-    registerIntegrationCommands(program);
-    const out: string[] = [];
-    const err: string[] = [];
-    const exits: number[] = [];
-    let exit: number | null = null;
-    const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
-      out.push(a.map(String).join(' '));
-    });
-    const errSpy = vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
-      err.push(a.map(String).join(' '));
-    });
-    // Records rather than throws. Throwing would be caught by the command's own
-    // try/catch, which then calls process.exit(1) — turning every asserted exit
-    // code into 1 and hiding which branch actually ran. Only the FIRST code is
-    // kept for the same reason: it is the one the real process would have used.
-    // The spy RECORDS rather than throws, because throwing is caught by the
-    // command's own try/catch and converted into exit(1) — which collapses
-    // every asserted exit code to 1 and hides which branch ran.
-    //
-    // The cost of not throwing is that execution CONTINUES past a simulated
-    // exit, so a missing `break` would let a branch fall through into the
-    // generic failure path while `exit` still reports the first code. Every
-    // code is therefore recorded: `exits` having more than one entry means the
-    // real process would already have terminated, and the test is observing
-    // code that could never run.
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
-      exits.push(code ?? 0);
-      if (exit === null) exit = code ?? 0;
-      return undefined;
-    }) as never);
-    try {
-      await program.parseAsync(['node', 'dkg', ...argv]);
-    } finally {
-      logSpy.mockRestore();
-      errSpy.mockRestore();
-      exitSpy.mockRestore();
-    }
-    return { out: out.join('\n'), err: err.join('\n'), exit, exits };
-  }
-
-  it('`install <manual>` prints the docs link and does not exit non-zero', async () => {
-    const r = await runInstall(['integration', 'install', 'alpha-chat']);
-    expect(r.exit).toBeNull();
-    expect(r.out).toContain('https://example.com/README.md');
-  });
-
-  it('`install <npm-global service> --dry-run` reaches the service installer with the pin', async () => {
-    const r = await runInstall(['integration', 'install', 'svc-ok', '--dry-run']);
-    expect(r.exit).toBeNull();
-    // Proves dispatch reached installService AND that --dry-run was forwarded.
-    expect(r.out).toContain('@acme/svc@2.0.0');
-    expect(r.out).toContain('Dry-run');
-  });
-
-  // A schema-valid npm-global service with no npmGlobal block cannot be
-  // automated. It must take the same graceful path docker/binary take, not
-  // throw out of installService into the generic "install failed".
-  it('`install` falls back gracefully for an npm-global service with no package metadata', async () => {
-    const r = await runInstall(['integration', 'install', 'svc-bare']);
-    expect(r.err).toContain('no npmGlobal.package/version');
-    expect(r.err).not.toMatch(/undefined/);
-    // Exactly one exit. Asserting only the FIRST code would still pass if the
-    // branch lost its `break` and fell through into installService, printing
-    // the graceful message and then the generic failure — the regression this
-    // test exists to catch.
-    expect(r.exits).toEqual([2]);
-    expect(r.err).not.toContain('Install failed');
-  });
-
-  // Regression guard for a fix that was previously verified only BELOW this
-  // boundary. `installService` accepted and rendered `apiUrl` correctly, and its
-  // unit test passed — while the command never passed the flag through, so the
-  // real CLI still printed the default node. Only a test that drives the actual
-  // command can catch a missing property on the call.
-  it('`install --api-url` reaches the service post-install guidance', async () => {
-    const r = await runInstall([
-      'integration',
-      'install',
-      'svc-ok',
-      '--dry-run',
-      '--api-url',
-      'http://10.0.0.5:9200',
-    ]);
-    expect(r.exits).toEqual([]);
-    expect(r.out).toContain('http://10.0.0.5:9200');
-    expect(r.out).not.toContain('default http://127.0.0.1:9200');
-  });
-
-  // Control: without the flag the guidance still renders, showing the effective
-  // node — so the test above cannot pass by never printing the DKG_API_URL line.
-  // Commander gives --api-url a default, so opts.apiUrl is always populated and
-  // the command path always echoes the URL actually in effect; the literal
-  // "default …" wording only appears for direct installService callers that
-  // pass no apiUrl at all.
-  it('`install --dry-run` shows the effective node when no --api-url is given', async () => {
-    const r = await runInstall(['integration', 'install', 'svc-ok', '--dry-run']);
-    expect(r.out).toContain('DKG_API_URL');
-    expect(r.out).toContain('http://127.0.0.1:9200');
-    expect(r.out).not.toContain('10.0.0.5');
-  });
-
-  // The gap between the two gates: registry-valid, whitespace package. It must
-  // take the same graceful path as missing metadata, not fall through to the
-  // generic failure because one layer checked truthiness and the other trimmed.
-  it('`install` treats a whitespace-only package as not automatable, not a hard failure', async () => {
-    const r = await runInstall(['integration', 'install', 'svc-blank']);
-    expect(r.exits).toEqual([2]);
-    expect(r.err).toContain('no npmGlobal.package/version');
-    expect(r.err).not.toContain('Install failed');
-  });
-
-  // Making docker/binary services readable also made this branch their public
-  // install behaviour. A regression routing them into installService would
-  // surface a generic "Install failed" (exit 1) instead of the graceful
-  // runtime-not-automated message — and no helper test would notice.
-  it('`install` gives a non-automated runtime the graceful path, not a generic failure', async () => {
-    const r = await runInstall(['integration', 'install', 'svc-binary']);
-    expect(r.exits).toEqual([2]);
-    expect(r.err).toContain('binary');
-    expect(r.err).toContain('not yet');
-    // The generic catch-all path would say this instead.
-    expect(r.err).not.toContain('Install failed');
   });
 });


### PR DESCRIPTION
## Summary
- add a Commander-level `integration installed --json` case with a detectable npm-global service
- use portable temp `npm` and `npm.cmd` shims so the test never reads the developer or CI host global npm state
- assert the public command reports the exact installed row, so dropping candidates or bypassing `detectInstalled` fails the test
- cover `integration info` for a schema-valid args-less MCP entry

## Verification
- `pnpm exec vitest run test/integrations.test.ts` (71 passed)
- `pnpm lint`

Closes #1998