### PR TITLE
feat(local-llm): support Ollama alongside llama.cpp

### DIFF
--- a/docs/use-dkg/local-llm-agent-runbook.md
+++ b/docs/use-dkg/local-llm-agent-runbook.md
@@ -101,50 +101,12 @@ OpenAI-compatible contract and DKG smoke tests.
 
 ## Install Ollama when selected
 
-Use the official [`Ollama Quickstart`](https://docs.ollama.com/quickstart) for
-the detected operating system. Resolve and verify the executable, then pull the
-model:
-
-```bash
-command -v ollama
-ollama --version
-ollama pull qwen3:8b
-```
-
-Start `ollama serve` only if the desktop application or system service is not
-already listening on `127.0.0.1:11434`. DKG requires at least an 8192-token
-Ollama context. Configure it through one of the supported ownership paths:
-
-- **Ollama desktop application:** open Settings, set **Context length** to at
-  least `8192`, then restart the application.
-- **Terminal-owned server:** start it with
-  `OLLAMA_CONTEXT_LENGTH=8192 ollama serve`.
-- **Linux systemd service:** run `sudo systemctl edit ollama`, add the override
-  below, then run `sudo systemctl daemon-reload` and
-  `sudo systemctl restart ollama`:
-
-  ```ini
-  [Service]
-  Environment="OLLAMA_CONTEXT_LENGTH=8192"
-  ```
-
-These are the official Ollama
-[`Context length`](https://docs.ollama.com/context-length) and
-[`server configuration`](https://docs.ollama.com/faq#how-do-i-configure-ollama-server)
-paths. Load the model once and verify the allocation before starting DKG chat:
-
-```bash
-ollama run qwen3:8b "Reply with OK."
-ollama ps
-```
-
-Require the selected model's `CONTEXT` value from `ollama ps` to be at least
-`8192`; HTTP 200 from `/v1/models` alone does not prove the context allocation.
-Then verify the shared readiness route:
-
-```bash
-curl -sS http://127.0.0.1:11434/v1/models
-```
+Complete the full guide's canonical
+[Install and run Ollama](local-llm.md#install-and-run-ollama) procedure. That
+single section owns installation, desktop/terminal/systemd server ownership,
+the minimum context, model loading, and readiness checks. Record the resolved
+executable, version, selected model tag, `ollama ps` context, and exact
+`/v1/models` match as agent evidence; do not restate or vary the policy here.
 
 ## Model decision table
 
@@ -187,9 +149,8 @@ Constraints:
 Procedure:
 1. Detect macOS, Linux, or Windows. For llama.cpp, install `llama-server`, set
    `LLAMA_SERVER` to its absolute path, and run `llama-server --version`. For
-   Ollama, install it from the official Quickstart, run `ollama --version`, and
-   pull the selected model tag. Do not continue if the selected executable
-   cannot run.
+   Ollama, complete the canonical Ollama procedure linked above. Do not continue
+   if the selected executable or its readiness gates fail.
 2. Detect whether this is an installed DKG or a source checkout. For an
    installed DKG, run `dkg doctor --json`, `dkg --version`, and `dkg status`.
    In a source checkout, build the CLI, MCP, and local-LLM packages and use
@@ -217,11 +178,8 @@ Procedure:
    Fix or remove any selector that errors or returns the wrong result shape.
 10. Start the selected backend. For llama.cpp, use an 8192-token context, Jinja
     templates, temperature 0.15, top-p 0.9, repeat penalty 1.05, host
-    127.0.0.1, and port 8080. For Ollama, configure at least 8192 tokens through
-    the desktop Context length setting, `OLLAMA_CONTEXT_LENGTH=8192 ollama serve`,
-    or the systemd service override; ensure the service is listening on
-    127.0.0.1:11434 and the selected model tag is pulled. Load it once and
-    require `ollama ps` to report `CONTEXT` of at least 8192.
+    127.0.0.1, and port 8080. For Ollama, complete every gate in the canonical
+    Ollama procedure linked above without copying or changing that policy.
 11. Run `curl -sS <server-origin>/v1/models` and require HTTP 200. For
     llama.cpp, also check `/health` and require `{"status":"ok"}`.
 12. Start the final chat with
@@ -294,35 +252,13 @@ dkg llm \
 
 ### Ollama launch
 
-Pull the model, start the service if it is not already running, and verify the
-model list:
+Complete the canonical
+[Install and run Ollama](local-llm.md#install-and-run-ollama) procedure first.
+It is the sole source for installation, context ownership, and readiness. Once
+that procedure passes, start the read-only DKG chat against the verified server:
 
 ```bash
 export DKG_PROJECT=<exact-context-graph-id>
-ollama pull qwen3:8b
-```
-
-Run the server in its own terminal if no Ollama service is already active:
-
-```bash
-OLLAMA_CONTEXT_LENGTH=8192 ollama serve
-```
-
-Then verify it from the DKG client terminal:
-
-```bash
-ollama run qwen3:8b "Reply with OK."
-ollama ps
-curl -sS http://127.0.0.1:11434/v1/models
-```
-
-Omit `ollama serve` if an existing Ollama desktop application or service
-already owns port `11434`; configure that owner through the desktop setting or
-systemd override documented above. Do not continue unless `ollama ps` reports
-at least `8192` for the selected model. Start the same read-only DKG chat against
-Ollama:
-
-```bash
 dkg llm \
   --interactive \
   --project "$DKG_PROJECT" \
@@ -332,7 +268,8 @@ dkg llm \
 ```
 
 For Node UI, export those endpoint and model values as `DKG_LLM_URL` and
-`DKG_LLM_MODEL` in the daemon environment before starting or restarting DKG.
+`DKG_LLM_MODEL`, and set `DKG_LLM_BACKEND=ollama`, in the daemon environment
+before starting or restarting DKG.
 
 For an explicitly approved Query Catalog build, use the recommended Qwen
 llama.cpp server and temporarily start this client:

--- a/docs/use-dkg/local-llm-agent-runbook.md
+++ b/docs/use-dkg/local-llm-agent-runbook.md
@@ -112,7 +112,35 @@ ollama pull qwen3:8b
 ```
 
 Start `ollama serve` only if the desktop application or system service is not
-already listening on `127.0.0.1:11434`. Verify the shared readiness route:
+already listening on `127.0.0.1:11434`. DKG requires at least an 8192-token
+Ollama context. Configure it through one of the supported ownership paths:
+
+- **Ollama desktop application:** open Settings, set **Context length** to at
+  least `8192`, then restart the application.
+- **Terminal-owned server:** start it with
+  `OLLAMA_CONTEXT_LENGTH=8192 ollama serve`.
+- **Linux systemd service:** run `sudo systemctl edit ollama`, add the override
+  below, then run `sudo systemctl daemon-reload` and
+  `sudo systemctl restart ollama`:
+
+  ```ini
+  [Service]
+  Environment="OLLAMA_CONTEXT_LENGTH=8192"
+  ```
+
+These are the official Ollama
+[`Context length`](https://docs.ollama.com/context-length) and
+[`server configuration`](https://docs.ollama.com/faq#how-do-i-configure-ollama-server)
+paths. Load the model once and verify the allocation before starting DKG chat:
+
+```bash
+ollama run qwen3:8b "Reply with OK."
+ollama ps
+```
+
+Require the selected model's `CONTEXT` value from `ollama ps` to be at least
+`8192`; HTTP 200 from `/v1/models` alone does not prove the context allocation.
+Then verify the shared readiness route:
 
 ```bash
 curl -sS http://127.0.0.1:11434/v1/models
@@ -189,8 +217,11 @@ Procedure:
    Fix or remove any selector that errors or returns the wrong result shape.
 10. Start the selected backend. For llama.cpp, use an 8192-token context, Jinja
     templates, temperature 0.15, top-p 0.9, repeat penalty 1.05, host
-    127.0.0.1, and port 8080. For Ollama, ensure its service is listening on
-    127.0.0.1:11434 and the selected model tag is pulled.
+    127.0.0.1, and port 8080. For Ollama, configure at least 8192 tokens through
+    the desktop Context length setting, `OLLAMA_CONTEXT_LENGTH=8192 ollama serve`,
+    or the systemd service override; ensure the service is listening on
+    127.0.0.1:11434 and the selected model tag is pulled. Load it once and
+    require `ollama ps` to report `CONTEXT` of at least 8192.
 11. Run `curl -sS <server-origin>/v1/models` and require HTTP 200. For
     llama.cpp, also check `/health` and require `{"status":"ok"}`.
 12. Start the final chat with
@@ -274,17 +305,22 @@ ollama pull qwen3:8b
 Run the server in its own terminal if no Ollama service is already active:
 
 ```bash
-ollama serve
+OLLAMA_CONTEXT_LENGTH=8192 ollama serve
 ```
 
 Then verify it from the DKG client terminal:
 
 ```bash
+ollama run qwen3:8b "Reply with OK."
+ollama ps
 curl -sS http://127.0.0.1:11434/v1/models
 ```
 
 Omit `ollama serve` if an existing Ollama desktop application or service
-already owns port `11434`. Start the same read-only DKG chat against Ollama:
+already owns port `11434`; configure that owner through the desktop setting or
+systemd override documented above. Do not continue unless `ollama ps` reports
+at least `8192` for the selected model. Start the same read-only DKG chat against
+Ollama:
 
 ```bash
 dkg llm \

--- a/docs/use-dkg/local-llm-agent-runbook.md
+++ b/docs/use-dkg/local-llm-agent-runbook.md
@@ -8,12 +8,23 @@ doc_type: runbook
 # Local LLM Agent Runbook
 
 Use this runbook when an operator asks an AI coding agent to start a local
-`llama.cpp` model, connect it to DKG, and prove that DKG tool use works. The
-agent must not report the setup as ready until the DKG daemon, model endpoint,
-Query Catalog policy, and smoke tests have all been checked.
+llama.cpp or Ollama model, connect it to DKG, and prove that DKG tool use works.
+The agent must not report the setup as ready until the DKG daemon, model
+endpoint, Query Catalog policy, and smoke tests have all been checked.
 
 For architecture, troubleshooting, and benchmark details, see
 [`Run a Local LLM with DKG`](local-llm.md).
+
+## Select the backend
+
+Keep the operator's explicit choice. If no backend is named, use llama.cpp as
+the reference server. Ollama is a supported alternative, not a replacement for
+llama.cpp.
+
+| Backend | Chat endpoint | Readiness | Recommended model value |
+| --- | --- | --- | --- |
+| llama.cpp | `http://127.0.0.1:8080/v1/chat/completions` | `/v1/models`, with `/health` fallback | `qwen3-8b-q4-k-m` |
+| Ollama | `http://127.0.0.1:11434/v1/chat/completions` | `/v1/models` | `qwen3:8b` |
 
 ## Install the default llama.cpp server
 
@@ -84,9 +95,28 @@ If Winget is unavailable or a custom CUDA build is required, use the Visual
 Studio or release-binary procedure in the full
 [`Windows instructions`](local-llm.md#windows).
 
-Do not silently replace `llama-server` with Ollama, LM Studio, vLLM, or another
-runtime. Another server is allowed only when the operator explicitly chooses
-it and its OpenAI-compatible endpoint passes the same DKG smoke tests.
+Do not silently change the selected backend. llama.cpp and Ollama are supported;
+any other runtime requires an explicit operator choice and must pass the same
+OpenAI-compatible contract and DKG smoke tests.
+
+## Install Ollama when selected
+
+Use the official [`Ollama Quickstart`](https://docs.ollama.com/quickstart) for
+the detected operating system. Resolve and verify the executable, then pull the
+model:
+
+```bash
+command -v ollama
+ollama --version
+ollama pull qwen3:8b
+```
+
+Start `ollama serve` only if the desktop application or system service is not
+already listening on `127.0.0.1:11434`. Verify the shared readiness route:
+
+```bash
+curl -sS http://127.0.0.1:11434/v1/models
+```
 
 ## Model decision table
 
@@ -97,8 +127,9 @@ it and its OpenAI-compatible endpoint passes the same DKG smoke tests.
 | Qwen3.8-27B UD-IQ1_M | Download `Qwen3.8-27B-UD-IQ1_M.gguf` from `unsloth/Qwen3.8-27B-GGUF`, then use `-m` | `qwen3.8-27b-iq1` | 9/13 | Not recommended on 16 GB. Slow and memory-heavy; catalog-first is mandatory |
 
 The score is from the repository's 13-scenario real-DKG benchmark on the
-reference 16 GB Apple Silicon machine. It is comparative evidence, not a
-universal hardware guarantee.
+reference 16 GB Apple Silicon machine using llama.cpp. It is comparative
+evidence, not an Ollama parity claim or universal hardware guarantee. An Ollama
+model/server combination must pass the smoke test and benchmark independently.
 
 ## Instruction to give an AI coding agent
 
@@ -112,9 +143,9 @@ ready for the operator.
 Constraints:
 - Work from the active DKG installation or repository; do not clone another DKG.
 - Discover absolute executable paths. Do not assume a user-specific home path.
-- Use llama.cpp `llama-server` as the reference inference server. If it is not
-  installed, follow "Install the default llama.cpp server" in this runbook;
-  do not substitute another server silently.
+- Keep the backend named by the operator: llama.cpp or Ollama. If none is
+  named, use llama.cpp as the reference. Follow the matching install section;
+  do not change backends silently.
 - Default to Qwen3-8B Q4_K_M unless the operator names another model.
 - Treat Bonsai Q1_0, 1-bit models, and other tool-weak models as catalog-first.
 - For a catalog-first model, do not start the final demo chat until a reviewed,
@@ -123,12 +154,14 @@ Constraints:
 - Never invent Context Graph IDs, query selectors, parameters, or DKG evidence.
 - Keep DKG writes disabled except during an explicitly approved catalog-build
   step. Never share, publish, register, or delete data without explicit approval.
-- Run one llama-server on port 8080 at a time.
+- Run one selected local model server on its configured port at a time.
 
 Procedure:
-1. Detect macOS, Linux, or Windows. Install `llama-server` with the matching
-   section in this runbook, set `LLAMA_SERVER` to its absolute path, and run
-   `llama-server --version`. Do not continue if the executable cannot run.
+1. Detect macOS, Linux, or Windows. For llama.cpp, install `llama-server`, set
+   `LLAMA_SERVER` to its absolute path, and run `llama-server --version`. For
+   Ollama, install it from the official Quickstart, run `ollama --version`, and
+   pull the selected model tag. Do not continue if the selected executable
+   cannot run.
 2. Detect whether this is an installed DKG or a source checkout. For an
    installed DKG, run `dkg doctor --json`, `dkg --version`, and `dkg status`.
    In a source checkout, build the CLI, MCP, and local-LLM packages and use
@@ -154,13 +187,16 @@ Procedure:
    representative values:
    `dkg query-catalog run "$DKG_PROJECT" <selector> --param name=value`.
    Fix or remove any selector that errors or returns the wrong result shape.
-10. Start the selected llama-server with an 8192-token context, Jinja templates,
-   temperature 0.15, top-p 0.9, repeat penalty 1.05, host 127.0.0.1, and port
-   8080. Wait for the model-loaded message.
-11. Run `curl -sS http://127.0.0.1:8080/health` and require `{"status":"ok"}`.
-12. Start the final chat with `dkg llm --interactive --project "$DKG_PROJECT"`.
+10. Start the selected backend. For llama.cpp, use an 8192-token context, Jinja
+    templates, temperature 0.15, top-p 0.9, repeat penalty 1.05, host
+    127.0.0.1, and port 8080. For Ollama, ensure its service is listening on
+    127.0.0.1:11434 and the selected model tag is pulled.
+11. Run `curl -sS <server-origin>/v1/models` and require HTTP 200. For
+    llama.cpp, also check `/health` and require `{"status":"ok"}`.
+12. Start the final chat with
+    `dkg llm --interactive --project "$DKG_PROJECT" --llama-url <chat-endpoint> --model <model>`.
     For catalog-first models also pass `--profile catalog`; do not pass
-    `--allow-write`. For the default Qwen model use `--profile auto`.
+    `--allow-write`. For the recommended Qwen model use `--profile auto`.
 13. Smoke test: ordinary `hello` must not call DKG; a node-status question must
     call `dkg_status`; a saved-query question must call
     `dkg_query_catalog_list`; running a selector must call
@@ -188,6 +224,8 @@ pnpm --filter @origintrail-official/dkg build
 Then use `node packages/cli/dist/cli.js` in place of `dkg` in the commands
 below. Set `DKG_HOME` explicitly when the source checkout must use a non-default
 node home.
+
+### llama.cpp reference launch
 
 Set values once in the shell running the client:
 
@@ -219,11 +257,49 @@ dkg llm \
   --interactive \
   --project "$DKG_PROJECT" \
   --profile auto \
+  --llama-url http://127.0.0.1:8080/v1/chat/completions \
   --model qwen3-8b-q4-k-m
 ```
 
+### Ollama launch
+
+Pull the model, start the service if it is not already running, and verify the
+model list:
+
+```bash
+export DKG_PROJECT=<exact-context-graph-id>
+ollama pull qwen3:8b
+```
+
+Run the server in its own terminal if no Ollama service is already active:
+
+```bash
+ollama serve
+```
+
+Then verify it from the DKG client terminal:
+
+```bash
+curl -sS http://127.0.0.1:11434/v1/models
+```
+
+Omit `ollama serve` if an existing Ollama desktop application or service
+already owns port `11434`. Start the same read-only DKG chat against Ollama:
+
+```bash
+dkg llm \
+  --interactive \
+  --project "$DKG_PROJECT" \
+  --profile auto \
+  --llama-url http://127.0.0.1:11434/v1/chat/completions \
+  --model qwen3:8b
+```
+
+For Node UI, export those endpoint and model values as `DKG_LLM_URL` and
+`DKG_LLM_MODEL` in the daemon environment before starting or restarting DKG.
+
 For an explicitly approved Query Catalog build, use the recommended Qwen
-server and temporarily start this client:
+llama.cpp server and temporarily start this client:
 
 ```bash
 dkg llm \

--- a/docs/use-dkg/local-llm.md
+++ b/docs/use-dkg/local-llm.md
@@ -235,16 +235,41 @@ Install Ollama using its official
 ```bash
 ollama --version
 ollama pull qwen3:8b
-ollama serve
+OLLAMA_CONTEXT_LENGTH=8192 ollama serve
 ```
 
 The desktop application may already have the server running. If `ollama serve`
 reports that port `11434` is already in use, keep the existing Ollama server and
-do not start a second one. Verify the shared OpenAI-compatible contract:
+do not start a second one. DKG's prompt, history, and tool budget require an
+Ollama context of at least 8192 tokens. For the desktop application, set the
+**Context length** slider in Settings to at least `8192` and restart the app. For
+a Linux system service, run `sudo systemctl edit ollama`, add this override, then
+reload and restart the service:
+
+```ini
+[Service]
+Environment="OLLAMA_CONTEXT_LENGTH=8192"
+```
 
 ```bash
+sudo systemctl daemon-reload
+sudo systemctl restart ollama
+```
+
+The commands follow Ollama's official
+[`Context length`](https://docs.ollama.com/context-length) and
+[`server configuration`](https://docs.ollama.com/faq#how-do-i-configure-ollama-server)
+guidance. Load the selected model, then verify both its allocation and the shared
+OpenAI-compatible contract:
+
+```bash
+ollama run qwen3:8b "Reply with OK."
+ollama ps
 curl -sS http://127.0.0.1:11434/v1/models
 ```
+
+Require `ollama ps` to report `CONTEXT` of at least `8192` for `qwen3:8b`.
+`/v1/models` returning HTTP 200 is not proof of the allocated context length.
 
 Use these DKG settings for Ollama:
 
@@ -469,16 +494,21 @@ In the model-server terminal, if the desktop application or system service is
 not already running:
 
 ```bash
-ollama serve
+OLLAMA_CONTEXT_LENGTH=8192 ollama serve
 ```
 
 From another terminal:
 
 ```bash
+ollama run qwen3:8b "Reply with OK."
+ollama ps
 curl -sS http://127.0.0.1:11434/v1/models
 ```
 
-If the desktop application already owns port `11434`, omit `ollama serve`.
+If the desktop application already owns port `11434`, omit `ollama serve`, set
+its Context length slider to at least `8192`, and restart it. If systemd owns the
+port, use the `OLLAMA_CONTEXT_LENGTH=8192` service override above. Require
+`ollama ps` to report at least `8192` before starting DKG chat.
 
 ## Terminal 3: start DKG chat
 

--- a/docs/use-dkg/local-llm.md
+++ b/docs/use-dkg/local-llm.md
@@ -7,11 +7,11 @@ doc_type: how-to
 
 # Run a Local LLM with DKG
 
-Use this guide to connect a local GGUF model to the DKG MCP tools through the
-OpenAI-compatible `llama.cpp` server. The model does not connect to the DKG
-daemon directly: `dkg llm` starts an MCP client, discovers the available tools
-with `tools/list`, validates every tool call, and writes a readable interaction
-trace.
+Use this guide to connect a local model to the DKG MCP tools through an
+OpenAI-compatible `llama.cpp` or Ollama server. The model does not connect to
+the DKG daemon directly: `dkg llm` starts an MCP client, discovers the available
+tools with `tools/list`, validates every tool call, and writes a readable
+interaction trace.
 
 The runtime is read-only by default. Write tools are exposed only with
 `--allow-write`, and the user must still explicitly request the mutation.
@@ -21,11 +21,13 @@ If you are delegating setup to a coding agent, give it the dedicated
 copy-paste instruction, model decision table, Query Catalog gate, exact launch
 commands, and completion checks.
 
-## Proposal: use llama.cpp as the reference LLM server
+## Supported local model servers
 
 Use [`llama.cpp`](https://github.com/ggml-org/llama.cpp) and its
 `llama-server` executable as the default, documented local inference server for
-DKG.
+DKG. [`Ollama`](https://docs.ollama.com/) is also supported through the same
+OpenAI-compatible API boundary. Choose one server per DKG local-LLM session;
+adding Ollama support does not remove or replace llama.cpp support.
 
 This selects the inference runtime, not the model family: `llama-server` can
 serve Qwen, Bonsai, Llama, and other compatible GGUF models. Qwen3-8B Q4_K_M
@@ -33,27 +35,28 @@ remains the recommended model below.
 
 The boundary should remain explicit:
 
-- `llama-server` is an operator-managed process. DKG does not silently install,
-  upgrade, start, or stop it.
+- The local model server is operator-managed. DKG does not silently install,
+  upgrade, start, or stop llama.cpp or Ollama.
 - `dkg llm` owns the MCP client, tool discovery, metadata-driven relevance
   routing, DKG system context, schema validation, retry policy, bounded chat
   history, and text trace.
-- Do not bypass that harness by attaching the DKG MCP server directly through
-  llama.cpp's own MCP configuration. That would skip DKG's tested system
-  context, tool-budget routing, validation, retry, and readable interaction log.
+- Do not bypass that harness by attaching the DKG MCP server directly through a
+  model server's own tool or MCP configuration. That would skip DKG's tested
+  system context, tool-budget routing, validation, retry, and readable
+  interaction log.
 - The default endpoint is
   `http://127.0.0.1:8080/v1/chat/completions`; `--llama-url` and `DKG_LLM_URL`
   remain escape hatches for another compatible server.
-- A supported server build must provide `llama-server`, GGUF model loading,
-  Jinja chat templates, the OpenAI-compatible chat-completions endpoint, and
-  the public `/health` endpoint.
+- A supported server must provide `POST /v1/chat/completions`, non-streaming
+  OpenAI-compatible responses, and OpenAI-style tool calls. `GET /v1/models` is
+  the provider-neutral readiness contract; llama.cpp's `GET /health` remains a
+  compatibility fallback if `/v1/models` is unavailable.
 - Keep the server bound to `127.0.0.1` by default. Remote or LAN exposure needs
   an explicit authentication and network-security decision.
 
-This gives DKG one reproducible reference path across macOS, Linux, and
-Windows without making the local-LLM client llama.cpp-specific internally. The
-upstream server documents the OpenAI-compatible API and reports readiness with
-HTTP 200 plus `{"status":"ok"}`.
+This gives DKG a reproducible llama.cpp reference path across macOS, Linux, and
+Windows while keeping the client provider-neutral. Readiness succeeds through
+`/v1/models` on either backend, or through llama.cpp's `/health` fallback.
 
 ## Install llama.cpp and llama-server
 
@@ -210,7 +213,7 @@ hf auth whoami
 Do not put a Hugging Face token in a command line, repository file, or DKG
 interaction log. Use `hf auth login` or the `HF_TOKEN` environment variable.
 
-### Verify the server contract
+### Verify the llama.cpp server contract
 
 Start one of the models below, wait for loading to finish, and verify both
 readiness and the OpenAI-compatible surface:
@@ -221,7 +224,42 @@ curl -sS http://127.0.0.1:8080/v1/models
 ```
 
 Windows PowerShell can use `curl.exe` with the same URLs. Do not start
-`dkg llm` until `/health` returns HTTP 200 and `{"status":"ok"}`.
+`dkg llm` until `/v1/models` returns HTTP 200. `/health` should also return HTTP
+200 and `{"status":"ok"}` for the reference llama.cpp server.
+
+## Install and run Ollama
+
+Install Ollama using its official
+[`Quickstart`](https://docs.ollama.com/quickstart), then pull and start a model:
+
+```bash
+ollama --version
+ollama pull qwen3:8b
+ollama serve
+```
+
+The desktop application may already have the server running. If `ollama serve`
+reports that port `11434` is already in use, keep the existing Ollama server and
+do not start a second one. Verify the shared OpenAI-compatible contract:
+
+```bash
+curl -sS http://127.0.0.1:11434/v1/models
+```
+
+Use these DKG settings for Ollama:
+
+```bash
+export DKG_LLM_URL=http://127.0.0.1:11434/v1/chat/completions
+export DKG_LLM_MODEL=qwen3:8b
+```
+
+Ollama documents its OpenAI-compatible chat-completions, model-list, streaming,
+and tools support in the
+[`OpenAI compatibility guide`](https://docs.ollama.com/api/openai-compatibility).
+DKG uses non-streaming requests. Some Ollama versions or models may return
+prose even when a tool is required; the DKG runtime retries once with an
+explicit tool-only instruction and then fails closed instead of accepting an
+ungrounded DKG answer.
 
 ## Recommended model
 
@@ -236,8 +274,9 @@ Silicon machine.
 | Qwen3.8-27B UD-IQ1_M | 9/13 | High memory pressure and very slow on 16 GB | Not recommended on 16 GB; the 1-bit quantization did not outperform Qwen3-8B Q4 |
 
 These scores compare the same 13 scenarios against a real DKG daemon and MCP
-server. They are reference results, not a universal hardware benchmark. A new
-model should pass the bundled real-DKG benchmark before it becomes a recommended
+server using the documented llama.cpp reference path. They are not Ollama
+parity claims or universal hardware results. A new model and server combination
+should pass the bundled real-DKG benchmark before it becomes a recommended
 default.
 
 ## Small-model rule: build the Query Catalog first
@@ -294,8 +333,8 @@ available to the small model.
 
 - A configured DKG node and Context Graph.
 - A built or installed `dkg` CLI containing the `dkg llm` command.
-- A recent `llama.cpp` build with `llama-server`.
-- Enough memory for the selected GGUF model and an 8192-token context.
+- A recent llama.cpp `llama-server` or Ollama installation.
+- Enough memory for the selected local model and its context window.
 
 Verify an installed node:
 
@@ -334,11 +373,15 @@ DKG_HOME="$DKG_HOME" \
 
 Leave the daemon running. Its default API is `http://127.0.0.1:9200`.
 
-## Terminal 2: start one local model
+## Terminal 2: start one local model server
+
+Choose either llama.cpp or Ollama. Do not run two servers on the same port.
+
+### Option A: llama.cpp reference server
 
 Run only one `llama-server` on port 8080 at a time.
 
-### Recommended: Qwen3-8B Q4_K_M
+#### Recommended: Qwen3-8B Q4_K_M
 
 ```bash
 /absolute/path/to/llama.cpp/build/bin/llama-server \
@@ -354,7 +397,7 @@ Run only one `llama-server` on port 8080 at a time.
   --port 8080
 ```
 
-### Low-memory experiment: Bonsai-8B Q1_0
+#### Low-memory experiment: Bonsai-8B Q1_0
 
 Use this model only after completing the Query-Catalog-first workflow above.
 
@@ -372,7 +415,7 @@ Use this model only after completing the Query-Catalog-first workflow above.
   --port 8080
 ```
 
-### 27B 1-bit experiment
+#### 27B 1-bit experiment
 
 This configuration is not recommended on a 16 GB machine. If testing it, use
 one slot and disable the unused vision projector:
@@ -406,6 +449,36 @@ Expected result:
 ```json
 {"status":"ok"}
 ```
+
+Also verify the provider-neutral readiness route:
+
+```bash
+curl -sS http://127.0.0.1:8080/v1/models
+```
+
+### Option B: Ollama
+
+Pull the model once, start Ollama if it is not already running, and verify its
+OpenAI-compatible model list:
+
+```bash
+ollama pull qwen3:8b
+```
+
+In the model-server terminal, if the desktop application or system service is
+not already running:
+
+```bash
+ollama serve
+```
+
+From another terminal:
+
+```bash
+curl -sS http://127.0.0.1:11434/v1/models
+```
+
+If the desktop application already owns port `11434`, omit `ollama serve`.
 
 ## Terminal 3: start DKG chat
 
@@ -450,6 +523,20 @@ The default endpoint is
 `http://127.0.0.1:8080/v1/chat/completions`. Override it with `--llama-url` or
 `DKG_LLM_URL`.
 
+For Ollama, use its endpoint and exact model tag:
+
+```bash
+dkg llm \
+  --interactive \
+  --project "$DKG_PROJECT" \
+  --llama-url http://127.0.0.1:11434/v1/chat/completions \
+  --model qwen3:8b
+```
+
+`--llama-url` is the existing compatibility option name; it accepts any
+supported OpenAI-compatible local endpoint and does not select llama.cpp by
+itself.
+
 ## Use the local LLM from Node UI
 
 Node UI exposes the same tested local-LLM runtime in the **Agents** panel. It
@@ -459,7 +546,7 @@ owns the session, MCP child process, DKG tool discovery, schema validation,
 read-only policy, and text trace.
 
 Set the model endpoint and model name in the environment that starts the DKG
-daemon:
+daemon. For llama.cpp:
 
 ```bash
 export DKG_LLM_URL=http://127.0.0.1:8080/v1/chat/completions
@@ -467,12 +554,22 @@ export DKG_LLM_MODEL=qwen3-8b-q4-k-m
 dkg start
 ```
 
+For Ollama:
+
+```bash
+export DKG_LLM_URL=http://127.0.0.1:11434/v1/chat/completions
+export DKG_LLM_MODEL=qwen3:8b
+dkg start
+```
+
 If the daemon is already running, restart it after changing these variables.
-Keep `llama-server` running in its own terminal, then open Node UI and select
-**DKG Local LLM** in the Agents panel. The integration remains read-only: the
-daemon always creates this UI runtime with writes disabled. The HTTP surface is
-also node-admin-only. Agent-scoped bearer tokens receive `403` and cannot start,
-continue, or clear the daemon-owned operator session.
+Keep the selected local model server running, then open Node UI and select **DKG
+Local LLM** in the Agents panel. There is no separate provider selector in the
+browser: Node UI uses `DKG_LLM_URL` and `DKG_LLM_MODEL` from the daemon
+environment. The integration remains read-only: the daemon always creates this
+UI runtime with writes disabled. The HTTP surface is also node-admin-only.
+Agent-scoped bearer tokens receive `403` and cannot start, continue, or clear
+the daemon-owned operator session.
 
 The selected Context Graph is sent with the first chat turn and becomes the
 session lock. Selecting another graph does not silently retarget the active
@@ -499,19 +596,24 @@ Graph lock reset are both complete.
 ```mermaid
 sequenceDiagram
   actor Operator
-  participant Llama as llama-server
+  participant Model as Local model server
   participant Daemon as DKG daemon
   participant Service as LocalLlmService
   participant UI as Node UI
 
-  Operator->>Llama: Start GGUF model on 127.0.0.1:8080
+  Operator->>Model: Start llama.cpp or Ollama
   Operator->>Daemon: Start DKG with DKG_LLM_URL and DKG_LLM_MODEL
   Daemon->>Service: Create read-only service
   Note over Service: No MCP child and no model session yet
   UI->>Daemon: GET /api/local-llm/health
   Daemon->>Service: health()
-  Service->>Llama: GET /health
-  Llama-->>Service: 200 {status: "ok"}
+  Service->>Model: GET /v1/models
+  alt OpenAI-compatible models route is ready
+    Model-->>Service: 200 model list
+  else Models route unavailable
+    Service->>Model: GET /health (llama.cpp fallback)
+    Model-->>Service: 200 {status: "ok"}
+  end
   Service-->>Daemon: ready, reachable, busy, initialized
   Daemon-->>UI: Render DKG Local LLM as available
 ```
@@ -530,7 +632,7 @@ sequenceDiagram
   participant API as DKG daemon API
   participant Service as LocalLlmService
   participant Runtime as DkgLocalLlmRuntime
-  participant Llama as llama-server
+  participant Model as Local model server
   participant MCP as dkg mcp serve
   participant DKG as DKG node and store
   participant Trace as Text trace
@@ -539,7 +641,7 @@ sequenceDiagram
   UI->>API: POST /api/local-llm/chat<br/>{message, sessionId, contextGraphId}
   API->>API: Validate body and Context Graph ID
   API->>Service: chat(message, contextGraphId)
-  Service->>Llama: GET /health
+  Service->>Model: GET /v1/models (or llama.cpp /health fallback)
   alt First turn in the daemon-owned session
     Service->>MCP: Start private stdio MCP child
     Service->>Runtime: Create read-only bounded runtime
@@ -547,15 +649,15 @@ sequenceDiagram
     MCP-->>Runtime: Tool names and JSON schemas
     Service->>Service: Lock session to Context Graph
   end
-  Runtime->>Llama: System context, history, and routed tool schemas
-  Llama-->>Runtime: dkg_query_catalog_list or dkg_query_catalog_run
+  Runtime->>Model: System context, history, and routed tool schemas
+  Model-->>Runtime: dkg_query_catalog_list or dkg_query_catalog_run
   Runtime->>Runtime: Validate schema, policy, and tool budget
   Runtime->>MCP: tools/call with explicit projectId
   MCP->>DKG: Execute catalog read
   DKG-->>MCP: DKG evidence
   MCP-->>Runtime: Structured tool result
-  Runtime->>Llama: DKG evidence for final answer
-  Llama-->>Runtime: Grounded response
+  Runtime->>Model: DKG evidence for final answer
+  Model-->>Runtime: Grounded response
   Runtime->>Trace: Append requests, tool calls, evidence, and answer
   Runtime-->>Service: Answer, tool calls, and trace path
   Service-->>API: Read-only response envelope
@@ -679,13 +781,19 @@ operator approval gate.
 
 ## Troubleshooting
 
-### `connection refused` on port 8080
+### `connection refused` on port 8080 or 11434
 
-The model is not loaded or `llama-server` stopped. Check:
+The selected model server is stopped or the configured URL uses the wrong
+port. Check its provider-neutral readiness route:
 
 ```bash
-curl -sS http://127.0.0.1:8080/health
+curl -sS http://127.0.0.1:8080/v1/models   # llama.cpp default
+curl -sS http://127.0.0.1:11434/v1/models  # Ollama default
 ```
+
+For llama.cpp, `curl -sS http://127.0.0.1:8080/health` is also supported as a
+readiness fallback. Confirm that the daemon's `DKG_LLM_URL` points to the same
+server and port, then restart the daemon if you changed the environment.
 
 ### The model invents selectors or SPARQL
 

--- a/docs/use-dkg/local-llm.md
+++ b/docs/use-dkg/local-llm.md
@@ -269,13 +269,17 @@ curl -sS http://127.0.0.1:11434/v1/models
 ```
 
 Require `ollama ps` to report `CONTEXT` of at least `8192` for `qwen3:8b`.
-`/v1/models` returning HTTP 200 is not proof of the allocated context length.
+`/v1/models` returning HTTP 200 is not proof of the allocated context length,
+and its `data` array must list the configured `qwen3:8b` model (the implicit
+`qwen3:latest` alias is also accepted). A different non-empty model list is not
+ready for this configuration.
 
 Use these DKG settings for Ollama:
 
 ```bash
 export DKG_LLM_URL=http://127.0.0.1:11434/v1/chat/completions
 export DKG_LLM_MODEL=qwen3:8b
+export DKG_LLM_BACKEND=ollama
 ```
 
 Ollama documents its OpenAI-compatible chat-completions, model-list, streaming,
@@ -483,32 +487,11 @@ curl -sS http://127.0.0.1:8080/v1/models
 
 ### Option B: Ollama
 
-Pull the model once, start Ollama if it is not already running, and verify its
-OpenAI-compatible model list:
-
-```bash
-ollama pull qwen3:8b
-```
-
-In the model-server terminal, if the desktop application or system service is
-not already running:
-
-```bash
-OLLAMA_CONTEXT_LENGTH=8192 ollama serve
-```
-
-From another terminal:
-
-```bash
-ollama run qwen3:8b "Reply with OK."
-ollama ps
-curl -sS http://127.0.0.1:11434/v1/models
-```
-
-If the desktop application already owns port `11434`, omit `ollama serve`, set
-its Context length slider to at least `8192`, and restart it. If systemd owns the
-port, use the `OLLAMA_CONTEXT_LENGTH=8192` service override above. Require
-`ollama ps` to report at least `8192` before starting DKG chat.
+Complete the canonical [Install and run Ollama](#install-and-run-ollama)
+procedure above. It owns the installation, server-ownership, minimum-context,
+model-list, and readiness policy; this terminal walkthrough intentionally does
+not repeat it. Leave the verified Ollama server running, then continue with the
+DKG client below.
 
 ## Terminal 3: start DKG chat
 
@@ -581,6 +564,7 @@ daemon. For llama.cpp:
 ```bash
 export DKG_LLM_URL=http://127.0.0.1:8080/v1/chat/completions
 export DKG_LLM_MODEL=qwen3-8b-q4-k-m
+export DKG_LLM_BACKEND=llama.cpp
 dkg start
 ```
 
@@ -589,14 +573,17 @@ For Ollama:
 ```bash
 export DKG_LLM_URL=http://127.0.0.1:11434/v1/chat/completions
 export DKG_LLM_MODEL=qwen3:8b
+export DKG_LLM_BACKEND=ollama
 dkg start
 ```
 
 If the daemon is already running, restart it after changing these variables.
 Keep the selected local model server running, then open Node UI and select **DKG
 Local LLM** in the Agents panel. There is no separate provider selector in the
-browser: Node UI uses `DKG_LLM_URL` and `DKG_LLM_MODEL` from the daemon
-environment. The integration remains read-only: the daemon always creates this
+browser: Node UI uses `DKG_LLM_URL`, `DKG_LLM_MODEL`, and `DKG_LLM_BACKEND`
+from the daemon environment. `DKG_LLM_BACKEND` accepts `ollama`, `llama.cpp`,
+or the backward-compatible default `auto`. The integration remains read-only:
+the daemon always creates this
 UI runtime with writes disabled. The HTTP surface is also node-admin-only.
 Agent-scoped bearer tokens receive `403` and cannot start, continue, or clear
 the daemon-owned operator session.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -315,6 +315,8 @@ dkg llm --interactive --model local-model
 dkg llm --project my-project "Which saved queries are available?"
 
 # Ollama example (llama.cpp remains available on the default port 8080)
+# First configure at least 8192 context in the Ollama app, terminal server, or service.
+# Load qwen3:8b and require `ollama ps` to report CONTEXT >= 8192.
 dkg llm --interactive \
   --llama-url http://127.0.0.1:11434/v1/chat/completions \
   --model qwen3:8b
@@ -322,6 +324,10 @@ dkg llm --interactive \
 
 The existing `--llama-url` option accepts either backend. The daemon and Node
 UI use the equivalent `DKG_LLM_URL` and `DKG_LLM_MODEL` environment variables.
+For a terminal-owned Ollama server, use
+`OLLAMA_CONTEXT_LENGTH=8192 ollama serve`; for the desktop app, set its Context
+length to at least `8192`; for systemd, set the same environment variable in the
+service override. Verify the loaded allocation with `ollama ps` before using DKG.
 
 `--project` explicitly pins the LLM session; inherited `DKG_PROJECT` and the
 MCP config's first Context Graph are not silent agent scopes. Without a pin,

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -304,7 +304,8 @@ Run `dkg <command> --help` for per-command options.
 
 ### Local LLM over DKG MCP
 
-Start an OpenAI-compatible local endpoint such as `llama-server`, then run:
+Start a supported OpenAI-compatible local endpoint with llama.cpp or Ollama,
+then run:
 
 ```bash
 # Interactive, read-only by default
@@ -312,7 +313,15 @@ dkg llm --interactive --model local-model
 
 # One-shot query-catalog discovery against a selected Context Graph
 dkg llm --project my-project "Which saved queries are available?"
+
+# Ollama example (llama.cpp remains available on the default port 8080)
+dkg llm --interactive \
+  --llama-url http://127.0.0.1:11434/v1/chat/completions \
+  --model qwen3:8b
 ```
+
+The existing `--llama-url` option accepts either backend. The daemon and Node
+UI use the equivalent `DKG_LLM_URL` and `DKG_LLM_MODEL` environment variables.
 
 `--project` explicitly pins the LLM session; inherited `DKG_PROJECT` and the
 MCP config's first Context Graph are not silent agent scopes. Without a pin,

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -315,19 +315,17 @@ dkg llm --interactive --model local-model
 dkg llm --project my-project "Which saved queries are available?"
 
 # Ollama example (llama.cpp remains available on the default port 8080)
-# First configure at least 8192 context in the Ollama app, terminal server, or service.
-# Load qwen3:8b and require `ollama ps` to report CONTEXT >= 8192.
 dkg llm --interactive \
   --llama-url http://127.0.0.1:11434/v1/chat/completions \
   --model qwen3:8b
 ```
 
 The existing `--llama-url` option accepts either backend. The daemon and Node
-UI use the equivalent `DKG_LLM_URL` and `DKG_LLM_MODEL` environment variables.
-For a terminal-owned Ollama server, use
-`OLLAMA_CONTEXT_LENGTH=8192 ollama serve`; for the desktop app, set its Context
-length to at least `8192`; for systemd, set the same environment variable in the
-service override. Verify the loaded allocation with `ollama ps` before using DKG.
+UI use the equivalent `DKG_LLM_URL`, `DKG_LLM_MODEL`, and
+`DKG_LLM_BACKEND=ollama` environment variables.
+Before using Ollama, complete the full guide's canonical
+[Ollama setup procedure](../../docs/use-dkg/local-llm.md#install-and-run-ollama);
+package quickstarts intentionally do not duplicate its operating policy.
 
 `--project` explicitly pins the LLM session; inherited `DKG_PROJECT` and the
 MCP config's first Context Graph are not silent agent scopes. Without a pin,

--- a/packages/cli/src/commands/llm.ts
+++ b/packages/cli/src/commands/llm.ts
@@ -265,7 +265,7 @@ export async function runLlmCommand(options: ResolvedLlmCommandOptions): Promise
 export function registerLlmCommand(program: Command): void {
   program
     .command('llm')
-    .description('Chat with the local DKG through an OpenAI-compatible llama.cpp server')
+    .description('Chat with the local DKG through an OpenAI-compatible local model server')
     .argument('[prompt...]', 'one-shot prompt; omit it to start interactive chat')
     .option('-i, --interactive', 'continue into a bounded interactive chat session')
     .option('--llama-url <url>', 'OpenAI-compatible chat-completions endpoint')

--- a/packages/cli/src/daemon/local-agents.ts
+++ b/packages/cli/src/daemon/local-agents.ts
@@ -100,7 +100,7 @@ export const LOCAL_AGENT_INTEGRATION_DEFINITIONS: Record<string, LocalAgentInteg
   'local-llm': {
     id: 'local-llm',
     name: 'DKG Local LLM',
-    description: 'Chat with a local llama.cpp model through the DKG MCP tool surface.',
+    description: 'Chat with a local llama.cpp or Ollama model through the DKG MCP tool surface.',
     transportKind: 'dkg-local-llm',
     daemonOwned: true,
     capabilities: {

--- a/packages/cli/src/daemon/local-llm-service.ts
+++ b/packages/cli/src/daemon/local-llm-service.ts
@@ -1,6 +1,10 @@
 import path from 'node:path';
 import process from 'node:process';
 import {
+  probeLocalModelEndpoint,
+  type LocalModelEndpointAvailability,
+} from '@origintrail-official/dkg-local-llm';
+import {
   createDkgLocalLlmRuntimeSession,
   type DkgLocalLlmRuntimeSession,
   type DkgLocalLlmRuntimeSessionOptions,
@@ -100,6 +104,10 @@ function trimmed(value: string | undefined): string | undefined {
   return value?.trim() || undefined;
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export function resolveDaemonLocalLlmSettings(
   dkgHome: string,
   env: NodeJS.ProcessEnv = process.env,
@@ -112,36 +120,6 @@ export function resolveDaemonLocalLlmSettings(
     defaultProjectId: trimmed(env.DKG_PROJECT),
     logDir: path.join(dkgHome, 'logs', 'local-llm'),
   };
-}
-
-export function localLlmHealthUrl(llamaUrl: string): string {
-  const url = new URL(llamaUrl);
-  url.pathname = '/health';
-  url.search = '';
-  url.hash = '';
-  return url.toString();
-}
-
-/**
- * Resolve the OpenAI-compatible model-list endpoint from a chat-completions
- * URL. Both llama.cpp and Ollama expose this route, so it is the primary
- * provider-neutral readiness contract. `/health` remains a fallback for older
- * or specially configured llama.cpp servers.
- */
-export function localLlmModelsUrl(llamaUrl: string): string {
-  const url = new URL(llamaUrl);
-  const chatSuffix = '/v1/chat/completions';
-  const normalizedPath = url.pathname.replace(/\/+$/, '');
-  url.pathname = normalizedPath.endsWith(chatSuffix)
-    ? `${normalizedPath.slice(0, -chatSuffix.length)}/v1/models`
-    : '/v1/models';
-  url.search = '';
-  url.hash = '';
-  return url.toString();
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 export function createDaemonLocalLlmService(
@@ -163,47 +141,18 @@ export function createDaemonLocalLlmService(
   let closePromise: Promise<void> | undefined;
   let initFailure: string | undefined;
 
-  const probe = async (): Promise<{ ready: boolean; reachable: boolean; error?: string }> => {
-    const attempts: string[] = [];
-    let reachable = false;
-    const targets = [
-      { label: 'OpenAI-compatible models probe', url: localLlmModelsUrl(settings.llamaUrl) },
-      { label: 'llama.cpp health fallback', url: localLlmHealthUrl(settings.llamaUrl) },
-    ];
-
-    for (const target of targets) {
-      try {
-        const response = await fetcher(target.url, {
-          method: 'GET',
-          headers: { Accept: 'application/json' },
-          signal: AbortSignal.timeout(probeTimeoutMs),
-        });
-        reachable = true;
-        if (response.ok) return { ready: true, reachable: true };
-        attempts.push(`${target.label} returned HTTP ${response.status}`);
-      } catch (error) {
-        attempts.push(`${target.label} failed: ${errorMessage(error)}`);
-      }
-    }
-
-    const prefix = reachable
-      ? 'Local LLM server is reachable but not ready'
-      : 'Local LLM server is offline';
-    return {
-      ready: false,
-      reachable,
-      error: `${prefix}: ${attempts.join('; ')}`,
-    };
-  };
+  const probe = (): Promise<LocalModelEndpointAvailability> => probeLocalModelEndpoint({
+    chatCompletionsUrl: settings.llamaUrl,
+    fetch: fetcher,
+    timeoutMs: probeTimeoutMs,
+  });
 
   const unavailableError = (
-    availability: { ready: boolean; reachable: boolean; error?: string },
+    availability: Exclude<LocalModelEndpointAvailability, { status: 'ready' }>,
   ): DaemonLocalLlmError => new DaemonLocalLlmError(
-    availability.reachable ? 'LOCAL_LLM_NOT_READY' : 'LOCAL_LLM_OFFLINE',
+    availability.status === 'not-ready' ? 'LOCAL_LLM_NOT_READY' : 'LOCAL_LLM_OFFLINE',
     503,
-    availability.error ?? (availability.reachable
-      ? 'The local LLM server is reachable but not ready.'
-      : 'The local LLM server is offline.'),
+    availability.error,
   );
 
   const closeSession = async (clearHistory: boolean): Promise<void> => {
@@ -217,19 +166,22 @@ export function createDaemonLocalLlmService(
   return {
     async health() {
       const availability = await probe();
-      const ready = availability.ready && !initFailure && !closed;
+      const reachable = availability.status !== 'offline';
+      const ready = availability.status === 'ready' && !initFailure && !closed;
       return {
         ok: ready,
         ready,
-        reachable: availability.reachable,
-        offline: !availability.reachable,
+        reachable,
+        offline: !reachable,
         busy: Boolean(activeOperation),
         initialized: Boolean(session),
         readOnly: true,
         sessionId: DKG_LOCAL_LLM_UI_SESSION_ID,
         ...(hasProjectLock && lockedProjectId ? { contextGraphId: lockedProjectId } : {}),
         ...(session?.trace.filePath ? { traceFile: session.trace.filePath } : {}),
-        ...(availability.error || initFailure ? { error: availability.error ?? initFailure } : {}),
+        ...(availability.status !== 'ready' || initFailure
+          ? { error: availability.status === 'ready' ? initFailure : availability.error }
+          : {}),
         ...(initFailure ? { initFailure } : {}),
       };
     },
@@ -283,7 +235,7 @@ export function createDaemonLocalLlmService(
       try {
         const availability = await probe();
         signal.throwIfAborted();
-        if (!availability.ready) throw unavailableError(availability);
+        if (availability.status !== 'ready') throw unavailableError(availability);
         if (!session) {
           try {
             const created = await createSession({
@@ -356,7 +308,9 @@ export function createDaemonLocalLlmService(
           if (error instanceof DaemonLocalLlmError) throw error;
           if (signal.aborted) signal.throwIfAborted();
           const availabilityAfterFailure = await probe();
-          if (!availabilityAfterFailure.ready) throw unavailableError(availabilityAfterFailure);
+          if (availabilityAfterFailure.status !== 'ready') {
+            throw unavailableError(availabilityAfterFailure);
+          }
           throw new DaemonLocalLlmError(
             'LOCAL_LLM_RUNTIME_ERROR',
             502,

--- a/packages/cli/src/daemon/local-llm-service.ts
+++ b/packages/cli/src/daemon/local-llm-service.ts
@@ -3,6 +3,7 @@ import process from 'node:process';
 import {
   probeLocalModelEndpoint,
   type LocalModelEndpointAvailability,
+  type LocalModelEndpointProbeStrategy,
 } from '@origintrail-official/dkg-local-llm';
 import {
   createDkgLocalLlmRuntimeSession,
@@ -96,6 +97,7 @@ export interface DaemonLocalLlmServiceOptions {
   cwd?: string;
   fetch?: typeof fetch;
   createSession?: SessionFactory;
+  probeStrategy?: LocalModelEndpointProbeStrategy;
   probeTimeoutMs?: number;
   stderr?: (line: string) => void;
 }
@@ -108,15 +110,41 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function resolveProbeStrategy(value: string | undefined): {
+  strategy: LocalModelEndpointProbeStrategy;
+  error?: string;
+} {
+  const configured = trimmed(value)?.toLowerCase();
+  if (!configured || configured === 'auto') return { strategy: { kind: 'auto' } };
+  if (configured === 'ollama') return { strategy: { kind: 'ollama' } };
+  if (['llama.cpp', 'llama-cpp', 'llamacpp'].includes(configured)) {
+    return { strategy: { kind: 'llama.cpp' } };
+  }
+  return {
+    strategy: { kind: 'auto' },
+    error: `DKG_LLM_BACKEND must be one of: auto, ollama, llama.cpp (received '${value?.trim()}')`,
+  };
+}
+
 export function resolveDaemonLocalLlmSettings(
   dkgHome: string,
   env: NodeJS.ProcessEnv = process.env,
-): { llamaUrl: string; model: string; defaultProjectId?: string; logDir: string } {
+): {
+  llamaUrl: string;
+  model: string;
+  probeStrategy: LocalModelEndpointProbeStrategy;
+  probeConfigurationError?: string;
+  defaultProjectId?: string;
+  logDir: string;
+} {
+  const probe = resolveProbeStrategy(env.DKG_LLM_BACKEND);
   return {
     llamaUrl: trimmed(env.DKG_LLM_URL)
       ?? trimmed(env.LLAMA_URL)
       ?? 'http://127.0.0.1:8080/v1/chat/completions',
     model: trimmed(env.DKG_LLM_MODEL) ?? trimmed(env.LLAMA_MODEL) ?? 'local-model',
+    probeStrategy: probe.strategy,
+    ...(probe.error ? { probeConfigurationError: probe.error } : {}),
     defaultProjectId: trimmed(env.DKG_PROJECT),
     logDir: path.join(dkgHome, 'logs', 'local-llm'),
   };
@@ -141,11 +169,22 @@ export function createDaemonLocalLlmService(
   let closePromise: Promise<void> | undefined;
   let initFailure: string | undefined;
 
-  const probe = (): Promise<LocalModelEndpointAvailability> => probeLocalModelEndpoint({
-    chatCompletionsUrl: settings.llamaUrl,
-    fetch: fetcher,
-    timeoutMs: probeTimeoutMs,
-  });
+  const probe = (): Promise<LocalModelEndpointAvailability> => {
+    if (settings.probeConfigurationError) {
+      return Promise.resolve(Object.freeze({
+        status: 'offline',
+        reachable: false,
+        error: `Local LLM endpoint configuration is invalid: ${settings.probeConfigurationError}`,
+      }));
+    }
+    return probeLocalModelEndpoint({
+      chatCompletionsUrl: settings.llamaUrl,
+      model: settings.model,
+      strategy: options.probeStrategy ?? settings.probeStrategy,
+      fetch: fetcher,
+      timeoutMs: probeTimeoutMs,
+    });
+  };
 
   const unavailableError = (
     availability: Exclude<LocalModelEndpointAvailability, { status: 'ready' }>,

--- a/packages/cli/src/daemon/local-llm-service.ts
+++ b/packages/cli/src/daemon/local-llm-service.ts
@@ -29,6 +29,7 @@ const DKG_LOCAL_LLM_STRICT_PROJECT_TOOLS = [
 
 export type LocalLlmErrorCode =
   | 'LOCAL_LLM_OFFLINE'
+  | 'LOCAL_LLM_NOT_READY'
   | 'LOCAL_LLM_BUSY'
   | 'LOCAL_LLM_PROJECT_MISMATCH'
   | 'LOCAL_LLM_INVALID_REQUEST'
@@ -121,6 +122,24 @@ export function localLlmHealthUrl(llamaUrl: string): string {
   return url.toString();
 }
 
+/**
+ * Resolve the OpenAI-compatible model-list endpoint from a chat-completions
+ * URL. Both llama.cpp and Ollama expose this route, so it is the primary
+ * provider-neutral readiness contract. `/health` remains a fallback for older
+ * or specially configured llama.cpp servers.
+ */
+export function localLlmModelsUrl(llamaUrl: string): string {
+  const url = new URL(llamaUrl);
+  const chatSuffix = '/v1/chat/completions';
+  const normalizedPath = url.pathname.replace(/\/+$/, '');
+  url.pathname = normalizedPath.endsWith(chatSuffix)
+    ? `${normalizedPath.slice(0, -chatSuffix.length)}/v1/models`
+    : '/v1/models';
+  url.search = '';
+  url.hash = '';
+  return url.toString();
+}
+
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -144,19 +163,48 @@ export function createDaemonLocalLlmService(
   let closePromise: Promise<void> | undefined;
   let initFailure: string | undefined;
 
-  const probe = async (): Promise<{ reachable: boolean; error?: string }> => {
-    try {
-      const response = await fetcher(localLlmHealthUrl(settings.llamaUrl), {
-        method: 'GET',
-        headers: { Accept: 'application/json' },
-        signal: AbortSignal.timeout(probeTimeoutMs),
-      });
-      if (response.ok) return { reachable: true };
-      return { reachable: false, error: `llama.cpp health returned HTTP ${response.status}` };
-    } catch (error) {
-      return { reachable: false, error: `Local llama.cpp server is offline: ${errorMessage(error)}` };
+  const probe = async (): Promise<{ ready: boolean; reachable: boolean; error?: string }> => {
+    const attempts: string[] = [];
+    let reachable = false;
+    const targets = [
+      { label: 'OpenAI-compatible models probe', url: localLlmModelsUrl(settings.llamaUrl) },
+      { label: 'llama.cpp health fallback', url: localLlmHealthUrl(settings.llamaUrl) },
+    ];
+
+    for (const target of targets) {
+      try {
+        const response = await fetcher(target.url, {
+          method: 'GET',
+          headers: { Accept: 'application/json' },
+          signal: AbortSignal.timeout(probeTimeoutMs),
+        });
+        reachable = true;
+        if (response.ok) return { ready: true, reachable: true };
+        attempts.push(`${target.label} returned HTTP ${response.status}`);
+      } catch (error) {
+        attempts.push(`${target.label} failed: ${errorMessage(error)}`);
+      }
     }
+
+    const prefix = reachable
+      ? 'Local LLM server is reachable but not ready'
+      : 'Local LLM server is offline';
+    return {
+      ready: false,
+      reachable,
+      error: `${prefix}: ${attempts.join('; ')}`,
+    };
   };
+
+  const unavailableError = (
+    availability: { ready: boolean; reachable: boolean; error?: string },
+  ): DaemonLocalLlmError => new DaemonLocalLlmError(
+    availability.reachable ? 'LOCAL_LLM_NOT_READY' : 'LOCAL_LLM_OFFLINE',
+    503,
+    availability.error ?? (availability.reachable
+      ? 'The local LLM server is reachable but not ready.'
+      : 'The local LLM server is offline.'),
+  );
 
   const closeSession = async (clearHistory: boolean): Promise<void> => {
     const current = session;
@@ -169,7 +217,7 @@ export function createDaemonLocalLlmService(
   return {
     async health() {
       const availability = await probe();
-      const ready = availability.reachable && !initFailure && !closed;
+      const ready = availability.ready && !initFailure && !closed;
       return {
         ok: ready,
         ready,
@@ -235,13 +283,7 @@ export function createDaemonLocalLlmService(
       try {
         const availability = await probe();
         signal.throwIfAborted();
-        if (!availability.reachable) {
-          throw new DaemonLocalLlmError(
-            'LOCAL_LLM_OFFLINE',
-            503,
-            availability.error ?? 'The local llama.cpp server is offline.',
-          );
-        }
+        if (!availability.ready) throw unavailableError(availability);
         if (!session) {
           try {
             const created = await createSession({
@@ -314,13 +356,7 @@ export function createDaemonLocalLlmService(
           if (error instanceof DaemonLocalLlmError) throw error;
           if (signal.aborted) signal.throwIfAborted();
           const availabilityAfterFailure = await probe();
-          if (!availabilityAfterFailure.reachable) {
-            throw new DaemonLocalLlmError(
-              'LOCAL_LLM_OFFLINE',
-              503,
-              availabilityAfterFailure.error ?? 'The local llama.cpp server is offline.',
-            );
-          }
+          if (!availabilityAfterFailure.ready) throw unavailableError(availabilityAfterFailure);
           throw new DaemonLocalLlmError(
             'LOCAL_LLM_RUNTIME_ERROR',
             502,

--- a/packages/cli/test/daemon-local-llm-route.test.ts
+++ b/packages/cli/test/daemon-local-llm-route.test.ts
@@ -204,6 +204,7 @@ describe('daemon local LLM routes', () => {
       ['LOCAL_LLM_BUSY', 409],
       ['LOCAL_LLM_PROJECT_MISMATCH', 409],
       ['LOCAL_LLM_OFFLINE', 503],
+      ['LOCAL_LLM_NOT_READY', 503],
       ['LOCAL_LLM_RUNTIME_ERROR', 502],
     ] as const) {
       const fake = service();

--- a/packages/cli/test/daemon-local-llm-service.test.ts
+++ b/packages/cli/test/daemon-local-llm-service.test.ts
@@ -60,13 +60,39 @@ describe('daemon local LLM service', () => {
     expect(resolveDaemonLocalLlmSettings('/tmp/dkg', {
       DKG_LLM_URL: ' http://127.0.0.1:9090/v1/chat/completions ',
       DKG_LLM_MODEL: ' qwen ',
+      DKG_LLM_BACKEND: ' llama-cpp ',
       DKG_PROJECT: ' testing ',
     })).toEqual({
       llamaUrl: 'http://127.0.0.1:9090/v1/chat/completions',
       model: 'qwen',
+      probeStrategy: { kind: 'llama.cpp' },
       defaultProjectId: 'testing',
       logDir: '/tmp/dkg/logs/local-llm',
     });
+  });
+
+  it('maps an invalid configured backend to structured offline health and chat errors', async () => {
+    const fetcher = vi.fn();
+    const createSession = vi.fn(async () => fakeSession());
+    const service = createDaemonLocalLlmService({
+      dkgHome: '/tmp/dkg',
+      env: { DKG_LLM_BACKEND: 'unknown-provider' },
+      fetch: fetcher as typeof fetch,
+      createSession,
+    });
+
+    expect(await service.health()).toEqual(expect.objectContaining({
+      ok: false,
+      ready: false,
+      reachable: false,
+      offline: true,
+      error: expect.stringContaining('DKG_LLM_BACKEND must be one of'),
+    }));
+    await expect(service.chat({ message: 'hello' })).rejects.toMatchObject({
+      code: 'LOCAL_LLM_OFFLINE', status: 503,
+    });
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(createSession).not.toHaveBeenCalled();
   });
 
   it('accepts Ollama readiness through /v1/models without requiring /health', async () => {
@@ -83,6 +109,7 @@ describe('daemon local LLM service', () => {
       env: {
         DKG_LLM_URL: 'http://127.0.0.1:11434/v1/chat/completions',
         DKG_LLM_MODEL: 'qwen3:8b',
+        DKG_LLM_BACKEND: 'ollama',
       },
       fetch: fetcher as typeof fetch,
       createSession,
@@ -106,6 +133,60 @@ describe('daemon local LLM service', () => {
       ]);
   });
 
+  it('keeps health and chat not-ready when the configured model is absent', async () => {
+    const fetcher = vi.fn(async () => Response.json({
+      object: 'list',
+      data: [{ id: 'llama3.2' }],
+    }));
+    const createSession = vi.fn(async () => fakeSession());
+    const service = createDaemonLocalLlmService({
+      dkgHome: '/tmp/dkg',
+      env: {
+        DKG_LLM_URL: 'http://127.0.0.1:11434/v1/chat/completions',
+        DKG_LLM_MODEL: 'qwen3:8b',
+        DKG_LLM_BACKEND: 'ollama',
+      },
+      fetch: fetcher as typeof fetch,
+      createSession,
+    });
+
+    expect(await service.health()).toEqual(expect.objectContaining({
+      ok: false,
+      ready: false,
+      reachable: true,
+      offline: false,
+      error: expect.stringContaining("Configured model 'qwen3:8b' is not listed"),
+    }));
+    await expect(service.chat({ message: 'hello' })).rejects.toMatchObject({
+      code: 'LOCAL_LLM_NOT_READY', status: 503,
+    });
+    expect(createSession).not.toHaveBeenCalled();
+  });
+
+  it('maps a malformed endpoint URL to structured offline health and chat errors', async () => {
+    const fetcher = vi.fn();
+    const createSession = vi.fn(async () => fakeSession());
+    const service = createDaemonLocalLlmService({
+      dkgHome: '/tmp/dkg',
+      env: { DKG_LLM_URL: 'not-a-url' },
+      fetch: fetcher as typeof fetch,
+      createSession,
+    });
+
+    expect(await service.health()).toEqual(expect.objectContaining({
+      ok: false,
+      ready: false,
+      reachable: false,
+      offline: true,
+      error: expect.stringContaining('endpoint configuration is invalid'),
+    }));
+    await expect(service.chat({ message: 'hello' })).rejects.toMatchObject({
+      code: 'LOCAL_LLM_OFFLINE', status: 503,
+    });
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(createSession).not.toHaveBeenCalled();
+  });
+
   it('keeps llama.cpp compatible through its /health readiness fallback', async () => {
     const fetcher = vi.fn(async (input: string | URL | Request) => {
       const url = String(input);
@@ -114,7 +195,10 @@ describe('daemon local LLM service', () => {
       return new Response('not found', { status: 404 });
     });
     const service = createDaemonLocalLlmService({
-      dkgHome: '/tmp/dkg', fetch: fetcher as typeof fetch, createSession: vi.fn(),
+      dkgHome: '/tmp/dkg',
+      env: { DKG_LLM_BACKEND: 'llama.cpp' },
+      fetch: fetcher as typeof fetch,
+      createSession: vi.fn(),
     });
 
     expect(await service.health()).toEqual(expect.objectContaining({
@@ -143,7 +227,10 @@ describe('daemon local LLM service', () => {
     });
     const createSession = vi.fn(async () => fakeSession());
     const service = createDaemonLocalLlmService({
-      dkgHome: '/tmp/dkg', fetch: fetcher as typeof fetch, createSession,
+      dkgHome: '/tmp/dkg',
+      env: { DKG_LLM_BACKEND: 'llama.cpp' },
+      fetch: fetcher as typeof fetch,
+      createSession,
     });
 
     expect(await service.health()).toEqual(expect.objectContaining({

--- a/packages/cli/test/daemon-local-llm-service.test.ts
+++ b/packages/cli/test/daemon-local-llm-service.test.ts
@@ -208,6 +208,40 @@ describe('daemon local LLM service', () => {
       .toEqual(['/v1/models', '/health']);
   });
 
+  it('keeps both llama.cpp readiness shapes compatible with the default auto backend', async () => {
+    const loadedFetch = vi.fn(async () => Response.json({
+      object: 'list',
+      data: [{ id: 'local-model', meta: { n_ctx_train: 32_768 } }],
+    }));
+    const loaded = createDaemonLocalLlmService({
+      dkgHome: '/tmp/dkg',
+      fetch: loadedFetch as typeof fetch,
+      createSession: vi.fn(),
+    });
+
+    expect(await loaded.health()).toEqual(expect.objectContaining({
+      ok: true, ready: true, reachable: true, offline: false,
+    }));
+    expect(loadedFetch).toHaveBeenCalledOnce();
+
+    const fallbackFetch = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/v1/models')) return new Response('not found', { status: 404 });
+      return Response.json({ status: 'ok' });
+    });
+    const fallback = createDaemonLocalLlmService({
+      dkgHome: '/tmp/dkg',
+      fetch: fallbackFetch as typeof fetch,
+      createSession: vi.fn(),
+    });
+
+    expect(await fallback.health()).toEqual(expect.objectContaining({
+      ok: true, ready: true, reachable: true, offline: false,
+    }));
+    expect(fallbackFetch.mock.calls.map(([input]) => new URL(String(input)).pathname))
+      .toEqual(['/v1/models', '/health']);
+  });
+
   it('keeps llama.cpp chat unavailable until a loading model becomes healthy', async () => {
     let healthy = false;
     const fetcher = vi.fn(async (input: string | URL | Request) => {

--- a/packages/cli/test/daemon-local-llm-service.test.ts
+++ b/packages/cli/test/daemon-local-llm-service.test.ts
@@ -2,14 +2,15 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   createDaemonLocalLlmService,
   DaemonLocalLlmError,
-  localLlmHealthUrl,
-  localLlmModelsUrl,
   resolveDaemonLocalLlmSettings,
 } from '../src/daemon/local-llm-service.js';
 import { listLocalAgentIntegrations } from '../src/daemon/local-agents.js';
 
 function onlineFetch(): typeof fetch {
-  return vi.fn(async () => Response.json({ object: 'list', data: [] })) as unknown as typeof fetch;
+  return vi.fn(async () => Response.json({
+    object: 'list',
+    data: [{ id: 'local-model' }],
+  })) as unknown as typeof fetch;
 }
 
 function fakeSession(options: {
@@ -68,15 +69,6 @@ describe('daemon local LLM service', () => {
     });
   });
 
-  it('derives provider-neutral models probes while retaining the llama.cpp health fallback', () => {
-    expect(localLlmModelsUrl('http://127.0.0.1:11434/v1/chat/completions'))
-      .toBe('http://127.0.0.1:11434/v1/models');
-    expect(localLlmModelsUrl('http://localhost:9000/proxy/v1/chat/completions?token=ignored'))
-      .toBe('http://localhost:9000/proxy/v1/models');
-    expect(localLlmHealthUrl('http://127.0.0.1:8080/v1/chat/completions'))
-      .toBe('http://127.0.0.1:8080/health');
-  });
-
   it('accepts Ollama readiness through /v1/models without requiring /health', async () => {
     const fetcher = vi.fn(async (input: string | URL | Request) => {
       const url = String(input);
@@ -130,6 +122,46 @@ describe('daemon local LLM service', () => {
     }));
     expect(fetcher.mock.calls.map(([input]) => new URL(String(input)).pathname))
       .toEqual(['/v1/models', '/health']);
+  });
+
+  it('keeps llama.cpp chat unavailable until a loading model becomes healthy', async () => {
+    let healthy = false;
+    const fetcher = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/v1/models')) {
+        return Response.json({
+          object: 'list',
+          data: [{ id: 'local-model', meta: null }],
+        });
+      }
+      if (url.endsWith('/health')) {
+        return healthy
+          ? Response.json({ status: 'ok' })
+          : new Response('loading model', { status: 503 });
+      }
+      return new Response('not found', { status: 404 });
+    });
+    const createSession = vi.fn(async () => fakeSession());
+    const service = createDaemonLocalLlmService({
+      dkgHome: '/tmp/dkg', fetch: fetcher as typeof fetch, createSession,
+    });
+
+    expect(await service.health()).toEqual(expect.objectContaining({
+      ok: false, ready: false, reachable: true, offline: false,
+    }));
+    await expect(service.chat({ message: 'hello' })).rejects.toMatchObject({
+      code: 'LOCAL_LLM_NOT_READY', status: 503,
+    });
+    expect(createSession).not.toHaveBeenCalled();
+
+    healthy = true;
+    expect(await service.health()).toEqual(expect.objectContaining({
+      ok: true, ready: true, reachable: true, offline: false,
+    }));
+    await expect(service.chat({ message: 'hello' })).resolves.toEqual(
+      expect.objectContaining({ text: 'DKG evidence answer' }),
+    );
+    expect(createSession).toHaveBeenCalledOnce();
   });
 
   it('distinguishes a reachable but incompatible server from an offline server', async () => {

--- a/packages/cli/test/daemon-local-llm-service.test.ts
+++ b/packages/cli/test/daemon-local-llm-service.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   createDaemonLocalLlmService,
   DaemonLocalLlmError,
+  localLlmHealthUrl,
+  localLlmModelsUrl,
   resolveDaemonLocalLlmSettings,
 } from '../src/daemon/local-llm-service.js';
 import { listLocalAgentIntegrations } from '../src/daemon/local-agents.js';
 
 function onlineFetch(): typeof fetch {
-  return vi.fn(async () => new Response('{"status":"ok"}', { status: 200 })) as unknown as typeof fetch;
+  return vi.fn(async () => Response.json({ object: 'list', data: [] })) as unknown as typeof fetch;
 }
 
 function fakeSession(options: {
@@ -63,6 +65,89 @@ describe('daemon local LLM service', () => {
       model: 'qwen',
       defaultProjectId: 'testing',
       logDir: '/tmp/dkg/logs/local-llm',
+    });
+  });
+
+  it('derives provider-neutral models probes while retaining the llama.cpp health fallback', () => {
+    expect(localLlmModelsUrl('http://127.0.0.1:11434/v1/chat/completions'))
+      .toBe('http://127.0.0.1:11434/v1/models');
+    expect(localLlmModelsUrl('http://localhost:9000/proxy/v1/chat/completions?token=ignored'))
+      .toBe('http://localhost:9000/proxy/v1/models');
+    expect(localLlmHealthUrl('http://127.0.0.1:8080/v1/chat/completions'))
+      .toBe('http://127.0.0.1:8080/health');
+  });
+
+  it('accepts Ollama readiness through /v1/models without requiring /health', async () => {
+    const fetcher = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url === 'http://127.0.0.1:11434/v1/models') {
+        return Response.json({ object: 'list', data: [{ id: 'qwen3:8b' }] });
+      }
+      return new Response('not found', { status: 404 });
+    });
+    const createSession = vi.fn(async () => fakeSession());
+    const service = createDaemonLocalLlmService({
+      dkgHome: '/tmp/dkg',
+      env: {
+        DKG_LLM_URL: 'http://127.0.0.1:11434/v1/chat/completions',
+        DKG_LLM_MODEL: 'qwen3:8b',
+      },
+      fetch: fetcher as typeof fetch,
+      createSession,
+    });
+
+    expect(await service.health()).toEqual(expect.objectContaining({
+      ok: true, ready: true, reachable: true, offline: false,
+    }));
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(String(fetcher.mock.calls[0][0])).toBe('http://127.0.0.1:11434/v1/models');
+    await expect(service.chat({ message: 'List saved queries', contextGraphId: 'testing' }))
+      .resolves.toEqual(expect.objectContaining({ text: 'DKG evidence answer' }));
+    expect(createSession).toHaveBeenCalledWith(expect.objectContaining({
+      llamaUrl: 'http://127.0.0.1:11434/v1/chat/completions',
+      model: 'qwen3:8b',
+    }));
+    expect(fetcher.mock.calls.map(([input]) => String(input)))
+      .toEqual([
+        'http://127.0.0.1:11434/v1/models',
+        'http://127.0.0.1:11434/v1/models',
+      ]);
+  });
+
+  it('keeps llama.cpp compatible through its /health readiness fallback', async () => {
+    const fetcher = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/v1/models')) return new Response('not found', { status: 404 });
+      if (url.endsWith('/health')) return Response.json({ status: 'ok' });
+      return new Response('not found', { status: 404 });
+    });
+    const service = createDaemonLocalLlmService({
+      dkgHome: '/tmp/dkg', fetch: fetcher as typeof fetch, createSession: vi.fn(),
+    });
+
+    expect(await service.health()).toEqual(expect.objectContaining({
+      ok: true, ready: true, reachable: true, offline: false,
+    }));
+    expect(fetcher.mock.calls.map(([input]) => new URL(String(input)).pathname))
+      .toEqual(['/v1/models', '/health']);
+  });
+
+  it('distinguishes a reachable but incompatible server from an offline server', async () => {
+    const service = createDaemonLocalLlmService({
+      dkgHome: '/tmp/dkg',
+      fetch: vi.fn(async () => new Response('not found', { status: 404 })) as unknown as typeof fetch,
+      createSession: vi.fn(),
+    });
+
+    expect(await service.health()).toEqual(expect.objectContaining({
+      ok: false,
+      ready: false,
+      reachable: true,
+      offline: false,
+      error: expect.stringContaining('reachable but not ready'),
+    }));
+    await expect(service.chat({ message: 'hello' })).rejects.toMatchObject({
+      code: 'LOCAL_LLM_NOT_READY', status: 503,
     });
   });
 

--- a/packages/local-llm/README.md
+++ b/packages/local-llm/README.md
@@ -65,28 +65,11 @@ curl -sS http://127.0.0.1:8080/v1/models
 Continue only when `/v1/models` returns HTTP 200. The llama.cpp `/health`
 response should also be `{"status":"ok"}`.
 
-Alternatively, use Ollama in the model-server terminal:
-
-```bash
-ollama pull qwen3:8b
-OLLAMA_CONTEXT_LENGTH=8192 ollama serve
-```
-
-If Ollama is already running as a desktop application or service, omit
-`ollama serve`. DKG requires at least an 8192-token context: set the desktop
-application's **Context length** slider to at least `8192`, or add
-`Environment="OLLAMA_CONTEXT_LENGTH=8192"` to a Linux systemd service override
-and restart that owner. See Ollama's official
-[`Context length`](https://docs.ollama.com/context-length) guidance. Load the
-model and verify its effective allocation before requiring HTTP 200:
-
-```bash
-ollama run qwen3:8b "Reply with OK."
-ollama ps
-curl -sS http://127.0.0.1:11434/v1/models
-```
-
-The selected model's `CONTEXT` value from `ollama ps` must be at least `8192`.
+Alternatively, complete the full guide's canonical
+[Ollama setup procedure](../../docs/use-dkg/local-llm.md#install-and-run-ollama).
+That section is the sole source for installation, server ownership, context,
+model loading, and readiness policy. Leave the verified server running, then
+use the Ollama client options below.
 
 ### Terminal 2: start interactive DKG chat
 

--- a/packages/local-llm/README.md
+++ b/packages/local-llm/README.md
@@ -1,8 +1,8 @@
 # `@origintrail-official/dkg-local-llm`
 
 Bounded local-model orchestration for the DKG MCP surface. The package talks to
-an OpenAI-compatible `llama.cpp` endpoint and receives its tools dynamically
-from MCP `tools/list`.
+an OpenAI-compatible llama.cpp or Ollama endpoint and receives its tools
+dynamically from MCP `tools/list`.
 
 The runtime is read-only by default. It tokenizes each prompt and dynamically
 ranks the discovered MCP tools by their names, descriptions, and input schemas
@@ -12,7 +12,7 @@ to eight schemas and 18,000 serialized JSON bytes. Mutations require
 
 It also provides:
 
-- llama.cpp-safe JSON Schema normalization (`\\d` becomes `[0-9]` losslessly);
+- local-server-safe JSON Schema normalization (`\\d` becomes `[0-9]` losslessly);
 - local argument validation and one repair retry;
 - repeated-call and tool-call-count guards;
 - bounded chat history whose old evidence is never treated as fresh;
@@ -36,10 +36,12 @@ Query-Catalog-first workflow for small models, see
 Start the DKG daemon first. Then use two terminals for the model server and the
 interactive DKG client.
 
-### Terminal 1: start Qwen with llama.cpp
+### Terminal 1: start Qwen with llama.cpp or Ollama
+
+llama.cpp remains the reference backend:
 
 ```bash
-/Users/lupus/projects/llama.cpp/build/bin/llama-server \
+/absolute/path/to/llama-server \
   -hf Qwen/Qwen3-8B-GGUF:Q4_K_M \
   -ngl 999 \
   -c 8192 \
@@ -57,9 +59,25 @@ another terminal:
 
 ```bash
 curl -sS http://127.0.0.1:8080/health
+curl -sS http://127.0.0.1:8080/v1/models
 ```
 
-Continue only when the response is `{"status":"ok"}`.
+Continue only when `/v1/models` returns HTTP 200. The llama.cpp `/health`
+response should also be `{"status":"ok"}`.
+
+Alternatively, use Ollama in the model-server terminal:
+
+```bash
+ollama pull qwen3:8b
+ollama serve
+```
+
+If Ollama is already running as a desktop application or service, omit
+`ollama serve`. From another terminal, require HTTP 200 from:
+
+```bash
+curl -sS http://127.0.0.1:11434/v1/models
+```
 
 ### Terminal 2: start interactive DKG chat
 
@@ -67,10 +85,11 @@ From the DKG repository root, start an interactive Qwen session against the
 `testing` Context Graph with an explicit session pin:
 
 ```bash
-DKG_HOME=/Users/lupus/dkg-local \
+DKG_HOME=/absolute/path/to/dkg-home \
 pnpm dkg llm \
   --interactive \
   --project testing \
+  --llama-url http://127.0.0.1:8080/v1/chat/completions \
   --model qwen3-8b-q4-k-m \
   --allow-write
 ```
@@ -84,12 +103,22 @@ an explicit user request. Omit `--allow-write` for the recommended read-only
 chat:
 
 ```bash
-DKG_HOME=/Users/lupus/dkg-local \
+DKG_HOME=/absolute/path/to/dkg-home \
 pnpm dkg llm \
   --interactive \
   --project testing \
+  --llama-url http://127.0.0.1:8080/v1/chat/completions \
   --model qwen3-8b-q4-k-m
 ```
+
+For Ollama, replace the last two options with:
+
+```bash
+--llama-url http://127.0.0.1:11434/v1/chat/completions \
+--model qwen3:8b
+```
+
+The legacy option name `--llama-url` accepts either supported backend.
 
 `--project` is an explicit LLM-session pin. The local-LLM command does not
 inherit `DKG_PROJECT` as an invisible default. A scoped tool call always carries
@@ -106,17 +135,17 @@ should use unique graph/asset names.
 
 ```bash
 # Terminal 1: start DKG from this checkout
-DKG_HOME=/Users/lupus/dkg-local \
+DKG_HOME=/absolute/path/to/dkg-home \
   node packages/cli/dist/cli.js daemon-foreground-worker
 
 # Terminal 2: start llama.cpp with one model
-/Users/lupus/projects/llama.cpp/build/bin/llama-server \
+/absolute/path/to/llama-server \
   -hf Qwen/Qwen3-8B-GGUF:Q4_K_M -ngl 999 -c 8192 \
   --flash-attn on --jinja --temp 0.15 --top-p 0.9 --repeat-penalty 1.05
 
 # Terminal 3: run 8 core scenarios plus 5 holdouts
 RUN_ID="$(date +%Y%m%d-%H%M%S)"
-DKG_HOME=/Users/lupus/dkg-local \
+DKG_HOME=/absolute/path/to/dkg-home \
 DKG_CLI_PATH="$PWD/packages/cli/dist/cli.js" \
 pnpm --filter @origintrail-official/dkg-local-llm benchmark:dkg -- \
   --allow-write \
@@ -125,6 +154,12 @@ pnpm --filter @origintrail-official/dkg-local-llm benchmark:dkg -- \
   --model qwen3-8b-q4-k-m \
   --label "qwen3-8b-q4-k-m-$RUN_ID"
 ```
+
+To validate Ollama rather than assume parity, start it with the intended model
+tag and add
+`--llama-url http://127.0.0.1:11434/v1/chat/completions --model qwen3:8b`
+to the benchmark command. Keep each model/server pair's output and score
+separate from the llama.cpp reference result.
 
 The suite covers Context Graph creation, two subgraphs, model-authored RDF,
 asset retrieval, raw SPARQL, parameterized query-catalog save/list/run, and five

--- a/packages/local-llm/README.md
+++ b/packages/local-llm/README.md
@@ -69,15 +69,24 @@ Alternatively, use Ollama in the model-server terminal:
 
 ```bash
 ollama pull qwen3:8b
-ollama serve
+OLLAMA_CONTEXT_LENGTH=8192 ollama serve
 ```
 
 If Ollama is already running as a desktop application or service, omit
-`ollama serve`. From another terminal, require HTTP 200 from:
+`ollama serve`. DKG requires at least an 8192-token context: set the desktop
+application's **Context length** slider to at least `8192`, or add
+`Environment="OLLAMA_CONTEXT_LENGTH=8192"` to a Linux systemd service override
+and restart that owner. See Ollama's official
+[`Context length`](https://docs.ollama.com/context-length) guidance. Load the
+model and verify its effective allocation before requiring HTTP 200:
 
 ```bash
+ollama run qwen3:8b "Reply with OK."
+ollama ps
 curl -sS http://127.0.0.1:11434/v1/models
 ```
+
+The selected model's `CONTEXT` value from `ollama ps` must be at least `8192`.
 
 ### Terminal 2: start interactive DKG chat
 
@@ -158,8 +167,12 @@ pnpm --filter @origintrail-official/dkg-local-llm benchmark:dkg -- \
 To validate Ollama rather than assume parity, start it with the intended model
 tag and add
 `--llama-url http://127.0.0.1:11434/v1/chat/completions --model qwen3:8b`
-to the benchmark command. Keep each model/server pair's output and score
-separate from the llama.cpp reference result.
+to the benchmark command. On the sub-24-GiB acceptance machine, retain
+`ollama ps` evidence showing at least `8192` context immediately before the run,
+then require the complete 13-scenario benchmark to finish without prompt or tool
+schema truncation at the default eight-tool/18,000-byte routing budget. Keep
+each model/server pair's output and score separate from the llama.cpp reference
+result.
 
 The suite covers Context Graph creation, two subgraphs, model-authored RDF,
 asset retrieval, raw SPARQL, parameterized query-catalog save/list/run, and five

--- a/packages/local-llm/package.json
+++ b/packages/local-llm/package.json
@@ -40,6 +40,7 @@
   "keywords": [
     "dkg",
     "llama.cpp",
+    "ollama",
     "local-llm",
     "mcp",
     "origintrail"

--- a/packages/local-llm/src/index.ts
+++ b/packages/local-llm/src/index.ts
@@ -19,6 +19,13 @@ export {
   type McpClientLike,
 } from './runtime.js';
 export {
+  localModelEndpointUrls,
+  probeLocalModelEndpoint,
+  type LocalModelEndpointAvailability,
+  type LocalModelEndpointProvider,
+  type ProbeLocalModelEndpointOptions,
+} from './model-endpoint.js';
+export {
   normalizeToolForLlama,
   parseAndValidateToolArguments,
   stableJson,

--- a/packages/local-llm/src/index.ts
+++ b/packages/local-llm/src/index.ts
@@ -19,10 +19,9 @@ export {
   type McpClientLike,
 } from './runtime.js';
 export {
-  localModelEndpointUrls,
   probeLocalModelEndpoint,
   type LocalModelEndpointAvailability,
-  type LocalModelEndpointProvider,
+  type LocalModelEndpointProbeStrategy,
   type ProbeLocalModelEndpointOptions,
 } from './model-endpoint.js';
 export {

--- a/packages/local-llm/src/model-endpoint.ts
+++ b/packages/local-llm/src/model-endpoint.ts
@@ -1,0 +1,187 @@
+export type LocalModelEndpointProvider = 'openai-models' | 'llama.cpp-health';
+
+export type LocalModelEndpointAvailability =
+  | Readonly<{
+    status: 'ready';
+    reachable: true;
+    provider: LocalModelEndpointProvider;
+    endpoint: string;
+  }>
+  | Readonly<{
+    status: 'not-ready';
+    reachable: true;
+    error: string;
+  }>
+  | Readonly<{
+    status: 'offline';
+    reachable: false;
+    error: string;
+  }>;
+
+export interface ProbeLocalModelEndpointOptions {
+  chatCompletionsUrl: string;
+  fetch?: typeof fetch;
+  timeoutMs?: number;
+}
+
+interface LocalModelEndpointUrls {
+  readonly models: string;
+  readonly health: string;
+}
+
+interface ModelListEntry {
+  readonly id: string;
+  readonly metadataState: 'absent' | 'loading' | 'loaded';
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function endpointUrl(
+  chatCompletionsUrl: string,
+  endpointSuffix: '/v1/models' | '/health',
+): string {
+  const url = new URL(chatCompletionsUrl);
+  const chatSuffix = '/v1/chat/completions';
+  const normalizedPath = url.pathname.replace(/\/+$/, '');
+  const prefix = normalizedPath.endsWith(chatSuffix)
+    ? normalizedPath.slice(0, -chatSuffix.length)
+    : '';
+  url.pathname = `${prefix}${endpointSuffix}`;
+  url.search = '';
+  url.hash = '';
+  return url.toString();
+}
+
+/** Derive provider probes while preserving a reverse-proxy path prefix. */
+export function localModelEndpointUrls(
+  chatCompletionsUrl: string,
+): Readonly<LocalModelEndpointUrls> {
+  return Object.freeze({
+    models: endpointUrl(chatCompletionsUrl, '/v1/models'),
+    health: endpointUrl(chatCompletionsUrl, '/health'),
+  });
+}
+
+function inspectModelList(value: unknown):
+  | Readonly<{ status: 'ready' }>
+  | Readonly<{ status: 'fallback'; reason: string }> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return Object.freeze({
+      status: 'fallback',
+      reason: 'OpenAI-compatible models probe returned a non-object response',
+    });
+  }
+  const data = (value as { data?: unknown }).data;
+  if (!Array.isArray(data)) {
+    return Object.freeze({
+      status: 'fallback',
+      reason: 'OpenAI-compatible models probe returned no model list',
+    });
+  }
+  const entries = data.flatMap((candidate): ModelListEntry[] => {
+    if (typeof candidate !== 'object' || candidate === null || Array.isArray(candidate)) return [];
+    const record = candidate as Record<string, unknown>;
+    if (typeof record.id !== 'string' || record.id.trim().length === 0) return [];
+    const metadataState = Object.hasOwn(record, 'meta')
+      ? record.meta !== null && typeof record.meta === 'object' && !Array.isArray(record.meta)
+        ? 'loaded'
+        : 'loading'
+      : 'absent';
+    return [{ id: record.id, metadataState }];
+  });
+  if (entries.length === 0) {
+    return Object.freeze({
+      status: 'fallback',
+      reason: 'OpenAI-compatible models probe returned no usable model',
+    });
+  }
+  if (entries.some(({ metadataState }) => metadataState !== 'loading')) {
+    return Object.freeze({ status: 'ready' });
+  }
+  return Object.freeze({
+    status: 'fallback',
+    reason: 'llama.cpp models are still loading',
+  });
+}
+
+/**
+ * Probe an OpenAI-compatible local model server without leaking provider
+ * branching into daemon lifecycle code. `/v1/models` is primary for Ollama and
+ * loaded llama.cpp models; `/health` remains the bounded llama.cpp fallback.
+ */
+export async function probeLocalModelEndpoint(
+  options: ProbeLocalModelEndpointOptions,
+): Promise<LocalModelEndpointAvailability> {
+  const fetcher = options.fetch ?? globalThis.fetch;
+  const timeoutMs = options.timeoutMs ?? 2_000;
+  if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new TypeError('Local model probe timeout must be a positive integer');
+  }
+  const urls = localModelEndpointUrls(options.chatCompletionsUrl);
+  const attempts: string[] = [];
+  let reachable = false;
+
+  try {
+    const response = await fetcher(urls.models, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    reachable = true;
+    if (response.ok) {
+      try {
+        const inspection = inspectModelList(await response.json());
+        if (inspection.status === 'ready') {
+          return Object.freeze({
+            status: 'ready',
+            reachable: true,
+            provider: 'openai-models',
+            endpoint: urls.models,
+          });
+        }
+        attempts.push(inspection.reason);
+      } catch (error) {
+        attempts.push(`OpenAI-compatible models probe returned invalid JSON: ${errorMessage(error)}`);
+      }
+    } else {
+      attempts.push(`OpenAI-compatible models probe returned HTTP ${response.status}`);
+    }
+  } catch (error) {
+    attempts.push(`OpenAI-compatible models probe failed: ${errorMessage(error)}`);
+  }
+
+  try {
+    const response = await fetcher(urls.health, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    reachable = true;
+    if (response.ok) {
+      return Object.freeze({
+        status: 'ready',
+        reachable: true,
+        provider: 'llama.cpp-health',
+        endpoint: urls.health,
+      });
+    }
+    attempts.push(`llama.cpp health fallback returned HTTP ${response.status}`);
+  } catch (error) {
+    attempts.push(`llama.cpp health fallback failed: ${errorMessage(error)}`);
+  }
+
+  if (reachable) {
+    return Object.freeze({
+      status: 'not-ready',
+      reachable: true,
+      error: `Local LLM server is reachable but not ready: ${attempts.join('; ')}`,
+    });
+  }
+  return Object.freeze({
+    status: 'offline',
+    reachable: false,
+    error: `Local LLM server is offline: ${attempts.join('; ')}`,
+  });
+}

--- a/packages/local-llm/src/model-endpoint.ts
+++ b/packages/local-llm/src/model-endpoint.ts
@@ -1,11 +1,12 @@
-export type LocalModelEndpointProvider = 'openai-models' | 'llama.cpp-health';
+export type LocalModelEndpointProbeStrategy =
+  | Readonly<{ kind: 'auto' }>
+  | Readonly<{ kind: 'ollama' }>
+  | Readonly<{ kind: 'llama.cpp' }>;
 
 export type LocalModelEndpointAvailability =
   | Readonly<{
     status: 'ready';
     reachable: true;
-    provider: LocalModelEndpointProvider;
-    endpoint: string;
   }>
   | Readonly<{
     status: 'not-ready';
@@ -20,6 +21,8 @@ export type LocalModelEndpointAvailability =
 
 export interface ProbeLocalModelEndpointOptions {
   chatCompletionsUrl: string;
+  model: string;
+  strategy?: LocalModelEndpointProbeStrategy;
   fetch?: typeof fetch;
   timeoutMs?: number;
 }
@@ -33,6 +36,11 @@ interface ModelListEntry {
   readonly id: string;
   readonly metadataState: 'absent' | 'loading' | 'loaded';
 }
+
+type ModelListInspection =
+  | Readonly<{ status: 'ready' }>
+  | Readonly<{ status: 'fallback'; reason: string }>
+  | Readonly<{ status: 'not-ready'; reason: string }>;
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -54,33 +62,26 @@ function endpointUrl(
   return url.toString();
 }
 
-/** Derive provider probes while preserving a reverse-proxy path prefix. */
-export function localModelEndpointUrls(
-  chatCompletionsUrl: string,
-): Readonly<LocalModelEndpointUrls> {
-  return Object.freeze({
+function localModelEndpointUrls(chatCompletionsUrl: string): LocalModelEndpointUrls {
+  return {
     models: endpointUrl(chatCompletionsUrl, '/v1/models'),
     health: endpointUrl(chatCompletionsUrl, '/health'),
-  });
+  };
 }
 
-function inspectModelList(value: unknown):
-  | Readonly<{ status: 'ready' }>
-  | Readonly<{ status: 'fallback'; reason: string }> {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    return Object.freeze({
-      status: 'fallback',
-      reason: 'OpenAI-compatible models probe returned a non-object response',
-    });
-  }
+function canonicalModelId(value: string): string {
+  return value.trim().toLowerCase().replace(/:latest$/, '');
+}
+
+function modelIdsMatch(configured: string, listed: string): boolean {
+  return canonicalModelId(configured) === canonicalModelId(listed);
+}
+
+function parseModelList(value: unknown): ModelListEntry[] | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
   const data = (value as { data?: unknown }).data;
-  if (!Array.isArray(data)) {
-    return Object.freeze({
-      status: 'fallback',
-      reason: 'OpenAI-compatible models probe returned no model list',
-    });
-  }
-  const entries = data.flatMap((candidate): ModelListEntry[] => {
+  if (!Array.isArray(data)) return undefined;
+  return data.flatMap((candidate): ModelListEntry[] => {
     if (typeof candidate !== 'object' || candidate === null || Array.isArray(candidate)) return [];
     const record = candidate as Record<string, unknown>;
     if (typeof record.id !== 'string' || record.id.trim().length === 0) return [];
@@ -91,25 +92,62 @@ function inspectModelList(value: unknown):
       : 'absent';
     return [{ id: record.id, metadataState }];
   });
-  if (entries.length === 0) {
-    return Object.freeze({
-      status: 'fallback',
-      reason: 'OpenAI-compatible models probe returned no usable model',
-    });
+}
+
+function inspectModelList(
+  value: unknown,
+  configuredModel: string,
+  strategy: LocalModelEndpointProbeStrategy,
+): ModelListInspection {
+  const entries = parseModelList(value);
+  if (!entries) {
+    return {
+      status: 'not-ready',
+      reason: 'OpenAI-compatible models probe returned no valid model list',
+    };
   }
-  if (entries.some(({ metadataState }) => metadataState !== 'loading')) {
-    return Object.freeze({ status: 'ready' });
+  const matching = entries.filter(({ id }) => modelIdsMatch(configuredModel, id));
+  if (matching.length === 0) {
+    return {
+      status: 'not-ready',
+      reason: `Configured model '${configuredModel}' is not listed by the local endpoint`,
+    };
   }
+
+  if (strategy.kind === 'ollama') return { status: 'ready' };
+  if (strategy.kind === 'llama.cpp') {
+    return matching.some(({ metadataState }) => metadataState === 'loaded')
+      ? { status: 'ready' }
+      : {
+        status: 'fallback',
+        reason: 'llama.cpp model metadata does not report the configured model as loaded',
+      };
+  }
+
+  // Auto preserves the provider-neutral model-list contract while recognizing
+  // llama.cpp's explicit loading marker. Callers that know the backend can
+  // select a strategy and avoid response-shape provider detection entirely.
+  return matching.some(({ metadataState }) => metadataState !== 'loading')
+    ? { status: 'ready' }
+    : { status: 'fallback', reason: 'llama.cpp model is still loading' };
+}
+
+function offline(error: string): LocalModelEndpointAvailability {
+  return Object.freeze({ status: 'offline', reachable: false, error });
+}
+
+function notReady(attempts: readonly string[]): LocalModelEndpointAvailability {
   return Object.freeze({
-    status: 'fallback',
-    reason: 'llama.cpp models are still loading',
+    status: 'not-ready',
+    reachable: true,
+    error: `Local LLM server is reachable but not ready: ${attempts.join('; ')}`,
   });
 }
 
 /**
- * Probe an OpenAI-compatible local model server without leaking provider
- * branching into daemon lifecycle code. `/v1/models` is primary for Ollama and
- * loaded llama.cpp models; `/health` remains the bounded llama.cpp fallback.
+ * Probe the exact configured model through an explicit backend strategy.
+ * `auto` preserves legacy llama.cpp and Ollama configuration; callers that know
+ * their backend can select its strategy without exposing endpoint details.
  */
 export async function probeLocalModelEndpoint(
   options: ProbeLocalModelEndpointOptions,
@@ -119,9 +157,21 @@ export async function probeLocalModelEndpoint(
   if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
     throw new TypeError('Local model probe timeout must be a positive integer');
   }
-  const urls = localModelEndpointUrls(options.chatCompletionsUrl);
+  const configuredModel = options.model.trim();
+  if (!configuredModel) {
+    return offline('Local LLM endpoint configuration is invalid: model must be non-empty');
+  }
+  const strategy = options.strategy ?? { kind: 'auto' };
+  let urls: LocalModelEndpointUrls;
+  try {
+    urls = localModelEndpointUrls(options.chatCompletionsUrl);
+  } catch (error) {
+    return offline(`Local LLM endpoint configuration is invalid: ${errorMessage(error)}`);
+  }
+
   const attempts: string[] = [];
   let reachable = false;
+  let useHealthFallback = strategy.kind !== 'ollama';
 
   try {
     const response = await fetcher(urls.models, {
@@ -132,24 +182,26 @@ export async function probeLocalModelEndpoint(
     reachable = true;
     if (response.ok) {
       try {
-        const inspection = inspectModelList(await response.json());
+        const inspection = inspectModelList(await response.json(), configuredModel, strategy);
         if (inspection.status === 'ready') {
-          return Object.freeze({
-            status: 'ready',
-            reachable: true,
-            provider: 'openai-models',
-            endpoint: urls.models,
-          });
+          return Object.freeze({ status: 'ready', reachable: true });
         }
         attempts.push(inspection.reason);
+        if (inspection.status === 'not-ready') return notReady(attempts);
       } catch (error) {
         attempts.push(`OpenAI-compatible models probe returned invalid JSON: ${errorMessage(error)}`);
+        return notReady(attempts);
       }
     } else {
       attempts.push(`OpenAI-compatible models probe returned HTTP ${response.status}`);
+      useHealthFallback = useHealthFallback && [404, 405, 501].includes(response.status);
     }
   } catch (error) {
     attempts.push(`OpenAI-compatible models probe failed: ${errorMessage(error)}`);
+  }
+
+  if (!useHealthFallback) {
+    return reachable ? notReady(attempts) : offline(`Local LLM server is offline: ${attempts.join('; ')}`);
   }
 
   try {
@@ -160,28 +212,28 @@ export async function probeLocalModelEndpoint(
     });
     reachable = true;
     if (response.ok) {
-      return Object.freeze({
-        status: 'ready',
-        reachable: true,
-        provider: 'llama.cpp-health',
-        endpoint: urls.health,
-      });
+      try {
+        const payload = await response.json() as { status?: unknown };
+        if (
+          typeof payload === 'object'
+          && payload !== null
+          && !Array.isArray(payload)
+          && payload.status === 'ok'
+        ) {
+          return Object.freeze({ status: 'ready', reachable: true });
+        }
+        attempts.push('llama.cpp health fallback did not return {"status":"ok"}');
+      } catch (error) {
+        attempts.push(`llama.cpp health fallback returned invalid JSON: ${errorMessage(error)}`);
+      }
+    } else {
+      attempts.push(`llama.cpp health fallback returned HTTP ${response.status}`);
     }
-    attempts.push(`llama.cpp health fallback returned HTTP ${response.status}`);
   } catch (error) {
     attempts.push(`llama.cpp health fallback failed: ${errorMessage(error)}`);
   }
 
-  if (reachable) {
-    return Object.freeze({
-      status: 'not-ready',
-      reachable: true,
-      error: `Local LLM server is reachable but not ready: ${attempts.join('; ')}`,
-    });
-  }
-  return Object.freeze({
-    status: 'offline',
-    reachable: false,
-    error: `Local LLM server is offline: ${attempts.join('; ')}`,
-  });
+  return reachable
+    ? notReady(attempts)
+    : offline(`Local LLM server is offline: ${attempts.join('; ')}`);
 }

--- a/packages/local-llm/src/runtime.ts
+++ b/packages/local-llm/src/runtime.ts
@@ -52,7 +52,7 @@ type ChatMessage = {
   tool_calls?: ToolCall[];
 };
 
-type LlamaResponse = {
+type OpenAiCompatibleResponse = {
   choices?: Array<{
     finish_reason?: string | null;
     message?: {
@@ -529,14 +529,14 @@ export class DkgLocalLlmRuntime {
     return undefined;
   }
 
-  private async callLlama(
+  private async callModel(
     messages: ChatMessage[],
     tools: OpenAiToolDefinition[],
     toolChoice: 'required' | 'auto' | undefined,
     round: number,
     maxTokens = this.maxTokens,
     signal?: AbortSignal,
-  ): Promise<LlamaResponse> {
+  ): Promise<OpenAiCompatibleResponse> {
     const body: Record<string, unknown> = {
       model: this.model,
       messages,
@@ -550,7 +550,7 @@ export class DkgLocalLlmRuntime {
     if (tools.length) body.tools = tools;
     if (toolChoice) body.tool_choice = toolChoice;
 
-    await this.trace.write(`LLAMA REQUEST ${round}`, { endpoint: this.llamaUrl, body });
+    await this.trace.write(`LLM REQUEST ${round}`, { endpoint: this.llamaUrl, body });
     signal?.throwIfAborted();
     const timeoutSignal = AbortSignal.timeout(this.requestTimeoutMs);
     const requestSignal = signal
@@ -565,17 +565,17 @@ export class DkgLocalLlmRuntime {
     const raw = await response.text();
     signal?.throwIfAborted();
     if (!response.ok) {
-      await this.trace.write(`LLAMA HTTP ERROR ${round}`, { status: response.status, body: raw });
-      throw new Error(`llama.cpp returned ${response.status}: ${raw}`);
+      await this.trace.write(`LLM HTTP ERROR ${round}`, { status: response.status, body: raw });
+      throw new Error(`Local LLM endpoint returned ${response.status}: ${raw}`);
     }
 
-    let parsed: LlamaResponse;
+    let parsed: OpenAiCompatibleResponse;
     try {
-      parsed = JSON.parse(raw) as LlamaResponse;
+      parsed = JSON.parse(raw) as OpenAiCompatibleResponse;
     } catch (error) {
-      throw new Error(`llama.cpp returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(`Local LLM endpoint returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
     }
-    await this.trace.write(`LLAMA RESPONSE ${round}`, parsed);
+    await this.trace.write(`LLM RESPONSE ${round}`, parsed);
     return parsed;
   }
 
@@ -689,7 +689,7 @@ export class DkgLocalLlmRuntime {
             ? []
             : openAiTools;
       const toolChoice = routedTools.length ? (requireTool ? 'required' : 'auto') : undefined;
-      const response = await this.callLlama(
+      const response = await this.callModel(
         messages,
         routedTools,
         toolChoice,
@@ -699,7 +699,7 @@ export class DkgLocalLlmRuntime {
       );
       const choice = response.choices?.[0];
       const assistant = choice?.message;
-      if (!assistant) throw new Error('llama.cpp returned no assistant choice.');
+      if (!assistant) throw new Error('Local LLM endpoint returned no assistant choice.');
       const toolCalls = assistant.tool_calls ?? [];
 
       if (toolCalls.length === 0) {
@@ -730,7 +730,7 @@ export class DkgLocalLlmRuntime {
           continue;
         }
         const answer = normalizeFinalAnswer(String(assistant.content ?? ''));
-        if (!answer) throw new Error('llama.cpp returned an empty final answer.');
+        if (!answer) throw new Error('Local LLM endpoint returned an empty final answer.');
         await this.trace.write('FINAL ANSWER', answer);
         await this.rememberTurn(prompt, answer, sessionEvidence, signal);
         return { answer, profile: route.profile, toolCalls: executed, traceFile: this.trace.filePath };

--- a/packages/local-llm/test/model-endpoint.test.ts
+++ b/packages/local-llm/test/model-endpoint.test.ts
@@ -1,60 +1,107 @@
 import { describe, expect, it, vi } from 'vitest';
-import {
-  localModelEndpointUrls,
-  probeLocalModelEndpoint,
-} from '../src/model-endpoint.js';
+import { probeLocalModelEndpoint } from '../src/model-endpoint.js';
+
+const DEFAULT_OPTIONS = {
+  chatCompletionsUrl: 'http://127.0.0.1:8080/v1/chat/completions',
+  model: 'local-model',
+} as const;
 
 describe('local model endpoint probing', () => {
-  it('derives standard and reverse-proxy-prefixed probe URLs', () => {
-    expect(localModelEndpointUrls(
-      'http://127.0.0.1:11434/v1/chat/completions?token=ignored#fragment',
-    )).toEqual({
-      models: 'http://127.0.0.1:11434/v1/models',
-      health: 'http://127.0.0.1:11434/health',
+  it('probes standard and reverse-proxy-prefixed backend paths privately', async () => {
+    const fetcher = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/v1/models')) return new Response('not found', { status: 404 });
+      return Response.json({ status: 'ok' });
     });
-    expect(localModelEndpointUrls(
-      'http://localhost:9000/proxy/v1/chat/completions?token=ignored',
-    )).toEqual({
-      models: 'http://localhost:9000/proxy/v1/models',
-      health: 'http://localhost:9000/proxy/health',
-    });
+
+    await expect(probeLocalModelEndpoint({
+      ...DEFAULT_OPTIONS,
+      chatCompletionsUrl: 'http://127.0.0.1:8080/v1/chat/completions?ignored=yes',
+      strategy: { kind: 'llama.cpp' },
+      fetch: fetcher as typeof fetch,
+    })).resolves.toEqual({ status: 'ready', reachable: true });
+    await expect(probeLocalModelEndpoint({
+      ...DEFAULT_OPTIONS,
+      chatCompletionsUrl: 'http://localhost:9000/proxy/v1/chat/completions#ignored',
+      strategy: { kind: 'llama.cpp' },
+      fetch: fetcher as typeof fetch,
+    })).resolves.toEqual({ status: 'ready', reachable: true });
+
+    expect(fetcher.mock.calls.map(([input]) => new URL(String(input)).pathname)).toEqual([
+      '/v1/models',
+      '/health',
+      '/proxy/v1/models',
+      '/proxy/health',
+    ]);
   });
 
-  it('accepts an Ollama-compatible non-empty model list without probing health', async () => {
+  it('accepts only the configured Ollama model and its :latest alias', async () => {
     const fetcher = vi.fn(async () => Response.json({
       object: 'list',
-      data: [{ id: 'qwen3:8b', object: 'model', owned_by: 'library' }],
+      data: [{ id: 'qwen3:latest', object: 'model', owned_by: 'library' }],
     }));
 
     await expect(probeLocalModelEndpoint({
+      ...DEFAULT_OPTIONS,
       chatCompletionsUrl: 'http://127.0.0.1:11434/v1/chat/completions',
+      model: 'qwen3',
+      strategy: { kind: 'ollama' },
+      fetch: fetcher as typeof fetch,
+    })).resolves.toEqual({ status: 'ready', reachable: true });
+    expect(fetcher).toHaveBeenCalledOnce();
+  });
+
+  it('preserves the Ollama model-list contract under the legacy auto strategy', async () => {
+    const fetcher = vi.fn(async () => Response.json({
+      object: 'list',
+      data: [{ id: 'local-model' }],
+    }));
+
+    await expect(probeLocalModelEndpoint({
+      ...DEFAULT_OPTIONS,
+      fetch: fetcher as typeof fetch,
+    })).resolves.toEqual({ status: 'ready', reachable: true });
+    expect(fetcher).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a non-empty model list that omits the configured model', async () => {
+    const fetcher = vi.fn(async () => Response.json({
+      object: 'list',
+      data: [{ id: 'llama3.2', object: 'model', owned_by: 'library' }],
+    }));
+
+    await expect(probeLocalModelEndpoint({
+      ...DEFAULT_OPTIONS,
+      chatCompletionsUrl: 'http://127.0.0.1:11434/v1/chat/completions',
+      model: 'qwen3:8b',
+      strategy: { kind: 'ollama' },
       fetch: fetcher as typeof fetch,
     })).resolves.toEqual({
-      status: 'ready',
+      status: 'not-ready',
       reachable: true,
-      provider: 'openai-models',
-      endpoint: 'http://127.0.0.1:11434/v1/models',
+      error: expect.stringContaining("Configured model 'qwen3:8b' is not listed"),
     });
     expect(fetcher).toHaveBeenCalledOnce();
   });
 
-  it('accepts llama.cpp model metadata only after it is loaded', async () => {
+  it('accepts the configured llama.cpp model only after loaded metadata appears', async () => {
     const fetcher = vi.fn(async () => Response.json({
       object: 'list',
-      data: [{ id: 'local-model', meta: { n_ctx_train: 32_768 } }],
+      data: [
+        { id: 'other-model', meta: { n_ctx_train: 32_768 } },
+        { id: 'local-model', meta: { n_ctx_train: 32_768 } },
+      ],
     }));
 
     await expect(probeLocalModelEndpoint({
-      chatCompletionsUrl: 'http://127.0.0.1:8080/v1/chat/completions',
+      ...DEFAULT_OPTIONS,
+      strategy: { kind: 'llama.cpp' },
       fetch: fetcher as typeof fetch,
-    })).resolves.toMatchObject({
-      status: 'ready',
-      provider: 'openai-models',
-    });
+    })).resolves.toEqual({ status: 'ready', reachable: true });
     expect(fetcher).toHaveBeenCalledOnce();
   });
 
-  it('keeps a loading llama.cpp server not-ready when health is unavailable', async () => {
+  it('keeps a loading llama.cpp model not-ready when health is unavailable', async () => {
     const fetcher = vi.fn(async (input: string | URL | Request) => {
       const url = String(input);
       if (url.endsWith('/v1/models')) {
@@ -67,18 +114,19 @@ describe('local model endpoint probing', () => {
     });
 
     await expect(probeLocalModelEndpoint({
-      chatCompletionsUrl: 'http://127.0.0.1:8080/v1/chat/completions',
+      ...DEFAULT_OPTIONS,
+      strategy: { kind: 'llama.cpp' },
       fetch: fetcher as typeof fetch,
     })).resolves.toEqual({
       status: 'not-ready',
       reachable: true,
-      error: expect.stringContaining('llama.cpp models are still loading'),
+      error: expect.stringContaining('does not report the configured model as loaded'),
     });
     expect(fetcher.mock.calls.map(([input]) => new URL(String(input)).pathname))
       .toEqual(['/v1/models', '/health']);
   });
 
-  it('uses llama.cpp health as a fallback for a loading model list', async () => {
+  it('accepts a loading llama.cpp model only after strict health becomes ready', async () => {
     const fetcher = vi.fn(async (input: string | URL | Request) => {
       const url = String(input);
       if (url.endsWith('/v1/models')) {
@@ -91,14 +139,64 @@ describe('local model endpoint probing', () => {
     });
 
     await expect(probeLocalModelEndpoint({
-      chatCompletionsUrl: 'http://127.0.0.1:8080/v1/chat/completions',
+      ...DEFAULT_OPTIONS,
+      strategy: { kind: 'llama.cpp' },
+      fetch: fetcher as typeof fetch,
+    })).resolves.toEqual({ status: 'ready', reachable: true });
+    expect(fetcher.mock.calls.map(([input]) => new URL(String(input)).pathname))
+      .toEqual(['/v1/models', '/health']);
+  });
+
+  it('uses a strict llama.cpp health response as the legacy fallback', async () => {
+    const fetcher = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/v1/models')) return new Response('not found', { status: 404 });
+      return Response.json({ status: 'ok' });
+    });
+
+    await expect(probeLocalModelEndpoint({
+      ...DEFAULT_OPTIONS,
+      strategy: { kind: 'llama.cpp' },
+      fetch: fetcher as typeof fetch,
+    })).resolves.toEqual({ status: 'ready', reachable: true });
+  });
+
+  it.each([
+    ['a non-ok payload', () => Response.json({ status: 'loading' })],
+    ['malformed JSON', () => new Response('<html>ok</html>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    })],
+  ])('rejects %s from the llama.cpp health fallback', async (_label, healthResponse) => {
+    const fetcher = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/v1/models')) return new Response('not found', { status: 404 });
+      return healthResponse();
+    });
+
+    await expect(probeLocalModelEndpoint({
+      ...DEFAULT_OPTIONS,
+      strategy: { kind: 'llama.cpp' },
       fetch: fetcher as typeof fetch,
     })).resolves.toEqual({
-      status: 'ready',
+      status: 'not-ready',
       reachable: true,
-      provider: 'llama.cpp-health',
-      endpoint: 'http://127.0.0.1:8080/health',
+      error: expect.stringContaining('health fallback'),
     });
+  });
+
+  it('returns structured offline availability for a malformed endpoint URL', async () => {
+    const fetcher = vi.fn();
+    await expect(probeLocalModelEndpoint({
+      ...DEFAULT_OPTIONS,
+      chatCompletionsUrl: 'not-a-url',
+      fetch: fetcher as typeof fetch,
+    })).resolves.toEqual({
+      status: 'offline',
+      reachable: false,
+      error: expect.stringContaining('endpoint configuration is invalid'),
+    });
+    expect(fetcher).not.toHaveBeenCalled();
   });
 
   it('reports offline only when neither probe reaches the server', async () => {
@@ -107,7 +205,7 @@ describe('local model endpoint probing', () => {
     });
 
     await expect(probeLocalModelEndpoint({
-      chatCompletionsUrl: 'http://127.0.0.1:8080/v1/chat/completions',
+      ...DEFAULT_OPTIONS,
       fetch: fetcher as typeof fetch,
     })).resolves.toEqual({
       status: 'offline',

--- a/packages/local-llm/test/model-endpoint.test.ts
+++ b/packages/local-llm/test/model-endpoint.test.ts
@@ -64,6 +64,34 @@ describe('local model endpoint probing', () => {
     expect(fetcher).toHaveBeenCalledOnce();
   });
 
+  it('preserves loaded llama.cpp metadata under the legacy auto strategy', async () => {
+    const fetcher = vi.fn(async () => Response.json({
+      object: 'list',
+      data: [{ id: 'local-model', meta: { n_ctx_train: 32_768 } }],
+    }));
+
+    await expect(probeLocalModelEndpoint({
+      ...DEFAULT_OPTIONS,
+      fetch: fetcher as typeof fetch,
+    })).resolves.toEqual({ status: 'ready', reachable: true });
+    expect(fetcher).toHaveBeenCalledOnce();
+  });
+
+  it('preserves the llama.cpp health fallback under the legacy auto strategy', async () => {
+    const fetcher = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/v1/models')) return new Response('not found', { status: 404 });
+      return Response.json({ status: 'ok' });
+    });
+
+    await expect(probeLocalModelEndpoint({
+      ...DEFAULT_OPTIONS,
+      fetch: fetcher as typeof fetch,
+    })).resolves.toEqual({ status: 'ready', reachable: true });
+    expect(fetcher.mock.calls.map(([input]) => new URL(String(input)).pathname))
+      .toEqual(['/v1/models', '/health']);
+  });
+
   it('rejects a non-empty model list that omits the configured model', async () => {
     const fetcher = vi.fn(async () => Response.json({
       object: 'list',

--- a/packages/local-llm/test/model-endpoint.test.ts
+++ b/packages/local-llm/test/model-endpoint.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  localModelEndpointUrls,
+  probeLocalModelEndpoint,
+} from '../src/model-endpoint.js';
+
+describe('local model endpoint probing', () => {
+  it('derives standard and reverse-proxy-prefixed probe URLs', () => {
+    expect(localModelEndpointUrls(
+      'http://127.0.0.1:11434/v1/chat/completions?token=ignored#fragment',
+    )).toEqual({
+      models: 'http://127.0.0.1:11434/v1/models',
+      health: 'http://127.0.0.1:11434/health',
+    });
+    expect(localModelEndpointUrls(
+      'http://localhost:9000/proxy/v1/chat/completions?token=ignored',
+    )).toEqual({
+      models: 'http://localhost:9000/proxy/v1/models',
+      health: 'http://localhost:9000/proxy/health',
+    });
+  });
+
+  it('accepts an Ollama-compatible non-empty model list without probing health', async () => {
+    const fetcher = vi.fn(async () => Response.json({
+      object: 'list',
+      data: [{ id: 'qwen3:8b', object: 'model', owned_by: 'library' }],
+    }));
+
+    await expect(probeLocalModelEndpoint({
+      chatCompletionsUrl: 'http://127.0.0.1:11434/v1/chat/completions',
+      fetch: fetcher as typeof fetch,
+    })).resolves.toEqual({
+      status: 'ready',
+      reachable: true,
+      provider: 'openai-models',
+      endpoint: 'http://127.0.0.1:11434/v1/models',
+    });
+    expect(fetcher).toHaveBeenCalledOnce();
+  });
+
+  it('accepts llama.cpp model metadata only after it is loaded', async () => {
+    const fetcher = vi.fn(async () => Response.json({
+      object: 'list',
+      data: [{ id: 'local-model', meta: { n_ctx_train: 32_768 } }],
+    }));
+
+    await expect(probeLocalModelEndpoint({
+      chatCompletionsUrl: 'http://127.0.0.1:8080/v1/chat/completions',
+      fetch: fetcher as typeof fetch,
+    })).resolves.toMatchObject({
+      status: 'ready',
+      provider: 'openai-models',
+    });
+    expect(fetcher).toHaveBeenCalledOnce();
+  });
+
+  it('keeps a loading llama.cpp server not-ready when health is unavailable', async () => {
+    const fetcher = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/v1/models')) {
+        return Response.json({
+          object: 'list',
+          data: [{ id: 'local-model', meta: null }],
+        });
+      }
+      return new Response('loading model', { status: 503 });
+    });
+
+    await expect(probeLocalModelEndpoint({
+      chatCompletionsUrl: 'http://127.0.0.1:8080/v1/chat/completions',
+      fetch: fetcher as typeof fetch,
+    })).resolves.toEqual({
+      status: 'not-ready',
+      reachable: true,
+      error: expect.stringContaining('llama.cpp models are still loading'),
+    });
+    expect(fetcher.mock.calls.map(([input]) => new URL(String(input)).pathname))
+      .toEqual(['/v1/models', '/health']);
+  });
+
+  it('uses llama.cpp health as a fallback for a loading model list', async () => {
+    const fetcher = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/v1/models')) {
+        return Response.json({
+          object: 'list',
+          data: [{ id: 'local-model', meta: null }],
+        });
+      }
+      return Response.json({ status: 'ok' });
+    });
+
+    await expect(probeLocalModelEndpoint({
+      chatCompletionsUrl: 'http://127.0.0.1:8080/v1/chat/completions',
+      fetch: fetcher as typeof fetch,
+    })).resolves.toEqual({
+      status: 'ready',
+      reachable: true,
+      provider: 'llama.cpp-health',
+      endpoint: 'http://127.0.0.1:8080/health',
+    });
+  });
+
+  it('reports offline only when neither probe reaches the server', async () => {
+    const fetcher = vi.fn(async () => {
+      throw new TypeError('fetch failed');
+    });
+
+    await expect(probeLocalModelEndpoint({
+      chatCompletionsUrl: 'http://127.0.0.1:8080/v1/chat/completions',
+      fetch: fetcher as typeof fetch,
+    })).resolves.toEqual({
+      status: 'offline',
+      reachable: false,
+      error: expect.stringContaining('Local LLM server is offline'),
+    });
+  });
+});

--- a/packages/local-llm/test/runtime.test.ts
+++ b/packages/local-llm/test/runtime.test.ts
@@ -165,6 +165,46 @@ describe('DkgLocalLlmRuntime', () => {
     expect(secondRequest.messages.at(-1).content).toContain('Structured DKG evidence');
   });
 
+  it('repairs one ignored required tool choice from an OpenAI-compatible backend', async () => {
+    const mcp = makeMcp();
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(answerResponse('I can answer without a tool.'))
+      .mockResolvedValueOnce(toolResponse('dkg_query_catalog_list', {}))
+      .mockResolvedValueOnce(answerResponse('One saved query: supply/lifecycle.'));
+    const runtime = await DkgLocalLlmRuntime.create({
+      mcp,
+      fetch: fetcher as typeof fetch,
+      projectId: 'testing',
+    });
+
+    const result = await runtime.run('Which DKG query catalog queries are saved?');
+
+    expect(result.answer).toBe('One saved query: supply/lifecycle.');
+    expect(mcp.callTool).toHaveBeenCalledOnce();
+    const firstRequest = JSON.parse(String(fetcher.mock.calls[0][1]?.body));
+    const repairRequest = JSON.parse(String(fetcher.mock.calls[1][1]?.body));
+    expect(firstRequest.tool_choice).toBe('required');
+    expect(repairRequest.tool_choice).toBe('required');
+    expect(repairRequest.messages.at(-1).content)
+      .toContain('Retry once with exactly one available tool call and no prose');
+  });
+
+  it('fails closed when an OpenAI-compatible backend ignores required tool choice twice', async () => {
+    const mcp = makeMcp();
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(answerResponse('First unsupported prose answer.'))
+      .mockResolvedValueOnce(answerResponse('Second unsupported prose answer.'));
+    const runtime = await DkgLocalLlmRuntime.create({
+      mcp,
+      fetch: fetcher as typeof fetch,
+      projectId: 'testing',
+    });
+
+    await expect(runtime.run('Which DKG query catalog queries are saved?'))
+      .rejects.toThrow('One-retry limit reached');
+    expect(mcp.callTool).not.toHaveBeenCalled();
+  });
+
   it('strictly pins model-supplied graph arguments and excludes unscoped discovery tools', async () => {
     const strictCatalogList: McpToolDefinition = {
       ...catalogList,

--- a/packages/node-ui/test/local-llm-ui.test.ts
+++ b/packages/node-ui/test/local-llm-ui.test.ts
@@ -21,7 +21,7 @@ function localLlmRecord() {
   return {
     id: 'local-llm',
     name: 'DKG Local LLM',
-    description: 'Chat with this DKG node through a local llama.cpp model.',
+    description: 'Chat with a local llama.cpp or Ollama model through the DKG MCP tool surface.',
     enabled: true,
     transport: { kind: 'dkg-local-llm' },
     capabilities: { localChat: true, connectFromUi: false },
@@ -31,7 +31,7 @@ function localLlmRecord() {
 }
 
 describe('DKG Local LLM Node UI surface', () => {
-  it('keeps the daemon-owned chat visible while llama.cpp is offline and has no Connect flow', async () => {
+  it('keeps the daemon-owned chat visible while the local LLM is offline and has no Connect flow', async () => {
     globalThis.fetch = vi.fn(async (input) => {
       const url = String(input);
       if (url.endsWith('/api/local-agent-integrations')) {
@@ -44,7 +44,7 @@ describe('DKG Local LLM Node UI surface', () => {
           reachable: false,
           offline: true,
           readOnly: true,
-          error: 'Local llama.cpp server is offline: fetch failed',
+          error: 'Local LLM server is offline: fetch failed',
         });
       }
       return json({ error: `Unexpected request: ${url}` }, 500);
@@ -61,7 +61,7 @@ describe('DKG Local LLM Node UI surface', () => {
       chatReady: false,
       status: 'bridge_offline',
       statusLabel: 'Bridge offline',
-      error: 'Local llama.cpp server is offline: fetch failed',
+      error: 'Local LLM server is offline: fetch failed',
     });
     await expect(connectLocalAgentIntegration('local-llm')).rejects.toThrow(
       'local connect is not available',


### PR DESCRIPTION
## Summary

Add Ollama as a supported OpenAI-compatible local model backend for CLI and Node UI while preserving llama.cpp as the reference and default path.

## Changes

- probe the provider-neutral `/v1/models` readiness endpoint used by both Ollama and current llama.cpp
- retain llama.cpp `/health` as a compatibility fallback
- distinguish offline servers from reachable but incompatible or unready servers
- make runtime traces and errors provider-neutral
- retain the existing one-retry, fail-closed behavior when a backend ignores required tool selection
- document llama.cpp and Ollama setup for CLI, Node UI, agent operation, and real-DKG benchmarking

## Test Plan

- [x] `pnpm run build:runtime:packages` (19-package runtime build)
- [x] local-LLM suite: 68 tests
- [x] focused daemon service and route suites: 29 tests
- [x] focused Node UI suite: 4 tests
- [x] `pnpm lint`
- [x] `git diff --check`
- [ ] Live Ollama sidecar test was not run because Ollama is not installed on the development machine; compatibility is covered by OpenAI-contract mocks and runtime orchestration tests.

## Related Issues

None.