### PR TITLE
fix(tooling): use canonical testnet network ID

### DIFF
--- a/scripts/lib/__tests__/testnet-publish-stress-preflight.test.mjs
+++ b/scripts/lib/__tests__/testnet-publish-stress-preflight.test.mjs
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '../../..');
+const PREFLIGHT = path.join(REPO_ROOT, 'scripts/testnet-publish-stress/preflight.mjs');
+
+async function networkIdFrom(relativePath) {
+  const contents = await readFile(path.join(REPO_ROOT, relativePath), 'utf8');
+  return JSON.parse(contents).networkId;
+}
+
+async function runPreflight(networkId) {
+  const requests = [];
+  const server = createServer((req, res) => {
+    requests.push(`${req.method} ${req.url}`);
+    res.setHeader('Content-Type', 'application/json');
+    if (req.url === '/api/status') {
+      res.end(JSON.stringify({
+        name: 'test',
+        version: 'test',
+        nodeRole: 'edge',
+        networkName: 'testnet',
+        networkId,
+        identityId: 'test',
+        hasIdentity: true,
+        connectedPeers: 0,
+      }));
+      return;
+    }
+
+    // A valid testnet ID gets past the guard. Stop there so this test never
+    // creates a context graph or performs any other write.
+    res.statusCode = 500;
+    res.end(JSON.stringify({ error: 'test stop' }));
+  });
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const address = server.address();
+  assert.notEqual(address, null);
+  assert.equal(typeof address, 'object');
+  const tempDirectory = await mkdtemp(path.join(tmpdir(), 'dkg-preflight-'));
+  const tokenFile = path.join(tempDirectory, 'auth.token');
+  await writeFile(tokenFile, 'test-token\n');
+
+  try {
+    const child = spawn(process.execPath, [PREFLIGHT], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        DKG_HOST: `http://127.0.0.1:${address.port}`,
+        DKG_TOKEN_FILE: tokenFile,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    const exitCode = await new Promise((resolve, reject) => {
+      child.once('error', reject);
+      child.once('close', resolve);
+    });
+    return { exitCode, requests, stderr, stdout };
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve());
+    });
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+}
+
+test('publish-stress preflight follows the canonical testnet network ID', async () => {
+  const canonicalTestnetId = await networkIdFrom('network/testnet.json');
+  const result = await runPreflight(canonicalTestnetId);
+
+  assert.equal(result.exitCode, 1, result.stderr);
+  assert.deepEqual(result.requests, [
+    'GET /api/status',
+    'GET /api/wallets/balances',
+  ]);
+  assert.match(result.stderr, /wallets failed: HTTP 500/);
+});
+
+test('publish-stress preflight rejects mainnet before balances or writes', async () => {
+  const mainnetId = await networkIdFrom('network/mainnet-base.json');
+  const result = await runPreflight(mainnetId);
+
+  assert.equal(result.exitCode, 2, result.stderr);
+  assert.deepEqual(result.requests, ['GET /api/status']);
+  assert.match(result.stderr, /Aborting\./);
+});
+
+test('publish-stress preflight rejects unrelated networks before balances or writes', async () => {
+  const result = await runPreflight('unrelated-test-network');
+
+  assert.equal(result.exitCode, 2, result.stderr);
+  assert.deepEqual(result.requests, ['GET /api/status']);
+  assert.match(result.stderr, /Aborting\./);
+});

--- a/scripts/lib/__tests__/testnet-publish-stress-preflight.test.mjs
+++ b/scripts/lib/__tests__/testnet-publish-stress-preflight.test.mjs
@@ -1,111 +1,108 @@
 import assert from 'node:assert/strict';
-import { spawn } from 'node:child_process';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
-import { createServer } from 'node:http';
-import { tmpdir } from 'node:os';
+import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { runPreflight } from '../../testnet-publish-stress/preflight-runner.mjs';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, '../../..');
-const PREFLIGHT = path.join(REPO_ROOT, 'scripts/testnet-publish-stress/preflight.mjs');
 
 async function networkIdFrom(relativePath) {
   const contents = await readFile(path.join(REPO_ROOT, relativePath), 'utf8');
   return JSON.parse(contents).networkId;
 }
 
-async function runPreflight(networkId) {
+async function runNetworkScenario(networkId, expectedNetworkId) {
   const requests = [];
-  const server = createServer((req, res) => {
-    requests.push(`${req.method} ${req.url}`);
-    res.setHeader('Content-Type', 'application/json');
-    if (req.url === '/api/status') {
-      res.end(JSON.stringify({
-        name: 'test',
-        version: 'test',
-        nodeRole: 'edge',
-        networkName: 'testnet',
-        networkId,
-        identityId: 'test',
-        hasIdentity: true,
-        connectedPeers: 0,
-      }));
-      return;
+  const logLines = [];
+  const apiCall = async (method, requestPath) => {
+    requests.push(`${method} ${requestPath}`);
+    assert.equal(method, 'GET', 'network-ID coverage must never issue a write');
+    if (requestPath === '/api/status') {
+      return {
+        ok: true,
+        status: 200,
+        json: {
+          name: 'test',
+          version: 'test',
+          nodeRole: 'edge',
+          networkName: 'testnet',
+          networkId,
+          identityId: 'test',
+          hasIdentity: true,
+          connectedPeers: 0,
+        },
+      };
     }
+    if (requestPath === '/api/wallets/balances') {
+      return {
+        ok: true,
+        status: 200,
+        json: {
+          balances: [{ address: '0x1', eth: '1', trac: '50', symbol: 'TRAC' }],
+          symbol: 'TRAC',
+          rpcUrl: 'http://unused.invalid',
+          chainId: 84532,
+        },
+      };
+    }
+    if (requestPath === '/api/context-graph/list') {
+      return {
+        ok: true,
+        status: 200,
+        json: {
+          contextGraphs: [{
+            id: 'did:dkg:base:84532/test-agent/miles-publish-stress-test',
+            onChainId: '0x01',
+          }],
+        },
+      };
+    }
+    assert.fail(`unexpected API request: ${method} ${requestPath}`);
+  };
 
-    // A valid testnet ID gets past the guard. Stop there so this test never
-    // creates a context graph or performs any other write.
-    res.statusCode = 500;
-    res.end(JSON.stringify({ error: 'test stop' }));
+  const outcome = await runPreflight({
+    apiCall,
+    expectedNetworkId,
+    runId: 'test',
+    log: (message) => logLines.push(message),
   });
-  await new Promise((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(0, '127.0.0.1', resolve);
-  });
-
-  const address = server.address();
-  assert.notEqual(address, null);
-  assert.equal(typeof address, 'object');
-  const tempDirectory = await mkdtemp(path.join(tmpdir(), 'dkg-preflight-'));
-  const tokenFile = path.join(tempDirectory, 'auth.token');
-  await writeFile(tokenFile, 'test-token\n');
-
-  try {
-    const child = spawn(process.execPath, [PREFLIGHT], {
-      cwd: REPO_ROOT,
-      env: {
-        ...process.env,
-        DKG_HOST: `http://127.0.0.1:${address.port}`,
-        DKG_TOKEN_FILE: tokenFile,
-      },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    let stdout = '';
-    let stderr = '';
-    child.stdout.setEncoding('utf8');
-    child.stderr.setEncoding('utf8');
-    child.stdout.on('data', (chunk) => { stdout += chunk; });
-    child.stderr.on('data', (chunk) => { stderr += chunk; });
-    const exitCode = await new Promise((resolve, reject) => {
-      child.once('error', reject);
-      child.once('close', resolve);
-    });
-    return { exitCode, requests, stderr, stdout };
-  } finally {
-    await new Promise((resolve, reject) => {
-      server.close((error) => error ? reject(error) : resolve());
-    });
-    await rm(tempDirectory, { recursive: true, force: true });
-  }
+  return { outcome, requests, stderr: logLines.join('\n') };
 }
 
 test('publish-stress preflight follows the canonical testnet network ID', async () => {
   const canonicalTestnetId = await networkIdFrom('network/testnet.json');
-  const result = await runPreflight(canonicalTestnetId);
+  const result = await runNetworkScenario(canonicalTestnetId, canonicalTestnetId);
 
-  assert.equal(result.exitCode, 1, result.stderr);
+  assert.deepEqual(result.outcome, {
+    exitCode: 0,
+    reason: 'ready',
+    resolvedCgId: 'did:dkg:base:84532/test-agent/miles-publish-stress-test',
+    onChainId: '0x01',
+  });
   assert.deepEqual(result.requests, [
     'GET /api/status',
     'GET /api/wallets/balances',
+    'GET /api/context-graph/list',
   ]);
-  assert.match(result.stderr, /wallets failed: HTTP 500/);
 });
 
 test('publish-stress preflight rejects mainnet before balances or writes', async () => {
   const mainnetId = await networkIdFrom('network/mainnet-base.json');
-  const result = await runPreflight(mainnetId);
+  const canonicalTestnetId = await networkIdFrom('network/testnet.json');
+  const result = await runNetworkScenario(mainnetId, canonicalTestnetId);
 
-  assert.equal(result.exitCode, 2, result.stderr);
+  assert.deepEqual(result.outcome, { exitCode: 2, reason: 'network_mismatch' });
   assert.deepEqual(result.requests, ['GET /api/status']);
   assert.match(result.stderr, /Aborting\./);
 });
 
 test('publish-stress preflight rejects unrelated networks before balances or writes', async () => {
-  const result = await runPreflight('unrelated-test-network');
+  const canonicalTestnetId = await networkIdFrom('network/testnet.json');
+  const result = await runNetworkScenario('unrelated-test-network', canonicalTestnetId);
 
-  assert.equal(result.exitCode, 2, result.stderr);
+  assert.deepEqual(result.outcome, { exitCode: 2, reason: 'network_mismatch' });
   assert.deepEqual(result.requests, ['GET /api/status']);
   assert.match(result.stderr, /Aborting\./);
 });

--- a/scripts/lib/__tests__/testnet-publish-stress-preflight.test.mjs
+++ b/scripts/lib/__tests__/testnet-publish-stress-preflight.test.mjs
@@ -1,5 +1,9 @@
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -11,6 +15,80 @@ const REPO_ROOT = path.resolve(HERE, '../../..');
 async function networkIdFrom(relativePath) {
   const contents = await readFile(path.join(REPO_ROOT, relativePath), 'utf8');
   return JSON.parse(contents).networkId;
+}
+
+async function runEntrypointScenario(networkId) {
+  const requests = [];
+  const server = createServer((request, response) => {
+    requests.push(`${request.method} ${request.url}`);
+    assert.equal(request.headers.authorization, 'Bearer test-token');
+    response.setHeader('content-type', 'application/json');
+    if (request.url === '/api/status') {
+      response.end(JSON.stringify({
+        name: 'test',
+        version: 'test',
+        nodeRole: 'edge',
+        networkName: 'testnet',
+        networkId,
+        identityId: 'test',
+        hasIdentity: true,
+        connectedPeers: 0,
+      }));
+      return;
+    }
+    if (request.url === '/api/wallets/balances') {
+      response.end(JSON.stringify({
+        balances: [{ address: '0x1', eth: '1', trac: '50', symbol: 'TRAC' }],
+        symbol: 'TRAC',
+        rpcUrl: 'http://unused.invalid',
+        chainId: 84532,
+      }));
+      return;
+    }
+    if (request.url === '/api/context-graph/list') {
+      response.end(JSON.stringify({
+        contextGraphs: [{
+          id: 'did:dkg:base:84532/test-agent/miles-publish-stress-test',
+          onChainId: '0x01',
+        }],
+      }));
+      return;
+    }
+    response.statusCode = 500;
+    response.end(JSON.stringify({ error: 'unexpected request' }));
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'dkg-preflight-test-'));
+  const tokenFile = path.join(tempDir, 'auth.token');
+  await writeFile(tokenFile, '# test\ntest-token\n');
+  const child = spawn(
+    process.execPath,
+    [path.join(REPO_ROOT, 'scripts/testnet-publish-stress/preflight.mjs')],
+    {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        DKG_HOST: `http://127.0.0.1:${address.port}`,
+        DKG_TOKEN_FILE: tokenFile,
+        STRESS_RUN_ID: 'test',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  let stderr = '';
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk) => { stderr += chunk; });
+  try {
+    const [exitCode] = await once(child, 'close');
+    return { exitCode, requests, stderr };
+  } finally {
+    server.close();
+    await once(server, 'close');
+    await rm(tempDir, { recursive: true, force: true });
+  }
 }
 
 async function runNetworkScenario(networkId, expectedNetworkId) {
@@ -73,14 +151,9 @@ async function runNetworkScenario(networkId, expectedNetworkId) {
 
 test('publish-stress preflight follows the canonical testnet network ID', async () => {
   const canonicalTestnetId = await networkIdFrom('network/testnet.json');
-  const result = await runNetworkScenario(canonicalTestnetId, canonicalTestnetId);
+  const result = await runEntrypointScenario(canonicalTestnetId);
 
-  assert.deepEqual(result.outcome, {
-    exitCode: 0,
-    reason: 'ready',
-    resolvedCgId: 'did:dkg:base:84532/test-agent/miles-publish-stress-test',
-    onChainId: '0x01',
-  });
+  assert.equal(result.exitCode, 0);
   assert.deepEqual(result.requests, [
     'GET /api/status',
     'GET /api/wallets/balances',
@@ -90,10 +163,9 @@ test('publish-stress preflight follows the canonical testnet network ID', async 
 
 test('publish-stress preflight rejects mainnet before balances or writes', async () => {
   const mainnetId = await networkIdFrom('network/mainnet-base.json');
-  const canonicalTestnetId = await networkIdFrom('network/testnet.json');
-  const result = await runNetworkScenario(mainnetId, canonicalTestnetId);
+  const result = await runEntrypointScenario(mainnetId);
 
-  assert.deepEqual(result.outcome, { exitCode: 2, reason: 'network_mismatch' });
+  assert.equal(result.exitCode, 2);
   assert.deepEqual(result.requests, ['GET /api/status']);
   assert.match(result.stderr, /Aborting\./);
 });
@@ -102,7 +174,7 @@ test('publish-stress preflight rejects unrelated networks before balances or wri
   const canonicalTestnetId = await networkIdFrom('network/testnet.json');
   const result = await runNetworkScenario('unrelated-test-network', canonicalTestnetId);
 
-  assert.deepEqual(result.outcome, { exitCode: 2, reason: 'network_mismatch' });
+  assert.equal(result.outcome, 2);
   assert.deepEqual(result.requests, ['GET /api/status']);
   assert.match(result.stderr, /Aborting\./);
 });

--- a/scripts/testnet-publish-stress/preflight-runner.mjs
+++ b/scripts/testnet-publish-stress/preflight-runner.mjs
@@ -1,5 +1,3 @@
-const DEFAULT_RUN_ID = '26may';
-
 function bar(log, label) {
   log(`\n=== ${label} ===`);
 }
@@ -10,14 +8,14 @@ function bar(log, label) {
  * @param {object} options
  * @param {(method: string, path: string, body?: unknown) => Promise<{ok: boolean, status: number, json: any}>} options.apiCall
  * @param {string} options.expectedNetworkId
- * @param {string} [options.runId]
+ * @param {string} options.runId Fully resolved by the entry point.
  * @param {(message: string) => void} [options.log]
  * @returns {Promise<{exitCode: number, reason: string, resolvedCgId?: string | null, onChainId?: string | null}>}
  */
 export async function runPreflight({
   apiCall,
   expectedNetworkId,
-  runId = DEFAULT_RUN_ID,
+  runId,
   log = console.error,
 }) {
   const cgShortId = `miles-publish-stress-${runId}`;

--- a/scripts/testnet-publish-stress/preflight-runner.mjs
+++ b/scripts/testnet-publish-stress/preflight-runner.mjs
@@ -1,0 +1,124 @@
+const DEFAULT_RUN_ID = '26may';
+
+function bar(log, label) {
+  log(`\n=== ${label} ===`);
+}
+
+/**
+ * Run the publish-stress preflight without owning transport or process state.
+ *
+ * @param {object} options
+ * @param {(method: string, path: string, body?: unknown) => Promise<{ok: boolean, status: number, json: any}>} options.apiCall
+ * @param {string} options.expectedNetworkId
+ * @param {string} [options.runId]
+ * @param {(message: string) => void} [options.log]
+ * @returns {Promise<{exitCode: number, reason: string, resolvedCgId?: string | null, onChainId?: string | null}>}
+ */
+export async function runPreflight({
+  apiCall,
+  expectedNetworkId,
+  runId = DEFAULT_RUN_ID,
+  log = console.error,
+}) {
+  const cgShortId = `miles-publish-stress-${runId}`;
+  const cgName = `Miles publish stress (${runId})`;
+  const cgDescription =
+    'Auto-created by scripts/testnet-publish-stress/preflight.mjs. ' +
+    'Hosts a stream of Wikidata-music KCs published from Miles\' edge node ' +
+    'against Base Sepolia (84532) to stress-test V10 publishing + give the ' +
+    'on-chain RandomSampling prover something to sample.';
+
+  bar(log, '1. Daemon status');
+  const status = await apiCall('GET', '/api/status');
+  if (!status.ok) {
+    log(`status failed: HTTP ${status.status}`);
+    return { exitCode: 1, reason: 'status_failed' };
+  }
+  const daemon = status.json;
+  log(`name=${daemon.name} version=${daemon.version} role=${daemon.nodeRole} network=${daemon.networkName} identity=${daemon.identityId} (has=${daemon.hasIdentity}) peers=${daemon.connectedPeers}`);
+  if (daemon.networkId !== expectedNetworkId) {
+    log(`WARN: networkId=${daemon.networkId} expected ${expectedNetworkId} (DKG V10 Testnet). Aborting.`);
+    return { exitCode: 2, reason: 'network_mismatch' };
+  }
+
+  bar(log, '2. Wallets');
+  const wallets = await apiCall('GET', '/api/wallets/balances');
+  if (!wallets.ok) {
+    log(`wallets failed: HTTP ${wallets.status}`);
+    return { exitCode: 1, reason: 'wallets_failed' };
+  }
+  for (const wallet of wallets.json.balances) {
+    log(`  ${wallet.address}  ETH=${wallet.eth}  ${wallet.symbol}=${wallet.trac}`);
+  }
+  const tracTotal = wallets.json.balances.reduce((sum, wallet) => sum + parseFloat(wallet.trac), 0);
+  const ethTotal = wallets.json.balances.reduce((sum, wallet) => sum + parseFloat(wallet.eth), 0);
+  log(`  TOTAL  ETH=${ethTotal.toFixed(6)}  ${wallets.json.symbol}=${tracTotal.toFixed(4)}`);
+  log(`  RPC: ${wallets.json.rpcUrl}  chain=${wallets.json.chainId}`);
+  if (tracTotal < 50) {
+    log('ERROR: total TRAC < 50; cannot proceed. Top up the operational wallets.');
+    return { exitCode: 2, reason: 'insufficient_trac' };
+  }
+
+  bar(log, '3. List existing context graphs');
+  let alreadyExists = false;
+  let resolvedCgId = null;
+  let onChainId = null;
+  const contextGraphs = await apiCall('GET', '/api/context-graph/list');
+  if (contextGraphs.ok && Array.isArray(contextGraphs.json.contextGraphs)) {
+    const match = contextGraphs.json.contextGraphs.find(
+      (cg) => cg.id === cgShortId || cg.id?.endsWith(`/${cgShortId}`),
+    );
+    if (match) {
+      alreadyExists = true;
+      resolvedCgId = match.id;
+      onChainId = match.onChainId;
+      log(`  Already present: id=${resolvedCgId} onChainId=${onChainId ?? '(local-only)'}`);
+    } else {
+      log(`  ${contextGraphs.json.contextGraphs.length} other CG(s) present; '${cgShortId}' not yet created.`);
+    }
+  } else {
+    log('  (no /api/context-graph/list response — will attempt create anyway)');
+  }
+
+  if (!alreadyExists) {
+    bar(log, '4. Create context graph + register on-chain');
+    const create = await apiCall('POST', '/api/context-graph/create', {
+      id: cgShortId,
+      name: cgName,
+      description: cgDescription,
+      accessPolicy: 0,
+      publishPolicy: 1,
+      register: true,
+    });
+    if (!create.ok) {
+      log(`create failed: HTTP ${create.status}: ${JSON.stringify(create.json).slice(0, 500)}`);
+      return { exitCode: 1, reason: 'create_failed' };
+    }
+    if (create.json.registered === false) {
+      log(`CG created LOCALLY only — on-chain register failed: ${create.json.registerError}`);
+      log('Cannot publish without on-chain CG. Investigate before continuing.');
+      return { exitCode: 2, reason: 'registration_failed' };
+    }
+    resolvedCgId = create.json.created;
+    onChainId = create.json.onChainId;
+    log(`  Created and registered: id=${resolvedCgId} onChainId=${onChainId} uri=${create.json.uri}`);
+  }
+
+  bar(log, '5. Resolved CG ID for publish-loop');
+  log(`  CG short id : ${cgShortId}`);
+  log(`  CG full id  : ${resolvedCgId}`);
+  log(`  On-chain id : ${onChainId}`);
+  log('');
+  log('Plumb into publish-loop.mjs via:');
+  log(`  export CG_ID=${resolvedCgId}`);
+  log('');
+  log('Next step:');
+  log(`  CG_ID=${resolvedCgId} PHASE=calibrate node scripts/testnet-publish-stress/publish-loop.mjs`);
+
+  return {
+    exitCode: 0,
+    reason: 'ready',
+    resolvedCgId,
+    onChainId,
+  };
+}

--- a/scripts/testnet-publish-stress/preflight-runner.mjs
+++ b/scripts/testnet-publish-stress/preflight-runner.mjs
@@ -10,7 +10,7 @@ function bar(log, label) {
  * @param {string} options.expectedNetworkId
  * @param {string} options.runId Fully resolved by the entry point.
  * @param {(message: string) => void} [options.log]
- * @returns {Promise<{exitCode: number, reason: string, resolvedCgId?: string | null, onChainId?: string | null}>}
+ * @returns {Promise<number>} Process exit code for the executable entry point.
  */
 export async function runPreflight({
   apiCall,
@@ -30,20 +30,20 @@ export async function runPreflight({
   const status = await apiCall('GET', '/api/status');
   if (!status.ok) {
     log(`status failed: HTTP ${status.status}`);
-    return { exitCode: 1, reason: 'status_failed' };
+    return 1;
   }
   const daemon = status.json;
   log(`name=${daemon.name} version=${daemon.version} role=${daemon.nodeRole} network=${daemon.networkName} identity=${daemon.identityId} (has=${daemon.hasIdentity}) peers=${daemon.connectedPeers}`);
   if (daemon.networkId !== expectedNetworkId) {
     log(`WARN: networkId=${daemon.networkId} expected ${expectedNetworkId} (DKG V10 Testnet). Aborting.`);
-    return { exitCode: 2, reason: 'network_mismatch' };
+    return 2;
   }
 
   bar(log, '2. Wallets');
   const wallets = await apiCall('GET', '/api/wallets/balances');
   if (!wallets.ok) {
     log(`wallets failed: HTTP ${wallets.status}`);
-    return { exitCode: 1, reason: 'wallets_failed' };
+    return 1;
   }
   for (const wallet of wallets.json.balances) {
     log(`  ${wallet.address}  ETH=${wallet.eth}  ${wallet.symbol}=${wallet.trac}`);
@@ -54,7 +54,7 @@ export async function runPreflight({
   log(`  RPC: ${wallets.json.rpcUrl}  chain=${wallets.json.chainId}`);
   if (tracTotal < 50) {
     log('ERROR: total TRAC < 50; cannot proceed. Top up the operational wallets.');
-    return { exitCode: 2, reason: 'insufficient_trac' };
+    return 2;
   }
 
   bar(log, '3. List existing context graphs');
@@ -90,12 +90,12 @@ export async function runPreflight({
     });
     if (!create.ok) {
       log(`create failed: HTTP ${create.status}: ${JSON.stringify(create.json).slice(0, 500)}`);
-      return { exitCode: 1, reason: 'create_failed' };
+      return 1;
     }
     if (create.json.registered === false) {
       log(`CG created LOCALLY only — on-chain register failed: ${create.json.registerError}`);
       log('Cannot publish without on-chain CG. Investigate before continuing.');
-      return { exitCode: 2, reason: 'registration_failed' };
+      return 2;
     }
     resolvedCgId = create.json.created;
     onChainId = create.json.onChainId;
@@ -113,10 +113,5 @@ export async function runPreflight({
   log('Next step:');
   log(`  CG_ID=${resolvedCgId} PHASE=calibrate node scripts/testnet-publish-stress/publish-loop.mjs`);
 
-  return {
-    exitCode: 0,
-    reason: 'ready',
-    resolvedCgId,
-    onChainId,
-  };
+  return 0;
 }

--- a/scripts/testnet-publish-stress/preflight.mjs
+++ b/scripts/testnet-publish-stress/preflight.mjs
@@ -26,6 +26,14 @@ const CG_DESCRIPTION =
   'Hosts a stream of Wikidata-music KCs published from Miles\' edge node ' +
   'against Base Sepolia (84532) to stress-test V10 publishing + give the ' +
   'on-chain RandomSampling prover something to sample.';
+const TESTNET_CONFIG_URL = new URL('../../network/testnet.json', import.meta.url);
+const TESTNET_NETWORK_ID = JSON.parse(
+  await readFile(TESTNET_CONFIG_URL, 'utf8'),
+).networkId;
+
+if (typeof TESTNET_NETWORK_ID !== 'string' || TESTNET_NETWORK_ID.length === 0) {
+  throw new Error(`Missing networkId in ${TESTNET_CONFIG_URL.pathname}`);
+}
 
 const TOKEN = (await readFile(TOKEN_FILE, 'utf8'))
   .split('\n')
@@ -59,8 +67,8 @@ bar('1. Daemon status');
   }
   const s = r.json;
   console.error(`name=${s.name} version=${s.version} role=${s.nodeRole} network=${s.networkName} identity=${s.identityId} (has=${s.hasIdentity}) peers=${s.connectedPeers}`);
-  if (s.networkId !== '7449c543ff04a550') {
-    console.error(`WARN: networkId=${s.networkId} expected 7449c543ff04a550 (DKG V10 Testnet). Aborting.`);
+  if (s.networkId !== TESTNET_NETWORK_ID) {
+    console.error(`WARN: networkId=${s.networkId} expected ${TESTNET_NETWORK_ID} (DKG V10 Testnet). Aborting.`);
     process.exit(2);
   }
 }

--- a/scripts/testnet-publish-stress/preflight.mjs
+++ b/scripts/testnet-publish-stress/preflight.mjs
@@ -50,9 +50,9 @@ async function apiCall(method, path, body) {
   return { ok: res.ok, status: res.status, json };
 }
 
-const outcome = await runPreflight({
+const exitCode = await runPreflight({
   apiCall,
   expectedNetworkId: TESTNET_NETWORK_ID,
   runId: RUN_ID,
 });
-process.exitCode = outcome.exitCode;
+process.exitCode = exitCode;

--- a/scripts/testnet-publish-stress/preflight.mjs
+++ b/scripts/testnet-publish-stress/preflight.mjs
@@ -15,17 +15,11 @@
 
 import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
+import { runPreflight } from './preflight-runner.mjs';
 
 const HOST = process.env.DKG_HOST ?? 'http://127.0.0.1:9200';
 const TOKEN_FILE = process.env.DKG_TOKEN_FILE ?? `${homedir()}/.dkg/auth.token`;
 const RUN_ID = process.env.STRESS_RUN_ID ?? '26may';
-const CG_SHORT_ID = `miles-publish-stress-${RUN_ID}`;
-const CG_NAME = `Miles publish stress (${RUN_ID})`;
-const CG_DESCRIPTION =
-  'Auto-created by scripts/testnet-publish-stress/preflight.mjs. ' +
-  'Hosts a stream of Wikidata-music KCs published from Miles\' edge node ' +
-  'against Base Sepolia (84532) to stress-test V10 publishing + give the ' +
-  'on-chain RandomSampling prover something to sample.';
 const TESTNET_CONFIG_URL = new URL('../../network/testnet.json', import.meta.url);
 const TESTNET_NETWORK_ID = JSON.parse(
   await readFile(TESTNET_CONFIG_URL, 'utf8'),
@@ -56,101 +50,9 @@ async function apiCall(method, path, body) {
   return { ok: res.ok, status: res.status, json };
 }
 
-function bar(s) { console.error(`\n=== ${s} ===`); }
-
-bar('1. Daemon status');
-{
-  const r = await apiCall('GET', '/api/status');
-  if (!r.ok) {
-    console.error(`status failed: HTTP ${r.status}`);
-    process.exit(1);
-  }
-  const s = r.json;
-  console.error(`name=${s.name} version=${s.version} role=${s.nodeRole} network=${s.networkName} identity=${s.identityId} (has=${s.hasIdentity}) peers=${s.connectedPeers}`);
-  if (s.networkId !== TESTNET_NETWORK_ID) {
-    console.error(`WARN: networkId=${s.networkId} expected ${TESTNET_NETWORK_ID} (DKG V10 Testnet). Aborting.`);
-    process.exit(2);
-  }
-}
-
-bar('2. Wallets');
-{
-  const r = await apiCall('GET', '/api/wallets/balances');
-  if (!r.ok) {
-    console.error(`wallets failed: HTTP ${r.status}`);
-    process.exit(1);
-  }
-  for (const w of r.json.balances) {
-    console.error(`  ${w.address}  ETH=${w.eth}  ${w.symbol}=${w.trac}`);
-  }
-  const tracTotal = r.json.balances.reduce((s, w) => s + parseFloat(w.trac), 0);
-  const ethTotal = r.json.balances.reduce((s, w) => s + parseFloat(w.eth), 0);
-  console.error(`  TOTAL  ETH=${ethTotal.toFixed(6)}  ${r.json.symbol}=${tracTotal.toFixed(4)}`);
-  console.error(`  RPC: ${r.json.rpcUrl}  chain=${r.json.chainId}`);
-  if (tracTotal < 50) {
-    console.error('ERROR: total TRAC < 50; cannot proceed. Top up the operational wallets.');
-    process.exit(2);
-  }
-}
-
-bar('3. List existing context graphs');
-let alreadyExists = false;
-let resolvedCgId = null;
-let onChainId = null;
-{
-  // Codex review on PR #722: the daemon-side route is `/api/context-graph/list`;
-  // GET `/api/context-graph` would not list existing CGs, which made this
-  // helper drop through to create() and exit on a duplicate-id 409 instead
-  // of being idempotent as documented.
-  const r = await apiCall('GET', '/api/context-graph/list');
-  if (r.ok && Array.isArray(r.json.contextGraphs)) {
-    const match = r.json.contextGraphs.find(
-      (cg) => cg.id === CG_SHORT_ID || cg.id?.endsWith(`/${CG_SHORT_ID}`),
-    );
-    if (match) {
-      alreadyExists = true;
-      resolvedCgId = match.id;
-      onChainId = match.onChainId;
-      console.error(`  Already present: id=${resolvedCgId} onChainId=${onChainId ?? '(local-only)'}`);
-    } else {
-      console.error(`  ${r.json.contextGraphs.length} other CG(s) present; '${CG_SHORT_ID}' not yet created.`);
-    }
-  } else {
-    console.error(`  (no /api/context-graph/list response — will attempt create anyway)`);
-  }
-}
-
-if (!alreadyExists) {
-  bar('4. Create context graph + register on-chain');
-  const r = await apiCall('POST', '/api/context-graph/create', {
-    id: CG_SHORT_ID,
-    name: CG_NAME,
-    description: CG_DESCRIPTION,
-    accessPolicy: 0,    // public
-    publishPolicy: 1,   // open
-    register: true,
-  });
-  if (!r.ok) {
-    console.error(`create failed: HTTP ${r.status}: ${JSON.stringify(r.json).slice(0, 500)}`);
-    process.exit(1);
-  }
-  if (r.json.registered === false) {
-    console.error(`CG created LOCALLY only — on-chain register failed: ${r.json.registerError}`);
-    console.error('Cannot publish without on-chain CG. Investigate before continuing.');
-    process.exit(2);
-  }
-  resolvedCgId = r.json.created;
-  onChainId = r.json.onChainId;
-  console.error(`  Created and registered: id=${resolvedCgId} onChainId=${onChainId} uri=${r.json.uri}`);
-}
-
-bar('5. Resolved CG ID for publish-loop');
-console.error(`  CG short id : ${CG_SHORT_ID}`);
-console.error(`  CG full id  : ${resolvedCgId}`);
-console.error(`  On-chain id : ${onChainId}`);
-console.error('');
-console.error('Plumb into publish-loop.mjs via:');
-console.error(`  export CG_ID=${resolvedCgId}`);
-console.error('');
-console.error('Next step:');
-console.error(`  CG_ID=${resolvedCgId} PHASE=calibrate node scripts/testnet-publish-stress/publish-loop.mjs`);
+const outcome = await runPreflight({
+  apiCall,
+  expectedNetworkId: TESTNET_NETWORK_ID,
+  runId: RUN_ID,
+});
+process.exitCode = outcome.exitCode;


### PR DESCRIPTION
Closes #1764.

## Summary
- load the expected network ID directly from the repository's canonical `network/testnet.json`
- keep exact-match protection against mainnet and unrelated networks
- add process-level regressions proving a mismatch exits after `/api/status`, before balances or any write endpoint
- verify the canonical testnet ID gets through the network guard

## Verification
- `node --test scripts/lib/__tests__/testnet-publish-stress-preflight.test.mjs` (3 passed)
- `pnpm test:scripts` (147 passed)
- `pnpm lint`
- `git diff --check`
