### PR TITLE
refactor(devnet): encapsulate PCA registration fixture

### DIFF
--- a/devnet/_bootstrap/suite-manifest.test.ts
+++ b/devnet/_bootstrap/suite-manifest.test.ts
@@ -4,12 +4,21 @@
 // forgotten in the sweep list / pnpm-workspace / package.json (otReviewAgent #1397).
 import { describe, it, expect } from 'vitest';
 import {
+  mkdtempSync,
   readdirSync,
   readFileSync,
+  rmSync,
   existsSync,
   statSync,
+  writeFileSync,
 } from 'node:fs';
 import { resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import {
+  scheduleSweepPhase,
+  selectSweepSuites,
+} from '../../scripts/lib/sweep-suite-selector.mjs';
 
 const DEVNET = resolve(import.meta.dirname, '..');
 const ROOT = resolve(DEVNET, '..');
@@ -19,8 +28,22 @@ const manifest = JSON.parse(readFileSync(resolve(DEVNET, 'suites.json'), 'utf8')
     publisherWalletIndex: number;
   };
   prCoverage: string[];
+  baselineOnly: string[];
   all: string[];
 };
+const SWEEP_SELECTOR = resolve(ROOT, 'scripts/lib/sweep-suite-selector.mjs');
+const SWEEP_PHASE_SCHEDULE = resolve(ROOT, 'scripts/lib/sweep-phase-schedule.sh');
+
+function runScheduledPhase(phase: 'baseline' | 'stability', round = 0, override?: string) {
+  const args = [SWEEP_SELECTOR, resolve(DEVNET, 'suites.json'), phase, String(round)];
+  if (override !== undefined) args.push(override);
+  const result = spawnSync(process.execPath, args, { encoding: 'utf8' });
+  expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+  return result.stdout.trim().split(/\r?\n/).filter(Boolean).map((line) => {
+    const [logTag, suite] = line.split('\t');
+    return { logTag, suite };
+  });
+}
 // Suite dirs actually present on disk: devnet/<x>/ with a vitest.config.ts, minus
 // the underscore-prefixed infra dirs (_bootstrap).
 const onDisk = readdirSync(DEVNET, { withFileTypes: true })
@@ -30,7 +53,8 @@ const onDisk = readdirSync(DEVNET, { withFileTypes: true })
   .sort();
 
 describe('devnet suite manifest (suites.json) — drift guard', () => {
-  it('declares the shared-sweep topology explicitly', () => {
+  it('declares the issue #2440 shared-sweep topology explicitly', () => {
+    expect(manifest.prCoverage).toContain('pr2440-pca-cg-registration');
     expect(manifest.sharedSweep).toEqual({
       nodeCount: 6,
       publisherWalletIndex: 1,
@@ -41,6 +65,136 @@ describe('devnet suite manifest (suites.json) — drift guard', () => {
     const missing = manifest.prCoverage.filter((s) => !manifest.all.includes(s));
     expect(missing, `prCoverage entries not in all: ${missing.join(', ')}`).toEqual([]);
   });
+
+  it('baselineOnly is a duplicate-free subset of prCoverage', () => {
+    const missing = manifest.baselineOnly.filter((s) => !manifest.prCoverage.includes(s));
+    expect(missing, `baselineOnly entries not in prCoverage: ${missing.join(', ')}`).toEqual([]);
+    expect(new Set(manifest.baselineOnly).size).toBe(manifest.baselineOnly.length);
+  });
+
+  it('has no duplicate suite entries', () => {
+    for (const [name, suites] of [
+      ['prCoverage', manifest.prCoverage],
+      ['all', manifest.all],
+    ] as const) {
+      expect(new Set(suites).size, `${name} contains duplicate entries`).toBe(suites.length);
+    }
+  });
+
+  it('schedules baselineOnly once and repeatable suites in every stability round', () => {
+    const selection = selectSweepSuites(manifest);
+
+    expect(selection.baseline).toEqual([...manifest.prCoverage, 'v10-end-to-end']);
+    expect(selection.stability).toEqual([
+      ...manifest.prCoverage.filter((suite) => !manifest.baselineOnly.includes(suite)),
+      'v10-end-to-end',
+    ]);
+    expect(new Set(selection.baseline).size, 'baseline selection contains duplicates').toBe(
+      selection.baseline.length,
+    );
+    expect(new Set(selection.stability).size, 'stability selection contains duplicates').toBe(
+      selection.stability.length,
+    );
+
+    const invocations = [
+      ...scheduleSweepPhase(selection, 'baseline'),
+      ...scheduleSweepPhase(selection, 'stability', 1),
+      ...scheduleSweepPhase(selection, 'stability', 2),
+    ];
+    const baselineInvocations = runScheduledPhase('baseline');
+    const firstStabilityRound = runScheduledPhase('stability', 1);
+    const secondStabilityRound = runScheduledPhase('stability', 2);
+    expect(baselineInvocations).toHaveLength(selection.baseline.length);
+    expect(firstStabilityRound).toHaveLength(selection.stability.length);
+    expect(secondStabilityRound).toHaveLength(selection.stability.length);
+
+    const operationalInvocations = [
+      ...baselineInvocations,
+      ...firstStabilityRound,
+      ...secondStabilityRound,
+    ];
+    expect(operationalInvocations.map(({ suite }) => suite)).toEqual(
+      invocations.map(({ suite }) => suite),
+    );
+
+    const invocationCount = (suite: string) =>
+      operationalInvocations.filter((invocation) => invocation.suite === suite).length;
+    for (const suite of manifest.baselineOnly) expect(invocationCount(suite)).toBe(1);
+    for (const suite of selection.stability) expect(invocationCount(suite)).toBe(3);
+    expect(operationalInvocations[0].logTag).toBe(`P1-${selection.baseline[0]}`);
+    expect(operationalInvocations.at(-1)?.logTag).toBe(
+      `P2-r2-${selection.stability.at(-1)}`,
+    );
+  });
+
+  it('preserves an explicit STABILITY_SUITES override verbatim', () => {
+    const override = 'pr2440-pca-cg-registration v10-core-flows';
+    const selection = selectSweepSuites(manifest, override);
+    expect(selection.stability).toEqual(override.split(' '));
+    expect(runScheduledPhase('stability', 1, override).map(({ suite }) => suite)).toEqual(
+      override.split(' '),
+    );
+  });
+
+  it.runIf(process.platform !== 'win32')(
+    'aborts before a phase loop when the selector fails or returns an empty schedule',
+    () => {
+      const fixture = mkdtempSync(resolve(tmpdir(), 'dkg-sweep-phase-'));
+      try {
+        const manifestPath = resolve(fixture, 'suites.json');
+        writeFileSync(manifestPath, '{}');
+        for (const [name, source] of [
+          ['failed-selector.mjs', 'process.exit(7);'],
+          ['empty-selector.mjs', ''],
+        ] as const) {
+          const selectorPath = resolve(fixture, name);
+          writeFileSync(selectorPath, source);
+          const result = spawnSync('bash', ['-c', [
+            'source "$SWEEP_PHASE_LOADER"',
+            'capture_sweep_phase_schedule baseline 0 || exit 2',
+            'printf "unexpected:%s" "$SWEEP_PHASE_SCHEDULE"',
+          ].join('\n')], {
+            encoding: 'utf8',
+            env: {
+              ...process.env,
+              SWEEP_PHASE_LOADER: SWEEP_PHASE_SCHEDULE,
+              SWEEP_SELECTOR: selectorPath,
+              SUITES_JSON: manifestPath,
+              STABILITY_OVERRIDE: '',
+            },
+          });
+          expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(2);
+          expect(result.stdout).not.toContain('unexpected:');
+        }
+      } finally {
+        rmSync(fixture, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.runIf(process.platform !== 'win32')(
+    'keeps a validated phase schedule in the parent shell',
+    () => {
+      const result = spawnSync('bash', ['-c', [
+        'source "$SWEEP_PHASE_LOADER"',
+        'capture_sweep_phase_schedule baseline 0 || exit 2',
+        'printf "%s" "$SWEEP_PHASE_SCHEDULE"',
+      ].join('\n')], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          SWEEP_PHASE_LOADER: SWEEP_PHASE_SCHEDULE,
+          SWEEP_SELECTOR,
+          SUITES_JSON: resolve(DEVNET, 'suites.json'),
+          STABILITY_OVERRIDE: '',
+        },
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stdout.trim().split(/\r?\n/)).toHaveLength(
+        selectSweepSuites(manifest).baseline.length,
+      );
+    },
+  );
 
   it('all == on-disk suites (no untracked or stale entries)', () => {
     const sorted = [...manifest.all].sort();

--- a/devnet/pr2440-pca-cg-registration/automated.test.ts
+++ b/devnet/pr2440-pca-cg-registration/automated.test.ts
@@ -1,0 +1,511 @@
+/**
+ * Issue #2440 — live PCA-covered Context Graph auto-registration.
+ *
+ * Preconditions:
+ *   pnpm run build
+ *   DEVNET_ENABLE_PUBLISHER=1 DEVNET_PUBLISHER_WALLET_INDEX=1 ./scripts/devnet.sh start 6
+ */
+import { existsSync } from 'node:fs';
+import { setTimeout as delay } from 'node:timers/promises';
+import { ethers } from 'ethers';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { detectDevnet } from '../_bootstrap/harness.js';
+import {
+  drainLivePcaPublisherInitializationCleanups,
+  LivePcaPublisherFixture,
+  retryLivePcaPublisherInitializationCleanup,
+  type FixtureAcceptedBroadcastCheckpoint,
+  type FixtureInitializationCheckpoint,
+  type RegistrationEvidence,
+  type WaivedRegistrationEvidence,
+} from './live-pca-publisher-fixture.js';
+
+const lower = (value: string): string => value.toLowerCase();
+
+async function expectWalletBFixtureOwnedBalanceInvariant(
+  before: { native: bigint; trac: bigint },
+): Promise<void> {
+  const after = await LivePcaPublisherFixture.captureWalletBBalances();
+  expect(after.trac).toBe(before.trac);
+  // Native gas belongs to the running publisher daemon. RandomSampling and
+  // other canonical maintenance may spend it concurrently with fixture setup
+  // or cleanup; the fixture boundary guarantees only that the wallet remains
+  // funded and that fixture transactions are never signed by wallet B.
+  expect(after.native).toBeGreaterThan(0n);
+}
+
+async function settleInitializationCleanup(initializationError: object): Promise<void> {
+  let cleanupError: unknown;
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      await retryLivePcaPublisherInitializationCleanup(initializationError);
+      return;
+    } catch (error) {
+      cleanupError = error;
+      if (attempt < 3) await delay(1_000);
+    }
+  }
+
+  try {
+    Object.defineProperty(initializationError, 'initializationCleanupError', {
+      configurable: true,
+      value: cleanupError,
+    });
+  } catch {
+    // A frozen injected error still remains the authoritative thrown value.
+  }
+  throw initializationError;
+}
+
+async function createLiveFixture(
+  options: Parameters<typeof LivePcaPublisherFixture.create>[0] = {},
+): Promise<LivePcaPublisherFixture> {
+  try {
+    return await LivePcaPublisherFixture.create(options);
+  } catch (error) {
+    if (typeof error === 'object' && error !== null) {
+      await settleInitializationCleanup(error);
+    }
+    throw error;
+  }
+}
+
+async function expectInitializationCleanup(
+  checkpoint: FixtureInitializationCheckpoint,
+  retainedPcaCount: bigint,
+  expectsKnownPcaAccountId = retainedPcaCount > 0n,
+): Promise<void> {
+  const before = await LivePcaPublisherFixture.captureMutableState();
+  const walletBBalancesBefore = await LivePcaPublisherFixture.captureWalletBBalances();
+  expect(walletBBalancesBefore.native).toBeGreaterThan(0n);
+  expect(walletBBalancesBefore.trac).toBeGreaterThan(0n);
+  const supplyBefore = await LivePcaPublisherFixture.capturePcaTotalSupply();
+  const initializationError = new Error(`injected ${checkpoint} failure`);
+  let fixtureDir = '';
+  let fixtureId = '';
+  let pcaAccountId = 0n;
+
+  try {
+    await expect(createLiveFixture({
+      initializationFault: {
+        checkpoint,
+        error: initializationError,
+        onReached: (context) => {
+          ({ fixtureDir, fixtureId, pcaAccountId } = context);
+        },
+      },
+    })).rejects.toBe(initializationError);
+  } finally {
+    await settleInitializationCleanup(initializationError);
+  }
+
+  expect(fixtureDir).not.toBe('');
+  expect(fixtureId).not.toBe('');
+  expect(existsSync(fixtureDir)).toBe(false);
+  expect(await LivePcaPublisherFixture.captureMutableState()).toEqual(before);
+  await expectWalletBFixtureOwnedBalanceInvariant(walletBBalancesBefore);
+  expect(await LivePcaPublisherFixture.capturePcaTotalSupply()).toBe(
+    supplyBefore + retainedPcaCount,
+  );
+  if (expectsKnownPcaAccountId) expect(pcaAccountId).toBeGreaterThan(0n);
+}
+
+async function expectCanonicalPcaOwner(accountId: bigint): Promise<void> {
+  const state = await detectDevnet(6);
+  expect(state).not.toBeNull();
+  const hub = new ethers.Contract(
+    state!.addrs.Hub,
+    ['function owner() view returns (address)'],
+    state!.provider,
+  );
+  expect(lower(await state!.nft.ownerOf(accountId))).toBe(lower(await hub.owner()));
+}
+
+async function expectAcceptedBroadcastCleanup(
+  checkpoint: FixtureAcceptedBroadcastCheckpoint,
+  retainedPcaCount: bigint,
+): Promise<void> {
+  const before = await LivePcaPublisherFixture.captureMutableState();
+  const supplyBefore = await LivePcaPublisherFixture.capturePcaTotalSupply();
+  const acceptedError = new Error(`injected accepted ${checkpoint} response loss`);
+  let transactionHash = '';
+  let pcaOwnerAddress = '';
+
+  await expect(createLiveFixture({
+    acceptedBroadcastFault: {
+      checkpoint,
+      error: acceptedError,
+      onAccepted: (context) => {
+        transactionHash = context.transaction.hash;
+        pcaOwnerAddress = context.pcaOwnerAddress;
+      },
+    },
+  })).rejects.toBe(acceptedError);
+
+  expect(transactionHash).toMatch(/^0x[0-9a-fA-F]{64}$/);
+  expect(pcaOwnerAddress).toMatch(/^0x[0-9a-fA-F]{40}$/);
+  const state = await detectDevnet(6);
+  expect(state).not.toBeNull();
+  const receipt = await state!.provider.getTransactionReceipt(transactionHash);
+  expect(receipt?.status).toBe(1);
+  expect(await state!.provider.getBalance(pcaOwnerAddress)).toBe(0n);
+  expect(await LivePcaPublisherFixture.captureMutableState()).toEqual(before);
+  expect(await LivePcaPublisherFixture.capturePcaTotalSupply()).toBe(
+    supplyBefore + retainedPcaCount,
+  );
+
+  if (retainedPcaCount > 0n) {
+    const pcaAddress = lower(await state!.nft.getAddress());
+    const erc721 = new ethers.Interface([
+      'event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)',
+    ]);
+    const accountIds = receipt!.logs.flatMap((log) => {
+      if (lower(log.address) !== pcaAddress) return [];
+      try {
+        const parsed = erc721.parseLog(log);
+        return parsed?.name === 'Transfer'
+          && lower(String(parsed.args.from)) === lower(ethers.ZeroAddress)
+          && lower(String(parsed.args.to)) === lower(pcaOwnerAddress)
+          ? [BigInt(parsed.args.tokenId)]
+          : [];
+      } catch {
+        return [];
+      }
+    });
+    expect(accountIds).toHaveLength(1);
+    await expectCanonicalPcaOwner(accountIds[0]!);
+  }
+}
+
+async function expectDeferredInitializationCleanup(
+  settle: 'drain' | 'retry',
+): Promise<void> {
+  const before = await LivePcaPublisherFixture.captureMutableState();
+  const supplyBefore = await LivePcaPublisherFixture.capturePcaTotalSupply();
+  const initializationError = new Error(`injected ${settle} initialization failure`);
+  const cleanupError = new Error(`injected ${settle} cleanup failure`);
+  let pcaAccountId = 0n;
+  let fixtureDir = '';
+
+  await expect(LivePcaPublisherFixture.create({
+    initializationFault: {
+      checkpoint: 'after-agent-registration',
+      error: initializationError,
+      onReached: (context) => {
+        ({ pcaAccountId, fixtureDir } = context);
+      },
+    },
+    cleanupFault: {
+      checkpoint: 'pca-detachment',
+      error: cleanupError,
+      failures: 1,
+    },
+  })).rejects.toBe(initializationError);
+
+  expect(pcaAccountId).toBeGreaterThan(0n);
+  expect(existsSync(fixtureDir)).toBe(false);
+  const pending = await LivePcaPublisherFixture.captureMutableState();
+  expect(pending.walletBAgentAccountId).toBe(pcaAccountId);
+
+  if (settle === 'retry') {
+    await retryLivePcaPublisherInitializationCleanup(initializationError);
+    await retryLivePcaPublisherInitializationCleanup(initializationError);
+  } else {
+    await drainLivePcaPublisherInitializationCleanups();
+    await drainLivePcaPublisherInitializationCleanups();
+    await retryLivePcaPublisherInitializationCleanup(initializationError);
+  }
+
+  expect(await LivePcaPublisherFixture.captureMutableState()).toEqual(before);
+  expect(await LivePcaPublisherFixture.capturePcaTotalSupply()).toBe(supplyBefore + 1n);
+  await expectCanonicalPcaOwner(pcaAccountId);
+}
+
+function expectPcaWaivedOpenRegistration(
+  fixture: LivePcaPublisherFixture,
+  registration: RegistrationEvidence,
+  observed: WaivedRegistrationEvidence,
+  waivedCountBefore: bigint,
+): void {
+  const { contextGraphId, receipt, created } = registration;
+  expect(receipt.status).toBe(1);
+  expect(lower(receipt.to!)).toBe(lower(fixture.contextGraphsAddress));
+  expect(lower(receipt.from)).toBe(lower(fixture.walletB.address));
+
+  expect(lower(created.args.owner)).toBe(lower(fixture.walletB.address));
+  expect(Number(created.args.accessPolicy)).toBe(0);
+  expect(Number(created.args.publishPolicy)).toBe(1);
+  expect(lower(created.args.publishAuthority)).toBe(lower(ethers.ZeroAddress));
+  expect(BigInt(created.args.publishAuthorityAccountId)).toBe(0n);
+
+  expect(observed.facadeWaivers, 'facade waiver event').toHaveLength(1);
+  expect(observed.storageWaivers, 'storage waiver event').toHaveLength(1);
+  expect(observed.deposits, 'waived registration deposit events').toHaveLength(0);
+  expect(BigInt(observed.facadeWaivers[0]!.args.contextGraphId)).toBe(contextGraphId);
+  expect(BigInt(observed.facadeWaivers[0]!.args.accountId)).toBe(fixture.pcaAccountId);
+  expect(lower(observed.facadeWaivers[0]!.args.creator)).toBe(lower(fixture.walletB.address));
+  expect(BigInt(observed.storageWaivers[0]!.args.accountId)).toBe(fixture.pcaAccountId);
+  expect(lower(observed.storageWaivers[0]!.args.creator)).toBe(lower(fixture.walletB.address));
+  expect(BigInt(observed.storageWaivers[0]!.args.newWaivedCount)).toBe(waivedCountBefore + 1n);
+  expect(observed.registrationDeposit).toBeGreaterThan(0n);
+  expect(BigInt(observed.storageWaivers[0]!.args.quota)).toBe(
+    observed.accountCommitment / observed.registrationDeposit,
+  );
+  expect(observed.waivedCountAfter).toBe(waivedCountBefore + 1n);
+
+  expect(lower(observed.storedOwner)).toBe(lower(fixture.walletB.address));
+  expect(observed.storedPublishPolicy).toBe(1);
+  expect(lower(observed.storedPublishAuthority)).toBe(lower(ethers.ZeroAddress));
+  expect(observed.storedPublishAuthorityAccountId).toBe(0n);
+  expect(observed.registrationEscrow).toBe(0n);
+  expect(observed.walletAAllowance).toBe(fixture.initialWalletAContextGraphsAllowance);
+  expect(observed.walletBAllowance).toBe(0n);
+  expect(
+    observed.tokenTransfers.filter((transfer) => {
+      const from = lower(String(transfer.args.from));
+      return from === lower(fixture.walletA.address) || from === lower(fixture.walletB.address);
+    }),
+    'operational-wallet transfers in the registration receipt',
+  ).toHaveLength(0);
+  expect(observed.walletAApprovals, 'wallet A registration approvals').toHaveLength(0);
+  expect(observed.walletBApprovals, 'wallet B registration approvals').toHaveLength(0);
+}
+
+function fixtureOwnedMutableState(
+  state: Awaited<ReturnType<typeof LivePcaPublisherFixture.captureMutableState>>,
+): Omit<typeof state, 'walletABalance' | 'walletBBalance'> {
+  const { walletABalance: _walletABalance, walletBBalance: _walletBBalance, ...owned } = state;
+  return owned;
+}
+
+describe.sequential('issue #2440 — PCA-covered live CG registration', () => {
+  afterAll(async () => {
+    await drainLivePcaPublisherInitializationCleanups();
+  }, 300_000);
+
+  describe.sequential('targeted fixture lifecycle cleanup', () => {
+    it('restores the dormant registration deposit after post-activation failure', async () => {
+      await expectInitializationCleanup('after-registration-deposit', 0n, false);
+    }, 300_000);
+
+    it('detaches but retains a canonical PCA after a post-creation failure', async () => {
+      await expectInitializationCleanup('after-pca-creation', 1n);
+    }, 300_000);
+
+    it('discovers and detaches a mined PCA when initialization fails before its ID is read', async () => {
+      await expectInitializationCleanup('after-pca-mint-before-read', 1n, false);
+    }, 300_000);
+
+    it('detaches but retains a canonical PCA after a post-agent failure', async () => {
+      await expectInitializationCleanup('after-agent-registration', 1n);
+    }, 300_000);
+
+    it('cleans PCA binding and temporary resources after a post-setup failure', async () => {
+      await expectInitializationCleanup('after-wallet-state', 1n);
+    }, 300_000);
+
+    it('reconciles accepted PCA funding when its broadcast response is lost', async () => {
+      await expectAcceptedBroadcastCleanup('pca-funding', 0n);
+    }, 300_000);
+
+    it('discovers an accepted PCA mint when its broadcast response is lost', async () => {
+      await expectAcceptedBroadcastCleanup('pca-mint', 1n);
+    }, 300_000);
+
+    it('retries a retained initialization cleanup and then becomes a no-op', async () => {
+      await expectDeferredInitializationCleanup('retry');
+    }, 300_000);
+
+    it('drains a retained initialization cleanup and then becomes a no-op', async () => {
+      await expectDeferredInitializationCleanup('drain');
+    }, 300_000);
+
+    it('preserves a canonical operational-wallet effect through successful disposal', async () => {
+      const baseline = await LivePcaPublisherFixture.captureMutableState();
+      const supplyBefore = await LivePcaPublisherFixture.capturePcaTotalSupply();
+      const local = await createLiveFixture();
+      const fixtureDir = local.fixtureDirectory;
+      const fixturePcaAccountId = local.pcaAccountId;
+      let unrelated: Awaited<ReturnType<
+        typeof local.submitUnrelatedOperationalWalletEffect
+      >> | undefined;
+      let disposed = false;
+      try {
+        unrelated = await local.submitUnrelatedOperationalWalletEffect();
+        expect(await local.token.balanceOf(local.walletA.address)).toBe(
+          baseline.walletABalance + unrelated.amount,
+        );
+
+        const walletBBalancesBeforeDispose =
+          await LivePcaPublisherFixture.captureWalletBBalances();
+        const firstDispose = local.dispose();
+        const secondDispose = local.dispose();
+        expect(secondDispose).toBe(firstDispose);
+        await firstDispose;
+        disposed = true;
+
+        expect(existsSync(fixtureDir)).toBe(false);
+        expect(await LivePcaPublisherFixture.capturePcaTotalSupply()).toBe(supplyBefore + 1n);
+        await expectWalletBFixtureOwnedBalanceInvariant(walletBBalancesBeforeDispose);
+        expect(lower(await local.pca.ownerOf(fixturePcaAccountId))).toBe(
+          lower(local.ownerWallet.address),
+        );
+        expect(await local.pca.agentToAccountId(local.walletB.address)).toBe(0n);
+        const current = await LivePcaPublisherFixture.captureMutableState();
+        expect(current).toEqual({
+          ...baseline,
+          walletABalance: baseline.walletABalance + unrelated.amount,
+        });
+
+        const receipt = await local.state.provider.getTransactionReceipt(
+          unrelated.transactionHash,
+        );
+        expect(receipt?.status).toBe(1);
+        expect(receipt?.blockHash).toBe(unrelated.blockHash);
+        const canonicalBlock = await local.state.provider.getBlock(unrelated.blockNumber);
+        expect(canonicalBlock?.hash).toBe(unrelated.blockHash);
+        expect(canonicalBlock?.transactions).toContain(unrelated.transactionHash);
+      } finally {
+        if (!disposed) await local.dispose();
+      }
+    }, 300_000);
+
+    it('creates, disposes, and recreates a distinct canonical fixture locally', async () => {
+      const baseline = await LivePcaPublisherFixture.captureMutableState();
+      const first = await createLiveFixture();
+      const firstFixtureId = first.fixtureId;
+      const firstPcaAccountId = first.pcaAccountId;
+      const walletBBalancesBeforeFirstDispose =
+        await LivePcaPublisherFixture.captureWalletBBalances();
+      await first.dispose();
+      await expectWalletBFixtureOwnedBalanceInvariant(walletBBalancesBeforeFirstDispose);
+
+      const recreated = await createLiveFixture();
+      try {
+        expect(recreated.fixtureId).not.toBe(firstFixtureId);
+        expect(recreated.pcaAccountId).toBeGreaterThan(firstPcaAccountId);
+        const flow = await recreated.createAndShareFlow('recreated');
+        const waivedBefore = await recreated.waivedCount();
+        const fromBlock = await recreated.blockNumber();
+        const published = await recreated.publishSync(flow);
+        expect(['confirmed', 'finalized']).toContain(published.status);
+        const registration = await recreated.findRegistration(flow.contextGraphId, fromBlock);
+        const observed = await recreated.collectWaivedRegistrationEvidence(
+          registration,
+          fromBlock,
+        );
+        expectPcaWaivedOpenRegistration(recreated, registration, observed, waivedBefore);
+        expect(await recreated.waitForVmVisibility(flow)).toBeGreaterThan(0);
+      } finally {
+        const walletBBalancesBeforeRecreatedDispose =
+          await LivePcaPublisherFixture.captureWalletBBalances();
+        await recreated.dispose();
+        await expectWalletBFixtureOwnedBalanceInvariant(
+          walletBBalancesBeforeRecreatedDispose,
+        );
+      }
+      expect(
+        fixtureOwnedMutableState(await LivePcaPublisherFixture.captureMutableState()),
+      ).toEqual(fixtureOwnedMutableState(baseline));
+    }, 600_000);
+  });
+
+  describe.sequential('publisher registration behavior', () => {
+    let fixture: LivePcaPublisherFixture;
+    let baseline: Awaited<ReturnType<typeof LivePcaPublisherFixture.captureMutableState>>;
+    let finalizedBroadcast: {
+      jobId: string;
+      transactionHash: string;
+      blockHash: string;
+      blockNumber: number;
+    } | undefined;
+
+    beforeAll(async () => {
+      baseline = await LivePcaPublisherFixture.captureMutableState();
+      fixture = await createLiveFixture();
+    }, 300_000);
+
+    afterAll(async () => {
+      if (!fixture) return;
+      const fixtureDir = fixture.fixtureDirectory;
+      const walletBBalancesBeforeDispose =
+        await LivePcaPublisherFixture.captureWalletBBalances();
+      await fixture.dispose();
+
+      expect(existsSync(fixtureDir)).toBe(false);
+      await expectWalletBFixtureOwnedBalanceInvariant(walletBBalancesBeforeDispose);
+      expect(
+        fixtureOwnedMutableState(await LivePcaPublisherFixture.captureMutableState()),
+      ).toEqual(fixtureOwnedMutableState(baseline));
+      if (finalizedBroadcast) {
+        const retainedJob = await fixture.readFinalizedPublisherJob(finalizedBroadcast.jobId);
+        expect(retainedJob.broadcast.txHash).toBe(finalizedBroadcast.transactionHash);
+
+        const retainedReceipt = await fixture.state.provider.getTransactionReceipt(
+          finalizedBroadcast.transactionHash,
+        );
+        expect(retainedReceipt?.status).toBe(1);
+        expect(retainedReceipt?.blockHash).toBe(finalizedBroadcast.blockHash);
+        expect(retainedReceipt?.blockNumber).toBe(finalizedBroadcast.blockNumber);
+
+        const retainedBlock = await fixture.state.provider.getBlock(finalizedBroadcast.blockNumber);
+        expect(retainedBlock?.hash).toBe(finalizedBroadcast.blockHash);
+        expect(retainedBlock?.transactions).toContain(finalizedBroadcast.transactionHash);
+      }
+    }, 300_000);
+
+    it('sync VM first-publish auto-registers an open graph with exact PCA-covered wallet B', async () => {
+      const flow = await fixture.createAndShareFlow('sync');
+      const waivedBefore = await fixture.waivedCount();
+      const fromBlock = await fixture.blockNumber();
+
+      const published = await fixture.publishSync(flow);
+      expect(['confirmed', 'finalized']).toContain(published.status);
+
+      const registration = await fixture.findRegistration(flow.contextGraphId, fromBlock);
+      const observed = await fixture.collectWaivedRegistrationEvidence(registration, fromBlock);
+      expectPcaWaivedOpenRegistration(fixture, registration, observed, waivedBefore);
+      expect(await fixture.waitForVmVisibility(flow)).toBeGreaterThan(0);
+    }, 600_000);
+
+    it('async VM first-publish retains selected wallet B through registration and broadcast', async () => {
+      const flow = await fixture.createAndShareFlow('async');
+      const waivedBefore = await fixture.waivedCount();
+      const fromBlock = await fixture.blockNumber();
+
+      const published = await fixture.publishAsync(flow);
+      expect(published.acceptedStatus).toBe('accepted');
+      expect(published.jobId).not.toBe('');
+      expect(published.job.request.jobType).toBe('knowledge-asset-vm-publish');
+      expect(published.job.request.knowledgeAssetVmPublish.contextGraphId).toBe(
+        flow.contextGraphId,
+      );
+      expect(published.job.request.knowledgeAssetVmPublish.name).toBe(flow.name);
+      expect(lower(published.job.claim.walletId)).toBe(lower(fixture.walletB.address));
+      expect(lower(published.job.broadcast.walletId)).toBe(
+        lower(fixture.walletB.address),
+      );
+      expect(published.job.broadcast.txHash).toMatch(/^0x[0-9a-fA-F]{64}$/);
+
+      const registration = await fixture.findRegistration(flow.contextGraphId, fromBlock);
+      const observed = await fixture.collectWaivedRegistrationEvidence(registration, fromBlock);
+      expectPcaWaivedOpenRegistration(fixture, registration, observed, waivedBefore);
+      expect(lower(published.job.broadcast.walletId)).toBe(lower(registration.receipt.from));
+
+      const broadcastReceipt = await fixture.findAsyncBroadcastReceipt(published.job);
+      expect(broadcastReceipt.status).toBe(1);
+      expect(lower(broadcastReceipt.from)).toBe(lower(fixture.walletB.address));
+      expect(lower(broadcastReceipt.to!)).toBe(
+        lower(fixture.knowledgeAssetsLifecycleAddress),
+      );
+      finalizedBroadcast = {
+        jobId: published.jobId,
+        transactionHash: published.job.broadcast.txHash,
+        blockHash: broadcastReceipt.blockHash,
+        blockNumber: broadcastReceipt.blockNumber,
+      };
+      expect(await fixture.waitForVmVisibility(flow)).toBeGreaterThan(0);
+    }, 600_000);
+
+  });
+});

--- a/devnet/pr2440-pca-cg-registration/cleanup-stack.test.ts
+++ b/devnet/pr2440-pca-cg-registration/cleanup-stack.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { CleanupStack } from './live-pca-publisher-lifecycle.js';
+
+describe('CleanupStack', () => {
+  it('shares an in-flight attempt, retains failures, and skips completed actions on retry', async () => {
+    const cleanup = new CleanupStack();
+    let completedRuns = 0;
+    let flakyRuns = 0;
+    let releaseFlaky!: () => void;
+    const flakyGate = new Promise<void>((resolve) => {
+      releaseFlaky = resolve;
+    });
+
+    cleanup.defer('completed action', () => {
+      completedRuns += 1;
+    });
+    cleanup.defer('flaky action', async () => {
+      flakyRuns += 1;
+      if (flakyRuns === 1) {
+        await flakyGate;
+        throw new Error('injected cleanup failure');
+      }
+    });
+
+    const firstAttempt = cleanup.dispose();
+    const concurrentAttempt = cleanup.dispose();
+    expect(concurrentAttempt).toBe(firstAttempt);
+    releaseFlaky();
+    await expect(firstAttempt).rejects.toThrow('flaky action: injected cleanup failure');
+    expect(flakyRuns).toBe(1);
+    expect(completedRuns).toBe(1);
+
+    const retryAttempt = cleanup.dispose();
+    expect(retryAttempt).not.toBe(firstAttempt);
+    await retryAttempt;
+    expect(flakyRuns).toBe(2);
+    expect(completedRuns).toBe(1);
+    const completedAttempt = cleanup.dispose();
+    expect(completedAttempt).not.toBe(retryAttempt);
+    await completedAttempt;
+    expect(flakyRuns).toBe(2);
+    expect(completedRuns).toBe(1);
+  });
+});

--- a/devnet/pr2440-pca-cg-registration/known-transaction.test.ts
+++ b/devnet/pr2440-pca-cg-registration/known-transaction.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  reconcileKnownTransaction,
+  shouldInjectAcceptedBroadcastFault,
+  type KnownTransaction,
+} from './live-pca-publisher-lifecycle.js';
+
+type Provider = Parameters<typeof reconcileKnownTransaction>[0];
+
+const transaction: KnownTransaction = {
+  from: '0x0000000000000000000000000000000000000001',
+  hash: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  nonce: 7,
+  signedTransaction: '0xdeadbeef',
+};
+
+function provider(overrides: Partial<Record<keyof Provider, unknown>> = {}): Provider {
+  return {
+    broadcastTransaction: vi.fn(),
+    getTransaction: vi.fn().mockResolvedValue(null),
+    getTransactionCount: vi.fn().mockResolvedValue(7),
+    getTransactionReceipt: vi.fn().mockResolvedValue(null),
+    waitForTransaction: vi.fn().mockResolvedValue({ status: 1 }),
+    ...overrides,
+  } as unknown as Provider;
+}
+
+describe('known transaction reconciliation', () => {
+  it('never injects an accepted-broadcast fault when the hook or checkpoint is absent', () => {
+    const fault = {
+      checkpoint: 'pca-mint' as const,
+      error: new Error('injected'),
+    };
+
+    expect(shouldInjectAcceptedBroadcastFault(undefined, undefined)).toBe(false);
+    expect(shouldInjectAcceptedBroadcastFault(fault, undefined)).toBe(false);
+    expect(shouldInjectAcceptedBroadcastFault(undefined, 'pca-mint')).toBe(false);
+    expect(shouldInjectAcceptedBroadcastFault(fault, 'pca-funding')).toBe(false);
+    expect(shouldInjectAcceptedBroadcastFault(fault, 'pca-mint')).toBe(true);
+  });
+
+  it('accepts an already-mined successful receipt without rebroadcasting', async () => {
+    const rpc = provider({
+      getTransactionReceipt: vi.fn().mockResolvedValue({ status: 1 }),
+    });
+
+    await expect(reconcileKnownTransaction(rpc, transaction)).resolves.toBe('succeeded');
+    expect(rpc.broadcastTransaction).not.toHaveBeenCalled();
+  });
+
+  it('rebroadcasts the exact signed payload while its nonce remains available', async () => {
+    const rpc = provider({
+      broadcastTransaction: vi.fn().mockResolvedValue({ hash: transaction.hash }),
+    });
+
+    await expect(reconcileKnownTransaction(rpc, transaction)).resolves.toBe('succeeded');
+    expect(rpc.broadcastTransaction).toHaveBeenCalledWith(transaction.signedTransaction);
+    expect(rpc.waitForTransaction).toHaveBeenCalledWith(transaction.hash, 1, 30_000);
+  });
+
+  it('reports replacement instead of rebroadcasting after the nonce is consumed', async () => {
+    const rpc = provider({
+      getTransactionCount: vi.fn().mockResolvedValue(8),
+    });
+
+    await expect(reconcileKnownTransaction(rpc, transaction)).resolves.toBe('replaced');
+    expect(rpc.broadcastTransaction).not.toHaveBeenCalled();
+  });
+
+  it('never replaces an unrelated pending transaction at the recorded nonce', async () => {
+    const getTransactionCount = vi.fn()
+      .mockResolvedValueOnce(7)
+      .mockResolvedValueOnce(8);
+    const rpc = provider({ getTransactionCount });
+
+    await expect(reconcileKnownTransaction(rpc, transaction)).rejects.toThrow(
+      'occupied by an unrelated pending transaction',
+    );
+    expect(rpc.broadcastTransaction).not.toHaveBeenCalled();
+    expect(getTransactionCount).toHaveBeenNthCalledWith(1, transaction.from, 'latest');
+    expect(getTransactionCount).toHaveBeenNthCalledWith(2, transaction.from, 'pending');
+  });
+
+  it('recovers an accepted transaction when the broadcast response is lost', async () => {
+    const getTransactionReceipt = vi.fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ status: 1 });
+    const rpc = provider({
+      broadcastTransaction: vi.fn().mockRejectedValue(new Error('connection reset')),
+      getTransactionReceipt,
+    });
+
+    await expect(reconcileKnownTransaction(rpc, transaction)).resolves.toBe('succeeded');
+    expect(getTransactionReceipt).toHaveBeenCalledTimes(2);
+  });
+
+  it('waits for a known pending transaction and reports a revert', async () => {
+    const rpc = provider({
+      getTransaction: vi.fn().mockResolvedValue({ hash: transaction.hash }),
+      waitForTransaction: vi.fn().mockResolvedValue({ status: 0 }),
+    });
+
+    await expect(reconcileKnownTransaction(rpc, transaction)).resolves.toBe('reverted');
+    expect(rpc.broadcastTransaction).not.toHaveBeenCalled();
+  });
+
+  it('reports a replacement when a failed broadcast races a consumed nonce', async () => {
+    const getTransactionCount = vi.fn()
+      .mockResolvedValueOnce(7)
+      .mockResolvedValueOnce(7)
+      .mockResolvedValueOnce(8);
+    const rpc = provider({
+      broadcastTransaction: vi.fn().mockRejectedValue(new Error('nonce too low')),
+      getTransactionCount,
+    });
+
+    await expect(reconcileKnownTransaction(rpc, transaction)).resolves.toBe('replaced');
+  });
+});

--- a/devnet/pr2440-pca-cg-registration/live-pca-publisher-fixture.ts
+++ b/devnet/pr2440-pca-cg-registration/live-pca-publisher-fixture.ts
@@ -1,0 +1,551 @@
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ethers } from 'ethers';
+import {
+  lexical,
+  nextNonce,
+  parseLastJsonBlock,
+  queryNode,
+  runDkgCli,
+  waitFor,
+  type CliResult,
+  type DevnetNode,
+  type DevnetState,
+} from '../_bootstrap/harness.js';
+import {
+  CONTEXT_GRAPHS_ABI,
+  CONTEXT_GRAPH_STORAGE_ABI,
+  PREDICATE,
+  TOKEN_ABI,
+  WAIVER_ABI,
+} from './pca-registration-contracts.js';
+import {
+  drainLivePcaPublisherInitializationCleanups,
+  LivePcaPublisherLifecycle,
+  retryLivePcaPublisherInitializationCleanup,
+  type FixtureAcceptedBroadcastCheckpoint,
+  type FixtureCleanupCheckpoint,
+  type FixtureInitializationCheckpoint,
+  type LivePcaPublisherFixtureCreateOptions,
+  type LivePcaPublisherMutableState,
+  type LivePcaPublisherResources,
+  type LivePcaPublisherWalletBalances,
+} from './live-pca-publisher-lifecycle.js';
+
+export {
+  drainLivePcaPublisherInitializationCleanups,
+  retryLivePcaPublisherInitializationCleanup,
+};
+export type {
+  FixtureAcceptedBroadcastCheckpoint,
+  FixtureCleanupCheckpoint,
+  FixtureInitializationCheckpoint,
+  LivePcaPublisherFixtureCreateOptions,
+  LivePcaPublisherMutableState,
+  LivePcaPublisherWalletBalances,
+};
+
+interface RawPublisherJob extends Record<string, unknown> {
+  status?: string;
+  claim?: { walletId?: string };
+  broadcast?: { walletId?: string; txHash?: string };
+  request?: {
+    jobType?: string;
+    knowledgeAssetVmPublish?: { contextGraphId?: string; name?: string };
+  };
+  failure?: unknown;
+}
+
+export interface FinalizedPublisherJob extends Record<string, unknown> {
+  status: 'finalized';
+  claim: { walletId: string };
+  broadcast: { walletId: string; txHash: string };
+  request: {
+    jobType: string;
+    knowledgeAssetVmPublish: { contextGraphId: string; name: string };
+  };
+}
+
+export interface FlowFixture {
+  contextGraphId: string;
+  name: string;
+  subject: string;
+  value: string;
+}
+
+export interface RegistrationEvidence {
+  contextGraphId: bigint;
+  receipt: ethers.TransactionReceipt;
+  created: ethers.LogDescription;
+}
+
+export interface WaivedRegistrationEvidence {
+  facadeWaivers: ethers.LogDescription[];
+  storageWaivers: ethers.LogDescription[];
+  deposits: ethers.LogDescription[];
+  accountCommitment: bigint;
+  registrationDeposit: bigint;
+  waivedCountAfter: bigint;
+  storedOwner: string;
+  storedPublishPolicy: number;
+  storedPublishAuthority: string;
+  storedPublishAuthorityAccountId: bigint;
+  registrationEscrow: bigint;
+  walletAAllowance: bigint;
+  walletBAllowance: bigint;
+  tokenTransfers: ethers.LogDescription[];
+  walletAApprovals: ethers.Log[];
+  walletBApprovals: ethers.Log[];
+}
+
+export interface AsyncPublishEvidence {
+  acceptedStatus: string;
+  jobId: string;
+  job: FinalizedPublisherJob;
+}
+
+export interface SyncPublishEvidence {
+  status: string;
+}
+
+export interface CanonicalTransactionEvidence {
+  transactionHash: string;
+  blockHash: string;
+  blockNumber: number;
+}
+
+export interface CanonicalOperationalWalletEffect extends CanonicalTransactionEvidence {
+  amount: bigint;
+  sourceAddress: string;
+  targetAddress: string;
+}
+
+const tokenIface = new ethers.Interface(TOKEN_ABI);
+const contextGraphsIface = new ethers.Interface(CONTEXT_GRAPHS_ABI);
+const contextGraphStorageIface = new ethers.Interface(CONTEXT_GRAPH_STORAGE_ABI);
+const waiverIface = new ethers.Interface(WAIVER_ABI);
+const lower = (value: string): string => value.toLowerCase();
+const unique = (prefix: string): string =>
+  `${prefix}-${Date.now().toString(36)}-${Math.floor(Math.random() * 1e9).toString(36)}`;
+
+function invariant(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function finalizedPublisherJob(raw: RawPublisherJob, jobId: string): FinalizedPublisherJob {
+  invariant(raw.status === 'finalized', `publisher job ${jobId} is not finalized`);
+  const claimWalletId = raw.claim?.walletId;
+  const broadcastWalletId = raw.broadcast?.walletId;
+  const txHash = raw.broadcast?.txHash;
+  const jobType = raw.request?.jobType;
+  const contextGraphId = raw.request?.knowledgeAssetVmPublish?.contextGraphId;
+  const name = raw.request?.knowledgeAssetVmPublish?.name;
+  invariant(typeof claimWalletId === 'string' && claimWalletId.length > 0,
+    `publisher job ${jobId} is missing claim wallet evidence`);
+  invariant(typeof broadcastWalletId === 'string' && broadcastWalletId.length > 0,
+    `publisher job ${jobId} is missing broadcast wallet evidence`);
+  invariant(typeof txHash === 'string' && /^0x[0-9a-fA-F]{64}$/.test(txHash),
+    `publisher job ${jobId} is missing a valid broadcast transaction hash`);
+  invariant(typeof jobType === 'string' && jobType.length > 0,
+    `publisher job ${jobId} is missing its request type`);
+  invariant(typeof contextGraphId === 'string' && contextGraphId.length > 0,
+    `publisher job ${jobId} is missing its context graph id`);
+  invariant(typeof name === 'string' && name.length > 0,
+    `publisher job ${jobId} is missing its knowledge asset name`);
+  return {
+    ...raw,
+    status: 'finalized',
+    claim: { walletId: claimWalletId },
+    broadcast: { walletId: broadcastWalletId, txHash },
+    request: {
+      jobType,
+      knowledgeAssetVmPublish: { contextGraphId, name },
+    },
+  };
+}
+
+function requireCliOk(result: CliResult, label: string): void {
+  invariant(
+    result.code === 0,
+    `${label} failed with exit ${result.code}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+}
+
+function parseContextGraphId(stdout: string): string {
+  const id = /^\s*ID:\s+(.+)$/m.exec(stdout)?.[1]?.trim();
+  if (!id) throw new Error(`could not parse context graph ID from:\n${stdout}`);
+  return id;
+}
+
+const addressTopic = (address: string): string => ethers.zeroPadValue(ethers.getAddress(address), 32);
+
+/**
+ * Exposes primitive #2440 scenario operations and typed evidence. Mutable
+ * resource ownership and targeted cleanup are delegated to LivePcaPublisherLifecycle.
+ */
+export class LivePcaPublisherFixture {
+  readonly state: DevnetState;
+  readonly node: DevnetNode;
+  readonly walletA: ethers.Wallet;
+  readonly walletB: ethers.Wallet;
+  readonly ownerWallet: ethers.Wallet;
+  readonly token: ethers.Contract;
+  readonly pca: ethers.Contract;
+  readonly parameters: ethers.Contract;
+  readonly contextGraphStorage: ethers.Contract;
+  readonly waiver: ethers.Contract;
+  readonly contextGraphsAddress: string;
+  readonly contextGraphStorageAddress: string;
+  readonly waiverAddress: string;
+  readonly knowledgeAssetsLifecycleAddress: string;
+  private readonly lifecycle: LivePcaPublisherLifecycle;
+
+  private constructor(lifecycle: LivePcaPublisherLifecycle) {
+    this.lifecycle = lifecycle;
+    const resources: LivePcaPublisherResources = lifecycle.resources;
+    this.state = resources.state;
+    this.node = resources.node;
+    this.walletA = resources.walletA;
+    this.walletB = resources.walletB;
+    this.ownerWallet = resources.ownerWallet;
+    this.token = resources.token;
+    this.pca = resources.pca;
+    this.parameters = resources.parameters;
+    this.contextGraphStorage = resources.contextGraphStorage;
+    this.waiver = resources.waiver;
+    this.contextGraphsAddress = resources.contextGraphsAddress;
+    this.contextGraphStorageAddress = resources.contextGraphStorageAddress;
+    this.waiverAddress = resources.waiverAddress;
+    this.knowledgeAssetsLifecycleAddress = resources.knowledgeAssetsLifecycleAddress;
+  }
+
+  static async captureMutableState(): Promise<LivePcaPublisherMutableState> {
+    return LivePcaPublisherLifecycle.captureMutableState();
+  }
+
+  static async capturePcaTotalSupply(): Promise<bigint> {
+    return LivePcaPublisherLifecycle.capturePcaTotalSupply();
+  }
+
+  static async captureWalletBBalances(): Promise<LivePcaPublisherWalletBalances> {
+    return LivePcaPublisherLifecycle.captureWalletBBalances();
+  }
+
+  static async create(
+    options: LivePcaPublisherFixtureCreateOptions = {},
+  ): Promise<LivePcaPublisherFixture> {
+    return new LivePcaPublisherFixture(await LivePcaPublisherLifecycle.create(options));
+  }
+
+  get pcaAccountId(): bigint {
+    return this.lifecycle.pcaAccountId;
+  }
+
+  get fixtureId(): string {
+    return this.lifecycle.fixtureId;
+  }
+
+  get fixtureDirectory(): string {
+    return this.lifecycle.fixtureDirectory;
+  }
+
+  get initialWalletABalance(): bigint {
+    return this.lifecycle.initialWalletABalance;
+  }
+
+  get initialWalletAContextGraphsAllowance(): bigint {
+    return this.lifecycle.initialWalletAContextGraphsAllowance;
+  }
+
+  get initialWalletBTracBalance(): bigint {
+    return this.lifecycle.initialWalletBTracBalance;
+  }
+
+  dispose(): Promise<void> {
+    return this.lifecycle.dispose();
+  }
+
+  async waivedCount(): Promise<bigint> {
+    return BigInt(await this.waiver.waivedCgCount(this.pcaAccountId));
+  }
+
+  async blockNumber(): Promise<number> {
+    return this.state.provider.getBlockNumber();
+  }
+
+  async createAndShareFlow(label: string): Promise<FlowFixture> {
+    const scopedLabel = `${this.fixtureId}-${label}`;
+    const slug = unique(`pr2440-${scopedLabel}`);
+    const created = await runDkgCli(this.node, [
+      'context-graph',
+      'create',
+      slug,
+      '--name',
+      `PR 2440 ${scopedLabel}`,
+      '--description',
+      `Issue 2440 ${scopedLabel} PCA registration coverage`,
+      '--access-policy',
+      '0',
+    ], 120_000);
+    requireCliOk(created, `${label} context-graph create`);
+    const contextGraphId = parseContextGraphId(created.stdout);
+
+    const name = unique(`pr2440-${scopedLabel}-ka`);
+    const subject = `urn:test:pr2440:${scopedLabel}:${Date.now()}:${Math.floor(Math.random() * 1e9)}`;
+    const value = `issue 2440 ${scopedLabel} ${Date.now()}`;
+    const filePath = join(this.fixtureDirectory, `${name}.nt`);
+    writeFileSync(filePath, `<${subject}> <${PREDICATE}> ${JSON.stringify(value)} .\n`, 'utf8');
+
+    const shared = await runDkgCli(this.node, [
+      'ka',
+      'create',
+      name,
+      '--context-graph-id',
+      contextGraphId,
+      '--input-file',
+      filePath,
+      '--share',
+    ], 180_000);
+    requireCliOk(shared, `${label} ka create --share`);
+    return { contextGraphId, name, subject, value };
+  }
+
+  async publishSync(flow: FlowFixture): Promise<SyncPublishEvidence> {
+    const published = await runDkgCli(this.node, [
+      'ka',
+      'publish',
+      flow.name,
+      '--context-graph-id',
+      flow.contextGraphId,
+      '--json',
+    ], 300_000);
+    requireCliOk(published, 'sync ka publish');
+    const result = parseLastJsonBlock<Record<string, unknown>>(published.stdout, 'sync ka publish');
+    return { status: String(result.status).toLowerCase() };
+  }
+
+  async publishAsync(flow: FlowFixture): Promise<AsyncPublishEvidence> {
+    const enqueued = await runDkgCli(this.node, [
+      'ka',
+      'publish-async',
+      flow.name,
+      '--context-graph-id',
+      flow.contextGraphId,
+      '--json',
+    ], 60_000);
+    requireCliOk(enqueued, 'async ka publish enqueue');
+    const accepted = parseLastJsonBlock<Record<string, unknown>>(
+      enqueued.stdout,
+      'async ka publish enqueue',
+    );
+    const jobId = String(accepted.jobId ?? '');
+    invariant(jobId.length > 0, 'async publish did not return a job id');
+    return {
+      acceptedStatus: String(accepted.status),
+      jobId,
+      job: await this.waitForPublisherJob(jobId),
+    };
+  }
+
+  async findRegistration(
+    localContextGraphId: string,
+    fromBlock: number,
+  ): Promise<RegistrationEvidence> {
+    const nameHash = ethers.keccak256(ethers.toUtf8Bytes(localContextGraphId));
+    const event = contextGraphStorageIface.getEvent('ContextGraphCreated');
+    if (!event) throw new Error('ContextGraphCreated ABI missing');
+    const logs = await this.state.provider.getLogs({
+      address: this.contextGraphStorageAddress,
+      fromBlock: fromBlock + 1,
+      toBlock: 'latest',
+      topics: [event.topicHash, null, null, nameHash],
+    });
+    invariant(logs.length === 1, `expected one ContextGraphCreated for ${localContextGraphId}`);
+    const created = contextGraphStorageIface.parseLog(logs[0]!);
+    invariant(created?.name === 'ContextGraphCreated', 'failed to parse ContextGraphCreated');
+    const receipt = await this.state.provider.getTransactionReceipt(logs[0]!.transactionHash);
+    invariant(receipt, 'registration transaction receipt must exist');
+    return {
+      contextGraphId: BigInt(created.args.contextGraphId),
+      receipt,
+      created,
+    };
+  }
+
+  async collectWaivedRegistrationEvidence(
+    evidence: RegistrationEvidence,
+    fromBlock: number,
+  ): Promise<WaivedRegistrationEvidence> {
+    const { contextGraphId, receipt } = evidence;
+    const facadeWaivers = this.parseExactEvents(
+      receipt,
+      this.contextGraphsAddress,
+      contextGraphsIface,
+      'ContextGraphRegistrationDepositWaived',
+    );
+    const storageWaivers = this.parseExactEvents(
+      receipt,
+      this.waiverAddress,
+      waiverIface,
+      'RegistrationDepositWaived',
+    );
+    const deposits = this.parseExactEvents(
+      receipt,
+      this.contextGraphsAddress,
+      contextGraphsIface,
+      'ContextGraphRegistrationDeposited',
+    );
+    const account = await this.pca.accounts(this.pcaAccountId);
+    const policy = await this.contextGraphStorage.getPublishPolicy(contextGraphId);
+    return {
+      facadeWaivers,
+      storageWaivers,
+      deposits,
+      accountCommitment: BigInt(account.committedTRAC ?? account[0]),
+      registrationDeposit: BigInt(
+        await this.parameters.contextGraphRegistrationDeposit(),
+      ),
+      waivedCountAfter: BigInt(await this.waiver.waivedCgCount(this.pcaAccountId)),
+      storedOwner: String(await this.contextGraphStorage.getContextGraphOwner(contextGraphId)),
+      storedPublishPolicy: Number(policy.publishPolicy ?? policy[0]),
+      storedPublishAuthority: String(policy.publishAuthority ?? policy[1]),
+      storedPublishAuthorityAccountId: BigInt(
+        await this.contextGraphStorage.getPublishAuthorityAccountId(contextGraphId),
+      ),
+      registrationEscrow: BigInt(
+        await this.contextGraphStorage.getRegistrationEscrow(contextGraphId),
+      ),
+      walletAAllowance: BigInt(
+        await this.token.allowance(this.walletA.address, this.contextGraphsAddress),
+      ),
+      walletBAllowance: BigInt(
+        await this.token.allowance(this.walletB.address, this.contextGraphsAddress),
+      ),
+      tokenTransfers: this.parseExactEvents(
+        receipt,
+        await this.token.getAddress(),
+        tokenIface,
+        'Transfer',
+      ),
+      walletAApprovals: await this.findRegistrationApprovals(
+        this.walletA.address,
+        fromBlock,
+        receipt.blockNumber,
+      ),
+      walletBApprovals: await this.findRegistrationApprovals(
+        this.walletB.address,
+        fromBlock,
+        receipt.blockNumber,
+      ),
+    };
+  }
+
+  async waitForVmVisibility(flow: FlowFixture): Promise<number> {
+    const rows = await waitFor(
+      `${flow.subject} visible in VM for ${flow.contextGraphId}`,
+      180_000,
+      5_000,
+      async () => {
+        const bindings = await queryNode(
+          this.node,
+          `SELECT ?o WHERE { GRAPH ?g { <${flow.subject}> <${PREDICATE}> ?o } }`,
+          { contextGraphId: flow.contextGraphId, view: 'verifiable-memory' },
+        );
+        return bindings.some((row) => lexical(row.o) === flow.value) ? bindings : null;
+      },
+    );
+    return rows.length;
+  }
+
+  async findAsyncBroadcastReceipt(
+    job: FinalizedPublisherJob,
+  ): Promise<ethers.TransactionReceipt> {
+    const receipt = await this.state.provider.getTransactionReceipt(job.broadcast.txHash);
+    invariant(receipt, 'finalized async broadcast transaction receipt must exist');
+    return receipt;
+  }
+
+  async readFinalizedPublisherJob(jobId: string): Promise<FinalizedPublisherJob> {
+    const current = await this.readPublisherJob(jobId);
+    if (current.status === 'failed') {
+      throw new Error(`publisher job ${jobId} failed: ${JSON.stringify(current.failure ?? current)}`);
+    }
+    if (current.status !== 'finalized') {
+      throw new Error(`publisher job ${jobId} is ${String(current.status)}, expected finalized`);
+    }
+    return finalizedPublisherJob(current, jobId);
+  }
+
+  async submitUnrelatedOperationalWalletEffect(
+    amount = 1n,
+  ): Promise<CanonicalOperationalWalletEffect> {
+    const receipt = await (await (this.token.connect(this.ownerWallet) as ethers.Contract).transfer(
+      this.walletA.address,
+      amount,
+      { nonce: await nextNonce(this.state.provider, this.ownerWallet.address) },
+    )).wait();
+    invariant(receipt, 'unrelated operational-wallet transaction receipt must exist');
+    return {
+      amount,
+      sourceAddress: this.ownerWallet.address,
+      targetAddress: this.walletA.address,
+      transactionHash: receipt.hash,
+      blockHash: receipt.blockHash,
+      blockNumber: receipt.blockNumber,
+    };
+  }
+
+  private parseExactEvents(
+    receipt: ethers.TransactionReceipt,
+    emitter: string,
+    iface: ethers.Interface,
+    eventName: string,
+  ): ethers.LogDescription[] {
+    return receipt.logs.flatMap((log) => {
+      if (lower(log.address) !== lower(emitter)) return [];
+      try {
+        const parsed = iface.parseLog(log);
+        return parsed?.name === eventName ? [parsed] : [];
+      } catch {
+        return [];
+      }
+    });
+  }
+
+  private async findRegistrationApprovals(
+    owner: string,
+    fromBlock: number,
+    toBlock: number,
+  ): Promise<ethers.Log[]> {
+    const approval = tokenIface.getEvent('Approval');
+    if (!approval) throw new Error('Approval ABI missing');
+    return this.state.provider.getLogs({
+      address: await this.token.getAddress(),
+      fromBlock: fromBlock + 1,
+      toBlock,
+      topics: [approval.topicHash, addressTopic(owner), addressTopic(this.contextGraphsAddress)],
+    });
+  }
+
+  private async waitForPublisherJob(jobId: string): Promise<FinalizedPublisherJob> {
+    const job = await waitFor(
+      `publisher job ${jobId} finalized`,
+      300_000,
+      5_000,
+      async () => {
+        const current = await this.readPublisherJob(jobId);
+        if (current.status === 'failed') {
+          throw new Error(`publisher job ${jobId} failed: ${JSON.stringify(current.failure ?? current)}`);
+        }
+        return current.status === 'finalized' ? finalizedPublisherJob(current, jobId) : null;
+      },
+    );
+    return job;
+  }
+
+  private async readPublisherJob(jobId: string): Promise<RawPublisherJob> {
+    const detail = await runDkgCli(this.node, ['publisher', 'job', jobId, '--payload'], 60_000);
+    requireCliOk(detail, `publisher job ${jobId}`);
+    return parseLastJsonBlock<RawPublisherJob>(detail.stdout, `publisher job ${jobId}`);
+  }
+}

--- a/devnet/pr2440-pca-cg-registration/live-pca-publisher-lifecycle.ts
+++ b/devnet/pr2440-pca-cg-registration/live-pca-publisher-lifecycle.ts
@@ -1,0 +1,1121 @@
+import { randomUUID } from 'node:crypto';
+import {
+  mkdtempSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ethers } from 'ethers';
+import {
+  detectDevnet,
+  ensureAllIdentities,
+  fetchStatus,
+  type DevnetNode,
+  type DevnetState,
+} from '../_bootstrap/harness.js';
+import { validateSharedSweepTopology } from '../../scripts/devnet-shared-sweep-preflight.mjs';
+import {
+  CONTEXT_GRAPHS_ABI,
+  CONTEXT_GRAPH_STORAGE_ABI,
+  PARAMETERS_ABI,
+  PCA_ABI,
+  TOKEN_ABI,
+  WAIVER_ABI,
+} from './pca-registration-contracts.js';
+
+const HUB_OWNER_PK =
+  '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const COMMITMENT_BASELINE = ethers.parseEther('500000');
+const REGISTRATION_DEPOSIT = ethers.parseEther('100');
+const lower = (value: string): string => value.toLowerCase();
+
+async function nextPendingNonce(
+  provider: ethers.JsonRpcProvider,
+  address: string,
+): Promise<number> {
+  const quantity = await provider.send('eth_getTransactionCount', [address, 'pending']);
+  return Number(BigInt(quantity));
+}
+
+export interface LivePcaPublisherResources {
+  state: DevnetState;
+  node: DevnetNode;
+  walletA: ethers.Wallet;
+  walletB: ethers.Wallet;
+  ownerWallet: ethers.Wallet;
+  token: ethers.Contract;
+  pca: ethers.Contract;
+  parameters: ethers.Contract;
+  contextGraphStorage: ethers.Contract;
+  waiver: ethers.Contract;
+  contextGraphsAddress: string;
+  contextGraphStorageAddress: string;
+  waiverAddress: string;
+  knowledgeAssetsLifecycleAddress: string;
+}
+
+export type FixtureInitializationCheckpoint =
+  | 'after-registration-deposit'
+  | 'after-pca-mint-before-read'
+  | 'after-pca-creation'
+  | 'after-agent-registration'
+  | 'after-wallet-state';
+
+export type FixtureAcceptedBroadcastCheckpoint =
+  | 'pca-funding'
+  | 'pca-mint';
+
+export type FixtureCleanupCheckpoint = 'pca-detachment';
+
+export interface LivePcaPublisherFixtureCreateOptions {
+  initializationFault?: {
+    checkpoint: FixtureInitializationCheckpoint;
+    error: Error;
+    onReached?: (context: {
+      fixtureDir: string;
+      fixtureId: string;
+      pcaAccountId: bigint;
+    }) => void;
+  };
+  acceptedBroadcastFault?: {
+    checkpoint: FixtureAcceptedBroadcastCheckpoint;
+    error: Error;
+    onAccepted?: (context: {
+      transaction: KnownTransaction;
+      pcaOwnerAddress: string;
+    }) => void;
+  };
+  cleanupFault?: {
+    checkpoint: FixtureCleanupCheckpoint;
+    error: Error;
+    failures?: number;
+  };
+}
+
+type AcceptedBroadcastFault = NonNullable<
+  LivePcaPublisherFixtureCreateOptions['acceptedBroadcastFault']
+>;
+
+export function shouldInjectAcceptedBroadcastFault(
+  fault: AcceptedBroadcastFault | undefined,
+  checkpoint: FixtureAcceptedBroadcastCheckpoint | undefined,
+): fault is AcceptedBroadcastFault {
+  return fault !== undefined
+    && checkpoint !== undefined
+    && fault.checkpoint === checkpoint;
+}
+
+export interface LivePcaPublisherMutableState {
+  registrationDeposit: bigint;
+  walletABalance: bigint;
+  walletAContextGraphsAllowance: bigint;
+  walletBBalance: bigint;
+  walletBContextGraphsAllowance: bigint;
+  walletBPcaAllowance: bigint;
+  walletAPcaBalance: bigint;
+  walletAAgentAccountId: bigint;
+  walletBPcaBalance: bigint;
+  walletBAgentAccountId: bigint;
+}
+
+export interface LivePcaPublisherWalletBalances {
+  native: bigint;
+  trac: bigint;
+}
+
+function invariant(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+type SharedSweepTopology = Awaited<ReturnType<typeof validateSharedSweepTopology>>;
+
+async function requireDevnet(): Promise<{
+  state: DevnetState;
+  topology: SharedSweepTopology;
+}> {
+  const topology = await validateSharedSweepTopology();
+  const state = await detectDevnet(topology.nodeCount);
+  if (!state) {
+    throw new Error(
+      `No ${topology.nodeCount}-node devnet detected. Start with DEVNET_ENABLE_PUBLISHER=1 ` +
+      `DEVNET_PUBLISHER_WALLET_INDEX=${topology.publisherWalletIndex} ` +
+      `./scripts/devnet.sh start ${topology.nodeCount} after pnpm run build.`,
+    );
+  }
+  return { state, topology };
+}
+
+async function prepareAndValidateDevnet(
+  state: DevnetState,
+  topology: SharedSweepTopology,
+): Promise<void> {
+  await ensureAllIdentities(state, 4);
+  const nodes = Object.values(state.nodes);
+  invariant(
+    nodes.length === topology.nodeCount,
+    `expected ${topology.nodeCount} devnet nodes, received ${nodes.length}`,
+  );
+  await Promise.all(nodes.map(fetchStatus));
+
+  invariant(
+    topology.publisherWalletIndex > 0,
+    'issue #2440 requires a non-primary publisher wallet',
+  );
+  const node = state.nodes[1];
+  invariant(node, 'issue #2440 requires devnet node 1');
+  const selected = node.opWallets[topology.publisherWalletIndex];
+  invariant(
+    selected,
+    `${node.home} requires operational wallet index ${topology.publisherWalletIndex}`,
+  );
+  invariant(
+    lower(new ethers.Wallet(selected.privateKey).address) === lower(selected.address),
+    `${node.home} selected publisher private key must control its configured address`,
+  );
+}
+
+async function resolveResources(
+  state: DevnetState,
+  publisherWalletIndex: number,
+): Promise<LivePcaPublisherResources> {
+  const nodes = Object.values(state.nodes);
+  invariant(nodes.length === 6, `expected six devnet nodes, received ${nodes.length}`);
+
+  const node = state.nodes[1]!;
+  const walletA = new ethers.Wallet(node.opWallets[0]!.privateKey, state.provider);
+  const walletB = new ethers.Wallet(
+    node.opWallets[publisherWalletIndex]!.privateKey,
+    state.provider,
+  );
+  invariant(lower(walletA.address) !== lower(walletB.address), 'publisher wallets must be distinct');
+  const ownerWallet = new ethers.Wallet(HUB_OWNER_PK, state.provider);
+
+  const token = new ethers.Contract(state.addrs.Token, TOKEN_ABI, state.provider);
+  const pca = new ethers.Contract(state.addrs.DKGPublishingConvictionNFT, PCA_ABI, state.provider);
+  const parameters = new ethers.Contract(state.addrs.ParametersStorage, PARAMETERS_ABI, state.provider);
+  const contextGraphsAddress = ethers.getAddress(state.addrs.ContextGraphs);
+  const contextGraphs = new ethers.Contract(
+    contextGraphsAddress,
+    CONTEXT_GRAPHS_ABI,
+    state.provider,
+  );
+  const contextGraphStorageAddress = ethers.getAddress(
+    await contextGraphs.contextGraphStorage(),
+  );
+  const contextGraphStorage = new ethers.Contract(
+    contextGraphStorageAddress,
+    CONTEXT_GRAPH_STORAGE_ABI,
+    state.provider,
+  );
+  const waiverAddress = ethers.getAddress(state.addrs.ContextGraphWaiverStorage);
+  const waiver = new ethers.Contract(waiverAddress, WAIVER_ABI, state.provider);
+  const knowledgeAssetsLifecycleAddress = ethers.getAddress(
+    await state.hub.getContractAddress('KnowledgeAssetsLifecycle'),
+  );
+  const hubOwner = ethers.getAddress(await new ethers.Contract(
+    state.addrs.Hub,
+    ['function owner() view returns (address)'],
+    state.provider,
+  ).owner());
+  invariant(hubOwner === ownerWallet.address, 'configured Hub owner key does not match deployment');
+  invariant(
+    await state.provider.getBalance(ownerWallet.address) > 0n,
+    'configured Hub owner needs native gas; restart the task-scoped devnet',
+  );
+
+  return {
+    state,
+    node,
+    walletA,
+    walletB,
+    ownerWallet,
+    token,
+    pca,
+    parameters,
+    contextGraphStorage,
+    waiver,
+    contextGraphsAddress,
+    contextGraphStorageAddress,
+    waiverAddress,
+    knowledgeAssetsLifecycleAddress,
+  };
+}
+
+async function captureMutableState(
+  resources: LivePcaPublisherResources,
+): Promise<LivePcaPublisherMutableState> {
+  const pcaAddress = await resources.pca.getAddress();
+  return {
+    registrationDeposit: BigInt(
+      await resources.parameters.contextGraphRegistrationDeposit(),
+    ),
+    walletABalance: BigInt(await resources.token.balanceOf(resources.walletA.address)),
+    walletAContextGraphsAllowance: BigInt(
+      await resources.token.allowance(
+        resources.walletA.address,
+        resources.contextGraphsAddress,
+      ),
+    ),
+    walletBBalance: BigInt(await resources.token.balanceOf(resources.walletB.address)),
+    walletBContextGraphsAllowance: BigInt(
+      await resources.token.allowance(
+        resources.walletB.address,
+        resources.contextGraphsAddress,
+      ),
+    ),
+    walletBPcaAllowance: BigInt(
+      await resources.token.allowance(resources.walletB.address, pcaAddress),
+    ),
+    walletAPcaBalance: BigInt(await resources.pca.balanceOf(resources.walletA.address)),
+    walletAAgentAccountId: BigInt(
+      await resources.pca.agentToAccountId(resources.walletA.address),
+    ),
+    walletBPcaBalance: BigInt(await resources.pca.balanceOf(resources.walletB.address)),
+    walletBAgentAccountId: BigInt(
+      await resources.pca.agentToAccountId(resources.walletB.address),
+    ),
+  };
+}
+
+async function captureWalletBBalances(
+  resources: LivePcaPublisherResources,
+): Promise<LivePcaPublisherWalletBalances> {
+  const [native, trac] = await Promise.all([
+    resources.state.provider.getBalance(resources.walletB.address),
+    resources.token.balanceOf(resources.walletB.address),
+  ]);
+  return { native: BigInt(native), trac: BigInt(trac) };
+}
+
+type CleanupAction = { label: string; run: () => void | Promise<void> };
+
+export interface KnownTransaction {
+  from: string;
+  hash: string;
+  nonce: number;
+  signedTransaction: string;
+}
+
+export type KnownTransactionOutcome = 'replaced' | 'reverted' | 'succeeded';
+
+type KnownTransactionProvider = Pick<
+  ethers.JsonRpcProvider,
+  | 'broadcastTransaction'
+  | 'getTransaction'
+  | 'getTransactionCount'
+  | 'getTransactionReceipt'
+  | 'waitForTransaction'
+>;
+
+export async function reconcileKnownTransaction(
+  provider: KnownTransactionProvider,
+  transaction: KnownTransaction,
+): Promise<KnownTransactionOutcome> {
+  const nonceDisposition = async (): Promise<'available' | 'occupied' | 'replaced'> => {
+    const latestNonce = await provider.getTransactionCount(transaction.from, 'latest');
+    if (latestNonce > transaction.nonce) return 'replaced';
+    const pendingNonce = await provider.getTransactionCount(transaction.from, 'pending');
+    return pendingNonce > transaction.nonce ? 'occupied' : 'available';
+  };
+  const outcomeFromReceipt = async (): Promise<KnownTransactionOutcome | undefined> => {
+    const receipt = await provider.getTransactionReceipt(transaction.hash);
+    if (!receipt) return undefined;
+    return receipt.status === 1 ? 'succeeded' : 'reverted';
+  };
+  const waitForReceipt = async (): Promise<KnownTransactionOutcome> => {
+    const receipt = await provider.waitForTransaction(transaction.hash, 1, 30_000);
+    if (!receipt) {
+      throw new Error(
+        `transaction ${transaction.hash} remains pending; cleanup must retry`,
+      );
+    }
+    return receipt.status === 1 ? 'succeeded' : 'reverted';
+  };
+
+  const existingOutcome = await outcomeFromReceipt();
+  if (existingOutcome) return existingOutcome;
+  if (await provider.getTransaction(transaction.hash)) return waitForReceipt();
+
+  const beforeBroadcast = await nonceDisposition();
+  if (beforeBroadcast === 'replaced') return 'replaced';
+  if (beforeBroadcast === 'occupied') {
+    throw new Error(
+      `transaction nonce ${transaction.nonce} for ${transaction.from} is occupied by an `
+      + 'unrelated pending transaction; cleanup must retry without replacement',
+    );
+  }
+
+  try {
+    const response = await provider.broadcastTransaction(transaction.signedTransaction);
+    invariant(
+      lower(response.hash) === lower(transaction.hash),
+      `broadcast hash mismatch: expected ${transaction.hash}, received ${response.hash}`,
+    );
+  } catch (broadcastError) {
+    const recoveredOutcome = await outcomeFromReceipt();
+    if (recoveredOutcome) return recoveredOutcome;
+    if (await provider.getTransaction(transaction.hash)) return waitForReceipt();
+    const afterFailure = await nonceDisposition();
+    if (afterFailure === 'replaced') return 'replaced';
+    if (afterFailure === 'occupied') {
+      throw new Error(
+        `transaction nonce ${transaction.nonce} for ${transaction.from} became occupied by `
+        + 'an unrelated pending transaction; cleanup must retry without replacement',
+        { cause: broadcastError },
+      );
+    }
+    throw broadcastError;
+  }
+
+  return waitForReceipt();
+}
+
+export class CleanupStack {
+  private readonly actions: Array<CleanupAction & { completed: boolean }> = [];
+  private inFlightPromise?: Promise<void>;
+
+  defer(label: string, run: CleanupAction['run']): void {
+    this.actions.push({ label, run, completed: false });
+  }
+
+  dispose(): Promise<void> {
+    if (this.inFlightPromise) return this.inFlightPromise;
+
+    const attempt = this.disposeInternal();
+    this.inFlightPromise = attempt;
+    attempt.then(
+      () => {
+        if (this.inFlightPromise === attempt) this.inFlightPromise = undefined;
+      },
+      () => {
+        if (this.inFlightPromise === attempt) this.inFlightPromise = undefined;
+      },
+    );
+    return attempt;
+  }
+
+  private async disposeInternal(): Promise<void> {
+    const failures: Error[] = [];
+    for (let index = this.actions.length - 1; index >= 0; index -= 1) {
+      const action = this.actions[index]!;
+      if (action.completed) continue;
+      try {
+        await action.run();
+        action.completed = true;
+      } catch (error) {
+        failures.push(new Error(`${action.label}: ${(error as Error).message}`));
+      }
+    }
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures,
+        `Fixture cleanup failed: ${failures.map((failure) => failure.message).join('; ')}`,
+      );
+    }
+  }
+}
+
+const pendingInitializationCleanups = new Map<object, CleanupStack>();
+
+export async function retryLivePcaPublisherInitializationCleanup(
+  initializationError: object,
+): Promise<void> {
+  const cleanup = pendingInitializationCleanups.get(initializationError);
+  if (!cleanup) return;
+  await cleanup.dispose();
+  pendingInitializationCleanups.delete(initializationError);
+}
+
+export async function drainLivePcaPublisherInitializationCleanups(): Promise<void> {
+  const failures: Error[] = [];
+  for (const [initializationError, cleanup] of pendingInitializationCleanups) {
+    try {
+      await cleanup.dispose();
+      pendingInitializationCleanups.delete(initializationError);
+    } catch (error) {
+      failures.push(error as Error);
+    }
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      `${failures.length} deferred PCA fixture initialization cleanup(s) still failed`,
+    );
+  }
+}
+
+export class LivePcaPublisherLifecycle {
+  readonly resources: LivePcaPublisherResources;
+  readonly fixtureId = randomUUID();
+  pcaAccountId = 0n;
+
+  private readonly initializationFault?: LivePcaPublisherFixtureCreateOptions['initializationFault'];
+  private readonly acceptedBroadcastFault?: LivePcaPublisherFixtureCreateOptions['acceptedBroadcastFault'];
+  private readonly cleanupFault?: LivePcaPublisherFixtureCreateOptions['cleanupFault'];
+  private cleanupFaultFailuresRemaining = 0;
+  private readonly pcaOwnerWallet: ethers.Wallet;
+  private fixtureDir = '';
+  private pcaFundingAmount = 0n;
+  private pcaGasFundingTransaction?: KnownTransaction;
+  private pcaGasRefundTransaction?: KnownTransaction;
+  private pcaAgentRegistrationTransaction?: KnownTransaction;
+  private pcaApprovalTransaction?: KnownTransaction;
+  private pcaFundingRefundTransaction?: KnownTransaction;
+  private pcaFundingTransaction?: KnownTransaction;
+  private pcaMintTransaction?: KnownTransaction;
+  private registrationDepositBefore = 0n;
+  private registrationDepositChanged = false;
+  private registrationDepositSetTransaction?: KnownTransaction;
+  private registrationDepositRestoreTransaction?: KnownTransaction;
+  private walletABalanceBefore = 0n;
+  private walletAContextGraphsAllowanceBefore = 0n;
+  private walletBTracBalanceBefore = 0n;
+
+  private constructor(
+    resources: LivePcaPublisherResources,
+    options: LivePcaPublisherFixtureCreateOptions,
+    private readonly cleanup: CleanupStack,
+  ) {
+    this.resources = resources;
+    this.initializationFault = options.initializationFault;
+    this.acceptedBroadcastFault = options.acceptedBroadcastFault;
+    this.cleanupFault = options.cleanupFault;
+    this.cleanupFaultFailuresRemaining = options.cleanupFault?.failures ?? 1;
+    this.pcaOwnerWallet = ethers.Wallet.createRandom().connect(resources.state.provider);
+  }
+
+  static async captureMutableState(): Promise<LivePcaPublisherMutableState> {
+    const { state, topology } = await requireDevnet();
+    await prepareAndValidateDevnet(state, topology);
+    return captureMutableState(await resolveResources(state, topology.publisherWalletIndex));
+  }
+
+  static async capturePcaTotalSupply(): Promise<bigint> {
+    const { state, topology } = await requireDevnet();
+    await prepareAndValidateDevnet(state, topology);
+    const resources = await resolveResources(state, topology.publisherWalletIndex);
+    return BigInt(await resources.pca.totalSupply());
+  }
+
+  static async captureWalletBBalances(): Promise<LivePcaPublisherWalletBalances> {
+    const { state, topology } = await requireDevnet();
+    await prepareAndValidateDevnet(state, topology);
+    return captureWalletBBalances(
+      await resolveResources(state, topology.publisherWalletIndex),
+    );
+  }
+
+  static async create(
+    options: LivePcaPublisherFixtureCreateOptions = {},
+  ): Promise<LivePcaPublisherLifecycle> {
+    const { state, topology } = await requireDevnet();
+    const cleanup = new CleanupStack();
+    try {
+      await prepareAndValidateDevnet(state, topology);
+      const lifecycle = new LivePcaPublisherLifecycle(
+        await resolveResources(state, topology.publisherWalletIndex),
+        options,
+        cleanup,
+      );
+      await lifecycle.initialize();
+      return lifecycle;
+    } catch (error) {
+      try {
+        await cleanup.dispose();
+      } catch {
+        if (typeof error === 'object' && error !== null) {
+          pendingInitializationCleanups.set(error, cleanup);
+        }
+      }
+      throw error;
+    }
+  }
+
+  get fixtureDirectory(): string {
+    return this.fixtureDir;
+  }
+
+  get initialWalletABalance(): bigint {
+    return this.walletABalanceBefore;
+  }
+
+  get initialWalletAContextGraphsAllowance(): bigint {
+    return this.walletAContextGraphsAllowanceBefore;
+  }
+
+  get initialWalletBTracBalance(): bigint {
+    return this.walletBTracBalanceBefore;
+  }
+
+  dispose(): Promise<void> {
+    return this.cleanup.dispose();
+  }
+
+  private async initialize(): Promise<void> {
+    const { pca, token, walletA, walletB, contextGraphsAddress } = this.resources;
+    this.fixtureDir = mkdtempSync(join(tmpdir(), `dkg-pr2440-${this.fixtureId}-`));
+    const fixtureDir = this.fixtureDir;
+    this.cleanup.defer('temporary fixture directory removal', () => {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    });
+
+    this.walletABalanceBefore = BigInt(await token.balanceOf(walletA.address));
+    this.walletAContextGraphsAllowanceBefore = BigInt(
+      await token.allowance(walletA.address, contextGraphsAddress),
+    );
+    const walletBBalancesBefore = await captureWalletBBalances(this.resources);
+    this.walletBTracBalanceBefore = walletBBalancesBefore.trac;
+    invariant(walletBBalancesBefore.native > 0n, 'wallet B needs native gas');
+
+    invariant(await pca.balanceOf(walletA.address) === 0n, 'wallet A must own no PCA');
+    invariant(
+      await pca.agentToAccountId(walletA.address) === 0n,
+      'wallet A must have no PCA agent binding',
+    );
+    invariant(await pca.balanceOf(walletB.address) === 0n, 'wallet B must own no PCA');
+    invariant(
+      await pca.agentToAccountId(walletB.address) === 0n,
+      'wallet B must have no PCA agent binding',
+    );
+    invariant(
+      await token.allowance(walletB.address, contextGraphsAddress) === 0n,
+      'wallet B ContextGraphs allowance must start at zero',
+    );
+    invariant(
+      await token.allowance(walletB.address, await pca.getAddress()) === 0n,
+      'wallet B PCA allowance must start at zero',
+    );
+    invariant(
+      await pca.balanceOf(this.pcaOwnerWallet.address) === 0n,
+      'fixture PCA owner must start without a PCA',
+    );
+    invariant(
+      await token.balanceOf(this.pcaOwnerWallet.address) === 0n,
+      'fixture PCA owner must start with zero TRAC',
+    );
+
+    await this.activateRegistrationDeposit();
+    this.failInitializationAt('after-registration-deposit');
+    await this.createEligiblePcaForWalletB();
+    this.failInitializationAt('after-wallet-state');
+    invariant(
+      await token.balanceOf(walletA.address) === this.walletABalanceBefore,
+      'fixture must not change wallet A TRAC',
+    );
+    invariant(
+      await token.allowance(walletA.address, contextGraphsAddress)
+        === this.walletAContextGraphsAllowanceBefore,
+      'fixture must not change wallet A ContextGraphs allowance',
+    );
+    invariant(
+      await token.balanceOf(walletB.address) === this.walletBTracBalanceBefore,
+      'fixture PCA setup must preserve wallet B TRAC',
+    );
+    invariant(
+      await this.resources.state.provider.getBalance(walletB.address)
+        > 0n,
+      'wallet B must retain native gas during fixture setup',
+    );
+    invariant(
+      await token.allowance(walletB.address, contextGraphsAddress) === 0n,
+      'wallet B ContextGraphs allowance must retain zero',
+    );
+  }
+
+  private failInitializationAt(checkpoint: FixtureInitializationCheckpoint): void {
+    if (this.initializationFault?.checkpoint !== checkpoint) return;
+    this.initializationFault.onReached?.({
+      fixtureDir: this.fixtureDir,
+      fixtureId: this.fixtureId,
+      pcaAccountId: this.pcaAccountId,
+    });
+    throw this.initializationFault.error;
+  }
+
+  private failCleanupAt(checkpoint: FixtureCleanupCheckpoint): void {
+    if (
+      this.cleanupFault?.checkpoint !== checkpoint
+      || this.cleanupFaultFailuresRemaining <= 0
+    ) return;
+    this.cleanupFaultFailuresRemaining -= 1;
+    throw this.cleanupFault.error;
+  }
+
+  private async discoverFixturePcaAccountId(): Promise<bigint> {
+    if (this.pcaAccountId > 0n) return this.pcaAccountId;
+    if (!this.pcaMintTransaction) return 0n;
+
+    const { state, pca } = this.resources;
+    const candidates = new Set<bigint>();
+    const outcome = await this.reconcileKnownTransaction(this.pcaMintTransaction);
+    if (outcome !== 'succeeded') return 0n;
+    const receipt = await state.provider.getTransactionReceipt(this.pcaMintTransaction.hash);
+    invariant(receipt, `fixture PCA mint ${this.pcaMintTransaction.hash} receipt disappeared`);
+
+    const pcaAddress = lower(await pca.getAddress());
+    for (const log of receipt.logs) {
+      if (lower(log.address) !== pcaAddress) continue;
+      try {
+        const parsed = pca.interface.parseLog(log);
+        if (
+          parsed?.name === 'Transfer'
+          && lower(String(parsed.args.from)) === lower(ethers.ZeroAddress)
+          && lower(String(parsed.args.to)) === lower(this.pcaOwnerWallet.address)
+        ) {
+          candidates.add(BigInt(parsed.args.tokenId));
+        }
+      } catch {
+        // Ignore unrelated logs emitted by the known PCA mint transaction.
+      }
+    }
+
+    if (candidates.size !== 1) {
+      throw new Error(
+        `known PCA mint ${this.pcaMintTransaction.hash} emitted ${candidates.size} `
+        + 'matching mint events; ownership preserved for retry/manual recovery',
+      );
+    }
+    const [accountId] = candidates;
+    this.pcaAccountId = accountId!;
+    return accountId!;
+  }
+
+  private async detachFixturePca(): Promise<void> {
+    const { state, ownerWallet, pca, walletB } = this.resources;
+    const pcaOwner = this.pcaOwnerWallet;
+    const accountId = await this.discoverFixturePcaAccountId();
+    if (accountId === 0n) {
+      await this.recoverUnconsumedPcaFunding();
+      return;
+    }
+
+    if (this.pcaAgentRegistrationTransaction) {
+      await this.reconcileKnownTransaction(this.pcaAgentRegistrationTransaction);
+    }
+    const cleanupAddress = ownerWallet.address;
+    const currentOwner = ethers.getAddress(await pca.ownerOf(accountId));
+    const currentAgentAccountId = BigInt(await pca.agentToAccountId(walletB.address));
+    if (lower(currentOwner) === lower(cleanupAddress)) {
+      invariant(currentAgentAccountId === 0n, 'detached fixture PCA retained wallet B agent');
+      return;
+    }
+    if (lower(currentOwner) !== lower(pcaOwner.address)) {
+      throw new Error(
+        `cleanup conflict: fixture PCA ${accountId} owner changed to ${currentOwner}; `
+        + 'ownership preserved for manual recovery',
+      );
+    }
+    if (currentAgentAccountId === accountId) {
+      await (await (pca.connect(pcaOwner) as ethers.Contract).deregisterAgent(
+        accountId,
+        walletB.address,
+        { nonce: await nextPendingNonce(state.provider, pcaOwner.address) },
+      )).wait();
+    } else if (currentAgentAccountId !== 0n) {
+      throw new Error(
+        `cleanup conflict: wallet B is bound to PCA ${currentAgentAccountId}, expected `
+        + `${accountId}; agent binding preserved for manual recovery`,
+      );
+    }
+    await (await (pca.connect(pcaOwner) as ethers.Contract).transferFrom(
+      pcaOwner.address,
+      cleanupAddress,
+      accountId,
+      { nonce: await nextPendingNonce(state.provider, pcaOwner.address) },
+    )).wait();
+    invariant(
+      lower(await pca.ownerOf(accountId)) === lower(cleanupAddress),
+      'fixture PCA canonical owner cleanup failed',
+    );
+    invariant(await pca.balanceOf(pcaOwner.address) === 0n, 'fixture PCA owner cleanup failed');
+    invariant(await pca.balanceOf(walletB.address) === 0n, 'publisher wallet gained PCA ownership');
+    invariant(
+      BigInt(await pca.agentToAccountId(walletB.address)) === 0n,
+      'fixture PCA agent cleanup failed',
+    );
+  }
+
+  private async recoverUnconsumedPcaFunding(): Promise<void> {
+    if (this.pcaGasFundingTransaction) {
+      await this.reconcileKnownTransaction(this.pcaGasFundingTransaction);
+    }
+    if (!this.pcaFundingTransaction || this.pcaFundingAmount === 0n) return;
+
+    const { state, ownerWallet, token, pca } = this.resources;
+    const pcaOwner = this.pcaOwnerWallet;
+    if (this.pcaFundingRefundTransaction) {
+      const refundOutcome = await this.reconcileKnownTransaction(
+        this.pcaFundingRefundTransaction,
+      );
+      if (refundOutcome === 'succeeded') {
+        this.pcaFundingAmount = 0n;
+        return;
+      }
+      this.pcaFundingRefundTransaction = undefined;
+    }
+
+    const fundingOutcome = await this.reconcileKnownTransaction(this.pcaFundingTransaction);
+    if (fundingOutcome !== 'succeeded') {
+      this.pcaFundingAmount = 0n;
+      return;
+    }
+
+    if (this.pcaApprovalTransaction) {
+      await this.reconcileKnownTransaction(this.pcaApprovalTransaction);
+    }
+
+    const pcaAddress = await pca.getAddress();
+    const allowance = BigInt(await token.allowance(pcaOwner.address, pcaAddress));
+    if (allowance === this.pcaFundingAmount) {
+      await (await (token.connect(pcaOwner) as ethers.Contract).approve(
+        pcaAddress,
+        0n,
+        { nonce: await nextPendingNonce(state.provider, pcaOwner.address) },
+      )).wait();
+    } else if (allowance !== 0n) {
+      throw new Error(
+        `cleanup conflict: fixture PCA owner allowance is ${allowance}, expected 0 or `
+        + `${this.pcaFundingAmount}; allowance preserved for manual recovery`,
+      );
+    }
+
+    const balance = BigInt(await token.balanceOf(pcaOwner.address));
+    if (balance < this.pcaFundingAmount) {
+      throw new Error(
+        `cleanup conflict: fixture PCA owner retains ${balance} of fixture funding `
+        + `${this.pcaFundingAmount}; balance preserved for retry/manual recovery`,
+      );
+    }
+    const refundRequest = await (token.connect(pcaOwner) as ethers.Contract)
+      .transfer.populateTransaction(
+      ownerWallet.address,
+      this.pcaFundingAmount,
+      { nonce: await nextPendingNonce(state.provider, pcaOwner.address) },
+      );
+    await this.broadcastKnownTransaction(
+      pcaOwner,
+      refundRequest,
+      (transaction) => {
+        this.pcaFundingRefundTransaction = transaction;
+      },
+    );
+    this.pcaFundingAmount = 0n;
+  }
+
+  private async refundPcaOwnerNativeBalance(): Promise<void> {
+    const { state, ownerWallet } = this.resources;
+    const pcaOwner = this.pcaOwnerWallet;
+    if (this.pcaGasFundingTransaction) {
+      await this.reconcileKnownTransaction(this.pcaGasFundingTransaction);
+    }
+    if (this.pcaGasRefundTransaction) {
+      const outcome = await this.reconcileKnownTransaction(this.pcaGasRefundTransaction);
+      if (outcome === 'succeeded') {
+        invariant(
+          await state.provider.getBalance(pcaOwner.address) === 0n,
+          'fixture PCA owner native refund mined without draining its balance',
+        );
+        return;
+      }
+      if (outcome === 'replaced') {
+        throw new Error(
+          'fixture PCA owner native refund was replaced; balance preserved for manual recovery',
+        );
+      }
+      this.pcaGasRefundTransaction = undefined;
+    }
+
+    const balance = await state.provider.getBalance(pcaOwner.address);
+    if (balance === 0n) return;
+    const gasLimit = 21_000n;
+    const gasPrice = BigInt(await state.provider.send('eth_gasPrice', []));
+    const gasCost = gasLimit * gasPrice;
+    invariant(
+      balance > gasCost,
+      `fixture PCA owner native balance ${balance} cannot cover refund gas ${gasCost}`,
+    );
+    await this.broadcastKnownTransaction(
+      pcaOwner,
+      {
+        type: 0,
+        nonce: await nextPendingNonce(state.provider, pcaOwner.address),
+        to: ownerWallet.address,
+        value: balance - gasCost,
+        gasLimit,
+        gasPrice,
+      },
+      (transaction) => {
+        this.pcaGasRefundTransaction = transaction;
+      },
+    );
+    invariant(
+      await state.provider.getBalance(pcaOwner.address) === 0n,
+      'fixture PCA owner native refund did not drain its balance',
+    );
+  }
+
+  private async reconcileKnownTransaction(
+    transaction: KnownTransaction,
+  ): Promise<KnownTransactionOutcome> {
+    return reconcileKnownTransaction(this.resources.state.provider, transaction);
+  }
+
+  private async broadcastKnownTransaction(
+    signer: ethers.Wallet,
+    request: ethers.TransactionRequest,
+    remember: (transaction: KnownTransaction) => void,
+    acceptedFaultCheckpoint?: FixtureAcceptedBroadcastCheckpoint,
+  ): Promise<void> {
+    invariant(
+      lower(signer.address) === lower(this.resources.ownerWallet.address)
+        || lower(signer.address) === lower(this.pcaOwnerWallet.address),
+      'fixture setup and cleanup transactions require a lifecycle-exclusive signer',
+    );
+    const populated = await signer.populateTransaction(request);
+    invariant(populated.nonce !== undefined, 'known transaction nonce is unavailable');
+    const signed = await signer.signTransaction(populated);
+    const transaction: KnownTransaction = {
+      from: signer.address,
+      hash: ethers.keccak256(signed),
+      nonce: Number(populated.nonce),
+      signedTransaction: signed,
+    };
+    remember(transaction);
+    const acceptedFault = this.acceptedBroadcastFault;
+    if (shouldInjectAcceptedBroadcastFault(acceptedFault, acceptedFaultCheckpoint)) {
+      const response = await this.resources.state.provider.broadcastTransaction(signed);
+      invariant(
+        lower(response.hash) === lower(transaction.hash),
+        `accepted fault broadcast hash mismatch: expected ${transaction.hash}, received ${response.hash}`,
+      );
+      acceptedFault.onAccepted?.({
+        transaction,
+        pcaOwnerAddress: this.pcaOwnerWallet.address,
+      });
+      throw acceptedFault.error;
+    }
+    const outcome = await this.reconcileKnownTransaction(transaction);
+    invariant(
+      outcome === 'succeeded',
+      `transaction ${transaction.hash} was ${outcome}`,
+    );
+  }
+
+  private async activateRegistrationDeposit(): Promise<void> {
+    const { state, ownerWallet, parameters } = this.resources;
+    this.registrationDepositBefore = BigInt(
+      await parameters.contextGraphRegistrationDeposit(),
+    );
+    invariant(
+      REGISTRATION_DEPOSIT > 0n && REGISTRATION_DEPOSIT < 1n << 96n,
+      'fixture registration deposit must be a positive uint96 value',
+    );
+    if (this.registrationDepositBefore === REGISTRATION_DEPOSIT) return;
+
+    // Register compensation before broadcasting. If the mined outcome is
+    // uncertain, cleanup reconciles this exact signed transaction first and
+    // then restores only state that still carries the fixture-owned value.
+    this.registrationDepositChanged = true;
+    this.cleanup.defer(
+      'registration deposit restoration',
+      () => this.restoreRegistrationDeposit(),
+    );
+    const request = await (parameters.connect(ownerWallet) as ethers.Contract)
+      .setContextGraphRegistrationDeposit.populateTransaction(
+        REGISTRATION_DEPOSIT,
+        { nonce: await nextPendingNonce(state.provider, ownerWallet.address) },
+      );
+    await this.broadcastKnownTransaction(
+      ownerWallet,
+      request,
+      (transaction) => {
+        this.registrationDepositSetTransaction = transaction;
+      },
+    );
+    invariant(
+      BigInt(await parameters.contextGraphRegistrationDeposit()) === REGISTRATION_DEPOSIT,
+      'fixture registration deposit activation failed',
+    );
+  }
+
+  private async restoreRegistrationDeposit(): Promise<void> {
+    if (!this.registrationDepositChanged) return;
+    const { state, ownerWallet, parameters } = this.resources;
+
+    if (this.registrationDepositSetTransaction) {
+      await this.reconcileKnownTransaction(this.registrationDepositSetTransaction);
+    }
+    if (this.registrationDepositRestoreTransaction) {
+      const outcome = await this.reconcileKnownTransaction(
+        this.registrationDepositRestoreTransaction,
+      );
+      if (outcome === 'succeeded') {
+        invariant(
+          BigInt(await parameters.contextGraphRegistrationDeposit())
+            === this.registrationDepositBefore,
+          'fixture registration deposit restore transaction mined without restoring the snapshot',
+        );
+        return;
+      }
+    }
+
+    const current = BigInt(await parameters.contextGraphRegistrationDeposit());
+    if (current === this.registrationDepositBefore) return;
+    if (current !== REGISTRATION_DEPOSIT) {
+      throw new Error(
+        `cleanup conflict: registration deposit changed to ${current}, expected fixture value `
+        + `${REGISTRATION_DEPOSIT}; external value preserved for retry/manual recovery`,
+      );
+    }
+
+    const request = await (parameters.connect(ownerWallet) as ethers.Contract)
+      .setContextGraphRegistrationDeposit.populateTransaction(
+        this.registrationDepositBefore,
+        { nonce: await nextPendingNonce(state.provider, ownerWallet.address) },
+      );
+    await this.broadcastKnownTransaction(
+      ownerWallet,
+      request,
+      (transaction) => {
+        this.registrationDepositRestoreTransaction = transaction;
+      },
+    );
+    invariant(
+      BigInt(await parameters.contextGraphRegistrationDeposit())
+        === this.registrationDepositBefore,
+      'fixture registration deposit restoration failed',
+    );
+  }
+
+  private async createEligiblePcaForWalletB(): Promise<void> {
+    const {
+      state,
+      node,
+      ownerWallet,
+      walletB,
+      token,
+      pca,
+      parameters,
+      waiver,
+    } = this.resources;
+    const pcaOwner = this.pcaOwnerWallet;
+    const floor = BigInt(await parameters.minPcaCommitmentForCgWaiver());
+    const commitment = floor > COMMITMENT_BASELINE ? floor * 2n : COMMITMENT_BASELINE;
+    invariant(commitment < 1n << 96n, 'fixture PCA commitment exceeds uint96');
+    invariant(
+      await token.balanceOf(ownerWallet.address) >= commitment,
+      'fixture owner lacks TRAC for canonical PCA funding',
+    );
+
+    this.cleanup.defer('fixture PCA discovery and detachment', async () => {
+      this.failCleanupAt('pca-detachment');
+      await this.detachFixturePca();
+      await this.refundPcaOwnerNativeBalance();
+    });
+
+    const gasFundingRequest: ethers.TransactionRequest = {
+      nonce: await nextPendingNonce(state.provider, ownerWallet.address),
+      to: pcaOwner.address,
+      value: ethers.parseEther('1'),
+    };
+    await this.broadcastKnownTransaction(
+      ownerWallet,
+      gasFundingRequest,
+      (transaction) => {
+        this.pcaGasFundingTransaction = transaction;
+      },
+    );
+
+    this.pcaFundingAmount = commitment;
+    const fundingRequest = await (token.connect(ownerWallet) as ethers.Contract)
+      .transfer.populateTransaction(
+        pcaOwner.address,
+        commitment,
+        { nonce: await nextPendingNonce(state.provider, ownerWallet.address) },
+      );
+    await this.broadcastKnownTransaction(
+      ownerWallet,
+      fundingRequest,
+      (transaction) => {
+        this.pcaFundingTransaction = transaction;
+      },
+      'pca-funding',
+    );
+    const fundedBalance = BigInt(await token.balanceOf(pcaOwner.address));
+    invariant(
+      fundedBalance === commitment,
+      `fixture PCA owner funding conflict: expected ${commitment}, found ${fundedBalance}; `
+      + 'concurrent TRAC was preserved and must not be committed by the fixture',
+    );
+    const pcaAddress = await pca.getAddress();
+    const approvalRequest = await (token.connect(pcaOwner) as ethers.Contract)
+      .approve.populateTransaction(
+        pcaAddress,
+        fundedBalance,
+        { nonce: await nextPendingNonce(state.provider, pcaOwner.address) },
+      );
+    await this.broadcastKnownTransaction(
+      pcaOwner,
+      approvalRequest,
+      (transaction) => {
+        this.pcaApprovalTransaction = transaction;
+      },
+    );
+    const mintRequest = await (pca.connect(pcaOwner) as ethers.Contract)
+      .createAccount.populateTransaction(
+        fundedBalance,
+        node.identityId,
+        { nonce: await nextPendingNonce(state.provider, pcaOwner.address) },
+      );
+    await this.broadcastKnownTransaction(
+      pcaOwner,
+      mintRequest,
+      (transaction) => {
+        this.pcaMintTransaction = transaction;
+      },
+      'pca-mint',
+    );
+    this.failInitializationAt('after-pca-mint-before-read');
+
+    invariant(await token.balanceOf(pcaOwner.address) === 0n, 'PCA mint must consume fixture owner TRAC');
+    invariant(await token.allowance(pcaOwner.address, pcaAddress) === 0n, 'PCA mint allowance must be consumed');
+    invariant(await pca.balanceOf(pcaOwner.address) === 1n, 'fixture owner must own fixture PCA');
+    invariant(await pca.balanceOf(walletB.address) === 0n, 'publisher wallet must not own a PCA');
+    this.pcaAccountId = await this.discoverFixturePcaAccountId();
+    invariant(
+      lower(await pca.ownerOf(this.pcaAccountId)) === lower(pcaOwner.address),
+      'fixture PCA owner mismatch',
+    );
+    this.failInitializationAt('after-pca-creation');
+
+    const registrationRequest = await (pca.connect(pcaOwner) as ethers.Contract)
+      .registerAgent.populateTransaction(
+        this.pcaAccountId,
+        walletB.address,
+        { nonce: await nextPendingNonce(state.provider, pcaOwner.address) },
+      );
+    await this.broadcastKnownTransaction(
+      pcaOwner,
+      registrationRequest,
+      (transaction) => {
+        this.pcaAgentRegistrationTransaction = transaction;
+      },
+    );
+    this.failInitializationAt('after-agent-registration');
+    invariant(
+      await pca.agentToAccountId(walletB.address) === this.pcaAccountId,
+      'fixture PCA agent registration failed',
+    );
+
+    const account = await pca.accounts(this.pcaAccountId);
+    invariant(BigInt(account.committedTRAC ?? account[0]) === fundedBalance, 'fixture PCA commitment mismatch');
+    invariant(Boolean(account.fullySwept ?? account[8]) === false, 'fixture PCA must be active');
+    const latest = await state.provider.getBlock('latest');
+    invariant(latest, 'latest block is unavailable');
+    invariant(
+      BigInt(account.expiresAtTimestamp ?? account[4]) > BigInt(latest.timestamp),
+      'fixture PCA must not be expired',
+    );
+    invariant(await waiver.waivedCgCount(this.pcaAccountId) === 0n, 'fixture PCA waiver count must start at zero');
+  }
+}

--- a/devnet/pr2440-pca-cg-registration/package.json
+++ b/devnet/pr2440-pca-cg-registration/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@origintrail-official/dkg-devnet-pr2440-pca-cg-registration",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": { "test:devnet": "vitest run --config vitest.config.ts" },
+  "dependencies": { "ethers": "^6.16.0" },
+  "devDependencies": { "vitest": "^4.0.18" }
+}

--- a/devnet/pr2440-pca-cg-registration/pca-registration-contracts.ts
+++ b/devnet/pr2440-pca-cg-registration/pca-registration-contracts.ts
@@ -1,0 +1,49 @@
+export const PREDICATE = 'https://schema.org/name';
+
+export const TOKEN_ABI = [
+  'function balanceOf(address owner) view returns (uint256)',
+  'function allowance(address owner, address spender) view returns (uint256)',
+  'function approve(address spender, uint256 amount) returns (bool)',
+  'function transfer(address to, uint256 amount) returns (bool)',
+  'event Approval(address indexed owner, address indexed spender, uint256 value)',
+  'event Transfer(address indexed from, address indexed to, uint256 value)',
+];
+
+export const PCA_ABI = [
+  'function createAccount(uint96 committedTRAC, uint72 primaryNode) returns (uint256)',
+  'function totalSupply() view returns (uint256)',
+  'function balanceOf(address owner) view returns (uint256)',
+  'function ownerOf(uint256 accountId) view returns (address)',
+  'function transferFrom(address from, address to, uint256 accountId)',
+  'function registerAgent(uint256 accountId, address agent)',
+  'function deregisterAgent(uint256 accountId, address agent)',
+  'function agentToAccountId(address agent) view returns (uint256)',
+  'function accounts(uint256 accountId) view returns (uint96 committedTRAC, uint40 createdAtEpoch, uint40 expiresAtEpoch, uint40 createdAtTimestamp, uint40 expiresAtTimestamp, uint72 primaryNode, uint96 cumulativeSpent, uint40 lastSettledWindow, bool fullySwept)',
+  'event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)',
+];
+
+export const PARAMETERS_ABI = [
+  'function contextGraphRegistrationDeposit() view returns (uint96)',
+  'function minPcaCommitmentForCgWaiver() view returns (uint96)',
+  'function setContextGraphRegistrationDeposit(uint96 amount)',
+];
+
+export const CONTEXT_GRAPHS_ABI = [
+  'function contextGraphStorage() view returns (address)',
+  'function createContextGraph(address[] participantAgents, uint256 metadataBatchId, uint8 accessPolicy, uint8 publishPolicy, address publishAuthority, uint256 publishAuthorityAccountId, bytes32 nameHash) returns (uint256)',
+  'event ContextGraphRegistrationDepositWaived(uint256 indexed contextGraphId, uint256 indexed accountId, address indexed creator)',
+  'event ContextGraphRegistrationDeposited(uint256 indexed contextGraphId, address indexed payer, uint96 amount)',
+];
+
+export const CONTEXT_GRAPH_STORAGE_ABI = [
+  'function getContextGraphOwner(uint256 contextGraphId) view returns (address)',
+  'function getPublishPolicy(uint256 contextGraphId) view returns (uint8 publishPolicy, address publishAuthority)',
+  'function getPublishAuthorityAccountId(uint256 contextGraphId) view returns (uint256)',
+  'function getRegistrationEscrow(uint256 contextGraphId) view returns (uint96)',
+  'event ContextGraphCreated(uint256 indexed contextGraphId, address indexed owner, bytes32 indexed nameHash, address[] participantAgents, uint256 metadataBatchId, uint8 accessPolicy, uint8 publishPolicy, address publishAuthority, uint256 publishAuthorityAccountId)',
+];
+
+export const WAIVER_ABI = [
+  'function waivedCgCount(uint256 accountId) view returns (uint256)',
+  'event RegistrationDepositWaived(uint256 indexed accountId, address indexed creator, uint256 newWaivedCount, uint256 quota)',
+];

--- a/devnet/pr2440-pca-cg-registration/vitest.config.ts
+++ b/devnet/pr2440-pca-cg-registration/vitest.config.ts
@@ -1,0 +1,23 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+const suiteTests = [
+  'automated.test.ts',
+  'cleanup-stack.test.ts',
+  'known-transaction.test.ts',
+].map((file) =>
+  resolve(import.meta.dirname, file).replace(/\\/g, '/'));
+
+export default defineConfig({
+  test: {
+    include: suiteTests,
+    testTimeout: 600_000,
+    hookTimeout: 300_000,
+    pool: 'forks',
+    sequence: { concurrent: false },
+    globals: false,
+  },
+  resolve: {
+    modules: [resolve(import.meta.dirname, '../../node_modules'), 'node_modules'],
+  },
+});

--- a/devnet/suites.json
+++ b/devnet/suites.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Single source of truth for the devnet suite set and shared sweep topology. `prCoverage` = the 10.0.2 PR-coverage suites the coverage sweep runs; `all` = every devnet/<dir> that has a vitest.config.ts (excluding _bootstrap). scripts/devnet-1002-coverage-sweep.sh reads this manifest; devnet/_bootstrap/suite-manifest.test.ts guards it against package.json / pnpm-workspace.yaml / on-disk drift.",
+  "_comment": "Single source of truth for the devnet suite set and shared sweep topology. `prCoverage` = the 10.0.2 PR-coverage suites run once in the baseline; `baselineOnly` = economically consumptive canonical-state suites excluded from the default repeated stability loop; `all` = every devnet/<dir> that has a vitest.config.ts (excluding _bootstrap). scripts/devnet-1002-coverage-sweep.sh reads this manifest; devnet/_bootstrap/suite-manifest.test.ts guards it against package.json / pnpm-workspace.yaml / on-disk drift.",
   "sharedSweep": {
     "nodeCount": 6,
     "publisherWalletIndex": 1
@@ -10,10 +10,14 @@
     "pr1388-okf-integration",
     "ka-lifecycle-cli",
     "pr1366-pca-deposit-waiver",
+    "pr2440-pca-cg-registration",
     "pr1369-folded-private-ack",
     "pr1387-bulk-register-agents",
     "pr1384-preserve-agents-on-transfer",
     "pr1370-admin-op-wallet"
+  ],
+  "baselineOnly": [
+    "pr2440-pca-cg-registration"
   ],
   "all": [
     "ack-candidate-isolation",
@@ -31,6 +35,7 @@
     "pr1386-term-canon",
     "pr1387-bulk-register-agents",
     "pr1388-okf-integration",
+    "pr2440-pca-cg-registration",
     "ka-lifecycle-cli",
     "rfc51-publishing-allocation",
     "rich-scenario",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "test:devnet:ka-lifecycle-cli": "vitest run --config devnet/ka-lifecycle-cli/vitest.config.ts",
     "test:devnet:kamstrup-query-catalog": "node devnet/query-catalog-kamstrup/run.mjs",
     "test:devnet:pr1366-pca-deposit-waiver": "vitest run --config devnet/pr1366-pca-deposit-waiver/vitest.config.ts",
+    "test:devnet:pr2440-pca-cg-registration": "vitest run --config devnet/pr2440-pca-cg-registration/vitest.config.ts",
     "test:devnet:pr1369-folded-private-ack": "vitest run --config devnet/pr1369-folded-private-ack/vitest.config.ts",
     "test:devnet:pr1387-bulk-register-agents": "vitest run --config devnet/pr1387-bulk-register-agents/vitest.config.ts",
     "test:devnet:pr1384-preserve-agents-on-transfer": "vitest run --config devnet/pr1384-preserve-agents-on-transfer/vitest.config.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,16 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
+  devnet/pr2440-pca-cg-registration:
+    dependencies:
+      ethers:
+        specifier: ^6.16.0
+        version: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    devDependencies:
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+
   devnet/rfc51-publishing-allocation:
     dependencies:
       ethers:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,7 @@ packages:
   - "devnet/pr1388-okf-integration"
   - "devnet/ka-lifecycle-cli"
   - "devnet/pr1366-pca-deposit-waiver"
+  - "devnet/pr2440-pca-cg-registration"
   - "devnet/pr1369-folded-private-ack"
   - "devnet/pr1387-bulk-register-agents"
   - "devnet/pr1384-preserve-agents-on-transfer"

--- a/scripts/devnet-1002-coverage-sweep.sh
+++ b/scripts/devnet-1002-coverage-sweep.sh
@@ -10,7 +10,7 @@
 #
 # Phases:
 #   1. ONE PASS of the manifest-listed PR-coverage suites + v10-end-to-end (baseline).
-#   2. STABILITY LOOP of those suites until (TARGET - ORCH reserve) elapses,
+#   2. STABILITY LOOP of repeatable suites until (TARGET - ORCH reserve) elapses,
 #      health-guarded, aggregating per-suite pass-rates → surfaces intermittents
 #      (RS timing, finalization dual-home race, SWM convergence).
 #   3. (opt-in, LAST) devnet-comprehensive.sh WITH soak — destructive; runs only
@@ -37,17 +37,32 @@ RUN_ORCHESTRATOR="${RUN_ORCHESTRATOR:-0}"
 SOAK_RS_SECONDS="${SOAK_RS_SECONDS:-1800}"
 if [ "$RUN_ORCHESTRATOR" = "1" ]; then ORCH_RESERVE_SECONDS="${ORCH_RESERVE_SECONDS:-5400}"; else ORCH_RESERVE_SECONDS=0; fi
 
-# Suite list is single-sourced in devnet/suites.json (guarded against drift by
-# devnet/_bootstrap/suite-manifest.test.ts). Read the PR-coverage set from there.
+# Suite classification is single-sourced in devnet/suites.json (guarded against
+# drift by devnet/_bootstrap/suite-manifest.test.ts). Baseline runs all PR
+# coverage; the default stability loop excludes economically consumptive suites
+# whose durable canonical state makes repetition unsafe without a clean devnet.
 SUITES_JSON="$REPO_ROOT/devnet/suites.json"
-NEW_SUITES=($(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).prCoverage.join(' '))" "$SUITES_JSON" 2>/dev/null))
-[ "${#NEW_SUITES[@]}" -gt 0 ] || { echo "FATAL: could not read prCoverage from $SUITES_JSON (need node in PATH)"; exit 2; }
-SWEEP_NODE_COUNT=$(node -e "process.stdout.write(String(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).sharedSweep.nodeCount))" "$SUITES_JSON" 2>/dev/null)
-STABILITY_SUITES="${STABILITY_SUITES:-${NEW_SUITES[*]} v10-end-to-end}"
+SWEEP_SELECTOR="$REPO_ROOT/scripts/lib/sweep-suite-selector.mjs"
+source "$REPO_ROOT/scripts/lib/sweep-phase-schedule.sh"
+STABILITY_OVERRIDE="${STABILITY_SUITES:-}"
+if ! SWEEP_SELECTION=$(node "$SWEEP_SELECTOR" "$SUITES_JSON" selection 0 "$STABILITY_OVERRIDE"); then
+  echo "FATAL: could not select sweep suites from $SUITES_JSON (need node in PATH)"; exit 2
+fi
+IFS=$'\t' read -r BASELINE_SUITES STABILITY_SUITES SWEEP_NODE_COUNT PR_COVERAGE_COUNT <<< "$SWEEP_SELECTION"
+[ -n "$BASELINE_SUITES" ] && [ -n "$STABILITY_SUITES" ] && [ "$SWEEP_NODE_COUNT" -gt 0 ] || {
+  echo "FATAL: sweep selector returned an invalid schedule for $SUITES_JSON"; exit 2
+}
 
 log() { echo "[1002-sweep $(date -u +'%H:%M:%S')] $*" | tee -a "$SUMMARY"; }
 elapsed() { echo $(( $(date +%s) - START )); }
 loop_deadline() { echo $(( TARGET_SECONDS - ORCH_RESERVE_SECONDS )); }
+
+load_scheduled_phase() { # $1=baseline|stability $2=round
+  if ! capture_sweep_phase_schedule "$1" "$2"; then
+    log "FATAL: sweep selector failed or returned an empty $1 schedule (round $2)"
+    return 2
+  fi
+}
 
 # devnet health: all 6 node APIs + hardhat reachable. Returns 0 healthy / 1 not.
 # BLIP-TOLERANT: a single probe can transiently ECONNRESET / time out on a busy
@@ -107,7 +122,7 @@ log "10.0.2 sweep. target=${TARGET_SECONDS}s orch=${RUN_ORCHESTRATOR} loop_deadl
 if ! pnpm vitest run --config devnet/_bootstrap/vitest.manifest.config.ts > "$RESULTS/manifest-guard.log" 2>&1; then
   log "FATAL: suite manifest drift — see $RESULTS/manifest-guard.log (run 'pnpm test:devnet:manifest')"; exit 2
 fi
-log "suite manifest consistent ($( echo "${NEW_SUITES[*]}" | wc -w | tr -d ' ') PR-coverage suites)."
+log "suite manifest consistent ($PR_COVERAGE_COUNT PR-coverage suites)."
 if ! DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}" \
   node "$REPO_ROOT/scripts/devnet-shared-sweep-preflight.mjs" \
   > "$RESULTS/topology-preflight.log" 2>&1; then
@@ -120,8 +135,14 @@ if ! healthy; then log "FATAL: devnet not healthy at start — restart it first"
 log "devnet healthy ($SWEEP_NODE_COUNT nodes + hardhat)."
 
 # ── Phase 1: baseline one pass ────────────────────────────────────
-log "═══ PHASE 1: baseline one pass (${STABILITY_SUITES}) ═══"
-for s in $STABILITY_SUITES; do r=$(run_suite "$s" "P1-$s"); log "  $(printf '%-6s' "$r") $s"; tally "$s" "$r"; done
+log "═══ PHASE 1: baseline one pass (${BASELINE_SUITES}) ═══"
+load_scheduled_phase baseline 0 || exit $?
+while IFS=$'\t' read -r tag s; do
+  [ -n "$s" ] || continue
+  r=$(run_suite "$s" "$tag")
+  log "  $(printf '%-6s' "$r") $s"
+  tally "$s" "$r"
+done <<< "$SWEEP_PHASE_SCHEDULE"
 
 # ── Phase 2: health-guarded stability loop ────────────────────────
 log "═══ PHASE 2: stability loop until $(loop_deadline)s elapsed (health-guarded) ═══"
@@ -133,12 +154,14 @@ while [ "$(elapsed)" -lt "$(loop_deadline)" ]; do
   fi
   ROUND=$(( ROUND + 1 ))
   log "── round $ROUND (elapsed $(elapsed)s / $(loop_deadline)s) ──"
-  for s in $STABILITY_SUITES; do
+  load_scheduled_phase stability "$ROUND" || exit $?
+  while IFS=$'\t' read -r tag s; do
+    [ -n "$s" ] || continue
     [ "$(elapsed)" -lt "$(loop_deadline)" ] || break
-    r=$(run_suite "$s" "P2-r${ROUND}-$s")
+    r=$(run_suite "$s" "$tag")
     [ "$r" = "pass" ] || log "    $r $s (round $ROUND)"
     tally "$s" "$r"
-  done
+  done <<< "$SWEEP_PHASE_SCHEDULE"
 done
 [ "$ABORTED" = "0" ] && log "PHASE 2 done: $ROUND rounds."
 

--- a/scripts/lib/sweep-phase-schedule.sh
+++ b/scripts/lib/sweep-phase-schedule.sh
@@ -1,0 +1,17 @@
+# Capture one selector phase in the current shell. The caller owns diagnostics
+# and exit policy; this boundary only guarantees that a successful result is a
+# non-empty, fully materialized schedule.
+capture_sweep_phase_schedule() { # $1=baseline|stability $2=round
+  local phase="$1" round="$2"
+  SWEEP_PHASE_SCHEDULE=""
+  if ! SWEEP_PHASE_SCHEDULE=$(node \
+    "$SWEEP_SELECTOR" \
+    "$SUITES_JSON" \
+    "$phase" \
+    "$round" \
+    "$STABILITY_OVERRIDE"); then
+    SWEEP_PHASE_SCHEDULE=""
+    return 1
+  fi
+  [ -n "$SWEEP_PHASE_SCHEDULE" ]
+}

--- a/scripts/lib/sweep-suite-selector.mjs
+++ b/scripts/lib/sweep-suite-selector.mjs
@@ -1,0 +1,98 @@
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const ALWAYS_REPEATABLE_SUITE = 'v10-end-to-end';
+
+function requireSuiteList(manifest, key) {
+  const suites = manifest?.[key];
+  if (!Array.isArray(suites) || suites.some((suite) => typeof suite !== 'string' || !suite)) {
+    throw new TypeError(`sweep manifest ${key} must be an array of non-empty suite names`);
+  }
+  return suites;
+}
+
+function overrideSuites(stabilityOverride) {
+  if (typeof stabilityOverride !== 'string' || stabilityOverride.trim() === '') return undefined;
+  return stabilityOverride.trim().split(/\s+/);
+}
+
+/**
+ * Canonical sweep policy. An explicit stability override is authoritative;
+ * baselineOnly filtering applies only to the default stability selection.
+ */
+export function selectSweepSuites(manifest, stabilityOverride) {
+  const prCoverage = requireSuiteList(manifest, 'prCoverage');
+  const baselineOnly = requireSuiteList(manifest, 'baselineOnly');
+  const baselineOnlySet = new Set(baselineOnly);
+  const explicitStability = overrideSuites(stabilityOverride);
+
+  return {
+    baseline: [...prCoverage, ALWAYS_REPEATABLE_SUITE],
+    stability: explicitStability ?? [
+      ...prCoverage.filter((suite) => !baselineOnlySet.has(suite)),
+      ALWAYS_REPEATABLE_SUITE,
+    ],
+  };
+}
+
+/** Return the exact records consumed by one operational sweep phase. */
+export function scheduleSweepPhase(selection, phase, round = 0) {
+  if (phase !== 'baseline' && phase !== 'stability') {
+    throw new TypeError(`unknown sweep phase: ${phase}`);
+  }
+  if (phase === 'stability' && (!Number.isInteger(round) || round < 1)) {
+    throw new TypeError('stability round must be a positive integer');
+  }
+
+  const suites = phase === 'baseline' ? selection.baseline : selection.stability;
+  return suites.map((suite) => ({
+    phase,
+    round,
+    suite,
+    logTag: phase === 'baseline' ? `P1-${suite}` : `P2-r${round}-${suite}`,
+  }));
+}
+
+function readManifest(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function writeCliOutput(manifestPath, mode, roundArg, stabilityOverride) {
+  const manifest = readManifest(manifestPath);
+  const selection = selectSweepSuites(manifest, stabilityOverride);
+
+  if (mode === 'selection') {
+    const nodeCount = manifest?.sharedSweep?.nodeCount;
+    if (!Number.isInteger(nodeCount) || nodeCount < 1) {
+      throw new TypeError('sweep manifest sharedSweep.nodeCount must be a positive integer');
+    }
+    process.stdout.write([
+      selection.baseline.join(' '),
+      selection.stability.join(' '),
+      String(nodeCount),
+      String(manifest.prCoverage.length),
+    ].join('\t'));
+    return;
+  }
+
+  const round = mode === 'stability' ? Number(roundArg) : 0;
+  const records = scheduleSweepPhase(selection, mode, round);
+  process.stdout.write(records.map(({ logTag, suite }) => `${logTag}\t${suite}`).join('\n'));
+  if (records.length > 0) process.stdout.write('\n');
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(process.argv[1]).href : '';
+if (import.meta.url === invokedPath) {
+  try {
+    const [, , manifestPath, mode, roundArg = '0', stabilityOverride] = process.argv;
+    if (!manifestPath || !mode) {
+      throw new TypeError(
+        'usage: node sweep-suite-selector.mjs <manifest> <selection|baseline|stability> [round] [stability override]',
+      );
+    }
+    writeCliOutput(manifestPath, mode, roundArg, stabilityOverride);
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 2;
+  }
+}


### PR DESCRIPTION
## Summary

Provides a real-transaction, daemon-safe six-node regression fixture for #2440. Behavioral assertions stay visible in the scenario file; primitive operations and typed evidence live in the fixture; lifecycle ownership, known-transaction reconciliation, and targeted cleanup live behind a dedicated owner. No whole-chain rewind is used, so canonical daemon jobs, VM materialization, and unrelated transactions survive fixture disposal.

The lifecycle temporarily activates the dormant shared-devnet registration deposit through the canonical Hub owner, restores it with conflict-aware cleanup, creates a private PCA owner, funds/mints/registers through remembered signed transactions, and returns unused native gas. Accepted-but-response-lost funding/mint cases, deterministic cleanup failures, error-keyed retry, global drain, recreate-after-disposal, and idempotent teardown are all exercised against live daemons.

Registration-cost evidence is scoped to the exact registration receipt: wallet B signs the waived registration, no operational wallet funds or approves a registration deposit, escrow remains zero, and sync/async first publish preserve the required signer continuity. Canonical RandomSampling gas and legitimate KA publish fees are not misclassified as fixture-owned registration costs.

The shared sweep materializes and validates each baseline/stability schedule before entering its parent-shell loop. Selector failures and unexpectedly empty schedules abort with exit 2 instead of being masked by Bash process substitution.

## Related

Completes #2440 together with #2442, #2443, and #2444.

PR 4 of 4, stacked on #2444.

## Files changed

- `automated.test.ts`: visible lifecycle, recovery, signer, waiver, receipt, sync, and async assertions.
- `live-pca-publisher-fixture.ts`: primitive operations, typed registration/publisher evidence, and deferred-cleanup registry.
- `live-pca-publisher-lifecycle.ts`: targeted lifecycle ownership, exact signed-transaction reconciliation, fault injection, PCA detachment, native/TRAC recovery, and conflict-aware deposit restoration.
- `known-transaction.test.ts` and `cleanup-stack.test.ts`: pure uncertain-broadcast and retry/idempotence coverage.
- Devnet manifest/scheduler integration: one baseline-only execution in the shared six-node sweep, reusing the canonical topology validator.
- `sweep-phase-schedule.sh`: fail-closed selector-status/empty-output bridge used by both operational loops and shell-level regressions.

## Test plan

- [x] Fresh exact-head WSL run: 3 files, 22/22 in 606.44 seconds at `ef7a5fbf763bd67da8b00f551b51cc74e9d88787`.
- [x] Strict preflight: exactly 6 nodes, publisher wallet index 1.
- [x] Both sync and async first-publish paths register through PCA-qualified wallet B; the async broadcast retains wallet B.
- [x] Accepted funding and mint response loss reconcile by remembered transaction identity without replacing unrelated nonces.
- [x] Error-keyed retry and global drain recover a one-shot detachment cleanup failure and become no-ops afterward.
- [x] Disposal restores fixture-owned deposit/allowance/binding resources, returns private-owner native gas, preserves canonical daemon effects, and supports a fresh second fixture.
- [x] Exact-head shell syntax, manifest/topology/scheduler suite 20/20, and offline lifecycle suite 9/9.
- [x] Exact-head root build and lint passed under WSL/Node 22.
- [x] Six nodes, Hardhat, harness ports, generated deployment registry, and WSL worktree were cleaned.
- [ ] Required CI and fresh reviewer verdict on exact head `ef7a5fbf763bd67da8b00f551b51cc74e9d88787`.
