### PR TITLE
fix(cli): show selected home when the daemon cannot be reached

### DIFF
--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -18,7 +18,7 @@ import {
   isSafeJobId,
   SAFE_JOB_ID_ERROR,
 } from '@origintrail-official/dkg-publisher';
-import { readApiPort, readPid, isProcessRunning, configExists, loadConfig, dkgDir } from './config.js';
+import { DkgHomeFiles, isProcessRunning } from './config.js';
 import {
   serializeAgentListOptions,
   type AgentListPageOptions,
@@ -587,29 +587,30 @@ export class ApiClient {
   }
 
   static async connect(opts: ApiClientConnectOptions = {}): Promise<ApiClient> {
-    const selectedHome = dkgDir();
+    const homeFiles = new DkgHomeFiles();
+    const selectedHome = homeFiles.home;
     const environmentToken = process.env.DKG_AUTH_TOKEN?.trim();
     const hasEnvPort = process.env.DKG_API_PORT !== undefined && process.env.DKG_API_PORT !== '';
     const envPort = hasEnvPort
       ? parseInt(process.env.DKG_API_PORT as string, 10)
       : null;
 
-    const filePort = hasEnvPort ? null : await readApiPort(selectedHome);
+    const filePort = hasEnvPort ? null : await homeFiles.readApiPort();
     let port = envPort ?? filePort;
     let configFallback: ConfigFallbackContext | undefined;
-    let config: Awaited<ReturnType<typeof loadConfig>> | null = null;
+    let config: Awaited<ReturnType<DkgHomeFiles['loadConfig']>> | null = null;
 
     // A persisted api.port contains only the bound port. Pair it with the
     // configured bind host so CLI commands reach daemons bound to a specific
     // non-loopback address. Keep the port usable if config parsing fails.
-    if (!hasEnvPort && filePort && configExists(selectedHome)) {
-      config = await loadConfig(selectedHome).catch(() => null);
+    if (!hasEnvPort && filePort && homeFiles.configExists()) {
+      config = await homeFiles.loadConfig().catch(() => null);
     }
 
     if (!port) {
-      const pid = await readPid(selectedHome);
-      if (opts.allowConfigFallback && !hasEnvPort && configExists(selectedHome)) {
-        config = config ?? await loadConfig(selectedHome);
+      const pid = await homeFiles.readPid();
+      if (opts.allowConfigFallback && !hasEnvPort && homeFiles.configExists()) {
+        config = config ?? await homeFiles.loadConfig();
         const configuredPort = Number.isFinite(config.apiPort) && config.apiPort > 0 ? config.apiPort : null;
         if (configuredPort && !isAmbiguousFallbackName(config.name)) {
           const missingFiles = ['api.port', ...(pid ? [] : ['daemon.pid'])];
@@ -621,14 +622,14 @@ export class ApiClient {
     }
 
     if (!port) {
-      const pid = await readPid(selectedHome);
+      const pid = await homeFiles.readPid();
       if (!pid || !isProcessRunning(pid)) {
         throw new Error(daemonNotRunningMessage(selectedHome));
       }
       throw new Error('Cannot read API port. Set DKG_API_PORT or restart: dkg stop && dkg start');
     }
 
-    const homeToken = await loadApiClientToken(selectedHome);
+    const homeToken = await loadApiClientToken(homeFiles);
     const token = environmentToken || homeToken;
     const portOrBaseUrl = !hasEnvPort && config
       ? configuredApiBaseUrl(config.apiHost, port)

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -18,7 +18,7 @@ import {
   isSafeJobId,
   SAFE_JOB_ID_ERROR,
 } from '@origintrail-official/dkg-publisher';
-import { readApiPort, readPid, isProcessRunning, configExists, loadConfig } from './config.js';
+import { readApiPort, readPid, isProcessRunning, configExists, loadConfig, dkgDir } from './config.js';
 import {
   serializeAgentListOptions,
   type AgentListPageOptions,
@@ -424,7 +424,12 @@ export interface ApiClientConnectOptions {
   allowConfigFallback?: boolean;
 }
 
-const DAEMON_NOT_RUNNING_MESSAGE = 'Daemon is not running. Start it with: dkg start';
+function daemonNotRunningMessage(selectedHome: string): string {
+  return `Daemon is not running at ${selectedHome}.\n`
+    + 'DKG_HOME selects the node directory checked by this command.\n'
+    + 'Start a daemon in that directory with: dkg start\n'
+    + 'For an existing devnet, select a node instead: DKG_HOME=.devnet/node1 dkg <command>';
+}
 const DEFAULT_NODE_NAME = 'dkg-node';
 
 function controlPlaneWarning(missingFiles: string[]): string | undefined {
@@ -562,21 +567,25 @@ export class ApiClient {
   private baseUrl: string;
   private token?: string;
   private expectedStatusName?: string;
+  private selectedHome: string;
   readonly controlPlaneWarning?: string;
 
   constructor(portOrBaseUrl: number | string, token?: string, opts?: {
     controlPlaneWarning?: string;
     expectedStatusName?: string;
+    selectedHome?: string;
   }) {
     this.baseUrl = typeof portOrBaseUrl === 'number'
       ? `http://127.0.0.1:${portOrBaseUrl}`
       : portOrBaseUrl.replace(/\/+$/, '');
     this.token = token;
     this.expectedStatusName = opts?.expectedStatusName;
+    this.selectedHome = opts?.selectedHome ?? dkgDir();
     this.controlPlaneWarning = opts?.controlPlaneWarning;
   }
 
   static async connect(opts: ApiClientConnectOptions = {}): Promise<ApiClient> {
+    const selectedHome = dkgDir();
     const hasEnvPort = process.env.DKG_API_PORT !== undefined && process.env.DKG_API_PORT !== '';
     const envPort = hasEnvPort
       ? parseInt(process.env.DKG_API_PORT as string, 10)
@@ -612,7 +621,7 @@ export class ApiClient {
     if (!port) {
       const pid = await readPid();
       if (!pid || !isProcessRunning(pid)) {
-        throw new Error(DAEMON_NOT_RUNNING_MESSAGE);
+        throw new Error(daemonNotRunningMessage(selectedHome));
       }
       throw new Error('Cannot read API port. Set DKG_API_PORT or restart: dkg stop && dkg start');
     }
@@ -623,7 +632,7 @@ export class ApiClient {
     const portOrBaseUrl = !hasEnvPort && config
       ? configuredApiBaseUrl(config.apiHost, port)
       : port;
-    return new ApiClient(portOrBaseUrl, token, { controlPlaneWarning: warning, expectedStatusName });
+    return new ApiClient(portOrBaseUrl, token, { controlPlaneWarning: warning, expectedStatusName, selectedHome });
   }
 
   async status(): Promise<DaemonStatusResponse> {
@@ -632,7 +641,7 @@ export class ApiClient {
       status = await this.get<unknown>('/api/status', { auth: false });
     } catch (err) {
       if (this.expectedStatusName && isConnectionFailure(err)) {
-        throw new Error(DAEMON_NOT_RUNNING_MESSAGE);
+        throw new Error(daemonNotRunningMessage(this.selectedHome));
       }
       throw err;
     }

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -23,7 +23,7 @@ import {
   serializeAgentListOptions,
   type AgentListPageOptions,
 } from '@origintrail-official/dkg-core';
-import { loadTokens } from './auth.js';
+import { loadApiClientToken } from './auth.js';
 import {
   finalizedPublishOptionsPayload,
   type KnowledgeAssetFinalizedPublishOptions,
@@ -588,12 +588,13 @@ export class ApiClient {
 
   static async connect(opts: ApiClientConnectOptions = {}): Promise<ApiClient> {
     const selectedHome = dkgDir();
+    const environmentToken = process.env.DKG_AUTH_TOKEN?.trim();
     const hasEnvPort = process.env.DKG_API_PORT !== undefined && process.env.DKG_API_PORT !== '';
     const envPort = hasEnvPort
       ? parseInt(process.env.DKG_API_PORT as string, 10)
       : null;
 
-    const filePort = hasEnvPort ? null : await readApiPort();
+    const filePort = hasEnvPort ? null : await readApiPort(selectedHome);
     let port = envPort ?? filePort;
     let configFallback: ConfigFallbackContext | undefined;
     let config: Awaited<ReturnType<typeof loadConfig>> | null = null;
@@ -601,14 +602,14 @@ export class ApiClient {
     // A persisted api.port contains only the bound port. Pair it with the
     // configured bind host so CLI commands reach daemons bound to a specific
     // non-loopback address. Keep the port usable if config parsing fails.
-    if (!hasEnvPort && filePort && configExists()) {
-      config = await loadConfig().catch(() => null);
+    if (!hasEnvPort && filePort && configExists(selectedHome)) {
+      config = await loadConfig(selectedHome).catch(() => null);
     }
 
     if (!port) {
-      const pid = await readPid();
-      if (opts.allowConfigFallback && !hasEnvPort && configExists()) {
-        config = config ?? await loadConfig();
+      const pid = await readPid(selectedHome);
+      if (opts.allowConfigFallback && !hasEnvPort && configExists(selectedHome)) {
+        config = config ?? await loadConfig(selectedHome);
         const configuredPort = Number.isFinite(config.apiPort) && config.apiPort > 0 ? config.apiPort : null;
         if (configuredPort && !isAmbiguousFallbackName(config.name)) {
           const missingFiles = ['api.port', ...(pid ? [] : ['daemon.pid'])];
@@ -620,16 +621,15 @@ export class ApiClient {
     }
 
     if (!port) {
-      const pid = await readPid();
+      const pid = await readPid(selectedHome);
       if (!pid || !isProcessRunning(pid)) {
         throw new Error(daemonNotRunningMessage(selectedHome));
       }
       throw new Error('Cannot read API port. Set DKG_API_PORT or restart: dkg stop && dkg start');
     }
 
-    const tokens = await loadTokens();
-    const environmentToken = process.env.DKG_AUTH_TOKEN?.trim();
-    const token = environmentToken || (tokens.size > 0 ? tokens.values().next().value : undefined);
+    const homeToken = await loadApiClientToken(selectedHome);
+    const token = environmentToken || homeToken;
     const portOrBaseUrl = !hasEnvPort && config
       ? configuredApiBaseUrl(config.apiHost, port)
       : port;

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -428,7 +428,7 @@ function daemonNotRunningMessage(selectedHome: string): string {
   return `Daemon is not running at ${selectedHome}.\n`
     + 'DKG_HOME selects the node directory checked by this command.\n'
     + 'Start a daemon in that directory with: dkg start\n'
-    + 'For an existing devnet, select a node instead: DKG_HOME=.devnet/node1 dkg <command>';
+    + 'For an existing devnet, set DKG_HOME to its node directory (for example .devnet/node1), then rerun this command.';
 }
 const DEFAULT_NODE_NAME = 'dkg-node';
 
@@ -563,25 +563,27 @@ export interface KnowledgeAssetPublishAuthorSelection {
   selectedAuthorAgentAddress?: string;
 }
 
+interface ConfigFallbackContext {
+  readonly expectedStatusName: string;
+  readonly selectedHome: string;
+  readonly controlPlaneWarning: string | undefined;
+}
+
 export class ApiClient {
   private baseUrl: string;
   private token?: string;
-  private expectedStatusName?: string;
-  private selectedHome: string;
+  private readonly configFallback?: Readonly<ConfigFallbackContext>;
   readonly controlPlaneWarning?: string;
 
   constructor(portOrBaseUrl: number | string, token?: string, opts?: {
-    controlPlaneWarning?: string;
-    expectedStatusName?: string;
-    selectedHome?: string;
+    configFallback?: ConfigFallbackContext;
   }) {
     this.baseUrl = typeof portOrBaseUrl === 'number'
       ? `http://127.0.0.1:${portOrBaseUrl}`
       : portOrBaseUrl.replace(/\/+$/, '');
     this.token = token;
-    this.expectedStatusName = opts?.expectedStatusName;
-    this.selectedHome = opts?.selectedHome ?? dkgDir();
-    this.controlPlaneWarning = opts?.controlPlaneWarning;
+    this.configFallback = opts?.configFallback && Object.freeze({ ...opts.configFallback });
+    this.controlPlaneWarning = this.configFallback?.controlPlaneWarning;
   }
 
   static async connect(opts: ApiClientConnectOptions = {}): Promise<ApiClient> {
@@ -593,8 +595,7 @@ export class ApiClient {
 
     const filePort = hasEnvPort ? null : await readApiPort();
     let port = envPort ?? filePort;
-    let warning: string | undefined;
-    let expectedStatusName: string | undefined;
+    let configFallback: ConfigFallbackContext | undefined;
     let config: Awaited<ReturnType<typeof loadConfig>> | null = null;
 
     // A persisted api.port contains only the bound port. Pair it with the
@@ -612,8 +613,8 @@ export class ApiClient {
         if (configuredPort && !isAmbiguousFallbackName(config.name)) {
           const missingFiles = ['api.port', ...(pid ? [] : ['daemon.pid'])];
           port = configuredPort;
-          expectedStatusName = config.name;
-          warning = controlPlaneWarning(missingFiles);
+          configFallback = { expectedStatusName: config.name, selectedHome,
+            controlPlaneWarning: controlPlaneWarning(missingFiles) };
         }
       }
     }
@@ -632,7 +633,7 @@ export class ApiClient {
     const portOrBaseUrl = !hasEnvPort && config
       ? configuredApiBaseUrl(config.apiHost, port)
       : port;
-    return new ApiClient(portOrBaseUrl, token, { controlPlaneWarning: warning, expectedStatusName, selectedHome });
+    return new ApiClient(portOrBaseUrl, token, { configFallback });
   }
 
   async status(): Promise<DaemonStatusResponse> {
@@ -640,12 +641,12 @@ export class ApiClient {
     try {
       status = await this.get<unknown>('/api/status', { auth: false });
     } catch (err) {
-      if (this.expectedStatusName && isConnectionFailure(err)) {
-        throw new Error(daemonNotRunningMessage(this.selectedHome));
+      if (this.configFallback && isConnectionFailure(err)) {
+        throw new Error(daemonNotRunningMessage(this.configFallback.selectedHome));
       }
       throw err;
     }
-    return requireDaemonStatusResponse(status, this.expectedStatusName);
+    return requireDaemonStatusResponse(status, this.configFallback?.expectedStatusName);
   }
 
   /**

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -8,10 +8,10 @@
 import { randomBytes, createHmac, timingSafeEqual, createHash } from 'node:crypto';
 import { readFile, writeFile, mkdir, chmod } from 'node:fs/promises';
 import { readFileSync, statSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { dirname } from 'node:path';
 import { existsSync } from 'node:fs';
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import { dkgDir } from './config.js';
+import { DkgHomeFiles } from './config.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -166,71 +166,49 @@ export function authenticatedAgentAddress(
 // Token file management
 // ---------------------------------------------------------------------------
 
-function tokenFilePath(): string {
-  return join(dkgDir(), 'auth.token');
+function tokenFilePath(homeFiles = new DkgHomeFiles()): string {
+  return homeFiles.tokenPath;
 }
 
 function generateToken(): string {
   return randomBytes(32).toString('base64url');
 }
 
-/**
- * Load tokens from disk + config. Auto-generates a token file if none exists.
- * Returns the set of valid tokens.
- */
-export async function loadTokens(authConfig?: AuthConfig): Promise<Set<string>> {
-  return loadTokensFromFile(tokenFilePath(), authConfig);
-}
-
-/** Resolve one client credential from an explicit home using the normal load/generate policy. */
-export async function loadApiClientToken(home: string): Promise<string | undefined> {
-  const tokens = await loadTokensFromFile(join(home, 'auth.token'));
-  return tokens.values().next().value;
-}
-
-async function loadTokensFromFile(filePath: string, authConfig?: AuthConfig): Promise<Set<string>> {
+/** Shared token-file policy; daemon reconciliation is deliberately outside it. */
+async function loadOrCreateTokenFile(filePath: string, generateIfEmpty: boolean): Promise<Set<string>> {
   const tokens = new Set<string>();
-  const fileTokens = new Set<string>();
-  // auth.ts:203). Track config-pinned
-  // tokens separately from file-derived ones so reconciliation /
-  // rotation can preserve them when a token happens to live in BOTH
-  // sources (a real-world rollout shape — operators sync the same
-  // admin token across config and `auth.token`).
-  const configTokens = new Set<string>();
-
-  if (authConfig?.tokens) {
-    for (const t of authConfig.tokens) {
-      if (t.length > 0) {
-        tokens.add(t);
-        configTokens.add(t);
-      }
-    }
-  }
-
-  // Load or generate the file-based token
   if (existsSync(filePath)) {
     try {
       const raw = await readFile(filePath, 'utf-8');
       for (const line of raw.split('\n')) {
-        const t = line.trim();
-        if (t.length > 0 && !t.startsWith('#')) {
-          tokens.add(t);
-          fileTokens.add(t);
-        }
+        const token = line.trim();
+        if (token.length > 0 && !token.startsWith('#')) tokens.add(token);
       }
-    } catch {
-      // Unreadable — generate a fresh one
-    }
+    } catch { /* Unreadable files follow the same generation policy as empty files. */ }
   }
-
-  if (tokens.size === 0) {
+  if (tokens.size === 0 && generateIfEmpty) {
     const token = generateToken();
     tokens.add(token);
-    fileTokens.add(token);
     await mkdir(dirname(filePath), { recursive: true });
     await writeFile(filePath, `# DKG node API token — treat this like a password\n${token}\n`, { mode: 0o600 });
     await chmod(filePath, 0o600);
   }
+  return tokens;
+}
+
+/** Select the first file token without registering daemon hot-reload state. */
+export async function loadApiClientToken(homeFiles: DkgHomeFiles): Promise<string | undefined> {
+  return (await loadOrCreateTokenFile(tokenFilePath(homeFiles), true)).values().next().value;
+}
+
+/** Load daemon tokens from config and disk, generating only when both are empty. */
+export async function loadTokens(authConfig?: AuthConfig): Promise<Set<string>> {
+  const filePath = tokenFilePath();
+  // Keep config tokens first and retain their provenance when a token also
+  // appears in the file, so rotation/reconciliation cannot revoke a pinned token.
+  const configTokens = new Set(authConfig?.tokens?.filter((token) => token.length > 0));
+  const fileTokens = await loadOrCreateTokenFile(filePath, configTokens.size === 0);
+  const tokens = new Set([...configTokens, ...fileTokens]);
 
   // CLI-11: record the file snapshot so `verifyToken`'s mtime-gated
   // reconciliation knows which tokens originated on disk and can

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -179,6 +179,16 @@ function generateToken(): string {
  * Returns the set of valid tokens.
  */
 export async function loadTokens(authConfig?: AuthConfig): Promise<Set<string>> {
+  return loadTokensFromFile(tokenFilePath(), authConfig);
+}
+
+/** Resolve one client credential from an explicit home using the normal load/generate policy. */
+export async function loadApiClientToken(home: string): Promise<string | undefined> {
+  const tokens = await loadTokensFromFile(join(home, 'auth.token'));
+  return tokens.values().next().value;
+}
+
+async function loadTokensFromFile(filePath: string, authConfig?: AuthConfig): Promise<Set<string>> {
   const tokens = new Set<string>();
   const fileTokens = new Set<string>();
   // auth.ts:203). Track config-pinned
@@ -198,7 +208,6 @@ export async function loadTokens(authConfig?: AuthConfig): Promise<Set<string>> 
   }
 
   // Load or generate the file-based token
-  const filePath = tokenFilePath();
   if (existsSync(filePath)) {
     try {
       const raw = await readFile(filePath, 'utf-8');

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -2111,24 +2111,24 @@ export async function swapSlot(target: 'a' | 'b'): Promise<void> {
   await writeFile(join(rDir, 'active'), target);
 }
 
-export function configPath(): string {
-  return join(dkgDir(), 'config.json');
+export function configPath(home: string = dkgDir()): string {
+  return join(home, 'config.json');
 }
 
-export function configYamlPath(): string {
-  return join(dkgDir(), 'config.yaml');
+export function configYamlPath(home: string = dkgDir()): string {
+  return join(home, 'config.yaml');
 }
 
-export function pidPath(): string {
-  return join(dkgDir(), 'daemon.pid');
+export function pidPath(home: string = dkgDir()): string {
+  return join(home, 'daemon.pid');
 }
 
 export function logPath(): string {
   return join(dkgDir(), 'daemon.log');
 }
 
-export function apiPortPath(): string {
-  return join(dkgDir(), 'api.port');
+export function apiPortPath(home: string = dkgDir()): string {
+  return join(home, 'api.port');
 }
 
 export async function ensureDkgDir(): Promise<void> {
@@ -2164,16 +2164,16 @@ export function readNodeRoleFromConfigSync(): 'edge' | 'core' {
   }
 }
 
-export async function loadConfig(): Promise<DkgConfig> {
+export async function loadConfig(home: string = dkgDir()): Promise<DkgConfig> {
   try {
-    const raw = await readFile(configPath(), 'utf-8');
+    const raw = await readFile(configPath(home), 'utf-8');
     return mergePersistedConfig(JSON.parse(raw));
   } catch (err) {
     if (!isEnoent(err)) throw err;
   }
 
   try {
-    const raw = await readFile(configYamlPath(), 'utf-8');
+    const raw = await readFile(configYamlPath(home), 'utf-8');
     return mergePersistedConfig(yaml.load(raw));
   } catch (err) {
     if (!isEnoent(err)) throw err;
@@ -2318,13 +2318,13 @@ export async function saveConfig(config: DkgConfig): Promise<void> {
   await writeFile(configPath(), JSON.stringify(config, null, 2) + '\n');
 }
 
-export function configExists(): boolean {
-  return existsSync(configPath()) || existsSync(configYamlPath());
+export function configExists(home: string = dkgDir()): boolean {
+  return existsSync(configPath(home)) || existsSync(configYamlPath(home));
 }
 
-export async function readPid(): Promise<number | null> {
+export async function readPid(home: string = dkgDir()): Promise<number | null> {
   try {
-    const raw = await readFile(pidPath(), 'utf-8');
+    const raw = await readFile(pidPath(home), 'utf-8');
     return parseInt(raw.trim(), 10);
   } catch {
     return null;
@@ -2345,9 +2345,9 @@ export async function removePid(): Promise<void> {
   }
 }
 
-export async function readApiPort(): Promise<number | null> {
+export async function readApiPort(home: string = dkgDir()): Promise<number | null> {
   try {
-    const raw = await readFile(apiPortPath(), 'utf-8');
+    const raw = await readFile(apiPortPath(home), 'utf-8');
     return parseInt(raw.trim(), 10);
   } catch {
     return null;

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -27,6 +27,7 @@ import {
   findPackageRepoDir,
   isDkgMonorepoRoot,
   resolveDkgConfigHome,
+  dkgAuthTokenPath,
   SELECTABLE_SETUP_NETWORKS,
 } from '@origintrail-official/dkg-core';
 import {
@@ -2111,29 +2112,69 @@ export async function swapSlot(target: 'a' | 'b'): Promise<void> {
   await writeFile(join(rDir, 'active'), target);
 }
 
-export function configPath(home: string = dkgDir()): string {
-  return join(home, 'config.json');
+/** Immutable filesystem context for one selected local daemon home. */
+export class DkgHomeFiles {
+  constructor(readonly home: string = dkgDir()) { Object.freeze(this); }
+
+  get configPath(): string { return join(this.home, 'config.json'); }
+  get configYamlPath(): string { return join(this.home, 'config.yaml'); }
+  get pidPath(): string { return join(this.home, 'daemon.pid'); }
+  get apiPortPath(): string { return join(this.home, 'api.port'); }
+  get tokenPath(): string { return dkgAuthTokenPath(this.home); }
+
+  configExists(): boolean { return existsSync(this.configPath) || existsSync(this.configYamlPath); }
+
+  readConfigSync(): unknown {
+    if (existsSync(this.configPath)) return JSON.parse(readFileSync(this.configPath, 'utf-8'));
+    if (existsSync(this.configYamlPath)) return yaml.load(readFileSync(this.configYamlPath, 'utf-8'));
+    return null;
+  }
+
+  async loadConfig(): Promise<DkgConfig> {
+    try {
+      return mergePersistedConfig(JSON.parse(await readFile(this.configPath, 'utf-8')));
+    } catch (err) {
+      if (!isEnoent(err)) throw err;
+    }
+    try {
+      return mergePersistedConfig(yaml.load(await readFile(this.configYamlPath, 'utf-8')));
+    } catch (err) {
+      if (!isEnoent(err)) throw err;
+    }
+    return { ...DEFAULT_CONFIG };
+  }
+
+  async saveConfig(config: DkgConfig): Promise<void> {
+    await mkdir(this.home, { recursive: true });
+    await writeFile(this.configPath, JSON.stringify(config, null, 2) + '\n');
+  }
+
+  readPid(): Promise<number | null> { return this.readControlNumber(this.pidPath); }
+  readApiPort(): Promise<number | null> { return this.readControlNumber(this.apiPortPath); }
+  async writePid(pid: number): Promise<void> { await writeFile(this.pidPath, String(pid)); }
+  async writeApiPort(port: number): Promise<void> { await writeFile(this.apiPortPath, String(port)); }
+  removePid(): Promise<void> { return this.removeControlFile(this.pidPath); }
+  removeApiPort(): Promise<void> { return this.removeControlFile(this.apiPortPath); }
+
+  private async readControlNumber(path: string): Promise<number | null> {
+    try { return parseInt((await readFile(path, 'utf-8')).trim(), 10); }
+    catch { return null; }
+  }
+
+  private async removeControlFile(path: string): Promise<void> {
+    try { await unlink(path); }
+    catch (err) { if (!isEnoent(err)) throw err; }
+  }
 }
 
-export function configYamlPath(home: string = dkgDir()): string {
-  return join(home, 'config.yaml');
-}
-
-export function pidPath(home: string = dkgDir()): string {
-  return join(home, 'daemon.pid');
-}
-
-export function logPath(): string {
-  return join(dkgDir(), 'daemon.log');
-}
-
-export function apiPortPath(home: string = dkgDir()): string {
-  return join(home, 'api.port');
-}
-
-export async function ensureDkgDir(): Promise<void> {
-  await mkdir(dkgDir(), { recursive: true });
-}
+// Compatibility helpers resolve a fresh home at their call boundary. Work that
+// spans multiple reads or writes retains a DkgHomeFiles instance instead.
+export function configPath(): string { return new DkgHomeFiles().configPath; }
+export function configYamlPath(): string { return new DkgHomeFiles().configYamlPath; }
+export function pidPath(): string { return new DkgHomeFiles().pidPath; }
+export function apiPortPath(): string { return new DkgHomeFiles().apiPortPath; }
+export function logPath(): string { return join(dkgDir(), 'daemon.log'); }
+export async function ensureDkgDir(): Promise<void> { await mkdir(dkgDir(), { recursive: true }); }
 
 function mergePersistedConfig(raw: unknown): DkgConfig {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { ...DEFAULT_CONFIG };
@@ -2144,43 +2185,15 @@ function isEnoent(err: unknown): boolean {
   return !!err && typeof err === 'object' && (err as { code?: unknown }).code === 'ENOENT';
 }
 
-function readPersistedConfigSync(): unknown {
-  if (existsSync(configPath())) {
-    return JSON.parse(readFileSync(configPath(), 'utf-8'));
-  }
-  if (existsSync(configYamlPath())) {
-    return yaml.load(readFileSync(configYamlPath(), 'utf-8'));
-  }
-  return null;
-}
-
 export function readNodeRoleFromConfigSync(): 'edge' | 'core' {
   try {
-    const parsed = readPersistedConfigSync();
+    const parsed = new DkgHomeFiles().readConfigSync();
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return 'edge';
     return (parsed as { nodeRole?: unknown }).nodeRole === 'core' ? 'core' : 'edge';
-  } catch {
-    return 'edge';
-  }
+  } catch { return 'edge'; }
 }
 
-export async function loadConfig(home: string = dkgDir()): Promise<DkgConfig> {
-  try {
-    const raw = await readFile(configPath(home), 'utf-8');
-    return mergePersistedConfig(JSON.parse(raw));
-  } catch (err) {
-    if (!isEnoent(err)) throw err;
-  }
-
-  try {
-    const raw = await readFile(configYamlPath(home), 'utf-8');
-    return mergePersistedConfig(yaml.load(raw));
-  } catch (err) {
-    if (!isEnoent(err)) throw err;
-  }
-
-  return { ...DEFAULT_CONFIG };
-}
+export async function loadConfig(): Promise<DkgConfig> { return new DkgHomeFiles().loadConfig(); }
 
 // =====================================================================
 // External-backend config validation (RFC 120, plan PR 1 item 6)
@@ -2313,60 +2326,14 @@ export function exitOnStoreConfigErrors(
   process.exit(1);
 }
 
-export async function saveConfig(config: DkgConfig): Promise<void> {
-  await ensureDkgDir();
-  await writeFile(configPath(), JSON.stringify(config, null, 2) + '\n');
-}
-
-export function configExists(home: string = dkgDir()): boolean {
-  return existsSync(configPath(home)) || existsSync(configYamlPath(home));
-}
-
-export async function readPid(home: string = dkgDir()): Promise<number | null> {
-  try {
-    const raw = await readFile(pidPath(home), 'utf-8');
-    return parseInt(raw.trim(), 10);
-  } catch {
-    return null;
-  }
-}
-
-export async function writePid(pid: number): Promise<void> {
-  await writeFile(pidPath(), String(pid));
-}
-
-export async function removePid(): Promise<void> {
-  const { unlink } = await import('node:fs/promises');
-  try {
-    await unlink(pidPath());
-  } catch (err) {
-    const code = err && typeof err === 'object' && 'code' in err ? (err as NodeJS.ErrnoException).code : undefined;
-    if (code !== 'ENOENT') throw err;
-  }
-}
-
-export async function readApiPort(home: string = dkgDir()): Promise<number | null> {
-  try {
-    const raw = await readFile(apiPortPath(home), 'utf-8');
-    return parseInt(raw.trim(), 10);
-  } catch {
-    return null;
-  }
-}
-
-export async function writeApiPort(port: number): Promise<void> {
-  await writeFile(apiPortPath(), String(port));
-}
-
-export async function removeApiPort(): Promise<void> {
-  const { unlink } = await import('node:fs/promises');
-  try {
-    await unlink(apiPortPath());
-  } catch (err) {
-    const code = err && typeof err === 'object' && 'code' in err ? (err as NodeJS.ErrnoException).code : undefined;
-    if (code !== 'ENOENT') throw err;
-  }
-}
+export async function saveConfig(config: DkgConfig): Promise<void> { await new DkgHomeFiles().saveConfig(config); }
+export function configExists(): boolean { return new DkgHomeFiles().configExists(); }
+export async function readPid(): Promise<number | null> { return new DkgHomeFiles().readPid(); }
+export async function writePid(pid: number): Promise<void> { await new DkgHomeFiles().writePid(pid); }
+export async function removePid(): Promise<void> { await new DkgHomeFiles().removePid(); }
+export async function readApiPort(): Promise<number | null> { return new DkgHomeFiles().readApiPort(); }
+export async function writeApiPort(port: number): Promise<void> { await new DkgHomeFiles().writeApiPort(port); }
+export async function removeApiPort(): Promise<void> { await new DkgHomeFiles().removeApiPort(); }
 
 export function isProcessRunning(pid: number): boolean {
   try {

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -1,7 +1,7 @@
 import * as configModule from '../src/config.js';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { existsSync } from 'node:fs';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { ApiClient } from '../src/api-client.js';
@@ -160,6 +160,55 @@ describe('ApiClient', () => {
       expect(result.status).toBe('unreachable');
       expect(result.jobStatus).toBe('partial');
     });
+
+    it.each(['persisted', 'fallback-json', 'fallback-yaml'] as const)(
+      'connect() keeps every local read in one home across a delayed read (%s)', async (mode) => {
+        const otherHome = join(tempDir, 'other-home');
+        await mkdir(otherHome);
+        process.env.DKG_HOME = tempDir;
+        delete process.env.DKG_API_PORT;
+        await writeFile(join(tempDir, 'daemon.pid'), '12345');
+        await writeFile(join(tempDir, 'auth.token'), 'home-a-token\n');
+        await writeFile(join(otherHome, 'auth.token'), 'home-b-token\n');
+        await writeFile(join(otherHome, 'config.json'), JSON.stringify({ name: 'node-b', apiPort: 9444, apiHost: '192.0.2.20' }));
+        if (mode === 'fallback-yaml') {
+          await writeFile(join(tempDir, 'config.yaml'), 'name: node-a\napiPort: 9317\napiHost: 192.0.2.10\n');
+        } else {
+          await writeFile(join(tempDir, 'config.json'), JSON.stringify({ name: 'node-a', apiPort: 9317, apiHost: '192.0.2.10' }));
+        }
+        if (mode === 'persisted') await writeFile(join(tempDir, 'api.port'), '9317');
+        let release!: () => void;
+        let markEntered!: () => void;
+        const gate = new Promise<void>((resolve) => { release = resolve; });
+        const entered = new Promise<void>((resolve) => { markEntered = resolve; });
+        const readPort = configModule.readApiPort;
+        const read = vi.spyOn(configModule, 'readApiPort').mockImplementation(async (...args) => {
+          const value = await readPort(...args);
+          markEntered();
+          await gate;
+          return value;
+        });
+        const { fetch, calls } = createTrackingFetch({ ok: true, status: 200, body: { agents: [] } });
+        globalThis.fetch = fetch;
+        try {
+          const connecting = ApiClient.connect({ allowConfigFallback: true });
+          await entered;
+          process.env.DKG_HOME = otherHome;
+          release();
+          const connected = await connecting;
+          await connected.agents();
+          expect(calls[0].url).toBe('http://192.0.2.10:9317/api/agents');
+          expect(new Headers(calls[0].opts.headers).get('Authorization')).toBe('Bearer home-a-token');
+          if (mode !== 'persisted') {
+            expect(connected.controlPlaneWarning).toContain('api.port');
+            expect(connected.controlPlaneWarning).not.toContain('daemon.pid');
+          }
+        } finally {
+          release();
+          read.mockRestore();
+        }
+      },
+    );
 
     it('connect() gives DKG_AUTH_TOKEN precedence over the selected home token file', async () => {
       process.env.DKG_HOME = tempDir;

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as configModule from '../src/config.js';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { existsSync } from 'node:fs';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -101,6 +102,18 @@ describe('ApiClient', () => {
     if (originalDkgAuthToken === undefined) delete process.env.DKG_AUTH_TOKEN;
     else process.env.DKG_AUTH_TOKEN = originalDkgAuthToken;
     await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('constructs direct remote clients without reading the local DKG home', () => {
+    const home = vi.spyOn(configModule, 'dkgDir').mockImplementation(() => {
+      throw new Error('unexpected local-home lookup');
+    });
+    try {
+      expect(() => new ApiClient('https://remote.example')).not.toThrow();
+      expect(home).not.toHaveBeenCalled();
+    } finally {
+      home.mockRestore();
+    }
   });
 
   describe('GET endpoints', () => {
@@ -303,7 +316,7 @@ describe('ApiClient', () => {
         .rejects.toThrow(`Daemon is not running at ${tempDir}.\n`
           + 'DKG_HOME selects the node directory checked by this command.\n'
           + 'Start a daemon in that directory with: dkg start\n'
-          + 'For an existing devnet, select a node instead: DKG_HOME=.devnet/node1 dkg <command>');
+          + 'For an existing devnet, set DKG_HOME to its node directory (for example .devnet/node1), then rerun this command.');
       expect(calls).toHaveLength(0);
       expect(existsSync(join(tempDir, 'api.port'))).toBe(false);
       expect(existsSync(join(tempDir, 'daemon.pid'))).toBe(false);

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -300,7 +300,10 @@ describe('ApiClient', () => {
       globalThis.fetch = fetch;
 
       await expect(ApiClient.connect({ allowConfigFallback: true }))
-        .rejects.toThrow('Daemon is not running. Start it with: dkg start');
+        .rejects.toThrow(`Daemon is not running at ${tempDir}.\n`
+          + 'DKG_HOME selects the node directory checked by this command.\n'
+          + 'Start a daemon in that directory with: dkg start\n'
+          + 'For an existing devnet, select a node instead: DKG_HOME=.devnet/node1 dkg <command>');
       expect(calls).toHaveLength(0);
       expect(existsSync(join(tempDir, 'api.port'))).toBe(false);
       expect(existsSync(join(tempDir, 'daemon.pid'))).toBe(false);
@@ -335,7 +338,10 @@ describe('ApiClient', () => {
 
       const connected = await ApiClient.connect({ allowConfigFallback: true });
 
-      await expect(connected.status()).rejects.toThrow('Daemon is not running. Start it with: dkg start');
+      // A client reports the home it connected through, even if a later command
+      // changes the process-wide selection before this request fails.
+      process.env.DKG_HOME = join(tempDir, 'another-node');
+      await expect(connected.status()).rejects.toThrow(`Daemon is not running at ${tempDir}.`);
       expect(calls).toHaveLength(1);
       expect(calls[0].url).toBe('http://127.0.0.1:9317/api/status');
       expect((calls[0].opts.headers as any).Authorization).toBeUndefined();
@@ -349,7 +355,7 @@ describe('ApiClient', () => {
       globalThis.fetch = fetch;
 
       const connected = await ApiClient.connect({ allowConfigFallback: true });
-      await expect(connected.status()).rejects.toThrow('Daemon is not running. Start it with: dkg start');
+      await expect(connected.status()).rejects.toThrow(`Daemon is not running at ${tempDir}.`);
     });
 
     it('does not let a hostile nested error getter escape transport classification', async () => {

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -104,15 +104,25 @@ describe('ApiClient', () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  it('constructs direct remote clients without reading the local DKG home', () => {
-    const home = vi.spyOn(configModule, 'dkgDir').mockImplementation(() => {
-      throw new Error('unexpected local-home lookup');
-    });
+  it('constructs direct remote clients without reading the local DKG home', async () => {
+    const home = vi.fn(() => { throw new Error('unexpected local-home context'); });
+    vi.resetModules();
+    vi.doMock('../src/config.js', () => ({
+      ...configModule,
+      DkgHomeFiles: class {
+        constructor() { home(); }
+      },
+    }));
     try {
-      expect(() => new ApiClient('https://remote.example')).not.toThrow();
+      const { ApiClient: RemoteApiClient } = await import('../src/api-client.js');
+      const mockedConfig = await import('../src/config.js');
+      expect(() => new mockedConfig.DkgHomeFiles()).toThrow('unexpected local-home context');
+      home.mockClear();
+      expect(() => new RemoteApiClient('https://remote.example')).not.toThrow();
       expect(home).not.toHaveBeenCalled();
     } finally {
-      home.mockRestore();
+      vi.doUnmock('../src/config.js');
+      vi.resetModules();
     }
   });
 

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -161,7 +161,7 @@ describe('ApiClient', () => {
       expect(result.jobStatus).toBe('partial');
     });
 
-    it.each(['persisted', 'fallback-json', 'fallback-yaml'] as const)(
+    it.each(['persisted', 'persisted-env-token', 'fallback-json', 'fallback-yaml'] as const)(
       'connect() keeps every local read in one home across a delayed read (%s)', async (mode) => {
         const otherHome = join(tempDir, 'other-home');
         await mkdir(otherHome);
@@ -176,14 +176,15 @@ describe('ApiClient', () => {
         } else {
           await writeFile(join(tempDir, 'config.json'), JSON.stringify({ name: 'node-a', apiPort: 9317, apiHost: '192.0.2.10' }));
         }
-        if (mode === 'persisted') await writeFile(join(tempDir, 'api.port'), '9317');
+        if (mode === 'persisted-env-token') process.env.DKG_AUTH_TOKEN = 'token-a';
+        if (mode.startsWith('persisted')) await writeFile(join(tempDir, 'api.port'), '9317');
         let release!: () => void;
         let markEntered!: () => void;
         const gate = new Promise<void>((resolve) => { release = resolve; });
         const entered = new Promise<void>((resolve) => { markEntered = resolve; });
-        const readPort = configModule.readApiPort;
-        const read = vi.spyOn(configModule, 'readApiPort').mockImplementation(async (...args) => {
-          const value = await readPort(...args);
+        const readPort = configModule.DkgHomeFiles.prototype.readApiPort;
+        const read = vi.spyOn(configModule.DkgHomeFiles.prototype, 'readApiPort').mockImplementation(async function () {
+          const value = await readPort.call(this);
           markEntered();
           await gate;
           return value;
@@ -194,12 +195,13 @@ describe('ApiClient', () => {
           const connecting = ApiClient.connect({ allowConfigFallback: true });
           await entered;
           process.env.DKG_HOME = otherHome;
+          if (mode === 'persisted-env-token') process.env.DKG_AUTH_TOKEN = 'token-b';
           release();
           const connected = await connecting;
           await connected.agents();
           expect(calls[0].url).toBe('http://192.0.2.10:9317/api/agents');
-          expect(new Headers(calls[0].opts.headers).get('Authorization')).toBe('Bearer home-a-token');
-          if (mode !== 'persisted') {
+          expect(new Headers(calls[0].opts.headers).get('Authorization')).toBe(mode === 'persisted-env-token' ? 'Bearer token-a' : 'Bearer home-a-token');
+          if (!mode.startsWith('persisted')) {
             expect(connected.controlPlaneWarning).toContain('api.port');
             expect(connected.controlPlaneWarning).not.toContain('daemon.pid');
           }

--- a/packages/cli/test/auth.test.ts
+++ b/packages/cli/test/auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
-import { writeFile, mkdir, rm } from 'node:fs/promises';
+import { writeFile, mkdir, rm, readFile, stat } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
@@ -9,7 +10,9 @@ import {
   extractBearerToken,
   httpAuthGuard,
   loadTokens,
+  loadApiClientToken,
 } from '../src/auth.js';
+import { DkgHomeFiles } from '../src/config.js';
 
 // ---------------------------------------------------------------------------
 // Unit tests for pure functions
@@ -108,6 +111,29 @@ describe('loadTokens', () => {
     expect(tokens.has('file-token')).toBe(true);
     expect(tokens.has('config-token')).toBe(true);
     expect(tokens.size).toBe(2);
+  });
+
+  it('selects the first file credential in the bound home without rewriting the file', async () => {
+    const files = new DkgHomeFiles();
+    const contents = '# header\n\n first-token \nsecond-token\nfirst-token\n';
+    await writeFile(files.tokenPath, contents);
+    process.env.DKG_HOME = join(tempDir, 'other-home');
+    expect(await loadApiClientToken(files)).toBe('first-token');
+    expect(await readFile(files.tokenPath, 'utf8')).toBe(contents);
+    expect(existsSync(new DkgHomeFiles().tokenPath)).toBe(false);
+  });
+
+  it('generates a private client token file and reuses that credential', async () => {
+    const files = new DkgHomeFiles();
+    const token = await loadApiClientToken(files);
+    expect(token).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(await loadApiClientToken(files)).toBe(token);
+    if (process.platform !== 'win32') expect((await stat(files.tokenPath)).mode & 0o777).toBe(0o600);
+  });
+
+  it('does not generate a daemon token file when config credentials already exist', async () => {
+    expect([...await loadTokens({ tokens: ['config-token'] })]).toEqual(['config-token']);
+    expect(existsSync(new DkgHomeFiles().tokenPath)).toBe(false);
   });
 });
 

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -9,6 +9,7 @@ import { computeNetworkId } from '../../core/src/genesis.js';
 import {
   loadNetworkConfig,
   loadConfig,
+  DkgHomeFiles,
   removePid,
   removeApiPort,
   saveConfig,
@@ -709,6 +710,35 @@ describe('localAgentIntegrations config round-trip', () => {
     if (origHome === undefined) delete process.env.DKG_HOME;
     else process.env.DKG_HOME = origHome;
     if (tempDir) await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('keeps symmetric control-file operations bound to one immutable home', async () => {
+    const files = new DkgHomeFiles();
+    const otherHome = join(tempDir, 'other-home');
+    await mkdir(otherHome);
+    process.env.DKG_HOME = otherHome;
+    expect(Object.isFrozen(files)).toBe(true);
+    expect(files.home).toBe(tempDir);
+    expect(files.tokenPath).toBe(dkgAuthTokenPath(tempDir));
+    await writePid(222);
+    await writeApiPort(9444);
+    await files.writePid(111);
+    await files.writeApiPort(9333);
+    await files.saveConfig({ ...await files.loadConfig(), name: 'home-a' });
+    expect(files.configExists()).toBe(true);
+    expect((await files.loadConfig()).name).toBe('home-a');
+    expect(files.readConfigSync()).toMatchObject({ name: 'home-a' });
+    expect(await files.readPid()).toBe(111);
+    expect(await files.readApiPort()).toBe(9333);
+    expect(await readPid()).toBe(222);
+    expect(await readApiPort()).toBe(9444);
+    expect(configExists()).toBe(false);
+    await files.removePid();
+    await files.removeApiPort();
+    expect(await files.readPid()).toBeNull();
+    expect(await files.readApiPort()).toBeNull();
+    expect(await readPid()).toBe(222);
+    expect(await readApiPort()).toBe(9444);
   });
 
   it('persists the generic local agent integration registry', async () => {


### PR DESCRIPTION
The daemon connection error now identifies the selected DKG home, explains that DKG_HOME chooses the node directory, and tells devnet users to select an existing node. The guidance is shell-neutral, so it also applies in native Windows PowerShell.

Config fallback captures the expected daemon name, selected home and control-plane warning in one immutable context owned by connect(). Directly constructed clients do not read local DKG configuration, and a fallback failure keeps naming the original home if DKG_HOME changes later.

Connection resolution retains one immutable DkgHomeFiles context for config, PID, API-port and auth-token paths. Its symmetric read/write/remove operations stay bound to the selected home; existing zero-argument helpers resolve a fresh context for compatibility. Client and daemon credentials share the canonical token-file load/generation primitive, while only daemon loading registers token reconciliation state.

Validation: 276 API/config/auth tests plus eight signed-request and token-rotation tests pass. Four delayed-read races include DKG_HOME and DKG_AUTH_TOKEN changes; moving credential selection after the await makes the new token race fail. Symmetric file operations, token ordering/generation/permissions, CLI build/type/package-boundary, repository lint and SPARQL diff checks pass.

Closes #349.
