### PR TITLE
feat(chain): prepare PCA-covered context graph registration

### DIFF
--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -610,13 +610,6 @@ export interface CreateOnChainContextGraphParams {
     */
   registrationDepositPolicy?: ContextGraphRegistrationDepositPolicy;
   /**
-   * Attempt-scoped operational signer pin. This is primarily used by publisher
-   * execution contexts; callers should prefer
-   * `prepareOnChainContextGraphRegistration` so the selected signer cannot
-   * drift between preflight, allowance recovery, and submission.
-   */
-  registrationSignerAddress?: string;
-  /**
    * OT-RFC-38 / LU-6 Phase B — opt-in stable wire identifier the
    * curator commits to at create time. Intended to be
    * `keccak256(bytes(cleartextId))` so the SWM gossip topic, envelope
@@ -642,28 +635,27 @@ export interface CreateOnChainContextGraphResult extends Omit<TxResult, 'context
 
 export type ContextGraphRegistrationCoverageSource = 'explicit' | 'owned' | 'agent' | 'none';
 
-export interface ContextGraphRegistrationCoverage {
-  source: ContextGraphRegistrationCoverageSource;
-  accountId?: bigint;
-}
+export type ContextGraphRegistrationCoverage =
+  | { source: 'none' }
+  | {
+      source: Exclude<ContextGraphRegistrationCoverageSource, 'none'>;
+      /** Positive PCA account id, validated when the capability is prepared. */
+      accountId: bigint;
+    };
 
 /**
  * Inputs consumed while selecting a context-graph registration capability.
  * `registrationSignerAddress` pins an operational signer when a publisher has
  * already selected one. `preferPcaCoveredSigner` is for an unpinned publisher
- * pool: the first configured signer with fully verified coverage is selected,
- * with the primary signer as the deterministic fallback.
+ * pool: fully verified owned coverage is preferred across the pool before
+ * consent-free agent bindings, with the primary signer as the deterministic
+ * fallback. An explicit PCA account always verifies the selected signer.
  */
 export interface PrepareContextGraphRegistrationOptions {
   registrationPcaAccountId?: bigint;
   registrationSignerAddress?: string;
   preferPcaCoveredSigner?: boolean;
 }
-
-export type PreparedCreateOnChainContextGraphParams = Omit<
-  CreateOnChainContextGraphParams,
-  'registrationPcaAccountId' | 'registrationSignerAddress'
->;
 
 /**
  * Immutable, signer-pinned registration capability. The implementation seals
@@ -674,7 +666,7 @@ export interface PreparedContextGraphRegistration {
   signerAddress: string;
   coverage: Readonly<ContextGraphRegistrationCoverage>;
   submit(
-    params: PreparedCreateOnChainContextGraphParams,
+    params: Omit<CreateOnChainContextGraphParams, 'registrationDepositPolicy'>,
   ): Promise<CreateOnChainContextGraphResult>;
 }
 
@@ -1613,7 +1605,16 @@ export interface ChainAdapter {
   prepareOnChainContextGraphRegistration?(
     options?: PrepareContextGraphRegistrationOptions,
   ): Promise<PreparedContextGraphRegistration>;
-  createOnChainContextGraph?(params: CreateOnChainContextGraphParams): Promise<CreateOnChainContextGraphResult>;
+  /**
+   * Compatibility wrapper around prepared registration. The first argument is
+   * always canonical context-graph data; optional attempt policy is kept in a
+   * separate preparation-options object. Omitting `preparationOptions`
+   * preserves the historical primary-signer/no-discovery path.
+   */
+  createOnChainContextGraph?(
+    params: CreateOnChainContextGraphParams,
+    preparationOptions?: PrepareContextGraphRegistrationOptions,
+  ): Promise<CreateOnChainContextGraphResult>;
   verify?(params: VerifyParams): Promise<TxResult>;
   publishToContextGraph?(params: PublishToContextGraphParams): Promise<OnChainPublishResult>;
 

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -607,8 +607,15 @@ export interface CreateOnChainContextGraphParams {
    * Registration-deposit behavior for this create attempt. `pca` uses an
    * account only for waiver coverage; `paid` explicitly disables coverage.
    * Omission preserves the legacy selector and its authority-coupled behavior.
-   */
+    */
   registrationDepositPolicy?: ContextGraphRegistrationDepositPolicy;
+  /**
+   * Attempt-scoped operational signer pin. This is primarily used by publisher
+   * execution contexts; callers should prefer
+   * `prepareOnChainContextGraphRegistration` so the selected signer cannot
+   * drift between preflight, allowance recovery, and submission.
+   */
+  registrationSignerAddress?: string;
   /**
    * OT-RFC-38 / LU-6 Phase B — opt-in stable wire identifier the
    * curator commits to at create time. Intended to be
@@ -631,6 +638,44 @@ export interface CreateOnChainContextGraphParams {
 
 export interface CreateOnChainContextGraphResult extends Omit<TxResult, 'contextGraphId'> {
   contextGraphId: bigint;
+}
+
+export type ContextGraphRegistrationCoverageSource = 'explicit' | 'owned' | 'agent' | 'none';
+
+export interface ContextGraphRegistrationCoverage {
+  source: ContextGraphRegistrationCoverageSource;
+  accountId?: bigint;
+}
+
+/**
+ * Inputs consumed while selecting a context-graph registration capability.
+ * `registrationSignerAddress` pins an operational signer when a publisher has
+ * already selected one. `preferPcaCoveredSigner` is for an unpinned publisher
+ * pool: the first configured signer with fully verified coverage is selected,
+ * with the primary signer as the deterministic fallback.
+ */
+export interface PrepareContextGraphRegistrationOptions {
+  registrationPcaAccountId?: bigint;
+  registrationSignerAddress?: string;
+  preferPcaCoveredSigner?: boolean;
+}
+
+export type PreparedCreateOnChainContextGraphParams = Omit<
+  CreateOnChainContextGraphParams,
+  'registrationPcaAccountId' | 'registrationSignerAddress'
+>;
+
+/**
+ * Immutable, signer-pinned registration capability. The implementation seals
+ * both the signer and coverage decision; `submit` deliberately has no override
+ * fields so allowance approval and every retry use the same signer.
+ */
+export interface PreparedContextGraphRegistration {
+  signerAddress: string;
+  coverage: Readonly<ContextGraphRegistrationCoverage>;
+  submit(
+    params: PreparedCreateOnChainContextGraphParams,
+  ): Promise<CreateOnChainContextGraphResult>;
 }
 
 export interface VerifyParams {
@@ -1565,6 +1610,9 @@ export interface ChainAdapter {
   ): Promise<boolean>;
 
   // On-Chain Context Graphs (ContextGraphs contract)
+  prepareOnChainContextGraphRegistration?(
+    options?: PrepareContextGraphRegistrationOptions,
+  ): Promise<PreparedContextGraphRegistration>;
   createOnChainContextGraph?(params: CreateOnChainContextGraphParams): Promise<CreateOnChainContextGraphResult>;
   verify?(params: VerifyParams): Promise<TxResult>;
   publishToContextGraph?(params: PublishToContextGraphParams): Promise<OnChainPublishResult>;

--- a/packages/chain/src/context-graph-registration-dispatch.ts
+++ b/packages/chain/src/context-graph-registration-dispatch.ts
@@ -1,4 +1,7 @@
-import type { ContextGraphRegistrationDepositPolicy } from './chain-adapter.js';
+import type {
+  ContextGraphRegistrationCoverage,
+  ContextGraphRegistrationDepositPolicy,
+} from './chain-adapter.js';
 
 export type ContextGraphLegacyCreateArgs = readonly [
   participantAgents: readonly string[],
@@ -23,29 +26,134 @@ export type ContextGraphCreateDispatch =
       ];
     };
 
-/** Keep selector compatibility at the EVM boundary, not in the shared policy. */
-export function resolveContextGraphCreateDispatch(
+type UnsupportedFacadeDisposition = 'reject' | 'paid-legacy-fallback';
+
+/**
+ * Internal, sealed registration decision. Call boundaries derive this once;
+ * transaction submission never combines public policy with coverage metadata.
+ */
+export type ContextGraphRegistrationExecutionPolicy =
+  | { mode: 'legacy' }
+  | { mode: 'paid'; unsupportedFacade: 'reject' }
+  | {
+      mode: 'pca';
+      accountId: bigint;
+      selector: 'additive';
+      unsupportedFacade: 'reject';
+    }
+  | {
+      mode: 'pca';
+      accountId: bigint;
+      selector: 'legacy-when-authority';
+      unsupportedFacade: UnsupportedFacadeDisposition;
+    };
+
+export type ContextGraphFacadeCapability =
+  | { state: 'supported'; version: string }
+  | { state: 'unsupported'; version: string };
+
+export type ContextGraphCreateDispatchResolution =
+  | { state: 'resolved'; dispatch: ContextGraphCreateDispatch }
+  | {
+      state: 'unsupported';
+      registrationMode: 'paid' | 'pca';
+      facadeVersion: string;
+    };
+
+function legacyDispatch(legacyArgs: ContextGraphLegacyCreateArgs): ContextGraphCreateDispatch {
+  return { method: 'createContextGraph', args: legacyArgs };
+}
+
+function additiveDispatch(
   legacyArgs: ContextGraphLegacyCreateArgs,
-  policy?: ContextGraphRegistrationDepositPolicy,
+  accountId: bigint,
 ): ContextGraphCreateDispatch {
+  return {
+    method: 'createContextGraphWithPcaCoverage',
+    args: [...legacyArgs, accountId],
+  };
+}
+
+function assertPositivePcaAccountId(accountId: bigint): void {
+  if (accountId <= 0n) {
+    throw new RangeError('PCA registration-deposit policy requires a positive accountId.');
+  }
+}
+
+export function executionPolicyFromDepositPolicy(
+  policy?: ContextGraphRegistrationDepositPolicy,
+): ContextGraphRegistrationExecutionPolicy {
   const resolvedPolicy: ContextGraphRegistrationDepositPolicy = policy ?? { mode: 'legacy' };
   switch (resolvedPolicy.mode) {
     case 'legacy':
-      return { method: 'createContextGraph', args: [...legacyArgs] };
+      return { mode: 'legacy' };
     case 'paid':
-      return {
-        method: 'createContextGraphWithPcaCoverage',
-        args: [...legacyArgs, 0n],
-      };
+      return { mode: 'paid', unsupportedFacade: 'reject' };
     case 'pca':
-      if (resolvedPolicy.accountId <= 0n) {
-        throw new Error('PCA registration-deposit policy requires a positive accountId.');
-      }
+      assertPositivePcaAccountId(resolvedPolicy.accountId);
       return {
-        method: 'createContextGraphWithPcaCoverage',
-        args: [...legacyArgs, resolvedPolicy.accountId],
+        mode: 'pca',
+        accountId: resolvedPolicy.accountId,
+        selector: 'additive',
+        unsupportedFacade: 'reject',
       };
     default:
       throw new Error('Unsupported Context Graph registration-deposit policy.');
   }
+}
+
+export function executionPolicyFromCoverage(
+  coverage: Readonly<ContextGraphRegistrationCoverage>,
+): ContextGraphRegistrationExecutionPolicy {
+  if (coverage.source === 'none') return { mode: 'legacy' };
+  assertPositivePcaAccountId(coverage.accountId);
+  return {
+    mode: 'pca',
+    accountId: coverage.accountId,
+    selector: 'legacy-when-authority',
+    unsupportedFacade: coverage.source === 'explicit'
+      ? 'reject'
+      : 'paid-legacy-fallback',
+  };
+}
+
+/**
+ * Resolve the sealed policy to one selector. The facade read stays lazy so
+ * legacy calls and authority-compatible PCA calls preserve old-facade support.
+ */
+export async function resolveContextGraphCreateDispatch(
+  legacyArgs: ContextGraphLegacyCreateArgs,
+  legacyCoverageAccountId: bigint,
+  policy: ContextGraphRegistrationExecutionPolicy,
+  readFacadeCapability: () => Promise<ContextGraphFacadeCapability>,
+): Promise<ContextGraphCreateDispatchResolution> {
+  if (policy.mode === 'legacy') {
+    return { state: 'resolved', dispatch: legacyDispatch(legacyArgs) };
+  }
+  if (
+    policy.mode === 'pca'
+    && policy.selector === 'legacy-when-authority'
+    && policy.accountId === legacyCoverageAccountId
+  ) {
+    return { state: 'resolved', dispatch: legacyDispatch(legacyArgs) };
+  }
+
+  const facade = await readFacadeCapability();
+  if (facade.state === 'unsupported') {
+    if (policy.mode === 'pca' && policy.unsupportedFacade === 'paid-legacy-fallback') {
+      return { state: 'resolved', dispatch: legacyDispatch(legacyArgs) };
+    }
+    return {
+      state: 'unsupported',
+      registrationMode: policy.mode,
+      facadeVersion: facade.version,
+    };
+  }
+
+  return {
+    state: 'resolved',
+    dispatch: policy.mode === 'paid'
+      ? additiveDispatch(legacyArgs, 0n)
+      : additiveDispatch(legacyArgs, policy.accountId),
+  };
 }

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -2803,6 +2803,16 @@ export class EVMChainAdapterBase {
     return address;
   }
 
+  /**
+   * Uncached coherence check for a capability decision made before a write.
+   * Most stale bindings self-heal when the retired contract reverts, but a
+   * local "unsupported" decision has no write to expose that marker.
+   */
+  protected async isCurrentHubContractAddress(name: string, boundAddress: string): Promise<boolean> {
+    const currentAddress = await this.readHubContractAddress(name);
+    return ethers.getAddress(currentAddress) === ethers.getAddress(boundAddress);
+  }
+
   protected async resolveAssetStorage(name: string, abiName?: string): Promise<Contract> {
     let address: string;
     try {

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -28,7 +28,7 @@ import { HubResolutionCache } from './hub-resolution-cache.js';
 import { SignerTxSerializer, type SignerTxLaneState } from './signer-tx-serializer.js';
 import { floorPublishTokenAmount, withSpan, getMetrics } from '@origintrail-official/dkg-core';
 import { loadAbi } from './evm-adapter-abi.js';
-import { errorCode, errorMessage, errorStatus, isTooLowAllowanceError, enrichEvmError, getPcaLogicInterface, HUB_STALE_ERROR_MARKERS, isInsufficientFundsError, InsufficientPublisherFundsError, formatNoFundedPublisherWalletMessage, type PublisherWalletBalance } from './evm-adapter-errors.js';
+import { errorCode, errorMessage, errorStatus, isTooLowAllowanceError, enrichEvmError, getPcaLogicInterface, isHubStaleError, isInsufficientFundsError, InsufficientPublisherFundsError, formatNoFundedPublisherWalletMessage, type PublisherWalletBalance } from './evm-adapter-errors.js';
 import { resolveRpcUrls, boundedRetryFetchRequest, withTimeout, isRetryableRpcError, assertSuccessfulReceipt, sleep } from './evm-adapter-rpc.js';
 import { rpcHost } from './rpc-failover-log.js';
 import { ChainRpcTransportError } from './chain-rpc-transport-error.js';
@@ -4108,8 +4108,7 @@ export class EVMChainAdapterBase {
       return await fn();
     } catch (err) {
       if (err instanceof Error) enrichEvmError(err);
-      const msg = err instanceof Error ? err.message : '';
-      if (HUB_STALE_ERROR_MARKERS.some((m) => msg.includes(m))) {
+      if (isHubStaleError(err)) {
         this.invalidateRandomSamplingPair();
         return await fn();
       }
@@ -4143,8 +4142,7 @@ export class EVMChainAdapterBase {
       return await fn();
     } catch (err) {
       if (err instanceof Error) enrichEvmError(err);
-      const msg = err instanceof Error ? err.message : '';
-      if (HUB_STALE_ERROR_MARKERS.some((m) => msg.includes(m))) {
+      if (isHubStaleError(err)) {
         this.invalidateAllBoundContracts();
         await this.init();
         return await fn();

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -15,15 +15,129 @@ import {
   CG_REGISTRY_REORG_BUFFER_BLOCKS,
 } from './evm-adapter-base.js';
 import {
+  ContextGraphFacadeVersionUnknownError,
+  ContextGraphRegistrationSignerUnavailableError,
+  HUB_STALE_ERROR_MARKERS,
+  PcaCoverageUnsupportedError,
   isTooLowAllowanceError,
 } from './evm-adapter-errors.js';
-import { ethers, Contract, type JsonRpcProvider } from 'ethers';
-import { ContextGraphChainScanPartialError, type ChainReadOptions, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type ContextGraphRegistryScanOptions, type ContextGraphRegistryScanPage, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
+import { ethers, Contract, type JsonRpcProvider, type Wallet } from 'ethers';
+import { ContextGraphChainScanPartialError, type ChainReadOptions, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type ContextGraphRegistryScanOptions, type ContextGraphRegistryScanPage, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult, type ContextGraphRegistrationCoverage, type PrepareContextGraphRegistrationOptions, type PreparedContextGraphRegistration, type PreparedCreateOnChainContextGraphParams } from './chain-adapter.js';
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
 import {
   resolveContextGraphCreateDispatch,
   type ContextGraphLegacyCreateArgs,
 } from './context-graph-registration-dispatch.js';
+
+export const MAX_AUTO_COVERAGE_CANDIDATES = 32;
+export const AUTO_COVERAGE_DISCOVERY_TIMEOUT_MS = 5_000;
+export const AUTO_COVERAGE_READ_CONCURRENCY = 4;
+
+const MINIMUM_PCA_WAIVER_FACADE_VERSION = [10, 0, 5] as const;
+const PARAMETERS_WAIVER_ABI = [
+  'function contextGraphRegistrationDeposit() view returns (uint96)',
+  'function minPcaCommitmentForCgWaiver() view returns (uint96)',
+] as const;
+
+type CoverageDiscoverySnapshot = {
+  deposit: bigint;
+  minimumCommitment: bigint;
+  latestTimestamp: bigint;
+  pca: Contract;
+  waiverStorage: Contract;
+  reads: CoverageReadLimiter;
+};
+
+type FacadeCapability =
+  | { state: 'supported'; version: string }
+  | { state: 'unsupported'; version: string };
+
+class CoverageDiscoveryDeadlineError extends Error {
+  constructor() {
+    super('Context-graph PCA coverage discovery exceeded its five-second budget.');
+    this.name = 'CoverageDiscoveryDeadlineError';
+  }
+}
+
+function withCoverageDeadline<T>(promise: Promise<T>, deadline: number): Promise<T> {
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) return Promise.reject(new CoverageDiscoveryDeadlineError());
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new CoverageDiscoveryDeadlineError()), remaining);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer);
+  });
+}
+
+/** A deadline-aware semaphore that caps all discovery RPC reads, not just workers. */
+class CoverageReadLimiter {
+  private active = 0;
+  private readonly waiting: Array<() => void> = [];
+
+  constructor(
+    private readonly deadline: number,
+    private readonly concurrency = AUTO_COVERAGE_READ_CONCURRENCY,
+  ) {}
+
+  async run<T>(read: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await withCoverageDeadline(Promise.resolve().then(read), this.deadline);
+    } finally {
+      this.release();
+    }
+  }
+
+  expired(): boolean {
+    return Date.now() >= this.deadline;
+  }
+
+  private async acquire(): Promise<void> {
+    if (Date.now() >= this.deadline) throw new CoverageDiscoveryDeadlineError();
+    if (this.active < this.concurrency) {
+      this.active += 1;
+      return;
+    }
+    let wake!: () => void;
+    const wait = new Promise<void>((resolve) => { wake = resolve; });
+    this.waiting.push(wake);
+    try {
+      await withCoverageDeadline(wait, this.deadline);
+    } catch (err) {
+      const index = this.waiting.indexOf(wake);
+      if (index >= 0) this.waiting.splice(index, 1);
+      throw err;
+    }
+  }
+
+  private release(): void {
+    const next = this.waiting.shift();
+    if (next) next();
+    else this.active -= 1;
+  }
+}
+
+function parsedFacadeVersion(version: unknown): FacadeCapability | undefined {
+  if (typeof version !== 'string') return undefined;
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?$/.exec(version.trim());
+  if (!match) return undefined;
+  const actual = match.slice(1, 4).map(Number);
+  const supported = actual.some((part, index) =>
+    part > MINIMUM_PCA_WAIVER_FACADE_VERSION[index]
+      && actual.slice(0, index).every(
+        (previous, previousIndex) => previous === MINIMUM_PCA_WAIVER_FACADE_VERSION[previousIndex],
+      ),
+  ) || actual.every(
+    (part, index) => part === MINIMUM_PCA_WAIVER_FACADE_VERSION[index],
+  );
+  return { state: supported ? 'supported' : 'unsupported', version: version.trim() };
+}
+
+function accountField(account: any, name: string, index: number): any {
+  return account?.[name] ?? account?.[index];
+}
 
 type ContextGraphRegistryScanPlan =
   | {
@@ -444,12 +558,311 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     ));
   }
 
-  async createOnChainContextGraph(params: CreateOnChainContextGraphParams): Promise<CreateOnChainContextGraphResult> {
+  async prepareOnChainContextGraphRegistration(
+    options: PrepareContextGraphRegistrationOptions = {},
+  ): Promise<PreparedContextGraphRegistration> {
     await this.init();
-    if (!this.contracts.contextGraphs || !this.contracts.contextGraphStorage) {
-      throw new Error('ContextGraphs contract not deployed. Deploy ContextGraphs and ContextGraphStorage first.');
+
+    const explicitAccountId = options.registrationPcaAccountId;
+    const hasExplicitCoverage = explicitAccountId !== undefined && explicitAccountId > 0n;
+    const pinnedSigner = options.registrationSignerAddress
+      ? this.registrationSignerByAddress(options.registrationSignerAddress)
+      : undefined;
+
+    if (hasExplicitCoverage) {
+      return this.sealContextGraphRegistration(
+        pinnedSigner ?? this.signer,
+        { source: 'explicit', accountId: explicitAccountId },
+      );
     }
 
+    // An unpinned synchronous publisher has not planned a publish signer yet.
+    // Reuse one snapshot/deadline for the whole configured pool and select the
+    // first signer with fully verified coverage. This is deterministic in pool
+    // order and falls back to the primary signer when discovery fails closed.
+    if (options.preferPcaCoveredSigner && !pinnedSigner) {
+      const deadline = Date.now() + AUTO_COVERAGE_DISCOVERY_TIMEOUT_MS;
+      const snapshot = await this.prepareCoverageDiscoverySnapshot(deadline);
+      if (snapshot) {
+        for (const signer of this.signerPool) {
+          const coverage = await this.discoverCoverageForSigner(signer, snapshot);
+          if (coverage.source !== 'none') {
+            return this.sealContextGraphRegistration(signer, coverage);
+          }
+          if (Date.now() >= deadline) break;
+        }
+      }
+      return this.sealContextGraphRegistration(this.signer, { source: 'none' });
+    }
+
+    const signer = pinnedSigner ?? this.signer;
+    const deadline = Date.now() + AUTO_COVERAGE_DISCOVERY_TIMEOUT_MS;
+    const snapshot = await this.prepareCoverageDiscoverySnapshot(deadline);
+    const coverage = snapshot
+      ? await this.discoverCoverageForSigner(signer, snapshot)
+      : { source: 'none' as const };
+    return this.sealContextGraphRegistration(signer, coverage);
+  }
+
+  async createOnChainContextGraph(
+    params: CreateOnChainContextGraphParams,
+  ): Promise<CreateOnChainContextGraphResult> {
+    const shouldPrepare =
+      params.registrationPcaAccountId !== undefined
+      || params.registrationSignerAddress !== undefined;
+    const prepared = shouldPrepare
+      ? await this.prepareOnChainContextGraphRegistration({
+          registrationPcaAccountId: params.registrationPcaAccountId,
+          registrationSignerAddress: params.registrationSignerAddress,
+        })
+      // Preserve the legacy direct-call path: callers that did not ask for a
+      // registration execution context do not incur PCA discovery reads.
+      : this.sealContextGraphRegistration(this.signer, { source: 'none' });
+    const {
+      registrationPcaAccountId: _registrationPcaAccountId,
+      registrationSignerAddress: _registrationSignerAddress,
+      ...submitParams
+    } = params;
+    return prepared.submit(submitParams);
+  }
+
+  private registrationSignerByAddress(address: string): Wallet {
+    let signer: Wallet | undefined;
+    try {
+      signer = this.findSignerByAddress(address);
+    } catch {
+      // Normalize malformed addresses into the same stable capability error as
+      // a valid address that is not present in the configured signer pool.
+    }
+    if (!signer) throw new ContextGraphRegistrationSignerUnavailableError(address);
+    return signer;
+  }
+
+  private sealContextGraphRegistration(
+    signer: Wallet,
+    coverage: ContextGraphRegistrationCoverage,
+  ): PreparedContextGraphRegistration {
+    const signerAddress = ethers.getAddress(signer.address);
+    const sealedCoverage = Object.freeze({ ...coverage });
+    const submit = async (
+      params: PreparedCreateOnChainContextGraphParams,
+    ): Promise<CreateOnChainContextGraphResult> => {
+      const runtimeParams = params as CreateOnChainContextGraphParams;
+      if (
+        runtimeParams == null
+        || Object.prototype.hasOwnProperty.call(runtimeParams, 'registrationPcaAccountId')
+        || Object.prototype.hasOwnProperty.call(runtimeParams, 'registrationSignerAddress')
+      ) {
+        throw new Error(
+          'Prepared context-graph registration does not accept signer or PCA coverage overrides.',
+        );
+      }
+      // A prepared capability may outlive adapter reconfiguration. Fail rather
+      // than substituting another pool signer; the captured wallet remains the
+      // only wallet this capability can use.
+      const available = this.findSignerByAddress(signerAddress);
+      if (!available || available !== signer) {
+        throw new ContextGraphRegistrationSignerUnavailableError(signerAddress);
+      }
+      return this.withHubStaleRetryAny(() =>
+        this.submitPreparedContextGraphRegistration(params, signer, sealedCoverage));
+    };
+    return Object.freeze({ signerAddress, coverage: sealedCoverage, submit });
+  }
+
+  private async prepareCoverageDiscoverySnapshot(
+    deadline: number,
+  ): Promise<CoverageDiscoverySnapshot | undefined> {
+    const pca = this.contracts.dkgPublishingConvictionNFT;
+    const configuredParameters = this.contracts.parametersStorage;
+    if (!pca || !configuredParameters) return undefined;
+
+    const reads = new CoverageReadLimiter(deadline);
+    try {
+      const parametersAddress = await reads.run(() => configuredParameters.getAddress());
+      const parameters = new Contract(parametersAddress, PARAMETERS_WAIVER_ABI, this.provider);
+      const deposit = BigInt(await reads.run(() => this.readContract(
+        parameters,
+        'parametersStorage.contextGraphRegistrationDeposit',
+        'contextGraphRegistrationDeposit',
+      )));
+      if (deposit === 0n) return undefined;
+
+      const [minimumCommitmentRaw, latestBlock, waiverStorage] = await Promise.all([
+        reads.run(() => this.readContract(
+          parameters,
+          'parametersStorage.minPcaCommitmentForCgWaiver',
+          'minPcaCommitmentForCgWaiver',
+        )),
+        reads.run(() => this.readTipProvider(
+          'latest block for context-graph PCA coverage',
+          (provider) => provider.getBlock('latest'),
+        )),
+        reads.run(() => this.resolveContract('ContextGraphWaiverStorage')),
+      ]);
+      if (!latestBlock) return undefined;
+      return {
+        deposit,
+        minimumCommitment: BigInt(minimumCommitmentRaw),
+        latestTimestamp: BigInt(latestBlock.timestamp),
+        pca,
+        waiverStorage,
+        reads,
+      };
+    } catch {
+      // Discovery is advisory. Any global read/deployment/budget failure retains
+      // the ordinary deposit path; the contract remains the authority at submit.
+      return undefined;
+    }
+  }
+
+  private async discoverCoverageForSigner(
+    signer: Wallet,
+    snapshot: CoverageDiscoverySnapshot,
+  ): Promise<ContextGraphRegistrationCoverage> {
+    try {
+      const balance = BigInt(await snapshot.reads.run(() => this.readContract(
+        snapshot.pca,
+        'pca.balanceOf registration signer',
+        'balanceOf',
+        signer.address,
+      )));
+      if (balance > BigInt(MAX_AUTO_COVERAGE_CANDIDATES)) {
+        // Do not consult an unsolicited agent binding after refusing amplified
+        // owner enumeration. The operator can still supply an explicit PCA ID.
+        return { source: 'none' };
+      }
+
+      const accountIds = await Promise.all(Array.from(
+        { length: Number(balance) },
+        (_unused, index) => snapshot.reads.run(async () => BigInt(await this.readContract(
+          snapshot.pca,
+          'pca.tokenOfOwnerByIndex registration coverage',
+          'tokenOfOwnerByIndex',
+          signer.address,
+          BigInt(index),
+        ))),
+      ));
+      accountIds.sort((left, right) => left < right ? -1 : left > right ? 1 : 0);
+
+      const ownerEligibility = await Promise.all(accountIds.map(async (accountId) => ({
+        accountId,
+        eligible: await this.registrationCoverageCandidateEligible(
+          signer.address,
+          accountId,
+          'owned',
+          snapshot,
+        ),
+      })));
+      const owned = ownerEligibility.find((candidate) => candidate.eligible);
+      if (owned) return { source: 'owned', accountId: owned.accountId };
+      if (snapshot.reads.expired()) return { source: 'none' };
+
+      const agentAccountId = BigInt(await snapshot.reads.run(() => this.readContract(
+        snapshot.pca,
+        'pca.agentToAccountId registration coverage',
+        'agentToAccountId',
+        signer.address,
+      )));
+      if (
+        agentAccountId > 0n
+        && await this.registrationCoverageCandidateEligible(
+          signer.address,
+          agentAccountId,
+          'agent',
+          snapshot,
+        )
+      ) {
+        return { source: 'agent', accountId: agentAccountId };
+      }
+    } catch {
+      // Enumeration, agent resolution, or total-budget failure makes automatic
+      // coverage unavailable. Never guess a candidate.
+    }
+    return { source: 'none' };
+  }
+
+  private async registrationCoverageCandidateEligible(
+    signerAddress: string,
+    accountId: bigint,
+    relation: 'owned' | 'agent',
+    snapshot: CoverageDiscoverySnapshot,
+  ): Promise<boolean> {
+    try {
+      const [account, waivedCountRaw, owner] = await Promise.all([
+        snapshot.reads.run(() => this.readContract(
+          snapshot.pca,
+          'pca.accounts registration coverage',
+          'accounts',
+          accountId,
+        )),
+        snapshot.reads.run(() => this.readContract(
+          snapshot.waiverStorage,
+          'contextGraphWaiverStorage.waivedCgCount',
+          'waivedCgCount',
+          accountId,
+        )),
+        relation === 'owned'
+          ? snapshot.reads.run(() => this.readContract(
+              snapshot.pca,
+              'pca.ownerOf registration coverage',
+              'ownerOf',
+              accountId,
+            ))
+          : Promise.resolve(signerAddress),
+      ]);
+      if (ethers.getAddress(String(owner)) !== ethers.getAddress(signerAddress)) return false;
+
+      const committed = BigInt(accountField(account, 'committedTRAC', 0) ?? 0n);
+      const expiresAtTimestamp = BigInt(accountField(account, 'expiresAtTimestamp', 4) ?? 0n);
+      const fullySwept = Boolean(accountField(account, 'fullySwept', 8));
+      if (
+        committed === 0n
+        || fullySwept
+        || committed < snapshot.minimumCommitment
+        || (expiresAtTimestamp !== 0n && snapshot.latestTimestamp >= expiresAtTimestamp)
+      ) return false;
+
+      const quota = committed / snapshot.deposit;
+      return quota > BigInt(waivedCountRaw);
+    } catch {
+      // Candidate-local failures mark only this candidate unverified; other
+      // owned candidates remain eligible for deterministic evaluation.
+      return false;
+    }
+  }
+
+  private async readContextGraphsFacadeCapability(
+    contextGraphs: Contract,
+  ): Promise<FacadeCapability> {
+    let rawVersion: unknown;
+    try {
+      rawVersion = await this.readContract(
+        contextGraphs,
+        'contextGraphs.version',
+        'version',
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '';
+      if (HUB_STALE_ERROR_MARKERS.some((marker) => message.includes(marker))) throw err;
+      throw new ContextGraphFacadeVersionUnknownError({ cause: err });
+    }
+    const capability = parsedFacadeVersion(rawVersion);
+    if (!capability) throw new ContextGraphFacadeVersionUnknownError();
+    return capability;
+  }
+
+  private async submitPreparedContextGraphRegistration(
+    params: PreparedCreateOnChainContextGraphParams,
+    signer: Wallet,
+    coverage: Readonly<ContextGraphRegistrationCoverage>,
+  ): Promise<CreateOnChainContextGraphResult> {
+    await this.init();
+    const contextGraphs = this.contracts.contextGraphs;
+    const contextGraphStorage = this.contracts.contextGraphStorage;
+    if (!contextGraphs || !contextGraphStorage) {
+      throw new Error('ContextGraphs contract not deployed. Deploy ContextGraphs and ContextGraphStorage first.');
+    }
     if (params.accessPolicy === undefined || params.publishPolicy === undefined) {
       throw new Error(
         'createOnChainContextGraph: `accessPolicy` and `publishPolicy` are required (SPEC_CG_MEMORY_MODEL). ' +
@@ -457,7 +870,6 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
       );
     }
 
-    const contextGraphs = this.contracts.contextGraphs;
     const legacyCreateArgs: ContextGraphLegacyCreateArgs = [
       params.participantAgents ?? [],
       params.metadataBatchId ?? 0n,
@@ -465,67 +877,56 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
       params.publishPolicy,
       params.publishAuthority ?? ethers.ZeroAddress,
       params.publishAuthorityAccountId ?? 0n,
-      // OT-RFC-38 / LU-6 Phase B — opt-in wire-id commitment. Default
-      // `bytes32(0)` opts out; the agent supplies a non-zero hash
-      // (typically `keccak256(bytes(cleartextId))`) to enable cores'
-      // chain-event-driven host-mode auto-subscribe path.
       params.nameHash ?? ethers.ZeroHash,
     ];
-    const createDispatch = resolveContextGraphCreateDispatch(
-      legacyCreateArgs,
-      params.registrationDepositPolicy,
-    );
-    const submitCreate = () =>
-      this.sendContractTransaction(
-        contextGraphs,
-        createDispatch.method,
-        createDispatch.args,
-        this.signer,
-        'create on-chain context graph',
-      );
+    const registrationAccountId = coverage.accountId ?? 0n;
+    const legacyCoverageAccountId = params.publishAuthorityAccountId ?? 0n;
+    let createDispatch = resolveContextGraphCreateDispatch(legacyCreateArgs);
 
-    // OT-RFC-53: when the registration deposit is active, createContextGraph
-    // pulls it via transferFrom and reverts until the ContextGraphs facade is
-    // approved. Recover LAZILY (mirrors the publish/update #888 allowance
-    // recovery): on a first-attempt revert, if a deposit is actually configured,
-    // approve it to the facade and retry once. The common path (deposit dormant)
-    // is a single tx with NO extra eth_call, so it never perturbs timing-
-    // sensitive integration tests.
+    if (registrationAccountId > 0n && registrationAccountId !== legacyCoverageAccountId) {
+      const facade = await this.readContextGraphsFacadeCapability(contextGraphs);
+      if (facade.state === 'supported') {
+        createDispatch = resolveContextGraphCreateDispatch(legacyCreateArgs, {
+          mode: 'pca',
+          accountId: registrationAccountId,
+        });
+      } else if (coverage.source === 'explicit') {
+        throw new PcaCoverageUnsupportedError(facade.version);
+      }
+      // Automatic coverage on a confirmed old facade deliberately falls back
+      // to the legacy paid path during rolling deployment.
+    }
+
+    const submitCreate = () => this.sendContractTransaction(
+      contextGraphs,
+      createDispatch.method,
+      createDispatch.args,
+      signer,
+      'create on-chain context graph',
+    );
     const receipt = await (async () => {
       try {
         return await submitCreate();
       } catch (err) {
-        // Only the deposit-allowance revert is recoverable here. Mirror the
-        // publish/update allowance recovery (`isTooLowAllowanceError`): an
-        // unrelated first-attempt revert (invalid access/publish policy, PCA
-        // coherence failure, paused contract, insufficient balance, RPC error)
-        // must NOT trigger a state-changing TRAC approval before re-failing.
-        if (!isTooLowAllowanceError(err)) {
-          throw err;
-        }
-        // #1340: read the deposit through the RPC-failover facade (`readContract`),
-        // NOT a bare call on the signer's primary-bound `parametersStorage` handle.
-        // A broken primary otherwise throws here → is swallowed to 0n → the TRAC
-        // approve + retry below never run, defeating failover for a new CG's first
-        // publish. `readContract` fails over on transport errors (429/5xx/timeout)
-        // and rethrows a decoded revert unchanged; the catch → 0n now fires only
-        // when ALL endpoints fail or the deposit is genuinely dormant.
-        const ps = this.contracts.parametersStorage as Contract | undefined;
+        if (!isTooLowAllowanceError(err)) throw err;
+        const parametersStorage = this.contracts.parametersStorage as Contract | undefined;
         let deposit = 0n;
         try {
-          deposit = ps
-            ? await this.readContract<bigint>(
-                ps,
+          deposit = parametersStorage
+            ? BigInt(await this.readContract(
+                parametersStorage,
                 'parametersStorage.contextGraphRegistrationDeposit',
                 'contextGraphRegistrationDeposit',
-              )
+              ))
             : 0n;
-        } catch {
+        } catch (depositError) {
+          const message = depositError instanceof Error ? depositError.message : '';
+          if (HUB_STALE_ERROR_MARKERS.some((marker) => message.includes(marker))) throw depositError;
           deposit = 0n;
         }
         if (deposit === 0n) throw err;
         await this.ensureV10ApproveTrac(
-          this.signer,
+          signer,
           await contextGraphs.getAddress(),
           deposit,
           'cg registration deposit',
@@ -538,7 +939,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     let contextGraphId: bigint | undefined;
     for (const log of receipt.logs) {
       try {
-        const parsed = this.contracts.contextGraphStorage!.interface.parseLog({
+        const parsed = contextGraphStorage.interface.parseLog({
           topics: [...log.topics],
           data: log.data,
         });
@@ -548,7 +949,6 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         }
       } catch { /* not this contract */ }
     }
-
     if (contextGraphId === undefined) {
       return {
         hash: receipt.hash,
@@ -558,7 +958,6 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         contextGraphId: 0n,
       };
     }
-
     return {
       hash: receipt.hash,
       blockNumber: receipt.blockNumber,

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -27,8 +27,12 @@ import { ethers, Contract, type JsonRpcProvider, type Wallet } from 'ethers';
 import { ContextGraphChainScanPartialError, type ChainReadOptions, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type ContextGraphRegistryScanOptions, type ContextGraphRegistryScanPage, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult, type ContextGraphRegistrationCoverage, type PrepareContextGraphRegistrationOptions, type PreparedContextGraphRegistration } from './chain-adapter.js';
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
 import {
+  executionPolicyFromCoverage,
+  executionPolicyFromDepositPolicy,
   resolveContextGraphCreateDispatch,
+  type ContextGraphFacadeCapability,
   type ContextGraphLegacyCreateArgs,
+  type ContextGraphRegistrationExecutionPolicy,
 } from './context-graph-registration-dispatch.js';
 import { parsePcaRegistrationCoverageAccount } from './evm-adapter-conviction.js';
 
@@ -55,10 +59,6 @@ type OwnedCoverageDiscovery = {
   coverage: ContextGraphRegistrationCoverage;
   allowAgentFallback: boolean;
 };
-
-type FacadeCapability =
-  | { state: 'supported'; version: string }
-  | { state: 'unsupported'; version: string };
 
 class CoverageDiscoveryDeadlineError extends Error {
   constructor() {
@@ -137,7 +137,7 @@ class CoverageReadLimiter {
   }
 }
 
-function parsedFacadeVersion(version: unknown): FacadeCapability | undefined {
+function parsedFacadeVersion(version: unknown): ContextGraphFacadeCapability | undefined {
   if (typeof version !== 'string') return undefined;
   const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$/.exec(
     version.trim(),
@@ -659,30 +659,14 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
       return prepared.submit(createParams);
     }
 
-    if (registrationDepositPolicy?.mode === 'pca') {
-      if (registrationDepositPolicy.accountId <= 0n) {
-        throw new RangeError('PCA registration-deposit policy requires a positive accountId.');
-      }
-      return this.withHubStaleRetryAny(() => this.submitPreparedContextGraphRegistration(
-        createParams,
-        this.signer,
-        { source: 'explicit', accountId: registrationDepositPolicy.accountId },
-        registrationDepositPolicy,
-      ));
-    }
-    if (registrationDepositPolicy?.mode === 'paid') {
-      return this.withHubStaleRetryAny(() => this.submitPreparedContextGraphRegistration(
-        createParams,
-        this.signer,
-        { source: 'none' },
-        registrationDepositPolicy,
-      ));
-    }
-
     // Preserve the legacy direct-call path: callers that did not ask for a
     // registration execution context do not incur PCA discovery reads.
-    return this.sealContextGraphRegistration(this.signer, { source: 'none' })
-      .submit(createParams);
+    const executionPolicy = executionPolicyFromDepositPolicy(registrationDepositPolicy);
+    return this.withHubStaleRetryAny(() => this.submitPreparedContextGraphRegistration(
+      createParams,
+      this.signer,
+      executionPolicy,
+    ));
   }
 
   private registrationSignerByAddress(address: string): Wallet {
@@ -762,6 +746,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     }
     const signerAddress = ethers.getAddress(signer.address);
     const sealedCoverage = Object.freeze({ ...coverage });
+    const executionPolicy = executionPolicyFromCoverage(sealedCoverage);
     const submit = async (
       params: Omit<CreateOnChainContextGraphParams, 'registrationDepositPolicy'>,
     ): Promise<CreateOnChainContextGraphResult> => {
@@ -777,7 +762,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         this.submitPreparedContextGraphRegistration(
           params,
           signer,
-          sealedCoverage,
+          executionPolicy,
         ));
     };
     return Object.freeze({ signerAddress, coverage: sealedCoverage, submit });
@@ -977,7 +962,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
 
   private async readContextGraphsFacadeCapability(
     contextGraphs: Contract,
-  ): Promise<FacadeCapability> {
+  ): Promise<ContextGraphFacadeCapability> {
     let rawVersion: unknown;
     try {
       rawVersion = await this.readContract(
@@ -994,11 +979,40 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     return capability;
   }
 
+  private async rejectUnsupportedRegistrationFacade(
+    contextGraphs: Contract,
+    registrationMode: 'paid' | 'pca',
+    facadeVersion: string,
+  ): Promise<never> {
+    const boundAddress = await contextGraphs.getAddress();
+    let currentBinding: boolean;
+    try {
+      currentBinding = await this.isCurrentHubContractAddress(
+        'ContextGraphs',
+        boundAddress,
+      );
+    } catch (err) {
+      if (isHubStaleError(err)) throw err;
+      throw new ContextGraphFacadeVersionUnknownError({ cause: err });
+    }
+    if (!currentBinding) {
+      throw new StaleHubBindingError(
+        'ContextGraphs',
+        boundAddress,
+      );
+    }
+    if (registrationMode === 'pca') {
+      throw new PcaCoverageUnsupportedError(facadeVersion);
+    }
+    throw new Error(
+      `ContextGraphs facade ${facadeVersion} does not support explicit paid registration.`,
+    );
+  }
+
   private async submitPreparedContextGraphRegistration(
     params: Omit<CreateOnChainContextGraphParams, 'registrationDepositPolicy'>,
     signer: Wallet,
-    coverage: Readonly<ContextGraphRegistrationCoverage>,
-    explicitPolicy?: Exclude<NonNullable<CreateOnChainContextGraphParams['registrationDepositPolicy']>, { mode: 'legacy' }>,
+    executionPolicy: Readonly<ContextGraphRegistrationExecutionPolicy>,
   ): Promise<CreateOnChainContextGraphResult> {
     await this.init();
     const contextGraphs = this.contracts.contextGraphs;
@@ -1022,66 +1036,21 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
       params.publishAuthorityAccountId ?? 0n,
       params.nameHash ?? ethers.ZeroHash,
     ];
-    const registrationAccountId = coverage.source === 'none' ? 0n : coverage.accountId;
     const legacyCoverageAccountId = params.publishAuthorityAccountId ?? 0n;
-    let createDispatch = resolveContextGraphCreateDispatch(legacyCreateArgs);
-
-    if (explicitPolicy) {
-      const facade = await this.readContextGraphsFacadeCapability(contextGraphs);
-      if (facade.state !== 'supported') {
-        if (explicitPolicy.mode === 'pca') {
-          let currentBinding: boolean;
-          try {
-            currentBinding = await this.isCurrentHubContractAddress(
-              'ContextGraphs',
-              await contextGraphs.getAddress(),
-            );
-          } catch (err) {
-            if (isHubStaleError(err)) throw err;
-            throw new ContextGraphFacadeVersionUnknownError({ cause: err });
-          }
-          if (!currentBinding) {
-            throw new StaleHubBindingError(
-              'ContextGraphs',
-              await contextGraphs.getAddress(),
-            );
-          }
-          throw new PcaCoverageUnsupportedError(facade.version);
-        }
-        throw new Error(
-          `ContextGraphs facade ${facade.version} does not support explicit paid registration.`,
-        );
-      }
-      createDispatch = resolveContextGraphCreateDispatch(createArgs, explicitPolicy);
-    } else if (registrationAccountId > 0n && registrationAccountId !== legacyCoverageAccountId) {
-      const facade = await this.readContextGraphsFacadeCapability(contextGraphs);
-      if (facade.state === 'supported') {
-        createDispatch = resolveContextGraphCreateDispatch(legacyCreateArgs, {
-          mode: 'pca',
-          accountId: registrationAccountId,
-        });
-      } else if (coverage.source === 'explicit') {
-        let currentBinding: boolean;
-        try {
-          currentBinding = await this.isCurrentHubContractAddress(
-            'ContextGraphs',
-            await contextGraphs.getAddress(),
-          );
-        } catch (err) {
-          if (isHubStaleError(err)) throw err;
-          throw new ContextGraphFacadeVersionUnknownError({ cause: err });
-        }
-        if (!currentBinding) {
-          throw new StaleHubBindingError(
-            'ContextGraphs',
-            await contextGraphs.getAddress(),
-          );
-        }
-        throw new PcaCoverageUnsupportedError(facade.version);
-      }
-      // Automatic coverage on a confirmed old facade deliberately falls back
-      // to the legacy paid path during rolling deployment.
+    const resolution = await resolveContextGraphCreateDispatch(
+      legacyCreateArgs,
+      legacyCoverageAccountId,
+      executionPolicy,
+      () => this.readContextGraphsFacadeCapability(contextGraphs),
+    );
+    if (resolution.state === 'unsupported') {
+      return this.rejectUnsupportedRegistrationFacade(
+        contextGraphs,
+        resolution.registrationMode,
+        resolution.facadeVersion,
+      );
     }
+    const createDispatch = resolution.dispatch;
 
     const submitCreate = () => this.sendContractTransaction(
       contextGraphs,

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -84,7 +84,17 @@ class CoverageReadLimiter {
   async run<T>(read: () => Promise<T>): Promise<T> {
     await this.acquire();
     try {
-      return await withCoverageDeadline(Promise.resolve().then(read), this.deadline);
+      // A queued waiter can be handed a semaphore slot at the deadline. Do not
+      // start a fresh RPC after the budget has expired; only the at-most-four
+      // reads already in flight may outlive their local timeout.
+      if (this.expired()) throw new CoverageDiscoveryDeadlineError();
+      return await withCoverageDeadline(
+        Promise.resolve().then(() => {
+          if (this.expired()) throw new CoverageDiscoveryDeadlineError();
+          return read();
+        }),
+        this.deadline,
+      );
     } finally {
       this.release();
     }
@@ -121,17 +131,22 @@ class CoverageReadLimiter {
 
 function parsedFacadeVersion(version: unknown): FacadeCapability | undefined {
   if (typeof version !== 'string') return undefined;
-  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?$/.exec(version.trim());
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$/.exec(
+    version.trim(),
+  );
   if (!match) return undefined;
   const actual = match.slice(1, 4).map(Number);
-  const supported = actual.some((part, index) =>
-    part > MINIMUM_PCA_WAIVER_FACADE_VERSION[index]
-      && actual.slice(0, index).every(
-        (previous, previousIndex) => previous === MINIMUM_PCA_WAIVER_FACADE_VERSION[previousIndex],
-      ),
-  ) || actual.every(
-    (part, index) => part === MINIMUM_PCA_WAIVER_FACADE_VERSION[index],
-  );
+  if (!actual.every(Number.isSafeInteger)) return undefined;
+  let comparison = 0;
+  for (let index = 0; index < actual.length; index += 1) {
+    if (actual[index] === MINIMUM_PCA_WAIVER_FACADE_VERSION[index]) continue;
+    comparison = actual[index] > MINIMUM_PCA_WAIVER_FACADE_VERSION[index] ? 1 : -1;
+    break;
+  }
+  // The floor is a stable release: 10.0.5-rc.x remains below it, while a
+  // prerelease of a later numeric version still necessarily contains the
+  // selector introduced in 10.0.5.
+  const supported = comparison > 0 || (comparison === 0 && match[4] === undefined);
   return { state: supported ? 'supported' : 'unsupported', version: version.trim() };
 }
 
@@ -891,6 +906,25 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           accountId: registrationAccountId,
         });
       } else if (coverage.source === 'explicit') {
+        let currentBinding: boolean;
+        try {
+          currentBinding = await this.isCurrentHubContractAddress(
+            'ContextGraphs',
+            await contextGraphs.getAddress(),
+          );
+        } catch (err) {
+          const message = err instanceof Error ? err.message : '';
+          if (HUB_STALE_ERROR_MARKERS.some((marker) => message.includes(marker))) throw err;
+          throw new ContextGraphFacadeVersionUnknownError({ cause: err });
+        }
+        if (!currentBinding) {
+          // Feed the ordinary stale-Hub recovery path. Unlike a retired facade
+          // write, an early capability rejection would otherwise never expose
+          // the canonical Hub authorization marker.
+          throw new Error(
+            'UnauthorizedAccess(Only Contracts in Hub): stale ContextGraphs facade capability binding',
+          );
+        }
         throw new PcaCoverageUnsupportedError(facade.version);
       }
       // Automatic coverage on a confirmed old facade deliberately falls back

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -16,18 +16,21 @@ import {
 } from './evm-adapter-base.js';
 import {
   ContextGraphFacadeVersionUnknownError,
+  ContextGraphRegistrationCoverageSignerUnavailableError,
   ContextGraphRegistrationSignerUnavailableError,
-  HUB_STALE_ERROR_MARKERS,
   PcaCoverageUnsupportedError,
+  StaleHubBindingError,
+  isHubStaleError,
   isTooLowAllowanceError,
 } from './evm-adapter-errors.js';
 import { ethers, Contract, type JsonRpcProvider, type Wallet } from 'ethers';
-import { ContextGraphChainScanPartialError, type ChainReadOptions, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type ContextGraphRegistryScanOptions, type ContextGraphRegistryScanPage, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult, type ContextGraphRegistrationCoverage, type PrepareContextGraphRegistrationOptions, type PreparedContextGraphRegistration, type PreparedCreateOnChainContextGraphParams } from './chain-adapter.js';
+import { ContextGraphChainScanPartialError, type ChainReadOptions, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type ContextGraphRegistryScanOptions, type ContextGraphRegistryScanPage, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult, type ContextGraphRegistrationCoverage, type PrepareContextGraphRegistrationOptions, type PreparedContextGraphRegistration } from './chain-adapter.js';
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
 import {
   resolveContextGraphCreateDispatch,
   type ContextGraphLegacyCreateArgs,
 } from './context-graph-registration-dispatch.js';
+import { parsePcaRegistrationCoverageAccount } from './evm-adapter-conviction.js';
 
 export const MAX_AUTO_COVERAGE_CANDIDATES = 32;
 export const AUTO_COVERAGE_DISCOVERY_TIMEOUT_MS = 5_000;
@@ -46,6 +49,11 @@ type CoverageDiscoverySnapshot = {
   pca: Contract;
   waiverStorage: Contract;
   reads: CoverageReadLimiter;
+};
+
+type OwnedCoverageDiscovery = {
+  coverage: ContextGraphRegistrationCoverage;
+  allowAgentFallback: boolean;
 };
 
 type FacadeCapability =
@@ -148,10 +156,6 @@ function parsedFacadeVersion(version: unknown): FacadeCapability | undefined {
   // selector introduced in 10.0.5.
   const supported = comparison > 0 || (comparison === 0 && match[4] === undefined);
   return { state: supported ? 'supported' : 'unsupported', version: version.trim() };
-}
-
-function accountField(account: any, name: string, index: number): any {
-  return account?.[name] ?? account?.[index];
 }
 
 type ContextGraphRegistryScanPlan =
@@ -579,14 +583,22 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     await this.init();
 
     const explicitAccountId = options.registrationPcaAccountId;
-    const hasExplicitCoverage = explicitAccountId !== undefined && explicitAccountId > 0n;
+    if (explicitAccountId !== undefined && explicitAccountId <= 0n) {
+      throw new RangeError('registrationPcaAccountId must be a positive PCA account id.');
+    }
     const pinnedSigner = options.registrationSignerAddress
       ? this.registrationSignerByAddress(options.registrationSignerAddress)
       : undefined;
 
-    if (hasExplicitCoverage) {
+    if (explicitAccountId !== undefined) {
+      const candidates = pinnedSigner
+        ? [pinnedSigner]
+        : options.preferPcaCoveredSigner
+          ? this.signerPool
+          : [this.signer];
+      const signer = await this.resolveExplicitCoverageSigner(explicitAccountId, candidates);
       return this.sealContextGraphRegistration(
-        pinnedSigner ?? this.signer,
+        signer,
         { source: 'explicit', accountId: explicitAccountId },
       );
     }
@@ -599,9 +611,21 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
       const deadline = Date.now() + AUTO_COVERAGE_DISCOVERY_TIMEOUT_MS;
       const snapshot = await this.prepareCoverageDiscoverySnapshot(deadline);
       if (snapshot) {
+        const agentCandidates: Wallet[] = [];
         for (const signer of this.signerPool) {
-          const coverage = await this.discoverCoverageForSigner(signer, snapshot);
-          if (coverage.source !== 'none') {
+          const owned = await this.discoverOwnedCoverageForSigner(signer, snapshot);
+          if (owned.coverage.source === 'owned') {
+            return this.sealContextGraphRegistration(signer, owned.coverage);
+          }
+          if (owned.allowAgentFallback) agentCandidates.push(signer);
+          if (Date.now() >= deadline) break;
+        }
+        // Ownership has stronger authority than a consent-free agent binding,
+        // so only consult agent mappings after every pool signer has had a
+        // bounded opportunity to prove owned coverage.
+        for (const signer of agentCandidates) {
+          const coverage = await this.discoverAgentCoverageForSigner(signer, snapshot);
+          if (coverage.source === 'agent') {
             return this.sealContextGraphRegistration(signer, coverage);
           }
           if (Date.now() >= deadline) break;
@@ -621,24 +645,14 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
 
   async createOnChainContextGraph(
     params: CreateOnChainContextGraphParams,
+    preparationOptions?: PrepareContextGraphRegistrationOptions,
   ): Promise<CreateOnChainContextGraphResult> {
-    const shouldPrepare =
-      params.registrationPcaAccountId !== undefined
-      || params.registrationSignerAddress !== undefined;
-    const prepared = shouldPrepare
-      ? await this.prepareOnChainContextGraphRegistration({
-          registrationPcaAccountId: params.registrationPcaAccountId,
-          registrationSignerAddress: params.registrationSignerAddress,
-        })
+    const prepared = preparationOptions !== undefined
+      ? await this.prepareOnChainContextGraphRegistration(preparationOptions)
       // Preserve the legacy direct-call path: callers that did not ask for a
       // registration execution context do not incur PCA discovery reads.
       : this.sealContextGraphRegistration(this.signer, { source: 'none' });
-    const {
-      registrationPcaAccountId: _registrationPcaAccountId,
-      registrationSignerAddress: _registrationSignerAddress,
-      ...submitParams
-    } = params;
-    return prepared.submit(submitParams);
+    return prepared.submit(params);
   }
 
   private registrationSignerByAddress(address: string): Wallet {
@@ -653,25 +667,71 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     return signer;
   }
 
+  /**
+   * Resolve one explicitly requested PCA against the configured signer pool.
+   * Ownership wins without per-signer reads; otherwise exact agent mappings
+   * are checked in deterministic pool order. Explicit intent fails closed and
+   * never silently degrades to the primary signer/deposit path.
+   */
+  private async resolveExplicitCoverageSigner(
+    accountId: bigint,
+    candidates: readonly Wallet[],
+  ): Promise<Wallet> {
+    const pca = this.contracts.dkgPublishingConvictionNFT;
+    if (!pca) {
+      throw new ContextGraphRegistrationCoverageSignerUnavailableError(accountId, {
+        cause: new Error('DKGPublishingConvictionNFT is not deployed.'),
+      });
+    }
+
+    let firstReadError: unknown;
+    try {
+      const owner = ethers.getAddress(String(await this.readContract(
+        pca,
+        'pca.ownerOf explicit registration coverage',
+        'ownerOf',
+        accountId,
+      )));
+      const ownerSigner = candidates.find(
+        (candidate) => ethers.getAddress(candidate.address) === owner,
+      );
+      if (ownerSigner) return ownerSigner;
+    } catch (err) {
+      firstReadError = err;
+    }
+
+    for (const signer of candidates) {
+      try {
+        const mappedAccountId = BigInt(await this.readContract(
+          pca,
+          'pca.agentToAccountId explicit registration coverage',
+          'agentToAccountId',
+          signer.address,
+        ));
+        if (mappedAccountId === accountId) return signer;
+      } catch (err) {
+        firstReadError ??= err;
+      }
+    }
+
+    throw new ContextGraphRegistrationCoverageSignerUnavailableError(accountId, {
+      cause: firstReadError,
+    });
+  }
+
   private sealContextGraphRegistration(
     signer: Wallet,
     coverage: ContextGraphRegistrationCoverage,
   ): PreparedContextGraphRegistration {
+    if (coverage.source !== 'none' && coverage.accountId <= 0n) {
+      throw new RangeError('Covered context-graph registration requires a positive PCA account id.');
+    }
     const signerAddress = ethers.getAddress(signer.address);
     const sealedCoverage = Object.freeze({ ...coverage });
     const submit = async (
-      params: PreparedCreateOnChainContextGraphParams,
+      params: CreateOnChainContextGraphParams,
     ): Promise<CreateOnChainContextGraphResult> => {
-      const runtimeParams = params as CreateOnChainContextGraphParams;
-      if (
-        runtimeParams == null
-        || Object.prototype.hasOwnProperty.call(runtimeParams, 'registrationPcaAccountId')
-        || Object.prototype.hasOwnProperty.call(runtimeParams, 'registrationSignerAddress')
-      ) {
-        throw new Error(
-          'Prepared context-graph registration does not accept signer or PCA coverage overrides.',
-        );
-      }
+      if (params == null) throw new TypeError('Prepared context-graph registration requires create parameters.');
       // A prepared capability may outlive adapter reconfiguration. Fail rather
       // than substituting another pool signer; the captured wallet remains the
       // only wallet this capability can use.
@@ -735,6 +795,17 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     signer: Wallet,
     snapshot: CoverageDiscoverySnapshot,
   ): Promise<ContextGraphRegistrationCoverage> {
+    const owned = await this.discoverOwnedCoverageForSigner(signer, snapshot);
+    if (owned.coverage.source === 'owned' || !owned.allowAgentFallback) {
+      return owned.coverage;
+    }
+    return this.discoverAgentCoverageForSigner(signer, snapshot);
+  }
+
+  private async discoverOwnedCoverageForSigner(
+    signer: Wallet,
+    snapshot: CoverageDiscoverySnapshot,
+  ): Promise<OwnedCoverageDiscovery> {
     try {
       const balance = BigInt(await snapshot.reads.run(() => this.readContract(
         snapshot.pca,
@@ -745,7 +816,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
       if (balance > BigInt(MAX_AUTO_COVERAGE_CANDIDATES)) {
         // Do not consult an unsolicited agent binding after refusing amplified
         // owner enumeration. The operator can still supply an explicit PCA ID.
-        return { source: 'none' };
+        return { coverage: { source: 'none' }, allowAgentFallback: false };
       }
 
       const accountIds = await Promise.all(Array.from(
@@ -770,9 +841,28 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         ),
       })));
       const owned = ownerEligibility.find((candidate) => candidate.eligible);
-      if (owned) return { source: 'owned', accountId: owned.accountId };
-      if (snapshot.reads.expired()) return { source: 'none' };
+      if (owned) {
+        return {
+          coverage: { source: 'owned', accountId: owned.accountId },
+          allowAgentFallback: false,
+        };
+      }
+      return {
+        coverage: { source: 'none' },
+        allowAgentFallback: !snapshot.reads.expired(),
+      };
+    } catch {
+      // A signer-level owner-enumeration or total-budget failure cannot safely
+      // fall through to an unsolicited agent binding.
+      return { coverage: { source: 'none' }, allowAgentFallback: false };
+    }
+  }
 
+  private async discoverAgentCoverageForSigner(
+    signer: Wallet,
+    snapshot: CoverageDiscoverySnapshot,
+  ): Promise<ContextGraphRegistrationCoverage> {
+    try {
       const agentAccountId = BigInt(await snapshot.reads.run(() => this.readContract(
         snapshot.pca,
         'pca.agentToAccountId registration coverage',
@@ -791,8 +881,8 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         return { source: 'agent', accountId: agentAccountId };
       }
     } catch {
-      // Enumeration, agent resolution, or total-budget failure makes automatic
-      // coverage unavailable. Never guess a candidate.
+      // Agent resolution or total-budget failure makes automatic coverage
+      // unavailable. Never guess a candidate.
     }
     return { source: 'none' };
   }
@@ -828,9 +918,9 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
       ]);
       if (ethers.getAddress(String(owner)) !== ethers.getAddress(signerAddress)) return false;
 
-      const committed = BigInt(accountField(account, 'committedTRAC', 0) ?? 0n);
-      const expiresAtTimestamp = BigInt(accountField(account, 'expiresAtTimestamp', 4) ?? 0n);
-      const fullySwept = Boolean(accountField(account, 'fullySwept', 8));
+      const parsedAccount = parsePcaRegistrationCoverageAccount(account);
+      if (!parsedAccount) return false;
+      const { committedTRAC: committed, expiresAtTimestamp, fullySwept } = parsedAccount;
       if (
         committed === 0n
         || fullySwept
@@ -858,8 +948,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         'version',
       );
     } catch (err) {
-      const message = err instanceof Error ? err.message : '';
-      if (HUB_STALE_ERROR_MARKERS.some((marker) => message.includes(marker))) throw err;
+      if (isHubStaleError(err)) throw err;
       throw new ContextGraphFacadeVersionUnknownError({ cause: err });
     }
     const capability = parsedFacadeVersion(rawVersion);
@@ -868,7 +957,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
   }
 
   private async submitPreparedContextGraphRegistration(
-    params: PreparedCreateOnChainContextGraphParams,
+    params: CreateOnChainContextGraphParams,
     signer: Wallet,
     coverage: Readonly<ContextGraphRegistrationCoverage>,
   ): Promise<CreateOnChainContextGraphResult> {
@@ -894,7 +983,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
       params.publishAuthorityAccountId ?? 0n,
       params.nameHash ?? ethers.ZeroHash,
     ];
-    const registrationAccountId = coverage.accountId ?? 0n;
+    const registrationAccountId = coverage.source === 'none' ? 0n : coverage.accountId;
     const legacyCoverageAccountId = params.publishAuthorityAccountId ?? 0n;
     let createDispatch = resolveContextGraphCreateDispatch(legacyCreateArgs);
 
@@ -913,16 +1002,13 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
             await contextGraphs.getAddress(),
           );
         } catch (err) {
-          const message = err instanceof Error ? err.message : '';
-          if (HUB_STALE_ERROR_MARKERS.some((marker) => message.includes(marker))) throw err;
+          if (isHubStaleError(err)) throw err;
           throw new ContextGraphFacadeVersionUnknownError({ cause: err });
         }
         if (!currentBinding) {
-          // Feed the ordinary stale-Hub recovery path. Unlike a retired facade
-          // write, an early capability rejection would otherwise never expose
-          // the canonical Hub authorization marker.
-          throw new Error(
-            'UnauthorizedAccess(Only Contracts in Hub): stale ContextGraphs facade capability binding',
+          throw new StaleHubBindingError(
+            'ContextGraphs',
+            await contextGraphs.getAddress(),
           );
         }
         throw new PcaCoverageUnsupportedError(facade.version);
@@ -954,8 +1040,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
               ))
             : 0n;
         } catch (depositError) {
-          const message = depositError instanceof Error ? depositError.message : '';
-          if (HUB_STALE_ERROR_MARKERS.some((marker) => message.includes(marker))) throw depositError;
+          if (isHubStaleError(depositError)) throw depositError;
           deposit = 0n;
         }
         if (deposit === 0n) throw err;

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -972,18 +972,18 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
       );
     } catch (err) {
       if (isHubStaleError(err)) throw err;
+      await this.assertCurrentContextGraphsFacade(contextGraphs);
       throw new ContextGraphFacadeVersionUnknownError({ cause: err });
     }
     const capability = parsedFacadeVersion(rawVersion);
-    if (!capability) throw new ContextGraphFacadeVersionUnknownError();
+    if (!capability) {
+      await this.assertCurrentContextGraphsFacade(contextGraphs);
+      throw new ContextGraphFacadeVersionUnknownError();
+    }
     return capability;
   }
 
-  private async rejectUnsupportedRegistrationFacade(
-    contextGraphs: Contract,
-    registrationMode: 'paid' | 'pca',
-    facadeVersion: string,
-  ): Promise<never> {
+  private async assertCurrentContextGraphsFacade(contextGraphs: Contract): Promise<void> {
     const boundAddress = await contextGraphs.getAddress();
     let currentBinding: boolean;
     try {
@@ -1001,6 +1001,14 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         boundAddress,
       );
     }
+  }
+
+  private async rejectUnsupportedRegistrationFacade(
+    contextGraphs: Contract,
+    registrationMode: 'paid' | 'pca',
+    facadeVersion: string,
+  ): Promise<never> {
+    await this.assertCurrentContextGraphsFacade(contextGraphs);
     if (registrationMode === 'pca') {
       throw new PcaCoverageUnsupportedError(facadeVersion);
     }

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -679,9 +679,9 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
   ): Promise<Wallet> {
     const pca = this.contracts.dkgPublishingConvictionNFT;
     if (!pca) {
-      throw new ContextGraphRegistrationCoverageSignerUnavailableError(accountId, {
-        cause: new Error('DKGPublishingConvictionNFT is not deployed.'),
-      });
+      throw new Error(
+        'DKGPublishingConvictionNFT is not deployed; explicit PCA registration coverage cannot be verified.',
+      );
     }
 
     let firstReadError: unknown;
@@ -714,9 +714,13 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
       }
     }
 
-    throw new ContextGraphRegistrationCoverageSignerUnavailableError(accountId, {
-      cause: firstReadError,
-    });
+    // A permanent signer mismatch is knowable only when every relationship
+    // read completed. If any owner/agent verification failed, preserve that
+    // original RPC, stale-binding, or decoded contract error so callers retain
+    // its retryability/classification instead of treating an outage as a
+    // terminal signer-configuration problem.
+    if (firstReadError !== undefined) throw firstReadError;
+    throw new ContextGraphRegistrationCoverageSignerUnavailableError(accountId);
   }
 
   private sealContextGraphRegistration(

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -647,12 +647,42 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     params: CreateOnChainContextGraphParams,
     preparationOptions?: PrepareContextGraphRegistrationOptions,
   ): Promise<CreateOnChainContextGraphResult> {
-    const prepared = preparationOptions !== undefined
-      ? await this.prepareOnChainContextGraphRegistration(preparationOptions)
-      // Preserve the legacy direct-call path: callers that did not ask for a
-      // registration execution context do not incur PCA discovery reads.
-      : this.sealContextGraphRegistration(this.signer, { source: 'none' });
-    return prepared.submit(params);
+    const { registrationDepositPolicy, ...createParams } = params;
+    if (preparationOptions !== undefined) {
+      if (registrationDepositPolicy && registrationDepositPolicy.mode !== 'legacy') {
+        throw new TypeError(
+          'Prepared context-graph registration seals its deposit policy; ' +
+          'do not also pass registrationDepositPolicy.',
+        );
+      }
+      const prepared = await this.prepareOnChainContextGraphRegistration(preparationOptions);
+      return prepared.submit(createParams);
+    }
+
+    if (registrationDepositPolicy?.mode === 'pca') {
+      if (registrationDepositPolicy.accountId <= 0n) {
+        throw new RangeError('PCA registration-deposit policy requires a positive accountId.');
+      }
+      return this.withHubStaleRetryAny(() => this.submitPreparedContextGraphRegistration(
+        createParams,
+        this.signer,
+        { source: 'explicit', accountId: registrationDepositPolicy.accountId },
+        registrationDepositPolicy,
+      ));
+    }
+    if (registrationDepositPolicy?.mode === 'paid') {
+      return this.withHubStaleRetryAny(() => this.submitPreparedContextGraphRegistration(
+        createParams,
+        this.signer,
+        { source: 'none' },
+        registrationDepositPolicy,
+      ));
+    }
+
+    // Preserve the legacy direct-call path: callers that did not ask for a
+    // registration execution context do not incur PCA discovery reads.
+    return this.sealContextGraphRegistration(this.signer, { source: 'none' })
+      .submit(createParams);
   }
 
   private registrationSignerByAddress(address: string): Wallet {
@@ -733,7 +763,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const signerAddress = ethers.getAddress(signer.address);
     const sealedCoverage = Object.freeze({ ...coverage });
     const submit = async (
-      params: CreateOnChainContextGraphParams,
+      params: Omit<CreateOnChainContextGraphParams, 'registrationDepositPolicy'>,
     ): Promise<CreateOnChainContextGraphResult> => {
       if (params == null) throw new TypeError('Prepared context-graph registration requires create parameters.');
       // A prepared capability may outlive adapter reconfiguration. Fail rather
@@ -744,7 +774,11 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         throw new ContextGraphRegistrationSignerUnavailableError(signerAddress);
       }
       return this.withHubStaleRetryAny(() =>
-        this.submitPreparedContextGraphRegistration(params, signer, sealedCoverage));
+        this.submitPreparedContextGraphRegistration(
+          params,
+          signer,
+          sealedCoverage,
+        ));
     };
     return Object.freeze({ signerAddress, coverage: sealedCoverage, submit });
   }
@@ -961,9 +995,10 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
   }
 
   private async submitPreparedContextGraphRegistration(
-    params: CreateOnChainContextGraphParams,
+    params: Omit<CreateOnChainContextGraphParams, 'registrationDepositPolicy'>,
     signer: Wallet,
     coverage: Readonly<ContextGraphRegistrationCoverage>,
+    explicitPolicy?: Exclude<NonNullable<CreateOnChainContextGraphParams['registrationDepositPolicy']>, { mode: 'legacy' }>,
   ): Promise<CreateOnChainContextGraphResult> {
     await this.init();
     const contextGraphs = this.contracts.contextGraphs;
@@ -991,7 +1026,34 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
     const legacyCoverageAccountId = params.publishAuthorityAccountId ?? 0n;
     let createDispatch = resolveContextGraphCreateDispatch(legacyCreateArgs);
 
-    if (registrationAccountId > 0n && registrationAccountId !== legacyCoverageAccountId) {
+    if (explicitPolicy) {
+      const facade = await this.readContextGraphsFacadeCapability(contextGraphs);
+      if (facade.state !== 'supported') {
+        if (explicitPolicy.mode === 'pca') {
+          let currentBinding: boolean;
+          try {
+            currentBinding = await this.isCurrentHubContractAddress(
+              'ContextGraphs',
+              await contextGraphs.getAddress(),
+            );
+          } catch (err) {
+            if (isHubStaleError(err)) throw err;
+            throw new ContextGraphFacadeVersionUnknownError({ cause: err });
+          }
+          if (!currentBinding) {
+            throw new StaleHubBindingError(
+              'ContextGraphs',
+              await contextGraphs.getAddress(),
+            );
+          }
+          throw new PcaCoverageUnsupportedError(facade.version);
+        }
+        throw new Error(
+          `ContextGraphs facade ${facade.version} does not support explicit paid registration.`,
+        );
+      }
+      createDispatch = resolveContextGraphCreateDispatch(createArgs, explicitPolicy);
+    } else if (registrationAccountId > 0n && registrationAccountId !== legacyCoverageAccountId) {
       const facade = await this.readContextGraphsFacadeCapability(contextGraphs);
       if (facade.state === 'supported') {
         createDispatch = resolveContextGraphCreateDispatch(legacyCreateArgs, {

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -94,6 +94,42 @@ export interface RawShardingTableNode extends ArrayLike<unknown> {
   stake?: unknown;
 }
 
+/** The only PCA `accounts()` fields needed by context-graph registration. */
+export interface PcaRegistrationCoverageAccount {
+  committedTRAC: bigint;
+  expiresAtTimestamp: bigint;
+  fullySwept: boolean;
+}
+
+/**
+ * Parse the narrow PCA `accounts()` projection used for registration-waiver
+ * eligibility. Ethers Results expose both named and positional fields, while
+ * lightweight RPC/test decoders may expose only one representation. Unknown,
+ * missing, wrongly typed, or impossible values return `undefined` so callers
+ * fail closed instead of manufacturing zero/false defaults.
+ */
+export function parsePcaRegistrationCoverageAccount(
+  raw: unknown,
+): PcaRegistrationCoverageAccount | undefined {
+  if (raw === null || typeof raw !== 'object') return undefined;
+  try {
+    const record = raw as Record<string | number, unknown>;
+    const committedTRAC = record.committedTRAC ?? record[0];
+    const expiresAtTimestamp = record.expiresAtTimestamp ?? record[4];
+    const fullySwept = record.fullySwept ?? record[8];
+    if (
+      typeof committedTRAC !== 'bigint'
+      || committedTRAC < 0n
+      || typeof expiresAtTimestamp !== 'bigint'
+      || expiresAtTimestamp < 0n
+      || typeof fullySwept !== 'boolean'
+    ) return undefined;
+    return { committedTRAC, expiresAtTimestamp, fullySwept };
+  } catch {
+    return undefined;
+  }
+}
+
 export function toShardingTableNode(raw: RawShardingTableNode): ShardingTableNode {
   return {
     nodeId: String(raw.nodeId ?? raw[0]),

--- a/packages/chain/src/evm-adapter-errors.ts
+++ b/packages/chain/src/evm-adapter-errors.ts
@@ -17,6 +17,59 @@ import {
 } from '@origintrail-official/dkg-core';
 import { loadAbi } from './evm-adapter-abi.js';
 
+export const PCA_COVERAGE_UNSUPPORTED_CODE = 'PCA_COVERAGE_UNSUPPORTED' as const;
+export const CONTEXT_GRAPH_FACADE_VERSION_UNKNOWN_CODE =
+  'CONTEXT_GRAPH_FACADE_VERSION_UNKNOWN' as const;
+export const CONTEXT_GRAPH_REGISTRATION_SIGNER_UNAVAILABLE_CODE =
+  'CONTEXT_GRAPH_REGISTRATION_SIGNER_UNAVAILABLE' as const;
+
+/**
+ * An explicit, decoupled PCA coverage request cannot be represented by the
+ * deployed ContextGraphs facade. Explicit intent must never silently become a
+ * paid legacy registration.
+ */
+export class PcaCoverageUnsupportedError extends Error {
+  readonly code = PCA_COVERAGE_UNSUPPORTED_CODE;
+  readonly facadeVersion: string;
+
+  constructor(facadeVersion: string) {
+    super(
+      `Explicit PCA registration coverage requires ContextGraphs 10.0.5 or newer; ` +
+      `the deployed facade reports ${facadeVersion}.`,
+    );
+    this.name = 'PcaCoverageUnsupportedError';
+    this.facadeVersion = facadeVersion;
+  }
+}
+
+/** A facade version could not be classified safely; retry after deployment/RPC recovery. */
+export class ContextGraphFacadeVersionUnknownError extends Error {
+  readonly code = CONTEXT_GRAPH_FACADE_VERSION_UNKNOWN_CODE;
+  readonly retryable = true;
+
+  constructor(options?: { cause?: unknown }) {
+    super(
+      'Unable to determine the deployed ContextGraphs facade capability; retry after the RPC or deployment state stabilizes.',
+      options,
+    );
+    this.name = 'ContextGraphFacadeVersionUnknownError';
+  }
+}
+
+/** The signer sealed into a prepared capability is no longer in the adapter pool. */
+export class ContextGraphRegistrationSignerUnavailableError extends Error {
+  readonly code = CONTEXT_GRAPH_REGISTRATION_SIGNER_UNAVAILABLE_CODE;
+  readonly signerAddress: string;
+
+  constructor(signerAddress: string) {
+    super(
+      `Prepared context-graph registration signer ${signerAddress} is no longer available in the EVM signer pool.`,
+    );
+    this.name = 'ContextGraphRegistrationSignerUnavailableError';
+    this.signerAddress = signerAddress;
+  }
+}
+
 export function errorMessage(err: unknown): string {
   if (err instanceof Error) return err.message;
   try { return JSON.stringify(err); } catch { return String(err); }

--- a/packages/chain/src/evm-adapter-errors.ts
+++ b/packages/chain/src/evm-adapter-errors.ts
@@ -22,6 +22,9 @@ export const CONTEXT_GRAPH_FACADE_VERSION_UNKNOWN_CODE =
   'CONTEXT_GRAPH_FACADE_VERSION_UNKNOWN' as const;
 export const CONTEXT_GRAPH_REGISTRATION_SIGNER_UNAVAILABLE_CODE =
   'CONTEXT_GRAPH_REGISTRATION_SIGNER_UNAVAILABLE' as const;
+export const CONTEXT_GRAPH_REGISTRATION_COVERAGE_SIGNER_UNAVAILABLE_CODE =
+  'CONTEXT_GRAPH_REGISTRATION_COVERAGE_SIGNER_UNAVAILABLE' as const;
+export const STALE_HUB_BINDING_CODE = 'STALE_HUB_BINDING' as const;
 
 /**
  * An explicit, decoupled PCA coverage request cannot be represented by the
@@ -67,6 +70,22 @@ export class ContextGraphRegistrationSignerUnavailableError extends Error {
     );
     this.name = 'ContextGraphRegistrationSignerUnavailableError';
     this.signerAddress = signerAddress;
+  }
+}
+
+/** No configured signer can exercise one explicitly requested PCA account. */
+export class ContextGraphRegistrationCoverageSignerUnavailableError extends Error {
+  readonly code = CONTEXT_GRAPH_REGISTRATION_COVERAGE_SIGNER_UNAVAILABLE_CODE;
+  readonly accountId: bigint;
+
+  constructor(accountId: bigint, options?: { cause?: unknown }) {
+    super(
+      `No configured EVM signer could be verified as the owner or exact registered agent ` +
+      `of explicit PCA account ${accountId}.`,
+      options,
+    );
+    this.name = 'ContextGraphRegistrationCoverageSignerUnavailableError';
+    this.accountId = accountId;
   }
 }
 
@@ -146,6 +165,29 @@ export const HUB_STALE_ERROR_MARKERS = [
   'Only Contracts in Hub',
   'UnauthorizedAccess(Only Contracts in Hub)',
 ];
+
+/** Local proof that a cached boot-bound contract no longer matches Hub. */
+export class StaleHubBindingError extends Error {
+  readonly code = STALE_HUB_BINDING_CODE;
+  readonly contractName: string;
+  readonly boundAddress?: string;
+
+  constructor(contractName: string, boundAddress?: string) {
+    super(
+      `Cached ${contractName} binding${boundAddress ? ` ${boundAddress}` : ''} is stale relative to Hub.`,
+    );
+    this.name = 'StaleHubBindingError';
+    this.contractName = contractName;
+    this.boundAddress = boundAddress;
+  }
+}
+
+/** Shared classifier for provider-reported Hub authorization and local coherence failures. */
+export function isHubStaleError(err: unknown): boolean {
+  if (err instanceof StaleHubBindingError) return true;
+  const message = err instanceof Error ? err.message : '';
+  return HUB_STALE_ERROR_MARKERS.some((marker) => message.includes(marker));
+}
 
 let _errorInterface: Interface | null = null;
 let _pcaLogicInterface: Interface | null = null;

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -39,9 +39,14 @@ export {
   PCA_COVERAGE_UNSUPPORTED_CODE,
   CONTEXT_GRAPH_FACADE_VERSION_UNKNOWN_CODE,
   CONTEXT_GRAPH_REGISTRATION_SIGNER_UNAVAILABLE_CODE,
+  CONTEXT_GRAPH_REGISTRATION_COVERAGE_SIGNER_UNAVAILABLE_CODE,
+  STALE_HUB_BINDING_CODE,
   PcaCoverageUnsupportedError,
   ContextGraphFacadeVersionUnknownError,
   ContextGraphRegistrationSignerUnavailableError,
+  ContextGraphRegistrationCoverageSignerUnavailableError,
+  StaleHubBindingError,
+  isHubStaleError,
   type PublisherWalletBalance,
 } from './evm-adapter-errors.js';
 export {
@@ -55,6 +60,10 @@ export {
   V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE,
 } from './evm-adapter-allowance.js';
 export type { EVMAdapterConfig } from './evm-adapter-types.js';
+export {
+  parsePcaRegistrationCoverageAccount,
+  type PcaRegistrationCoverageAccount,
+} from './evm-adapter-conviction.js';
 
 /**
  * EVM chain adapter implementing the V9 ChainAdapter interface.

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -45,8 +45,6 @@ export {
   ContextGraphFacadeVersionUnknownError,
   ContextGraphRegistrationSignerUnavailableError,
   ContextGraphRegistrationCoverageSignerUnavailableError,
-  StaleHubBindingError,
-  isHubStaleError,
   type PublisherWalletBalance,
 } from './evm-adapter-errors.js';
 export {
@@ -60,11 +58,6 @@ export {
   V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE,
 } from './evm-adapter-allowance.js';
 export type { EVMAdapterConfig } from './evm-adapter-types.js';
-export {
-  parsePcaRegistrationCoverageAccount,
-  type PcaRegistrationCoverageAccount,
-} from './evm-adapter-conviction.js';
-
 /**
  * EVM chain adapter implementing the V9 ChainAdapter interface.
  * Resolves contract addresses dynamically from the Hub.

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -36,6 +36,12 @@ export {
   isNoFundedPublisherWalletError,
   NO_FUNDED_PUBLISHER_WALLET_CODE,
   formatNoFundedPublisherWalletMessage,
+  PCA_COVERAGE_UNSUPPORTED_CODE,
+  CONTEXT_GRAPH_FACADE_VERSION_UNKNOWN_CODE,
+  CONTEXT_GRAPH_REGISTRATION_SIGNER_UNAVAILABLE_CODE,
+  PcaCoverageUnsupportedError,
+  ContextGraphFacadeVersionUnknownError,
+  ContextGraphRegistrationSignerUnavailableError,
   type PublisherWalletBalance,
 } from './evm-adapter-errors.js';
 export {

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -148,9 +148,16 @@ export {
   PCA_COVERAGE_UNSUPPORTED_CODE,
   CONTEXT_GRAPH_FACADE_VERSION_UNKNOWN_CODE,
   CONTEXT_GRAPH_REGISTRATION_SIGNER_UNAVAILABLE_CODE,
+  CONTEXT_GRAPH_REGISTRATION_COVERAGE_SIGNER_UNAVAILABLE_CODE,
+  STALE_HUB_BINDING_CODE,
   PcaCoverageUnsupportedError,
   ContextGraphFacadeVersionUnknownError,
   ContextGraphRegistrationSignerUnavailableError,
+  ContextGraphRegistrationCoverageSignerUnavailableError,
+  StaleHubBindingError,
+  isHubStaleError,
+  parsePcaRegistrationCoverageAccount,
+  type PcaRegistrationCoverageAccount,
   type PublisherWalletBalance,
 } from './evm-adapter.js';
 export { NoChainAdapter } from './no-chain-adapter.js';

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -145,6 +145,12 @@ export {
   InsufficientPublisherFundsError,
   isNoFundedPublisherWalletError,
   NO_FUNDED_PUBLISHER_WALLET_CODE,
+  PCA_COVERAGE_UNSUPPORTED_CODE,
+  CONTEXT_GRAPH_FACADE_VERSION_UNKNOWN_CODE,
+  CONTEXT_GRAPH_REGISTRATION_SIGNER_UNAVAILABLE_CODE,
+  PcaCoverageUnsupportedError,
+  ContextGraphFacadeVersionUnknownError,
+  ContextGraphRegistrationSignerUnavailableError,
   type PublisherWalletBalance,
 } from './evm-adapter.js';
 export { NoChainAdapter } from './no-chain-adapter.js';

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -154,10 +154,6 @@ export {
   ContextGraphFacadeVersionUnknownError,
   ContextGraphRegistrationSignerUnavailableError,
   ContextGraphRegistrationCoverageSignerUnavailableError,
-  StaleHubBindingError,
-  isHubStaleError,
-  parsePcaRegistrationCoverageAccount,
-  type PcaRegistrationCoverageAccount,
   type PublisherWalletBalance,
 } from './evm-adapter.js';
 export { NoChainAdapter } from './no-chain-adapter.js';

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -45,6 +45,7 @@ import {
   MerkleRootMismatchError,
   ChallengeNoLongerActiveError,
 } from './chain-adapter.js';
+import { ContextGraphRegistrationCoverageSignerUnavailableError } from './evm-adapter-errors.js';
 import { ethers } from 'ethers';
 
 export const MOCK_DEFAULT_SIGNER = '0x' + '1'.repeat(40);
@@ -1253,6 +1254,19 @@ export class MockChainAdapter implements ChainAdapter {
       throw new Error(
         `Mock: registration signer ${options.registrationSignerAddress} is unavailable`,
       );
+    }
+
+    if (options.registrationPcaAccountId !== undefined) {
+      const account = this.convictionAccounts.get(options.registrationPcaAccountId);
+      const signerKey = signerAddress.toLowerCase();
+      const ownsAccount = account?.owner.toLowerCase() === signerKey;
+      const isExactAgent = this.agentToConvictionAccount.get(signerKey)
+        === options.registrationPcaAccountId;
+      if (!ownsAccount && !isExactAgent) {
+        throw new ContextGraphRegistrationCoverageSignerUnavailableError(
+          options.registrationPcaAccountId,
+        );
+      }
     }
 
     const coverage = Object.freeze(options.registrationPcaAccountId !== undefined

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -20,7 +20,6 @@ import type {
   CreateOnChainContextGraphResult,
   PrepareContextGraphRegistrationOptions,
   PreparedContextGraphRegistration,
-  PreparedCreateOnChainContextGraphParams,
   VerifyParams,
   PublishToContextGraphParams,
   V10PublishParams,
@@ -1224,6 +1223,12 @@ export class MockChainAdapter implements ChainAdapter {
   async prepareOnChainContextGraphRegistration(
     options: PrepareContextGraphRegistrationOptions = {},
   ): Promise<PreparedContextGraphRegistration> {
+    if (
+      options.registrationPcaAccountId !== undefined
+      && options.registrationPcaAccountId <= 0n
+    ) {
+      throw new RangeError('registrationPcaAccountId must be a positive PCA account id.');
+    }
     let signerAddress: string;
     try {
       signerAddress = ethers.getAddress(await this.getSignerAddress());
@@ -1254,23 +1259,21 @@ export class MockChainAdapter implements ChainAdapter {
       ? { source: 'explicit' as const, accountId: options.registrationPcaAccountId }
       : { source: 'none' as const });
     const submit = async (
-      params: PreparedCreateOnChainContextGraphParams,
+      params: CreateOnChainContextGraphParams,
     ): Promise<CreateOnChainContextGraphResult> => {
-      const runtimeParams = params as CreateOnChainContextGraphParams;
-      if (
-        Object.prototype.hasOwnProperty.call(runtimeParams, 'registrationPcaAccountId')
-        || Object.prototype.hasOwnProperty.call(runtimeParams, 'registrationSignerAddress')
-      ) {
-        throw new Error(
-          'Prepared context-graph registration does not accept signer or PCA coverage overrides.',
-        );
-      }
       return this.createOnChainContextGraph(params);
     };
     return Object.freeze({ signerAddress, coverage, submit });
   }
 
-  async createOnChainContextGraph(params: CreateOnChainContextGraphParams): Promise<CreateOnChainContextGraphResult> {
+  async createOnChainContextGraph(
+    params: CreateOnChainContextGraphParams,
+    preparationOptions?: PrepareContextGraphRegistrationOptions,
+  ): Promise<CreateOnChainContextGraphResult> {
+    if (preparationOptions !== undefined) {
+      const prepared = await this.prepareOnChainContextGraphRegistration(preparationOptions);
+      return prepared.submit(params);
+    }
     if (params.accessPolicy === undefined || params.publishPolicy === undefined) {
       throw new Error(
         'Mock createOnChainContextGraph: `accessPolicy` and `publishPolicy` are required (SPEC_CG_MEMORY_MODEL).',

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -1273,7 +1273,7 @@ export class MockChainAdapter implements ChainAdapter {
       ? { source: 'explicit' as const, accountId: options.registrationPcaAccountId }
       : { source: 'none' as const });
     const submit = async (
-      params: CreateOnChainContextGraphParams,
+      params: Omit<CreateOnChainContextGraphParams, 'registrationDepositPolicy'>,
     ): Promise<CreateOnChainContextGraphResult> => {
       return this.createOnChainContextGraph(params);
     };
@@ -1284,29 +1284,36 @@ export class MockChainAdapter implements ChainAdapter {
     params: CreateOnChainContextGraphParams,
     preparationOptions?: PrepareContextGraphRegistrationOptions,
   ): Promise<CreateOnChainContextGraphResult> {
+    const { registrationDepositPolicy, ...createParams } = params;
     if (preparationOptions !== undefined) {
+      if (registrationDepositPolicy && registrationDepositPolicy.mode !== 'legacy') {
+        throw new TypeError(
+          'Prepared context-graph registration seals its deposit policy; ' +
+          'do not also pass registrationDepositPolicy.',
+        );
+      }
       const prepared = await this.prepareOnChainContextGraphRegistration(preparationOptions);
-      return prepared.submit(params);
+      return prepared.submit(createParams);
     }
-    if (params.accessPolicy === undefined || params.publishPolicy === undefined) {
+    if (createParams.accessPolicy === undefined || createParams.publishPolicy === undefined) {
       throw new Error(
         'Mock createOnChainContextGraph: `accessPolicy` and `publishPolicy` are required (SPEC_CG_MEMORY_MODEL).',
       );
     }
-    const { accessPolicy, publishPolicy } = params;
+    const { accessPolicy, publishPolicy } = createParams;
     if (accessPolicy !== 0 && accessPolicy !== 1) {
       throw new Error('Mock: invalid accessPolicy');
     }
     if (publishPolicy !== 0 && publishPolicy !== 1) {
       throw new Error('Mock: invalid publishPolicy');
     }
-    const registrationDepositPolicy = params.registrationDepositPolicy ?? { mode: 'legacy' as const };
-    switch (registrationDepositPolicy.mode) {
+    const resolvedDepositPolicy = registrationDepositPolicy ?? { mode: 'legacy' as const };
+    switch (resolvedDepositPolicy.mode) {
       case 'legacy':
       case 'paid':
         break;
       case 'pca':
-        if (registrationDepositPolicy.accountId <= 0n) {
+        if (resolvedDepositPolicy.accountId <= 0n) {
           throw new Error('Mock: PCA registration-deposit policy requires a positive accountId');
         }
         break;

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -1275,7 +1275,13 @@ export class MockChainAdapter implements ChainAdapter {
     const submit = async (
       params: Omit<CreateOnChainContextGraphParams, 'registrationDepositPolicy'>,
     ): Promise<CreateOnChainContextGraphResult> => {
-      return this.createOnChainContextGraph(params);
+      const registrationDepositPolicy = coverage.source === 'explicit'
+        ? { mode: 'pca' as const, accountId: coverage.accountId }
+        : { mode: 'legacy' as const };
+      return this.createOnChainContextGraphAs(
+        { ...params, registrationDepositPolicy },
+        signerAddress,
+      );
     };
     return Object.freeze({ signerAddress, coverage, submit });
   }
@@ -1295,6 +1301,15 @@ export class MockChainAdapter implements ChainAdapter {
       const prepared = await this.prepareOnChainContextGraphRegistration(preparationOptions);
       return prepared.submit(createParams);
     }
+    return this.createOnChainContextGraphAs(params, this.signerAddress);
+  }
+
+  private async createOnChainContextGraphAs(
+    params: CreateOnChainContextGraphParams,
+    transactionSignerAddress: string,
+  ): Promise<CreateOnChainContextGraphResult> {
+    const normalizedTransactionSigner = ethers.getAddress(transactionSignerAddress);
+    const { registrationDepositPolicy, ...createParams } = params;
     if (createParams.accessPolicy === undefined || createParams.publishPolicy === undefined) {
       throw new Error(
         'Mock createOnChainContextGraph: `accessPolicy` and `publishPolicy` are required (SPEC_CG_MEMORY_MODEL).',
@@ -1328,7 +1343,7 @@ export class MockChainAdapter implements ChainAdapter {
     publishAuthority = ethers.getAddress(publishAuthority);
     if (publishPolicy === 0) {
       if (publishAuthority === ethers.ZeroAddress) {
-        publishAuthority = ethers.getAddress(this.signerAddress);
+        publishAuthority = normalizedTransactionSigner;
       }
       if (publishAuthorityAccountId !== 0n) {
         const pcaOwner = await this.getPublishingConvictionAccountOwner(publishAuthorityAccountId);
@@ -1382,7 +1397,7 @@ export class MockChainAdapter implements ChainAdapter {
 
     const contextGraphId = this.nextContextGraphId++;
     this.contextGraphs.set(contextGraphId, {
-      manager: this.signerAddress,
+      manager: normalizedTransactionSigner,
       participantAgents: participantAgents.map((agent) => ethers.getAddress(agent)),
       metadataBatchId: params.metadataBatchId ?? 0n,
       accessPolicy,
@@ -1396,9 +1411,9 @@ export class MockChainAdapter implements ChainAdapter {
 
     this.pushEvent('ContextGraphCreated', {
       contextGraphId: contextGraphId.toString(),
-      creator: this.signerAddress,
-      owner: this.signerAddress,
-      manager: this.signerAddress,
+      creator: normalizedTransactionSigner,
+      owner: normalizedTransactionSigner,
+      manager: normalizedTransactionSigner,
       participantAgents: participantAgents.map((agent) => ethers.getAddress(agent)),
       accessPolicy,
       publishPolicy,

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -18,6 +18,9 @@ import type {
   KAUpdateVerification,
   CreateOnChainContextGraphParams,
   CreateOnChainContextGraphResult,
+  PrepareContextGraphRegistrationOptions,
+  PreparedContextGraphRegistration,
+  PreparedCreateOnChainContextGraphParams,
   VerifyParams,
   PublishToContextGraphParams,
   V10PublishParams,
@@ -1213,6 +1216,59 @@ export class MockChainAdapter implements ChainAdapter {
     nameHash?: string | null;
   }>();
   private nextContextGraphId = 1n;
+
+  async getSignerAddress(): Promise<string> {
+    return ethers.getAddress(this.signerAddress);
+  }
+
+  async prepareOnChainContextGraphRegistration(
+    options: PrepareContextGraphRegistrationOptions = {},
+  ): Promise<PreparedContextGraphRegistration> {
+    let signerAddress: string;
+    try {
+      signerAddress = ethers.getAddress(await this.getSignerAddress());
+    } catch {
+      const signerList = (this as unknown as {
+        getSignerAddresses?: () => Promise<string[]>;
+      }).getSignerAddresses;
+      const candidates = typeof signerList === 'function'
+        ? await signerList.call(this)
+        : [];
+      const candidate = candidates.find((address) =>
+        ethers.isAddress(address) && ethers.getAddress(address) !== ethers.ZeroAddress);
+      if (!candidate) {
+        throw new Error('Mock adapter does not expose its registration-tx signer');
+      }
+      signerAddress = ethers.getAddress(candidate);
+    }
+    if (
+      options.registrationSignerAddress !== undefined
+      && ethers.getAddress(options.registrationSignerAddress) !== signerAddress
+    ) {
+      throw new Error(
+        `Mock: registration signer ${options.registrationSignerAddress} is unavailable`,
+      );
+    }
+
+    const coverage = Object.freeze(options.registrationPcaAccountId !== undefined
+      ? { source: 'explicit' as const, accountId: options.registrationPcaAccountId }
+      : { source: 'none' as const });
+    const submit = async (
+      params: PreparedCreateOnChainContextGraphParams,
+    ): Promise<CreateOnChainContextGraphResult> => {
+      const runtimeParams = params as CreateOnChainContextGraphParams;
+      if (
+        Object.prototype.hasOwnProperty.call(runtimeParams, 'registrationPcaAccountId')
+        || Object.prototype.hasOwnProperty.call(runtimeParams, 'registrationSignerAddress')
+      ) {
+        throw new Error(
+          'Prepared context-graph registration does not accept signer or PCA coverage overrides.',
+        );
+      }
+      return this.createOnChainContextGraph(params);
+    };
+    return Object.freeze({ signerAddress, coverage, submit });
+  }
 
   async createOnChainContextGraph(params: CreateOnChainContextGraphParams): Promise<CreateOnChainContextGraphResult> {
     if (params.accessPolicy === undefined || params.publishPolicy === undefined) {

--- a/packages/chain/test/context-graph-registration-dispatch.unit.test.ts
+++ b/packages/chain/test/context-graph-registration-dispatch.unit.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+  executionPolicyFromCoverage,
+  executionPolicyFromDepositPolicy,
   resolveContextGraphCreateDispatch,
+  type ContextGraphFacadeCapability,
   type ContextGraphLegacyCreateArgs,
 } from '../src/context-graph-registration-dispatch.js';
 
@@ -14,38 +17,139 @@ describe('Context Graph registration-deposit dispatch', () => {
     7n,
     'nameHash',
   ];
+  const facade = (state: ContextGraphFacadeCapability['state']) => async () => ({
+    state,
+    version: state === 'supported' ? '10.0.5' : '10.0.4',
+  }) as ContextGraphFacadeCapability;
 
-  it('preserves legacy selector compatibility for omission and explicit legacy policy', () => {
-    const omitted = resolveContextGraphCreateDispatch(legacyArgs);
-    const explicit = resolveContextGraphCreateDispatch(legacyArgs, { mode: 'legacy' });
-
-    expect(omitted).toEqual({ method: 'createContextGraph', args: [...legacyArgs] });
-    expect(explicit).toEqual(omitted);
-    expect(omitted.args).toHaveLength(7);
+  it('derives one execution policy for every direct public policy', () => {
+    expect(executionPolicyFromDepositPolicy()).toEqual({ mode: 'legacy' });
+    expect(executionPolicyFromDepositPolicy({ mode: 'legacy' })).toEqual({ mode: 'legacy' });
+    expect(executionPolicyFromDepositPolicy({ mode: 'paid' })).toEqual({
+      mode: 'paid',
+      unsupportedFacade: 'reject',
+    });
+    expect(executionPolicyFromDepositPolicy({ mode: 'pca', accountId: 19n })).toEqual({
+      mode: 'pca',
+      accountId: 19n,
+      selector: 'additive',
+      unsupportedFacade: 'reject',
+    });
   });
 
-  it('dispatches explicit PCA coverage through the additive selector', () => {
-    const dispatch = resolveContextGraphCreateDispatch(
+  it('derives explicit and automatic prepared coverage with distinct old-facade dispositions', () => {
+    expect(executionPolicyFromCoverage({ source: 'none' })).toEqual({ mode: 'legacy' });
+    expect(executionPolicyFromCoverage({ source: 'explicit', accountId: 19n })).toEqual({
+      mode: 'pca',
+      accountId: 19n,
+      selector: 'legacy-when-authority',
+      unsupportedFacade: 'reject',
+    });
+    for (const source of ['owned', 'agent'] as const) {
+      expect(executionPolicyFromCoverage({ source, accountId: 19n })).toEqual({
+        mode: 'pca',
+        accountId: 19n,
+        selector: 'legacy-when-authority',
+        unsupportedFacade: 'paid-legacy-fallback',
+      });
+    }
+  });
+
+  it('preserves legacy omission without reading facade capability', async () => {
+    let reads = 0;
+    const resolved = await resolveContextGraphCreateDispatch(
       legacyArgs,
-      { mode: 'pca', accountId: 19n },
+      0n,
+      executionPolicyFromDepositPolicy(),
+      async () => { reads += 1; return facade('supported')(); },
     );
 
-    expect(dispatch).toEqual({
-      method: 'createContextGraphWithPcaCoverage',
-      args: [...legacyArgs, 19n],
+    expect(resolved).toEqual({
+      state: 'resolved',
+      dispatch: { method: 'createContextGraph', args: [...legacyArgs] },
     });
-    expect(dispatch.args).toHaveLength(8);
+    expect(reads).toBe(0);
   });
 
-  it('dispatches explicit paid registration through additive zero coverage', () => {
-    expect(resolveContextGraphCreateDispatch(legacyArgs, { mode: 'paid' })).toEqual({
-      method: 'createContextGraphWithPcaCoverage',
-      args: [...legacyArgs, 0n],
+  it('dispatches direct PCA additively even when graph authority has the same account', async () => {
+    await expect(resolveContextGraphCreateDispatch(
+      legacyArgs,
+      19n,
+      executionPolicyFromDepositPolicy({ mode: 'pca', accountId: 19n }),
+      facade('supported'),
+    )).resolves.toEqual({
+      state: 'resolved',
+      dispatch: {
+        method: 'createContextGraphWithPcaCoverage',
+        args: [...legacyArgs, 19n],
+      },
+    });
+  });
+
+  it('dispatches direct paid registration through additive zero coverage', async () => {
+    await expect(resolveContextGraphCreateDispatch(
+      legacyArgs,
+      0n,
+      executionPolicyFromDepositPolicy({ mode: 'paid' }),
+      facade('supported'),
+    )).resolves.toEqual({
+      state: 'resolved',
+      dispatch: {
+        method: 'createContextGraphWithPcaCoverage',
+        args: [...legacyArgs, 0n],
+      },
+    });
+  });
+
+  it('keeps authority-compatible prepared coverage on the legacy selector without a facade read', async () => {
+    let reads = 0;
+    const resolved = await resolveContextGraphCreateDispatch(
+      legacyArgs,
+      19n,
+      executionPolicyFromCoverage({ source: 'explicit', accountId: 19n }),
+      async () => { reads += 1; return facade('unsupported')(); },
+    );
+
+    expect(resolved).toEqual({
+      state: 'resolved',
+      dispatch: { method: 'createContextGraph', args: [...legacyArgs] },
+    });
+    expect(reads).toBe(0);
+  });
+
+  it('rejects explicit PCA and paid policies on an unsupported facade', async () => {
+    const policies = [
+      executionPolicyFromDepositPolicy({ mode: 'pca', accountId: 19n }),
+      executionPolicyFromCoverage({ source: 'explicit', accountId: 19n }),
+      executionPolicyFromDepositPolicy({ mode: 'paid' }),
+    ];
+    for (const policy of policies) {
+      await expect(resolveContextGraphCreateDispatch(
+        legacyArgs,
+        0n,
+        policy,
+        facade('unsupported'),
+      )).resolves.toMatchObject({
+        state: 'unsupported',
+        facadeVersion: '10.0.4',
+      });
+    }
+  });
+
+  it('falls automatic PCA coverage back to paid legacy on an unsupported facade', async () => {
+    await expect(resolveContextGraphCreateDispatch(
+      legacyArgs,
+      0n,
+      executionPolicyFromCoverage({ source: 'owned', accountId: 19n }),
+      facade('unsupported'),
+    )).resolves.toEqual({
+      state: 'resolved',
+      dispatch: { method: 'createContextGraph', args: [...legacyArgs] },
     });
   });
 
   it('rejects a PCA policy that collapses into paid semantics', () => {
-    expect(() => resolveContextGraphCreateDispatch(legacyArgs, { mode: 'pca', accountId: 0n }))
+    expect(() => executionPolicyFromDepositPolicy({ mode: 'pca', accountId: 0n }))
       .toThrow(/positive accountId/);
   });
 });

--- a/packages/chain/test/evm-adapter-cg-deposit-failover.unit.test.ts
+++ b/packages/chain/test/evm-adapter-cg-deposit-failover.unit.test.ts
@@ -16,6 +16,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
+import { StaleHubBindingError } from '../src/evm-adapter-errors.js';
 
 const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
@@ -134,6 +135,67 @@ describe('createOnChainContextGraph — TooLowAllowance recovery uses the failov
     expect(backupHits).toBe(0); // no failover on a healthy primary
     expect(ensureSpy.calls).toHaveLength(1);
     expect(result.success).toBe(true);
+  });
+
+  it('refreshes contracts when the allowance-recovery deposit read detects a stale Hub binding', async () => {
+    const { a, ensureSpy } = makeCgAdapter({
+      depositRead: async () => {
+        throw new StaleHubBindingError('ParametersStorage');
+      },
+    });
+    const oldFacade = a.contracts.contextGraphs;
+    const newFacade = { getAddress: async () => '0x' + 'bb'.repeat(20) };
+    let refreshedDepositReads = 0;
+    const newParametersStorage = {
+      connect: () => ({
+        contextGraphRegistrationDeposit: async () => {
+          refreshedDepositReads += 1;
+          return DEPOSIT;
+        },
+      }),
+    };
+    a.invalidateAllBoundContracts = () => {
+      a.contracts = {
+        ...a.contracts,
+        contextGraphs: newFacade,
+        parametersStorage: newParametersStorage,
+      };
+    };
+    const attemptsByFacade = new Map<unknown, number>();
+    const receipt = {
+      logs: [{ topics: [], data: '0x' }],
+      hash: '0xhash',
+      blockNumber: 1,
+      index: 0,
+      status: 1,
+    };
+    const sendSpy = recorder(async (facade: unknown, ..._args: unknown[]) => {
+      const attempt = (attemptsByFacade.get(facade) ?? 0) + 1;
+      attemptsByFacade.set(facade, attempt);
+      if (attempt === 1) throw tooLowAllowanceRevert();
+      return receipt;
+    });
+    a.sendContractTransaction = sendSpy;
+
+    const result = await a.createOnChainContextGraph(CG_PARAMS);
+
+    expect(sendSpy.calls.map((call) => call[0])).toEqual([
+      oldFacade,
+      newFacade,
+      newFacade,
+    ]);
+    expect(sendSpy.calls.map((call) => call[3])).toEqual([
+      a.signer,
+      a.signer,
+      a.signer,
+    ]);
+    expect(refreshedDepositReads).toBe(1);
+    expect(ensureSpy.calls).toHaveLength(1);
+    expect(ensureSpy.calls[0][0]).toBe(a.signer);
+    expect(ensureSpy.calls[0][1]).toBe(await newFacade.getAddress());
+    expect(ensureSpy.calls[0][2]).toBe(DEPOSIT);
+    expect(result.success).toBe(true);
+    expect(result.contextGraphId).toBe(7n);
   });
 
   it('dormant deposit (reads 0): no approve (deposit===0n branch), original revert propagates', async () => {

--- a/packages/chain/test/evm-adapter-cg-deposit.test.ts
+++ b/packages/chain/test/evm-adapter-cg-deposit.test.ts
@@ -25,7 +25,7 @@ describe('EVMChainAdapter — OT-RFC-53 CG registration deposit approval', () =>
   let hubAddress: string;
   let baseSnapshot: string;
   const DEPOSIT = ethers.parseEther('100');
-  const PCA_COMMITMENT = ethers.parseEther('50000');
+  const PCA_COMMITMENT = ethers.parseEther('500000');
 
   beforeAll(async () => {
     const ctx = getSharedContext();
@@ -92,28 +92,14 @@ describe('EVMChainAdapter — OT-RFC-53 CG registration deposit approval', () =>
     return waiver.waivedCgCount(accountId);
   };
 
-  const createPca = async (owner: Wallet): Promise<bigint> => {
+  const getTokenBalance = async (owner: string): Promise<bigint> => {
     const tokenAddr = await hub().getContractAddress('Token');
-    const pcaAddr = await hub().getContractAddress('DKGPublishingConvictionNFT');
     const token = new Contract(
       tokenAddr,
-      ['function approve(address,uint256) returns (bool)'],
-      owner,
+      ['function balanceOf(address) view returns (uint256)'],
+      provider,
     );
-    const pca = new Contract(
-      pcaAddr,
-      [
-        'function createAccount(uint96,uint72) returns (uint256)',
-        'function balanceOf(address) view returns (uint256)',
-        'function tokenOfOwnerByIndex(address,uint256) view returns (uint256)',
-      ],
-      owner,
-    );
-    await mintTokens(provider, hubAddress, HARDHAT_KEYS.DEPLOYER, owner.address, PCA_COMMITMENT);
-    await (await token.approve(pcaAddr, PCA_COMMITMENT)).wait();
-    await (await pca.createAccount(PCA_COMMITMENT, 0)).wait();
-    const ownedCount = BigInt(await pca.balanceOf(owner.address));
-    return pca.tokenOfOwnerByIndex(owner.address, ownedCount - 1n);
+    return token.balanceOf(owner);
   };
 
   // Count CORE_OP→ContextGraphs TRAC approvals since `fromBlock` — proves whether the
@@ -183,26 +169,52 @@ describe('EVMChainAdapter — OT-RFC-53 CG registration deposit approval', () =>
     expect(await approvalCount(coreOpAddress, fromBlock + 1)).toBe(0);
   });
 
-  it('uses independent PCA coverage for an open graph without approval or stored authority', async () => {
+  it('submits PCA-covered registration through the real additive facade selector', async () => {
     await setDeposit(DEPOSIT);
-    const coreOp = new Wallet(HARDHAT_KEYS.CORE_OP, provider);
-    const accountId = await createPca(coreOp);
-    const waivedBefore = await waivedCount(accountId);
-    const fromBlock = await provider.getBlockNumber();
+    const pcaOwner = new Wallet(HARDHAT_KEYS.EXTRA1, provider);
+    const existingBalance = await getTokenBalance(pcaOwner.address);
+    await mintTokens(
+      provider,
+      hubAddress,
+      HARDHAT_KEYS.DEPLOYER,
+      pcaOwner.address,
+      PCA_COMMITMENT,
+    );
+    const committedTrac = existingBalance + PCA_COMMITMENT;
+    expect(committedTrac).toBeLessThan(1n << 96n);
 
-    const adapter = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
-    const result = await adapter.createOnChainContextGraph({
+    const adapter = createEVMAdapter(HARDHAT_KEYS.EXTRA1);
+    const { accountId } = await adapter.createPublishingConvictionAccount(committedTrac);
+    expect(await getTokenBalance(pcaOwner.address)).toBe(0n);
+
+    const waivedBefore = await waivedCount(accountId);
+    const prepared = await adapter.prepareOnChainContextGraphRegistration({
+      preferPcaCoveredSigner: true,
+    });
+    expect(prepared.signerAddress).toBe(pcaOwner.address);
+    expect(prepared.coverage).toEqual({ source: 'owned', accountId });
+
+    const fromBlock = await provider.getBlockNumber();
+    const result = await prepared.submit({
       accessPolicy: 0,
       publishPolicy: 1,
-      registrationDepositPolicy: { mode: 'pca', accountId },
     });
 
     expect(result.success).toBe(true);
-    expect(result.contextGraphId > 0n).toBe(true);
-    expect(await waivedCount(accountId)).toBe(waivedBefore + 1n);
+    expect(result.contextGraphId).toBeGreaterThan(0n);
     expect(await getEscrow(result.contextGraphId)).toBe(0n);
+    expect(await waivedCount(accountId)).toBe(waivedBefore + 1n);
     expect(await getPublishAuthorityAccountId(result.contextGraphId)).toBe(0n);
-    expect(await approvalCount(coreOp.address, fromBlock + 1)).toBe(0);
+    expect(await approvalCount(pcaOwner.address, fromBlock + 1)).toBe(0);
+
+    const transaction = await provider.getTransaction(result.hash);
+    expect(transaction).not.toBeNull();
+    expect(transaction!.from).toBe(pcaOwner.address);
+    expect(transaction!.data.slice(0, 10)).toBe(
+      ethers.id(
+        'createContextGraphWithPcaCoverage(address[],uint256,uint8,uint8,address,uint256,bytes32,uint256)',
+      ).slice(0, 10),
+    );
   });
 
   it('explicitly pays despite an eligible PCA publish authority', async () => {

--- a/packages/chain/test/evm-adapter-cg-registration-coverage.unit.test.ts
+++ b/packages/chain/test/evm-adapter-cg-registration-coverage.unit.test.ts
@@ -795,6 +795,59 @@ describe('facade capability and allowance/stale-Hub behavior', () => {
     }
   });
 
+  it.each([
+    ['unreadable', new Error('RPC unavailable')],
+    ['malformed', 'release-candidate'],
+  ])('refreshes a retired %s facade before resolving its unknown version', async (_label, oldVersion) => {
+    const adapter = makeAdapter();
+    const oldFacade = { getAddress: async () => OLD_FACADE };
+    const newFacade = { getAddress: async () => NEW_FACADE };
+    const storage = storageDouble();
+    const pca = { kind: 'pca' };
+    adapter.contracts = {
+      contextGraphs: oldFacade,
+      contextGraphStorage: storage,
+      parametersStorage: { kind: 'old-parameters' },
+      dkgPublishingConvictionNFT: pca,
+    };
+    adapter.readContract = async (
+      contract: unknown,
+      _label: string,
+      method: string,
+    ) => {
+      if (method === 'version') {
+        if (contract === oldFacade && oldVersion instanceof Error) throw oldVersion;
+        return contract === oldFacade ? oldVersion : '10.0.5';
+      }
+      if (method === 'ownerOf') return adapter.signerPool[0].address;
+      if (method === 'agentToAccountId') return 0n;
+      throw new Error(`unexpected read ${method}`);
+    };
+    adapter.isCurrentHubContractAddress = async (
+      _name: string,
+      boundAddress: string,
+    ) => boundAddress === NEW_FACADE;
+    adapter.invalidateAllBoundContracts = () => {
+      adapter.contracts = {
+        contextGraphs: newFacade,
+        contextGraphStorage: storage,
+        parametersStorage: { kind: 'new-parameters' },
+        dkgPublishingConvictionNFT: pca,
+      };
+    };
+    const send = recorder(async (..._args: unknown[]) => successfulReceipt());
+    adapter.sendContractTransaction = send;
+    const prepared = await adapter.prepareOnChainContextGraphRegistration({
+      registrationPcaAccountId: 5n,
+    });
+
+    await prepared.submit(CREATE_PARAMS);
+
+    expect(send.calls).toHaveLength(1);
+    expect(send.calls[0][0]).toBe(newFacade);
+    expect(send.calls[0][1]).toBe('createContextGraphWithPcaCoverage');
+  });
+
   it('falls back to a paid legacy registration for automatic coverage on a confirmed old facade', async () => {
     const adapter = makeAdapter();
     configureSubmission(adapter, '10.0.4');

--- a/packages/chain/test/evm-adapter-cg-registration-coverage.unit.test.ts
+++ b/packages/chain/test/evm-adapter-cg-registration-coverage.unit.test.ts
@@ -665,6 +665,60 @@ describe('facade capability and allowance/stale-Hub behavior', () => {
     expect(send.calls[0][3]).toBe(adapter.signerPool[0]);
   });
 
+  it('dispatches a direct PCA policy without off-chain signer verification', async () => {
+    const adapter = makeAdapter();
+    configureSubmission(adapter, '10.0.5');
+    const send = recorder(async (..._args: unknown[]) => successfulReceipt());
+    adapter.sendContractTransaction = send;
+    const prepare = recorder(async () => {
+      throw new Error('direct PCA policy must leave eligibility to the contract');
+    });
+    adapter.prepareOnChainContextGraphRegistration = prepare;
+
+    await adapter.createOnChainContextGraph({
+      ...CREATE_PARAMS,
+      publishAuthorityAccountId: 5n,
+      registrationDepositPolicy: { mode: 'pca', accountId: 5n },
+    });
+
+    expect(prepare.calls).toEqual([]);
+    expect(send.calls[0][1]).toBe('createContextGraphWithPcaCoverage');
+    expect(send.calls[0][2]).toEqual([
+      [], 0n, 0, 1, expect.any(String), 5n, expect.any(String), 5n,
+    ]);
+  });
+
+  it('maps an explicit paid policy to the additive selector with account zero', async () => {
+    const adapter = makeAdapter();
+    configureSubmission(adapter, '10.0.5');
+    const send = recorder(async (..._args: unknown[]) => successfulReceipt());
+    adapter.sendContractTransaction = send;
+
+    await adapter.createOnChainContextGraph({
+      ...CREATE_PARAMS,
+      registrationDepositPolicy: { mode: 'paid' },
+    });
+
+    expect(send.calls[0][1]).toBe('createContextGraphWithPcaCoverage');
+    expect(send.calls[0][2].at(-1)).toBe(0n);
+  });
+
+  it('rejects a policy override when registration preparation seals the policy', async () => {
+    const adapter = makeAdapter();
+    const prepare = recorder(async () => {
+      throw new Error('conflicting inputs must fail before preparation');
+    });
+    adapter.prepareOnChainContextGraphRegistration = prepare;
+
+    await expect(adapter.createOnChainContextGraph({
+      ...CREATE_PARAMS,
+      registrationDepositPolicy: { mode: 'paid' },
+    }, {
+      registrationPcaAccountId: 5n,
+    })).rejects.toThrow(/seals its deposit policy/);
+    expect(prepare.calls).toEqual([]);
+  });
+
   it.each([
     '10.0.5',
     '10.0.5+build.1',

--- a/packages/chain/test/evm-adapter-cg-registration-coverage.unit.test.ts
+++ b/packages/chain/test/evm-adapter-cg-registration-coverage.unit.test.ts
@@ -1,0 +1,438 @@
+import { describe, expect, it } from 'vitest';
+import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
+import {
+  AUTO_COVERAGE_DISCOVERY_TIMEOUT_MS,
+  AUTO_COVERAGE_READ_CONCURRENCY,
+  MAX_AUTO_COVERAGE_CANDIDATES,
+} from '../src/evm-adapter-context-graph.js';
+import {
+  ContextGraphFacadeVersionUnknownError,
+  PcaCoverageUnsupportedError,
+} from '../src/evm-adapter-errors.js';
+
+const PRIMARY_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const SECONDARY_PK = '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d';
+const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
+const OLD_FACADE = '0x' + '11'.repeat(20);
+const NEW_FACADE = '0x' + '22'.repeat(20);
+
+function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterConfig {
+  return {
+    rpcUrl: 'http://127.0.0.1:59998',
+    privateKey: PRIMARY_PK,
+    adminPrivateKey: ADMIN_PK,
+    hubAddress: '0x0000000000000000000000000000000000000001',
+    chainId: 'evm:31337',
+    staticNetwork: false,
+    ...overrides,
+  };
+}
+
+function makeAdapter(additionalKeys: string[] = []) {
+  const adapter: any = new EVMChainAdapter(minimalConfig({ additionalKeys }));
+  adapter.initialized = true;
+  adapter.init = async () => { adapter.initialized = true; };
+  return adapter;
+}
+
+function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
+  const calls: A[] = [];
+  const fn = (...args: A): R => { calls.push(args); return impl(...args); };
+  return Object.assign(fn, { calls });
+}
+
+function successfulReceipt(contextGraphId = 17n) {
+  return {
+    logs: [{ topics: [], data: '0x' }],
+    hash: '0xhash',
+    blockNumber: 1,
+    index: 0,
+    status: 1,
+    contextGraphId,
+  };
+}
+
+function storageDouble() {
+  return {
+    interface: {
+      parseLog: () => ({ name: 'ContextGraphCreated', args: { contextGraphId: 17n } }),
+    },
+  };
+}
+
+function immediateReads() {
+  return {
+    run: <T>(read: () => Promise<T>) => read(),
+    expired: () => false,
+  };
+}
+
+function coverageSnapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    deposit: 100n,
+    minimumCommitment: 100n,
+    latestTimestamp: 1_000n,
+    pca: { kind: 'pca' },
+    waiverStorage: { kind: 'waiver' },
+    reads: immediateReads(),
+    ...overrides,
+  };
+}
+
+function configureSubmission(
+  adapter: any,
+  version: string | Error,
+  facadeAddress = NEW_FACADE,
+) {
+  const contextGraphs = { getAddress: async () => facadeAddress };
+  adapter.contracts = {
+    contextGraphs,
+    contextGraphStorage: storageDouble(),
+    parametersStorage: { kind: 'parameters' },
+  };
+  adapter.readContract = async (
+    _contract: unknown,
+    _label: string,
+    method: string,
+  ) => {
+    if (method === 'version') {
+      if (version instanceof Error) throw version;
+      return version;
+    }
+    if (method === 'contextGraphRegistrationDeposit') return 100n;
+    throw new Error(`unexpected read ${method}`);
+  };
+  return contextGraphs;
+}
+
+const CREATE_PARAMS = { accessPolicy: 0, publishPolicy: 1 } as const;
+
+describe('prepared context-graph PCA registration coverage', () => {
+  it('pins pooled registration to signer B when only B has verified coverage', async () => {
+    const adapter = makeAdapter([SECONDARY_PK]);
+    const [walletA, walletB] = adapter.signerPool;
+    adapter.prepareCoverageDiscoverySnapshot = async () => coverageSnapshot();
+    adapter.discoverCoverageForSigner = async (signer: { address: string }) =>
+      signer.address === walletB.address
+        ? { source: 'owned', accountId: 8n }
+        : { source: 'none' };
+    const contextGraphs = configureSubmission(adapter, '10.0.5');
+    const send = recorder(async (..._args: unknown[]) => successfulReceipt());
+    adapter.sendContractTransaction = send;
+
+    const prepared = await adapter.prepareOnChainContextGraphRegistration({
+      preferPcaCoveredSigner: true,
+    });
+    const result = await prepared.submit(CREATE_PARAMS);
+
+    expect(prepared.signerAddress).toBe(walletB.address);
+    expect(prepared.coverage).toEqual({ source: 'owned', accountId: 8n });
+    expect(send.calls[0][0]).toBe(contextGraphs);
+    expect(send.calls[0][1]).toBe('createContextGraphWithPcaCoverage');
+    expect(send.calls[0][2]).toEqual([[], 0n, 0, 1, expect.any(String), 0n, expect.any(String), 8n]);
+    expect(send.calls[0][3]).toBe(walletB);
+    expect(send.calls[0][3]).not.toBe(walletA);
+    expect(result.success).toBe(true);
+  });
+
+  it('honors an exact signer pin and does not substitute a better-covered pool signer', async () => {
+    const adapter = makeAdapter([SECONDARY_PK]);
+    const [walletA, walletB] = adapter.signerPool;
+    adapter.prepareCoverageDiscoverySnapshot = async () => coverageSnapshot();
+    adapter.discoverCoverageForSigner = async (signer: { address: string }) =>
+      signer.address === walletB.address
+        ? { source: 'owned', accountId: 8n }
+        : { source: 'none' };
+
+    const prepared = await adapter.prepareOnChainContextGraphRegistration({
+      registrationSignerAddress: walletA.address,
+      preferPcaCoveredSigner: true,
+    });
+
+    expect(prepared.signerAddress).toBe(walletA.address);
+    expect(prepared.coverage).toEqual({ source: 'none' });
+  });
+
+  it('seals capability fields and rejects runtime signer/PCA override smuggling', async () => {
+    const adapter = makeAdapter();
+    const prepared = await adapter.prepareOnChainContextGraphRegistration({
+      registrationPcaAccountId: 4n,
+    });
+
+    expect(Object.isFrozen(prepared)).toBe(true);
+    expect(Object.isFrozen(prepared.coverage)).toBe(true);
+    await expect(prepared.submit({
+      ...CREATE_PARAMS,
+      registrationPcaAccountId: 9n,
+    } as any)).rejects.toThrow(/does not accept signer or PCA coverage overrides/);
+  });
+});
+
+describe('automatic PCA coverage discovery bounds and eligibility', () => {
+  it('pins the advertised 32-candidate, four-read, five-second bounds', () => {
+    expect(MAX_AUTO_COVERAGE_CANDIDATES).toBe(32);
+    expect(AUTO_COVERAGE_READ_CONCURRENCY).toBe(4);
+    expect(AUTO_COVERAGE_DISCOVERY_TIMEOUT_MS).toBe(5_000);
+  });
+
+  it('over-cap ownership skips both enumeration and unsolicited agent fallback', async () => {
+    const adapter = makeAdapter();
+    const signer = adapter.signerPool[0];
+    const methods: string[] = [];
+    adapter.readContract = async (
+      _contract: unknown,
+      _label: string,
+      method: string,
+    ) => {
+      methods.push(method);
+      if (method === 'balanceOf') return 33n;
+      throw new Error(`unexpected read ${method}`);
+    };
+
+    const coverage = await adapter.discoverCoverageForSigner(signer, coverageSnapshot());
+
+    expect(coverage).toEqual({ source: 'none' });
+    expect(methods).toEqual(['balanceOf']);
+  });
+
+  it('sorts owned IDs, skips an under-floor candidate, and applies current quota', async () => {
+    const adapter = makeAdapter();
+    const signer = adapter.signerPool[0];
+    adapter.readContract = async (
+      _contract: unknown,
+      _label: string,
+      method: string,
+      ...args: unknown[]
+    ) => {
+      if (method === 'balanceOf') return 3n;
+      if (method === 'tokenOfOwnerByIndex') return [9n, 3n, 7n][Number(args[1])];
+      if (method === 'ownerOf') return signer.address;
+      if (method === 'accounts') {
+        const accountId = BigInt(args[0] as bigint);
+        if (accountId === 3n) return { committedTRAC: 99n, expiresAtTimestamp: 0n, fullySwept: false };
+        return { committedTRAC: 1_000n, expiresAtTimestamp: 0n, fullySwept: false };
+      }
+      if (method === 'waivedCgCount') {
+        const accountId = BigInt(args[0] as bigint);
+        return accountId === 7n ? 10n : 9n;
+      }
+      if (method === 'agentToAccountId') return 0n;
+      throw new Error(`unexpected read ${method}`);
+    };
+
+    const coverage = await adapter.discoverCoverageForSigner(signer, coverageSnapshot());
+
+    // 3 is below the live floor; 7 has exhausted committed/deposit == 10;
+    // 9 is the first fully eligible account despite enumeration order [9,3,7].
+    expect(coverage).toEqual({ source: 'owned', accountId: 9n });
+  });
+
+  it('continues after a candidate-local read failure and uses the next eligible owner', async () => {
+    const adapter = makeAdapter();
+    const signer = adapter.signerPool[0];
+    adapter.readContract = async (
+      _contract: unknown,
+      _label: string,
+      method: string,
+      ...args: unknown[]
+    ) => {
+      if (method === 'balanceOf') return 2n;
+      if (method === 'tokenOfOwnerByIndex') return BigInt(Number(args[1]) + 1);
+      if (method === 'accounts' && args[0] === 1n) throw new Error('candidate-local RPC failure');
+      if (method === 'accounts') return { committedTRAC: 1_000n, expiresAtTimestamp: 0n, fullySwept: false };
+      if (method === 'ownerOf') return signer.address;
+      if (method === 'waivedCgCount') return 0n;
+      if (method === 'agentToAccountId') return 0n;
+      throw new Error(`unexpected read ${method}`);
+    };
+
+    await expect(adapter.discoverCoverageForSigner(signer, coverageSnapshot()))
+      .resolves.toEqual({ source: 'owned', accountId: 2n });
+  });
+
+  it('uses the exact strict-agent mapping only after no owned candidate qualifies', async () => {
+    const adapter = makeAdapter();
+    const signer = adapter.signerPool[0];
+    adapter.readContract = async (
+      _contract: unknown,
+      _label: string,
+      method: string,
+      ...args: unknown[]
+    ) => {
+      if (method === 'balanceOf') return 0n;
+      if (method === 'agentToAccountId') return 12n;
+      if (method === 'accounts') return { committedTRAC: 1_000n, expiresAtTimestamp: 0n, fullySwept: false };
+      if (method === 'waivedCgCount') return 2n;
+      throw new Error(`unexpected read ${method}(${args.join(',')})`);
+    };
+
+    await expect(adapter.discoverCoverageForSigner(signer, coverageSnapshot()))
+      .resolves.toEqual({ source: 'agent', accountId: 12n });
+  });
+
+  it('fails closed to deposit when enumeration hits its total-budget failure seam', async () => {
+    const adapter = makeAdapter();
+    const signer = adapter.signerPool[0];
+    const methods: string[] = [];
+    adapter.readContract = async (
+      _contract: unknown,
+      _label: string,
+      method: string,
+    ) => {
+      methods.push(method);
+      if (method === 'balanceOf') return 1n;
+      if (method === 'tokenOfOwnerByIndex') throw new Error('discovery deadline');
+      throw new Error(`unexpected read ${method}`);
+    };
+
+    await expect(adapter.discoverCoverageForSigner(signer, coverageSnapshot()))
+      .resolves.toEqual({ source: 'none' });
+    expect(methods).not.toContain('agentToAccountId');
+  });
+});
+
+describe('facade capability and allowance/stale-Hub behavior', () => {
+  it('uses the additive selector on 10.0.5+ and preserves legacy selector for matching authority coverage', async () => {
+    const adapter = makeAdapter();
+    configureSubmission(adapter, '10.0.5');
+    const send = recorder(async (..._args: unknown[]) => successfulReceipt());
+    adapter.sendContractTransaction = send;
+    const prepared = await adapter.prepareOnChainContextGraphRegistration({ registrationPcaAccountId: 5n });
+
+    await prepared.submit(CREATE_PARAMS);
+    expect(send.calls[0][1]).toBe('createContextGraphWithPcaCoverage');
+    expect(send.calls[0][2]).toHaveLength(8);
+
+    send.calls.length = 0;
+    await prepared.submit({ ...CREATE_PARAMS, publishAuthorityAccountId: 5n });
+    expect(send.calls[0][1]).toBe('createContextGraph');
+    expect(send.calls[0][2]).toHaveLength(7);
+  });
+
+  it('rejects explicit decoupled coverage on a confirmed old facade before any transaction', async () => {
+    const adapter = makeAdapter();
+    configureSubmission(adapter, '10.0.4');
+    const send = recorder(async (..._args: unknown[]) => successfulReceipt());
+    adapter.sendContractTransaction = send;
+    const prepared = await adapter.prepareOnChainContextGraphRegistration({ registrationPcaAccountId: 5n });
+
+    await expect(prepared.submit(CREATE_PARAMS)).rejects.toBeInstanceOf(PcaCoverageUnsupportedError);
+    expect(send.calls).toEqual([]);
+  });
+
+  it('treats malformed and unreadable facade versions as retryable unknown, with no transaction', async () => {
+    for (const version of ['release-candidate', new Error('RPC unavailable')]) {
+      const adapter = makeAdapter();
+      configureSubmission(adapter, version);
+      const send = recorder(async (..._args: unknown[]) => successfulReceipt());
+      adapter.sendContractTransaction = send;
+      const prepared = await adapter.prepareOnChainContextGraphRegistration({ registrationPcaAccountId: 5n });
+
+      const rejected = prepared.submit(CREATE_PARAMS).catch((error: unknown) => error);
+      const error = await rejected;
+      expect(error).toBeInstanceOf(ContextGraphFacadeVersionUnknownError);
+      expect(error.retryable).toBe(true);
+      expect(send.calls).toEqual([]);
+    }
+  });
+
+  it('falls back to a paid legacy registration for automatic coverage on a confirmed old facade', async () => {
+    const adapter = makeAdapter();
+    configureSubmission(adapter, '10.0.4');
+    const send = recorder(async (..._args: unknown[]) => successfulReceipt());
+    adapter.sendContractTransaction = send;
+    const prepared = adapter.sealContextGraphRegistration(
+      adapter.signerPool[0],
+      { source: 'owned', accountId: 5n },
+    );
+
+    await prepared.submit(CREATE_PARAMS);
+    expect(send.calls[0][1]).toBe('createContextGraph');
+    expect(send.calls[0][2]).toHaveLength(7);
+  });
+
+  it('uses one signer for create, forced approval, and retry after an eligibility race', async () => {
+    const adapter = makeAdapter([SECONDARY_PK]);
+    const walletB = adapter.signerPool[1];
+    const contextGraphs = configureSubmission(adapter, '10.0.5');
+    let attempt = 0;
+    const send = recorder(async (..._args: unknown[]) => {
+      attempt += 1;
+      if (attempt === 1) throw new Error('execution reverted: TooLowAllowance(TRAC, 0, 100)');
+      return successfulReceipt();
+    });
+    const approve = recorder(async (..._args: unknown[]) => {});
+    adapter.sendContractTransaction = send;
+    adapter.ensureV10ApproveTrac = approve;
+    const prepared = adapter.sealContextGraphRegistration(
+      walletB,
+      { source: 'owned', accountId: 8n },
+    );
+
+    await prepared.submit(CREATE_PARAMS);
+
+    expect(send.calls).toHaveLength(2);
+    expect(send.calls.map((call) => call[3])).toEqual([walletB, walletB]);
+    expect(send.calls.map((call) => call[1])).toEqual([
+      'createContextGraphWithPcaCoverage',
+      'createContextGraphWithPcaCoverage',
+    ]);
+    expect(approve.calls).toHaveLength(1);
+    expect(approve.calls[0][0]).toBe(walletB);
+    expect(approve.calls[0][1]).toBe(await contextGraphs.getAddress());
+    expect(approve.calls[0][4]).toBe(true);
+  });
+
+  it('re-resolves facade/version/spender after stale Hub while retaining signer and coverage', async () => {
+    const adapter = makeAdapter([SECONDARY_PK]);
+    const walletB = adapter.signerPool[1];
+    const oldFacade = { getAddress: async () => OLD_FACADE };
+    const newFacade = { getAddress: async () => NEW_FACADE };
+    const oldContracts = {
+      contextGraphs: oldFacade,
+      contextGraphStorage: storageDouble(),
+      parametersStorage: { kind: 'old-parameters' },
+    };
+    const newContracts = {
+      contextGraphs: newFacade,
+      contextGraphStorage: storageDouble(),
+      parametersStorage: { kind: 'new-parameters' },
+    };
+    adapter.contracts = oldContracts;
+    adapter.readContract = async (
+      _contract: unknown,
+      _label: string,
+      method: string,
+    ) => method === 'version' ? '10.0.5' : 100n;
+    adapter.invalidateAllBoundContracts = () => { adapter.contracts = newContracts; };
+
+    const sendsByFacade = new Map<unknown, number>();
+    const send = recorder(async (facade: unknown, ..._args: unknown[]) => {
+      const count = (sendsByFacade.get(facade) ?? 0) + 1;
+      sendsByFacade.set(facade, count);
+      if (facade === oldFacade && count === 1) {
+        throw new Error('execution reverted: TooLowAllowance(TRAC, 0, 100)');
+      }
+      if (facade === oldFacade) {
+        throw new Error('execution reverted: UnauthorizedAccess(Only Contracts in Hub)');
+      }
+      if (count === 1) throw new Error('execution reverted: TooLowAllowance(TRAC, 0, 100)');
+      return successfulReceipt();
+    });
+    const approve = recorder(async (..._args: unknown[]) => {});
+    adapter.sendContractTransaction = send;
+    adapter.ensureV10ApproveTrac = approve;
+    const prepared = adapter.sealContextGraphRegistration(
+      walletB,
+      { source: 'owned', accountId: 8n },
+    );
+
+    await prepared.submit(CREATE_PARAMS);
+
+    expect(send.calls).toHaveLength(4);
+    expect(send.calls.every((call) => call[3] === walletB)).toBe(true);
+    expect(send.calls.every((call) => (call[2] as unknown[]).at(-1) === 8n)).toBe(true);
+    expect(approve.calls.map((call) => call[0])).toEqual([walletB, walletB]);
+    expect(approve.calls.map((call) => call[1])).toEqual([OLD_FACADE, NEW_FACADE]);
+  });
+});

--- a/packages/chain/test/evm-adapter-cg-registration-coverage.unit.test.ts
+++ b/packages/chain/test/evm-adapter-cg-registration-coverage.unit.test.ts
@@ -102,6 +102,7 @@ function configureSubmission(
     if (method === 'contextGraphRegistrationDeposit') return 100n;
     throw new Error(`unexpected read ${method}`);
   };
+  adapter.isCurrentHubContractAddress = async () => true;
   return contextGraphs;
 }
 
@@ -309,19 +310,25 @@ describe('facade capability and allowance/stale-Hub behavior', () => {
     expect(send.calls[0][2]).toHaveLength(7);
   });
 
-  it('rejects explicit decoupled coverage on a confirmed old facade before any transaction', async () => {
-    const adapter = makeAdapter();
-    configureSubmission(adapter, '10.0.4');
-    const send = recorder(async (..._args: unknown[]) => successfulReceipt());
-    adapter.sendContractTransaction = send;
-    const prepared = await adapter.prepareOnChainContextGraphRegistration({ registrationPcaAccountId: 5n });
+  it('rejects explicit decoupled coverage on old or floor-prerelease facades before any transaction', async () => {
+    for (const version of ['10.0.4', '10.0.5-rc.1']) {
+      const adapter = makeAdapter();
+      configureSubmission(adapter, version);
+      const send = recorder(async (..._args: unknown[]) => successfulReceipt());
+      adapter.sendContractTransaction = send;
+      const prepared = await adapter.prepareOnChainContextGraphRegistration({ registrationPcaAccountId: 5n });
 
-    await expect(prepared.submit(CREATE_PARAMS)).rejects.toBeInstanceOf(PcaCoverageUnsupportedError);
-    expect(send.calls).toEqual([]);
+      await expect(prepared.submit(CREATE_PARAMS)).rejects.toBeInstanceOf(PcaCoverageUnsupportedError);
+      expect(send.calls).toEqual([]);
+    }
   });
 
   it('treats malformed and unreadable facade versions as retryable unknown, with no transaction', async () => {
-    for (const version of ['release-candidate', new Error('RPC unavailable')]) {
+    for (const version of [
+      'release-candidate',
+      '999999999999999999999999.0.0',
+      new Error('RPC unavailable'),
+    ]) {
       const adapter = makeAdapter();
       configureSubmission(adapter, version);
       const send = recorder(async (..._args: unknown[]) => successfulReceipt());
@@ -381,6 +388,48 @@ describe('facade capability and allowance/stale-Hub behavior', () => {
     expect(approve.calls[0][0]).toBe(walletB);
     expect(approve.calls[0][1]).toBe(await contextGraphs.getAddress());
     expect(approve.calls[0][4]).toBe(true);
+  });
+
+  it('refreshes a retired old facade before rejecting explicit coverage as unsupported', async () => {
+    const adapter = makeAdapter();
+    const oldFacade = { getAddress: async () => OLD_FACADE };
+    const newFacade = { getAddress: async () => NEW_FACADE };
+    const storage = storageDouble();
+    adapter.contracts = {
+      contextGraphs: oldFacade,
+      contextGraphStorage: storage,
+      parametersStorage: { kind: 'parameters' },
+    };
+    adapter.readContract = async (
+      contract: unknown,
+      _label: string,
+      method: string,
+    ) => {
+      if (method === 'version') return contract === oldFacade ? '10.0.4' : '10.0.5';
+      throw new Error(`unexpected read ${method}`);
+    };
+    adapter.isCurrentHubContractAddress = async (
+      _name: string,
+      boundAddress: string,
+    ) => boundAddress === NEW_FACADE;
+    adapter.invalidateAllBoundContracts = () => {
+      adapter.contracts = {
+        contextGraphs: newFacade,
+        contextGraphStorage: storage,
+        parametersStorage: { kind: 'parameters' },
+      };
+    };
+    const send = recorder(async (..._args: unknown[]) => successfulReceipt());
+    adapter.sendContractTransaction = send;
+    const prepared = await adapter.prepareOnChainContextGraphRegistration({
+      registrationPcaAccountId: 5n,
+    });
+
+    await prepared.submit(CREATE_PARAMS);
+
+    expect(send.calls).toHaveLength(1);
+    expect(send.calls[0][0]).toBe(newFacade);
+    expect(send.calls[0][1]).toBe('createContextGraphWithPcaCoverage');
   });
 
   it('re-resolves facade/version/spender after stale Hub while retaining signer and coverage', async () => {

--- a/packages/chain/test/evm-adapter-cg-registration-coverage.unit.test.ts
+++ b/packages/chain/test/evm-adapter-cg-registration-coverage.unit.test.ts
@@ -703,6 +703,20 @@ describe('facade capability and allowance/stale-Hub behavior', () => {
     expect(send.calls[0][2].at(-1)).toBe(0n);
   });
 
+  it('rejects direct PCA coverage on an unsupported current facade', async () => {
+    const adapter = makeAdapter();
+    configureSubmission(adapter, '10.0.4');
+    const send = recorder(async (..._args: unknown[]) => successfulReceipt());
+    adapter.sendContractTransaction = send;
+
+    await expect(adapter.createOnChainContextGraph({
+      ...CREATE_PARAMS,
+      registrationDepositPolicy: { mode: 'pca', accountId: 5n },
+    })).rejects.toBeInstanceOf(PcaCoverageUnsupportedError);
+
+    expect(send.calls).toEqual([]);
+  });
+
   it('rejects a policy override when registration preparation seals the policy', async () => {
     const adapter = makeAdapter();
     const prepare = recorder(async () => {

--- a/packages/chain/test/evm-adapter-cg-registration-coverage.unit.test.ts
+++ b/packages/chain/test/evm-adapter-cg-registration-coverage.unit.test.ts
@@ -10,6 +10,7 @@ import {
   ContextGraphRegistrationCoverageSignerUnavailableError,
   PcaCoverageUnsupportedError,
 } from '../src/evm-adapter-errors.js';
+import { ChainRpcTransportError } from '../src/chain-rpc-transport-error.js';
 
 const PRIMARY_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 const SECONDARY_PK = '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d';
@@ -283,6 +284,36 @@ describe('prepared context-graph PCA registration coverage', () => {
     expect(error.accountId).toBe(8n);
   });
 
+  it.each(['ownerOf', 'agentToAccountId'] as const)(
+    'preserves a retryable %s verification failure instead of fabricating a signer mismatch',
+    async (failingMethod) => {
+      const adapter = makeAdapter();
+      const pca = { kind: 'pca' };
+      const rpcError = new ChainRpcTransportError(
+        'RPC_ENDPOINTS_EXHAUSTED',
+        `${failingMethod} RPC endpoints exhausted`,
+      );
+      adapter.contracts = { ...adapter.contracts, dkgPublishingConvictionNFT: pca };
+      adapter.readContract = async (
+        contract: unknown,
+        _label: string,
+        method: string,
+      ) => {
+        if (contract !== pca) throw new Error(`unexpected contract read ${method}`);
+        if (method === failingMethod) throw rpcError;
+        if (method === 'ownerOf') return UNRELATED_ADDRESS;
+        if (method === 'agentToAccountId') return 0n;
+        throw new Error(`unexpected PCA read ${method}`);
+      };
+
+      const rejected = adapter.prepareOnChainContextGraphRegistration({
+        registrationPcaAccountId: 8n,
+      }).catch((error: unknown) => error);
+
+      expect(await rejected).toBe(rpcError);
+    },
+  );
+
   it('verifies a hard pin without rotating to a different matching pool signer', async () => {
     const adapter = makeAdapter([SECONDARY_PK]);
     const [walletA, walletB] = adapter.signerPool;
@@ -492,6 +523,68 @@ describe('automatic PCA coverage discovery bounds and eligibility', () => {
       .resolves.toEqual({ source: 'owned', accountId: 2n });
   });
 
+  it.each([
+    {
+      label: 'fully swept',
+      account: { committedTRAC: 1_000n, expiresAtTimestamp: 0n, fullySwept: true },
+      ownerMatches: true,
+      snapshot: {},
+      expected: { source: 'none' },
+    },
+    {
+      label: 'expired exactly at the latest block timestamp',
+      account: { committedTRAC: 1_000n, expiresAtTimestamp: 1_000n, fullySwept: false },
+      ownerMatches: true,
+      snapshot: {},
+      expected: { source: 'none' },
+    },
+    {
+      label: 'not yet expired',
+      account: { committedTRAC: 1_000n, expiresAtTimestamp: 1_001n, fullySwept: false },
+      ownerMatches: true,
+      snapshot: {},
+      expected: { source: 'owned', accountId: 1n },
+    },
+    {
+      label: 'owner mismatch',
+      account: { committedTRAC: 1_000n, expiresAtTimestamp: 0n, fullySwept: false },
+      ownerMatches: false,
+      snapshot: {},
+      expected: { source: 'none' },
+    },
+    {
+      label: 'zero commitment even with a zero minimum floor',
+      account: { committedTRAC: 0n, expiresAtTimestamp: 0n, fullySwept: false },
+      ownerMatches: true,
+      snapshot: { minimumCommitment: 0n },
+      expected: { source: 'none' },
+    },
+  ])('treats $label with fail-closed eligibility semantics', async ({
+    account,
+    ownerMatches,
+    snapshot,
+    expected,
+  }) => {
+    const adapter = makeAdapter();
+    const signer = adapter.signerPool[0];
+    adapter.readContract = async (
+      _contract: unknown,
+      _label: string,
+      method: string,
+    ) => {
+      if (method === 'balanceOf') return 1n;
+      if (method === 'tokenOfOwnerByIndex') return 1n;
+      if (method === 'ownerOf') return ownerMatches ? signer.address : UNRELATED_ADDRESS;
+      if (method === 'accounts') return account;
+      if (method === 'waivedCgCount') return 0n;
+      if (method === 'agentToAccountId') return 0n;
+      throw new Error(`unexpected read ${method}`);
+    };
+
+    await expect(adapter.discoverCoverageForSigner(signer, coverageSnapshot(snapshot)))
+      .resolves.toEqual(expected);
+  });
+
   it('uses the exact strict-agent mapping only after no owned candidate qualifies', async () => {
     const adapter = makeAdapter();
     const signer = adapter.signerPool[0];
@@ -572,9 +665,14 @@ describe('facade capability and allowance/stale-Hub behavior', () => {
     expect(send.calls[0][3]).toBe(adapter.signerPool[0]);
   });
 
-  it('uses the additive selector on 10.0.5+ and preserves legacy selector for matching authority coverage', async () => {
+  it.each([
+    '10.0.5',
+    '10.0.5+build.1',
+    '10.0.6-rc.1',
+    '11.0.0',
+  ])('uses the additive selector on supported facade version %s', async (version) => {
     const adapter = makeAdapter();
-    configureSubmission(adapter, '10.0.5');
+    configureSubmission(adapter, version);
     const send = recorder(async (..._args: unknown[]) => successfulReceipt());
     adapter.sendContractTransaction = send;
     const prepared = await adapter.prepareOnChainContextGraphRegistration({ registrationPcaAccountId: 5n });
@@ -582,8 +680,15 @@ describe('facade capability and allowance/stale-Hub behavior', () => {
     await prepared.submit(CREATE_PARAMS);
     expect(send.calls[0][1]).toBe('createContextGraphWithPcaCoverage');
     expect(send.calls[0][2]).toHaveLength(8);
+  });
 
-    send.calls.length = 0;
+  it('preserves the legacy selector when publish authority provides the same coverage', async () => {
+    const adapter = makeAdapter();
+    configureSubmission(adapter, '10.0.5');
+    const send = recorder(async (..._args: unknown[]) => successfulReceipt());
+    adapter.sendContractTransaction = send;
+    const prepared = await adapter.prepareOnChainContextGraphRegistration({ registrationPcaAccountId: 5n });
+
     await prepared.submit({ ...CREATE_PARAMS, publishAuthorityAccountId: 5n });
     expect(send.calls[0][1]).toBe('createContextGraph');
     expect(send.calls[0][2]).toHaveLength(7);

--- a/packages/chain/test/evm-adapter-cg-registration-coverage.unit.test.ts
+++ b/packages/chain/test/evm-adapter-cg-registration-coverage.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
 import {
   AUTO_COVERAGE_DISCOVERY_TIMEOUT_MS,
@@ -7,6 +7,7 @@ import {
 } from '../src/evm-adapter-context-graph.js';
 import {
   ContextGraphFacadeVersionUnknownError,
+  ContextGraphRegistrationCoverageSignerUnavailableError,
   PcaCoverageUnsupportedError,
 } from '../src/evm-adapter-errors.js';
 
@@ -15,6 +16,8 @@ const SECONDARY_PK = '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b
 const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
 const OLD_FACADE = '0x' + '11'.repeat(20);
 const NEW_FACADE = '0x' + '22'.repeat(20);
+const PARAMETERS_ADDRESS = '0x' + '33'.repeat(20);
+const UNRELATED_ADDRESS = '0x' + '44'.repeat(20);
 
 function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterConfig {
   return {
@@ -79,13 +82,73 @@ function coverageSnapshot(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function configureExplicitCoverage(
+  adapter: any,
+  options: {
+    owner: string;
+    agentAccounts?: ReadonlyMap<string, bigint>;
+  },
+) {
+  const pca = { kind: 'pca' };
+  adapter.contracts = { ...adapter.contracts, dkgPublishingConvictionNFT: pca };
+  adapter.readContract = async (
+    contract: unknown,
+    _label: string,
+    method: string,
+    ...args: unknown[]
+  ) => {
+    if (contract !== pca) throw new Error(`unexpected contract read ${method}`);
+    if (method === 'ownerOf') return options.owner;
+    if (method === 'agentToAccountId') {
+      return options.agentAccounts?.get(String(args[0]).toLowerCase()) ?? 0n;
+    }
+    throw new Error(`unexpected PCA read ${method}`);
+  };
+  return pca;
+}
+
+function configureRealCoverageDiscovery(
+  adapter: any,
+  read: (method: string, ...args: unknown[]) => unknown | Promise<unknown>,
+) {
+  const pca = { kind: 'pca' };
+  const waiverStorage = { kind: 'waiver' };
+  adapter.contracts = {
+    ...adapter.contracts,
+    dkgPublishingConvictionNFT: pca,
+    parametersStorage: { getAddress: async () => PARAMETERS_ADDRESS },
+  };
+  adapter.resolveContract = async (name: string) => {
+    if (name === 'ContextGraphWaiverStorage') return waiverStorage;
+    throw new Error(`unexpected contract resolution ${name}`);
+  };
+  adapter.readTipProvider = async () => ({ timestamp: 1_000 });
+  adapter.readContract = async (
+    _contract: unknown,
+    _label: string,
+    method: string,
+    ...args: unknown[]
+  ) => {
+    if (method === 'contextGraphRegistrationDeposit') return 100n;
+    if (method === 'minPcaCommitmentForCgWaiver') return 100n;
+    return read(method, ...args);
+  };
+  return { pca, waiverStorage };
+}
+
 function configureSubmission(
   adapter: any,
   version: string | Error,
   facadeAddress = NEW_FACADE,
 ) {
+  const previousRead = Object.prototype.hasOwnProperty.call(adapter, 'readContract')
+    ? adapter.readContract.bind(adapter)
+    : undefined;
   const contextGraphs = { getAddress: async () => facadeAddress };
   adapter.contracts = {
+    ...adapter.contracts,
+    dkgPublishingConvictionNFT:
+      adapter.contracts?.dkgPublishingConvictionNFT ?? { kind: 'pca' },
     contextGraphs,
     contextGraphStorage: storageDouble(),
     parametersStorage: { kind: 'parameters' },
@@ -94,12 +157,16 @@ function configureSubmission(
     _contract: unknown,
     _label: string,
     method: string,
+    ...args: unknown[]
   ) => {
     if (method === 'version') {
       if (version instanceof Error) throw version;
       return version;
     }
     if (method === 'contextGraphRegistrationDeposit') return 100n;
+    if (previousRead) return previousRead(_contract, _label, method, ...args);
+    if (method === 'ownerOf') return adapter.signerPool[0].address;
+    if (method === 'agentToAccountId') return 0n;
     throw new Error(`unexpected read ${method}`);
   };
   adapter.isCurrentHubContractAddress = async () => true;
@@ -108,22 +175,33 @@ function configureSubmission(
 
 const CREATE_PARAMS = { accessPolicy: 0, publishPolicy: 1 } as const;
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe('prepared context-graph PCA registration coverage', () => {
-  it('pins pooled registration to signer B when only B has verified coverage', async () => {
+  it('uses real discovery to pin pooled registration to signer B when only B has verified coverage', async () => {
     const adapter = makeAdapter([SECONDARY_PK]);
     const [walletA, walletB] = adapter.signerPool;
-    adapter.prepareCoverageDiscoverySnapshot = async () => coverageSnapshot();
-    adapter.discoverCoverageForSigner = async (signer: { address: string }) =>
-      signer.address === walletB.address
-        ? { source: 'owned', accountId: 8n }
-        : { source: 'none' };
-    const contextGraphs = configureSubmission(adapter, '10.0.5');
-    const send = recorder(async (..._args: unknown[]) => successfulReceipt());
-    adapter.sendContractTransaction = send;
+    configureRealCoverageDiscovery(adapter, async (method, ...args) => {
+      if (method === 'balanceOf') return args[0] === walletB.address ? 1n : 0n;
+      if (method === 'tokenOfOwnerByIndex') return 8n;
+      if (method === 'accounts') {
+        return { committedTRAC: 1_000n, expiresAtTimestamp: 0n, fullySwept: false };
+      }
+      if (method === 'ownerOf') return walletB.address;
+      if (method === 'waivedCgCount') return 0n;
+      if (method === 'agentToAccountId') return 0n;
+      throw new Error(`unexpected read ${method}`);
+    });
 
     const prepared = await adapter.prepareOnChainContextGraphRegistration({
       preferPcaCoveredSigner: true,
     });
+    const contextGraphs = configureSubmission(adapter, '10.0.5');
+    const send = recorder(async (..._args: unknown[]) => successfulReceipt());
+    adapter.sendContractTransaction = send;
+
     const result = await prepared.submit(CREATE_PARAMS);
 
     expect(prepared.signerAddress).toBe(walletB.address);
@@ -139,11 +217,17 @@ describe('prepared context-graph PCA registration coverage', () => {
   it('honors an exact signer pin and does not substitute a better-covered pool signer', async () => {
     const adapter = makeAdapter([SECONDARY_PK]);
     const [walletA, walletB] = adapter.signerPool;
-    adapter.prepareCoverageDiscoverySnapshot = async () => coverageSnapshot();
-    adapter.discoverCoverageForSigner = async (signer: { address: string }) =>
-      signer.address === walletB.address
-        ? { source: 'owned', accountId: 8n }
-        : { source: 'none' };
+    configureRealCoverageDiscovery(adapter, async (method, ...args) => {
+      if (method === 'balanceOf') return args[0] === walletB.address ? 1n : 0n;
+      if (method === 'tokenOfOwnerByIndex') return 8n;
+      if (method === 'accounts') {
+        return { committedTRAC: 1_000n, expiresAtTimestamp: 0n, fullySwept: false };
+      }
+      if (method === 'ownerOf') return walletB.address;
+      if (method === 'waivedCgCount') return 0n;
+      if (method === 'agentToAccountId') return 0n;
+      throw new Error(`unexpected read ${method}`);
+    });
 
     const prepared = await adapter.prepareOnChainContextGraphRegistration({
       registrationSignerAddress: walletA.address,
@@ -154,18 +238,90 @@ describe('prepared context-graph PCA registration coverage', () => {
     expect(prepared.coverage).toEqual({ source: 'none' });
   });
 
-  it('seals capability fields and rejects runtime signer/PCA override smuggling', async () => {
+  it('selects a secondary owner for explicit unpinned coverage', async () => {
+    const adapter = makeAdapter([SECONDARY_PK]);
+    const walletB = adapter.signerPool[1];
+    configureExplicitCoverage(adapter, { owner: walletB.address });
+
+    const prepared = await adapter.prepareOnChainContextGraphRegistration({
+      registrationPcaAccountId: 8n,
+      preferPcaCoveredSigner: true,
+    });
+
+    expect(prepared.signerAddress).toBe(walletB.address);
+    expect(prepared.coverage).toEqual({ source: 'explicit', accountId: 8n });
+  });
+
+  it('selects a secondary exact agent for explicit unpinned coverage', async () => {
+    const adapter = makeAdapter([SECONDARY_PK]);
+    const walletB = adapter.signerPool[1];
+    configureExplicitCoverage(adapter, {
+      owner: UNRELATED_ADDRESS,
+      agentAccounts: new Map([[walletB.address.toLowerCase(), 8n]]),
+    });
+
+    const prepared = await adapter.prepareOnChainContextGraphRegistration({
+      registrationPcaAccountId: 8n,
+      preferPcaCoveredSigner: true,
+    });
+
+    expect(prepared.signerAddress).toBe(walletB.address);
+    expect(prepared.coverage).toEqual({ source: 'explicit', accountId: 8n });
+  });
+
+  it('fails explicit unpinned coverage before submit when no configured signer matches', async () => {
+    const adapter = makeAdapter([SECONDARY_PK]);
+    configureExplicitCoverage(adapter, { owner: UNRELATED_ADDRESS });
+
+    const rejected = adapter.prepareOnChainContextGraphRegistration({
+      registrationPcaAccountId: 8n,
+      preferPcaCoveredSigner: true,
+    }).catch((error: unknown) => error);
+
+    const error = await rejected;
+    expect(error).toBeInstanceOf(ContextGraphRegistrationCoverageSignerUnavailableError);
+    expect(error.accountId).toBe(8n);
+  });
+
+  it('verifies a hard pin without rotating to a different matching pool signer', async () => {
+    const adapter = makeAdapter([SECONDARY_PK]);
+    const [walletA, walletB] = adapter.signerPool;
+    configureExplicitCoverage(adapter, {
+      owner: walletB.address,
+      agentAccounts: new Map([[walletA.address.toLowerCase(), 8n]]),
+    });
+
+    const pinnedAgent = await adapter.prepareOnChainContextGraphRegistration({
+      registrationPcaAccountId: 8n,
+      registrationSignerAddress: walletA.address,
+      preferPcaCoveredSigner: true,
+    });
+    expect(pinnedAgent.signerAddress).toBe(walletA.address);
+
+    configureExplicitCoverage(adapter, { owner: walletB.address });
+    await expect(adapter.prepareOnChainContextGraphRegistration({
+      registrationPcaAccountId: 8n,
+      registrationSignerAddress: walletA.address,
+      preferPcaCoveredSigner: true,
+    })).rejects.toBeInstanceOf(ContextGraphRegistrationCoverageSignerUnavailableError);
+  });
+
+  it('seals capability fields and rejects non-positive coverage IDs', async () => {
     const adapter = makeAdapter();
+    configureExplicitCoverage(adapter, { owner: adapter.signerPool[0].address });
     const prepared = await adapter.prepareOnChainContextGraphRegistration({
       registrationPcaAccountId: 4n,
     });
 
     expect(Object.isFrozen(prepared)).toBe(true);
     expect(Object.isFrozen(prepared.coverage)).toBe(true);
-    await expect(prepared.submit({
-      ...CREATE_PARAMS,
-      registrationPcaAccountId: 9n,
-    } as any)).rejects.toThrow(/does not accept signer or PCA coverage overrides/);
+    await expect(adapter.prepareOnChainContextGraphRegistration({
+      registrationPcaAccountId: 0n,
+    })).rejects.toThrow(/positive PCA account id/);
+    expect(() => adapter.sealContextGraphRegistration(
+      adapter.signerPool[0],
+      { source: 'owned', accountId: 0n },
+    )).toThrow(/positive PCA account id/);
   });
 });
 
@@ -174,6 +330,91 @@ describe('automatic PCA coverage discovery bounds and eligibility', () => {
     expect(MAX_AUTO_COVERAGE_CANDIDATES).toBe(32);
     expect(AUTO_COVERAGE_READ_CONCURRENCY).toBe(4);
     expect(AUTO_COVERAGE_DISCOVERY_TIMEOUT_MS).toBe(5_000);
+  });
+
+  it('prefers secondary owned coverage over an earlier consent-free agent binding', async () => {
+    const adapter = makeAdapter([SECONDARY_PK]);
+    const [walletA, walletB] = adapter.signerPool;
+    configureRealCoverageDiscovery(adapter, async (method, ...args) => {
+      if (method === 'balanceOf') return args[0] === walletB.address ? 1n : 0n;
+      if (method === 'tokenOfOwnerByIndex') return 8n;
+      if (method === 'agentToAccountId') return args[0] === walletA.address ? 7n : 0n;
+      if (method === 'ownerOf') return walletB.address;
+      if (method === 'accounts') {
+        return { committedTRAC: 1_000n, expiresAtTimestamp: 0n, fullySwept: false };
+      }
+      if (method === 'waivedCgCount') return 0n;
+      throw new Error(`unexpected read ${method}`);
+    });
+
+    const prepared = await adapter.prepareOnChainContextGraphRegistration({
+      preferPcaCoveredSigner: true,
+    });
+
+    expect(prepared.signerAddress).toBe(walletB.address);
+    expect(prepared.coverage).toEqual({ source: 'owned', accountId: 8n });
+  });
+
+  it('caps real public preparation discovery at four concurrent RPC reads', async () => {
+    const adapter = makeAdapter();
+    const signer = adapter.signerPool[0];
+    let active = 0;
+    let maxActive = 0;
+    configureRealCoverageDiscovery(adapter, async (method, ...args) => {
+      if (method === 'balanceOf') return 8n;
+      if (method === 'tokenOfOwnerByIndex') {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        active -= 1;
+        return BigInt(Number(args[1]) + 1);
+      }
+      if (method === 'accounts') {
+        return { committedTRAC: 1_000n, expiresAtTimestamp: 0n, fullySwept: false };
+      }
+      if (method === 'ownerOf') return signer.address;
+      if (method === 'waivedCgCount') return 0n;
+      if (method === 'agentToAccountId') return 0n;
+      throw new Error(`unexpected read ${method}`);
+    });
+
+    const prepared = await adapter.prepareOnChainContextGraphRegistration({
+      preferPcaCoveredSigner: true,
+    });
+
+    expect(prepared.coverage).toEqual({ source: 'owned', accountId: 1n });
+    expect(maxActive).toBe(AUTO_COVERAGE_READ_CONCURRENCY);
+  });
+
+  it('stops queued public preparation reads at five seconds without post-budget starts', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const adapter = makeAdapter();
+    let tokenReadStarts = 0;
+    configureRealCoverageDiscovery(adapter, async (method) => {
+      if (method === 'balanceOf') return 8n;
+      if (method === 'tokenOfOwnerByIndex') {
+        tokenReadStarts += 1;
+        return new Promise<bigint>(() => {});
+      }
+      throw new Error(`unexpected read ${method}`);
+    });
+
+    const preparing = adapter.prepareOnChainContextGraphRegistration({
+      preferPcaCoveredSigner: true,
+    });
+    for (let turns = 0; turns < 20 && tokenReadStarts < AUTO_COVERAGE_READ_CONCURRENCY; turns += 1) {
+      await vi.advanceTimersByTimeAsync(0);
+    }
+    expect(tokenReadStarts).toBe(AUTO_COVERAGE_READ_CONCURRENCY);
+
+    await vi.advanceTimersByTimeAsync(AUTO_COVERAGE_DISCOVERY_TIMEOUT_MS);
+    const prepared = await preparing;
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(prepared.coverage).toEqual({ source: 'none' });
+    expect(tokenReadStarts).toBe(AUTO_COVERAGE_READ_CONCURRENCY);
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it('over-cap ownership skips both enumeration and unsolicited agent fallback', async () => {
@@ -293,6 +534,44 @@ describe('automatic PCA coverage discovery bounds and eligibility', () => {
 });
 
 describe('facade capability and allowance/stale-Hub behavior', () => {
+  it('keeps canonical create data separate while the direct wrapper prepares an explicit hard pin', async () => {
+    const adapter = makeAdapter([SECONDARY_PK]);
+    const walletB = adapter.signerPool[1];
+    configureExplicitCoverage(adapter, { owner: walletB.address });
+    const contextGraphs = configureSubmission(adapter, '10.0.5');
+    const send = recorder(async (..._args: unknown[]) => successfulReceipt());
+    adapter.sendContractTransaction = send;
+
+    await adapter.createOnChainContextGraph(CREATE_PARAMS, {
+      registrationPcaAccountId: 5n,
+      registrationSignerAddress: walletB.address,
+      preferPcaCoveredSigner: true,
+    });
+
+    expect(Object.keys(CREATE_PARAMS)).toEqual(['accessPolicy', 'publishPolicy']);
+    expect(send.calls[0][0]).toBe(contextGraphs);
+    expect(send.calls[0][1]).toBe('createContextGraphWithPcaCoverage');
+    expect(send.calls[0][2]).toEqual([[], 0n, 0, 1, expect.any(String), 0n, expect.any(String), 5n]);
+    expect(send.calls[0][3]).toBe(walletB);
+  });
+
+  it('preserves the old direct-create wrapper path without PCA discovery', async () => {
+    const adapter = makeAdapter();
+    configureSubmission(adapter, '10.0.5');
+    const send = recorder(async (..._args: unknown[]) => successfulReceipt());
+    adapter.sendContractTransaction = send;
+    const prepare = recorder(async () => {
+      throw new Error('legacy wrapper must not prepare coverage');
+    });
+    adapter.prepareOnChainContextGraphRegistration = prepare;
+
+    await adapter.createOnChainContextGraph(CREATE_PARAMS);
+
+    expect(prepare.calls).toEqual([]);
+    expect(send.calls[0][1]).toBe('createContextGraph');
+    expect(send.calls[0][3]).toBe(adapter.signerPool[0]);
+  });
+
   it('uses the additive selector on 10.0.5+ and preserves legacy selector for matching authority coverage', async () => {
     const adapter = makeAdapter();
     configureSubmission(adapter, '10.0.5');
@@ -399,6 +678,7 @@ describe('facade capability and allowance/stale-Hub behavior', () => {
       contextGraphs: oldFacade,
       contextGraphStorage: storage,
       parametersStorage: { kind: 'parameters' },
+      dkgPublishingConvictionNFT: { kind: 'pca' },
     };
     adapter.readContract = async (
       contract: unknown,
@@ -406,6 +686,8 @@ describe('facade capability and allowance/stale-Hub behavior', () => {
       method: string,
     ) => {
       if (method === 'version') return contract === oldFacade ? '10.0.4' : '10.0.5';
+      if (method === 'ownerOf') return adapter.signerPool[0].address;
+      if (method === 'agentToAccountId') return 0n;
       throw new Error(`unexpected read ${method}`);
     };
     adapter.isCurrentHubContractAddress = async (
@@ -417,6 +699,7 @@ describe('facade capability and allowance/stale-Hub behavior', () => {
         contextGraphs: newFacade,
         contextGraphStorage: storage,
         parametersStorage: { kind: 'parameters' },
+        dkgPublishingConvictionNFT: { kind: 'pca' },
       };
     };
     const send = recorder(async (..._args: unknown[]) => successfulReceipt());
@@ -441,18 +724,25 @@ describe('facade capability and allowance/stale-Hub behavior', () => {
       contextGraphs: oldFacade,
       contextGraphStorage: storageDouble(),
       parametersStorage: { kind: 'old-parameters' },
+      dkgPublishingConvictionNFT: { kind: 'pca' },
     };
     const newContracts = {
       contextGraphs: newFacade,
       contextGraphStorage: storageDouble(),
       parametersStorage: { kind: 'new-parameters' },
+      dkgPublishingConvictionNFT: { kind: 'pca' },
     };
     adapter.contracts = oldContracts;
     adapter.readContract = async (
       _contract: unknown,
       _label: string,
       method: string,
-    ) => method === 'version' ? '10.0.5' : 100n;
+    ) => {
+      if (method === 'version') return '10.0.5';
+      if (method === 'ownerOf') return walletB.address;
+      if (method === 'agentToAccountId') return 0n;
+      return 100n;
+    };
     adapter.invalidateAllBoundContracts = () => { adapter.contracts = newContracts; };
 
     const sendsByFacade = new Map<unknown, number>();

--- a/packages/chain/test/evm-adapter-pca-registration-parser.unit.test.ts
+++ b/packages/chain/test/evm-adapter-pca-registration-parser.unit.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { parsePcaRegistrationCoverageAccount } from '../src/evm-adapter-conviction.js';
+
+describe('parsePcaRegistrationCoverageAccount', () => {
+  it('parses named PCA account fields', () => {
+    expect(parsePcaRegistrationCoverageAccount({
+      committedTRAC: 1_000n,
+      expiresAtTimestamp: 2_000n,
+      fullySwept: false,
+    })).toEqual({
+      committedTRAC: 1_000n,
+      expiresAtTimestamp: 2_000n,
+      fullySwept: false,
+    });
+  });
+
+  it('parses the positional PCA accounts tuple fields', () => {
+    const tuple = [1_000n, 1n, 2n, 3n, 2_000n, 4n, 5n, 6n, true];
+
+    expect(parsePcaRegistrationCoverageAccount(tuple)).toEqual({
+      committedTRAC: 1_000n,
+      expiresAtTimestamp: 2_000n,
+      fullySwept: true,
+    });
+  });
+
+  it.each([
+    null,
+    {},
+    { committedTRAC: '1000', expiresAtTimestamp: 2_000n, fullySwept: false },
+    { committedTRAC: 1_000n, expiresAtTimestamp: -1n, fullySwept: false },
+    { committedTRAC: 1_000n, expiresAtTimestamp: 2_000n, fullySwept: 0 },
+    [1_000n, 1n, 2n, 3n, 2_000n],
+  ])('fails closed for malformed input %#', (raw) => {
+    expect(parsePcaRegistrationCoverageAccount(raw)).toBeUndefined();
+  });
+});

--- a/packages/chain/test/mock-adapter-parity.test.ts
+++ b/packages/chain/test/mock-adapter-parity.test.ts
@@ -97,6 +97,20 @@ const MOCK_EXEMPT_FROM_EVM = new Set<string>([
   'nextSigner',
   'nextAuthorizedSigner',
   'findSignerByAddress',
+  // Prepared CG registration internals. The public capability and compatibility
+  // wrapper are mirrored by MockChainAdapter; these helpers depend on EVM
+  // wallet pools, live PCA/facade reads, and Hub coherence.
+  'registrationSignerByAddress',
+  'resolveExplicitCoverageSigner',
+  'sealContextGraphRegistration',
+  'prepareCoverageDiscoverySnapshot',
+  'discoverCoverageForSigner',
+  'discoverOwnedCoverageForSigner',
+  'discoverAgentCoverageForSigner',
+  'registrationCoverageCandidateEligible',
+  'readContextGraphsFacadeCapability',
+  'submitPreparedContextGraphRegistration',
+  'isCurrentHubContractAddress',
   // PR #2300 r2 — isReceiptBlockFinalAndCanonical is a REAL ChainAdapter capability now (update
   // recognition consumes it), and the mock implements it from its finality seam: no exemption.
   'resolvePinnedPublisherSigner', // EVM signer-pool authorization/funding helper; mock has no wallet pool

--- a/packages/chain/test/mock-adapter-publishing-conviction-v10.test.ts
+++ b/packages/chain/test/mock-adapter-publishing-conviction-v10.test.ts
@@ -9,9 +9,53 @@ import { ethers } from 'ethers';
 import { MockChainAdapter } from '../src/mock-adapter.js';
 import { toShardingTableNode } from '../src/evm-adapter-conviction.js';
 import type { PcaRpcMethod } from '../src/chain-adapter.js';
+import { ContextGraphRegistrationCoverageSignerUnavailableError } from '../src/evm-adapter-errors.js';
 
 const SIGNER = '0x1111111111111111111111111111111111111111';
 const COMMITTED = ethers.parseEther('10000');
+
+describe('MockChainAdapter — explicit context-graph registration coverage parity', () => {
+  const AGENT = '0x2222222222222222222222222222222222222222';
+  const STRANGER = '0x3333333333333333333333333333333333333333';
+
+  it('prepares explicit coverage for the account owner', async () => {
+    const mock = new MockChainAdapter('mock:31337', SIGNER);
+    const { accountId } = await mock.createPublishingConvictionAccount(COMMITTED);
+
+    await expect(mock.prepareOnChainContextGraphRegistration({
+      registrationPcaAccountId: accountId,
+    })).resolves.toMatchObject({
+      signerAddress: ethers.getAddress(SIGNER),
+      coverage: { source: 'explicit', accountId },
+    });
+  });
+
+  it('prepares explicit coverage for the exact registered agent', async () => {
+    const mock = new MockChainAdapter('mock:31337', SIGNER);
+    const { accountId } = await mock.createPublishingConvictionAccount(COMMITTED);
+    await mock.registerPublishingConvictionAgent(accountId, AGENT);
+    mock.getSignerAddress = async () => ethers.getAddress(AGENT);
+
+    await expect(mock.prepareOnChainContextGraphRegistration({
+      registrationPcaAccountId: accountId,
+    })).resolves.toMatchObject({
+      signerAddress: ethers.getAddress(AGENT),
+      coverage: { source: 'explicit', accountId },
+    });
+  });
+
+  it.each([
+    ['missing account', 999n],
+    ['signer mismatch', 1n],
+  ])('rejects explicit coverage for a %s', async (_label, accountId) => {
+    const mock = new MockChainAdapter('mock:31337', SIGNER);
+    if (accountId === 1n) mock.seedConvictionAccount(STRANGER);
+
+    await expect(mock.prepareOnChainContextGraphRegistration({
+      registrationPcaAccountId: accountId,
+    })).rejects.toBeInstanceOf(ContextGraphRegistrationCoverageSignerUnavailableError);
+  });
+});
 
 describe('MockChainAdapter — V10 conviction account create/read', () => {
   it('createPublishingConvictionAccount mints to the signer with an incrementing id', async () => {

--- a/packages/chain/test/mock-adapter-publishing-conviction-v10.test.ts
+++ b/packages/chain/test/mock-adapter-publishing-conviction-v10.test.ts
@@ -55,6 +55,16 @@ describe('MockChainAdapter — explicit context-graph registration coverage pari
       registrationPcaAccountId: accountId,
     })).rejects.toBeInstanceOf(ContextGraphRegistrationCoverageSignerUnavailableError);
   });
+
+  it('leaves direct PCA-policy eligibility to contract semantics', async () => {
+    const mock = new MockChainAdapter('mock:31337', SIGNER);
+
+    await expect(mock.createOnChainContextGraph({
+      accessPolicy: 0,
+      publishPolicy: 1,
+      registrationDepositPolicy: { mode: 'pca', accountId: 999n },
+    })).resolves.toMatchObject({ success: true });
+  });
 });
 
 describe('MockChainAdapter — V10 conviction account create/read', () => {

--- a/packages/chain/test/mock-adapter-publishing-conviction-v10.test.ts
+++ b/packages/chain/test/mock-adapter-publishing-conviction-v10.test.ts
@@ -44,6 +44,35 @@ describe('MockChainAdapter — explicit context-graph registration coverage pari
     });
   });
 
+  it('submits with the prepared signer as creator, manager, and default authority', async () => {
+    const mock = new MockChainAdapter('mock:31337', SIGNER);
+    const { accountId } = await mock.createPublishingConvictionAccount(COMMITTED);
+    await mock.registerPublishingConvictionAgent(accountId, AGENT);
+    mock.getSignerAddress = async () => ethers.getAddress(AGENT);
+    const prepared = await mock.prepareOnChainContextGraphRegistration({
+      registrationPcaAccountId: accountId,
+    });
+
+    const created = await prepared.submit({ accessPolicy: 1, publishPolicy: 0 });
+
+    const graph = mock.getContextGraph(created.contextGraphId);
+    expect(graph?.manager).toBe(ethers.getAddress(AGENT));
+    await expect(mock.getContextGraphPublishPolicy(created.contextGraphId)).resolves.toEqual({
+      publishPolicy: 0,
+      publishAuthority: ethers.getAddress(AGENT),
+    });
+    const events = [];
+    for await (const event of mock.listenForEvents({ eventTypes: ['ContextGraphCreated'] })) {
+      events.push(event);
+    }
+    expect(events).toHaveLength(1);
+    expect(events[0].data).toMatchObject({
+      creator: ethers.getAddress(AGENT),
+      owner: ethers.getAddress(AGENT),
+      manager: ethers.getAddress(AGENT),
+    });
+  });
+
   it.each([
     ['missing account', 999n],
     ['signer mismatch', 1n],

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -1,5 +1,5 @@
 import type { Quad, SharedMemoryGraphScope, TripleStore } from '@origintrail-official/dkg-storage';
-import type { ChainAdapter, OnChainPublishResult, AddBatchToContextGraphParams, PreBroadcastSignal } from '@origintrail-official/dkg-chain';
+import type { ChainAdapter, OnChainPublishResult, AddBatchToContextGraphParams, PreBroadcastSignal, PrepareContextGraphRegistrationOptions, PreparedContextGraphRegistration } from '@origintrail-official/dkg-chain';
 import type { PreBroadcastRecord } from './publisher.js';
 import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import type { EventBus, GraphKnowledgeAssetScope, OperationContext } from '@origintrail-official/dkg-core';
@@ -1466,6 +1466,50 @@ export class DKGPublisher implements Publisher {
   /** RFC-001 §9 fallback author when no agent override is supplied. Returns undefined if no signer configured. */
   async publisherFallbackAuthorAddress(): Promise<string | undefined> {
     return this.resolvePublisherAddress();
+  }
+
+  /**
+   * Prepare context-graph registration in this publisher's execution context.
+   * A configured/resolved publisher is pinned exactly; an unpinned signer pool
+   * asks the adapter for its deterministic PCA-aware registration selection.
+   * The private adapter and wallet never escape this boundary.
+   */
+  async prepareContextGraphRegistration(
+    options: PrepareContextGraphRegistrationOptions = {},
+  ): Promise<PreparedContextGraphRegistration> {
+    const prepare = this.chain.prepareOnChainContextGraphRegistration;
+    if (!prepare) {
+      throw new Error(
+        'prepareContextGraphRegistration: chain adapter does not support prepared context-graph registration.',
+      );
+    }
+
+    const selection = await this.resolvePublisherAddressSelection();
+    const requestedPin = options.registrationSignerAddress
+      ? normalizePublisherAddress(options.registrationSignerAddress)
+      : undefined;
+    if (options.registrationSignerAddress && !requestedPin) {
+      throw new Error(
+        `prepareContextGraphRegistration: invalid registration signer address ${options.registrationSignerAddress}.`,
+      );
+    }
+    if (
+      selection.planningPin
+      && requestedPin
+      && selection.planningPin.toLowerCase() !== requestedPin.toLowerCase()
+    ) {
+      throw new Error(
+        `prepareContextGraphRegistration: requested signer ${requestedPin} does not match ` +
+        `${selection.planningPinLabel ?? 'the configured publisher'} ${selection.planningPin}.`,
+      );
+    }
+
+    const registrationSignerAddress = selection.planningPin ?? requestedPin;
+    return prepare.call(this.chain, {
+      registrationPcaAccountId: options.registrationPcaAccountId,
+      registrationSignerAddress,
+      preferPcaCoveredSigner: registrationSignerAddress === undefined,
+    });
   }
 
   /** Sign EIP-712 typed data with the publisher's own wallet. Returns KAv10's compact (r, vs). */

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -454,6 +454,21 @@ export type PublisherAddressResolverResult =
   | PublisherAddressResolverSelection
   | undefined;
 
+/**
+ * The selected publisher cannot prepare a sealed context-graph registration
+ * because its chain adapter predates the optional preparation capability.
+ * Callers may use this typed signal to preserve the legacy direct, paid path;
+ * all other preparation failures remain fatal.
+ */
+export class ContextGraphRegistrationPreparationUnsupportedError extends Error {
+  readonly code = 'CONTEXT_GRAPH_REGISTRATION_PREPARATION_UNSUPPORTED' as const;
+
+  constructor() {
+    super('Chain adapter does not support prepared context-graph registration.');
+    this.name = 'ContextGraphRegistrationPreparationUnsupportedError';
+  }
+}
+
 export interface DKGPublisherConfig {
   store: TripleStore;
   chain: ChainAdapter;
@@ -1531,9 +1546,7 @@ export class DKGPublisher implements Publisher {
   ): Promise<PreparedContextGraphRegistration> {
     const prepare = this.chain.prepareOnChainContextGraphRegistration;
     if (!prepare) {
-      throw new Error(
-        'prepareContextGraphRegistration: chain adapter does not support prepared context-graph registration.',
-      );
+      throw new ContextGraphRegistrationPreparationUnsupportedError();
     }
 
     const selection = await this.resolvePublisherAddressSelection();

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -1,5 +1,14 @@
 import type { Quad, SharedMemoryGraphScope, TripleStore } from '@origintrail-official/dkg-storage';
-import type { ChainAdapter, OnChainPublishResult, AddBatchToContextGraphParams, PreBroadcastSignal, PrepareContextGraphRegistrationOptions, PreparedContextGraphRegistration } from '@origintrail-official/dkg-chain';
+import type {
+  ChainAdapter,
+  OnChainPublishResult,
+  AddBatchToContextGraphParams,
+  PreBroadcastSignal,
+  PrepareContextGraphRegistrationOptions,
+  PreparedContextGraphRegistration,
+  CreateOnChainContextGraphParams,
+  CreateOnChainContextGraphResult,
+} from '@origintrail-official/dkg-chain';
 import type { PreBroadcastRecord } from './publisher.js';
 import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import type { EventBus, GraphKnowledgeAssetScope, OperationContext } from '@origintrail-official/dkg-core';
@@ -572,6 +581,17 @@ interface PublisherAddressResolutionOptions {
   includeReservingPublisherProbe?: boolean;
   includeGenericSignMessageProbe?: boolean;
 }
+
+interface PublisherRegistrationSelection extends PublisherAddressResolution {
+  registrationPin:
+    | { disposition: 'hard'; address: string }
+    | { disposition: 'advisory' };
+}
+
+type PublisherContextGraphRegistrationOptions = Pick<
+  PrepareContextGraphRegistrationOptions,
+  'registrationPcaAccountId' | 'registrationSignerAddress'
+>;
 
 function normalizePublisherAddress(address: string | undefined): string | undefined {
   if (address === undefined) return undefined;
@@ -1476,7 +1496,7 @@ export class DKGPublisher implements Publisher {
   private async resolvePublisherAddressSelection(
     contextGraphId?: bigint,
     options: PublisherAddressResolutionOptions = {},
-  ): Promise<PublisherAddressResolution> {
+  ): Promise<PublisherRegistrationSelection> {
     if (this.publisherAddress) {
       return {
         address: this.publisherAddress,
@@ -1542,7 +1562,7 @@ export class DKGPublisher implements Publisher {
    * escape this boundary.
    */
   async prepareContextGraphRegistration(
-    options: PrepareContextGraphRegistrationOptions = {},
+    options: PublisherContextGraphRegistrationOptions = {},
   ): Promise<PreparedContextGraphRegistration> {
     const prepare = this.chain.prepareOnChainContextGraphRegistration;
     if (!prepare) {
@@ -1578,6 +1598,49 @@ export class DKGPublisher implements Publisher {
       registrationSignerAddress,
       preferPcaCoveredSigner: registrationSignerAddress === undefined,
     });
+  }
+
+  /**
+   * Seal the compatibility path for adapters that predate prepared context-
+   * graph registration. Hard publisher identities must match the adapter that
+   * will submit; advisory inference leaves that direct adapter signer in
+   * control. The caller receives only the authoritative signer (when the
+   * adapter exposes it) and a one-purpose submit capability.
+   */
+  async prepareLegacyContextGraphRegistration(): Promise<{
+    readonly signerAddress?: string;
+    submit(params: CreateOnChainContextGraphParams): Promise<CreateOnChainContextGraphResult>;
+  }> {
+    if (typeof this.chain.createOnChainContextGraph !== 'function') {
+      throw new Error('Chain adapter does not support direct context-graph registration.');
+    }
+
+    const [selection, directSignerAddress] = await Promise.all([
+      this.resolvePublisherAddressSelection(),
+      this.inferAdapterPublisherAddress(undefined, {
+        includeReservingPublisherProbe: false,
+      }),
+    ]);
+    const hardRegistrationPin = selection.registrationPin.disposition === 'hard'
+      ? selection.registrationPin.address
+      : undefined;
+    if (
+      hardRegistrationPin
+      && (
+        !directSignerAddress
+        || hardRegistrationPin.toLowerCase() !== directSignerAddress.toLowerCase()
+      )
+    ) {
+      throw new Error(
+        `Configured publisher ${hardRegistrationPin} does not match the legacy direct chain signer ` +
+        `${directSignerAddress ?? '(unavailable)'}.`,
+      );
+    }
+
+    return {
+      ...(directSignerAddress ? { signerAddress: directSignerAddress } : {}),
+      submit: (params) => this.chain.createOnChainContextGraph!(params),
+    };
   }
 
   /** Sign EIP-712 typed data with the publisher's own wallet. Returns KAv10's compact (r, vs). */

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -442,6 +442,18 @@ export interface KaIdAllocator {
   markReconciled(): void;
 }
 
+export interface PublisherAddressResolverSelection {
+  address: string;
+  registrationPin: 'hard' | 'advisory';
+  /** Human-readable diagnostics only; never interpreted as signer policy. */
+  source: string;
+}
+
+export type PublisherAddressResolverResult =
+  | string
+  | PublisherAddressResolverSelection
+  | undefined;
+
 export interface DKGPublisherConfig {
   store: TripleStore;
   chain: ChainAdapter;
@@ -449,15 +461,15 @@ export interface DKGPublisherConfig {
   keypair: Ed25519Keypair;
   publisherNodeIdentityId?: bigint;
   publisherAddress?: string;
-  /** Retryable publisher address resolver for adapter-backed signing. */
-  publisherAddressResolver?: (contextGraphId?: bigint) => Promise<string | undefined>;
   /**
-   * Whether resolver output is a hard signer pin for CG registration. Defaults
-   * to true for custom resolvers. The agent's generic adapter-inference
-   * resolver sets this false so an unplanned sync publish can choose a
-   * PCA-covered signer from the adapter pool.
+   * Retryable publisher address resolver for adapter-backed signing. Legacy
+   * string results remain hard registration pins; new callers should return a
+   * typed result so curated authority can be hard while generic adapter
+   * inference remains advisory.
    */
-  publisherAddressResolverPinsRegistration?: boolean;
+  publisherAddressResolver?: (
+    contextGraphId?: bigint,
+  ) => Promise<PublisherAddressResolverResult>;
   /** EVM private key for signing publish requests (hex string with 0x prefix) */
   publisherPrivateKey?: string;
   /**
@@ -1153,8 +1165,9 @@ export class DKGPublisher implements Publisher {
   readonly knownBatchContextGraphs: Map<string, string>;
   private publisherNodeIdentityId: bigint;
   private readonly publisherAddress?: string;
-  private readonly publisherAddressResolver?: (contextGraphId?: bigint) => Promise<string | undefined>;
-  private readonly publisherAddressResolverPinsRegistration: boolean;
+  private readonly publisherAddressResolver?: (
+    contextGraphId?: bigint,
+  ) => Promise<PublisherAddressResolverResult>;
   private readonly publisherWallet?: ethers.Wallet;
   private readonly publisherPlanner: PublisherPlanner;
   private adapterSignMessagePublisherAddress?: string;
@@ -1184,8 +1197,6 @@ export class DKGPublisher implements Publisher {
     this.keypair = config.keypair;
     this.publisherNodeIdentityId = config.publisherNodeIdentityId ?? 0n;
     this.publisherAddressResolver = config.publisherAddressResolver;
-    this.publisherAddressResolverPinsRegistration =
-      config.publisherAddressResolverPinsRegistration !== false;
 
     const configuredPublisherAddress = normalizePublisherAddress(config.publisherAddress);
     if (config.publisherPrivateKey) {
@@ -1458,19 +1469,49 @@ export class DKGPublisher implements Publisher {
         planningPinLabel: this.publisherWallet
           ? 'publisherPrivateKey'
           : 'configured publisherAddress',
+        registrationPin: { disposition: 'hard', address: this.publisherAddress },
       };
     }
     if (this.publisherAddressResolver) {
-      const resolved = normalizePublisherAddress(await this.publisherAddressResolver(contextGraphId));
+      const resolverResult = await this.publisherAddressResolver(contextGraphId);
+      const typedResult = typeof resolverResult === 'object' && resolverResult !== null
+        ? resolverResult
+        : undefined;
+      if (
+        typedResult
+        && (
+          (typedResult.registrationPin !== 'hard' && typedResult.registrationPin !== 'advisory')
+          || typeof typedResult.source !== 'string'
+          || typedResult.source.trim().length === 0
+        )
+      ) {
+        throw new Error(
+          'publisherAddressResolver returned an invalid typed result; expected ' +
+          `{ address, registrationPin: 'hard' | 'advisory', source }.`
+        );
+      }
+      const resolved = normalizePublisherAddress(
+        typeof resolverResult === 'string' ? resolverResult : typedResult?.address,
+      );
+      if (typedResult && !resolved) {
+        throw new Error('publisherAddressResolver returned an invalid typed address.');
+      }
       if (resolved) {
+        const registrationDisposition = typedResult?.registrationPin ?? 'hard';
         return {
           address: resolved,
           planningPin: resolved,
-          planningPinLabel: 'publisherAddressResolver',
+          planningPinLabel: typedResult?.source.trim() ?? 'publisherAddressResolver',
+          registrationPin: registrationDisposition === 'hard'
+            ? { disposition: 'hard', address: resolved }
+            : { disposition: 'advisory' },
         };
       }
     }
-    return { address: await this.inferAdapterPublisherAddress(contextGraphId, options) };
+    return {
+      address: await this.inferAdapterPublisherAddress(contextGraphId, options),
+      registrationPin: { disposition: 'advisory' },
+    };
   }
 
   /** RFC-001 §9 fallback author when no agent override is supplied. Returns undefined if no signer configured. */
@@ -1480,9 +1521,10 @@ export class DKGPublisher implements Publisher {
 
   /**
    * Prepare context-graph registration in this publisher's execution context.
-   * A configured/resolved publisher is pinned exactly; an unpinned signer pool
-   * asks the adapter for its deterministic PCA-aware registration selection.
-   * The private adapter and wallet never escape this boundary.
+   * A configured publisher or hard resolver result is pinned exactly; an
+   * advisory resolver leaves the signer pool unpinned so the adapter performs
+   * deterministic PCA-aware selection. The private adapter and wallet never
+   * escape this boundary.
    */
   async prepareContextGraphRegistration(
     options: PrepareContextGraphRegistrationOptions = {},
@@ -1503,24 +1545,21 @@ export class DKGPublisher implements Publisher {
         `prepareContextGraphRegistration: invalid registration signer address ${options.registrationSignerAddress}.`,
       );
     }
-    const resolverPinIsAdvisory =
-      selection.planningPinLabel === 'publisherAddressResolver'
-      && !this.publisherAddressResolverPinsRegistration;
+    const hardRegistrationPin = selection.registrationPin.disposition === 'hard'
+      ? selection.registrationPin.address
+      : undefined;
     if (
-      !resolverPinIsAdvisory
-      && selection.planningPin
+      hardRegistrationPin
       && requestedPin
-      && selection.planningPin.toLowerCase() !== requestedPin.toLowerCase()
+      && hardRegistrationPin.toLowerCase() !== requestedPin.toLowerCase()
     ) {
       throw new Error(
         `prepareContextGraphRegistration: requested signer ${requestedPin} does not match ` +
-        `${selection.planningPinLabel ?? 'the configured publisher'} ${selection.planningPin}.`,
+        `${selection.planningPinLabel ?? 'the configured publisher'} ${hardRegistrationPin}.`,
       );
     }
 
-    const registrationSignerAddress = resolverPinIsAdvisory
-      ? requestedPin
-      : selection.planningPin ?? requestedPin;
+    const registrationSignerAddress = hardRegistrationPin ?? requestedPin;
     return prepare.call(this.chain, {
       registrationPcaAccountId: options.registrationPcaAccountId,
       registrationSignerAddress,

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -451,6 +451,13 @@ export interface DKGPublisherConfig {
   publisherAddress?: string;
   /** Retryable publisher address resolver for adapter-backed signing. */
   publisherAddressResolver?: (contextGraphId?: bigint) => Promise<string | undefined>;
+  /**
+   * Whether resolver output is a hard signer pin for CG registration. Defaults
+   * to true for custom resolvers. The agent's generic adapter-inference
+   * resolver sets this false so an unplanned sync publish can choose a
+   * PCA-covered signer from the adapter pool.
+   */
+  publisherAddressResolverPinsRegistration?: boolean;
   /** EVM private key for signing publish requests (hex string with 0x prefix) */
   publisherPrivateKey?: string;
   /**
@@ -1147,6 +1154,7 @@ export class DKGPublisher implements Publisher {
   private publisherNodeIdentityId: bigint;
   private readonly publisherAddress?: string;
   private readonly publisherAddressResolver?: (contextGraphId?: bigint) => Promise<string | undefined>;
+  private readonly publisherAddressResolverPinsRegistration: boolean;
   private readonly publisherWallet?: ethers.Wallet;
   private readonly publisherPlanner: PublisherPlanner;
   private adapterSignMessagePublisherAddress?: string;
@@ -1176,6 +1184,8 @@ export class DKGPublisher implements Publisher {
     this.keypair = config.keypair;
     this.publisherNodeIdentityId = config.publisherNodeIdentityId ?? 0n;
     this.publisherAddressResolver = config.publisherAddressResolver;
+    this.publisherAddressResolverPinsRegistration =
+      config.publisherAddressResolverPinsRegistration !== false;
 
     const configuredPublisherAddress = normalizePublisherAddress(config.publisherAddress);
     if (config.publisherPrivateKey) {
@@ -1493,8 +1503,12 @@ export class DKGPublisher implements Publisher {
         `prepareContextGraphRegistration: invalid registration signer address ${options.registrationSignerAddress}.`,
       );
     }
+    const resolverPinIsAdvisory =
+      selection.planningPinLabel === 'publisherAddressResolver'
+      && !this.publisherAddressResolverPinsRegistration;
     if (
-      selection.planningPin
+      !resolverPinIsAdvisory
+      && selection.planningPin
       && requestedPin
       && selection.planningPin.toLowerCase() !== requestedPin.toLowerCase()
     ) {
@@ -1504,7 +1518,9 @@ export class DKGPublisher implements Publisher {
       );
     }
 
-    const registrationSignerAddress = selection.planningPin ?? requestedPin;
+    const registrationSignerAddress = resolverPinIsAdvisory
+      ? requestedPin
+      : selection.planningPin ?? requestedPin;
     return prepare.call(this.chain, {
       registrationPcaAccountId: options.registrationPcaAccountId,
       registrationSignerAddress,

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -96,6 +96,8 @@ export {
   CuratorRejectedError,
   assertValidPrecomputedUpdateAttestation,
   type DKGPublisherConfig,
+  type PublisherAddressResolverResult,
+  type PublisherAddressResolverSelection,
   type WorkspaceSenderKeyEncryptInput,
   type WorkspaceSenderKeyEncryptor,
   type ShareOptions,

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -94,6 +94,7 @@ export {
   MultiRootPublishNotAtomicError,
   CuratorUnconfirmedError,
   CuratorRejectedError,
+  ContextGraphRegistrationPreparationUnsupportedError,
   assertValidPrecomputedUpdateAttestation,
   type DKGPublisherConfig,
   type PublisherAddressResolverResult,

--- a/packages/publisher/src/publisher-planning.ts
+++ b/packages/publisher/src/publisher-planning.ts
@@ -21,7 +21,11 @@ export interface PublisherSigner {
 export interface PublisherAddressResolution {
   address?: string;
   planningPin?: string;
-  planningPinLabel?: 'publisherPrivateKey' | 'configured publisherAddress' | 'publisherAddressResolver';
+  /** Diagnostics only; signer policy is carried exclusively by registrationPin. */
+  planningPinLabel?: string;
+  registrationPin:
+    | { disposition: 'hard'; address: string }
+    | { disposition: 'advisory' };
 }
 
 interface PublisherPlanningStateLocal {

--- a/packages/publisher/src/publisher-planning.ts
+++ b/packages/publisher/src/publisher-planning.ts
@@ -21,11 +21,7 @@ export interface PublisherSigner {
 export interface PublisherAddressResolution {
   address?: string;
   planningPin?: string;
-  /** Diagnostics only; signer policy is carried exclusively by registrationPin. */
   planningPinLabel?: string;
-  registrationPin:
-    | { disposition: 'hard'; address: string }
-    | { disposition: 'advisory' };
 }
 
 interface PublisherPlanningStateLocal {

--- a/packages/publisher/test/publisher-no-random-wallet.test.ts
+++ b/packages/publisher/test/publisher-no-random-wallet.test.ts
@@ -1520,6 +1520,54 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
     });
   });
 
+  it('seals legacy direct registration around the adapter signer, not an advisory author hint', async () => {
+    const advisoryWallet = new ethers.Wallet(TEST_KEY);
+    const directWallet = new ethers.Wallet(TEST_KEY_ALT);
+    const chain = new MockChainAdapter('mock:31337', directWallet.address);
+    const create = vi.spyOn(chain, 'createOnChainContextGraph');
+    const publisher = new DKGPublisher({
+      store: new OxigraphStore(),
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair: await generateEd25519Keypair(),
+      publisherAddressResolver: async () => ({
+        address: advisoryWallet.address,
+        registrationPin: 'advisory',
+        source: 'generic-adapter-inference',
+      }),
+    });
+
+    const legacy = await publisher.prepareLegacyContextGraphRegistration();
+    expect(legacy.signerAddress).toBe(directWallet.address);
+    await legacy.submit({
+      accessPolicy: 1,
+      publishPolicy: 1,
+      participantAgents: [],
+      nameHash: ethers.ZeroHash,
+    });
+
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects legacy direct registration when a hard publisher pin differs from the adapter signer', async () => {
+    const pinnedWallet = new ethers.Wallet(TEST_KEY);
+    const directWallet = new ethers.Wallet(TEST_KEY_ALT);
+    const publisher = new DKGPublisher({
+      store: new OxigraphStore(),
+      chain: new MockChainAdapter('mock:31337', directWallet.address),
+      eventBus: new TypedEventBus(),
+      keypair: await generateEd25519Keypair(),
+      publisherAddressResolver: async () => ({
+        address: pinnedWallet.address,
+        registrationPin: 'hard',
+        source: 'configured-publisher',
+      }),
+    });
+
+    await expect(publisher.prepareLegacyContextGraphRegistration())
+      .rejects.toThrow(/does not match the legacy direct chain signer/);
+  });
+
   it('keeps a legacy string resolver result as a hard registration pin', async () => {
     const wallet = new ethers.Wallet(TEST_KEY);
     const chain = new MockChainAdapter('mock:31337', wallet.address);

--- a/packages/publisher/test/publisher-no-random-wallet.test.ts
+++ b/packages/publisher/test/publisher-no-random-wallet.test.ts
@@ -1479,6 +1479,28 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
       .toBe(walletB.address.toLowerCase());
   });
 
+  it('treats generic adapter address inference as advisory for CG registration', async () => {
+    const walletA = new ethers.Wallet(TEST_KEY);
+    const chain = new MockChainAdapter();
+    const prepare = vi.spyOn(chain, 'prepareOnChainContextGraphRegistration');
+    const publisher = new DKGPublisher({
+      store: new OxigraphStore(),
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair: await generateEd25519Keypair(),
+      publisherAddressResolver: async () => walletA.address,
+      publisherAddressResolverPinsRegistration: false,
+    });
+
+    await publisher.prepareContextGraphRegistration();
+
+    expect(prepare).toHaveBeenCalledWith({
+      registrationPcaAccountId: undefined,
+      registrationSignerAddress: undefined,
+      preferPcaCoveredSigner: true,
+    });
+  });
+
   it('invokes adapter-owned planning before signer discovery and binds the planned address', async () => {
     const wallet = new ethers.Wallet(TEST_KEY_ALT);
     const chain = new PlanOnlySigningChain(wallet);

--- a/packages/publisher/test/publisher-no-random-wallet.test.ts
+++ b/packages/publisher/test/publisher-no-random-wallet.test.ts
@@ -43,6 +43,7 @@ import {
 } from '@origintrail-official/dkg-core';
 import {
   MockChainAdapter,
+  NoChainAdapter,
   type ChainAdapter,
   type OnChainPublishResult,
   type PublisherPublishPlanRequest,
@@ -1501,6 +1502,21 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
       registrationPcaAccountId: undefined,
       registrationSignerAddress: undefined,
       preferPcaCoveredSigner: true,
+    });
+  });
+
+  it('reports missing adapter preparation support with a typed compatibility signal', async () => {
+    const chain = new NoChainAdapter();
+    const publisher = new DKGPublisher({
+      store: new OxigraphStore(),
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair: await generateEd25519Keypair(),
+    });
+
+    await expect(publisher.prepareContextGraphRegistration()).rejects.toMatchObject({
+      name: 'ContextGraphRegistrationPreparationUnsupportedError',
+      code: 'CONTEXT_GRAPH_REGISTRATION_PREPARATION_UNSUPPORTED',
     });
   });
 

--- a/packages/publisher/test/publisher-no-random-wallet.test.ts
+++ b/packages/publisher/test/publisher-no-random-wallet.test.ts
@@ -1594,6 +1594,7 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
     const walletB = new ethers.Wallet(TEST_KEY_ALT);
     const chain = new MockChainAdapter('mock:31337', walletA.address);
     const prepare = vi.spyOn(chain, 'prepareOnChainContextGraphRegistration');
+    const { accountId } = await chain.createPublishingConvictionAccount(ethers.parseEther('10000'));
     const publisher = new DKGPublisher({
       store: new OxigraphStore(),
       chain,
@@ -1606,9 +1607,9 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
       }),
     });
 
-    await publisher.prepareContextGraphRegistration({ registrationPcaAccountId: 8n });
+    await publisher.prepareContextGraphRegistration({ registrationPcaAccountId: accountId });
     expect(prepare).toHaveBeenCalledWith({
-      registrationPcaAccountId: 8n,
+      registrationPcaAccountId: accountId,
       registrationSignerAddress: walletA.address,
       preferPcaCoveredSigner: false,
     });

--- a/packages/publisher/test/publisher-no-random-wallet.test.ts
+++ b/packages/publisher/test/publisher-no-random-wallet.test.ts
@@ -1479,7 +1479,7 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
       .toBe(walletB.address.toLowerCase());
   });
 
-  it('treats generic adapter address inference as advisory for CG registration', async () => {
+  it('treats an explicitly advisory publisher resolver as unpinned for CG registration', async () => {
     const walletA = new ethers.Wallet(TEST_KEY);
     const chain = new MockChainAdapter();
     const prepare = vi.spyOn(chain, 'prepareOnChainContextGraphRegistration');
@@ -1488,8 +1488,11 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
       chain,
       eventBus: new TypedEventBus(),
       keypair: await generateEd25519Keypair(),
-      publisherAddressResolver: async () => walletA.address,
-      publisherAddressResolverPinsRegistration: false,
+      publisherAddressResolver: async () => ({
+        address: walletA.address,
+        registrationPin: 'advisory',
+        source: 'generic-adapter-inference',
+      }),
     });
 
     await publisher.prepareContextGraphRegistration();
@@ -1499,6 +1502,57 @@ describe('DKGPublisher: no random publisher wallet without explicit key', () => 
       registrationSignerAddress: undefined,
       preferPcaCoveredSigner: true,
     });
+  });
+
+  it('keeps a legacy string resolver result as a hard registration pin', async () => {
+    const wallet = new ethers.Wallet(TEST_KEY);
+    const chain = new MockChainAdapter('mock:31337', wallet.address);
+    const prepare = vi.spyOn(chain, 'prepareOnChainContextGraphRegistration');
+    const publisher = new DKGPublisher({
+      store: new OxigraphStore(),
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair: await generateEd25519Keypair(),
+      publisherAddressResolver: async () => wallet.address,
+    });
+
+    await publisher.prepareContextGraphRegistration();
+
+    expect(prepare).toHaveBeenCalledWith({
+      registrationPcaAccountId: undefined,
+      registrationSignerAddress: wallet.address,
+      preferPcaCoveredSigner: false,
+    });
+  });
+
+  it('passes a hard resolver registration pin through and rejects caller substitution', async () => {
+    const walletA = new ethers.Wallet(TEST_KEY);
+    const walletB = new ethers.Wallet(TEST_KEY_ALT);
+    const chain = new MockChainAdapter('mock:31337', walletA.address);
+    const prepare = vi.spyOn(chain, 'prepareOnChainContextGraphRegistration');
+    const publisher = new DKGPublisher({
+      store: new OxigraphStore(),
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair: await generateEd25519Keypair(),
+      publisherAddressResolver: async () => ({
+        address: walletA.address,
+        registrationPin: 'hard',
+        source: 'curated-authority',
+      }),
+    });
+
+    await publisher.prepareContextGraphRegistration({ registrationPcaAccountId: 8n });
+    expect(prepare).toHaveBeenCalledWith({
+      registrationPcaAccountId: 8n,
+      registrationSignerAddress: walletA.address,
+      preferPcaCoveredSigner: false,
+    });
+
+    await expect(publisher.prepareContextGraphRegistration({
+      registrationSignerAddress: walletB.address,
+    })).rejects.toThrow(/does not match curated-authority/);
+    expect(prepare).toHaveBeenCalledTimes(1);
   });
 
   it('invokes adapter-owned planning before signer discovery and binds the planned address', async () => {


### PR DESCRIPTION
## Summary

Adds an immutable prepared-registration capability to the chain and publisher layers. Preparation seals the exact signer, facade version, and registration-deposit policy; submission cannot substitute those values. Automatic discovery is capped at 32 owned PCAs, concurrency 4, and a five-second total budget before strict-agent and paid fallbacks.

Direct and prepared registration share one policy resolver/dispatch path. Explicit coverage preserves retryable RPC/stale-Hub failures and reports signer mismatch only after successful negative owner/agent reads. Unknown cached facade versions are refreshed before dispatch, deposit reads recover from stale Hub mappings, and the mock adapter now enforces the same owner/exact-agent and fail-closed eligibility semantics.

The additive path is exercised through a real Hardhat-backed adapter transaction using the checked-in ABI, including an ineligible-PCA paid fallback before and after lazy approval.

## Related

Part of #2440.

PR 2 of 4, stacked on #2442. Followed by #2444 and #2445.

## Files changed

- Chain registration policy, errors, adapter implementation, mock parity, ABI, and pin.
- Bounded PCA discovery and sealed preparation/submission.
- Publisher preparation plus isolated legacy compatibility execution.
- Eligibility, relationship, version, stale-Hub/RPC recovery, and real-Hardhat coverage.

## Test plan

- [x] Exact-head focused chain tests: 4 files, 97/97.
- [x] Full chain unit lane: 62 files, 1,158 passed, 1 existing skip on the reviewed stack.
- [x] Real Hardhat adapter registration and paid fallback covered.
- [x] Final stacked build: 24/24 package tasks and 5/5 UI tasks.
- [x] Root lint passed under WSL/Node 22.
- [ ] Required CI and fresh reviewer verdict on exact head `1b7e10327c8ecc59712ee1a44725fb97af5e1ed4`.
