### PR TITLE
Replace weak UI and storage checks with behavioral assertions

### DIFF
--- a/packages/core/test/context-graph-join-policy.test.ts
+++ b/packages/core/test/context-graph-join-policy.test.ts
@@ -28,6 +28,13 @@ describe('context graph join policy validation', () => {
   });
 
   it.each([
+    { label: 'an empty graph', patch: { contextGraphId: '' } },
+    { label: 'a non-string graph with a length', patch: { contextGraphId: { length: 1 } } },
+    { label: 'an unknown mode', patch: { mode: 'automatic' } },
+    { label: 'a zero member cap', patch: { maxMembers: 0 } },
+    { label: 'a negative member cap', patch: { maxMembers: -1 } },
+    { label: 'a zero approval cap', patch: { maxApprovalsPerHour: 0 } },
+    { label: 'a negative approval cap', patch: { maxApprovalsPerHour: -1 } },
     { label: 'a future version', patch: { version: 2 } },
     { label: 'the wrong graph', patch: { contextGraphId: 'did:dkg:cg:other' } },
     { label: 'an empty owner', patch: { ownerDid: '' } },
@@ -50,6 +57,9 @@ describe('context graph join policy validation', () => {
 
     expect(parseContextGraphJoinPolicyRecord(policy, base.contextGraphId)).toBeNull();
     expect(isBoundedOpenEnrollmentPolicy(policy, base.contextGraphId)).toBe(false);
+    if (!('contextGraphId' in patch) || patch.contextGraphId !== 'did:dkg:cg:other') {
+      expect(parseContextGraphJoinPolicyRecord(policy)).toBeNull();
+    }
   });
 
   it('canonicalizes manual policies without stale open-enrollment caps', () => {
@@ -62,5 +72,16 @@ describe('context graph join policy validation', () => {
       ...base,
       mode: 'manual',
     });
+  });
+
+  it('rejects array objects even if they carry otherwise valid policy fields', () => {
+    const array = Object.assign([], { ...base, mode: 'manual' });
+    expect(parseContextGraphJoinPolicyRecord(array)).toBeNull();
+    expect(isBoundedOpenEnrollmentPolicy(array)).toBe(false);
+  });
+
+  it('rejects functions carrying otherwise valid policy fields', () => {
+    const callable = Object.assign(() => undefined, { ...base, mode: 'manual' });
+    expect(parseContextGraphJoinPolicyRecord(callable)).toBeNull();
   });
 });

--- a/packages/core/test/context-graph-join-policy.test.ts
+++ b/packages/core/test/context-graph-join-policy.test.ts
@@ -36,7 +36,6 @@ describe('context graph join policy validation', () => {
     { label: 'a zero approval cap', patch: { maxApprovalsPerHour: 0 } },
     { label: 'a negative approval cap', patch: { maxApprovalsPerHour: -1 } },
     { label: 'a future version', patch: { version: 2 } },
-    { label: 'the wrong graph', patch: { contextGraphId: 'did:dkg:cg:other' } },
     { label: 'an empty owner', patch: { ownerDid: '' } },
     { label: 'a non-finite update time', patch: { updatedAt: Number.NaN } },
     { label: 'a missing member cap', patch: { maxMembers: undefined } },
@@ -57,9 +56,14 @@ describe('context graph join policy validation', () => {
 
     expect(parseContextGraphJoinPolicyRecord(policy, base.contextGraphId)).toBeNull();
     expect(isBoundedOpenEnrollmentPolicy(policy, base.contextGraphId)).toBe(false);
-    if (!('contextGraphId' in patch) || patch.contextGraphId !== 'did:dkg:cg:other') {
-      expect(parseContextGraphJoinPolicyRecord(policy)).toBeNull();
-    }
+    expect(parseContextGraphJoinPolicyRecord(policy)).toBeNull();
+  });
+
+  it('accepts a valid record without a context constraint and rejects a different expected graph', () => {
+    const policy = { ...base, mode: 'open', maxMembers: 100, maxApprovalsPerHour: 10 };
+    expect(parseContextGraphJoinPolicyRecord(policy)).toEqual(policy);
+    expect(parseContextGraphJoinPolicyRecord(policy, 'did:dkg:cg:other')).toBeNull();
+    expect(isBoundedOpenEnrollmentPolicy(policy, 'did:dkg:cg:other')).toBe(false);
   });
 
   it('canonicalizes manual policies without stale open-enrollment caps', () => {

--- a/packages/core/test/retry-queue.resource.test.ts
+++ b/packages/core/test/retry-queue.resource.test.ts
@@ -1,0 +1,17 @@
+import { expect, it } from 'vitest';
+import { RetryQueue } from '../src/retry-queue.js';
+
+it('a repeated outage retains one entry per destination and expires from the first failure', () => {
+  const queue = new RetryQueue<{ destination: number }>({ backoffs: [10, 100, 1000], maxAgeMs: 20_000 });
+  const destinations = 64;
+  for (let attempt = 0; attempt < 10_000; attempt++) {
+    const destination = attempt % destinations;
+    const entry = queue.enqueueFailure(String(destination), { destination }, 'transport unavailable', attempt);
+    expect(entry.nextAttemptAt - attempt).toBeLessThanOrEqual(1000);
+  }
+  expect(queue.size()).toBe(destinations);
+  expect(queue.due(12_000)).toHaveLength(destinations);
+  expect(queue.dropExpired(20_064)).toHaveLength(destinations);
+  expect(queue.size()).toBe(0);
+  expect(queue.due(30_000)).toEqual([]);
+});

--- a/packages/node-ui/test/notifications-pane.dom.test.ts
+++ b/packages/node-ui/test/notifications-pane.dom.test.ts
@@ -317,6 +317,24 @@ describe('NotificationsPane — interaction + a11y (happy-dom)', () => {
     expect(container.textContent).toContain('You added 3 assertions');
     expect(container.querySelector('.v10-notif-by-self')).toBeTruthy();
   });
+
+  it('approved and activity rows open their graph, while rejected rows cannot navigate', () => {
+    const open = vi.fn();
+    const feed = makeFeed({ activity: [
+      { kind: 'join_approved', id: 20, cgId: 'cg:approved', contextGraphName: 'Approved', ts: 1, read: false },
+      { kind: 'join_rejected', id: 21, cgId: 'cg:rejected', contextGraphName: 'Rejected', ts: 2, read: false },
+      { kind: 'digest', id: 'digest', cgId: 'cg:activity', contextGraphName: 'Activity', event: 'created', count: 1, ts: 3, read: false },
+    ] });
+    act(() => root.render(React.createElement(NotificationsPane, { feed, onOpenContextGraph: open })));
+    const navigable = [...container.querySelectorAll<HTMLElement>('[role="button"], button')]
+      .filter((element) => /Approved|Activity/.test(element.textContent ?? '') && element.getAttribute('aria-disabled') !== 'true');
+    act(() => { for (const element of navigable) element.click(); });
+    expect(open.mock.calls.map(([graph]) => graph)).toEqual(expect.arrayContaining(['cg:approved', 'cg:activity']));
+    const rejected = container.querySelector<HTMLElement>('[aria-disabled="true"]');
+    expect(rejected).not.toBeNull();
+    act(() => rejected!.click());
+    expect(open).not.toHaveBeenCalledWith('cg:rejected');
+  });
 });
 
 describe('NotificationsBell — disclosure keyboard + focus (happy-dom)', () => {

--- a/packages/node-ui/test/ui-compat.test.ts
+++ b/packages/node-ui/test/ui-compat.test.ts
@@ -321,27 +321,7 @@ describe('synced status logic', () => {
   });
 });
 
-// Redesign reverses the old "notifications are non-interactive" guard:
-// incoming join requests are now actionable (inline Approve/Deny) and
-// activity/approved rows open their context graph. This guard asserts the
-// new intended interactivity lives in the row components.
-describe('notification rows are actionable', () => {
-  const rows = readFile('components/Notifications/rows.tsx');
-
-  it('join request row exposes inline Approve / Deny controls', () => {
-    expect(rows).toContain('Approve');
-    expect(rows).toContain('onApprove');
-    expect(rows).toContain('onDeny');
-    // Deny is a two-tap inline confirm, never a modal.
-    expect(rows).toContain('confirming-deny');
-  });
-
-  it('activity + approved rows open their context graph; rejected is a dead-end', () => {
-    expect(rows).toContain('onOpen(item.cgId)');
-    // Rejected confirmation renders as a non-interactive row.
-    expect(rows).toContain('aria-disabled="true"');
-  });
-});
+// Notification interactions are exercised by notifications-pane.dom.test.ts.
 
 // NOTE: the dashboard "Import Memories" Quick Action was removed in PR6
 // (dashboard revamp). Import still launches from the left sidebar; the

--- a/packages/storage/test/adapter-parity.test.ts
+++ b/packages/storage/test/adapter-parity.test.ts
@@ -1,88 +1,32 @@
-/**
- * Same logical TripleStore operations on Oxigraph vs BlazegraphStore (real HTTP test server)
- * so backends stay aligned on counts and delete semantics (03 §16 graph isolation).
- */
-import { createServer, type Server } from 'node:http';
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { OxigraphStore, BlazegraphStore, type Quad } from '../src/index.js';
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import { OxigraphStore, BlazegraphStore, SparqlHttpStore, type TripleStore } from '../src/index.js';
+import { startOxigraphSparqlEndpoint, type OxigraphSparqlEndpoint } from './helpers/oxigraph-sparql-endpoint.js';
 
-const G = 'http://parity.test/g';
-const Q1: Quad = { subject: 'http://parity.test/s1', predicate: 'http://parity.test/p', object: '"a"', graph: G };
-const Q2: Quad = { subject: 'http://parity.test/s2', predicate: 'http://parity.test/p', object: '"b"', graph: G };
+let endpoint: OxigraphSparqlEndpoint;
+beforeAll(async () => { endpoint = await startOxigraphSparqlEndpoint(); });
+afterAll(async () => { await endpoint.close(); });
 
-let server: Server;
-let blazeUrl: string;
-let queryCount = 0;
-
-describe('TripleStore adapter parity (Oxigraph vs test-server Blazegraph)', () => {
-  beforeAll(async () => {
-    await new Promise<void>((resolve) => {
-      server = createServer((req, res) => {
-        let body = '';
-        req.on('data', (chunk) => { body += chunk; });
-        req.on('end', () => {
-          // Direct POST (W3C SPARQL 1.1): queries arrive as a raw body with
-          // Content-Type application/sparql-query; writes (n-quads insert /
-          // application/sparql-update) are everything else.
-          const contentType = String(req.headers['content-type'] ?? '');
-          if (!contentType.includes('application/sparql-query')) {
-            res.writeHead(200);
-            res.end();
-            return;
-          }
-          queryCount++;
-          const decoded = body;
-          if (decoded.includes('COUNT(*)')) {
-            const c = queryCount <= 1 ? '2' : '1';
-            res.writeHead(200, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({
-              head: { vars: ['c'] },
-              results: { bindings: [{ c: { type: 'literal', value: c, datatype: 'http://www.w3.org/2001/XMLSchema#integer' } }] },
-            }));
-            return;
-          }
-          res.writeHead(200, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ head: { vars: [] }, results: { bindings: [] } }));
-        });
-      });
-      server.listen(0, '127.0.0.1', () => {
-        const port = (server.address() as { port: number }).port;
-        blazeUrl = `http://127.0.0.1:${port}/sparql`;
-        resolve();
-      });
-    });
-  });
-
-  afterAll(async () => {
-    await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
-  });
-
-  it('insert two quads then countQuads(graph) is 2 for both backends', async () => {
-    const ox = new OxigraphStore();
-    await ox.insert([Q1, Q2]);
-    expect(await ox.countQuads(G)).toBe(2);
-    await ox.close();
-
-    queryCount = 0;
-    const blaze = new BlazegraphStore(blazeUrl);
-    await blaze.insert([Q1, Q2]);
-    expect(await blaze.countQuads(G)).toBe(2);
-    expect(queryCount).toBeGreaterThanOrEqual(1);
-  });
-
-  it('deleteByPattern removes one quad and leaves count 1 (Oxigraph; Blazegraph test server)', async () => {
-    const ox = new OxigraphStore();
-    await ox.insert([Q1, Q2]);
-    const removedOx = await ox.deleteByPattern({ graph: G, subject: 'http://parity.test/s1' });
-    expect(removedOx).toBe(1);
-    expect(await ox.countQuads(G)).toBe(1);
-    await ox.close();
-
-    queryCount = 0;
-    const blaze = new BlazegraphStore(blazeUrl);
-    await blaze.insert([Q1, Q2]);
-    const removedBlaze = await blaze.deleteByPattern({ graph: G, subject: 'http://parity.test/s1' });
-    expect(removedBlaze).toBe(1);
-    expect(await blaze.countQuads(G)).toBe(1);
-  });
+// The HTTP fixture executes RDF operations in Oxigraph. This is an adapter
+// protocol test; native Blazegraph conformance lives in test-systems/.
+it.each(['embedded', 'sparql-http', 'blazegraph-http'] as const)('%s preserves real stored state across duplicate insert and scoped deletion', async (backend) => {
+  const store: TripleStore = backend === 'embedded' ? new OxigraphStore()
+    : backend === 'sparql-http' ? new SparqlHttpStore({ queryEndpoint: endpoint.queryEndpoint, updateEndpoint: endpoint.updateEndpoint })
+      : new BlazegraphStore(endpoint.queryEndpoint);
+  const graph = `urn:parity:${backend}`;
+  const other = `${graph}:private`;
+  const quads = [
+    { graph, subject: 'urn:one', predicate: 'urn:p', object: '"one"' },
+    { graph, subject: 'urn:two', predicate: 'urn:p', object: '"two"' },
+    { graph: other, subject: 'urn:one', predicate: 'urn:p', object: '"private"' },
+  ];
+  try {
+    await store.insert(quads); await store.insert(quads);
+    expect(await store.countQuads(graph)).toBe(2);
+    expect(await store.deleteByPattern({ graph, subject: 'urn:one' })).toBe(1);
+    expect(await store.countQuads(graph)).toBe(1);
+    expect(await store.countQuads(other)).toBe(1);
+    expect(await store.deleteByPattern({ graph, subject: 'urn:one' })).toBe(0);
+    const result = await store.query(`SELECT ?s ?o WHERE { GRAPH <${graph}> { ?s <urn:p> ?o } }`);
+    expect(result).toMatchObject({ type: 'bindings', bindings: [{ s: 'urn:two', o: '"two"' }] });
+  } finally { await store.close(); }
 });

--- a/packages/storage/test/adapter-parity.test.ts
+++ b/packages/storage/test/adapter-parity.test.ts
@@ -8,11 +8,13 @@ afterAll(async () => { await endpoint.close(); });
 
 // The HTTP fixture executes RDF operations in Oxigraph. This is an adapter
 // protocol test; native Blazegraph conformance lives in test-systems/.
-it.each(['embedded', 'sparql-http', 'blazegraph-http'] as const)('%s preserves real stored state across duplicate insert and scoped deletion', async (backend) => {
-  const store: TripleStore = backend === 'embedded' ? new OxigraphStore()
-    : backend === 'sparql-http' ? new SparqlHttpStore({ queryEndpoint: endpoint.queryEndpoint, updateEndpoint: endpoint.updateEndpoint })
-      : new BlazegraphStore(endpoint.queryEndpoint);
-  const graph = `urn:parity:${backend}`;
+it.each<{ name: string; createStore: () => TripleStore }>([
+  { name: 'embedded', createStore: () => new OxigraphStore() },
+  { name: 'sparql-http', createStore: () => new SparqlHttpStore({ queryEndpoint: endpoint.queryEndpoint, updateEndpoint: endpoint.updateEndpoint }) },
+  { name: 'blazegraph-http', createStore: () => new BlazegraphStore(endpoint.queryEndpoint) },
+])('$name preserves real stored state across duplicate insert and scoped deletion', async ({ name, createStore }) => {
+  const store = createStore();
+  const graph = `urn:parity:${name}`;
   const other = `${graph}:private`;
   const quads = [
     { graph, subject: 'urn:one', predicate: 'urn:p', object: '"one"' },

--- a/packages/storage/test/helpers/oxigraph-sparql-endpoint.ts
+++ b/packages/storage/test/helpers/oxigraph-sparql-endpoint.ts
@@ -85,7 +85,7 @@ export async function startOxigraphSparqlEndpoint(): Promise<OxigraphSparqlEndpo
           res.end();
           return;
         }
-        if (req.url?.includes('/update')) {
+        if (req.url?.includes('/update') || contentType.includes('application/sparql-update')) {
           store.update(body);
           res.writeHead(204);
           res.end();


### PR DESCRIPTION
Replace two notification source-substring checks with component behavior, and replace storage adapters' canned HTTP count replies with a real embedded SPARQL endpoint. The notification test checks approved/activity navigation and verifies that rejected rows cannot navigate; existing approve/deny, error and keyboard coverage remains in the DOM suite.

Add authority-policy boundary/fallback cases and a deterministic 10,000-failure retry-queue check for bounded entries, capped backoff, expiry and complete drain. Existing architecture and export guards remain.

Validation on this branch:
- Core policy/resource tests: 20 passed.
- Storage adapter parity: three passed.
- Notification DOM and UI compatibility files: 107 passed, 38 existing skips.

Before splitting the branch, a controlled removal of notification navigation failed the replacement test, while renaming its callback with behavior preserved passed. The storage adapter test exercises the HTTP contract through embedded Oxigraph; real native Blazegraph conformance is included in the integration PR.

Integration and CI rollout: #2479. This focused PR should merge before that integration PR.
