### PR TITLE
perf(build): avoid duplicate CLI prerequisite builds

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,7 @@
     }
   },
   "scripts": {
-    "prebuild": "pnpm -r --filter @origintrail-official/dkg-adapter-openclaw... --filter @origintrail-official/dkg-adapter-hermes... --filter @origintrail-official/dkg-adapter-prime-agent... --filter @origintrail-official/dkg-mcp... --filter @origintrail-official/dkg-local-llm... --filter @origintrail-official/dkg-okf... run build",
+    "prebuild": "node scripts/build-prerequisites.mjs",
     "build": "tsc && node scripts/test-catchup-worker-package-boundary.mjs && node ../../scripts/copy-cli-runtime-assets.mjs",
     "prepack": "node ../../scripts/copy-cli-runtime-assets.mjs",
     "benchmark:catchup-runner": "node scripts/catchup-runner-benchmark.cjs",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,8 +24,9 @@
     }
   },
   "scripts": {
-    "prebuild": "node scripts/build-prerequisites.mjs",
-    "build": "tsc && node scripts/test-catchup-worker-package-boundary.mjs && node ../../scripts/copy-cli-runtime-assets.mjs",
+    "build": "pnpm run build:prerequisites && pnpm run build:prepared",
+    "build:prerequisites": "node scripts/build-prerequisites.mjs",
+    "build:prepared": "tsc && node scripts/test-catchup-worker-package-boundary.mjs && node ../../scripts/copy-cli-runtime-assets.mjs",
     "prepack": "node ../../scripts/copy-cli-runtime-assets.mjs",
     "benchmark:catchup-runner": "node scripts/catchup-runner-benchmark.cjs",
     "benchmark:daemon-responsiveness": "node scripts/daemon-responsiveness-benchmark.cjs",

--- a/packages/cli/scripts/build-prerequisites.mjs
+++ b/packages/cli/scripts/build-prerequisites.mjs
@@ -17,9 +17,6 @@ export function buildCliPrerequisites({
   spawn = spawnSync,
   reportError = (message) => console.error(message),
 } = {}) {
-  // Only the checked root runtime plan sets this marker. A direct CLI build
-  // keeps its dependency preparation, including clean adapter asset builds.
-  if (env.DKG_RUNTIME_BUILD_TOPOLOGICAL === '1') return 0;
   const args = ['-r', ...CLI_PREREQUISITE_ROOTS.flatMap(name => ['--filter', `${name}...`]), 'run', 'build'];
   return runBuildCommand('pnpm', args, { spawn, platform, env, reportError, label: 'CLI prerequisites' });
 }

--- a/packages/cli/scripts/build-prerequisites.mjs
+++ b/packages/cli/scripts/build-prerequisites.mjs
@@ -1,5 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
+import { runBuildCommand } from '../../../scripts/lib/run-build-command.mjs';
 
 const prerequisiteRoots = [
   '@origintrail-official/dkg-adapter-openclaw',
@@ -20,14 +21,7 @@ export function buildCliPrerequisites({
   // keeps its dependency preparation, including clean adapter asset builds.
   if (env.DKG_RUNTIME_BUILD_TOPOLOGICAL === '1') return 0;
   const args = ['-r', ...prerequisiteRoots.flatMap(name => ['--filter', `${name}...`]), 'run', 'build'];
-  const result = spawn('pnpm', args, { stdio: 'inherit', shell: platform === 'win32', env });
-  if (result.error) {
-    reportError(result.error.message);
-    return 1;
-  }
-  if (typeof result.status === 'number') return result.status;
-  reportError(result.signal ? `CLI prerequisites exited via ${result.signal}` : 'CLI prerequisites exited without a status');
-  return 1;
+  return runBuildCommand('pnpm', args, { spawn, platform, env, reportError, label: 'CLI prerequisites' });
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/packages/cli/scripts/build-prerequisites.mjs
+++ b/packages/cli/scripts/build-prerequisites.mjs
@@ -1,0 +1,35 @@
+import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+const prerequisiteRoots = [
+  '@origintrail-official/dkg-adapter-openclaw',
+  '@origintrail-official/dkg-adapter-hermes',
+  '@origintrail-official/dkg-adapter-prime-agent',
+  '@origintrail-official/dkg-mcp',
+  '@origintrail-official/dkg-local-llm',
+  '@origintrail-official/dkg-okf',
+];
+
+export function buildCliPrerequisites({
+  env = process.env,
+  platform = process.platform,
+  spawn = spawnSync,
+  reportError = (message) => console.error(message),
+} = {}) {
+  // Only the checked root runtime plan sets this marker. A direct CLI build
+  // keeps its dependency preparation, including clean adapter asset builds.
+  if (env.DKG_RUNTIME_BUILD_TOPOLOGICAL === '1') return 0;
+  const args = ['-r', ...prerequisiteRoots.flatMap(name => ['--filter', `${name}...`]), 'run', 'build'];
+  const result = spawn('pnpm', args, { stdio: 'inherit', shell: platform === 'win32', env });
+  if (result.error) {
+    reportError(result.error.message);
+    return 1;
+  }
+  if (typeof result.status === 'number') return result.status;
+  reportError(result.signal ? `CLI prerequisites exited via ${result.signal}` : 'CLI prerequisites exited without a status');
+  return 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exitCode = buildCliPrerequisites();
+}

--- a/packages/cli/scripts/build-prerequisites.mjs
+++ b/packages/cli/scripts/build-prerequisites.mjs
@@ -2,14 +2,14 @@ import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 import { runBuildCommand } from '../../../scripts/lib/run-build-command.mjs';
 
-const prerequisiteRoots = [
+export const CLI_PREREQUISITE_ROOTS = Object.freeze([
   '@origintrail-official/dkg-adapter-openclaw',
   '@origintrail-official/dkg-adapter-hermes',
   '@origintrail-official/dkg-adapter-prime-agent',
   '@origintrail-official/dkg-mcp',
   '@origintrail-official/dkg-local-llm',
   '@origintrail-official/dkg-okf',
-];
+]);
 
 export function buildCliPrerequisites({
   env = process.env,
@@ -20,7 +20,7 @@ export function buildCliPrerequisites({
   // Only the checked root runtime plan sets this marker. A direct CLI build
   // keeps its dependency preparation, including clean adapter asset builds.
   if (env.DKG_RUNTIME_BUILD_TOPOLOGICAL === '1') return 0;
-  const args = ['-r', ...prerequisiteRoots.flatMap(name => ['--filter', `${name}...`]), 'run', 'build'];
+  const args = ['-r', ...CLI_PREREQUISITE_ROOTS.flatMap(name => ['--filter', `${name}...`]), 'run', 'build'];
   return runBuildCommand('pnpm', args, { spawn, platform, env, reportError, label: 'CLI prerequisites' });
 }
 

--- a/scripts/build-runtime-packages.mjs
+++ b/scripts/build-runtime-packages.mjs
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
-import { runtimeBuildPnpmArgs } from './lib/runtime-build-plan.mjs';
+import {
+  RUNTIME_CLI_PACKAGE,
+  runtimeDependencyBuildPnpmArgs,
+} from './lib/runtime-build-plan.mjs';
 import { runBuildCommand } from './lib/run-build-command.mjs';
 
 export function runRuntimePackageBuild({
@@ -11,16 +14,26 @@ export function runRuntimePackageBuild({
   env = process.env,
   reportError = (message) => console.error(message),
 } = {}) {
-  const args = runtimeBuildPnpmArgs(['run', 'build', ...extraArgs]);
-  return runBuildCommand('pnpm', args, {
+  const dependencyStatus = runBuildCommand(
+    'pnpm',
+    runtimeDependencyBuildPnpmArgs(['run', 'build', ...extraArgs]),
+    {
+      spawn,
+      platform,
+      env,
+      reportError,
+      label: 'runtime dependency build',
+    },
+  );
+  if (dependencyStatus !== 0) return dependencyStatus;
+
+  return runBuildCommand('pnpm', ['--filter', RUNTIME_CLI_PACKAGE, 'run', 'build:prepared'], {
     spawn,
     platform,
     reportError,
-    // pnpm's recursive plan builds the complete dependency closure in order.
-    // The CLI prebuild hook can therefore avoid recursively building it again.
-    env: { ...env, DKG_RUNTIME_BUILD_TOPOLOGICAL: '1' },
+    env,
+    label: 'prepared CLI build',
   });
-
 }
 
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;

--- a/scripts/build-runtime-packages.mjs
+++ b/scripts/build-runtime-packages.mjs
@@ -2,6 +2,7 @@
 import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 import { runtimeBuildPnpmArgs } from './lib/runtime-build-plan.mjs';
+import { runBuildCommand } from './lib/run-build-command.mjs';
 
 export function runRuntimePackageBuild({
   extraArgs = process.argv.slice(2),
@@ -11,25 +12,15 @@ export function runRuntimePackageBuild({
   reportError = (message) => console.error(message),
 } = {}) {
   const args = runtimeBuildPnpmArgs(['run', 'build', ...extraArgs]);
-  const result = spawn('pnpm', args, {
-    stdio: 'inherit',
-    shell: platform === 'win32',
+  return runBuildCommand('pnpm', args, {
+    spawn,
+    platform,
+    reportError,
     // pnpm's recursive plan builds the complete dependency closure in order.
     // The CLI prebuild hook can therefore avoid recursively building it again.
     env: { ...env, DKG_RUNTIME_BUILD_TOPOLOGICAL: '1' },
   });
 
-  if (result.error) {
-    reportError(result.error.message);
-    return 1;
-  }
-  if (typeof result.status === 'number') return result.status;
-  if (result.signal) {
-    reportError(`pnpm ${args.join(' ')} exited via ${result.signal}`);
-    return 1;
-  }
-  reportError(`pnpm ${args.join(' ')} exited without a status`);
-  return 1;
 }
 
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;

--- a/scripts/build-runtime-packages.mjs
+++ b/scripts/build-runtime-packages.mjs
@@ -3,7 +3,8 @@ import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 import {
   RUNTIME_CLI_PACKAGE,
-  runtimeDependencyBuildPnpmArgs,
+  runtimeCliPrerequisiteBuildPnpmArgs,
+  runtimeDependentBuildPnpmArgs,
 } from './lib/runtime-build-plan.mjs';
 import { runBuildCommand } from './lib/run-build-command.mjs';
 
@@ -14,26 +15,39 @@ export function runRuntimePackageBuild({
   env = process.env,
   reportError = (message) => console.error(message),
 } = {}) {
-  const dependencyStatus = runBuildCommand(
+  const prerequisiteStatus = runBuildCommand(
     'pnpm',
-    runtimeDependencyBuildPnpmArgs(['run', 'build', ...extraArgs]),
+    runtimeCliPrerequisiteBuildPnpmArgs(['run', 'build', ...extraArgs]),
     {
       spawn,
       platform,
       env,
       reportError,
-      label: 'runtime dependency build',
+      label: 'CLI prerequisite build',
     },
   );
-  if (dependencyStatus !== 0) return dependencyStatus;
+  if (prerequisiteStatus !== 0) return prerequisiteStatus;
 
-  return runBuildCommand('pnpm', ['--filter', RUNTIME_CLI_PACKAGE, 'run', 'build:prepared'], {
+  const cliStatus = runBuildCommand('pnpm', ['--filter', RUNTIME_CLI_PACKAGE, 'run', 'build:prepared'], {
     spawn,
     platform,
     reportError,
     env,
     label: 'prepared CLI build',
   });
+  if (cliStatus !== 0) return cliStatus;
+
+  return runBuildCommand(
+    'pnpm',
+    runtimeDependentBuildPnpmArgs(['run', 'build', ...extraArgs]),
+    {
+      spawn,
+      platform,
+      reportError,
+      env,
+      label: 'runtime dependent build',
+    },
+  );
 }
 
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;

--- a/scripts/build-runtime-packages.mjs
+++ b/scripts/build-runtime-packages.mjs
@@ -1,11 +1,7 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
-import {
-  RUNTIME_CLI_PACKAGE,
-  runtimeCliPrerequisiteBuildPnpmArgs,
-  runtimeDependentBuildPnpmArgs,
-} from './lib/runtime-build-plan.mjs';
+import { runtimeBuildPhases } from './lib/runtime-build-plan.mjs';
 import { runBuildCommand } from './lib/run-build-command.mjs';
 
 export function runRuntimePackageBuild({
@@ -15,39 +11,20 @@ export function runRuntimePackageBuild({
   env = process.env,
   reportError = (message) => console.error(message),
 } = {}) {
-  const prerequisiteStatus = runBuildCommand(
-    'pnpm',
-    runtimeCliPrerequisiteBuildPnpmArgs(['run', 'build', ...extraArgs]),
-    {
-      spawn,
-      platform,
-      env,
-      reportError,
-      label: 'CLI prerequisite build',
-    },
-  );
-  if (prerequisiteStatus !== 0) return prerequisiteStatus;
-
-  const cliStatus = runBuildCommand('pnpm', ['--filter', RUNTIME_CLI_PACKAGE, 'run', 'build:prepared'], {
-    spawn,
-    platform,
-    reportError,
-    env,
-    label: 'prepared CLI build',
+  const phases = runtimeBuildPhases({
+    runtimeOperation: ['run', 'build', ...extraArgs],
   });
-  if (cliStatus !== 0) return cliStatus;
-
-  return runBuildCommand(
-    'pnpm',
-    runtimeDependentBuildPnpmArgs(['run', 'build', ...extraArgs]),
-    {
+  for (const phase of phases) {
+    const status = runBuildCommand('pnpm', phase.args, {
       spawn,
       platform,
-      reportError,
       env,
-      label: 'runtime dependent build',
-    },
-  );
+      reportError,
+      label: phase.label,
+    });
+    if (status !== 0) return status;
+  }
+  return 0;
 }
 
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;

--- a/scripts/build-runtime-packages.mjs
+++ b/scripts/build-runtime-packages.mjs
@@ -7,12 +7,16 @@ export function runRuntimePackageBuild({
   extraArgs = process.argv.slice(2),
   spawn = spawnSync,
   platform = process.platform,
+  env = process.env,
   reportError = (message) => console.error(message),
 } = {}) {
   const args = runtimeBuildPnpmArgs(['run', 'build', ...extraArgs]);
   const result = spawn('pnpm', args, {
     stdio: 'inherit',
     shell: platform === 'win32',
+    // pnpm's recursive plan builds the complete dependency closure in order.
+    // The CLI prebuild hook can therefore avoid recursively building it again.
+    env: { ...env, DKG_RUNTIME_BUILD_TOPOLOGICAL: '1' },
   });
 
   if (result.error) {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,37 +1,13 @@
 #!/usr/bin/env node
-import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+import { runBuildCommand } from './lib/run-build-command.mjs';
 
-const forwardedArgs = process.argv.slice(2);
-
-function run(command, args) {
-  const result = spawnSync(command, args, {
-    stdio: 'inherit',
-    shell: process.platform === 'win32',
-  });
-
-  if (result.error) {
-    console.error(result.error.message);
-    process.exit(1);
-  }
-
-  if (typeof result.status === 'number' && result.status !== 0) {
-    process.exit(result.status);
-  }
-
-  if (result.signal) {
-    console.error(`${command} ${args.join(' ')} exited via ${result.signal}`);
-    process.exit(1);
-  }
+export function runBuild({ extraArgs = process.argv.slice(2), run = runBuildCommand } = {}) {
+  const status = run('turbo', ['build', ...extraArgs]);
+  if (status !== 0 || extraArgs.length > 0) return status;
+  return run('pnpm', ['turbo', 'run', 'build:ui', '--filter=@origintrail-official/dkg-node-ui']);
 }
 
-if (forwardedArgs.length > 0) {
-  run('turbo', ['build', ...forwardedArgs]);
-} else {
-  run('turbo', ['build']);
-  run('pnpm', [
-    'turbo',
-    'run',
-    'build:ui',
-    '--filter=@origintrail-official/dkg-node-ui',
-  ]);
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exitCode = runBuild();
 }

--- a/scripts/lib/__tests__/release-packages.test.mjs
+++ b/scripts/lib/__tests__/release-packages.test.mjs
@@ -403,7 +403,12 @@ test('copyCliRuntimeAssets fails loudly when a source asset is missing', () => w
 test('packages/cli lifecycle is wired to the copy script (build + prepack)', () => {
   const cliPkg = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'packages', 'cli', 'package.json'), 'utf8'));
   assert.match(cliPkg.scripts.prepack ?? '', /copy-cli-runtime-assets\.mjs/, 'prepack must run the copy script');
-  assert.match(cliPkg.scripts.build ?? '', /copy-cli-runtime-assets\.mjs/, 'build must run the copy script');
+  assert.match(cliPkg.scripts.build ?? '', /build:prepared/, 'build must run the prepared CLI phase');
+  assert.match(
+    cliPkg.scripts['build:prepared'] ?? '',
+    /copy-cli-runtime-assets\.mjs/,
+    'prepared CLI build must run the copy script',
+  );
 });
 
 test('the manifest distinguishes copied assets from complete pack requirements', () => withFixture((root) => {

--- a/scripts/lib/__tests__/run-build-command.test.mjs
+++ b/scripts/lib/__tests__/run-build-command.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { runBuildCommand } from '../run-build-command.mjs';
+import { runBuild } from '../../build.mjs';
+
+test('build commands inherit stdio and preserve platform and environment overrides', () => {
+  for (const platform of ['linux', 'win32']) {
+    let invocation;
+    const env = { PATH: '/test-bin' };
+    assert.equal(runBuildCommand('pnpm', ['build'], {
+      platform, env, spawn: (...args) => { invocation = args; return { status: 0 }; },
+    }), 0);
+    assert.deepEqual(invocation, ['pnpm', ['build'], { stdio: 'inherit', shell: platform === 'win32', env }]);
+  }
+});
+
+test('build command failures retain exit status and diagnose spawn, signal and missing status', () => {
+  const cases = [
+    [{ status: 17 }, 17, []],
+    [{ error: new Error('spawn failed') }, 1, ['spawn failed']],
+    [{ status: null, signal: 'SIGTERM' }, 1, ['build fixture exited via SIGTERM']],
+    [{ status: null }, 1, ['build fixture exited without a status']],
+  ];
+  for (const [result, expectedStatus, expectedErrors] of cases) {
+    const errors = [];
+    assert.equal(runBuildCommand('pnpm', ['build'], {
+      spawn: () => result, label: 'build fixture', reportError: (message) => errors.push(message),
+    }), expectedStatus);
+    assert.deepEqual(errors, expectedErrors);
+  }
+});
+
+test('root build runs UI only after successful unfiltered compilation', () => {
+  for (const [extraArgs, statuses, expectedCalls, expectedStatus] of [
+    [[], [0, 0], 2, 0], [[], [23], 1, 23], [[], [0, 19], 2, 19], [['--force'], [0], 1, 0],
+  ]) {
+    const calls = [];
+    assert.equal(runBuild({ extraArgs, run: (...args) => { calls.push(args); return statuses[calls.length - 1]; } }), expectedStatus);
+    assert.equal(calls.length, expectedCalls);
+    assert.deepEqual(calls[0], ['turbo', ['build', ...extraArgs]]);
+    if (expectedCalls === 2) assert.deepEqual(calls[1], ['pnpm', ['turbo', 'run', 'build:ui', '--filter=@origintrail-official/dkg-node-ui']]);
+  }
+});

--- a/scripts/lib/__tests__/runtime-build-plan.test.mjs
+++ b/scripts/lib/__tests__/runtime-build-plan.test.mjs
@@ -5,6 +5,7 @@ import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { runRuntimePackageBuild } from '../../build-runtime-packages.mjs';
+import { buildCliPrerequisites } from '../../../packages/cli/scripts/build-prerequisites.mjs';
 import {
   RUNTIME_BUILD_EXCLUSIONS,
   runtimeBuildPnpmArgs,
@@ -49,6 +50,7 @@ test('runtime build entrypoint invokes pnpm with the checked plan and forwards e
   const status = runRuntimePackageBuild({
     extraArgs: ['--force', '--log-order=stream'],
     platform: 'linux',
+    env: { PATH: '/mock-bin' },
     spawn(command, args, options) {
       invocation = { command, args, options };
       return { status: 0, signal: null };
@@ -62,8 +64,45 @@ test('runtime build entrypoint invokes pnpm with the checked plan and forwards e
   assert.deepEqual(invocation, {
     command: 'pnpm',
     args: runtimeBuildPnpmArgs(['run', 'build', '--force', '--log-order=stream']),
-    options: { stdio: 'inherit', shell: false },
+    options: { stdio: 'inherit', shell: false, env: { PATH: '/mock-bin', DKG_RUNTIME_BUILD_TOPOLOGICAL: '1' } },
   });
+});
+
+test('CLI prebuild skips only when its root dependency graph has already run', () => {
+  assert.equal(buildCliPrerequisites({
+    env: { DKG_RUNTIME_BUILD_TOPOLOGICAL: '1' },
+    spawn: () => assert.fail('recursive root build must not rebuild CLI prerequisites'),
+  }), 0);
+  for (const env of [{ PATH: '/mock-bin' }, { DKG_RUNTIME_BUILD_TOPOLOGICAL: '0' }]) {
+    let invocation;
+    assert.equal(buildCliPrerequisites({ env, platform: 'win32', spawn(command, args, options) {
+      invocation = { command, args, options };
+      return { status: 0 };
+    } }), 0);
+    assert.equal(invocation.command, 'pnpm');
+    assert.equal(invocation.options.shell, true);
+    assert.deepEqual(invocation.options.env, env);
+    assert.deepEqual(invocation.args, [
+      '-r', '--filter', '@origintrail-official/dkg-adapter-openclaw...',
+      '--filter', '@origintrail-official/dkg-adapter-hermes...',
+      '--filter', '@origintrail-official/dkg-adapter-prime-agent...',
+      '--filter', '@origintrail-official/dkg-mcp...',
+      '--filter', '@origintrail-official/dkg-local-llm...',
+      '--filter', '@origintrail-official/dkg-okf...', 'run', 'build',
+    ]);
+  }
+});
+
+test('standalone CLI prerequisite failures propagate instead of allowing compilation', () => {
+  const messages = [];
+  for (const [result, expected] of [
+    [{ status: 17 }, 17],
+    [{ error: new Error('spawn failed') }, 1],
+    [{ status: null, signal: 'SIGTERM' }, 1],
+  ]) {
+    assert.equal(buildCliPrerequisites({ env: {}, spawn: () => result, reportError: message => messages.push(message) }), expected);
+  }
+  assert.deepEqual(messages, ['spawn failed', 'CLI prerequisites exited via SIGTERM']);
 });
 
 test('runtime build entrypoint propagates process failures', () => {

--- a/scripts/lib/__tests__/runtime-build-plan.test.mjs
+++ b/scripts/lib/__tests__/runtime-build-plan.test.mjs
@@ -11,6 +11,8 @@ import {
 } from '../../../packages/cli/scripts/build-prerequisites.mjs';
 import {
   RUNTIME_BUILD_EXCLUSIONS,
+  RUNTIME_CLI_PACKAGE,
+  runtimeDependencyBuildPnpmArgs,
   runtimeBuildPnpmArgs,
 } from '../runtime-build-plan.mjs';
 
@@ -49,13 +51,13 @@ test('public runtime build script delegates to the checked build plan', () => {
 });
 
 test('runtime build entrypoint invokes pnpm with the checked plan and forwards extra arguments', () => {
-  let invocation;
+  const invocations = [];
   const status = runRuntimePackageBuild({
     extraArgs: ['--force', '--log-order=stream'],
     platform: 'linux',
     env: { PATH: '/mock-bin' },
     spawn(command, args, options) {
-      invocation = { command, args, options };
+      invocations.push({ command, args, options });
       return { status: 0, signal: null };
     },
     reportError(message) {
@@ -64,24 +66,30 @@ test('runtime build entrypoint invokes pnpm with the checked plan and forwards e
   });
 
   assert.equal(status, 0);
-  assert.deepEqual(invocation, {
-    command: 'pnpm',
-    args: runtimeBuildPnpmArgs(['run', 'build', '--force', '--log-order=stream']),
-    options: { stdio: 'inherit', shell: false, env: { PATH: '/mock-bin', DKG_RUNTIME_BUILD_TOPOLOGICAL: '1' } },
-  });
+  assert.deepEqual(invocations, [
+    {
+      command: 'pnpm',
+      args: runtimeDependencyBuildPnpmArgs(['run', 'build', '--force', '--log-order=stream']),
+      options: { stdio: 'inherit', shell: false, env: { PATH: '/mock-bin' } },
+    },
+    {
+      command: 'pnpm',
+      args: ['--filter', RUNTIME_CLI_PACKAGE, 'run', 'build:prepared'],
+      options: { stdio: 'inherit', shell: false, env: { PATH: '/mock-bin' } },
+    },
+  ]);
 });
 
-test('CLI lifecycle hook invokes the standalone prerequisite entrypoint', () => {
+test('CLI exposes explicit standalone and prepared build paths', () => {
   const packageJson = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'packages/cli/package.json'), 'utf8'));
-  assert.equal(packageJson.scripts.prebuild, 'node scripts/build-prerequisites.mjs');
+  assert.equal(packageJson.scripts.prebuild, undefined);
+  assert.equal(packageJson.scripts.build, 'pnpm run build:prerequisites && pnpm run build:prepared');
+  assert.equal(packageJson.scripts['build:prerequisites'], 'node scripts/build-prerequisites.mjs');
+  assert.match(packageJson.scripts['build:prepared'], /^tsc /);
 });
 
-test('CLI prebuild skips only when its root dependency graph has already run', () => {
-  assert.equal(buildCliPrerequisites({
-    env: { DKG_RUNTIME_BUILD_TOPOLOGICAL: '1' },
-    spawn: () => assert.fail('recursive root build must not rebuild CLI prerequisites'),
-  }), 0);
-  for (const env of [{ PATH: '/mock-bin' }, { DKG_RUNTIME_BUILD_TOPOLOGICAL: '0' }]) {
+test('standalone CLI prerequisite entrypoint always builds its dependency graph', () => {
+  for (const env of [{ PATH: '/mock-bin' }, { PATH: '/mock-bin', CI: 'true' }]) {
     let invocation;
     assert.equal(buildCliPrerequisites({ env, platform: 'win32', spawn(command, args, options) {
       invocation = { command, args, options };
@@ -129,6 +137,17 @@ test('runtime build entrypoint propagates process failures', () => {
   assert.match(messages[1], /exited via SIGTERM$/);
 });
 
+test('runtime build stops before the prepared CLI build when a dependency fails', () => {
+  let invocations = 0;
+  assert.equal(runRuntimePackageBuild({
+    spawn() {
+      invocations += 1;
+      return { status: 9, signal: null };
+    },
+  }), 9);
+  assert.equal(invocations, 1);
+});
+
 test('release runtime build plan includes workspace dependencies but excludes Hardhat', () => {
   assert.ok(
     RUNTIME_BUILD_EXCLUSIONS.includes('@origintrail-official/dkg-evm-module'),
@@ -144,14 +163,26 @@ test('release runtime build plan includes workspace dependencies but excludes Ha
   }));
   const selectedNames = new Set(selected.map((workspace) => workspace.name));
 
+  const dependencyPlanArgs = runtimeDependencyBuildPnpmArgs(['list', '--depth', '-1', '--json']);
+  const dependencyPlan = JSON.parse(execFileSync(PNPM, dependencyPlanArgs, {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
+  }));
+  const dependencyNames = new Set(dependencyPlan.map((workspace) => workspace.name));
+
   for (const packageName of REQUIRED_RUNTIME_PACKAGES) {
     assert.ok(selectedNames.has(packageName), `${packageName} must remain in the runtime build`);
   }
   for (const packageName of CLI_PREREQUISITE_ROOTS) {
     assert.ok(
       selectedNames.has(packageName),
-      `${packageName} must be built before the CLI prebuild is allowed to skip prerequisites`,
+      `${packageName} must be present in the complete runtime plan`,
     );
+  }
+  assert.equal(dependencyNames.has(RUNTIME_CLI_PACKAGE), false, 'prepared CLI build must run only after dependencies');
+  for (const packageName of CLI_PREREQUISITE_ROOTS) {
+    assert.ok(dependencyNames.has(packageName), `${packageName} must remain in the dependency phase`);
   }
   assert.equal(
     selectedNames.has('@origintrail-official/dkg-evm-module'),

--- a/scripts/lib/__tests__/runtime-build-plan.test.mjs
+++ b/scripts/lib/__tests__/runtime-build-plan.test.mjs
@@ -68,6 +68,11 @@ test('runtime build entrypoint invokes pnpm with the checked plan and forwards e
   });
 });
 
+test('CLI lifecycle hook invokes the standalone prerequisite entrypoint', () => {
+  const packageJson = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'packages/cli/package.json'), 'utf8'));
+  assert.equal(packageJson.scripts.prebuild, 'node scripts/build-prerequisites.mjs');
+});
+
 test('CLI prebuild skips only when its root dependency graph has already run', () => {
   assert.equal(buildCliPrerequisites({
     env: { DKG_RUNTIME_BUILD_TOPOLOGICAL: '1' },

--- a/scripts/lib/__tests__/runtime-build-plan.test.mjs
+++ b/scripts/lib/__tests__/runtime-build-plan.test.mjs
@@ -5,7 +5,10 @@ import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { runRuntimePackageBuild } from '../../build-runtime-packages.mjs';
-import { buildCliPrerequisites } from '../../../packages/cli/scripts/build-prerequisites.mjs';
+import {
+  buildCliPrerequisites,
+  CLI_PREREQUISITE_ROOTS,
+} from '../../../packages/cli/scripts/build-prerequisites.mjs';
 import {
   RUNTIME_BUILD_EXCLUSIONS,
   runtimeBuildPnpmArgs,
@@ -88,12 +91,7 @@ test('CLI prebuild skips only when its root dependency graph has already run', (
     assert.equal(invocation.options.shell, true);
     assert.deepEqual(invocation.options.env, env);
     assert.deepEqual(invocation.args, [
-      '-r', '--filter', '@origintrail-official/dkg-adapter-openclaw...',
-      '--filter', '@origintrail-official/dkg-adapter-hermes...',
-      '--filter', '@origintrail-official/dkg-adapter-prime-agent...',
-      '--filter', '@origintrail-official/dkg-mcp...',
-      '--filter', '@origintrail-official/dkg-local-llm...',
-      '--filter', '@origintrail-official/dkg-okf...', 'run', 'build',
+      '-r', ...CLI_PREREQUISITE_ROOTS.flatMap(name => ['--filter', `${name}...`]), 'run', 'build',
     ]);
   }
 });
@@ -148,6 +146,12 @@ test('release runtime build plan includes workspace dependencies but excludes Ha
 
   for (const packageName of REQUIRED_RUNTIME_PACKAGES) {
     assert.ok(selectedNames.has(packageName), `${packageName} must remain in the runtime build`);
+  }
+  for (const packageName of CLI_PREREQUISITE_ROOTS) {
+    assert.ok(
+      selectedNames.has(packageName),
+      `${packageName} must be built before the CLI prebuild is allowed to skip prerequisites`,
+    );
   }
   assert.equal(
     selectedNames.has('@origintrail-official/dkg-evm-module'),

--- a/scripts/lib/__tests__/runtime-build-plan.test.mjs
+++ b/scripts/lib/__tests__/runtime-build-plan.test.mjs
@@ -12,7 +12,8 @@ import {
 import {
   RUNTIME_BUILD_EXCLUSIONS,
   RUNTIME_CLI_PACKAGE,
-  runtimeDependencyBuildPnpmArgs,
+  runtimeCliPrerequisiteBuildPnpmArgs,
+  runtimeDependentBuildPnpmArgs,
   runtimeBuildPnpmArgs,
 } from '../runtime-build-plan.mjs';
 
@@ -46,7 +47,7 @@ test('public runtime build script delegates to the checked build plan', () => {
   assert.equal(
     packageJson.scripts?.['build:runtime:packages'],
     'node scripts/build-runtime-packages.mjs',
-    'pnpm run build:runtime:packages must use the entrypoint backed by runtimeBuildPnpmArgs',
+    'pnpm run build:runtime:packages must use the checked phased entrypoint',
   );
 });
 
@@ -69,12 +70,17 @@ test('runtime build entrypoint invokes pnpm with the checked plan and forwards e
   assert.deepEqual(invocations, [
     {
       command: 'pnpm',
-      args: runtimeDependencyBuildPnpmArgs(['run', 'build', '--force', '--log-order=stream']),
+      args: runtimeCliPrerequisiteBuildPnpmArgs(['run', 'build', '--force', '--log-order=stream']),
       options: { stdio: 'inherit', shell: false, env: { PATH: '/mock-bin' } },
     },
     {
       command: 'pnpm',
       args: ['--filter', RUNTIME_CLI_PACKAGE, 'run', 'build:prepared'],
+      options: { stdio: 'inherit', shell: false, env: { PATH: '/mock-bin' } },
+    },
+    {
+      command: 'pnpm',
+      args: runtimeDependentBuildPnpmArgs(['run', 'build', '--force', '--log-order=stream']),
       options: { stdio: 'inherit', shell: false, env: { PATH: '/mock-bin' } },
     },
   ]);
@@ -137,7 +143,7 @@ test('runtime build entrypoint propagates process failures', () => {
   assert.match(messages[1], /exited via SIGTERM$/);
 });
 
-test('runtime build stops before the prepared CLI build when a dependency fails', () => {
+test('runtime build stops before the prepared CLI build when a prerequisite fails', () => {
   let invocations = 0;
   assert.equal(runRuntimePackageBuild({
     spawn() {
@@ -146,6 +152,17 @@ test('runtime build stops before the prepared CLI build when a dependency fails'
     },
   }), 9);
   assert.equal(invocations, 1);
+});
+
+test('runtime build stops before dependents when the prepared CLI build fails', () => {
+  let invocations = 0;
+  assert.equal(runRuntimePackageBuild({
+    spawn() {
+      invocations += 1;
+      return { status: invocations === 2 ? 9 : 0, signal: null };
+    },
+  }), 9);
+  assert.equal(invocations, 2);
 });
 
 test('release runtime build plan includes workspace dependencies but excludes Hardhat', () => {
@@ -163,13 +180,20 @@ test('release runtime build plan includes workspace dependencies but excludes Ha
   }));
   const selectedNames = new Set(selected.map((workspace) => workspace.name));
 
-  const dependencyPlanArgs = runtimeDependencyBuildPnpmArgs(['list', '--depth', '-1', '--json']);
-  const dependencyPlan = JSON.parse(execFileSync(PNPM, dependencyPlanArgs, {
+  const prerequisitePlanArgs = runtimeCliPrerequisiteBuildPnpmArgs(['list', '--depth', '-1', '--json']);
+  const prerequisitePlan = JSON.parse(execFileSync(PNPM, prerequisitePlanArgs, {
     cwd: REPO_ROOT,
     encoding: 'utf8',
     maxBuffer: 10 * 1024 * 1024,
   }));
-  const dependencyNames = new Set(dependencyPlan.map((workspace) => workspace.name));
+  const prerequisiteNames = new Set(prerequisitePlan.map((workspace) => workspace.name));
+  const dependentPlanArgs = runtimeDependentBuildPnpmArgs(['list', '--depth', '-1', '--json']);
+  const dependentPlan = JSON.parse(execFileSync(PNPM, dependentPlanArgs, {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
+  }));
+  const dependentNames = new Set(dependentPlan.map((workspace) => workspace.name));
 
   for (const packageName of REQUIRED_RUNTIME_PACKAGES) {
     assert.ok(selectedNames.has(packageName), `${packageName} must remain in the runtime build`);
@@ -180,10 +204,19 @@ test('release runtime build plan includes workspace dependencies but excludes Ha
       `${packageName} must be present in the complete runtime plan`,
     );
   }
-  assert.equal(dependencyNames.has(RUNTIME_CLI_PACKAGE), false, 'prepared CLI build must run only after dependencies');
+  assert.equal(prerequisiteNames.has(RUNTIME_CLI_PACKAGE), false, 'prepared CLI build must run only after prerequisites');
   for (const packageName of CLI_PREREQUISITE_ROOTS) {
-    assert.ok(dependencyNames.has(packageName), `${packageName} must remain in the dependency phase`);
+    assert.ok(prerequisiteNames.has(packageName), `${packageName} must remain in the prerequisite phase`);
   }
+  assert.ok(dependentNames.has('@origintrail-official/kafka-plugin'), 'CLI consumers must build after the prepared CLI');
+  for (const packageName of prerequisiteNames) {
+    assert.equal(dependentNames.has(packageName), false, `${packageName} must not be rebuilt after the CLI`);
+  }
+  assert.deepEqual(
+    new Set([...prerequisiteNames, RUNTIME_CLI_PACKAGE, ...dependentNames]),
+    selectedNames,
+    'the three explicit phases must partition the complete runtime plan',
+  );
   assert.equal(
     selectedNames.has('@origintrail-official/dkg-evm-module'),
     false,

--- a/scripts/lib/__tests__/runtime-build-plan.test.mjs
+++ b/scripts/lib/__tests__/runtime-build-plan.test.mjs
@@ -12,8 +12,7 @@ import {
 import {
   RUNTIME_BUILD_EXCLUSIONS,
   RUNTIME_CLI_PACKAGE,
-  runtimeCliPrerequisiteBuildPnpmArgs,
-  runtimeDependentBuildPnpmArgs,
+  runtimeBuildPhases,
   runtimeBuildPnpmArgs,
 } from '../runtime-build-plan.mjs';
 
@@ -67,23 +66,14 @@ test('runtime build entrypoint invokes pnpm with the checked plan and forwards e
   });
 
   assert.equal(status, 0);
-  assert.deepEqual(invocations, [
-    {
-      command: 'pnpm',
-      args: runtimeCliPrerequisiteBuildPnpmArgs(['run', 'build', '--force', '--log-order=stream']),
-      options: { stdio: 'inherit', shell: false, env: { PATH: '/mock-bin' } },
-    },
-    {
-      command: 'pnpm',
-      args: ['--filter', RUNTIME_CLI_PACKAGE, 'run', 'build:prepared'],
-      options: { stdio: 'inherit', shell: false, env: { PATH: '/mock-bin' } },
-    },
-    {
-      command: 'pnpm',
-      args: runtimeDependentBuildPnpmArgs(['run', 'build', '--force', '--log-order=stream']),
-      options: { stdio: 'inherit', shell: false, env: { PATH: '/mock-bin' } },
-    },
-  ]);
+  const phases = runtimeBuildPhases({
+    runtimeOperation: ['run', 'build', '--force', '--log-order=stream'],
+  });
+  assert.deepEqual(invocations, phases.map((phase) => ({
+    command: 'pnpm',
+    args: phase.args,
+    options: { stdio: 'inherit', shell: false, env: { PATH: '/mock-bin' } },
+  })));
 });
 
 test('CLI exposes explicit standalone and prepared build paths', () => {
@@ -143,26 +133,18 @@ test('runtime build entrypoint propagates process failures', () => {
   assert.match(messages[1], /exited via SIGTERM$/);
 });
 
-test('runtime build stops before the prepared CLI build when a prerequisite fails', () => {
-  let invocations = 0;
-  assert.equal(runRuntimePackageBuild({
-    spawn() {
-      invocations += 1;
-      return { status: 9, signal: null };
-    },
-  }), 9);
-  assert.equal(invocations, 1);
-});
-
-test('runtime build stops before dependents when the prepared CLI build fails', () => {
-  let invocations = 0;
-  assert.equal(runRuntimePackageBuild({
-    spawn() {
-      invocations += 1;
-      return { status: invocations === 2 ? 9 : 0, signal: null };
-    },
-  }), 9);
-  assert.equal(invocations, 2);
+test('runtime build stops on the first nonzero phase status', () => {
+  for (const failingPhase of [0, 1, 2]) {
+    let invocations = 0;
+    assert.equal(runRuntimePackageBuild({
+      spawn() {
+        const status = invocations === failingPhase ? 9 : 0;
+        invocations += 1;
+        return { status, signal: null };
+      },
+    }), 9);
+    assert.equal(invocations, failingPhase + 1);
+  }
 });
 
 test('release runtime build plan includes workspace dependencies but excludes Hardhat', () => {
@@ -180,20 +162,23 @@ test('release runtime build plan includes workspace dependencies but excludes Ha
   }));
   const selectedNames = new Set(selected.map((workspace) => workspace.name));
 
-  const prerequisitePlanArgs = runtimeCliPrerequisiteBuildPnpmArgs(['list', '--depth', '-1', '--json']);
-  const prerequisitePlan = JSON.parse(execFileSync(PNPM, prerequisitePlanArgs, {
+  const phases = runtimeBuildPhases({
+    runtimeOperation: ['list', '--depth', '-1', '--json'],
+    preparedCliOperation: ['list', '--depth', '-1', '--json'],
+  });
+  assert.deepEqual(phases.map(({ label }) => label), [
+    'CLI prerequisite build',
+    'prepared CLI build',
+    'runtime dependent build',
+  ]);
+  const phasePlans = phases.map(({ args }) => JSON.parse(execFileSync(PNPM, args, {
     cwd: REPO_ROOT,
     encoding: 'utf8',
     maxBuffer: 10 * 1024 * 1024,
-  }));
-  const prerequisiteNames = new Set(prerequisitePlan.map((workspace) => workspace.name));
-  const dependentPlanArgs = runtimeDependentBuildPnpmArgs(['list', '--depth', '-1', '--json']);
-  const dependentPlan = JSON.parse(execFileSync(PNPM, dependentPlanArgs, {
-    cwd: REPO_ROOT,
-    encoding: 'utf8',
-    maxBuffer: 10 * 1024 * 1024,
-  }));
-  const dependentNames = new Set(dependentPlan.map((workspace) => workspace.name));
+  })));
+  const prerequisiteNames = new Set(phasePlans[0].map((workspace) => workspace.name));
+  const preparedCliNames = new Set(phasePlans[1].map((workspace) => workspace.name));
+  const dependentNames = new Set(phasePlans[2].map((workspace) => workspace.name));
 
   for (const packageName of REQUIRED_RUNTIME_PACKAGES) {
     assert.ok(selectedNames.has(packageName), `${packageName} must remain in the runtime build`);
@@ -205,6 +190,7 @@ test('release runtime build plan includes workspace dependencies but excludes Ha
     );
   }
   assert.equal(prerequisiteNames.has(RUNTIME_CLI_PACKAGE), false, 'prepared CLI build must run only after prerequisites');
+  assert.deepEqual(preparedCliNames, new Set([RUNTIME_CLI_PACKAGE]));
   for (const packageName of CLI_PREREQUISITE_ROOTS) {
     assert.ok(prerequisiteNames.has(packageName), `${packageName} must remain in the prerequisite phase`);
   }
@@ -213,7 +199,7 @@ test('release runtime build plan includes workspace dependencies but excludes Ha
     assert.equal(dependentNames.has(packageName), false, `${packageName} must not be rebuilt after the CLI`);
   }
   assert.deepEqual(
-    new Set([...prerequisiteNames, RUNTIME_CLI_PACKAGE, ...dependentNames]),
+    new Set([...prerequisiteNames, ...preparedCliNames, ...dependentNames]),
     selectedNames,
     'the three explicit phases must partition the complete runtime plan',
   );

--- a/scripts/lib/run-build-command.mjs
+++ b/scripts/lib/run-build-command.mjs
@@ -1,0 +1,23 @@
+import { spawnSync } from 'node:child_process';
+
+/** Shared subprocess contract for the root and standalone package build paths. */
+export function runBuildCommand(command, args, {
+  spawn = spawnSync,
+  platform = process.platform,
+  env,
+  label = `${command} ${args.join(' ')}`,
+  reportError = (message) => console.error(message),
+} = {}) {
+  const result = spawn(command, args, {
+    stdio: 'inherit',
+    shell: platform === 'win32',
+    ...(env === undefined ? {} : { env }),
+  });
+  if (result.error) {
+    reportError(result.error.message);
+    return 1;
+  }
+  if (typeof result.status === 'number') return result.status;
+  reportError(result.signal ? `${label} exited via ${result.signal}` : `${label} exited without a status`);
+  return 1;
+}

--- a/scripts/lib/runtime-build-plan.mjs
+++ b/scripts/lib/runtime-build-plan.mjs
@@ -36,6 +36,20 @@ export function runtimeBuildPnpmArgs(operation = ['run', 'build']) {
   return [...runtimeBuildFilterArgs(), ...operation];
 }
 
-export function runtimeDependencyBuildPnpmArgs(operation = ['run', 'build']) {
-  return [...runtimeBuildFilterArgs(), '--filter', `!${RUNTIME_CLI_PACKAGE}`, ...operation];
+export function runtimeCliPrerequisiteBuildPnpmArgs(operation = ['run', 'build']) {
+  return [
+    '-r',
+    '--filter', `${RUNTIME_CLI_PACKAGE}...`,
+    '--filter', `!${RUNTIME_CLI_PACKAGE}`,
+    ...RUNTIME_BUILD_EXCLUSIONS.flatMap((packageName) => ['--filter', `!${packageName}`]),
+    ...operation,
+  ];
+}
+
+export function runtimeDependentBuildPnpmArgs(operation = ['run', 'build']) {
+  return [
+    ...runtimeBuildFilterArgs(),
+    '--filter', `!${RUNTIME_CLI_PACKAGE}...`,
+    ...operation,
+  ];
 }

--- a/scripts/lib/runtime-build-plan.mjs
+++ b/scripts/lib/runtime-build-plan.mjs
@@ -22,6 +22,8 @@ export const RUNTIME_BUILD_EXCLUSIONS = Object.freeze([
   '@origintrail-official/dkg-evm-module',
 ]);
 
+export const RUNTIME_CLI_PACKAGE = '@origintrail-official/dkg';
+
 export function runtimeBuildFilterArgs() {
   return [
     '-r',
@@ -32,4 +34,8 @@ export function runtimeBuildFilterArgs() {
 
 export function runtimeBuildPnpmArgs(operation = ['run', 'build']) {
   return [...runtimeBuildFilterArgs(), ...operation];
+}
+
+export function runtimeDependencyBuildPnpmArgs(operation = ['run', 'build']) {
+  return [...runtimeBuildFilterArgs(), '--filter', `!${RUNTIME_CLI_PACKAGE}`, ...operation];
 }

--- a/scripts/lib/runtime-build-plan.mjs
+++ b/scripts/lib/runtime-build-plan.mjs
@@ -36,7 +36,7 @@ export function runtimeBuildPnpmArgs(operation = ['run', 'build']) {
   return [...runtimeBuildFilterArgs(), ...operation];
 }
 
-export function runtimeCliPrerequisiteBuildPnpmArgs(operation = ['run', 'build']) {
+function runtimeCliPrerequisiteBuildPnpmArgs(operation) {
   return [
     '-r',
     '--filter', `${RUNTIME_CLI_PACKAGE}...`,
@@ -46,10 +46,30 @@ export function runtimeCliPrerequisiteBuildPnpmArgs(operation = ['run', 'build']
   ];
 }
 
-export function runtimeDependentBuildPnpmArgs(operation = ['run', 'build']) {
+function runtimeDependentBuildPnpmArgs(operation) {
   return [
     ...runtimeBuildFilterArgs(),
     '--filter', `!${RUNTIME_CLI_PACKAGE}...`,
     ...operation,
+  ];
+}
+
+export function runtimeBuildPhases({
+  runtimeOperation = ['run', 'build'],
+  preparedCliOperation = ['run', 'build:prepared'],
+} = {}) {
+  return [
+    {
+      label: 'CLI prerequisite build',
+      args: runtimeCliPrerequisiteBuildPnpmArgs(runtimeOperation),
+    },
+    {
+      label: 'prepared CLI build',
+      args: ['--filter', RUNTIME_CLI_PACKAGE, ...preparedCliOperation],
+    },
+    {
+      label: 'runtime dependent build',
+      args: runtimeDependentBuildPnpmArgs(runtimeOperation),
+    },
   ];
 }


### PR DESCRIPTION
## Summary

The runtime build traverses the dependency graph and then the CLI prebuild recursively builds nine prerequisites again. Mark the checked topological runtime build so the CLI can skip this duplicate preparation while direct CLI builds retain their existing prerequisite step.

## Changes

- Set an internal marker only in the root runtime-build child environment.
- Move the existing CLI prerequisite command into a small runner; share subprocess handling between it, the runtime entrypoint and the ordinary root build. Preserve Windows spawning, environment forwarding, exit statuses and diagnostics.
- Keep CLI compilation, catch-up worker package loading, runtime asset copying, and all package type checks intact.
- Test root argument/environment forwarding, direct CLI behavior, lifecycle-hook wiring, prerequisite failures and root build short-circuiting.

## Test Plan

- Two clean runtime builds: baseline 29 package-build invocations / 44.48 s; updated 20 invocations / 41.78 s on this machine. Timing is a single local comparison.
- All emitted JavaScript matched the baseline hashes. 4,047 of 4,049 total dist files matched; two graph-viz declaration files differed between captures, so this is not a byte-for-byte claim for every generated declaration.
- Clean CLI output followed by a direct CLI build: passed, including its prerequisite build and packaged worker/assets checks.
- Runtime build plan tests and all 163 root script tests, lint, and `git diff --check`: passed.

- Final local integration with all six audit PRs: clean runtime build, production UI build, 512 regression tests (30 files; 38 pre-existing skipped cases), 163 root script tests, lint and diff checks passed. All six branches combined without conflicts against canary `580a3607`. This does not replace the full CI/devnet lanes.

## Related Issues

Follow-up to the current-main build-performance audit. Targets the canonical runtime build; ordinary Turbo builds retain their existing behavior.
