### PR TITLE
fix(openclaw): rebuild local adapter before packing

### DIFF
--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -22,6 +22,7 @@
   ],
   "scripts": {
     "build": "pnpm clean && tsc",
+    "prepack": "pnpm run build",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage && node ../../scripts/ci/check-coverage.mjs adapter-openclaw",
     "clean": "node -e \"const fs=require('fs'); for (const p of ['dist','tsconfig.tsbuildinfo']) fs.rmSync(p,{recursive:true,force:true});\""

--- a/scripts/lib/__tests__/release-packages.test.mjs
+++ b/scripts/lib/__tests__/release-packages.test.mjs
@@ -97,13 +97,11 @@ function packAndInstallFixture({
     shell: process.platform === 'win32',
   });
   assert.equal(packed.status, 0, `npm pack failed for ${installedPackageName}: ${packed.stderr}`);
-  const report = JSON.parse(packed.stdout);
-  const filename = (Array.isArray(report) ? report[0] : report)?.filename;
-  assert.equal(
-    typeof filename,
-    'string',
-    `npm pack did not report a tarball filename for ${installedPackageName}`,
-  );
+  // Lifecycle scripts may write to stdout even with npm's --json flag.
+  // Each fixture owns a fresh destination, so inspect the actual packed artifact.
+  const tarballs = fs.readdirSync(packDir).filter((entry) => entry.endsWith('.tgz'));
+  assert.equal(tarballs.length, 1, `expected one tarball for ${installedPackageName}`);
+  const [filename] = tarballs;
   const extracted = spawnSync('tar', [
     '-xzf',
     path.join(packDir, filename),
@@ -529,6 +527,66 @@ test('the packed CLI resolves the typed Blazegraph runtime subpath for a consume
       getNewLine: () => '\n',
     }),
   );
+}));
+
+test('packing OpenClaw from source builds consumable JavaScript and declarations', () => withFixture((root) => {
+  const source = path.join(REPO_ROOT, 'packages', 'adapter-openclaw');
+  const cleanPackage = path.join(root, 'packages', 'adapter-openclaw');
+  const manifest = JSON.parse(fs.readFileSync(path.join(source, 'package.json'), 'utf8'));
+  const { packageManager } = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'));
+  writePackage(root, '.', { name: 'openclaw-pack-fixture', private: true, packageManager });
+  fs.mkdirSync(cleanPackage, { recursive: true });
+  for (const entry of ['src', 'package.json', 'tsconfig.json', ...manifest.files.filter((entry) => entry !== 'dist')]) {
+    const from = path.join(source, entry);
+    if (fs.existsSync(from)) fs.cpSync(from, path.join(cleanPackage, entry), { recursive: true });
+  }
+  fs.copyFileSync(path.join(REPO_ROOT, 'tsconfig.base.json'), path.join(root, 'tsconfig.base.json'));
+  // Use the installed build tools and built workspace dependencies. The adapter
+  // itself starts without any build output, independently of the CI build.
+  fs.symlinkSync(path.join(REPO_ROOT, 'node_modules'), path.join(root, 'node_modules'), 'junction');
+  assert.equal(fs.existsSync(path.join(cleanPackage, 'dist')), false);
+  assert.equal(fs.existsSync(path.join(cleanPackage, 'tsconfig.tsbuildinfo')), false);
+
+  const { consumerDir, installedPackageDir } = packAndInstallFixture({
+    root,
+    fixtureName: 'openclaw',
+    sourcePackageDir: cleanPackage,
+    installedPackageName: manifest.name,
+  });
+  assert.ok(fs.existsSync(path.join(installedPackageDir, 'dist', 'index.js')));
+  assert.ok(fs.existsSync(path.join(installedPackageDir, 'dist', 'index.d.ts')));
+
+  const consumer = path.join(consumerDir, 'consumer.mjs');
+  fs.writeFileSync(consumer, [
+    "import { DkgDaemonClient } from '@origintrail-official/dkg-adapter-openclaw';",
+    "if (typeof DkgDaemonClient !== 'function') throw new Error('missing client export');",
+    '',
+  ].join('\n'));
+  const imported = spawnSync(process.execPath, [consumer], { cwd: consumerDir, encoding: 'utf8', timeout: 30_000 });
+  assert.equal(imported.status, 0, `packed OpenClaw import failed: ${imported.stderr}`);
+
+  const typedConsumer = path.join(consumerDir, 'consumer.mts');
+  fs.writeFileSync(typedConsumer, [
+    "import { DkgDaemonClient, type DkgClientOptions } from '@origintrail-official/dkg-adapter-openclaw';",
+    'export function createClient(options: DkgClientOptions): DkgDaemonClient {',
+    '  return new DkgDaemonClient(options);',
+    '}',
+    '',
+  ].join('\n'));
+  const program = ts.createProgram([typedConsumer], {
+    module: ts.ModuleKind.NodeNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    target: ts.ScriptTarget.ES2022,
+    noEmit: true,
+    skipLibCheck: true,
+    strict: true,
+  });
+  const diagnostics = ts.getPreEmitDiagnostics(program);
+  assert.equal(diagnostics.length, 0, ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+    getCanonicalFileName: (file) => file,
+    getCurrentDirectory: () => consumerDir,
+    getNewLine: () => '\n',
+  }));
 }));
 
 test('the packed storage package preserves representative legacy dist imports', {

--- a/scripts/lib/__tests__/release-packages.test.mjs
+++ b/scripts/lib/__tests__/release-packages.test.mjs
@@ -537,11 +537,14 @@ test('packing OpenClaw from source builds consumable JavaScript and declarations
   const manifest = JSON.parse(fs.readFileSync(path.join(source, 'package.json'), 'utf8'));
   const { packageManager } = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'));
   writePackage(root, '.', { name: 'openclaw-pack-fixture', private: true, packageManager });
-  fs.mkdirSync(cleanPackage, { recursive: true });
-  for (const entry of ['src', 'package.json', 'tsconfig.json', ...manifest.files.filter((entry) => entry !== 'dist')]) {
-    const from = path.join(source, entry);
-    if (fs.existsSync(from)) fs.cpSync(from, path.join(cleanPackage, entry), { recursive: true });
-  }
+  // Copy the source checkout, including unpublished build scripts/configs.
+  // Published `files` entries are a separate contract from prepack inputs.
+  const generatedEntries = new Set(['dist', 'node_modules', 'coverage', 'test-results', '.git']);
+  fs.cpSync(source, cleanPackage, {
+    recursive: true,
+    filter: (entry) => !generatedEntries.has(path.basename(entry))
+      && !entry.endsWith('.tsbuildinfo'),
+  });
   fs.copyFileSync(path.join(REPO_ROOT, 'tsconfig.base.json'), path.join(root, 'tsconfig.base.json'));
   // Use the installed build tools and built workspace dependencies. The adapter
   // itself starts without any build output, independently of the CI build.

--- a/scripts/lib/__tests__/release-packages.test.mjs
+++ b/scripts/lib/__tests__/release-packages.test.mjs
@@ -529,7 +529,9 @@ test('the packed CLI resolves the typed Blazegraph runtime subpath for a consume
   assertTypeScriptConsumer(consumerPath, { esModuleInterop: true });
 }));
 
-test('packing OpenClaw from source builds consumable JavaScript and declarations', () => withFixture((root) => {
+test('packing OpenClaw from source builds consumable JavaScript and declarations', {
+  skip: NPM_AVAILABLE && TAR_AVAILABLE ? false : 'npm and tar are required',
+}, () => withFixture((root) => {
   const source = path.join(REPO_ROOT, 'packages', 'adapter-openclaw');
   const cleanPackage = path.join(root, 'packages', 'adapter-openclaw');
   const manifest = JSON.parse(fs.readFileSync(path.join(source, 'package.json'), 'utf8'));

--- a/scripts/lib/__tests__/release-packages.test.mjs
+++ b/scripts/lib/__tests__/release-packages.test.mjs
@@ -66,6 +66,24 @@ function withFixture(fn) {
   }
 }
 
+function assertTypeScriptConsumer(consumerPath, compilerOptions = {}) {
+  const program = ts.createProgram([consumerPath], {
+    module: ts.ModuleKind.NodeNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    target: ts.ScriptTarget.ES2022,
+    noEmit: true,
+    strict: true,
+    skipLibCheck: false,
+    ...compilerOptions,
+  });
+  const diagnostics = ts.getPreEmitDiagnostics(program);
+  assert.equal(diagnostics.length, 0, ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+    getCanonicalFileName: (file) => file,
+    getCurrentDirectory: () => path.dirname(consumerPath),
+    getNewLine: () => '\n',
+  }));
+}
+
 function packAndInstallFixture({
   root,
   fixtureName,
@@ -508,25 +526,7 @@ test('the packed CLI resolves the typed Blazegraph runtime subpath for a consume
     'void metadata;',
     '',
   ].join('\n'));
-  const program = ts.createProgram([consumerPath], {
-    esModuleInterop: true,
-    module: ts.ModuleKind.NodeNext,
-    moduleResolution: ts.ModuleResolutionKind.NodeNext,
-    noEmit: true,
-    skipLibCheck: false,
-    strict: true,
-    target: ts.ScriptTarget.ES2022,
-  });
-  const diagnostics = ts.getPreEmitDiagnostics(program);
-  assert.equal(
-    diagnostics.length,
-    0,
-    ts.formatDiagnosticsWithColorAndContext(diagnostics, {
-      getCanonicalFileName: (file) => file,
-      getCurrentDirectory: () => consumerDir,
-      getNewLine: () => '\n',
-    }),
-  );
+  assertTypeScriptConsumer(consumerPath, { esModuleInterop: true });
 }));
 
 test('packing OpenClaw from source builds consumable JavaScript and declarations', () => withFixture((root) => {
@@ -573,20 +573,7 @@ test('packing OpenClaw from source builds consumable JavaScript and declarations
     '}',
     '',
   ].join('\n'));
-  const program = ts.createProgram([typedConsumer], {
-    module: ts.ModuleKind.NodeNext,
-    moduleResolution: ts.ModuleResolutionKind.NodeNext,
-    target: ts.ScriptTarget.ES2022,
-    noEmit: true,
-    skipLibCheck: true,
-    strict: true,
-  });
-  const diagnostics = ts.getPreEmitDiagnostics(program);
-  assert.equal(diagnostics.length, 0, ts.formatDiagnosticsWithColorAndContext(diagnostics, {
-    getCanonicalFileName: (file) => file,
-    getCurrentDirectory: () => consumerDir,
-    getNewLine: () => '\n',
-  }));
+  assertTypeScriptConsumer(typedConsumer, { skipLibCheck: true });
 }));
 
 test('the packed storage package preserves representative legacy dist imports', {

--- a/scripts/lib/__tests__/release-packages.test.mjs
+++ b/scripts/lib/__tests__/release-packages.test.mjs
@@ -43,6 +43,11 @@ const NPM_AVAILABLE = (() => {
   }
 })();
 const TAR_AVAILABLE = spawnSync('tar', ['--version'], { encoding: 'utf8' }).status === 0;
+const GIT_AVAILABLE = spawnSync('git', ['--version'], { encoding: 'utf8' }).status === 0;
+const REPO_CHECKOUT_AVAILABLE = GIT_AVAILABLE && spawnSync('git', [
+  '-C', REPO_ROOT, 'rev-parse', '--is-inside-work-tree',
+], { encoding: 'utf8' }).stdout?.trim() === 'true';
+
 
 const SCRIPT_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../release-packages.mjs');
 
@@ -63,6 +68,19 @@ function withFixture(fn) {
     return fn(root);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/** Git owns the source inventory; read working-tree contents so pending edits are exercised. */
+function materializeTrackedPackage(sourceRoot, relativePackage, destination) {
+  const tracked = spawnSync('git', ['-C', sourceRoot, 'ls-files', '-z', '--', relativePackage], { encoding: 'utf8' });
+  assert.equal(tracked.status, 0, `cannot enumerate tracked package inputs: ${tracked.stderr}`);
+  const files = tracked.stdout.split('\0').filter(Boolean);
+  assert.ok(files.length > 0, 'the source package must have tracked inputs');
+  for (const relative of files) {
+    const target = path.join(destination, path.relative(relativePackage, relative));
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.copyFileSync(path.join(sourceRoot, relative), target);
   }
 }
 
@@ -529,26 +547,45 @@ test('the packed CLI resolves the typed Blazegraph runtime subpath for a consume
   assertTypeScriptConsumer(consumerPath, { esModuleInterop: true });
 }));
 
+test('tracked package fixtures include unpublished build inputs and exclude generated state', {
+  skip: GIT_AVAILABLE ? false : 'git is required',
+}, () => withFixture((root) => {
+  const sourceRoot = path.join(root, 'source');
+  const relativePackage = 'packages/fixture';
+  const source = path.join(sourceRoot, relativePackage);
+  writePackage(sourceRoot, relativePackage, { name: 'fixture', files: ['dist'] });
+  fs.writeFileSync(path.join(source, 'tsconfig.build.json'), '{"compilerOptions":{}}');
+  fs.writeFileSync(path.join(sourceRoot, '.gitignore'), '.turbo/\ndist/\n*.tsbuildinfo\n');
+  assert.equal(spawnSync('git', ['init', '-q', sourceRoot]).status, 0);
+  assert.equal(spawnSync('git', ['-C', sourceRoot, 'add', '.gitignore', relativePackage]).status, 0);
+  // A pending edit must be used instead of the staged version.
+  const editedConfig = '{"compilerOptions":{"strict":true}}';
+  fs.writeFileSync(path.join(source, 'tsconfig.build.json'), editedConfig);
+  for (const generated of ['.turbo/cache', 'dist/index.js', 'tsconfig.tsbuildinfo']) {
+    fs.mkdirSync(path.dirname(path.join(source, generated)), { recursive: true });
+    fs.writeFileSync(path.join(source, generated), 'generated');
+  }
+  const target = path.join(root, 'checkout');
+  materializeTrackedPackage(sourceRoot, relativePackage, target);
+  assert.deepEqual(fs.readdirSync(target).sort(), ['package.json', 'tsconfig.build.json']);
+  assert.equal(fs.readFileSync(path.join(target, 'tsconfig.build.json'), 'utf8'), editedConfig);
+}));
+
 test('packing OpenClaw from source builds consumable JavaScript and declarations', {
-  skip: NPM_AVAILABLE && TAR_AVAILABLE ? false : 'npm and tar are required',
+  skip: NPM_AVAILABLE && TAR_AVAILABLE && REPO_CHECKOUT_AVAILABLE ? false : 'npm, tar and a Git checkout are required',
 }, () => withFixture((root) => {
   const source = path.join(REPO_ROOT, 'packages', 'adapter-openclaw');
   const cleanPackage = path.join(root, 'packages', 'adapter-openclaw');
   const manifest = JSON.parse(fs.readFileSync(path.join(source, 'package.json'), 'utf8'));
   const { packageManager } = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'));
   writePackage(root, '.', { name: 'openclaw-pack-fixture', private: true, packageManager });
-  // Copy the source checkout, including unpublished build scripts/configs.
-  // Published `files` entries are a separate contract from prepack inputs.
-  const generatedEntries = new Set(['dist', 'node_modules', 'coverage', 'test-results', '.git']);
-  fs.cpSync(source, cleanPackage, {
-    recursive: true,
-    filter: (entry) => !generatedEntries.has(path.basename(entry))
-      && !entry.endsWith('.tsbuildinfo'),
-  });
+  materializeTrackedPackage(REPO_ROOT, 'packages/adapter-openclaw', cleanPackage);
   fs.copyFileSync(path.join(REPO_ROOT, 'tsconfig.base.json'), path.join(root, 'tsconfig.base.json'));
   // Use the installed build tools and built workspace dependencies. The adapter
   // itself starts without any build output, independently of the CI build.
   fs.symlinkSync(path.join(REPO_ROOT, 'node_modules'), path.join(root, 'node_modules'), 'junction');
+  assert.ok(fs.existsSync(path.join(cleanPackage, 'tsconfig.json')), 'unpublished build config is required');
+  assert.equal(fs.existsSync(path.join(cleanPackage, '.turbo')), false);
   assert.equal(fs.existsSync(path.join(cleanPackage, 'dist')), false);
   assert.equal(fs.existsSync(path.join(cleanPackage, 'tsconfig.tsbuildinfo')), false);
 


### PR DESCRIPTION
Packing the OpenClaw adapter from a local checkout could ship an old dist directory even when source files had changed. Add a prepack hook that invokes the existing clean build, so a failed build stops packing.

Closes #21.

Validation: all 27 release-package tests pass. The new regression copies the adapter source without dist or the TypeScript build cache, invokes the real npm pack lifecycle, inspects the tarball for dist/index.js and dist/index.d.ts, imports it from a consumer, and compiles a consumer of its declarations using the built workspace dependencies. The packaging helper now inspects its owned output directory because lifecycle logs can accompany npm JSON output. An additional manual pnpm pack check confirms a seeded stale artifact is removed. Repository disabled-test audit passes. Final-head CI is pending.
