### PR TITLE
chore(release): bump package versions to 10.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkg-v10",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "dkgBuild": {

--- a/packages/adapter-elizaos/package.json
+++ b/packages/adapter-elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-elizaos",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "description": "ElizaOS plugin adapter — turns any ElizaOS agent into a DKG V10 node",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-hermes",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "description": "Hermes Agent adapter — connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-openclaw",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "description": "OpenClaw plugin adapter for connecting a DKG V10 node and chat bridge to an OpenClaw agent",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-prime-agent/package.json
+++ b/packages/adapter-prime-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-prime-agent",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "description": "Prime Intellect Prime Agent adapter — collocates a Prime Agent with a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-agent",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "type": "module",
   "engines": {
     "node": ">=22.13.0 <23.0.0 || >=23.4.0"

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-chain",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "type": "module",
   "engines": {
     "node": ">=22.13.0 <23.0.0 || >=23.4.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-core",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/epcis/package.json
+++ b/packages/epcis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-epcis",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-evm-module",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "description": "DKG V10 smart contracts (forked from V8 dkg-evm-module)",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "description": "RDF Knowledge Graph Visualizer — force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kafka-plugin/package.json
+++ b/packages/kafka-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/kafka-plugin",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/local-llm/package.json
+++ b/packages/local-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-local-llm",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "description": "Bounded local-LLM tool runtime for the DKG MCP surface.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-dkg/package.json
+++ b/packages/mcp-dkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-mcp",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "description": "MCP server that exposes the local DKG daemon (projects, sub-graphs, activity, chat) to Cursor, Claude Code, and any other MCP-aware coding assistant.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/network-sim/package.json
+++ b/packages/network-sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-network-sim",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-node-ui",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/okf/package.json
+++ b/packages/okf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-okf",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-publisher",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-query",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/random-sampling/package.json
+++ b/packages/random-sampling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-random-sampling",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rdf-utils/package.json
+++ b/packages/rdf-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-rdf-utils",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-storage",
-  "version": "10.0.15",
+  "version": "10.1.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- bump the root manifest and all 22 package manifests from `10.0.15` to `10.1.0`
- keep every release package on one version so npm publication, CLI identity, daemon status, and build metadata remain aligned
- make no runtime, configuration, protocol, or activation changes in this PR

## Impact

After this lands, builds and packages produced from `testnet-canary` identify as DKG `10.1.0`. This establishes the new minor release line for the already-integrated RFC-64 and related canary work without changing its behavior.

Creation base: `testnet-canary` `7d1753cec2bcce9383acd84549901015e55c52c9`, including RFC-64 authority-fence PR #2451 and the certified private cell-11 behavior.

## Before

```mermaid
sequenceDiagram
    participant Operator
    participant Build as DKG build
    participant Packages as Release packages
    participant Node as Running node

    Operator->>Build: Build current testnet-canary
    Build->>Packages: Read 10.0.15 from 23 manifests
    Packages-->>Node: Report release identity 10.0.15
```

## After

```mermaid
sequenceDiagram
    participant Operator
    participant Build as DKG build
    participant Packages as Release packages
    participant Node as Running node

    Operator->>Build: Build current testnet-canary
    Build->>Packages: Read 10.1.0 from 23 manifests
    Packages-->>Node: Report release identity 10.1.0
```

## Validation

- `node scripts/release-packages.mjs verify-versions --version 10.1.0` — 23/23 manifests aligned
- `pnpm install --frozen-lockfile`
- `pnpm build` — 24/24 package build tasks plus Node UI production build
- `node --test scripts/lib/__tests__/release-packages.test.mjs` — 26/26 passed
- `pnpm --filter @origintrail-official/dkg exec vitest run test/local-llm-runtime-factory.test.ts` — 2/2 passed
- `pnpm lint`
- `git diff --check`

## Release note

This is version preparation only. Tagging, npm publication, network rollout, and promotion remain separate release operations.
