### PR TITLE
ci: reuse shared EVM artifacts in agent and publisher shards

### DIFF
--- a/.github/actions/restore-evm-node-test-artifacts/action.yml
+++ b/.github/actions/restore-evm-node-test-artifacts/action.yml
@@ -1,0 +1,15 @@
+name: Restore EVM node test artifacts
+description: Restore this run's shared Hardhat 0.8.20/london compiler outputs.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: evm-node-test-artifacts
+        path: ${{ runner.temp }}/evm-node-test-artifacts
+    - name: Extract compiler outputs
+      shell: bash
+      env:
+        ARTIFACT_DIR: ${{ runner.temp }}/evm-node-test-artifacts
+      run: tar -xzf "${ARTIFACT_DIR}/evm-node-test-artifacts.tgz"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,7 +342,7 @@ jobs:
   evm-node-test-artifacts:
     name: Compile EVM test artifacts (0.8.20/london)
     needs: changes
-    if: needs.changes.outputs.tornado_core == 'true' || needs.changes.outputs.bura_cli == 'true' || needs.changes.outputs.kosava_hardhat_plugins == 'true'
+    if: needs.changes.outputs.tornado_core == 'true' || needs.changes.outputs.tornado_publisher == 'true' || needs.changes.outputs.tornado_agent == 'true' || needs.changes.outputs.bura_cli == 'true' || needs.changes.outputs.kosava_hardhat_plugins == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -578,7 +578,7 @@ jobs:
   # ------------------------------------------------------------------
   tornado-publisher:
     name: "Tornado: publisher [${{ matrix.shard }}/4]"
-    needs: [changes, build]
+    needs: [changes, build, evm-node-test-artifacts]
     if: needs.changes.outputs.tornado_publisher == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -603,6 +603,14 @@ jobs:
           path: /tmp
       - name: Restore build outputs
         run: tar -xzf /tmp/build-outputs.tgz
+      # Publisher globalSetup deploys the same Hardhat contracts as chain/CLI.
+      # Restore the shared compiler outputs before starting its isolated node.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: evm-node-test-artifacts
+          path: /tmp
+      - name: Restore EVM test artifacts
+        run: tar -xzf /tmp/evm-node-test-artifacts.tgz
       - name: "Publisher tests (shard ${{ matrix.shard }}/4)"
         run: |
           node scripts/ci/run-vitest-junit.mjs \
@@ -641,7 +649,7 @@ jobs:
   # ------------------------------------------------------------------
   tornado-agent:
     name: "Tornado: agent [${{ matrix.shard }}/10]"
-    needs: [changes, build]
+    needs: [changes, build, evm-node-test-artifacts]
     if: needs.changes.outputs.tornado_agent == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -666,6 +674,12 @@ jobs:
           path: /tmp
       - name: Restore build outputs
         run: tar -xzf /tmp/build-outputs.tgz
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: evm-node-test-artifacts
+          path: /tmp
+      - name: Restore EVM test artifacts
+        run: tar -xzf /tmp/evm-node-test-artifacts.tgz
       - name: "Agent tests (shard ${{ matrix.shard }}/10)"
         working-directory: packages/agent
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,10 @@ jobs:
     outputs:
       full_ci: ${{ steps.plan.outputs.full_ci }}
       run_node: ${{ steps.plan.outputs.run_node }}
+      # The protected-history controller pin predates this capability output.
+      # Keep its trusted lane outputs as a compatibility path until a reviewed
+      # controller rotation after merge; never execute candidate policy here.
+      node_test_artifacts: ${{ steps.plan.outputs.node_test_artifacts || (steps.plan.outputs.tornado_core == 'true' || steps.plan.outputs.tornado_publisher == 'true' || steps.plan.outputs.tornado_agent == 'true' || steps.plan.outputs.bura_cli == 'true' || steps.plan.outputs.kosava_hardhat_plugins == 'true') }}
       tornado_core: ${{ steps.plan.outputs.tornado_core }}
       tornado_blazegraph: ${{ steps.plan.outputs.tornado_blazegraph }}
       tornado_publisher: ${{ steps.plan.outputs.tornado_publisher }}
@@ -342,7 +346,7 @@ jobs:
   evm-node-test-artifacts:
     name: Compile EVM test artifacts (0.8.20/london)
     needs: changes
-    if: needs.changes.outputs.tornado_core == 'true' || needs.changes.outputs.tornado_publisher == 'true' || needs.changes.outputs.tornado_agent == 'true' || needs.changes.outputs.bura_cli == 'true' || needs.changes.outputs.kosava_hardhat_plugins == 'true'
+    if: needs.changes.outputs.node_test_artifacts == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,14 +439,8 @@ jobs:
           path: /tmp
       - name: Restore build outputs
         run: tar -xzf /tmp/build-outputs.tgz
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - uses: ./.github/actions/restore-evm-node-test-artifacts
         if: matrix.suite == 'chain'
-        with:
-          name: evm-node-test-artifacts
-          path: /tmp
-      - name: Restore EVM test artifacts
-        if: matrix.suite == 'chain'
-        run: tar -xzf /tmp/evm-node-test-artifacts.tgz
 
       - name: Core, RDF utilities, and storage tests
         if: matrix.suite == 'core'
@@ -605,12 +599,7 @@ jobs:
         run: tar -xzf /tmp/build-outputs.tgz
       # Publisher globalSetup deploys the same Hardhat contracts as chain/CLI.
       # Restore the shared compiler outputs before starting its isolated node.
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: evm-node-test-artifacts
-          path: /tmp
-      - name: Restore EVM test artifacts
-        run: tar -xzf /tmp/evm-node-test-artifacts.tgz
+      - uses: ./.github/actions/restore-evm-node-test-artifacts
       - name: "Publisher tests (shard ${{ matrix.shard }}/4)"
         run: |
           node scripts/ci/run-vitest-junit.mjs \
@@ -674,12 +663,7 @@ jobs:
           path: /tmp
       - name: Restore build outputs
         run: tar -xzf /tmp/build-outputs.tgz
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: evm-node-test-artifacts
-          path: /tmp
-      - name: Restore EVM test artifacts
-        run: tar -xzf /tmp/evm-node-test-artifacts.tgz
+      - uses: ./.github/actions/restore-evm-node-test-artifacts
       - name: "Agent tests (shard ${{ matrix.shard }}/10)"
         working-directory: packages/agent
         run: |
@@ -741,12 +725,7 @@ jobs:
           path: /tmp
       - name: Restore build outputs
         run: tar -xzf /tmp/build-outputs.tgz
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: evm-node-test-artifacts
-          path: /tmp
-      - name: Restore EVM test artifacts
-        run: tar -xzf /tmp/evm-node-test-artifacts.tgz
+      - uses: ./.github/actions/restore-evm-node-test-artifacts
       - name: "Verify provisioned Blazegraph image contract"
         if: matrix.shard == 1
         run: bash scripts/ci/verify-blazegraph-image-contract.sh
@@ -1024,12 +1003,7 @@ jobs:
           path: /tmp
       - name: Restore build outputs
         run: tar -xzf /tmp/build-outputs.tgz
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: evm-node-test-artifacts
-          path: /tmp
-      - name: Restore EVM test artifacts
-        run: tar -xzf /tmp/evm-node-test-artifacts.tgz
+      - uses: ./.github/actions/restore-evm-node-test-artifacts
       - name: "random-sampling tests (real Hardhat, no mocks)"
         run: pnpm --filter @origintrail-official/dkg-random-sampling test
       - name: "kafka-plugin tests (real Hardhat, no mocks)"

--- a/scripts/lib/__tests__/ci-delta.test.mjs
+++ b/scripts/lib/__tests__/ci-delta.test.mjs
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import { parse } from 'yaml';
 import { fileURLToPath } from 'node:url';
 import {
   CI_LANES,
@@ -762,8 +763,18 @@ test('aggregate gates reject failed or accidentally skipped selected jobs', () =
 });
 
 test('all shared Hardhat consumers require and restore the matching artifact', () => {
-  const workflow = fs.readFileSync(path.join(REPO_ROOT, '.github/workflows/ci.yml'), 'utf8');
-  const producer = workflowJobBlock(workflow, 'evm-node-test-artifacts');
+  const { jobs } = parse(fs.readFileSync(path.join(REPO_ROOT, '.github/workflows/ci.yml'), 'utf8'));
+  const restorePath = './.github/actions/restore-evm-node-test-artifacts';
+  const action = parse(fs.readFileSync(path.join(REPO_ROOT, restorePath, 'action.yml'), 'utf8'));
+  assert.equal(action.runs.using, 'composite');
+  const download = action.runs.steps.find((step) => step.uses?.startsWith('actions/download-artifact@'));
+  assert.match(download.uses, /@[a-f0-9]{40}$/);
+  assert.equal(download.with.name, 'evm-node-test-artifacts');
+  assert.equal(download.with.path, '${{ runner.temp }}/evm-node-test-artifacts');
+  const extract = action.runs.steps.find((step) => step.run);
+  assert.equal(extract.shell, 'bash');
+  assert.equal(extract.env.ARTIFACT_DIR, download.with.path);
+  assert.match(extract.run, /tar -xzf "\$\{ARTIFACT_DIR\}\/evm-node-test-artifacts\.tgz"/);
   for (const [job, lane] of [
     ['tornado-core', 'tornado_core'],
     ['tornado-agent', 'tornado_agent'],
@@ -771,11 +782,15 @@ test('all shared Hardhat consumers require and restore the matching artifact', (
     ['bura-cli', 'bura_cli'],
     ['kosava-hardhat-plugins', 'kosava_hardhat_plugins'],
   ]) {
-    const consumer = workflowJobBlock(workflow, job);
-    assert.match(consumer, /needs: \[changes, build, evm-node-test-artifacts\]/, job);
-    assert.match(consumer, /name: evm-node-test-artifacts/, job);
-    assert.match(consumer, /tar -xzf \/tmp\/evm-node-test-artifacts\.tgz/, job);
-    assert.ok(producer.includes(`needs.changes.outputs.${lane} == 'true'`), lane);
+    const consumer = jobs[job];
+    const dependencies = new Set([consumer.needs].flat());
+    for (const dependency of ['changes', 'build', 'evm-node-test-artifacts']) {
+      assert.ok(dependencies.has(dependency), `${job} requires ${dependency}`);
+    }
+    const restores = consumer.steps.filter((step) => step.uses === restorePath);
+    assert.equal(restores.length, 1, job);
+    assert.equal(restores[0].if, job === 'tornado-core' ? "matrix.suite == 'chain'" : undefined);
+    assert.ok(jobs['evm-node-test-artifacts'].if.includes(`needs.changes.outputs.${lane} == 'true'`), lane);
   }
 });
 

--- a/scripts/lib/__tests__/ci-delta.test.mjs
+++ b/scripts/lib/__tests__/ci-delta.test.mjs
@@ -10,6 +10,8 @@ import {
   CI_LANES,
   EVM_SCOPES,
   NODE_EVM_LANES,
+  NODE_TEST_ARTIFACT_LANES,
+  needsNodeTestArtifacts,
   WORKSPACE_OWNING_EVM_SCOPES,
   WORKSPACE_OWNING_LANES,
   WORKSPACE_RULES,
@@ -775,13 +777,13 @@ test('all shared Hardhat consumers require and restore the matching artifact', (
   assert.equal(extract.shell, 'bash');
   assert.equal(extract.env.ARTIFACT_DIR, download.with.path);
   assert.match(extract.run, /tar -xzf "\$\{ARTIFACT_DIR\}\/evm-node-test-artifacts\.tgz"/);
-  for (const [job, lane] of [
-    ['tornado-core', 'tornado_core'],
-    ['tornado-agent', 'tornado_agent'],
-    ['tornado-publisher', 'tornado_publisher'],
-    ['bura-cli', 'bura_cli'],
-    ['kosava-hardhat-plugins', 'kosava_hardhat_plugins'],
-  ]) {
+  assert.equal(jobs['evm-node-test-artifacts'].if, "needs.changes.outputs.node_test_artifacts == 'true'");
+  const output = jobs.changes.outputs.node_test_artifacts;
+  assert.ok(output.startsWith('${{ steps.plan.outputs.node_test_artifacts || ('));
+  const legacyLanes = [...output.matchAll(/steps\.plan\.outputs\.(\w+) == 'true'/g)].map((match) => match[1]);
+  assert.deepEqual(new Set(legacyLanes), new Set(NODE_TEST_ARTIFACT_LANES));
+  for (const lane of NODE_TEST_ARTIFACT_LANES) {
+    const job = PRIMARY_LANE_JOBS[lane];
     const consumer = jobs[job];
     const dependencies = new Set([consumer.needs].flat());
     for (const dependency of ['changes', 'build', 'evm-node-test-artifacts']) {
@@ -790,7 +792,30 @@ test('all shared Hardhat consumers require and restore the matching artifact', (
     const restores = consumer.steps.filter((step) => step.uses === restorePath);
     assert.equal(restores.length, 1, job);
     assert.equal(restores[0].if, job === 'tornado-core' ? "matrix.suite == 'chain'" : undefined);
-    assert.ok(jobs['evm-node-test-artifacts'].if.includes(`needs.changes.outputs.${lane} == 'true'`), lane);
+  }
+});
+
+test('artifact capability selects its producer and gate for each consumer lane only', () => {
+  assert.equal(NODE_TEST_ARTIFACT_LANES.length, 5);
+  for (const lane of CI_LANES) {
+    const plan = {
+      ...planCi({ eventName: 'push' }), mode: 'delta', fullCi: false,
+      runNode: Object.hasOwn(PRIMARY_LANE_JOBS, lane) && lane !== 'bura_blazegraph_arm64',
+      lanes: Object.fromEntries(CI_LANES.map((candidate) => [candidate, candidate === lane])),
+    };
+    const selected = NODE_TEST_ARTIFACT_LANES.includes(lane);
+    assert.equal(needsNodeTestArtifacts(plan), selected, lane);
+    assert.equal(githubOutputsForPlan(plan).node_test_artifacts, String(selected), lane);
+    const needs = {
+      changes: { result: 'success' }, build: { result: 'success' },
+      ...Object.fromEntries(Object.values(PRIMARY_LANE_JOBS).map((job) => [job, { result: 'success' }])),
+      'evm-node-test-artifacts': { result: 'skipped' },
+      'evm-devnet-test-artifacts': { result: 'success' },
+      'abi-freshness': { result: 'success' }, solidity: { result: 'success' },
+      'solidity-coverage': { result: 'skipped' }, 'tornado-static-analysis': { result: 'success' },
+    };
+    const errors = validatePrimaryResults({ eventName: 'pull_request', plan, needs });
+    assert.deepEqual(errors, selected ? ['evm-node-test-artifacts was selected but ended with skipped'] : [], lane);
   }
 });
 

--- a/scripts/lib/__tests__/ci-delta.test.mjs
+++ b/scripts/lib/__tests__/ci-delta.test.mjs
@@ -761,6 +761,24 @@ test('aggregate gates reject failed or accidentally skipped selected jobs', () =
   }).join('\n'), /failure/);
 });
 
+test('all shared Hardhat consumers require and restore the matching artifact', () => {
+  const workflow = fs.readFileSync(path.join(REPO_ROOT, '.github/workflows/ci.yml'), 'utf8');
+  const producer = workflowJobBlock(workflow, 'evm-node-test-artifacts');
+  for (const [job, lane] of [
+    ['tornado-core', 'tornado_core'],
+    ['tornado-agent', 'tornado_agent'],
+    ['tornado-publisher', 'tornado_publisher'],
+    ['bura-cli', 'bura_cli'],
+    ['kosava-hardhat-plugins', 'kosava_hardhat_plugins'],
+  ]) {
+    const consumer = workflowJobBlock(workflow, job);
+    assert.match(consumer, /needs: \[changes, build, evm-node-test-artifacts\]/, job);
+    assert.match(consumer, /name: evm-node-test-artifacts/, job);
+    assert.match(consumer, /tar -xzf \/tmp\/evm-node-test-artifacts\.tgz/, job);
+    assert.ok(producer.includes(`needs.changes.outputs.${lane} == 'true'`), lane);
+  }
+});
+
 test('aggregate gate accepts the full-push and docs-only job shapes', () => {
   const laneJobs = Object.values(PRIMARY_LANE_JOBS);
   const full = planCi({ eventName: 'push' });

--- a/scripts/lib/ci-delta.mjs
+++ b/scripts/lib/ci-delta.mjs
@@ -18,6 +18,16 @@ export const CI_LANES = Object.freeze([...NODE_EVM_LANES, 'contracts']);
 
 export const EVM_SCOPES = Object.freeze(['chain', 'publisher', 'agent']);
 
+// Lanes that restore the shared Hardhat 0.8.20/london compiler outputs.
+export const NODE_TEST_ARTIFACT_LANES = Object.freeze([
+  'tornado_core', 'tornado_publisher', 'tornado_agent', 'bura_cli', 'kosava_hardhat_plugins',
+]);
+
+export function needsNodeTestArtifacts(plan) {
+  return NODE_TEST_ARTIFACT_LANES.some((lane) => plan.lanes?.[lane] === true);
+}
+
+
 export const WORKSPACE_RULES = Object.freeze({
   'packages/core': {
     lanes: [
@@ -584,6 +594,7 @@ export function githubOutputsForPlan(plan) {
   return {
     full_ci: String(plan.fullCi),
     run_node: String(plan.runNode),
+    node_test_artifacts: String(needsNodeTestArtifacts(plan)),
     abi_freshness: String(plan.abiFreshnessRelevant),
     ...Object.fromEntries(CI_LANES.map((lane) => [lane, String(plan.lanes[lane])])),
     evm_matrix: JSON.stringify(plan.evmScopes),

--- a/scripts/lib/ci-results.mjs
+++ b/scripts/lib/ci-results.mjs
@@ -1,4 +1,4 @@
-import { CI_LANES, EVM_SCOPES, NODE_EVM_LANES } from './ci-delta.mjs';
+import { CI_LANES, EVM_SCOPES, NODE_EVM_LANES, needsNodeTestArtifacts } from './ci-delta.mjs';
 
 export const PRIMARY_LANE_JOBS = Object.freeze({
   tornado_core: 'tornado-core',
@@ -83,12 +83,7 @@ export function validatePrimaryResults({ eventName, plan, needs }) {
   requireSuccess(needs, 'changes', true, errors);
   requireSuccess(needs, 'build', plan.runNode, errors);
 
-  const needsNodeTestArtifacts = Boolean(
-    plan.lanes?.tornado_core
-    || plan.lanes?.bura_cli
-    || plan.lanes?.kosava_hardhat_plugins
-  );
-  requireSuccess(needs, 'evm-node-test-artifacts', needsNodeTestArtifacts, errors);
+  requireSuccess(needs, 'evm-node-test-artifacts', needsNodeTestArtifacts(plan), errors);
   requireSuccess(
     needs,
     'evm-devnet-test-artifacts',


### PR DESCRIPTION
Agent and publisher shards now restore the same-run Hardhat compiler artifact already used by chain, CLI, and plugin tests, avoiding fourteen repeated contract compilations while retaining isolated deployments.

All five consumers use one local restore action. A canonical artifact-capability set derives the planner boolean, aggregate requirement, and workflow policy tests. The producer reads one output. Because the protected-history controller pin predates that output, the workflow derives a compatibility value from its existing trusted lane outputs until a reviewed controller rotation after merge. The pin remains unchanged; each consumer still directly requires the producer.

Validation:
- Parsed-YAML policy checks cover dependency membership, all five action invocations, the core chain-only condition, and producer selection/aggregate requirements for every individual lane.
- 24 CI policy tests, repository lint, actionlint, and diff checks pass on the revised implementation.
- Before the review refactor, all ten agent and four publisher shards passed in Actions run 33936167980. Publisher shards 3/4 saved 81s/90s against the audited main run; these are initial cross-run observations, not a controlled benchmark.
- CI is rerunning for the latest review fixes.

Part 1 of the requested CI improvements. Independent PR targeting `testnet-canary`.
