### PR TITLE
fix(agent): preserve queued UPDATE intent across retries

### DIFF
--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -790,6 +790,8 @@ function recordPublishOutcome(
 // symbol is module-private so a public `agent.update(...)` caller cannot opt
 // into the retry allowance and author protocol-reserved skolem IRIs.
 const INTERNAL_ROOTLESS_UPDATE_ORIGIN = Symbol('dkg-agent:internal-rootless-update-origin');
+// Only queued execution can reuse the share snapshot frozen in its job request.
+const INTERNAL_QUEUED_UPDATE_OPERATION = Symbol('dkg-agent:internal-queued-update-operation');
 
 // Serialize the full "validate current V2 head -> stage exact SWM replacement
 // -> submit update" sequence per KA. Without this, two concurrent HTTP calls
@@ -1989,6 +1991,10 @@ export class PublishMethods extends DKGAgentBase {
       privateMerkleRoot?: PublishOptions['privateMerkleRoot'];
       privateTripleCount?: PublishOptions['privateTripleCount'];
       [INTERNAL_ROOTLESS_UPDATE_ORIGIN]?: true;
+      [INTERNAL_QUEUED_UPDATE_OPERATION]?: Readonly<{
+        shareOperationId: string;
+        publisherPeerId: string;
+      }>;
       accessPolicy?: PublishOptions['accessPolicy'];
       allowedPeers?: PublishOptions['allowedPeers'];
     },
@@ -2113,26 +2119,26 @@ export class PublishMethods extends DKGAgentBase {
       throw new Error('Graph-scoped update private Merkle root does not match canonical private content');
     }
 
-    // Direct HTTP/SDK updates and finalized-assertion updates converge through
-    // the same trusted SWM boundary. Stage the immutable private version first
-    // (it cannot overwrite the previous commitment), then atomically replace
-    // the stable public SWM graph and remove historical checksum aliases before
-    // the publisher reloads it. Any failure remains retryable and cannot touch
-    // verifiable memory or the chain.
-    const graphManager = new GraphManager(this.store);
-    const updatePrivateStore = new PrivateContentStore(this.store, graphManager);
-    await updatePrivateStore.replaceKnowledgeAssetPrivateTriples(
-      contextGraphId,
-      updateScope,
-      canonicalParts.privateQuads,
-      opts?.subGraphName,
-    );
-    // Persist the exact update snapshot and monotonic SWM head before the
-    // publisher can cross the chain write-ahead boundary. If the process dies
+    // A queued UPDATE already owns a promoted immutable snapshot. Reuse it
+    // without rewriting either private content or the operation/head metadata
+    // that same-job retry validates. Direct updates still stage fresh content.
+    const queuedOperation = opts?.[INTERNAL_QUEUED_UPDATE_OPERATION];
+    if (!queuedOperation) {
+      const graphManager = new GraphManager(this.store);
+      const updatePrivateStore = new PrivateContentStore(this.store, graphManager);
+      await updatePrivateStore.replaceKnowledgeAssetPrivateTriples(
+        contextGraphId,
+        updateScope,
+        canonicalParts.privateQuads,
+        opts?.subGraphName,
+      );
+    }
+    // Stage a direct update, or validate the existing queued snapshot, before
+    // the publisher can cross the chain write-ahead boundary. If the process dies
     // after the transaction lands but before local VM materialization, chain
     // reconciliation can now resolve the staged version, counts, private
     // commitment, publisher, and immutable public payload without guessing.
-    const updateOperationId = ctx.operationId;
+    const updateOperationId = queuedOperation?.shareOperationId ?? ctx.operationId;
     const publisher = opts?.publisherOverride ?? this.publisher;
     const stagedOperation = await this.publisher.stageKnowledgeAssetSharedWorkingMemoryV1({
       contextGraphId,
@@ -2144,10 +2150,15 @@ export class PublishMethods extends DKGAgentBase {
         ? { privateMerkleRoot: canonicalPrivateMerkleRoot }
         : {}),
       privateTripleCount: canonicalParts.privateQuads.length,
-      publisherPeerId: this.node.peerId.toString(),
+      publisherPeerId: queuedOperation?.publisherPeerId ?? this.node.peerId.toString(),
       agentAddress: updateScope.agentAddress,
       subGraphName: opts?.subGraphName,
       timestamp: new Date(),
+      ...(queuedOperation ? {
+        reuseExistingOperation: true,
+        accessPolicy: opts?.accessPolicy,
+        allowedPeers: opts?.allowedPeers,
+      } : {}),
     });
       // GH #842: thread the on-chain cgId so the publisher can promote the update
       // payload into the per-cgId partition the RS prover reads. Without it,
@@ -5428,6 +5439,10 @@ export class PublishMethods extends DKGAgentBase {
           ...(snapshotPrivateRoot ? { privateMerkleRoot: snapshotPrivateRoot } : {}),
           privateTripleCount: seal.privateTripleCount,
           [INTERNAL_ROOTLESS_UPDATE_ORIGIN]: true,
+          [INTERNAL_QUEUED_UPDATE_OPERATION]: {
+            shareOperationId: request.shareOperationId,
+            publisherPeerId: publishOptions.publisherPeerId ?? this.peerId,
+          },
           ...queuedKnowledgeAssetAccessEnvelope(request),
         },
       );

--- a/packages/agent/test/e2e-memory-layers.test.ts
+++ b/packages/agent/test/e2e-memory-layers.test.ts
@@ -11,6 +11,9 @@
  */
 import { describe, it, expect, afterEach, beforeAll, afterAll, vi } from 'vitest';
 import { waitForSharedMemorySubscriber } from './_helpers/gossip-readiness.js';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { makeTestKaNumberAllocator } from "./_helpers/ka-allocator.js";
 import { DKGAgent as RealDKGAgent, type DKGAgentConfig } from '../src/index.js';
 import { SEAL_CAPABILITY_GAP_CODE } from '../src/dkg-agent-publish.js';
@@ -20,10 +23,14 @@ import { buildKnowledgeAssetUal } from '@origintrail-official/dkg-chain';
 import { ethers } from 'ethers';
 import {
   resolvePublishedKnowledgeAssetWorkspaceHead,
+  resolveKnowledgeAssetOperationPublicQuads,
+  FileWorkspacePublicSnapshotStore,
   SWM_CURRENT_ASSERTION_PRED,
   TripleStoreAsyncLiftPublisher,
+  type KnowledgeAssetVmPublishRequest,
 } from '@origintrail-official/dkg-publisher';
-import { GraphManager } from '@origintrail-official/dkg-storage';
+import { GraphManager, PrivateContentStore, createManagedOxigraphSparqlStoreV1 } from '@origintrail-official/dkg-storage';
+import { startOxigraphSparqlEndpoint } from '../../storage/test/helpers/oxigraph-sparql-endpoint.js';
 import { installHardhatACKProvider } from './_helpers/v10-acks.js';
 import { extractFromMarkdown } from '../../cli/src/extraction/markdown-extractor.js';
 import {
@@ -92,6 +99,296 @@ async function createAgent(name: string, overrides: Partial<DKGAgentConfig> = {}
   await installHardhatACKProvider(agent, chain);
   return agent;
 }
+
+describe('queued named KA UPDATE retry [GH#2482]', () => {
+  type RetryCase = {
+    label: string;
+    accessPolicy: 'ownerOnly' | 'allowList';
+    allowedPeers?: string[];
+    privatePayload?: boolean;
+    reopen?: boolean;
+  };
+
+  const allowList = [' reader-b ', 'reader-a', 'reader-b', ''];
+
+  async function withUpdateFixture(
+    options: RetryCase,
+    run: (fixture: Awaited<ReturnType<typeof prepareUpdate>>) => Promise<void>,
+  ) {
+    const endpoint = options.reopen ? await startOxigraphSparqlEndpoint() : undefined;
+    const dataDir = options.reopen
+      ? await mkdtemp(join(tmpdir(), 'dkg-queued-update-reopen-'))
+      : undefined;
+    const ownedAgents: DKGAgent[] = [];
+    const openAgent = async () => {
+      const publicSnapshotStore = dataDir
+        ? new FileWorkspacePublicSnapshotStore(join(dataDir, 'snapshots'), undefined, { gc: { enabled: false } })
+        : undefined;
+      const agent = await createAgent(`QueuedUpdateRetry-${options.label}`, {
+        ...(dataDir ? { dataDir, publicSnapshotStore } : {}),
+        ...(endpoint ? {
+          store: createManagedOxigraphSparqlStoreV1({
+            queryEndpoint: endpoint.queryEndpoint,
+            updateEndpoint: endpoint.updateEndpoint,
+          }),
+        } : {}),
+      });
+      ownedAgents.push(agent);
+      return { agent, publicSnapshotStore };
+    };
+    try {
+      await run(await prepareUpdate(options, openAgent));
+    } finally {
+      vi.restoreAllMocks();
+      for (const agent of ownedAgents) {
+        await agent.stop();
+        await agent.store.close();
+        const index = agents.indexOf(agent);
+        if (index >= 0) agents.splice(index, 1);
+      }
+      await endpoint?.close();
+      if (dataDir) await rm(dataDir, { recursive: true, force: true });
+    }
+  }
+
+  async function prepareUpdate(
+    options: RetryCase,
+    openAgent: () => Promise<{
+      agent: DKGAgent;
+      publicSnapshotStore?: FileWorkspacePublicSnapshotStore;
+    }>,
+  ) {
+    let { agent, publicSnapshotStore } = await openAgent();
+    const cg = `queued-update-retry-${options.label}`;
+    const name = 'retry-same-named-ka';
+    const root = `${ENTITY_BASE}:${options.label}`;
+    await agent.createContextGraph({ id: cg, name: 'Queued UPDATE retry' });
+    await agent.registerContextGraph(cg);
+    await agent.assertion.create(cg, name);
+    await agent.assertion.write(cg, name, [
+      { subject: root, predicate: 'http://schema.org/name', object: '"v1"' },
+    ]);
+    await agent.assertion.promote(cg, name);
+    expect((await agent.publishFromFinalizedAssertion(cg, name)).status).toBe('confirmed');
+
+    await agent.assertion.pullFrom(cg, name, 'vm', { onConflict: 'replace' });
+    await agent.assertion.write(cg, name, [
+      { subject: root, predicate: 'http://schema.org/name', object: '"v2"' },
+    ]);
+    if (options.privatePayload) {
+      await agent.publisher.assertionWritePrivate(cg, name, agent.defaultAgentAddress ?? agent.peerId, [{
+        subject: root,
+        predicate: 'urn:private:note',
+        object: '"private v2"',
+        graph: '',
+      }]);
+    }
+    await agent.assertion.finalize(cg, name);
+    const promoted = await agent.assertion.promote(cg, name, {
+      accessPolicy: options.accessPolicy,
+      allowedPeers: options.allowedPeers,
+    });
+    expect(promoted.publishReady).toBe(true);
+    const intent = await agent.resolveFinalizedAssertionVmPublishIntent(cg, name);
+    expect(intent).toMatchObject({
+      shareOperationId: promoted.shareOperationId,
+      assertionVersion: '2',
+      accessPolicy: options.accessPolicy,
+      privateTripleCount: options.privatePayload ? 1 : 0,
+    });
+    expect(intent.vmCurrentAssertion).toBeDefined();
+
+    const writeAhead = vi.fn();
+    const confirmations = vi.fn();
+    const makeQueue = () => new TripleStoreAsyncLiftPublisher(agent.store, {
+      publicSnapshotStore,
+      knowledgeAssetVmPublishHandler: {
+        preflight: async ({ request }) => agent.preflightQueuedKnowledgeAssetVmPublishExecution(request),
+        execute: async ({ request, publishOptions }) => agent.publishQueuedKnowledgeAssetVmPublish(request, {
+          ...publishOptions,
+          onBeforeBroadcast: async (record) => {
+            writeAhead(record);
+            await publishOptions.onBeforeBroadcast?.(record);
+          },
+          onPublishConfirmed: (record) => {
+            confirmations(record);
+            publishOptions.onPublishConfirmed?.(record);
+          },
+        }),
+      },
+    });
+    let queue = makeQueue();
+    const jobId = await queue.enqueueKnowledgeAssetVmPublish(intent);
+    const admitted = await queue.getStatus(jobId);
+    expect(admitted?.status).toBe('accepted');
+    const originalRequest = structuredClone(admitted!.request);
+
+    const readWorkspace = async (request: KnowledgeAssetVmPublishRequest = intent) => ({
+      head: await resolvePublishedKnowledgeAssetWorkspaceHead({
+        store: agent.store,
+        graphManager: new GraphManager(agent.store),
+        contextGraphId: cg,
+        kaUal: request.kaUal!,
+      }),
+      operation: await resolveKnowledgeAssetOperationPublicQuads({
+        store: agent.store,
+        graphManager: new GraphManager(agent.store),
+        contextGraphId: cg,
+        shareOperationId: request.shareOperationId,
+        kaUal: request.kaUal!,
+        assertionVersion: request.assertionVersion!,
+        publicSnapshotStore,
+      }),
+    });
+    const originalWorkspace = await readWorkspace();
+    expect(originalWorkspace.head).toMatchObject({
+      shareOperationId: intent.shareOperationId,
+      assertionVersion: intent.assertionVersion,
+      accessPolicy: intent.accessPolicy,
+      publicQuadsDigest: originalWorkspace.operation.publicQuadsDigest,
+      publisherPeerId: originalWorkspace.operation.publisherPeerId,
+    });
+    expect([...(originalWorkspace.head?.allowedPeers ?? [])].sort()).toEqual(
+      options.accessPolicy === 'allowList' ? ['reader-a', 'reader-b'] : [],
+    );
+
+    let dispatch = vi.spyOn((agent as any).chain, 'updateKnowledgeCollectionV10');
+    let settlement = vi.spyOn(agent as any, '_stampQueuedKnowledgeAssetVmPublishedLifecycle');
+    const privateReplace = vi.spyOn(PrivateContentStore.prototype, 'replaceKnowledgeAssetPrivateTriples');
+    // The real queued handler and agent.update run, including the native staging
+    // boundary. The author attestation already exists by design; this one-shot
+    // dependency failure precedes TRANSACTION signing, write-ahead and dispatch.
+    const publisherUpdate = vi.spyOn(agent.publisher, 'updateKnowledgeAssetFromStagedSharedWorkingMemoryV1')
+      .mockRejectedValueOnce(new Error('controlled RPC unavailable before update transaction signing'));
+    const failed = await queue.processNext('wallet-1');
+    expect(failed?.jobId).toBe(jobId);
+    expect(failed?.status, JSON.stringify(failed?.failure)).toBe('failed');
+    expect(failed?.failure?.code).toBe('rpc_unavailable');
+    expect(failed?.retries.retryCount).toBe(0);
+    expect(failed?.request).toEqual(originalRequest);
+    expect(failed?.broadcast).toBeUndefined();
+    expect(publisherUpdate).toHaveBeenCalledOnce();
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(writeAhead).not.toHaveBeenCalled();
+    expect(confirmations).not.toHaveBeenCalled();
+    expect(settlement).not.toHaveBeenCalled();
+    // Before the fix this is operation B with missing access metadata, produced
+    // by update itself. No test writes a fabricated mismatch into the store.
+    // Keep going on the regression baseline so its SAME native job also reaches
+    // retry validation and exposes the resulting terminal publish_intent_stale.
+    expect.soft(await readWorkspace()).toEqual(originalWorkspace);
+    expect.soft(privateReplace).not.toHaveBeenCalled();
+    privateReplace.mockRestore();
+
+    if (options.reopen) {
+      const originalPeerId = agent.peerId;
+      await agent.stop();
+      await agent.store.close();
+      publisherUpdate.mockRestore();
+      dispatch.mockRestore();
+      settlement.mockRestore();
+      ({ agent, publicSnapshotStore } = await openAgent());
+      expect(agent.peerId).toBe(originalPeerId);
+      queue = makeQueue();
+      dispatch = vi.spyOn((agent as any).chain, 'updateKnowledgeCollectionV10');
+      settlement = vi.spyOn(agent as any, '_stampQueuedKnowledgeAssetVmPublishedLifecycle');
+      // Fresh managed adapter, agent, file snapshot reader and native queue.
+      // The HTTP fixture remains available: this proves client/agent reopen,
+      // not backend process restart or disk crash durability.
+      expect(await queue.getStatus(jobId)).toMatchObject({
+        jobId,
+        status: 'failed',
+        request: originalRequest,
+        retries: { retryCount: 0 },
+      });
+      expect(await readWorkspace()).toEqual(originalWorkspace);
+    }
+
+    return {
+      agent, cg, name, root, intent, queue, jobId, originalRequest, originalWorkspace,
+      readWorkspace, dispatch, writeAhead, confirmations, settlement,
+    };
+  }
+
+  it.each<RetryCase>([
+    { label: 'owner-only', accessPolicy: 'ownerOnly' },
+    { label: 'allow-list', accessPolicy: 'allowList', allowedPeers: allowList },
+    { label: 'private', accessPolicy: 'ownerOnly', privatePayload: true },
+    { label: 'managed-reopen', accessPolicy: 'allowList', allowedPeers: allowList, reopen: true },
+  ])('retries and finalizes the same $label UPDATE job once [GH#2482]', async (options) => {
+    await withUpdateFixture(options, async (fixture) => {
+      const { queue, jobId, originalRequest, dispatch, writeAhead, confirmations, settlement } = fixture;
+      expect(await queue.retryDetailed({ jobId })).toEqual({ retried: 1, blockedPendingRecovery: 0, skipped: 0 });
+      expect(await queue.getStatus(jobId)).toMatchObject({
+        jobId, status: 'accepted', request: originalRequest, retries: { retryCount: 1 },
+      });
+      const finalized = await queue.processNext('wallet-1');
+      expect(finalized?.status, JSON.stringify(finalized?.failure)).toBe('finalized');
+      expect(finalized).toMatchObject({ jobId, request: originalRequest, retries: { retryCount: 1 } });
+      expect(finalized?.broadcast).toMatchObject({ operationKind: 'update', txHash: expect.any(String) });
+      expect(finalized?.inclusion).toBeDefined();
+      expect(dispatch).toHaveBeenCalledOnce();
+      expect(writeAhead).toHaveBeenCalledOnce();
+      expect(confirmations).toHaveBeenCalledOnce();
+      expect(settlement).toHaveBeenCalledOnce();
+      expect(writeAhead.mock.calls[0]?.[0].txHash).toBe(finalized?.broadcast?.txHash);
+      expect(confirmations.mock.calls[0]?.[0].txHash).toBe(finalized?.broadcast?.txHash);
+      expect(await fixture.agent.assertion.history(fixture.cg, fixture.name)).toMatchObject({
+        state: 'published',
+        memoryLayer: MemoryLayer.VerifiableMemory,
+        vmCurrentAssertion: fixture.intent.sealMerkleRoot.slice(2),
+      });
+      // Successful finalization consumes the SWM head and its operation metadata;
+      // the immutable queue request remains available as the completed job record.
+      expect(await resolvePublishedKnowledgeAssetWorkspaceHead({
+        store: fixture.agent.store,
+        graphManager: new GraphManager(fixture.agent.store),
+        contextGraphId: fixture.cg,
+        kaUal: fixture.intent.kaUal!,
+      })).toBeUndefined();
+      expect(await queue.processNext('wallet-1')).toBeNull();
+      expect(dispatch).toHaveBeenCalledOnce();
+      expect(settlement).toHaveBeenCalledOnce();
+    });
+  }, 180_000);
+
+  it.each(['content', 'access'] as const)('rejects genuine intervening %s re-promote after UPDATE failure [GH#2482]', async (change) => {
+    await withUpdateFixture({ label: `stale-${change}`, accessPolicy: 'ownerOnly' }, async (fixture) => {
+      const { agent, cg, name, root, queue, jobId, intent } = fixture;
+      await agent.assertion.pullFrom(cg, name, 'swm', { onConflict: 'replace' });
+      if (change === 'content') {
+        await agent.assertion.write(cg, name, [
+          { subject: root, predicate: 'http://schema.org/name', object: '"superseding caller content"' },
+        ]);
+      }
+      await agent.assertion.finalize(cg, name);
+      await agent.assertion.promote(cg, name, change === 'access'
+        ? { accessPolicy: 'allowList', allowedPeers: ['new-reader'] }
+        : { accessPolicy: 'ownerOnly' });
+      const newerIntent = await agent.resolveFinalizedAssertionVmPublishIntent(cg, name);
+      expect(newerIntent.shareOperationId).not.toBe(intent.shareOperationId);
+      const newerWorkspace = await fixture.readWorkspace(newerIntent);
+      if (change === 'content') expect(newerIntent.sealMerkleRoot).not.toBe(intent.sealMerkleRoot);
+      else expect(newerWorkspace.head).toMatchObject({ accessPolicy: 'allowList', allowedPeers: ['new-reader'] });
+
+      expect(await queue.retryDetailed({ jobId })).toEqual({ retried: 1, blockedPendingRecovery: 0, skipped: 0 });
+      const rejected = await queue.processNext('wallet-1');
+      expect(rejected).toMatchObject({
+        jobId,
+        status: 'failed',
+        request: fixture.originalRequest,
+        retries: { retryCount: 1 },
+        failure: { code: 'publish_intent_stale', retryable: false },
+      });
+      expect(fixture.dispatch).not.toHaveBeenCalled();
+      expect(fixture.writeAhead).not.toHaveBeenCalled();
+      expect(fixture.confirmations).not.toHaveBeenCalled();
+      expect(fixture.settlement).not.toHaveBeenCalled();
+      expect(await fixture.readWorkspace(newerIntent)).toEqual(newerWorkspace);
+      expect((await fixture.readWorkspace()).operation).toEqual(fixture.originalWorkspace.operation);
+    });
+  }, 180_000);
+});
 
 describe('Memory layer isolation (single agent)', () => {
   it('resolveByKaId recovers a non-default lifecycle author from the KA record', async () => {

--- a/packages/agent/test/e2e-memory-layers.test.ts
+++ b/packages/agent/test/e2e-memory-layers.test.ts
@@ -253,6 +253,7 @@ describe('queued named KA UPDATE retry [GH#2482]', () => {
     );
 
     let dispatch = vi.spyOn((agent as any).chain, 'updateKnowledgeCollectionV10');
+    // Both CREATE and UPDATE reach this shared settlement hook after their branch.
     let settlement = vi.spyOn(agent as any, '_stampQueuedKnowledgeAssetVmPublishedLifecycle');
     const privateReplace = vi.spyOn(PrivateContentStore.prototype, 'replaceKnowledgeAssetPrivateTriples');
     // The real queued handler and agent.update run, including the native staging
@@ -3314,7 +3315,6 @@ describe('Query views', () => {
     };
 
     // CREATE branch — no prior vmCurrentAssertion.
-    const intentForUpdate = await agent.resolveFinalizedAssertionVmPublishIntent(CG_ID, name);
     const created = await runQueued();
     expect(created?.status).toBe('finalized');
     expect(created?.broadcast?.txHash).toMatch(/^0x[0-9a-f]+$/i);
@@ -3326,26 +3326,35 @@ describe('Query views', () => {
     // UPDATE branch — the hop that actually dropped it. GH#2270 r4: `agent.update` stays REAL and
     // the double sits on the underlying PUBLISHER's update entry, so this row pins the whole
     // agent-side chain of custody — queued handler → the real `agent.update` preconditions → the
-    // publisher — receiving the IDENTICAL callback. Driving the real send would need a fresh full
-    // share/reopen lifecycle, so with the publisher doubled there is no send here to prevent;
+    // publisher — receiving the IDENTICAL callback. Prepare a real promoted UPDATE so its
+    // immutable operation survives the native reuse boundary. The publisher double prevents send;
     // rejection-stops-the-send for the update path is proven at the publisher's own boundary in
     // `pre-broadcast-signal-await.test.ts`, and this row pins callback identity only.
+    await agent.assertion.pullFrom(CG_ID, name, 'vm', { onConflict: 'replace' });
+    await agent.assertion.write(CG_ID, name, [
+      { subject: root, predicate: 'http://schema.org/name', object: '"v2"' },
+    ]);
+    await agent.assertion.finalize(CG_ID, name);
+    await agent.assertion.promote(CG_ID, name);
+    const intentForUpdate = await agent.resolveFinalizedAssertionVmPublishIntent(CG_ID, name);
+    const updateSnapshot = await resolveKnowledgeAssetOperationPublicQuads({
+      store: agent.store,
+      graphManager: new GraphManager(agent.store),
+      contextGraphId: CG_ID,
+      shareOperationId: intentForUpdate.shareOperationId,
+      kaUal: intentForUpdate.kaUal!,
+      assertionVersion: intentForUpdate.assertionVersion!,
+    });
     const realPublisher = (agent as any).publisher;
     const publisherUpdateSpy = vi.spyOn(realPublisher, 'updateKnowledgeAssetFromStagedSharedWorkingMemoryV1')
       .mockResolvedValue({ status: 'failed', kaManifest: [] } as never);
     const recorder = () => {};
     try {
       await agent.publishQueuedKnowledgeAssetVmPublish(
+        intentForUpdate,
         {
-          ...intentForUpdate,
-          vmCurrentAssertion: intentForUpdate.sealMerkleRoot.slice(2),
-          // The real update path enforces that the queued version ADVANCES past the published
-          // lifecycle pointer; the create half above published version 1.
-          assertionVersion: '2',
-        },
-        {
-          quads: [{ subject: root, predicate: 'http://schema.org/name', object: '"v1"', graph: '' }],
-          publisherPeerId: 'queued-update-branch',
+          quads: updateSnapshot.quads,
+          publisherPeerId: updateSnapshot.publisherPeerId,
           onBeforeBroadcast: recorder,
         } as never,
       ).catch(() => undefined);

--- a/packages/publisher/src/knowledge-asset-swm-staging.ts
+++ b/packages/publisher/src/knowledge-asset-swm-staging.ts
@@ -14,7 +14,10 @@ import {
 } from '@origintrail-official/dkg-storage';
 
 import { swmKaWriteLockKey, withKeyedLocks } from './keyed-lock.js';
+import { toHex } from './metadata.js';
 import {
+  resolveKnowledgeAssetOperationPublicQuads,
+  resolveKnowledgeAssetWorkspaceHead,
   storeKnowledgeAssetOperationPublicQuads,
   storeKnowledgeAssetWorkspaceHead,
 } from './workspace-resolution.js';
@@ -35,6 +38,8 @@ export interface StageKnowledgeAssetSharedWorkingMemoryInputV1 {
   readonly agentAddress?: string;
   readonly subGraphName?: string;
   readonly timestamp?: Date;
+  /** Validate and reuse an already-promoted queued intent without restaging it. */
+  readonly reuseExistingOperation?: true;
 }
 
 export interface StagedKnowledgeAssetSharedWorkingMemoryV1 {
@@ -84,6 +89,74 @@ export async function stageKnowledgeAssetSharedWorkingMemoryStorageV1(
       },
     };
     const swmGraph = canonicalSharedMemoryScopeWriteGraph(swmBucket, sharedMemoryScope);
+    const publicQuadsDigest = workspacePublicQuadsDigest(publicQuads);
+    if (input.reuseExistingOperation) {
+      // A queued UPDATE already owns durable operation bytes and an access
+      // envelope. Rewriting either would invalidate its retry intent or restore
+      // stale work over a newer promotion. Validate under the writer lock and
+      // leave every graph, operation row and original timestamp untouched.
+      const head = await resolveKnowledgeAssetWorkspaceHead({
+        store: input.store,
+        graphManager,
+        contextGraphId: input.contextGraphId,
+        kaUal: scope.ual,
+        subGraphName: input.subGraphName,
+      });
+      const normalizePeers = (peers: readonly string[] = []): string => JSON.stringify(
+        [...new Set(peers.map((peer) => peer.trim()).filter(Boolean))].sort(),
+      );
+      const privateMerkleRoot = input.privateMerkleRoot === undefined
+        ? undefined
+        : `0x${toHex(input.privateMerkleRoot)}`;
+      const stale = (): Error & { code: 'PUBLISH_INTENT_STALE' } => Object.assign(
+        new Error(`Queued SWM operation ${input.shareOperationId} no longer matches its immutable intent`),
+        { code: 'PUBLISH_INTENT_STALE' as const },
+      );
+      if (
+        !head
+        || head.shareOperationId !== input.shareOperationId
+        || head.assertionVersion !== scope.assertionVersion
+        || head.publicQuadsDigest !== publicQuadsDigest
+        || head.publicTripleCount !== publicQuads.length
+        || head.privateTripleCount !== (input.privateTripleCount ?? 0)
+        || head.privateMerkleRoot?.toLowerCase() !== privateMerkleRoot
+        || head.publisherPeerId !== input.publisherPeerId?.trim()
+        || input.accessPolicy === undefined
+        || head.accessPolicy !== input.accessPolicy
+        || normalizePeers(head.allowedPeers) !== normalizePeers(input.allowedPeers)
+      ) {
+        throw stale();
+      }
+      // The resolver checks stored bytes against their recorded digest/count.
+      // Let operational read failures propagate; they are not evidence of drift.
+      const snapshot = await resolveKnowledgeAssetOperationPublicQuads({
+        store: input.store,
+        graphManager,
+        contextGraphId: input.contextGraphId,
+        shareOperationId: input.shareOperationId,
+        kaUal: scope.ual,
+        assertionVersion: scope.assertionVersion,
+        subGraphName: input.subGraphName,
+        publicSnapshotStore: input.publicSnapshotStore,
+      });
+      if (
+        snapshot.publicQuadsDigest !== publicQuadsDigest
+        || snapshot.quads.length !== publicQuads.length
+        || snapshot.publisherPeerId !== head.publisherPeerId
+      ) {
+        throw stale();
+      }
+      return Object.freeze({
+        contextGraphId: input.contextGraphId,
+        shareOperationId: input.shareOperationId,
+        kaUal: scope.ual,
+        assertionVersion: scope.assertionVersion,
+        ...(input.subGraphName === undefined ? {} : { subGraphName: input.subGraphName }),
+        swmGraph,
+        tripleCount: publicQuads.length,
+        publicQuadsDigest,
+      });
+    }
     const priorSwmGraphs = await resolveSharedMemoryScopeGraphs(
       input.store,
       swmBucket,
@@ -149,7 +222,7 @@ export async function stageKnowledgeAssetSharedWorkingMemoryStorageV1(
       ...(input.subGraphName === undefined ? {} : { subGraphName: input.subGraphName }),
       swmGraph,
       tripleCount: publicQuads.length,
-      publicQuadsDigest: workspacePublicQuadsDigest(publicQuads),
+      publicQuadsDigest,
     });
   });
 }

--- a/packages/publisher/test/knowledge-asset-swm-staging.test.ts
+++ b/packages/publisher/test/knowledge-asset-swm-staging.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   TRUST_LEVEL_PREDICATE,
@@ -9,10 +9,12 @@ import {
 import { GraphManager, OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 
 import { DKGPublisher } from '../src/dkg-publisher.js';
+import type { StageKnowledgeAssetSharedWorkingMemoryInputV1 } from '../src/knowledge-asset-swm-staging.js';
 import {
   resolveKnowledgeAssetOperationPublicQuads,
   resolveKnowledgeAssetWorkspaceHead,
 } from '../src/workspace-resolution.js';
+import type { WorkspacePublicSnapshotStore } from '../src/workspace-snapshot-store.js';
 
 const CONTEXT_GRAPH_ID = 'staging-lock-cg';
 const UAL = 'did:dkg:otp:20430/0x1111111111111111111111111111111111111111/7';
@@ -202,7 +204,197 @@ describe('knowledge-asset SWM staging', () => {
       stagedOperation: first,
     })).rejects.toThrow(/immutable reference/u);
   });
+
+  it.each([
+    { policy: 'ownerOnly', externalSnapshots: false },
+    { policy: 'ownerOnly', externalSnapshots: true },
+    { policy: 'allowList', externalSnapshots: false },
+    { policy: 'allowList', externalSnapshots: true },
+  ] as const)('reuses $policy intent without writes (external snapshots: $externalSnapshots)', async ({ policy, externalSnapshots }) => {
+    const fixture = await createReusableOperation({
+      accessPolicy: policy,
+      ...(policy === 'allowList' ? { allowedPeers: ['peer-b', 'peer-a'] } : {}),
+    }, externalSnapshots);
+    const before = await resolveKnowledgeAssetWorkspaceHead(fixture.headInput);
+    const assertNoWrites = trackStoreWrites(fixture.store);
+    fixture.snapshotStore.putSnapshot.mockClear();
+
+    const reused = await fixture.publisher.stageKnowledgeAssetSharedWorkingMemoryV1({
+      ...fixture.input,
+      // Peer equality follows queued validation's set-normalization contract.
+      allowedPeers: policy === 'allowList' ? [' peer-a ', 'peer-b', 'peer-a', ''] : ['', ' '],
+      timestamp: new Date('2026-09-05T12:00:00.000Z'),
+      reuseExistingOperation: true,
+    });
+
+    expect(reused).toEqual(fixture.staged);
+    expect(Object.isFrozen(reused)).toBe(true);
+    expect(await resolveKnowledgeAssetWorkspaceHead(fixture.headInput)).toEqual(before);
+    assertNoWrites();
+    expect(fixture.snapshotStore.putSnapshot).not.toHaveBeenCalled();
+    if (externalSnapshots) expect(fixture.snapshotStore.getSnapshot).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { field: 'share identity', changed: { shareOperationId: 'other-operation' } },
+    { field: 'assertion version', changed: { assertionVersion: '3' } },
+    { field: 'equal-count public content', changed: { quads: B } },
+    { field: 'public count', changed: { quads: [...A, ...B] } },
+    { field: 'private commitment', changed: { privateMerkleRoot: new Uint8Array(32).fill(9) } },
+    { field: 'missing private commitment', changed: { privateMerkleRoot: undefined } },
+    { field: 'private count', changed: { privateTripleCount: 2 } },
+    { field: 'publisher', changed: { publisherPeerId: 'other-publisher' } },
+    { field: 'missing publisher', changed: { publisherPeerId: undefined } },
+    { field: 'access policy', changed: { accessPolicy: 'public' } },
+    { field: 'missing access policy', changed: { accessPolicy: undefined } },
+    { field: 'allowed peers', changed: { allowedPeers: ['peer-a', 'peer-c'] } },
+  ] satisfies { field: string; changed: Partial<StageKnowledgeAssetSharedWorkingMemoryInputV1> }[])(
+    'rejects changed $field without restoring metadata', async ({ changed }) => {
+      const fixture = await createReusableOperation({ accessPolicy: 'allowList', allowedPeers: ['peer-a', 'peer-b'] }, true);
+      const before = await resolveKnowledgeAssetWorkspaceHead(fixture.headInput);
+      const assertNoWrites = trackStoreWrites(fixture.store);
+      fixture.snapshotStore.putSnapshot.mockClear();
+
+      await expect(fixture.publisher.stageKnowledgeAssetSharedWorkingMemoryV1({
+        ...fixture.input,
+        ...changed,
+        reuseExistingOperation: true,
+      })).rejects.toMatchObject({ code: 'PUBLISH_INTENT_STALE' });
+
+      expect(await resolveKnowledgeAssetWorkspaceHead(fixture.headInput)).toEqual(before);
+      assertNoWrites();
+      expect(fixture.snapshotStore.putSnapshot).not.toHaveBeenCalled();
+    },
+  );
+
+  it('preserves a newer head when the queued operation still exists', async () => {
+    const fixture = await createReusableOperation();
+    await fixture.publisher.stageKnowledgeAssetSharedWorkingMemoryV1({
+      ...fixture.input,
+      shareOperationId: 'newer-operation',
+      quads: B,
+    });
+    const newerHead = await resolveKnowledgeAssetWorkspaceHead(fixture.headInput);
+    const assertNoWrites = trackStoreWrites(fixture.store);
+
+    await expect(fixture.publisher.stageKnowledgeAssetSharedWorkingMemoryV1({
+      ...fixture.input,
+      reuseExistingOperation: true,
+    })).rejects.toMatchObject({ code: 'PUBLISH_INTENT_STALE' });
+
+    expect(await resolveKnowledgeAssetWorkspaceHead(fixture.headInput)).toEqual(newerHead);
+    expect(await readGraphObjects(fixture.store, newerHead!.assertionGraph)).toEqual(['"b"']);
+    expect((await resolveKnowledgeAssetOperationPublicQuads({
+      ...fixture.headInput,
+      assertionVersion: VERSION,
+      shareOperationId: fixture.input.shareOperationId,
+    })).quads).toMatchObject(A);
+    assertNoWrites();
+  });
+
+  it('does not recreate a missing head', async () => {
+    const fixture = await createReusableOperation();
+    await fixture.store.deleteByPattern({
+      graph: fixture.graphManager.sharedMemoryMetaUri(CONTEXT_GRAPH_ID),
+      subject: `${UAL}#dkg-swm-head`,
+    });
+    const assertNoWrites = trackStoreWrites(fixture.store);
+
+    await expect(fixture.publisher.stageKnowledgeAssetSharedWorkingMemoryV1({
+      ...fixture.input,
+      reuseExistingOperation: true,
+    })).rejects.toMatchObject({ code: 'PUBLISH_INTENT_STALE' });
+    expect(await resolveKnowledgeAssetWorkspaceHead(fixture.headInput)).toBeUndefined();
+    assertNoWrites();
+  });
+
+  it('rejects corrupted snapshot bytes without repairing them', async () => {
+    const fixture = await createReusableOperation({}, true);
+    fixture.snapshotStore.getSnapshot.mockResolvedValue([...B]);
+    const assertNoWrites = trackStoreWrites(fixture.store);
+    fixture.snapshotStore.putSnapshot.mockClear();
+
+    await expect(fixture.publisher.stageKnowledgeAssetSharedWorkingMemoryV1({
+      ...fixture.input,
+      reuseExistingOperation: true,
+    })).rejects.toThrow(/snapshot is missing or corrupt/u);
+    assertNoWrites();
+    expect(fixture.snapshotStore.putSnapshot).not.toHaveBeenCalled();
+  });
+
+  it.each(['head', 'snapshot'] as const)('preserves operational %s read errors', async (read) => {
+    const fixture = await createReusableOperation({}, true);
+    const error = Object.assign(new Error(`${read} temporarily unavailable`), { code: 'STORE_BUSY' });
+    const assertNoWrites = trackStoreWrites(fixture.store);
+    fixture.snapshotStore.putSnapshot.mockClear();
+    if (read === 'head') vi.spyOn(fixture.store, 'query').mockRejectedValueOnce(error);
+    else fixture.snapshotStore.getSnapshot.mockRejectedValueOnce(error);
+
+    await expect(fixture.publisher.stageKnowledgeAssetSharedWorkingMemoryV1({
+      ...fixture.input,
+      reuseExistingOperation: true,
+    })).rejects.toBe(error);
+    assertNoWrites();
+    expect(fixture.snapshotStore.putSnapshot).not.toHaveBeenCalled();
+  });
 });
+
+async function createReusableOperation(
+  overrides: Partial<StageKnowledgeAssetSharedWorkingMemoryInputV1> = {},
+  externalSnapshots = false,
+) {
+  const store = new OxigraphStore();
+  const graphManager = new GraphManager(store);
+  const snapshots = new Map<string, Quad[]>();
+  const snapshotStore = {
+    putSnapshot: vi.fn<WorkspacePublicSnapshotStore['putSnapshot']>(async ({ digest, quads }) => {
+      snapshots.set(digest, quads.map((quad) => ({ ...quad })));
+      return { ref: digest, byteLength: 0 };
+    }),
+    getSnapshot: vi.fn<WorkspacePublicSnapshotStore['getSnapshot']>(async (digest) => snapshots.get(digest) ?? null),
+  };
+  const publisher = new DKGPublisher({
+    store,
+    chain: { chainId: 'none' } as never,
+    eventBus: new TypedEventBus(),
+    keypair: await generateEd25519Keypair(),
+    ...(externalSnapshots ? { publicSnapshotStore: snapshotStore } : {}),
+  });
+  const input: StageKnowledgeAssetSharedWorkingMemoryInputV1 = {
+    contextGraphId: CONTEXT_GRAPH_ID,
+    kaUal: UAL,
+    assertionVersion: VERSION,
+    shareOperationId: 'queued-operation',
+    quads: A,
+    privateMerkleRoot: new Uint8Array(32).fill(7),
+    privateTripleCount: 1,
+    publisherPeerId: 'original-publisher',
+    accessPolicy: 'ownerOnly',
+    timestamp: new Date('2026-07-19T12:00:00.000Z'),
+    ...overrides,
+  };
+  const staged = await publisher.stageKnowledgeAssetSharedWorkingMemoryV1(input);
+  return {
+    store,
+    graphManager,
+    publisher,
+    snapshotStore,
+    input,
+    staged,
+    headInput: { store, graphManager, contextGraphId: CONTEXT_GRAPH_ID, kaUal: UAL },
+  };
+}
+
+function trackStoreWrites(store: OxigraphStore): () => void {
+  const writes = ([
+    'insert', 'delete', 'deleteByPattern', 'deleteByPatternWithoutCount',
+    'createGraph', 'dropGraph', 'replaceGraph', 'replaceGraphAndSubject',
+    'replaceSubject', 'deleteBySubjectPrefix', 'update',
+  ] as const).map((method) => vi.spyOn(store, method));
+  return () => {
+    for (const write of writes) expect(write).not.toHaveBeenCalled();
+  };
+}
 
 async function readGraphObjects(store: OxigraphStore, graph: string): Promise<string[]> {
   const result = await store.query(


### PR DESCRIPTION
## Summary

A failed queued UPDATE could replace its own promoted SWM operation with the execution context ID and drop its access policy. Retrying the unchanged job then failed with `publish_intent_stale`.

Queued UPDATE now validates and reuses the original promoted operation under the existing SWM writer lock. It preserves public/private content and operation/head metadata, including the promoted operation's publisher and normalized access envelope. Direct updates continue to stage fresh operations, and the existing stale-intent validator remains unchanged.

This prevents new self-invalidations; it does not repair historical jobs whose original head was already replaced. The existing SWM lock does not serialize every promotion and confirmed cleanup path; broader races among those paths and chain execution remain outside this fix.

## Related

- Fixes #2482

## Diagrams

Before:

```mermaid
sequenceDiagram
    participant Job
    participant Agent
    participant SWM
    participant Publisher
    participant Chain
    Job->>Agent: Execute queued UPDATE for operation A
    Agent->>SWM: Stage operation B, replace head, omit access fields
    Agent->>Publisher: Update from staged B
    Publisher--xAgent: Pre-dispatch failure
    Job->>Agent: Retry same immutable request A
    Agent->>SWM: Validate head against A
    SWM-->>Agent: Head B differs
    Agent-->>Job: publish_intent_stale
```

After:

```mermaid
sequenceDiagram
    participant Job
    participant Agent
    participant SWM
    participant Publisher
    participant Chain
    Job->>Agent: Execute queued UPDATE for operation A
    Agent->>SWM: Validate and reuse A under writer lock
    SWM-->>Agent: Exact snapshot and access envelope, no writes
    Agent->>Publisher: Update from staged A
    Publisher--xAgent: Pre-dispatch failure
    Job->>Agent: Retry same immutable request A
    Agent->>SWM: Validate and reuse A
    Agent->>Publisher: Update from staged A
    Publisher->>Chain: Submit one update transaction
    Publisher-->>Job: Finalize once
```

## Files changed

| File | What |
| --- | --- |
| `packages/agent/src/dkg-agent-publish.ts` | Distinguish queued UPDATE with a private marker, preserve its share identity/publisher/access fields, and skip private restaging. |
| `packages/publisher/src/knowledge-asset-swm-staging.ts` | Validate existing queued head/snapshot before returning a reference without writes. |
| `packages/publisher/test/knowledge-asset-swm-staging.test.ts` | Prove normalization, drift rejection, snapshot integrity, read-error propagation, and zero writes. |
| `packages/agent/test/e2e-memory-layers.test.ts` | Exercise real failed UPDATE/same-job retry, private data, managed reopen, and intervening caller changes. |

## Test plan

- [x] Publisher staging and existing retry/journal unit suites: 118 tests passed (24 staging, 94 retry/journal).
- [x] Agent rootless-update-boundary, rootless-update-error and queued-publish-options: 20 tests passed.
- [x] Publisher and agent builds, including type fixtures and package export/root checks.
- [x] Unpatched base d05e6d3c1: all six new cases fail on native head/access mismatch; same-job ownerOnly retry independently reaches terminal `publish_intent_stale`.
- [x] Patched Hardhat lifecycle regression: 6/6 pass for ownerOnly, nonempty normalized allowList, private payload, managed adapter/agent/queue reopen, and genuine intervening content/access changes.
- [x] Full Hardhat memory-layer suite at 86a12b670: 61/61 passed, including all six new cases, successful UPDATE/CREATE, and the existing write-ahead callback test using a genuinely promoted UPDATE.
- [x] Repository lint in WSL and final diff audit; no new disabled-test findings. Native Windows lint wrapper cannot spawn pnpm.cmd, so the unchanged check ran in Linux.

The managed reopen fixture keeps its embedded HTTP store running while recreating the clients and reloading the same job; it establishes client/agent reopen, not backend process or disk crash durability. The injected failure is after real UPDATE staging and before transaction signing/write-ahead/broadcast; the author attestation is prepared earlier by the existing lifecycle.
