### PR TITLE
fix(agent): recover finalized private catalog rows from VM

### DIFF
--- a/packages/agent/src/rfc64/swm-catalog-durable-asset-resolver-v1.ts
+++ b/packages/agent/src/rfc64/swm-catalog-durable-asset-resolver-v1.ts
@@ -3,7 +3,6 @@
 /** Source-owned durable SWM catalog asset loading and strict validation. */
 
 import {
-  assertSafeIri,
   canonicalGraphScopedAuthorSealFromAssertionSealV1,
   computeCanonicalGraphScopedAuthorSealDigestV1,
   computeKaProjectionDigestV1,
@@ -18,12 +17,15 @@ import {
   type SwmAuthorInventoryRowV1,
 } from '@origintrail-official/dkg-core';
 import {
+  ExactGraphReadError,
   GraphManager,
+  readExactGraphPaged,
   type Quad,
   type TripleStore,
 } from '@origintrail-official/dkg-storage';
 import {
   computeFlatKCRootV10,
+  readConfirmedGraphKnowledgeAssetMetadataEnvelope,
   resolveKnowledgeAssetOperationPublicQuads,
   resolvePublishedKnowledgeAssetWorkspaceHead,
   type WorkspacePublicSnapshotStore,
@@ -55,6 +57,22 @@ interface ResolvedStrictSealV1 {
   readonly seal: CanonicalGraphScopedAuthorSealV1;
 }
 
+type DurableCatalogAssetResolutionV1 =
+  | Readonly<{
+      kind: 'inventory-row';
+      row: Readonly<SwmAuthorInventoryRowV1>;
+      laneKind: 'public' | 'private';
+    }>
+  | Readonly<{
+      kind: 'confirmed-vm-repair';
+      identity: Readonly<Rfc64DurableCatalogAssetIdentityV1>;
+    }>;
+
+interface DurableCatalogAssetResolverInputV1 extends DurableCatalogAssetResolverBaseV1 {
+  readonly resolution: DurableCatalogAssetResolutionV1;
+  readonly publicSnapshotStore?: WorkspacePublicSnapshotStore;
+}
+
 /** Resolve one exact durable workspace row; missing or divergent heads fail closed. */
 export async function resolveRfc64InventoryWorkspaceCatalogAssetV1(
   params: Readonly<DurableCatalogAssetResolverBaseV1 & {
@@ -63,59 +81,20 @@ export async function resolveRfc64InventoryWorkspaceCatalogAssetV1(
     readonly publicSnapshotStore?: WorkspacePublicSnapshotStore;
   }>,
 ): Promise<Rfc64PublicCatalogSuccessorAssetInputV1> {
-  const { graphManager, seal } = await resolveStrictSealV1(params, params.row);
-  const head = await resolvePublishedKnowledgeAssetWorkspaceHead({
+  return resolveDurableCatalogAssetV1({
     store: params.store,
-    graphManager,
     contextGraphId: params.contextGraphId,
-    kaUal: params.row.kaUal,
+    authorAddress: params.authorAddress,
+    ...(params.signal === undefined ? {} : { signal: params.signal }),
+    ...(params.publicSnapshotStore === undefined
+      ? {}
+      : { publicSnapshotStore: params.publicSnapshotStore }),
+    resolution: Object.freeze({
+      kind: 'inventory-row',
+      row: params.row,
+      laneKind: params.laneKind,
+    }),
   });
-  throwIfAbortedV1(params.signal);
-
-  let projectionBytes: Uint8Array;
-  // Finalized private placements remain in the tier-neutral author inventory
-  // after their byte-identical SWM twin is retired. Rebuild those rows from
-  // the exact VM graph; public lanes must continue to require a workspace head.
-  if (head === undefined) {
-    if (params.laneKind !== 'private') {
-      throw new Error(`durable RFC-64 workspace head differs for ${params.row.kaUal}`);
-    }
-    projectionBytes = await resolveFinalizedVmProjectionBytesV1(
-      params,
-      params.row,
-      seal,
-      'agent.rfc64.swmInventory.catalogReconcile.vmProjection',
-    );
-  } else {
-    if (
-      head.assertionVersion !== params.row.assertionVersion
-      || head.shareOperationId !== params.row.shareOperationId
-      || head.publicTripleCount !== Number(params.row.publicTripleCount)
-      || head.privateTripleCount !== Number(params.row.privateTripleCount)
-      || !laneAcceptsWorkspaceHeadV1(params.laneKind, head.accessPolicy)
-    ) {
-      throw new Error(`durable RFC-64 workspace head differs for ${params.row.kaUal}`);
-    }
-    const snapshot = await resolveKnowledgeAssetOperationPublicQuads({
-      store: params.store,
-      graphManager,
-      contextGraphId: params.contextGraphId,
-      shareOperationId: head.shareOperationId,
-      kaUal: params.row.kaUal,
-      assertionVersion: params.row.assertionVersion,
-      publicSnapshotStore: params.publicSnapshotStore,
-    });
-    throwIfAbortedV1(params.signal);
-    assertProjectionMatchesSealV1(snapshot.quads, seal, params.row.kaUal);
-    projectionBytes = encodeCanonicalCgSharedPublicRootProjectionV1(snapshot.quads);
-  }
-
-  if (computeKaProjectionDigestV1(projectionBytes) !== params.row.projectionDigest) {
-    throw new Error(
-      `durable RFC-64 projection differs from signed inventory row ${params.row.kaUal}`,
-    );
-  }
-  return catalogAssetV1(params.row.assertionCoordinate, projectionBytes, seal);
 }
 
 /** Resolve one confirmed-VM repair from an exact workspace or finalized VM graph. */
@@ -125,69 +104,148 @@ export async function resolveRfc64ConfirmedVmRepairCatalogAssetV1(
     readonly publicSnapshotStore?: WorkspacePublicSnapshotStore;
   }>,
 ): Promise<Rfc64PublicCatalogSuccessorAssetInputV1> {
-  const { graphManager, seal } = await resolveStrictSealV1(params, params.identity);
+  return resolveDurableCatalogAssetV1({
+    store: params.store,
+    contextGraphId: params.contextGraphId,
+    authorAddress: params.authorAddress,
+    ...(params.signal === undefined ? {} : { signal: params.signal }),
+    ...(params.publicSnapshotStore === undefined
+      ? {}
+      : { publicSnapshotStore: params.publicSnapshotStore }),
+    resolution: Object.freeze({
+      kind: 'confirmed-vm-repair',
+      identity: params.identity,
+    }),
+  });
+}
+
+async function resolveDurableCatalogAssetV1(
+  params: Readonly<DurableCatalogAssetResolverInputV1>,
+): Promise<Rfc64PublicCatalogSuccessorAssetInputV1> {
+  const { resolution } = params;
+  const identity = resolution.kind === 'inventory-row'
+    ? resolution.row
+    : resolution.identity;
+  const laneKind = resolution.kind === 'inventory-row'
+    ? resolution.laneKind
+    : 'private';
+  const { graphManager, seal } = await resolveStrictSealV1(params, identity);
   const head = await resolvePublishedKnowledgeAssetWorkspaceHead({
     store: params.store,
     graphManager,
     contextGraphId: params.contextGraphId,
-    kaUal: params.identity.kaUal,
+    kaUal: identity.kaUal,
   });
   throwIfAbortedV1(params.signal);
 
-  let projectionBytes: Uint8Array;
+  let projectionQuads: readonly Quad[];
+  // Finalized private placements remain in the tier-neutral author inventory
+  // after their byte-identical SWM twin is retired. Rebuild those rows from
+  // exact confirmed VM state; public lanes continue to require a workspace head.
   if (head === undefined) {
-    projectionBytes = await resolveFinalizedVmProjectionBytesV1(
+    if (laneKind !== 'private') {
+      throw new Error(`durable RFC-64 workspace head differs for ${identity.kaUal}`);
+    }
+    projectionQuads = await resolveFinalizedVmProjectionQuadsV1(
       params,
-      params.identity,
+      identity,
       seal,
-      'agent.rfc64.finalizedPrivateCatalogRepair.vmProjection',
+      resolution.kind === 'inventory-row'
+        ? 'agent.rfc64.swmInventory.catalogReconcile.vmProjection'
+        : 'agent.rfc64.finalizedPrivateCatalogRepair.vmProjection',
     );
   } else {
+    const inventoryRowDiffers = resolution.kind === 'inventory-row' && (
+      head.shareOperationId !== resolution.row.shareOperationId
+      || head.publicTripleCount !== Number(resolution.row.publicTripleCount)
+      || head.privateTripleCount !== Number(resolution.row.privateTripleCount)
+    );
     if (
-      head.assertionVersion !== params.identity.assertionVersion
+      head.assertionVersion !== identity.assertionVersion
       || head.publicTripleCount !== Number(seal.publicTripleCount)
       || head.privateTripleCount !== Number(seal.privateTripleCount)
-      || !laneAcceptsWorkspaceHeadV1('private', head.accessPolicy)
+      || !laneAcceptsWorkspaceHeadV1(laneKind, head.accessPolicy)
+      || inventoryRowDiffers
     ) {
-      throw new Error(`durable RFC-64 workspace head differs for ${params.identity.kaUal}`);
+      throw new Error(`durable RFC-64 workspace head differs for ${identity.kaUal}`);
     }
     const snapshot = await resolveKnowledgeAssetOperationPublicQuads({
       store: params.store,
       graphManager,
       contextGraphId: params.contextGraphId,
       shareOperationId: head.shareOperationId,
-      kaUal: params.identity.kaUal,
-      assertionVersion: params.identity.assertionVersion,
+      kaUal: identity.kaUal,
+      assertionVersion: identity.assertionVersion,
       publicSnapshotStore: params.publicSnapshotStore,
     });
     throwIfAbortedV1(params.signal);
-    assertProjectionMatchesSealV1(snapshot.quads, seal, params.identity.kaUal);
-    projectionBytes = encodeCanonicalCgSharedPublicRootProjectionV1(snapshot.quads);
+    projectionQuads = snapshot.quads;
   }
-  return catalogAssetV1(params.identity.assertionCoordinate, projectionBytes, seal);
+
+  assertProjectionMatchesSealV1(projectionQuads, seal, identity.kaUal);
+  const projectionBytes = encodeCanonicalCgSharedPublicRootProjectionV1(projectionQuads);
+  if (
+    resolution.kind === 'inventory-row'
+    && computeKaProjectionDigestV1(projectionBytes) !== resolution.row.projectionDigest
+  ) {
+    throw new Error(
+      `durable RFC-64 projection differs from signed inventory row ${identity.kaUal}`,
+    );
+  }
+  return catalogAssetV1(identity.assertionCoordinate, projectionBytes, seal);
 }
 
-async function resolveFinalizedVmProjectionBytesV1(
+async function resolveFinalizedVmProjectionQuadsV1(
   params: Readonly<DurableCatalogAssetResolverBaseV1>,
   identity: Readonly<Rfc64DurableCatalogAssetIdentityV1>,
   seal: Readonly<CanonicalGraphScopedAuthorSealV1>,
   source: string,
-): Promise<Uint8Array> {
+): Promise<readonly Quad[]> {
   const vmGraph = knowledgeAssetLayerGraphUri(
     params.contextGraphId,
     MemoryLayer.VerifiableMemory,
     createGraphKnowledgeAssetScope(identity.kaUal, identity.assertionVersion),
   );
-  const result = await params.store.query(
-    `CONSTRUCT { ?subject ?predicate ?object } WHERE { GRAPH <${assertSafeIri(vmGraph)}> { ?subject ?predicate ?object } }`,
-    { source, signal: params.signal },
-  );
+  const stored = await readConfirmedGraphKnowledgeAssetMetadataEnvelope(params.store, {
+    contextGraphId: params.contextGraphId,
+    ual: identity.kaUal,
+  });
   throwIfAbortedV1(params.signal);
-  if (result.type !== 'quads' || result.quads.length !== Number(seal.publicTripleCount)) {
+  const expectedPrivateMerkleRoot = seal.privateMerkleRoot === null
+    ? undefined
+    : ethers.getBytes(seal.privateMerkleRoot);
+  const expectedMerkleRoot = ethers.getBytes(seal.assertionMerkleRoot);
+  if (
+    stored.state !== 'confirmed'
+    || stored.envelope.assertionVersion !== identity.assertionVersion
+    || stored.envelope.batchId !== BigInt(seal.reservedKaId)
+    || stored.envelope.publicTripleCount !== Number(seal.publicTripleCount)
+    || stored.envelope.privateTripleCount !== Number(seal.privateTripleCount)
+    || !equalOptionalBytesV1(
+      stored.envelope.privateMerkleRoot,
+      expectedPrivateMerkleRoot,
+    )
+    || !equalBytesV1(stored.envelope.merkleRoot, expectedMerkleRoot)
+    || stored.envelope.assertionGraph !== vmGraph
+    || stored.envelope.subGraphName !== undefined
+  ) {
     throw new Error(`durable finalized VM projection differs for ${identity.kaUal}`);
   }
-  assertProjectionMatchesSealV1(result.quads, seal, identity.kaUal);
-  return encodeCanonicalCgSharedPublicRootProjectionV1(result.quads);
+  let quads: Quad[];
+  try {
+    quads = await readExactGraphPaged(params.store, vmGraph, {
+      expectedQuadCount: Number(seal.publicTripleCount),
+      outputGraph: '',
+      queryOptions: { source, signal: params.signal },
+    });
+  } catch (error) {
+    if (error instanceof ExactGraphReadError && error.kind === 'integrity') {
+      throw new Error(`durable finalized VM projection differs for ${identity.kaUal}`);
+    }
+    throw error;
+  }
+  throwIfAbortedV1(params.signal);
+  return quads;
 }
 
 async function resolveStrictSealV1(
@@ -258,4 +316,18 @@ function assertProjectionMatchesSealV1(
   if (actualRoot !== seal.assertionMerkleRoot) {
     throw new Error(`durable finalized VM projection differs for ${kaUal}`);
   }
+}
+
+function equalBytesV1(left: Uint8Array, right: Uint8Array): boolean {
+  return left.length === right.length
+    && left.every((byte, index) => byte === right[index]);
+}
+
+function equalOptionalBytesV1(
+  left: Uint8Array | undefined,
+  right: Uint8Array | undefined,
+): boolean {
+  return left === undefined || right === undefined
+    ? left === right
+    : equalBytesV1(left, right);
 }

--- a/packages/agent/src/rfc64/swm-catalog-durable-asset-resolver-v1.ts
+++ b/packages/agent/src/rfc64/swm-catalog-durable-asset-resolver-v1.ts
@@ -71,45 +71,45 @@ export async function resolveRfc64InventoryWorkspaceCatalogAssetV1(
     kaUal: params.row.kaUal,
   });
   throwIfAbortedV1(params.signal);
+
+  let projectionBytes: Uint8Array;
   // Finalized private placements remain in the tier-neutral author inventory
   // after their byte-identical SWM twin is retired. Rebuild those rows from
   // the exact VM graph; public lanes must continue to require a workspace head.
-  if (head === undefined && params.laneKind === 'private') {
-    const projectionBytes = await resolveFinalizedVmProjectionBytesV1(
+  if (head === undefined) {
+    if (params.laneKind !== 'private') {
+      throw new Error(`durable RFC-64 workspace head differs for ${params.row.kaUal}`);
+    }
+    projectionBytes = await resolveFinalizedVmProjectionBytesV1(
       params,
       params.row,
       seal,
       'agent.rfc64.swmInventory.catalogReconcile.vmProjection',
     );
-    if (computeKaProjectionDigestV1(projectionBytes) !== params.row.projectionDigest) {
-      throw new Error(
-        `durable RFC-64 projection differs from signed inventory row ${params.row.kaUal}`,
-      );
+  } else {
+    if (
+      head.assertionVersion !== params.row.assertionVersion
+      || head.shareOperationId !== params.row.shareOperationId
+      || head.publicTripleCount !== Number(params.row.publicTripleCount)
+      || head.privateTripleCount !== Number(params.row.privateTripleCount)
+      || !laneAcceptsWorkspaceHeadV1(params.laneKind, head.accessPolicy)
+    ) {
+      throw new Error(`durable RFC-64 workspace head differs for ${params.row.kaUal}`);
     }
-    return catalogAssetV1(params.row.assertionCoordinate, projectionBytes, seal);
+    const snapshot = await resolveKnowledgeAssetOperationPublicQuads({
+      store: params.store,
+      graphManager,
+      contextGraphId: params.contextGraphId,
+      shareOperationId: head.shareOperationId,
+      kaUal: params.row.kaUal,
+      assertionVersion: params.row.assertionVersion,
+      publicSnapshotStore: params.publicSnapshotStore,
+    });
+    throwIfAbortedV1(params.signal);
+    assertProjectionMatchesSealV1(snapshot.quads, seal, params.row.kaUal);
+    projectionBytes = encodeCanonicalCgSharedPublicRootProjectionV1(snapshot.quads);
   }
-  if (
-    head === undefined
-    || head.assertionVersion !== params.row.assertionVersion
-    || head.shareOperationId !== params.row.shareOperationId
-    || head.publicTripleCount !== Number(params.row.publicTripleCount)
-    || head.privateTripleCount !== Number(params.row.privateTripleCount)
-    || !laneAcceptsWorkspaceHeadV1(params.laneKind, head.accessPolicy)
-  ) {
-    throw new Error(`durable RFC-64 workspace head differs for ${params.row.kaUal}`);
-  }
-  const snapshot = await resolveKnowledgeAssetOperationPublicQuads({
-    store: params.store,
-    graphManager,
-    contextGraphId: params.contextGraphId,
-    shareOperationId: head.shareOperationId,
-    kaUal: params.row.kaUal,
-    assertionVersion: params.row.assertionVersion,
-    publicSnapshotStore: params.publicSnapshotStore,
-  });
-  throwIfAbortedV1(params.signal);
-  assertProjectionMatchesSealV1(snapshot.quads, seal, params.row.kaUal);
-  const projectionBytes = encodeCanonicalCgSharedPublicRootProjectionV1(snapshot.quads);
+
   if (computeKaProjectionDigestV1(projectionBytes) !== params.row.projectionDigest) {
     throw new Error(
       `durable RFC-64 projection differs from signed inventory row ${params.row.kaUal}`,

--- a/packages/agent/src/rfc64/swm-catalog-durable-asset-resolver-v1.ts
+++ b/packages/agent/src/rfc64/swm-catalog-durable-asset-resolver-v1.ts
@@ -71,6 +71,23 @@ export async function resolveRfc64InventoryWorkspaceCatalogAssetV1(
     kaUal: params.row.kaUal,
   });
   throwIfAbortedV1(params.signal);
+  // Finalized private placements remain in the tier-neutral author inventory
+  // after their byte-identical SWM twin is retired. Rebuild those rows from
+  // the exact VM graph; public lanes must continue to require a workspace head.
+  if (head === undefined && params.laneKind === 'private') {
+    const projectionBytes = await resolveFinalizedVmProjectionBytesV1(
+      params,
+      params.row,
+      seal,
+      'agent.rfc64.swmInventory.catalogReconcile.vmProjection',
+    );
+    if (computeKaProjectionDigestV1(projectionBytes) !== params.row.projectionDigest) {
+      throw new Error(
+        `durable RFC-64 projection differs from signed inventory row ${params.row.kaUal}`,
+      );
+    }
+    return catalogAssetV1(params.row.assertionCoordinate, projectionBytes, seal);
+  }
   if (
     head === undefined
     || head.assertionVersion !== params.row.assertionVersion
@@ -119,24 +136,12 @@ export async function resolveRfc64ConfirmedVmRepairCatalogAssetV1(
 
   let projectionBytes: Uint8Array;
   if (head === undefined) {
-    const vmGraph = knowledgeAssetLayerGraphUri(
-      params.contextGraphId,
-      MemoryLayer.VerifiableMemory,
-      createGraphKnowledgeAssetScope(
-        params.identity.kaUal,
-        params.identity.assertionVersion,
-      ),
+    projectionBytes = await resolveFinalizedVmProjectionBytesV1(
+      params,
+      params.identity,
+      seal,
+      'agent.rfc64.finalizedPrivateCatalogRepair.vmProjection',
     );
-    const result = await params.store.query(
-      `CONSTRUCT { ?subject ?predicate ?object } WHERE { GRAPH <${assertSafeIri(vmGraph)}> { ?subject ?predicate ?object } }`,
-      { source: 'agent.rfc64.finalizedPrivateCatalogRepair.vmProjection', signal: params.signal },
-    );
-    throwIfAbortedV1(params.signal);
-    if (result.type !== 'quads' || result.quads.length !== Number(seal.publicTripleCount)) {
-      throw new Error(`durable finalized VM projection differs for ${params.identity.kaUal}`);
-    }
-    assertProjectionMatchesSealV1(result.quads, seal, params.identity.kaUal);
-    projectionBytes = encodeCanonicalCgSharedPublicRootProjectionV1(result.quads);
   } else {
     if (
       head.assertionVersion !== params.identity.assertionVersion
@@ -160,6 +165,29 @@ export async function resolveRfc64ConfirmedVmRepairCatalogAssetV1(
     projectionBytes = encodeCanonicalCgSharedPublicRootProjectionV1(snapshot.quads);
   }
   return catalogAssetV1(params.identity.assertionCoordinate, projectionBytes, seal);
+}
+
+async function resolveFinalizedVmProjectionBytesV1(
+  params: Readonly<DurableCatalogAssetResolverBaseV1>,
+  identity: Readonly<Rfc64DurableCatalogAssetIdentityV1>,
+  seal: Readonly<CanonicalGraphScopedAuthorSealV1>,
+  source: string,
+): Promise<Uint8Array> {
+  const vmGraph = knowledgeAssetLayerGraphUri(
+    params.contextGraphId,
+    MemoryLayer.VerifiableMemory,
+    createGraphKnowledgeAssetScope(identity.kaUal, identity.assertionVersion),
+  );
+  const result = await params.store.query(
+    `CONSTRUCT { ?subject ?predicate ?object } WHERE { GRAPH <${assertSafeIri(vmGraph)}> { ?subject ?predicate ?object } }`,
+    { source, signal: params.signal },
+  );
+  throwIfAbortedV1(params.signal);
+  if (result.type !== 'quads' || result.quads.length !== Number(seal.publicTripleCount)) {
+    throw new Error(`durable finalized VM projection differs for ${identity.kaUal}`);
+  }
+  assertProjectionMatchesSealV1(result.quads, seal, identity.kaUal);
+  return encodeCanonicalCgSharedPublicRootProjectionV1(result.quads);
 }
 
 async function resolveStrictSealV1(

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -444,29 +444,7 @@ async function seedPreexistingFinalizedTwinV1(
     MemoryLayer.VerifiableMemory,
     scope,
   );
-  const vmMetadata = generateGraphKnowledgeAssetMetadata({
-    contextGraphId: CONTEXT_GRAPH_ID,
-    ual: seal.kaUal,
-    merkleRoot: ethers.getBytes(seal.assertionMerkleRoot),
-    publisherPeerId: 'rfc64-finalized-catalog-v1',
-    accessPolicy: 'ownerOnly',
-    allowedPeers: [],
-    timestamp: new Date(seal.assertionFinalizedAt),
-    assertionVersion: seal.assertionVersion,
-    authorAddress: seal.authorAddress,
-    publicTripleCount: Number(seal.publicTripleCount),
-    privateTripleCount: Number(seal.privateTripleCount),
-    assertionGraph: vmGraph,
-  }, {
-    status: 'confirmed',
-    confirmation: {
-      kind: 'finalized-materialization',
-      provenance: {
-        batchId: BigInt(seal.reservedKaId),
-        materializedVersion: { blockNumber: 124, txIndex: 0 },
-      },
-    },
-  });
+  const vmMetadata = confirmedVmMetadataForSealV1(seal, vmGraph);
   await agent.store.insert([
     ...PROJECTION_QUADS.map((quad) => ({ ...quad, graph: vmGraph })),
     ...vmMetadata,
@@ -504,6 +482,38 @@ async function seedPreexistingFinalizedTwinV1(
     publicQuadsDigest,
   )).toBe(true);
   return Object.freeze({ swmGraph, vmGraph, publicQuadsDigest });
+}
+
+function confirmedVmMetadataForSealV1(
+  seal: CanonicalGraphScopedAuthorSealV1,
+  assertionGraph: string,
+): readonly Quad[] {
+  return generateGraphKnowledgeAssetMetadata({
+    contextGraphId: CONTEXT_GRAPH_ID,
+    ual: seal.kaUal,
+    merkleRoot: ethers.getBytes(seal.assertionMerkleRoot),
+    publisherPeerId: 'rfc64-finalized-catalog-v1',
+    accessPolicy: 'ownerOnly',
+    allowedPeers: [],
+    timestamp: new Date(seal.assertionFinalizedAt),
+    assertionVersion: seal.assertionVersion,
+    authorAddress: seal.authorAddress,
+    publicTripleCount: Number(seal.publicTripleCount),
+    privateTripleCount: Number(seal.privateTripleCount),
+    ...(seal.privateMerkleRoot === null
+      ? {}
+      : { privateMerkleRoot: ethers.getBytes(seal.privateMerkleRoot) }),
+    assertionGraph,
+  }, {
+    status: 'confirmed',
+    confirmation: {
+      kind: 'finalized-materialization',
+      provenance: {
+        batchId: BigInt(seal.reservedKaId),
+        materializedVersion: { blockNumber: 124, txIndex: 0 },
+      },
+    },
+  });
 }
 
 function seededSubscriptionStore(contextGraphId: string): ContextGraphSubscriptionStore {
@@ -5389,8 +5399,14 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
         repairOnlySeal.assertionVersion!,
       ),
     );
+    const repairOnlyCanonicalSeal = canonicalGraphScopedAuthorSealFromAssertionSealV1(
+      repairOnlySeal,
+    );
     await author.store.insert(
-      PROJECTION_QUADS.map((quad) => ({ ...quad, graph: repairOnlyVmGraph })),
+      [
+        ...PROJECTION_QUADS.map((quad) => ({ ...quad, graph: repairOnlyVmGraph })),
+        ...confirmedVmMetadataForSealV1(repairOnlyCanonicalSeal, repairOnlyVmGraph),
+      ],
     );
     await (author as any).publisher.clearPublishedKnowledgeAssetSwm(
       CONTEXT_GRAPH_ID,
@@ -5401,9 +5417,6 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       undefined,
       createOperationContext('publish'),
       repairOnlySeal.kaUal!,
-    );
-    const repairOnlyCanonicalSeal = canonicalGraphScopedAuthorSealFromAssertionSealV1(
-      repairOnlySeal,
     );
     const repairStore = (author as any).rfc64PersistenceV1
       .finalizedPrivatePlacementRepairs;

--- a/packages/agent/test/rfc64-swm-catalog-durable-asset-resolver-v1.test.ts
+++ b/packages/agent/test/rfc64-swm-catalog-durable-asset-resolver-v1.test.ts
@@ -1,0 +1,203 @@
+import {
+  buildAssertionSealQuads,
+  buildAuthorAttestationTypedData,
+  computeCanonicalGraphScopedAuthorSealDigestV1,
+  computeKaProjectionDigestV1,
+  contextGraphAssertionUri,
+  contextGraphMetaUri,
+  createGraphKnowledgeAssetScope,
+  encodeCanonicalCgSharedPublicRootProjectionV1,
+  knowledgeAssetLayerGraphUri,
+  MemoryLayer,
+  type CanonicalGraphScopedAuthorSealV1,
+  type ContextGraphIdV1,
+  type Digest32V1,
+  type EvmAddressV1,
+  type SwmAuthorInventoryRowV1,
+} from '@origintrail-official/dkg-core';
+import { computeFlatKCRootV10 } from '@origintrail-official/dkg-publisher';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { ethers } from 'ethers';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { resolveRfc64InventoryWorkspaceCatalogAssetV1 } from
+  '../src/rfc64/swm-catalog-durable-asset-resolver-v1.js';
+
+const AUTHOR_WALLET = new ethers.Wallet(`0x${'73'.repeat(32)}`);
+const AUTHOR = AUTHOR_WALLET.address.toLowerCase() as EvmAddressV1;
+const CONTEXT_GRAPH_ID =
+  '0x1111111111111111111111111111111111111111/durable-vm-fallback' as ContextGraphIdV1;
+const ASSERTION_COORDINATE = 'retained-finalized-private-row';
+const KAV10 = '0x4444444444444444444444444444444444444444' as EvmAddressV1;
+const KA_NUMBER = 17n;
+const PROJECTION_QUADS: readonly Quad[] = Object.freeze([
+  Object.freeze({
+    subject: 'https://example.org/alice',
+    predicate: 'https://schema.org/name',
+    object: '"Alice"',
+    graph: '',
+  }),
+]);
+const PROJECTION_BYTES = encodeCanonicalCgSharedPublicRootProjectionV1(PROJECTION_QUADS);
+
+let store: OxigraphStore;
+let seal: CanonicalGraphScopedAuthorSealV1;
+let row: SwmAuthorInventoryRowV1;
+
+beforeEach(async () => {
+  store = new OxigraphStore();
+  seal = await createSeal();
+  row = Object.freeze({
+    assertionCoordinate: ASSERTION_COORDINATE,
+    assertionVersion: seal.assertionVersion,
+    kaUal: seal.kaUal,
+    shareOperationId: 'retired-workspace-operation',
+    projectionDigest: computeKaProjectionDigestV1(PROJECTION_BYTES),
+    publicTripleCount: seal.publicTripleCount,
+    privateTripleCount: seal.privateTripleCount,
+    sealDigest: computeCanonicalGraphScopedAuthorSealDigestV1(seal),
+    sharedAt: '1788192000000',
+    expiresAt: null,
+  }) as SwmAuthorInventoryRowV1;
+  await seedDurableSeal(store, seal);
+});
+
+describe('RFC-64 durable SWM inventory catalog asset resolver', () => {
+  it('uses an exact finalized VM projection for a retained private row without an SWM head', async () => {
+    await seedVmProjection(store, seal, PROJECTION_QUADS);
+
+    await expect(resolve('private')).resolves.toMatchObject({
+      assertionCoordinate: ASSERTION_COORDINATE,
+      projectionBytes: PROJECTION_BYTES,
+      seal,
+    });
+  });
+
+  it('does not permit the finalized VM fallback for a public lane', async () => {
+    await seedVmProjection(store, seal, PROJECTION_QUADS);
+
+    await expect(resolve('public')).rejects.toThrow(
+      `durable RFC-64 workspace head differs for ${seal.kaUal}`,
+    );
+  });
+
+  it('rejects a finalized VM projection that differs from the signed inventory row', async () => {
+    await seedVmProjection(store, seal, PROJECTION_QUADS);
+    row = Object.freeze({
+      ...row,
+      projectionDigest: `0x${'ef'.repeat(32)}` as Digest32V1,
+    });
+
+    await expect(resolve('private')).rejects.toThrow(
+      `durable RFC-64 projection differs from signed inventory row ${seal.kaUal}`,
+    );
+  });
+
+  it('rejects finalized VM bytes that differ from the strict author seal', async () => {
+    await seedVmProjection(store, seal, [{
+      ...PROJECTION_QUADS[0]!,
+      object: '"Mallory"',
+    }]);
+
+    await expect(resolve('private')).rejects.toThrow(
+      `durable finalized VM projection differs for ${seal.kaUal}`,
+    );
+  });
+
+  it('rejects a missing finalized VM projection', async () => {
+    await expect(resolve('private')).rejects.toThrow(
+      `durable finalized VM projection differs for ${seal.kaUal}`,
+    );
+  });
+});
+
+function resolve(laneKind: 'public' | 'private') {
+  return resolveRfc64InventoryWorkspaceCatalogAssetV1({
+    store,
+    contextGraphId: CONTEXT_GRAPH_ID,
+    authorAddress: AUTHOR,
+    laneKind,
+    row,
+  });
+}
+
+async function createSeal(): Promise<CanonicalGraphScopedAuthorSealV1> {
+  const assertionMerkleRoot = ethers.hexlify(
+    computeFlatKCRootV10([...PROJECTION_QUADS], []),
+  ) as Digest32V1;
+  const reservedKaId = ((BigInt(AUTHOR) << 96n) | KA_NUMBER).toString();
+  const typedData = buildAuthorAttestationTypedData({
+    chainId: 20430n,
+    kav10Address: KAV10,
+    merkleRoot: ethers.getBytes(assertionMerkleRoot),
+    authorAddress: AUTHOR,
+    reservedKaId: BigInt(reservedKaId),
+  });
+  const signature = ethers.Signature.from(await AUTHOR_WALLET.signTypedData(
+    typedData.domain,
+    typedData.types,
+    typedData.message,
+  ));
+  return Object.freeze({
+    assertionMerkleRoot,
+    authorAddress: AUTHOR,
+    authorAttestationR: signature.r,
+    authorAttestationVS: signature.yParityAndS,
+    authorSchemeVersion: '1',
+    assertedAtChainId: '20430',
+    assertedAtKav10Address: KAV10,
+    reservedKaId,
+    assertionFinalizedAt: '2026-09-01T00:00:00.000Z',
+    contentScopeVersion: '2',
+    kaUal: `did:dkg:otp:20430/${AUTHOR}/${KA_NUMBER}`,
+    assertionVersion: '1',
+    publicTripleCount: String(PROJECTION_QUADS.length),
+    privateTripleCount: '0',
+    privateMerkleRoot: null,
+  }) as CanonicalGraphScopedAuthorSealV1;
+}
+
+async function seedDurableSeal(
+  target: OxigraphStore,
+  canonicalSeal: CanonicalGraphScopedAuthorSealV1,
+): Promise<void> {
+  const assertionUri = contextGraphAssertionUri(
+    CONTEXT_GRAPH_ID,
+    AUTHOR,
+    ASSERTION_COORDINATE,
+  );
+  await target.insert(buildAssertionSealQuads({
+    assertionUri,
+    metaGraph: contextGraphMetaUri(CONTEXT_GRAPH_ID),
+    merkleRoot: ethers.getBytes(canonicalSeal.assertionMerkleRoot),
+    authorAddress: canonicalSeal.authorAddress,
+    authorAttestationR: ethers.getBytes(canonicalSeal.authorAttestationR),
+    authorAttestationVS: ethers.getBytes(canonicalSeal.authorAttestationVS),
+    authorSchemeVersion: 1,
+    chainId: BigInt(canonicalSeal.assertedAtChainId),
+    kav10Address: canonicalSeal.assertedAtKav10Address,
+    reservedKaId: BigInt(canonicalSeal.reservedKaId),
+    finalizedAtIso: canonicalSeal.assertionFinalizedAt,
+    contentScopeVersion: 2,
+    kaUal: canonicalSeal.kaUal,
+    assertionVersion: canonicalSeal.assertionVersion,
+    publicTripleCount: Number(canonicalSeal.publicTripleCount),
+    privateTripleCount: Number(canonicalSeal.privateTripleCount),
+  }));
+}
+
+async function seedVmProjection(
+  target: OxigraphStore,
+  canonicalSeal: CanonicalGraphScopedAuthorSealV1,
+  quads: readonly Quad[],
+): Promise<void> {
+  const vmGraph = knowledgeAssetLayerGraphUri(
+    CONTEXT_GRAPH_ID,
+    MemoryLayer.VerifiableMemory,
+    createGraphKnowledgeAssetScope(
+      canonicalSeal.kaUal,
+      canonicalSeal.assertionVersion,
+    ),
+  );
+  await target.insert(quads.map((quad) => ({ ...quad, graph: vmGraph })));
+}

--- a/packages/agent/test/rfc64-swm-catalog-durable-asset-resolver-v1.test.ts
+++ b/packages/agent/test/rfc64-swm-catalog-durable-asset-resolver-v1.test.ts
@@ -97,6 +97,8 @@ describe('RFC-64 durable SWM inventory catalog asset resolver', () => {
   });
 
   it('rejects a missing finalized VM projection', async () => {
+    await seedVmProjection(store, seal, []);
+
     await expect(resolve('private')).rejects.toThrow(
       `durable finalized VM projection differs for ${seal.kaUal}`,
     );

--- a/packages/agent/test/rfc64-swm-catalog-durable-asset-resolver-v1.test.ts
+++ b/packages/agent/test/rfc64-swm-catalog-durable-asset-resolver-v1.test.ts
@@ -15,7 +15,10 @@ import {
   type EvmAddressV1,
   type SwmAuthorInventoryRowV1,
 } from '@origintrail-official/dkg-core';
-import { computeFlatKCRootV10 } from '@origintrail-official/dkg-publisher';
+import {
+  computeFlatKCRootV10,
+  generateGraphKnowledgeAssetMetadata,
+} from '@origintrail-official/dkg-publisher';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import { ethers } from 'ethers';
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -47,18 +50,7 @@ let row: SwmAuthorInventoryRowV1;
 beforeEach(async () => {
   store = new OxigraphStore();
   seal = await createSeal();
-  row = Object.freeze({
-    assertionCoordinate: ASSERTION_COORDINATE,
-    assertionVersion: seal.assertionVersion,
-    kaUal: seal.kaUal,
-    shareOperationId: 'retired-workspace-operation',
-    projectionDigest: computeKaProjectionDigestV1(PROJECTION_BYTES),
-    publicTripleCount: seal.publicTripleCount,
-    privateTripleCount: seal.privateTripleCount,
-    sealDigest: computeCanonicalGraphScopedAuthorSealDigestV1(seal),
-    sharedAt: '1788192000000',
-    expiresAt: null,
-  }) as SwmAuthorInventoryRowV1;
+  row = createInventoryRow(seal);
   await seedDurableSeal(store, seal);
 });
 
@@ -109,6 +101,42 @@ describe('RFC-64 durable SWM inventory catalog asset resolver', () => {
       `durable finalized VM projection differs for ${seal.kaUal}`,
     );
   });
+
+  it('rejects a headless private update when VM metadata confirms an older version', async () => {
+    const confirmedV1 = await createSeal({
+      assertionVersion: '1',
+      privateMerkleRoot: `0x${'11'.repeat(32)}` as Digest32V1,
+    });
+    seal = await createSeal({
+      assertionVersion: '2',
+      privateMerkleRoot: `0x${'22'.repeat(32)}` as Digest32V1,
+    });
+    row = createInventoryRow(seal);
+    store = new OxigraphStore();
+    await seedDurableSeal(store, seal);
+    await seedVmProjection(store, confirmedV1, PROJECTION_QUADS);
+
+    await expect(resolve('private')).rejects.toThrow(
+      `durable finalized VM projection differs for ${seal.kaUal}`,
+    );
+  });
+
+  it('accepts a headless private update when VM metadata confirms the exact version', async () => {
+    seal = await createSeal({
+      assertionVersion: '2',
+      privateMerkleRoot: `0x${'22'.repeat(32)}` as Digest32V1,
+    });
+    row = createInventoryRow(seal);
+    store = new OxigraphStore();
+    await seedDurableSeal(store, seal);
+    await seedVmProjection(store, seal, PROJECTION_QUADS);
+
+    await expect(resolve('private')).resolves.toMatchObject({
+      assertionCoordinate: ASSERTION_COORDINATE,
+      projectionBytes: PROJECTION_BYTES,
+      seal,
+    });
+  });
 });
 
 function resolve(laneKind: 'public' | 'private') {
@@ -121,9 +149,33 @@ function resolve(laneKind: 'public' | 'private') {
   });
 }
 
-async function createSeal(): Promise<CanonicalGraphScopedAuthorSealV1> {
+function createInventoryRow(
+  canonicalSeal: CanonicalGraphScopedAuthorSealV1,
+): SwmAuthorInventoryRowV1 {
+  return Object.freeze({
+    assertionCoordinate: ASSERTION_COORDINATE,
+    assertionVersion: canonicalSeal.assertionVersion,
+    kaUal: canonicalSeal.kaUal,
+    shareOperationId: 'retired-workspace-operation',
+    projectionDigest: computeKaProjectionDigestV1(PROJECTION_BYTES),
+    publicTripleCount: canonicalSeal.publicTripleCount,
+    privateTripleCount: canonicalSeal.privateTripleCount,
+    sealDigest: computeCanonicalGraphScopedAuthorSealDigestV1(canonicalSeal),
+    sharedAt: '1788192000000',
+    expiresAt: null,
+  }) as SwmAuthorInventoryRowV1;
+}
+
+async function createSeal(options: Readonly<{
+  assertionVersion?: string;
+  privateMerkleRoot?: Digest32V1;
+}> = {}): Promise<CanonicalGraphScopedAuthorSealV1> {
+  const privateMerkleRoot = options.privateMerkleRoot ?? null;
   const assertionMerkleRoot = ethers.hexlify(
-    computeFlatKCRootV10([...PROJECTION_QUADS], []),
+    computeFlatKCRootV10(
+      [...PROJECTION_QUADS],
+      privateMerkleRoot === null ? [] : [ethers.getBytes(privateMerkleRoot)],
+    ),
   ) as Digest32V1;
   const reservedKaId = ((BigInt(AUTHOR) << 96n) | KA_NUMBER).toString();
   const typedData = buildAuthorAttestationTypedData({
@@ -150,10 +202,10 @@ async function createSeal(): Promise<CanonicalGraphScopedAuthorSealV1> {
     assertionFinalizedAt: '2026-09-01T00:00:00.000Z',
     contentScopeVersion: '2',
     kaUal: `did:dkg:otp:20430/${AUTHOR}/${KA_NUMBER}`,
-    assertionVersion: '1',
+    assertionVersion: options.assertionVersion ?? '1',
     publicTripleCount: String(PROJECTION_QUADS.length),
-    privateTripleCount: '0',
-    privateMerkleRoot: null,
+    privateTripleCount: privateMerkleRoot === null ? '0' : '1',
+    privateMerkleRoot,
   }) as CanonicalGraphScopedAuthorSealV1;
 }
 
@@ -182,6 +234,9 @@ async function seedDurableSeal(
     kaUal: canonicalSeal.kaUal,
     assertionVersion: canonicalSeal.assertionVersion,
     publicTripleCount: Number(canonicalSeal.publicTripleCount),
+    ...(canonicalSeal.privateMerkleRoot === null
+      ? {}
+      : { privateMerkleRoot: ethers.getBytes(canonicalSeal.privateMerkleRoot) }),
     privateTripleCount: Number(canonicalSeal.privateTripleCount),
   }));
 }
@@ -199,5 +254,33 @@ async function seedVmProjection(
       canonicalSeal.assertionVersion,
     ),
   );
-  await target.insert(quads.map((quad) => ({ ...quad, graph: vmGraph })));
+  await target.insert([
+    ...quads.map((quad) => ({ ...quad, graph: vmGraph })),
+    ...generateGraphKnowledgeAssetMetadata({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ual: canonicalSeal.kaUal,
+      merkleRoot: ethers.getBytes(canonicalSeal.assertionMerkleRoot),
+      publisherPeerId: 'rfc64-finalized-catalog-test',
+      authorAddress: canonicalSeal.authorAddress,
+      accessPolicy: 'ownerOnly',
+      allowedPeers: [],
+      timestamp: new Date(canonicalSeal.assertionFinalizedAt),
+      assertionVersion: canonicalSeal.assertionVersion,
+      publicTripleCount: Number(canonicalSeal.publicTripleCount),
+      privateTripleCount: Number(canonicalSeal.privateTripleCount),
+      ...(canonicalSeal.privateMerkleRoot === null
+        ? {}
+        : { privateMerkleRoot: ethers.getBytes(canonicalSeal.privateMerkleRoot) }),
+      assertionGraph: vmGraph,
+    }, {
+      status: 'confirmed',
+      confirmation: {
+        kind: 'finalized-materialization',
+        provenance: {
+          batchId: BigInt(canonicalSeal.reservedKaId),
+          materializedVersion: { blockNumber: 1, txIndex: 0 },
+        },
+      },
+    }),
+  ]);
 }

--- a/packages/agent/vitest.rfc64-unit-tests.ts
+++ b/packages/agent/vitest.rfc64-unit-tests.ts
@@ -5,6 +5,7 @@ export const RFC64_UNIT_TESTS = [
   "test/rfc64-inventory-v1-applied-head.test.ts",
   "test/rfc64-swm-author-inventory-persistence-v1.test.ts",
   "test/rfc64-swm-author-inventory-producer-v1.test.ts",
+  "test/rfc64-swm-catalog-durable-asset-resolver-v1.test.ts",
   "test/rfc64-swm-inventory-catalog-reconciler-v1.test.ts",
   "test/rfc64-swm-inventory-shadow-runtime-v1.test.ts",
   "test/rfc64-catalog-upsert-planner-v1.test.ts",


### PR DESCRIPTION
## Summary

- allow retained finalized private inventory rows to rebuild from their exact VM graph after the SWM workspace head is retired
- require the VM fallback to carry a confirmed metadata envelope matching the requested UAL, assertion version, batch, public/private counts, Merkle roots, and canonical graph
- read the exact VM projection through the canonical paged storage helper
- preserve the existing fail-closed workspace-head requirement for public lanes
- funnel inventory-row recovery and confirmed private repair through one internal discriminated resolver, with the existing exports kept as thin adapters
- verify the canonical projection digest against signed inventory rows

## Release certification failure

The local RFC-64 10/11 blackbox runs reached finalized VM parity but stalled at 8/20 SWM catalog recovery. Finalized private placements intentionally remain in the tier-neutral author inventory after their byte-identical SWM twins are retired. Cold reconciliation incorrectly required those retained rows to still have an SWM workspace head and rejected them with `durable RFC-64 workspace head differs`.

## Validation

- `pnpm --filter @origintrail-official/dkg-agent test:unit`
  - 241 test files passed
  - 3,496 tests passed; 5 skipped; 0 failed
- `pnpm --filter @origintrail-official/dkg-agent exec tsc --noEmit`
- `pnpm --filter @origintrail-official/dkg-agent build`
- `pnpm lint`
- focused resolver, inventory reconciler, and native-wiring integration suites
- `git diff --check`

## Regression coverage

The resolver tests cover private VM fallback, public-lane rejection, signed inventory digest mismatch, same-count VM corruption, and a missing VM graph. They also prove that a stale confirmed v1 VM graph cannot satisfy a headless v2 private update with identical public bytes but a different private commitment, while exact confirmed-v2 metadata succeeds. The native-wiring integration fixture now mirrors production finalized VM state by persisting its confirmed metadata envelope.