### PR TITLE
Measure Hermes Python coverage and test CLI contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -959,6 +959,7 @@ jobs:
         # unset) skips gracefully when Python is absent.
         env:
           DKG_REQUIRE_PYTEST: '1'
+          DKG_CI_COVERAGE: '1'
         run: |
           pnpm \
             --filter @origintrail-official/dkg-epcis \
@@ -973,6 +974,17 @@ jobs:
             --filter @origintrail-official/dkg-adapter-prime-agent \
             --filter @origintrail-official/dkg-demo \
             run test
+      - name: Upload Hermes Python test and coverage reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hermes-python-reports
+          path: |
+            packages/adapter-hermes/test-results/hermes-python.xml
+            packages/adapter-hermes/coverage-python/
+          retention-days: 14
+          if-no-files-found: error
+
 
   # ------------------------------------------------------------------
   # Hardhat-backed Kosava lane — `random-sampling` and `kafka-plugin`.

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ snapshots/_cache_phase1_neuroweb_epoch16.json
 # OKF export test writes reconstructed bundles here at runtime.
 devnet/**/.okf-export-*/
 devnet/**/.okf-manifest-*.json
+
+**/coverage-python/
+**/.coverage

--- a/packages/adapter-hermes/.coveragerc
+++ b/packages/adapter-hermes/.coveragerc
@@ -1,0 +1,14 @@
+[run]
+branch = true
+source = hermes-plugin
+relative_files = true
+
+[report]
+precision = 2
+fail_under = 34
+
+[json]
+output = coverage-python/coverage.json
+
+[xml]
+output = coverage-python/coverage.xml

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -24,7 +24,7 @@
     "test": "vitest run && node pytests/run-pytest.mjs",
     "test:ts": "vitest run",
     "test:py": "node pytests/run-pytest.mjs",
-    "test:coverage": "vitest run --coverage",
+    "test:coverage": "vitest run --coverage && node pytests/run-pytest.mjs --coverage",
     "clean": "node -e \"const fs=require('fs'); for (const p of ['dist','tsconfig.tsbuildinfo']) fs.rmSync(p,{recursive:true,force:true});\""
   },
   "dependencies": {

--- a/packages/adapter-hermes/pytests/requirements.txt
+++ b/packages/adapter-hermes/pytests/requirements.txt
@@ -5,6 +5,8 @@
 #
 # Install: pip install -r packages/adapter-hermes/pytests/requirements.txt
 pytest==9.0.2
+pytest-cov==7.0.0
+click==8.1.8
 eth-utils==6.0.0
 # eth-utils ships NO keccak backend by default; eth_utils.to_checksum_address
 # computes a keccak256 to pick the EIP-55 casing and RAISES without one, which

--- a/packages/adapter-hermes/pytests/run-pytest.mjs
+++ b/packages/adapter-hermes/pytests/run-pytest.mjs
@@ -19,7 +19,7 @@
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
-import { mkdirSync, rmSync, readFileSync, readdirSync } from 'node:fs';
+import { mkdirSync, rmSync } from 'node:fs';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const pkgRoot = resolve(here, '..');
@@ -91,7 +91,7 @@ mkdirSync(resolve(pkgRoot, 'test-results'), { recursive: true });
 rmSync(resolve(pkgRoot, 'test-results/hermes-python.xml'), { force: true });
 if (COVERAGE) rmSync(resolve(pkgRoot, 'coverage-python'), { recursive: true, force: true });
 const result = spawnSync(cmd, [...prefix, '-m', 'pytest', '--junitxml=test-results/hermes-python.xml', ...(COVERAGE ? [
-  '--cov=hermes-plugin', '--cov-branch', '--cov-report=term', '--cov-report=json:coverage-python/coverage.json', '--cov-report=xml:coverage-python/coverage.xml', '--cov-fail-under=34',
+  '--cov', '--cov-report=term', '--cov-report=json', '--cov-report=xml',
 ] : [])], {
   cwd: pkgRoot,
   stdio: 'inherit',
@@ -102,12 +102,12 @@ if (result.error) {
   process.exit(1);
 }
 if (result.status === 0 && COVERAGE) {
-  const report = JSON.parse(readFileSync(resolve(pkgRoot, 'coverage-python/coverage.json'), 'utf8'));
-  const expected = readdirSync(resolve(pkgRoot, 'hermes-plugin')).filter((file) => file.endsWith('.py')).map((file) => `hermes-plugin/${file}`).sort();
-  const actual = Object.keys(report.files).map((file) => file.replaceAll('\\', '/')).sort();
-  if (JSON.stringify(actual) !== JSON.stringify(expected) || report.totals.num_statements <= 0) {
-    throw new Error('Python coverage omitted production files or included non-production files');
+  // coverage.py owns source discovery, report formats, path handling and gates.
+  for (const args of [[], ['--include=hermes-plugin/cli.py', '--fail-under=97']]) {
+    const gate = spawnSync(cmd, [...prefix, '-m', 'coverage', 'report', ...args], {
+      cwd: pkgRoot, stdio: 'inherit',
+    });
+    if (gate.error || gate.status !== 0) process.exit(gate.status ?? 1);
   }
-  if (report.files['hermes-plugin/cli.py'].summary.percent_covered < 97) throw new Error('Hermes CLI coverage regressed below 97%');
 }
 process.exit(result.status ?? 1);

--- a/packages/adapter-hermes/pytests/run-pytest.mjs
+++ b/packages/adapter-hermes/pytests/run-pytest.mjs
@@ -19,11 +19,13 @@
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { mkdirSync, rmSync, readFileSync, readdirSync } from 'node:fs';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const pkgRoot = resolve(here, '..');
 
-const REQUIRED = process.env.DKG_REQUIRE_PYTEST === '1';
+const COVERAGE = process.argv.includes('--coverage') || process.env.DKG_CI_COVERAGE === '1';
+const REQUIRED = COVERAGE || process.env.DKG_REQUIRE_PYTEST === '1';
 
 const candidates =
   process.platform === 'win32'
@@ -47,7 +49,7 @@ function pytestProbe(cmd, prefix) {
     [
       ...prefix,
       '-c',
-      'import pytest, requests; from eth_utils import to_checksum_address; '
+      (COVERAGE ? 'import pytest_cov; ' : '') + 'import pytest, requests, click; from eth_utils import to_checksum_address; '
         + "assert to_checksum_address('0x52908400098527886e0f7030069857d2e4169ee7')"
         + " == '0x52908400098527886E0F7030069857D2E4169EE7'",
     ],
@@ -71,12 +73,12 @@ for (const [cmd, prefix] of candidates) {
 if (!runner) {
   const msg =
     'Python pytest suite skipped — no Python interpreter with the required deps ' +
-    '(pytest, eth_utils, requests) was found. Install Python 3 and ' +
+    '(pytest, eth_utils, requests, click; pytest-cov for coverage) was found. Install Python 3 and ' +
     '`pip install -r packages/adapter-hermes/pytests/requirements.txt` to run it.';
   if (REQUIRED) {
     console.error(
       `[adapter-hermes] ${msg}\n` +
-        'DKG_REQUIRE_PYTEST=1 is set (CI) — the Python suite is REQUIRED, failing.',
+        'CI or coverage requires the Python suite; failing.',
     );
     process.exit(1);
   }
@@ -85,7 +87,12 @@ if (!runner) {
 }
 
 const [cmd, prefix] = runner;
-const result = spawnSync(cmd, [...prefix, '-m', 'pytest'], {
+mkdirSync(resolve(pkgRoot, 'test-results'), { recursive: true });
+rmSync(resolve(pkgRoot, 'test-results/hermes-python.xml'), { force: true });
+if (COVERAGE) rmSync(resolve(pkgRoot, 'coverage-python'), { recursive: true, force: true });
+const result = spawnSync(cmd, [...prefix, '-m', 'pytest', '--junitxml=test-results/hermes-python.xml', ...(COVERAGE ? [
+  '--cov=hermes-plugin', '--cov-branch', '--cov-report=term', '--cov-report=json:coverage-python/coverage.json', '--cov-report=xml:coverage-python/coverage.xml', '--cov-fail-under=34',
+] : [])], {
   cwd: pkgRoot,
   stdio: 'inherit',
 });
@@ -93,5 +100,14 @@ const result = spawnSync(cmd, [...prefix, '-m', 'pytest'], {
 if (result.error) {
   console.error(`[adapter-hermes] Failed to launch pytest: ${result.error.message}`);
   process.exit(1);
+}
+if (result.status === 0 && COVERAGE) {
+  const report = JSON.parse(readFileSync(resolve(pkgRoot, 'coverage-python/coverage.json'), 'utf8'));
+  const expected = readdirSync(resolve(pkgRoot, 'hermes-plugin')).filter((file) => file.endsWith('.py')).map((file) => `hermes-plugin/${file}`).sort();
+  const actual = Object.keys(report.files).map((file) => file.replaceAll('\\', '/')).sort();
+  if (JSON.stringify(actual) !== JSON.stringify(expected) || report.totals.num_statements <= 0) {
+    throw new Error('Python coverage omitted production files or included non-production files');
+  }
+  if (report.files['hermes-plugin/cli.py'].summary.percent_covered < 97) throw new Error('Hermes CLI coverage regressed below 97%');
 }
 process.exit(result.status ?? 1);

--- a/packages/adapter-hermes/pytests/test_cli_contract.py
+++ b/packages/adapter-hermes/pytests/test_cli_contract.py
@@ -1,0 +1,96 @@
+"""Invoke the actual Click commands and verify effects on client/cache boundaries."""
+import importlib
+from copy import deepcopy
+from unittest.mock import Mock
+
+import click
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def cli_fixture(plugin_module, monkeypatch):
+    module = importlib.import_module(f"{plugin_module.__name__}.cli")
+    client_module = importlib.import_module(f"{plugin_module.__name__}.client")
+    client = Mock()
+    client.health_check.return_value = True
+    client.status.return_value = {"peerId": "peer-test"}
+    client.list_context_graphs.return_value = [{"id": "cg:test", "name": "Test"}]
+    client.query.return_value = {"bindings": [{"value": "actual"}]}
+    client.store_turn.return_value = {"success": True}
+    client.write_assertion.return_value = {"success": True}
+    monkeypatch.setattr(client_module, "DKGClient", Mock(return_value=client))
+    monkeypatch.setattr(plugin_module, "_load_config", lambda: {"agent_name": "agent", "context_graph": "cg:test", "daemon_url": "http://127.0.0.1:1"})
+    cache = {"memory": [{"content": "retained fact"}], "user": [], "queued_writes": []}
+    monkeypatch.setattr(plugin_module, "_load_cache", lambda _agent: deepcopy(cache))
+    saved = []
+    monkeypatch.setattr(plugin_module, "_save_cache", lambda value, agent: saved.append((deepcopy(value), agent)))
+    cli = click.Group()
+    module.register_cli(cli)
+    return CliRunner(), cli, client, cache, saved
+
+
+def test_status_and_query_are_scoped_to_configured_graph(cli_fixture):
+    runner, cli, client, _cache, _saved = cli_fixture
+    status = runner.invoke(cli, ["dkg", "status"])
+    assert status.exit_code == 0
+    assert "CONNECTED" in status.output and "peer-test" in status.output
+    query = runner.invoke(cli, ["dkg", "query", "SELECT ?s WHERE { ?s ?p ?o }"])
+    assert query.exit_code == 0 and "actual" in query.output
+    client.query.assert_called_once_with("SELECT ?s WHERE { ?s ?p ?o }", "cg:test")
+
+
+@pytest.mark.parametrize("command", ["query", "sync"])
+def test_unreachable_daemon_fails_without_writes(cli_fixture, command):
+    runner, cli, client, _cache, saved = cli_fixture
+    client.health_check.return_value = False
+    result = runner.invoke(cli, ["dkg", command] + (["ASK {}"] if command == "query" else []))
+    assert result.exit_code == 1 and "not reachable" in result.output
+    client.write_assertion.assert_not_called()
+    assert saved == []
+
+
+def test_offline_status_reports_cached_counts(cli_fixture):
+    runner, cli, client, cache, _saved = cli_fixture
+    client.health_check.return_value = False
+    cache["queued_writes"] = [{"type": "memory"}]
+    result = runner.invoke(cli, ["dkg", "status"])
+    assert result.exit_code == 0 and "OFFLINE" in result.output
+    assert "Cached memory entries: 1" in result.output and "Queued writes: 1" in result.output
+
+
+@pytest.mark.parametrize("failure", [None, "response", "exception", "empty"])
+def test_sync_retains_failed_writes_and_only_clears_confirmed_work(cli_fixture, failure):
+    runner, cli, client, cache, saved = cli_fixture
+    queued = [{"type": "memory", "target": "memory"}, {"type": "turn", "session_id": "s", "user": "u", "assistant": "a", "idempotency_key": "stable"}]
+    cache["queued_writes"] = deepcopy(queued)
+    if failure == "response":
+        client.write_assertion.return_value = {"success": False, "error": "store unavailable"}
+        client.store_turn.return_value = {"success": False, "error": "store unavailable"}
+    elif failure == "exception":
+        client.write_assertion.side_effect = RuntimeError("lost reply")
+        client.store_turn.side_effect = RuntimeError("lost reply")
+    elif failure == "empty":
+        cache["memory"] = []
+    result = runner.invoke(cli, ["dkg", "sync"])
+    assert result.exit_code == 0, result.output
+    assert len(saved) == 1 and saved[0][1] == "agent"
+    remaining = saved[0][0]["queued_writes"]
+    if failure in ("response", "exception"):
+        assert sorted(item["type"] for item in remaining) == ["memory", "turn"]
+    elif failure == "empty":
+        assert remaining == [queued[0]]
+    else:
+        assert remaining == []
+        args = client.write_assertion.call_args.args
+        assert args[1] == "cg:test" and args[2][0]["subject"] == "urn:hermes:agent:memory"
+    assert client.store_turn.call_args.kwargs["idempotency_key"] == "stable"
+    client.close.assert_called_once()
+
+
+def test_empty_queue_does_not_write(cli_fixture):
+    runner, cli, client, _cache, saved = cli_fixture
+    result = runner.invoke(cli, ["dkg", "sync"])
+    assert result.exit_code == 0 and "Nothing to sync" in result.output
+    client.write_assertion.assert_not_called()
+    assert saved == []

--- a/packages/adapter-hermes/pytests/test_cli_contract.py
+++ b/packages/adapter-hermes/pytests/test_cli_contract.py
@@ -2,6 +2,7 @@
 import importlib
 from copy import deepcopy
 from unittest.mock import Mock
+from types import SimpleNamespace
 
 import click
 import pytest
@@ -27,70 +28,73 @@ def cli_fixture(plugin_module, monkeypatch):
     monkeypatch.setattr(plugin_module, "_save_cache", lambda value, agent: saved.append((deepcopy(value), agent)))
     cli = click.Group()
     module.register_cli(cli)
-    return CliRunner(), cli, client, cache, saved
+    return SimpleNamespace(runner=CliRunner(), cli=cli, client=client, cache=cache, saved=saved)
 
 
 def test_status_and_query_are_scoped_to_configured_graph(cli_fixture):
-    runner, cli, client, _cache, _saved = cli_fixture
-    status = runner.invoke(cli, ["dkg", "status"])
+    h = cli_fixture
+    status = h.runner.invoke(h.cli, ["dkg", "status"])
     assert status.exit_code == 0
     assert "CONNECTED" in status.output and "peer-test" in status.output
-    query = runner.invoke(cli, ["dkg", "query", "SELECT ?s WHERE { ?s ?p ?o }"])
+    query = h.runner.invoke(h.cli, ["dkg", "query", "SELECT ?s WHERE { ?s ?p ?o }"])
     assert query.exit_code == 0 and "actual" in query.output
-    client.query.assert_called_once_with("SELECT ?s WHERE { ?s ?p ?o }", "cg:test")
+    h.client.query.assert_called_once_with("SELECT ?s WHERE { ?s ?p ?o }", "cg:test")
 
 
 @pytest.mark.parametrize("command", ["query", "sync"])
 def test_unreachable_daemon_fails_without_writes(cli_fixture, command):
-    runner, cli, client, _cache, saved = cli_fixture
-    client.health_check.return_value = False
-    result = runner.invoke(cli, ["dkg", command] + (["ASK {}"] if command == "query" else []))
+    h = cli_fixture
+    h.client.health_check.return_value = False
+    result = h.runner.invoke(h.cli, ["dkg", command] + (["ASK {}"] if command == "query" else []))
     assert result.exit_code == 1 and "not reachable" in result.output
-    client.write_assertion.assert_not_called()
-    assert saved == []
+    h.client.query.assert_not_called()
+    h.client.store_turn.assert_not_called()
+    h.client.write_assertion.assert_not_called()
+    assert h.saved == []
 
 
 def test_offline_status_reports_cached_counts(cli_fixture):
-    runner, cli, client, cache, _saved = cli_fixture
-    client.health_check.return_value = False
-    cache["queued_writes"] = [{"type": "memory"}]
-    result = runner.invoke(cli, ["dkg", "status"])
+    h = cli_fixture
+    h.client.health_check.return_value = False
+    h.cache["queued_writes"] = [{"type": "memory"}]
+    result = h.runner.invoke(h.cli, ["dkg", "status"])
     assert result.exit_code == 0 and "OFFLINE" in result.output
     assert "Cached memory entries: 1" in result.output and "Queued writes: 1" in result.output
 
 
 @pytest.mark.parametrize("failure", [None, "response", "exception", "empty"])
 def test_sync_retains_failed_writes_and_only_clears_confirmed_work(cli_fixture, failure):
-    runner, cli, client, cache, saved = cli_fixture
+    h = cli_fixture
     queued = [{"type": "memory", "target": "memory"}, {"type": "turn", "session_id": "s", "user": "u", "assistant": "a", "idempotency_key": "stable"}]
-    cache["queued_writes"] = deepcopy(queued)
+    h.cache["queued_writes"] = deepcopy(queued)
     if failure == "response":
-        client.write_assertion.return_value = {"success": False, "error": "store unavailable"}
-        client.store_turn.return_value = {"success": False, "error": "store unavailable"}
+        h.client.write_assertion.return_value = {"success": False, "error": "store unavailable"}
+        h.client.store_turn.return_value = {"success": False, "error": "store unavailable"}
     elif failure == "exception":
-        client.write_assertion.side_effect = RuntimeError("lost reply")
-        client.store_turn.side_effect = RuntimeError("lost reply")
+        h.client.write_assertion.side_effect = RuntimeError("lost reply")
+        h.client.store_turn.side_effect = RuntimeError("lost reply")
     elif failure == "empty":
-        cache["memory"] = []
-    result = runner.invoke(cli, ["dkg", "sync"])
+        h.cache["memory"] = []
+    result = h.runner.invoke(h.cli, ["dkg", "sync"])
     assert result.exit_code == 0, result.output
-    assert len(saved) == 1 and saved[0][1] == "agent"
-    remaining = saved[0][0]["queued_writes"]
+    assert len(h.saved) == 1 and h.saved[0][1] == "agent"
+    remaining = h.saved[0][0]["queued_writes"]
     if failure in ("response", "exception"):
         assert sorted(item["type"] for item in remaining) == ["memory", "turn"]
     elif failure == "empty":
         assert remaining == [queued[0]]
     else:
         assert remaining == []
-        args = client.write_assertion.call_args.args
+        args = h.client.write_assertion.call_args.args
         assert args[1] == "cg:test" and args[2][0]["subject"] == "urn:hermes:agent:memory"
-    assert client.store_turn.call_args.kwargs["idempotency_key"] == "stable"
-    client.close.assert_called_once()
+    assert h.client.store_turn.call_args.kwargs["idempotency_key"] == "stable"
+    h.client.close.assert_called_once()
 
 
 def test_empty_queue_does_not_write(cli_fixture):
-    runner, cli, client, _cache, saved = cli_fixture
-    result = runner.invoke(cli, ["dkg", "sync"])
+    h = cli_fixture
+    result = h.runner.invoke(h.cli, ["dkg", "sync"])
     assert result.exit_code == 0 and "Nothing to sync" in result.output
-    client.write_assertion.assert_not_called()
-    assert saved == []
+    h.client.write_assertion.assert_not_called()
+    h.client.store_turn.assert_not_called()
+    assert h.saved == []

--- a/packages/adapter-hermes/pytests/test_coverage_runner.py
+++ b/packages/adapter-hermes/pytests/test_coverage_runner.py
@@ -1,0 +1,55 @@
+"""Run the real cross-platform launcher against a tiny nested Python package."""
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+PACKAGE = Path(__file__).resolve().parent.parent
+
+
+@pytest.mark.parametrize("gap", [None, "cli", "overall"])
+def test_launcher_discovers_nested_modules_and_enforces_both_gates(tmp_path, gap):
+    (tmp_path / "pytests").mkdir()
+    nested = tmp_path / "hermes-plugin" / "nested"
+    nested.mkdir(parents=True)
+    (nested / "__init__.py").write_text("")
+    shutil.copy(PACKAGE / ".coveragerc", tmp_path / ".coveragerc")
+    shutil.copy(PACKAGE / "pytests" / "run-pytest.mjs", tmp_path / "pytests" / "run-pytest.mjs")
+    (tmp_path / "pytest.ini").write_text("[pytest]\ntestpaths = pytests\n")
+    cli = "def value():\n    return 1\n"
+    if gap == "cli":
+        cli += "def unused():\n    return 0\n"
+    (tmp_path / "hermes-plugin" / "cli.py").write_text(cli)
+    helper = "def value():\n    return 2\n"
+    if gap == "overall":
+        # A never-imported nested module must still enter the denominator.
+        (nested / "unimported.py").write_text("\n".join(f"constant_{i} = {i}" for i in range(40)))
+    (nested / "helper.py").write_text(helper)
+    (tmp_path / "pytests" / "test_sample.py").write_text(
+        "from pathlib import Path\nimport runpy\n"
+        "def test_values():\n"
+        "    for source in ['cli.py', 'nested/helper.py']:\n"
+        "        assert runpy.run_path(str(Path('hermes-plugin') / source))['value']() > 0\n"
+    )
+    env = {key: value for key, value in os.environ.items() if not key.startswith(("COV_CORE_", "COVERAGE_"))}
+    env.update(DKG_CI_COVERAGE="1", DKG_REQUIRE_PYTEST="1")
+    result = subprocess.run(
+        ["node", "pytests/run-pytest.mjs"], cwd=tmp_path, env=env,
+        capture_output=True, text=True, timeout=60,
+    )
+    assert (result.returncode == 0) == (gap is None), result.stdout + result.stderr
+    report = json.loads((tmp_path / "coverage-python" / "coverage.json").read_text())
+    # coverage.py normalizes platform paths; assert the contract on every OS.
+    files = {name.replace("\\", "/"): data for name, data in report["files"].items()}
+    assert "hermes-plugin/nested/helper.py" in files
+    assert (tmp_path / "coverage-python" / "coverage.xml").is_file()
+    assert (tmp_path / "test-results" / "hermes-python.xml").is_file()
+    if gap == "cli":
+        assert report["totals"]["percent_covered"] >= 34
+        assert files["hermes-plugin/cli.py"]["summary"]["percent_covered"] < 97
+    elif gap == "overall":
+        assert files["hermes-plugin/nested/unimported.py"]["summary"]["covered_lines"] == 0
+        assert report["totals"]["percent_covered"] < 34

--- a/packages/agent/test/e2e-chain.test.ts
+++ b/packages/agent/test/e2e-chain.test.ts
@@ -10,6 +10,7 @@ import {
   MemoryLayer,
   createGraphKnowledgeAssetScope,
   knowledgeAssetLayerGraphUri,
+  contextGraphFinalizationTopic,
   type PrecomputedUpdateAttestation,
 } from '@origintrail-official/dkg-core';
 import {
@@ -434,7 +435,7 @@ describe('E2E: DKGAgent with real blockchain', () => {
     agents[0].subscribeToContextGraph(gossipCG);
     agents[1].subscribeToContextGraph(gossipCG);
     await expect.poll(
-      () => agents[0].gossip.getSubscribers(`dkg/context-graph/${gossipCG}/finalization`),
+      () => agents[0].gossip.getSubscribers(contextGraphFinalizationTopic(gossipCG)),
       { timeout: 10_000 },
     ).toContain(agents[1].peerId);
 

--- a/packages/agent/test/e2e-chain.test.ts
+++ b/packages/agent/test/e2e-chain.test.ts
@@ -425,25 +425,18 @@ describe('E2E: DKGAgent with real blockchain', () => {
 
   it('second agent sees new publish via gossipsub without manual sync', async () => {
 
-    const chainAdapter = new EVMChainAdapter(
-      makeAdapterConfig(ctx.rpcUrl, ctx.hubAddress, HARDHAT_KEYS.EXTRA1),
-    );
-    const cgResult = await chainAdapter.createOnChainContextGraph({
-      accessPolicy: 0,
-      publishPolicy: 1,
-    });
-    const gossipCG = String(cgResult.contextGraphId);
-
-    await agents[0].createContextGraph({
-      id: gossipCG,
-      name: 'Gossip Verification',
-    });
-    const sub3 = (agents[0] as any).subscribedContextGraphs.get(gossipCG);
-    if (sub3) sub3.onChainId = gossipCG;
-
+    const gossipCG = 'gossip-verification-e2e';
+    await agents[0].createContextGraph({ id: gossipCG, name: 'Gossip Verification' });
+    await agents[0].registerContextGraph(gossipCG);
+    // Subscription is authorization gated on discovered CG metadata. A fixed
+    // sleep could publish before the receiver knew the graph or its topic.
+    await expect.poll(() => agents[1].contextGraphExists(gossipCG), { timeout: 10_000 }).toBe(true);
     agents[0].subscribeToContextGraph(gossipCG);
     agents[1].subscribeToContextGraph(gossipCG);
-    await new Promise((r) => setTimeout(r, 1000));
+    await expect.poll(
+      () => agents[0].gossip.getSubscribers(`dkg/context-graph/${gossipCG}/finalization`),
+      { timeout: 10_000 },
+    ).toContain(agents[1].peerId);
 
     const quads = [
       {
@@ -456,18 +449,13 @@ describe('E2E: DKGAgent with real blockchain', () => {
 
     await agents[0].publish(gossipCG, quads);
 
-    // Wait for gossip propagation
-    await new Promise((r) => setTimeout(r, 3000));
-
-    const result = await agents[1].query(
-      `SELECT ?name WHERE { <did:dkg:test:GossipEntity> <http://schema.org/name> ?name }`,
-      { contextGraphId: gossipCG },
-    );
-
-    expect(result).toBeDefined();
-    expect(result.bindings).toBeDefined();
-    expect(result.bindings.length).toBeGreaterThanOrEqual(1);
-    const names = result.bindings.map((b: any) => b.name?.value ?? b.name);
-    expect(names.some((n: string) => n.includes('GossipTest'))).toBe(true);
+    // Observe delivery without triggering manual sync or assuming a fixed delay.
+    await expect.poll(async () => {
+      const result = await agents[1].query(
+        `SELECT ?name WHERE { <did:dkg:test:GossipEntity> <http://schema.org/name> ?name }`,
+        { contextGraphId: gossipCG },
+      );
+      return result.bindings.map((binding: any) => binding.name?.value ?? binding.name);
+    }, { timeout: 15_000 }).toContain('"GossipTest"');
   }, 60_000);
 });


### PR DESCRIPTION
Measure the complete Hermes Python source tree, including unimported and nested modules, and require Python prerequisites in CI. Native coverage configuration owns source/branch measurement, JSON/XML reports, the 34% overall floor and the 97% CLI floor; the Node launcher handles execution and propagates failures.

CLI contract cases cover offline commands, unreachable/empty inputs, retry and pending-confirmation behavior. Negative assertions verify that unreachable or empty inputs make no query, turn-store or assertion-write calls. Test fixtures use named fields. Three real launcher probes prove nested-source inclusion and independent overall/CLI threshold failures, while checking JUnit and coverage artifacts.

The existing supporting CI lane provisions Python, enables coverage and uploads its reports. Its EVM dependency also includes the gossip-readiness repair: wait for discovered graph metadata and the canonical finalization topic's subscriber before publishing.

Validation: 169 Python tests passed; 34.45% combined statement/branch coverage and 97.87% CLI coverage. All production modules are included. Nine agent-chain EVM cases passed with the readiness repair. Current-head GitHub CI is green.

These percentages measure pytest execution; Python calls from TypeScript tests provide separate behavioral evidence. Integration and coverage rollout: #2479. Merge this focused PR first.
