### PR TITLE
fix(sync): fail closed on durable metadata snapshot timeout

### DIFF
--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -11,9 +11,9 @@ import {
 } from '@origintrail-official/dkg-core';
 import {
   asGraphWriteRevisionSource,
-  isStoreOperationTimeoutError,
   StoreResponseTooLargeError,
   StoreSchedulerBusyError,
+  isStoreOperationTimeoutError,
   type QueryOptions,
   type TripleStore,
   type ChangelogReader,

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -11,6 +11,7 @@ import {
 } from '@origintrail-official/dkg-core';
 import {
   asGraphWriteRevisionSource,
+  isStoreOperationTimeoutError,
   StoreResponseTooLargeError,
   type QueryOptions,
   type TripleStore,
@@ -24,6 +25,7 @@ import {
   SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE,
   SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS,
   SYNC_RESPONDER_SNAPSHOT_BUILD_PAGE_ROWS,
+  SyncRowSnapshotFallbackError,
 } from './snapshot-cache.js';
 import { bytesToHex } from '@noble/hashes/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
@@ -2149,6 +2151,12 @@ function isPerSnapshotBudgetError(error: unknown): error is SyncRowSnapshotBudge
     (error.reason === 'snapshot_rows' || error.reason === 'snapshot_bytes');
 }
 
+function isSnapshotPageFallbackError(
+  error: unknown,
+): error is SyncRowSnapshotBudgetError | SyncRowSnapshotFallbackError {
+  return isPerSnapshotBudgetError(error) || error instanceof SyncRowSnapshotFallbackError;
+}
+
 /**
  * Session-plan getter shared by the plan-backed lanes (exact-graph and TTL SWM
  * meta), owning the one lifecycle both must agree on:
@@ -2207,11 +2215,11 @@ function createSessionPlanGetter<T>(
 /**
  * Serve one responder page, owning the single budget-fallback policy for every
  * memoized phase. It tries the stable-snapshot cache first, but an
- * intrinsically-oversized snapshot (over the PER-snapshot row/byte budget) must
- * stay syncable, so it falls back to the session-less store-bounded page read
- * for this and every later page of the session. The memo remembers the
- * per-snapshot rejection for the session, so subsequent pages reach this
- * fallback without repeating the full materialization inside the memo.
+ * intrinsically-oversized snapshot (over the PER-snapshot row/byte budget), or
+ * a full snapshot query that exceeds the store deadline, must stay syncable.
+ * It falls back to the session-less store-bounded page read for this and every
+ * later page of the session. The memo remembers the typed rejection, so later
+ * pages do not repeat the same doomed full-snapshot query.
  *
  * GLOBAL (process-wide) budget pressure is deliberately NOT swallowed here: it
  * is not a `snapshot_rows`/`snapshot_bytes` error, so it propagates as the quiet
@@ -2299,9 +2307,10 @@ interface ResponderRowsPageOptions {
   /** Session snapshot loader; omitted phases build via the store-paged loader. */
   loadSnapshot?: () => Promise<readonly SyncRow[]>;
   /**
-   * Whether a PER-snapshot rows/bytes budget refusal degrades to the
-   * store-bounded page loader for this and every later page of the session
-   * (defaults to true; global budget pressure always propagates).
+   * Whether an intrinsic snapshot refusal (rows/bytes budget or typed store
+   * deadline) degrades to the store-bounded page loader for this and every
+   * later page of the session (defaults to true; global budget pressure always
+   * propagates).
    */
   fallbackOnPerSnapshotBudget?: boolean;
   /**
@@ -2346,7 +2355,7 @@ async function readResponderRowsPage(
       subjectAtomic,
     );
   } catch (error) {
-    if (!isPerSnapshotBudgetError(error) || !fallbackOnPerSnapshotBudget) throw error;
+    if (!isSnapshotPageFallbackError(error) || !fallbackOnPerSnapshotBudget) throw error;
     return loadStoreBoundedPage(safeOffset, safeLimit, signal);
   }
 }
@@ -3679,6 +3688,13 @@ async function readBoundedDurableMetaSnapshot(
         .filter((row): row is SyncRow => Boolean(row.s && row.p && row.o))
       : [];
   } catch (error) {
+    if (isStoreOperationTimeoutError(error)) {
+      throw new SyncRowSnapshotFallbackError({
+        key: cache.key,
+        reason: 'store_timeout',
+        cause: error,
+      });
+    }
     if (!(error instanceof StoreResponseTooLargeError)) throw error;
     const actualBytes = typeof error.actualBytes === 'bigint'
       ? Number(error.actualBytes > BigInt(Number.MAX_SAFE_INTEGER)

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -13,6 +13,7 @@ import {
   asGraphWriteRevisionSource,
   isStoreOperationTimeoutError,
   StoreResponseTooLargeError,
+  StoreSchedulerBusyError,
   type QueryOptions,
   type TripleStore,
   type ChangelogReader,
@@ -3688,7 +3689,10 @@ async function readBoundedDurableMetaSnapshot(
         .filter((row): row is SyncRow => Boolean(row.s && row.p && row.o))
       : [];
   } catch (error) {
-    if (isStoreOperationTimeoutError(error)) {
+    if (
+      isStoreOperationTimeoutError(error)
+      || (error instanceof StoreSchedulerBusyError && error.reason === 'queue_wait_timeout')
+    ) {
       throw new SyncRowSnapshotFallbackError({
         key: cache.key,
         reason: 'store_timeout',

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -12,8 +12,6 @@ import {
 import {
   asGraphWriteRevisionSource,
   StoreResponseTooLargeError,
-  StoreSchedulerBusyError,
-  isStoreOperationTimeoutError,
   type QueryOptions,
   type TripleStore,
   type ChangelogReader,
@@ -26,7 +24,7 @@ import {
   SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_BYTES_ESTIMATE,
   SYNC_RESPONDER_SNAPSHOT_BUILD_MAX_ROWS,
   SYNC_RESPONDER_SNAPSHOT_BUILD_PAGE_ROWS,
-  SyncRowSnapshotFallbackError,
+  isSyncRowSnapshotPagingRequiredError,
 } from './snapshot-cache.js';
 import { bytesToHex } from '@noble/hashes/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
@@ -926,12 +924,8 @@ export async function readSwmMetaPage(params: {
           cache,
         )
         : undefined,
-      // The per-snapshot budget fallback MUST stay enabled here (#1847): it
-      // degrades to the bounded plan-paged reader above, never to the deleted
-      // global-sort query. This policy used to be a positional boolean, and
-      // passing `params.cutoffIso == null` in that position is the exact defect
-      // that made every 64,000-row `_meta` CG permanently unsyncable on mainnet.
-      fallbackOnPerSnapshotBudget: true,
+      // Intrinsic snapshot-size refusals always degrade to the bounded
+      // plan-paged reader above, never to the deleted global-sort query (#1847).
     },
   );
 }
@@ -2147,17 +2141,6 @@ async function readPagedDurableDeltaRowsAcrossGraphs(
   );
 }
 
-function isPerSnapshotBudgetError(error: unknown): error is SyncRowSnapshotBudgetError {
-  return error instanceof SyncRowSnapshotBudgetError &&
-    (error.reason === 'snapshot_rows' || error.reason === 'snapshot_bytes');
-}
-
-function isSnapshotPageFallbackError(
-  error: unknown,
-): error is SyncRowSnapshotBudgetError | SyncRowSnapshotFallbackError {
-  return isPerSnapshotBudgetError(error) || error instanceof SyncRowSnapshotFallbackError;
-}
-
 /**
  * Session-plan getter shared by the plan-backed lanes (exact-graph and TTL SWM
  * meta), owning the one lifecycle both must agree on:
@@ -2216,11 +2199,11 @@ function createSessionPlanGetter<T>(
 /**
  * Serve one responder page, owning the single budget-fallback policy for every
  * memoized phase. It tries the stable-snapshot cache first, but an
- * intrinsically-oversized snapshot (over the PER-snapshot row/byte budget), or
- * a full snapshot query that exceeds the store deadline, must stay syncable.
- * It falls back to the session-less store-bounded page read for this and every
- * later page of the session. The memo remembers the typed rejection, so later
- * pages do not repeat the same doomed full-snapshot query.
+ * intrinsically-oversized snapshot (over the PER-snapshot row/byte budget) must
+ * stay syncable, so it falls back to the store-bounded page read for this and
+ * every later page of the session. Transient store errors propagate: they are
+ * not proof of intrinsic size, and OFFSET paging cannot provide an immutable
+ * session view when the underlying graph may change between requests.
  *
  * GLOBAL (process-wide) budget pressure is deliberately NOT swallowed here: it
  * is not a `snapshot_rows`/`snapshot_bytes` error, so it propagates as the quiet
@@ -2298,22 +2281,9 @@ async function loadStorePagedSnapshot(
   }
 }
 
-/**
- * Optional behavior of {@link readResponderRowsPage}, named instead of
- * positional: a bare boolean in this helper's signature is how the #1847
- * production defect happened (`params.cutoffIso == null` read as the fallback
- * policy), so call sites must now spell the policy out.
- */
 interface ResponderRowsPageOptions {
   /** Session snapshot loader; omitted phases build via the store-paged loader. */
   loadSnapshot?: () => Promise<readonly SyncRow[]>;
-  /**
-   * Whether an intrinsic snapshot refusal (rows/bytes budget or typed store
-   * deadline) degrades to the store-bounded page loader for this and every
-   * later page of the session (defaults to true; global budget pressure always
-   * propagates).
-   */
-  fallbackOnPerSnapshotBudget?: boolean;
   /**
    * Extend a served page forward so it ends on a `(g, s)` subject boundary,
    * never mid-subject (#1788). Only the durable-meta lane sets this: its rows
@@ -2337,7 +2307,6 @@ async function readResponderRowsPage(
   options?: ResponderRowsPageOptions,
 ): Promise<SyncRow[]> {
   const loadSnapshot = options?.loadSnapshot;
-  const fallbackOnPerSnapshotBudget = options?.fallbackOnPerSnapshotBudget ?? true;
   const subjectAtomic = options?.subjectAtomic ?? false;
   const safeOffset = Math.max(0, Math.floor(offset));
   const safeLimit = Math.max(0, Math.floor(limit));
@@ -2356,7 +2325,7 @@ async function readResponderRowsPage(
       subjectAtomic,
     );
   } catch (error) {
-    if (!isSnapshotPageFallbackError(error) || !fallbackOnPerSnapshotBudget) throw error;
+    if (!isSyncRowSnapshotPagingRequiredError(error)) throw error;
     return loadStoreBoundedPage(safeOffset, safeLimit, signal);
   }
 }
@@ -3689,16 +3658,6 @@ async function readBoundedDurableMetaSnapshot(
         .filter((row): row is SyncRow => Boolean(row.s && row.p && row.o))
       : [];
   } catch (error) {
-    if (
-      isStoreOperationTimeoutError(error)
-      || (error instanceof StoreSchedulerBusyError && error.reason === 'queue_wait_timeout')
-    ) {
-      throw new SyncRowSnapshotFallbackError({
-        key: cache.key,
-        reason: 'store_timeout',
-        cause: error,
-      });
-    }
     if (!(error instanceof StoreResponseTooLargeError)) throw error;
     const actualBytes = typeof error.actualBytes === 'bigint'
       ? Number(error.actualBytes > BigInt(Number.MAX_SAFE_INTEGER)

--- a/packages/agent/src/sync/responder/snapshot-cache.ts
+++ b/packages/agent/src/sync/responder/snapshot-cache.ts
@@ -88,7 +88,7 @@ interface CachedSnapshot {
 }
 
 interface RejectedSnapshot {
-  error: SyncRowSnapshotBudgetError;
+  error: SyncRowSnapshotBudgetError | SyncRowSnapshotFallbackError;
   cleanupTimer: ReturnType<typeof setTimeout>;
   refreshGeneration?: string;
 }
@@ -122,6 +122,38 @@ export class SyncRowSnapshotLimitError extends Error {
     this.inflightEntries = params.inflightEntries;
     this.activeEntries = activeEntries;
   }
+}
+
+/**
+ * A full immutable snapshot could not be built, but the same responder session
+ * can still be served safely through its bounded store-page loader.
+ *
+ * This is deliberately distinct from {@link SyncRowSnapshotBudgetError}: a
+ * backend deadline is not evidence that the graph crossed a row/byte budget,
+ * and must not be reported to operators as one.
+ */
+export class SyncRowSnapshotFallbackError extends Error {
+  readonly key: string;
+  readonly reason: 'store_timeout';
+
+  constructor(params: { key: string; reason: 'store_timeout'; cause?: unknown }) {
+    super(
+      `Sync responder snapshot requires bounded store paging (key=${params.key}, reason=${params.reason})`,
+      params.cause === undefined ? undefined : { cause: params.cause },
+    );
+    this.name = 'SyncRowSnapshotFallbackError';
+    this.key = params.key;
+    this.reason = params.reason;
+  }
+}
+
+function isRememberedSnapshotRejection(
+  error: unknown,
+): error is SyncRowSnapshotBudgetError | SyncRowSnapshotFallbackError {
+  return error instanceof SyncRowSnapshotFallbackError || (
+    error instanceof SyncRowSnapshotBudgetError
+    && (error.reason === 'snapshot_rows' || error.reason === 'snapshot_bytes')
+  );
 }
 
 function asAbortError(reason: unknown): Error {
@@ -211,7 +243,7 @@ export function createResponderSyncRowListMemo(
 
   const rememberRejected = (
     key: string,
-    error: SyncRowSnapshotBudgetError,
+    error: SyncRowSnapshotBudgetError | SyncRowSnapshotFallbackError,
     refreshGeneration?: string,
   ) => {
     deleteRejected(key);
@@ -453,10 +485,7 @@ export function createResponderSyncRowListMemo(
           // a response/heap safety bound. Remember intrinsic rejections exactly
           // like storeCached() does, so later pages in this responder session go
           // straight to bounded store paging instead of repeating the full load.
-          if (
-            error instanceof SyncRowSnapshotBudgetError &&
-            (error.reason === 'snapshot_rows' || error.reason === 'snapshot_bytes')
-          ) {
+          if (isRememberedSnapshotRejection(error)) {
             const stale = cached.get(key);
             if (stale) deleteCached(key, 'replaced');
             rememberRejected(key, error, options?.refreshGeneration);

--- a/packages/agent/src/sync/responder/snapshot-cache.ts
+++ b/packages/agent/src/sync/responder/snapshot-cache.ts
@@ -88,7 +88,7 @@ interface CachedSnapshot {
 }
 
 interface RejectedSnapshot {
-  error: SyncRowSnapshotBudgetError | SyncRowSnapshotFallbackError;
+  error: SyncRowSnapshotBudgetError;
   cleanupTimer: ReturnType<typeof setTimeout>;
   refreshGeneration?: string;
 }
@@ -125,35 +125,15 @@ export class SyncRowSnapshotLimitError extends Error {
 }
 
 /**
- * A full immutable snapshot could not be built, but the same responder session
- * can still be served safely through its bounded store-page loader.
- *
- * This is deliberately distinct from {@link SyncRowSnapshotBudgetError}: a
- * backend deadline is not evidence that the graph crossed a row/byte budget,
- * and must not be reported to operators as one.
+ * The one canonical marker for an intrinsic snapshot-size refusal. These
+ * errors may safely switch a responder session to its bounded page loader;
+ * transient store failures must retain their own types and propagate instead.
  */
-export class SyncRowSnapshotFallbackError extends Error {
-  readonly key: string;
-  readonly reason: 'store_timeout';
-
-  constructor(params: { key: string; reason: 'store_timeout'; cause?: unknown }) {
-    super(
-      `Sync responder snapshot requires bounded store paging (key=${params.key}, reason=${params.reason})`,
-      params.cause === undefined ? undefined : { cause: params.cause },
-    );
-    this.name = 'SyncRowSnapshotFallbackError';
-    this.key = params.key;
-    this.reason = params.reason;
-  }
-}
-
-function isRememberedSnapshotRejection(
+export function isSyncRowSnapshotPagingRequiredError(
   error: unknown,
-): error is SyncRowSnapshotBudgetError | SyncRowSnapshotFallbackError {
-  return error instanceof SyncRowSnapshotFallbackError || (
-    error instanceof SyncRowSnapshotBudgetError
-    && (error.reason === 'snapshot_rows' || error.reason === 'snapshot_bytes')
-  );
+): error is SyncRowSnapshotBudgetError {
+  return error instanceof SyncRowSnapshotBudgetError
+    && (error.reason === 'snapshot_rows' || error.reason === 'snapshot_bytes');
 }
 
 function asAbortError(reason: unknown): Error {
@@ -243,7 +223,7 @@ export function createResponderSyncRowListMemo(
 
   const rememberRejected = (
     key: string,
-    error: SyncRowSnapshotBudgetError | SyncRowSnapshotFallbackError,
+    error: SyncRowSnapshotBudgetError,
     refreshGeneration?: string,
   ) => {
     deleteRejected(key);
@@ -342,7 +322,7 @@ export function createResponderSyncRowListMemo(
           // fallback without re-materializing. Global (process-wide) pressure is
           // transient and is NOT remembered — a retry re-attempts admission and
           // succeeds once other sessions drain (and the drop above eases pressure).
-          if (error.reason === 'snapshot_rows' || error.reason === 'snapshot_bytes') {
+          if (isSyncRowSnapshotPagingRequiredError(error)) {
             rememberRejected(key, error, refreshGeneration);
           }
         }
@@ -485,7 +465,7 @@ export function createResponderSyncRowListMemo(
           // a response/heap safety bound. Remember intrinsic rejections exactly
           // like storeCached() does, so later pages in this responder session go
           // straight to bounded store paging instead of repeating the full load.
-          if (isRememberedSnapshotRejection(error)) {
+          if (isSyncRowSnapshotPagingRequiredError(error)) {
             const stale = cached.get(key);
             if (stale) deleteCached(key, 'replaced');
             rememberRejected(key, error, options?.refreshGeneration);

--- a/packages/agent/test/sync-responder-durable-meta-subject-atomic.test.ts
+++ b/packages/agent/test/sync-responder-durable-meta-subject-atomic.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { contextGraphMetaGraphUri } from '@origintrail-official/dkg-core';
-import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import {
+  OxigraphStore,
+  StoreOperationTimeoutError,
+  type Quad,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
+import {
+  createResponderSyncRowListMemo,
   DurableMetaPageFrameError,
   readDurableMetaPage,
   serializeResponderRowsWithinByteBudget,
@@ -105,6 +111,58 @@ function assertNoDuplicatesOrGaps(pages: Row[][]): void {
 }
 
 describe('durable-meta subject-atomic paging (#1788)', () => {
+  it('remembers a full-snapshot store timeout and uses bounded pages for the session', async () => {
+    const backingStore = new OxigraphStore();
+    await backingStore.insert(Array.from({ length: 3 }, (_, index) => ({
+      graph: META,
+      subject: `did:dkg:activity:timeout-fallback-${index}`,
+      predicate: `${DKG_NS}label`,
+      object: `"row-${index}"`,
+    })));
+    let snapshotQueries = 0;
+    const query = vi.fn<TripleStore['query']>(async (sparql, options) => {
+      if (options?.source === 'sync.responder.readDurableMetaGraphSnapshot') {
+        snapshotQueries += 1;
+        throw new StoreOperationTimeoutError({
+          backend: 'test',
+          operation: 'query',
+          storeOperation: 'query',
+          timeoutMs: 30_000,
+        });
+      }
+      return backingStore.query(sparql, options);
+    });
+    const store = { query } as TripleStore;
+    const memo = createResponderSyncRowListMemo();
+    const cacheKey = 'durable-meta:timeout-fallback';
+
+    const first = await readDurableMetaPage({
+      store,
+      contextGraphId: CG,
+      registeredSubGraphNames: [],
+      offset: 0,
+      limit: 1,
+      rowListMemo: memo,
+      rowListCacheKey: cacheKey,
+    });
+    const second = await readDurableMetaPage({
+      store,
+      contextGraphId: CG,
+      registeredSubGraphNames: [],
+      offset: first.length,
+      limit: 1,
+      rowListMemo: memo,
+      rowListCacheKey: cacheKey,
+    });
+
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(1);
+    expect(snapshotQueries).toBe(1);
+    expect(query.mock.calls.filter(([, options]) =>
+      options?.source === 'sync.responder.readDurableMetaRowsPage')).toHaveLength(2);
+    await backingStore.close();
+  });
+
   it('cached path: extends a page across the seal boundary, never splitting it', async () => {
     const limit = 10;
     const fillerA: Row[] = Array.from({ length: 5 }, (_, i) => ({

--- a/packages/agent/test/sync-responder-durable-meta-subject-atomic.test.ts
+++ b/packages/agent/test/sync-responder-durable-meta-subject-atomic.test.ts
@@ -125,27 +125,25 @@ describe('durable-meta subject-atomic paging (#1788)', () => {
       'sync.responder.readDurableMetaGraphSnapshot',
       { storeOperation: 'query' },
     )],
-  ])('remembers a full-snapshot %s and uses bounded pages for the session', async (_label, deadlineError) => {
-    const backingStore = new OxigraphStore();
-    await backingStore.insert(Array.from({ length: 3 }, (_, index) => ({
-      graph: META,
-      subject: `did:dkg:activity:timeout-fallback-${index}`,
-      predicate: `${DKG_NS}label`,
-      object: `"row-${index}"`,
-    })));
+  ])('propagates a full-snapshot %s without entering mutable OFFSET paging', async (
+    _label,
+    deadlineError,
+  ) => {
     let snapshotQueries = 0;
-    const query = vi.fn<TripleStore['query']>(async (sparql, options) => {
+    const firstError = deadlineError();
+    const secondError = deadlineError();
+    const query = vi.fn<TripleStore['query']>(async (_sparql, options) => {
       if (options?.source === 'sync.responder.readDurableMetaGraphSnapshot') {
         snapshotQueries += 1;
-        throw deadlineError();
+        throw snapshotQueries === 1 ? firstError : secondError;
       }
-      return backingStore.query(sparql, options);
+      throw new Error(`unexpected store query: ${options?.source ?? 'unknown'}`);
     });
     const store = { query } as TripleStore;
     const memo = createResponderSyncRowListMemo();
-    const cacheKey = 'durable-meta:timeout-fallback';
+    const cacheKey = 'durable-meta:timeout-propagation';
 
-    const first = await readDurableMetaPage({
+    await expect(readDurableMetaPage({
       store,
       contextGraphId: CG,
       registeredSubGraphNames: [],
@@ -153,23 +151,23 @@ describe('durable-meta subject-atomic paging (#1788)', () => {
       limit: 1,
       rowListMemo: memo,
       rowListCacheKey: cacheKey,
-    });
-    const second = await readDurableMetaPage({
+    })).rejects.toBe(firstError);
+    await expect(readDurableMetaPage({
       store,
       contextGraphId: CG,
       registeredSubGraphNames: [],
-      offset: first.length,
+      offset: 0,
       limit: 1,
       rowListMemo: memo,
       rowListCacheKey: cacheKey,
-    });
+    })).rejects.toBe(secondError);
 
-    expect(first).toHaveLength(1);
-    expect(second).toHaveLength(1);
-    expect(snapshotQueries).toBe(1);
+    // A transient timeout is neither memoized as intrinsic size evidence nor
+    // converted into a mutable ordered page stream. A retry re-attempts the
+    // immutable snapshot and preserves the original operator-visible cause.
+    expect(snapshotQueries).toBe(2);
     expect(query.mock.calls.filter(([, options]) =>
-      options?.source === 'sync.responder.readDurableMetaRowsPage')).toHaveLength(2);
-    await backingStore.close();
+      options?.source === 'sync.responder.readDurableMetaRowsPage')).toHaveLength(0);
   });
 
   it('cached path: extends a page across the seal boundary, never splitting it', async () => {

--- a/packages/agent/test/sync-responder-durable-meta-subject-atomic.test.ts
+++ b/packages/agent/test/sync-responder-durable-meta-subject-atomic.test.ts
@@ -3,6 +3,7 @@ import { contextGraphMetaGraphUri } from '@origintrail-official/dkg-core';
 import {
   OxigraphStore,
   StoreOperationTimeoutError,
+  StoreSchedulerBusyError,
   type Quad,
   type TripleStore,
 } from '@origintrail-official/dkg-storage';
@@ -111,7 +112,20 @@ function assertNoDuplicatesOrGaps(pages: Row[][]): void {
 }
 
 describe('durable-meta subject-atomic paging (#1788)', () => {
-  it('remembers a full-snapshot store timeout and uses bounded pages for the session', async () => {
+  it.each([
+    ['backend deadline', () => new StoreOperationTimeoutError({
+      backend: 'test',
+      operation: 'query',
+      storeOperation: 'query',
+      timeoutMs: 30_000,
+    })],
+    ['scheduler queue-wait deadline', () => new StoreSchedulerBusyError(
+      'queue_wait_timeout',
+      'background',
+      'sync.responder.readDurableMetaGraphSnapshot',
+      { storeOperation: 'query' },
+    )],
+  ])('remembers a full-snapshot %s and uses bounded pages for the session', async (_label, deadlineError) => {
     const backingStore = new OxigraphStore();
     await backingStore.insert(Array.from({ length: 3 }, (_, index) => ({
       graph: META,
@@ -123,12 +137,7 @@ describe('durable-meta subject-atomic paging (#1788)', () => {
     const query = vi.fn<TripleStore['query']>(async (sparql, options) => {
       if (options?.source === 'sync.responder.readDurableMetaGraphSnapshot') {
         snapshotQueries += 1;
-        throw new StoreOperationTimeoutError({
-          backend: 'test',
-          operation: 'query',
-          storeOperation: 'query',
-          timeoutMs: 30_000,
-        });
+        throw deadlineError();
       }
       return backingStore.query(sparql, options);
     });

--- a/packages/agent/test/sync-responder-durable-meta-subject-atomic.test.ts
+++ b/packages/agent/test/sync-responder-durable-meta-subject-atomic.test.ts
@@ -1,14 +1,10 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { contextGraphMetaGraphUri } from '@origintrail-official/dkg-core';
 import {
   OxigraphStore,
-  StoreOperationTimeoutError,
-  StoreSchedulerBusyError,
   type Quad,
-  type TripleStore,
 } from '@origintrail-official/dkg-storage';
 import {
-  createResponderSyncRowListMemo,
   DurableMetaPageFrameError,
   readDurableMetaPage,
   serializeResponderRowsWithinByteBudget,
@@ -112,64 +108,6 @@ function assertNoDuplicatesOrGaps(pages: Row[][]): void {
 }
 
 describe('durable-meta subject-atomic paging (#1788)', () => {
-  it.each([
-    ['backend deadline', () => new StoreOperationTimeoutError({
-      backend: 'test',
-      operation: 'query',
-      storeOperation: 'query',
-      timeoutMs: 30_000,
-    })],
-    ['scheduler queue-wait deadline', () => new StoreSchedulerBusyError(
-      'queue_wait_timeout',
-      'background',
-      'sync.responder.readDurableMetaGraphSnapshot',
-      { storeOperation: 'query' },
-    )],
-  ])('propagates a full-snapshot %s without entering mutable OFFSET paging', async (
-    _label,
-    deadlineError,
-  ) => {
-    let snapshotQueries = 0;
-    const firstError = deadlineError();
-    const secondError = deadlineError();
-    const query = vi.fn<TripleStore['query']>(async (_sparql, options) => {
-      if (options?.source === 'sync.responder.readDurableMetaGraphSnapshot') {
-        snapshotQueries += 1;
-        throw snapshotQueries === 1 ? firstError : secondError;
-      }
-      throw new Error(`unexpected store query: ${options?.source ?? 'unknown'}`);
-    });
-    const store = { query } as TripleStore;
-    const memo = createResponderSyncRowListMemo();
-    const cacheKey = 'durable-meta:timeout-propagation';
-
-    await expect(readDurableMetaPage({
-      store,
-      contextGraphId: CG,
-      registeredSubGraphNames: [],
-      offset: 0,
-      limit: 1,
-      rowListMemo: memo,
-      rowListCacheKey: cacheKey,
-    })).rejects.toBe(firstError);
-    await expect(readDurableMetaPage({
-      store,
-      contextGraphId: CG,
-      registeredSubGraphNames: [],
-      offset: 0,
-      limit: 1,
-      rowListMemo: memo,
-      rowListCacheKey: cacheKey,
-    })).rejects.toBe(secondError);
-
-    // A transient timeout is neither memoized as intrinsic size evidence nor
-    // converted into a mutable ordered page stream. A retry re-attempts the
-    // immutable snapshot and preserves the original operator-visible cause.
-    expect(snapshotQueries).toBe(2);
-    expect(query.mock.calls.filter(([, options]) =>
-      options?.source === 'sync.responder.readDurableMetaRowsPage')).toHaveLength(0);
-  });
-
   it('cached path: extends a page across the seal boundary, never splitting it', async () => {
     const limit = 10;
     const fillerA: Row[] = Array.from({ length: 5 }, (_, i) => ({

--- a/packages/agent/test/sync-responder-snapshot-failure-policy.test.ts
+++ b/packages/agent/test/sync-responder-snapshot-failure-policy.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  StoreOperationTimeoutError,
+  StoreSchedulerBusyError,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
+import {
+  createResponderSyncRowListMemo,
+  readDurableMetaPage,
+} from '../src/sync/responder/graph-plan.js';
+
+const CONTEXT_GRAPH_ID = 'snapshot-failure-policy';
+
+describe('responder immutable-snapshot failure policy', () => {
+  it.each([
+    ['backend deadline', () => new StoreOperationTimeoutError({
+      backend: 'test',
+      operation: 'query',
+      storeOperation: 'query',
+      timeoutMs: 30_000,
+    })],
+    ['scheduler queue-wait deadline', () => new StoreSchedulerBusyError(
+      'queue_wait_timeout',
+      'background',
+      'sync.responder.readDurableMetaGraphSnapshot',
+      { storeOperation: 'query' },
+    )],
+  ])('propagates a full-snapshot %s without entering mutable OFFSET paging', async (
+    _label,
+    deadlineError,
+  ) => {
+    let snapshotQueries = 0;
+    const firstError = deadlineError();
+    const secondError = deadlineError();
+    const query = vi.fn<TripleStore['query']>(async (_sparql, options) => {
+      if (options?.source === 'sync.responder.readDurableMetaGraphSnapshot') {
+        snapshotQueries += 1;
+        throw snapshotQueries === 1 ? firstError : secondError;
+      }
+      throw new Error(`unexpected store query: ${options?.source ?? 'unknown'}`);
+    });
+    const store = { query } as TripleStore;
+    const memo = createResponderSyncRowListMemo();
+    const cacheKey = 'durable-meta:timeout-propagation';
+
+    await expect(readDurableMetaPage({
+      store,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      registeredSubGraphNames: [],
+      offset: 0,
+      limit: 1,
+      rowListMemo: memo,
+      rowListCacheKey: cacheKey,
+    })).rejects.toBe(firstError);
+    await expect(readDurableMetaPage({
+      store,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      registeredSubGraphNames: [],
+      offset: 0,
+      limit: 1,
+      rowListMemo: memo,
+      rowListCacheKey: cacheKey,
+    })).rejects.toBe(secondError);
+
+    // A transient deadline is neither memoized as intrinsic size evidence nor
+    // converted into a mutable ordered page stream. Retry the immutable
+    // snapshot and preserve the original operator-visible cause.
+    expect(snapshotQueries).toBe(2);
+    expect(query.mock.calls.filter(([, options]) =>
+      options?.source === 'sync.responder.readDurableMetaRowsPage')).toHaveLength(0);
+  });
+});

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -81,6 +81,7 @@ export default defineConfig({
       "test/sync-responder-log-volume.test.ts",
       "test/sync-responder-snapshot-cache.test.ts",
       "test/sync-responder-durable-meta-subject-atomic.test.ts",
+      "test/sync-responder-snapshot-failure-policy.test.ts",
       "test/sync-responder-cursor.test.ts",
       "test/sync-responder-oversized-fallback.test.ts",
       "test/sync-responder-swm-meta-ceiling.test.ts",


### PR DESCRIPTION
## Summary

- propagate typed backend and scheduler queue-wait timeouts from durable-metadata snapshot construction
- never reinterpret a transient store timeout as permission to enter mutable OFFSET paging
- centralize the intrinsic snapshot-size paging marker and use it consistently in the memo and responder
- remove the optional budget-named fallback flag so row/byte overflow remains the sole paging trigger

## Why this is needed before 10.0.15

The proposed timeout fallback could combine pages from different graph states when durable metadata changed between requests. A transient timeout is not proof that a snapshot is intrinsically too large, so this revision keeps the original typed cause and lets the requester retry the immutable snapshot.

Only proven per-snapshot row or byte budget overflow may use the existing bounded page path. Global memory pressure and arbitrary store errors continue to propagate.

This is a release-safety guard, not the complete performance remedy for Cinna. A future timeout fallback requires a stable keyset cursor or a revision anchor that can prove the graph did not mutate across pages.

## Validation

- durable-meta, snapshot-cache, and oversized SWM-meta suites: 64/64 passed
- regressions cover backend and scheduler queue-wait deadlines
- each proves the original error propagates, the failure is not memoized as a size marker, and no OFFSET page query runs
- full agent build and package checks passed
- repository lint passed
- diff whitespace check passed

Base: exact testnet-canary SHA 19826cabe972c14fc53d69768cf24e3c31316acb.