### PR TITLE
refactor(core): use canonical SPARQL scanning for query parameters

### DIFF
--- a/packages/core/src/query-catalog-parameters.ts
+++ b/packages/core/src/query-catalog-parameters.ts
@@ -10,6 +10,7 @@
  */
 
 import { isSafeIri, sparqlString } from './sparql-safe.js';
+import { prepareSparql } from '@origintrail-official/dkg-rdf-utils/sparql';
 
 export const QUERY_CATALOG_PARAMETER_TYPES = [
   'string',
@@ -222,82 +223,30 @@ function isMissing(value: unknown): value is undefined | null {
 function scanQueryCatalogTemplatePlaceholders(
   template: string,
 ): QueryCatalogTemplatePlaceholder[] {
-  const placeholders: QueryCatalogTemplatePlaceholder[] = [];
-  let index = 0;
-  let quote: "'" | '"' | "'''" | '"""' | undefined;
-  let inComment = false;
-  let inIri = false;
+  // Placeholders are not SPARQL syntax. Substitute an inert RDF term of the
+  // same UTF-16 length only for lexical analysis. This also lets the canonical
+  // scanner mask IRI bodies containing placeholder-looking text, without
+  // teaching the SPARQL lexer a query-catalog-specific syntax extension.
+  const candidates = [...template.matchAll(/\{\{([A-Za-z][A-Za-z0-9_]*)\}\}/g)];
+  const lexicalSource = template.replace(/\{\{([A-Za-z][A-Za-z0-9_]*)\}\}/g,
+    (placeholder) => '0'.repeat(placeholder.length));
+  const prepared = prepareSparql(lexicalSource);
+  if (prepared.status !== 'valid') {
+    throw new Error('SPARQL template contains invalid lexical syntax.');
+  }
 
-  while (index < template.length) {
-    const char = template[index];
-    if (inComment) {
-      if (char === '\n' || char === '\r') inComment = false;
-      index += 1;
-      continue;
+  const placeholders: QueryCatalogTemplatePlaceholder[] = [];
+  for (const match of candidates) {
+    const start = match.index;
+    if (prepared.masked[start] === ' ') continue;
+    const end = start + match[0].length;
+    const before = template[start - 1];
+    const after = template[end];
+    if ((before && /[A-Za-z0-9_?:.%~-]/.test(before))
+      || (after && /[A-Za-z0-9_?:.%~-]/.test(after))) {
+      throw new Error(`Query parameter ${match[1]} must occupy a complete SPARQL term position.`);
     }
-    if (quote) {
-      if (char === '\\') {
-        index += 2;
-        continue;
-      }
-      if (template.startsWith(quote, index)) {
-        index += quote.length;
-        quote = undefined;
-      } else {
-        index += 1;
-      }
-      continue;
-    }
-    if (inIri) {
-      if (char === '\\') {
-        index += 2;
-        continue;
-      }
-      if (char === '>') inIri = false;
-      index += 1;
-      continue;
-    }
-    if (char === '#') {
-      inComment = true;
-      index += 1;
-      continue;
-    }
-    if (template.startsWith("'''", index) || template.startsWith('"""', index)) {
-      quote = template.slice(index, index + 3) as "'''" | '"""';
-      index += 3;
-      continue;
-    }
-    if (char === "'" || char === '"') {
-      quote = char;
-      index += 1;
-      continue;
-    }
-    if (
-      char === '<'
-      && template[index + 1] !== '='
-      && template[index + 1] !== '{'
-      && !/\s/.test(template[index + 1] ?? '')
-    ) {
-      inIri = true;
-      index += 1;
-      continue;
-    }
-    if (template.startsWith('{{', index)) {
-      const match = template.slice(index).match(/^\{\{([A-Za-z][A-Za-z0-9_]*)\}\}/);
-      if (match) {
-        const end = index + match[0].length;
-        const before = template[index - 1];
-        const after = template[end];
-        if ((before && /[A-Za-z0-9_?:.%~-]/.test(before))
-          || (after && /[A-Za-z0-9_?:.%~-]/.test(after))) {
-          throw new Error(`Query parameter ${match[1]} must occupy a complete SPARQL term position.`);
-        }
-        placeholders.push({ name: match[1], start: index, end });
-        index = end;
-        continue;
-      }
-    }
-    index += 1;
+    placeholders.push({ name: match[1], start, end });
   }
   return placeholders;
 }

--- a/packages/core/test/query-catalog-parameters.test.ts
+++ b/packages/core/test/query-catalog-parameters.test.ts
@@ -108,4 +108,42 @@ describe('query catalog parameters', () => {
       { maximum: 10 },
     )).toBe('SELECT ?score WHERE { ?s <urn:score> ?score . FILTER(?score<10) }');
   });
+
+  it('keeps scanning after a compact comparison with a literal right operand', () => {
+    const template = 'SELECT ?score WHERE { ?s <urn:score> ?score . FILTER(?score<10 && ?score<{{maximum}}) }';
+    expect(renderQueryCatalogTemplate(template, [{ name: 'maximum', type: 'number' }], { maximum: 7 }))
+      .toBe(template.replace('{{maximum}}', '7'));
+  });
+
+  it('uses canonical string, comment, and IRI masking without shifting replacement offsets', () => {
+    const template = String.raw`SELECT * WHERE {
+      BIND('😀 {{single}}' AS ?a)
+      BIND("escaped \" {{double}}" AS ?b)
+      BIND('''long ' {{longSingle}}''' AS ?c)
+      BIND("""long " {{longDouble}}""" AS ?d)
+      BIND(<urn:example:{{iri}}> AS ?e)
+      \u0023 {{encodedComment}}
+      BIND(\u0022{{encodedString}}\u0022 AS ?f)
+      BIND({{first}} AS ?first)
+      BIND({{second}} AS ?second)
+    }`;
+    expect(renderQueryCatalogTemplate(template,
+      [{ name: 'first', type: 'integer' }, { name: 'second', type: 'string' }],
+      { first: 12, second: 'done' }))
+      .toBe(template.replace('{{first}}', '12').replace('{{second}}', '"done"'));
+  });
+
+  it.each(['?{{value}}', 'prefix:{{value}}', '{{value}}suffix', '{{value}}:suffix'])(
+    'preserves complete-term rejection for %s', (term) => {
+      expect(() => renderQueryCatalogTemplate(`ASK { BIND(${term} AS ?v) }`,
+        [{ name: 'value', type: 'string' }], { value: 'safe' }))
+        .toThrow('Query parameter value must occupy a complete SPARQL term position.');
+    },
+  );
+
+  it('rejects active Unicode escapes that fail the canonical lexical safety check', () => {
+    expect(() => renderQueryCatalogTemplate(String.raw`ASK { \u005Cu0053ERVICE {{value}} }`,
+      [{ name: 'value', type: 'iri' }], { value: 'urn:test' }))
+      .toThrow('SPARQL template contains invalid lexical syntax.');
+  });
 });


### PR DESCRIPTION
Query-catalog placeholder discovery maintained a separate partial SPARQL lexer, which could mistake a compact comparison for an IRI and miss later parameters. Reuse the canonical RDF-utils scanner for strings, comments, IRIs, comparison context, and Unicode lexical safety. For scanning only, replace candidate placeholders with inert terms of identical UTF-16 width, preserving original replacement offsets and the existing complete-term error.

Closes #2353.

Validation: all 1,898 core tests pass with the existing coverage ratchets. Focused regressions cover compact literal comparisons, short/long/escaped strings, Unicode-encoded delimiters, comments, placeholder-looking IRI bodies, surrogate-pair offsets, multiple replacements, and complete-term rejection. The core TypeScript/type-test build and repository lint checks pass. Remote CI is pending.
