### PR TITLE
chore(release): bump package versions to 10.0.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkg-v10",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "dkgBuild": {

--- a/packages/adapter-elizaos/package.json
+++ b/packages/adapter-elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-elizaos",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "description": "ElizaOS plugin adapter — turns any ElizaOS agent into a DKG V10 node",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-hermes",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "description": "Hermes Agent adapter — connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-openclaw",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "description": "OpenClaw plugin adapter for connecting a DKG V10 node and chat bridge to an OpenClaw agent",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-prime-agent/package.json
+++ b/packages/adapter-prime-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-prime-agent",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "description": "Prime Intellect Prime Agent adapter — collocates a Prime Agent with a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-agent",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "type": "module",
   "engines": {
     "node": ">=22.13.0 <23.0.0 || >=23.4.0"

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-chain",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "type": "module",
   "engines": {
     "node": ">=22.13.0 <23.0.0 || >=23.4.0"

--- a/packages/cli/src/local-llm-runtime-factory.ts
+++ b/packages/cli/src/local-llm-runtime-factory.ts
@@ -12,6 +12,7 @@ import {
   type McpClientLike,
   type ToolProfile,
 } from '@origintrail-official/dkg-local-llm';
+import { DKG_CLI_PACKAGE_VERSION } from './package-version.js';
 
 export interface DkgLocalLlmRuntimeSessionOptions {
   dkgHome: string;
@@ -92,7 +93,7 @@ export async function createDkgLocalLlmRuntimeSession(
     void trace.write('DKG MCP STDERR', line);
   });
 
-  const mcp = new Client({ name: 'dkg-local-llm', version: '10.0.15' });
+  const mcp = new Client({ name: 'dkg-local-llm', version: DKG_CLI_PACKAGE_VERSION });
   let closed = false;
   try {
     const initializationTimeoutMs = options.initializationTimeoutMs ?? 60_000;

--- a/packages/cli/src/local-llm-runtime-factory.ts
+++ b/packages/cli/src/local-llm-runtime-factory.ts
@@ -92,7 +92,7 @@ export async function createDkgLocalLlmRuntimeSession(
     void trace.write('DKG MCP STDERR', line);
   });
 
-  const mcp = new Client({ name: 'dkg-local-llm', version: '10.0.14' });
+  const mcp = new Client({ name: 'dkg-local-llm', version: '10.0.15' });
   let closed = false;
   try {
     const initializationTimeoutMs = options.initializationTimeoutMs ?? 60_000;

--- a/packages/cli/src/package-version.ts
+++ b/packages/cli/src/package-version.ts
@@ -1,0 +1,11 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const packageJson = require('../package.json') as { version?: unknown };
+
+if (typeof packageJson.version !== 'string' || packageJson.version.length === 0) {
+  throw new Error('DKG CLI package version is unavailable');
+}
+
+/** Version of the installed CLI package, sourced from its package manifest. */
+export const DKG_CLI_PACKAGE_VERSION = packageJson.version;

--- a/packages/cli/test/local-llm-runtime-factory.test.ts
+++ b/packages/cli/test/local-llm-runtime-factory.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const sdk = vi.hoisted(() => {
@@ -23,7 +24,10 @@ vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
 }));
 
 import { createDkgLocalLlmRuntimeSession } from '../src/local-llm-runtime-factory.js';
-import { DKG_CLI_PACKAGE_VERSION } from '../src/package-version.js';
+
+const cliPackageJson = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+) as { version: string };
 
 describe('local LLM runtime factory initialization lifecycle', () => {
   beforeEach(() => {
@@ -81,7 +85,7 @@ describe('local LLM runtime factory initialization lifecycle', () => {
 
     expect(sdk.Client).toHaveBeenCalledWith({
       name: 'dkg-local-llm',
-      version: DKG_CLI_PACKAGE_VERSION,
+      version: cliPackageJson.version,
     });
     const connectSignal = sdk.client.connect.mock.calls[0][1]?.signal;
     const listSignal = sdk.client.listTools.mock.calls[0][1]?.signal;

--- a/packages/cli/test/local-llm-runtime-factory.test.ts
+++ b/packages/cli/test/local-llm-runtime-factory.test.ts
@@ -23,6 +23,7 @@ vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
 }));
 
 import { createDkgLocalLlmRuntimeSession } from '../src/local-llm-runtime-factory.js';
+import { DKG_CLI_PACKAGE_VERSION } from '../src/package-version.js';
 
 describe('local LLM runtime factory initialization lifecycle', () => {
   beforeEach(() => {
@@ -78,6 +79,10 @@ describe('local LLM runtime factory initialization lifecycle', () => {
       initializationTimeoutMs: 5_000,
     });
 
+    expect(sdk.Client).toHaveBeenCalledWith({
+      name: 'dkg-local-llm',
+      version: DKG_CLI_PACKAGE_VERSION,
+    });
     const connectSignal = sdk.client.connect.mock.calls[0][1]?.signal;
     const listSignal = sdk.client.listTools.mock.calls[0][1]?.signal;
     expect(connectSignal).toBeInstanceOf(AbortSignal);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-core",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/epcis/package.json
+++ b/packages/epcis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-epcis",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-evm-module",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "description": "DKG V10 smart contracts (forked from V8 dkg-evm-module)",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "description": "RDF Knowledge Graph Visualizer — force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kafka-plugin/package.json
+++ b/packages/kafka-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/kafka-plugin",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/local-llm/benchmark/harness.test.mjs
+++ b/packages/local-llm/benchmark/harness.test.mjs
@@ -4,7 +4,7 @@ import {
   modelAssetLifecyclePass,
   validateBenchmarkCall,
 } from './harness.mjs';
-import { applyPersistenceVerification } from './real-dkg.mjs';
+import { applyPersistenceVerification, benchmarkClientInfo } from './real-dkg.mjs';
 
 const target = {
   graphId: 'bench-1',
@@ -13,6 +13,14 @@ const target = {
 };
 
 describe('real-DKG benchmark guard', () => {
+  it('uses the installed local-LLM package version in MCP client metadata', async () => {
+    const packageJson = await import('../package.json', { with: { type: 'json' } });
+    await expect(benchmarkClientInfo()).resolves.toEqual({
+      name: 'dkg-local-llm-real-benchmark',
+      version: packageJson.default.version,
+    });
+  });
+
   it('locks graph, asset, and subgraph write targets', () => {
     expect(validateBenchmarkCall('dkg_context_graph_create', { id: 'other' }, target))
       .toContain('id must equal bench-1');

--- a/packages/local-llm/benchmark/real-dkg.mjs
+++ b/packages/local-llm/benchmark/real-dkg.mjs
@@ -28,6 +28,17 @@ const PACKAGE_ROOT = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const REPO_ROOT = path.resolve(PACKAGE_ROOT, '../..');
 const DEFAULT_LLAMA_URL = 'http://127.0.0.1:8080/v1/chat/completions';
 
+export async function benchmarkClientInfo(packageRoot = PACKAGE_ROOT) {
+  const packageJson = JSON.parse(await fs.readFile(path.join(packageRoot, 'package.json'), 'utf8'));
+  if (typeof packageJson.version !== 'string' || packageJson.version.length === 0) {
+    throw new Error('DKG local-LLM package version is unavailable');
+  }
+  return {
+    name: 'dkg-local-llm-real-benchmark',
+    version: packageJson.version,
+  };
+}
+
 function timestampSlug() {
   return new Date().toISOString().replace(/[-:TZ.]/g, '').slice(0, 14).toLowerCase();
 }
@@ -398,7 +409,7 @@ async function main() {
     }
   });
 
-  const client = new Client({ name: 'dkg-local-llm-real-benchmark', version: '10.0.15' });
+  const client = new Client(await benchmarkClientInfo());
   const target = {
     graphId: options.graphId,
     assetName: options.assetName,

--- a/packages/local-llm/benchmark/real-dkg.mjs
+++ b/packages/local-llm/benchmark/real-dkg.mjs
@@ -398,7 +398,7 @@ async function main() {
     }
   });
 
-  const client = new Client({ name: 'dkg-local-llm-real-benchmark', version: '10.0.14' });
+  const client = new Client({ name: 'dkg-local-llm-real-benchmark', version: '10.0.15' });
   const target = {
     graphId: options.graphId,
     assetName: options.assetName,

--- a/packages/local-llm/package.json
+++ b/packages/local-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-local-llm",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "description": "Bounded local-LLM tool runtime for the DKG MCP surface.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-dkg/package.json
+++ b/packages/mcp-dkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-mcp",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "description": "MCP server that exposes the local DKG daemon (projects, sub-graphs, activity, chat) to Cursor, Claude Code, and any other MCP-aware coding assistant.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/network-sim/package.json
+++ b/packages/network-sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-network-sim",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-node-ui",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/okf/package.json
+++ b/packages/okf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-okf",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-publisher",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-query",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/random-sampling/package.json
+++ b/packages/random-sampling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-random-sampling",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rdf-utils/package.json
+++ b/packages/rdf-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-rdf-utils",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-storage",
-  "version": "10.0.14",
+  "version": "10.0.15",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- bump the root manifest and all 22 package manifests from 10.0.14 to 10.0.15
- update the local-LLM MCP client identity strings to report 10.0.15
- leave the changelog under Unreleased while the canary composition is still changing

## Candidate status

This PR is **version preparation, not a release freeze**. It is intentionally open while additional PRs continue to land on testnet-canary. Before the final release gate, refresh this branch onto the chosen canary head and pin that exact SHA in the release evidence.

Creation base: testnet-canary 916517b287d09bbd2a6428ca4475d4257ac6e973, including #2415, #2419, and #2421.

## Validation

- pnpm release:verify-versions --version 10.0.15 — 23/23 manifests
- pnpm install --frozen-lockfile
- pnpm build — 24/24 package build tasks plus Node UI production build
- git diff --check

The full exact-SHA RFC-64 00/01/10/11 release certification remains pending until the canary composition is frozen.