### PR TITLE
fix(cli): explain Windows symlink permissions during release activation

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -26,6 +26,7 @@ import {
   blueGreenSlotReady,
   findPackageRepoDir,
   isDkgMonorepoRoot,
+  hasErrorCode,
   resolveDkgConfigHome,
   SELECTABLE_SETUP_NETWORKS,
 } from '@origintrail-official/dkg-core';
@@ -2109,8 +2110,7 @@ export async function swapSlot(target: 'a' | 'b'): Promise<void> {
   try {
     await symlink(target, tmpLink);
   } catch (error) {
-    if (process.platform === 'win32' && error && typeof error === 'object'
-      && 'code' in error && error.code === 'EPERM') {
+    if (process.platform === 'win32' && hasErrorCode(error, 'EPERM')) {
       throw Object.assign(new Error(
         `Cannot create the DKG release-slot link at ${tmpLink}. Windows requires permission to create symbolic links. `
         + 'Enable Developer Mode in Windows Settings (search for "Developer Mode"), then retry the command. '

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -2106,7 +2106,20 @@ export async function swapSlot(target: 'a' | 'b'): Promise<void> {
   } catch { /* link doesn't exist yet */ }
 
   try { await unlink(tmpLink); } catch { /* ok if missing */ }
-  await symlink(target, tmpLink);
+  try {
+    await symlink(target, tmpLink);
+  } catch (error) {
+    if (process.platform === 'win32' && error && typeof error === 'object'
+      && 'code' in error && error.code === 'EPERM') {
+      throw Object.assign(new Error(
+        `Cannot create the DKG release-slot link at ${tmpLink}. Windows requires permission to create symbolic links. `
+        + 'Enable Developer Mode in Windows Settings (search for "Developer Mode"), then retry the command. '
+        + 'Alternatively, retry from an Administrator terminal. The active release was not changed.',
+        { cause: error },
+      ), { code: 'EPERM' });
+    }
+    throw error;
+  }
   await rename(tmpLink, currentLink);
   await writeFile(join(rDir, 'active'), target);
 }

--- a/packages/cli/test/slot-helpers.test.ts
+++ b/packages/cli/test/slot-helpers.test.ts
@@ -1,7 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, mkdir, writeFile, readFile, readlink, rm } from 'node:fs/promises';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, mkdir, writeFile, readFile, readlink, rm, symlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return { ...actual, symlink: vi.fn(actual.symlink) };
+});
 
 let tmpDir: string;
 let prevDkgHome: string | undefined;
@@ -99,6 +104,41 @@ describe('slot helpers', () => {
 
     expect(await readlink(join(rDir, 'current'))).toBe('a');
     expect((await readFile(join(rDir, 'active'), 'utf-8')).trim()).toBe('a');
+  });
+
+  it.each([
+    { platform: 'win32', code: 'EPERM', guidance: true },
+    { platform: 'darwin', code: 'EPERM', guidance: false },
+    { platform: 'win32', code: 'EACCES', guidance: false },
+  ])('preserves activation on $platform symlink $code and explains Windows privileges', async ({ platform, code, guidance }) => {
+    const { swapSlot, releasesDir, activeSlot } = await importHelpers();
+    const rDir = releasesDir();
+    await mkdir(join(rDir, 'a'), { recursive: true });
+    await mkdir(join(rDir, 'b'), { recursive: true });
+    await swapSlot('a');
+    const failure = Object.assign(new Error('symlink denied'), { code });
+    vi.mocked(symlink).mockRejectedValueOnce(failure);
+    const descriptor = Object.getOwnPropertyDescriptor(process, 'platform')!;
+    try {
+      Object.defineProperty(process, 'platform', { value: platform });
+      const attempt = swapSlot('b');
+      if (guidance) {
+        await expect(attempt).rejects.toMatchObject({
+          code: 'EPERM', cause: failure,
+          message: expect.stringContaining(`Cannot create the DKG release-slot link at ${join(rDir, 'current.tmp')}`),
+        });
+        await expect(attempt).rejects.toThrow('Enable Developer Mode');
+        await expect(attempt).rejects.toThrow('Administrator terminal');
+      } else {
+        await expect(attempt).rejects.toBe(failure);
+      }
+    } finally {
+      Object.defineProperty(process, 'platform', descriptor);
+    }
+    expect(await activeSlot()).toBe('a');
+    expect(await readFile(join(rDir, 'active'), 'utf8')).toBe('a');
+    await swapSlot('b');
+    expect(await activeSlot()).toBe('b');
   });
 
   it('repoDir() resolves to the current repo root', async () => {


### PR DESCRIPTION
When Windows refuses release-slot symlink creation with EPERM, explain how to enable Developer Mode or retry from an Administrator terminal. Include the link path and preserve the original error as the cause and EPERM as the code. Activation fails before changing the current release or active-slot marker.

This implements issue #33's actionable-diagnostic option. It retains the existing symlink/rename activation mechanism and still requires Windows symlink permission.

Validation: 16 slot-helper tests pass, including injected Windows EPERM, unchanged unrelated errors, preservation of the active release after failure and a successful retry. The filesystem operations run locally on macOS; the Windows permission error is injected. CLI build/type/package-boundary checks, repository lint and diff checks pass.

Closes #33.
