### PR TITLE
docs(cli): point integration authors to the canonical schema

### DIFF
--- a/packages/cli/src/integrations/schema.ts
+++ b/packages/cli/src/integrations/schema.ts
@@ -1,9 +1,12 @@
 // TypeScript shape of a DKG integration registry entry.
 //
-// Mirrors schema/integration.schema.json in OriginTrail/dkg-integrations. Only
-// the fields the CLI actually consumes are typed strongly; the rest ride in
-// `[unknownExtras: string]: unknown` so a schema bump in the registry doesn't
-// break the CLI without a corresponding code change here.
+// Integration authors should validate entries against the canonical JSON Schema:
+// https://github.com/OriginTrail/dkg-integrations/blob/main/schema/integration.schema.json
+// That schema and registry CI define authoring requirements, including category,
+// schemaVersion and v10PrimitivesUsed. This module models the CLI's runtime
+// consumption contract: isIntegrationEntry checks fields needed for dispatch,
+// while unknown extras preserve forward compatibility with registry updates.
+// Passing this runtime guard alone does not establish registry acceptance.
 
 export type TrustTier = 'community' | 'verified' | 'featured';
 export type MemoryLayer = 'WM' | 'SWM' | 'VM';
@@ -307,4 +310,3 @@ function isValidInstallSpec(v: unknown): boolean {
       return false;
   }
 }
-


### PR DESCRIPTION
Link integration authors directly to the canonical registry JSON Schema from the CLI schema module. Clarify that the local runtime guard validates fields needed for CLI dispatch and preserves unknown fields for compatibility; registry CI owns authoring requirements.

Validation: verified the canonical schema URL through GitHub, and lint/diff checks pass. Comment-only change; runtime behavior is unchanged.

Closes #311.
