### PR TITLE
fix(p2p): retry empty identity responses as transport failures

### DIFF
--- a/packages/agent/src/p2p/network-admission-coordinator.ts
+++ b/packages/agent/src/p2p/network-admission-coordinator.ts
@@ -285,6 +285,16 @@ export class NetworkAdmissionCoordinator {
     }
   }
 
+  private transientProbeFailure(
+    remotePeer: CanonicalPeerId,
+    ctx: OperationContext,
+    message: string,
+  ): NetworkAdmissionProbeError {
+    this.admission.rememberRetryableProbeFailure(remotePeer, message, 'transient');
+    this.log?.warn(ctx, `Network identity probe for ${remotePeer.slice(-8)} failed retryably: ${message}`);
+    return new NetworkAdmissionProbeError(remotePeer, message);
+  }
+
   private async probePeer(
     remotePeer: CanonicalPeerId,
     ctx: OperationContext,
@@ -311,10 +321,6 @@ export class NetworkAdmissionCoordinator {
         new TextEncoder().encode(JSON.stringify(request)),
         { timeoutMs: this.probeTimeoutMs, signal },
       );
-      // A peer stopping mid-probe can close its stream before sending bytes.
-      // Treat that EOF like other interrupted transport attempts; no identity
-      // document arrived to justify the longer malformed-response cooldown.
-      if (response.byteLength === 0) throw new Error('identity probe ended without a response');
     } catch (err) {
       if (signal.aborted) throw abortErrorFromSignal(signal.reason);
       const message = err instanceof Error ? err.message : String(err);
@@ -327,11 +333,14 @@ export class NetworkAdmissionCoordinator {
       // reject a healthy restarting peer across *every* protocol for minutes
       // (the admission gate is protocol-agnostic). The exponential transient
       // backoff lets a booting peer recover on its next probe instead.
-      this.admission.rememberRetryableProbeFailure(remotePeer, message, 'transient');
-      this.log?.warn(ctx, `Network identity probe for ${remotePeer.slice(-8)} failed retryably: ${message}`);
-      throw new NetworkAdmissionProbeError(remotePeer, message);
+      throw this.transientProbeFailure(remotePeer, ctx, message);
     }
     if (signal.aborted) throw abortErrorFromSignal(signal.reason);
+    // A stream can close before sending an identity document. This is retryable
+    // transport interruption; only a nonempty malformed document is unreadable.
+    if (response.byteLength === 0) {
+      throw this.transientProbeFailure(remotePeer, ctx, 'identity probe ended without a response');
+    }
 
     let claimed: unknown;
     try {

--- a/packages/agent/src/p2p/network-admission-coordinator.ts
+++ b/packages/agent/src/p2p/network-admission-coordinator.ts
@@ -285,14 +285,14 @@ export class NetworkAdmissionCoordinator {
     }
   }
 
-  private transientProbeFailure(
+  private throwTransientProbeFailure(
     remotePeer: CanonicalPeerId,
     ctx: OperationContext,
     message: string,
-  ): NetworkAdmissionProbeError {
+  ): never {
     this.admission.rememberRetryableProbeFailure(remotePeer, message, 'transient');
     this.log?.warn(ctx, `Network identity probe for ${remotePeer.slice(-8)} failed retryably: ${message}`);
-    return new NetworkAdmissionProbeError(remotePeer, message);
+    throw new NetworkAdmissionProbeError(remotePeer, message);
   }
 
   private async probePeer(
@@ -333,13 +333,13 @@ export class NetworkAdmissionCoordinator {
       // reject a healthy restarting peer across *every* protocol for minutes
       // (the admission gate is protocol-agnostic). The exponential transient
       // backoff lets a booting peer recover on its next probe instead.
-      throw this.transientProbeFailure(remotePeer, ctx, message);
+      this.throwTransientProbeFailure(remotePeer, ctx, message);
     }
     if (signal.aborted) throw abortErrorFromSignal(signal.reason);
     // A stream can close before sending an identity document. This is retryable
     // transport interruption; only a nonempty malformed document is unreadable.
     if (response.byteLength === 0) {
-      throw this.transientProbeFailure(remotePeer, ctx, 'identity probe ended without a response');
+      this.throwTransientProbeFailure(remotePeer, ctx, 'identity probe ended without a response');
     }
 
     let claimed: unknown;

--- a/packages/agent/src/p2p/network-admission-coordinator.ts
+++ b/packages/agent/src/p2p/network-admission-coordinator.ts
@@ -311,6 +311,10 @@ export class NetworkAdmissionCoordinator {
         new TextEncoder().encode(JSON.stringify(request)),
         { timeoutMs: this.probeTimeoutMs, signal },
       );
+      // A peer stopping mid-probe can close its stream before sending bytes.
+      // Treat that EOF like other interrupted transport attempts; no identity
+      // document arrived to justify the longer malformed-response cooldown.
+      if (response.byteLength === 0) throw new Error('identity probe ended without a response');
     } catch (err) {
       if (signal.aborted) throw abortErrorFromSignal(signal.reason);
       const message = err instanceof Error ? err.message : String(err);

--- a/packages/agent/test/network-admission-coordinator.test.ts
+++ b/packages/agent/test/network-admission-coordinator.test.ts
@@ -330,6 +330,44 @@ describe('NetworkAdmissionCoordinator', () => {
     expect(sendIdentityProbe).toHaveBeenCalledTimes(3);
   });
 
+  it('retries empty identity responses on the bounded transport schedule and requires a signed proof', async () => {
+    let now = 1_000;
+    let attempts = 0;
+    const sendIdentityProbe = vi.fn(async (_peerId: string, data: Uint8Array) => {
+      if (++attempts <= 3) return new Uint8Array();
+      const response = await signNetworkIdentityResponse({
+        request: JSON.parse(new TextDecoder().decode(data)),
+        identity,
+        responderPeerId: REMOTE_PEER_ID,
+        sign: (payload) => ed25519Sign(payload, REMOTE_PRIVATE_KEY_SEED),
+      });
+      return new TextEncoder().encode(JSON.stringify(response));
+    });
+    const fixture = buildCoordinator({
+      identity, sendIdentityProbe, now: () => now,
+      probeBackoff: { transientBaseMs: 100, transientMaxMs: 150 },
+    });
+    for (const [index, delay] of [100, 150, 150].entries()) {
+      await expect(fixture.coordinator.ensureAdmitted(REMOTE_PEER_ID, createOperationContext('connect')))
+        .rejects.toMatchObject({ code: 'NETWORK_ADMISSION_PROBE_FAILED' });
+      expect(fixture.admission.getRetryableProbeBackoff(REMOTE_PEER_ID))
+        .toMatchObject({ kind: 'transient', retryAfterMs: delay, failures: index + 1 });
+      expect(fixture.coordinator.isAcceptedPeer(REMOTE_PEER_ID)).toBe(false);
+      expect(fixture.coordinator.isRejectedPeer(REMOTE_PEER_ID)).toBe(false);
+      now += delay - 1;
+      await expect(fixture.coordinator.ensureAdmitted(REMOTE_PEER_ID, createOperationContext('connect')))
+        .rejects.toMatchObject({ code: 'NETWORK_ADMISSION_PROBE_FAILED' });
+      expect(sendIdentityProbe).toHaveBeenCalledTimes(index + 1);
+      now += 1;
+    }
+    await expect(fixture.coordinator.ensureAdmitted(REMOTE_PEER_ID, createOperationContext('connect')))
+      .resolves.toBe(true);
+    expect(sendIdentityProbe).toHaveBeenCalledTimes(4);
+    expect(fixture.admission.getRetryableProbeBackoff(REMOTE_PEER_ID)).toBeUndefined();
+    expect(fixture.coordinator.isAcceptedPeer(REMOTE_PEER_ID)).toBe(true);
+    expect(fixture.deletePeerFromPeerStore).not.toHaveBeenCalled();
+  });
+
   it('uses unreadable-response backoff before retrying malformed probe responses', async () => {
     let now = 1_000;
     const sendIdentityProbe = vi.fn(async () => new TextEncoder().encode('REMOTE_SENTINEL_NOT_JSON'));

--- a/packages/agent/test/network-admission-coordinator.test.ts
+++ b/packages/agent/test/network-admission-coordinator.test.ts
@@ -330,44 +330,6 @@ describe('NetworkAdmissionCoordinator', () => {
     expect(sendIdentityProbe).toHaveBeenCalledTimes(3);
   });
 
-  it('retries empty identity responses on the bounded transport schedule and requires a signed proof', async () => {
-    let now = 1_000;
-    let attempts = 0;
-    const sendIdentityProbe = vi.fn(async (_peerId: string, data: Uint8Array) => {
-      if (++attempts <= 3) return new Uint8Array();
-      const response = await signNetworkIdentityResponse({
-        request: JSON.parse(new TextDecoder().decode(data)),
-        identity,
-        responderPeerId: REMOTE_PEER_ID,
-        sign: (payload) => ed25519Sign(payload, REMOTE_PRIVATE_KEY_SEED),
-      });
-      return new TextEncoder().encode(JSON.stringify(response));
-    });
-    const fixture = buildCoordinator({
-      identity, sendIdentityProbe, now: () => now,
-      probeBackoff: { transientBaseMs: 100, transientMaxMs: 150 },
-    });
-    for (const [index, delay] of [100, 150, 150].entries()) {
-      await expect(fixture.coordinator.ensureAdmitted(REMOTE_PEER_ID, createOperationContext('connect')))
-        .rejects.toMatchObject({ code: 'NETWORK_ADMISSION_PROBE_FAILED' });
-      expect(fixture.admission.getRetryableProbeBackoff(REMOTE_PEER_ID))
-        .toMatchObject({ kind: 'transient', retryAfterMs: delay, failures: index + 1 });
-      expect(fixture.coordinator.isAcceptedPeer(REMOTE_PEER_ID)).toBe(false);
-      expect(fixture.coordinator.isRejectedPeer(REMOTE_PEER_ID)).toBe(false);
-      now += delay - 1;
-      await expect(fixture.coordinator.ensureAdmitted(REMOTE_PEER_ID, createOperationContext('connect')))
-        .rejects.toMatchObject({ code: 'NETWORK_ADMISSION_PROBE_FAILED' });
-      expect(sendIdentityProbe).toHaveBeenCalledTimes(index + 1);
-      now += 1;
-    }
-    await expect(fixture.coordinator.ensureAdmitted(REMOTE_PEER_ID, createOperationContext('connect')))
-      .resolves.toBe(true);
-    expect(sendIdentityProbe).toHaveBeenCalledTimes(4);
-    expect(fixture.admission.getRetryableProbeBackoff(REMOTE_PEER_ID)).toBeUndefined();
-    expect(fixture.coordinator.isAcceptedPeer(REMOTE_PEER_ID)).toBe(true);
-    expect(fixture.deletePeerFromPeerStore).not.toHaveBeenCalled();
-  });
-
   it('uses unreadable-response backoff before retrying malformed probe responses', async () => {
     let now = 1_000;
     const sendIdentityProbe = vi.fn(async () => new TextEncoder().encode('REMOTE_SENTINEL_NOT_JSON'));
@@ -670,11 +632,14 @@ describe('NetworkAdmissionCoordinator', () => {
     expect(sendIdentityProbe).toHaveBeenCalledTimes(2);
   });
 
-  it('clears cached retry backoff after a successful signed probe', async () => {
+  it.each(['transport error', 'empty response'])('clears transient backoff after %s and a successful signed probe', async (failure) => {
     let attempt = 0;
     const sendIdentityProbe = vi.fn(async (_peerId: string, data: Uint8Array) => {
       attempt += 1;
-      if (attempt === 1) throw new Error('stream timeout');
+      if (attempt === 1) {
+        if (failure === 'empty response') return new Uint8Array();
+        throw new Error('stream timeout');
+      }
 
       const request = JSON.parse(new TextDecoder().decode(data));
       const response = await signNetworkIdentityResponse({
@@ -690,7 +655,9 @@ describe('NetworkAdmissionCoordinator', () => {
     await expect(
       fixture.coordinator.ensureAdmitted(REMOTE_PEER_ID, createOperationContext('connect')),
     ).rejects.toMatchObject({ code: 'NETWORK_ADMISSION_PROBE_FAILED' });
-    expect(fixture.admission.getRetryableProbeBackoff(REMOTE_PEER_ID)).toBeDefined();
+    expect(fixture.admission.getRetryableProbeBackoff(REMOTE_PEER_ID)).toMatchObject({ kind: 'transient' });
+    expect(fixture.coordinator.isAcceptedPeer(REMOTE_PEER_ID)).toBe(false);
+    expect(fixture.coordinator.isRejectedPeer(REMOTE_PEER_ID)).toBe(false);
 
     await expect(
       fixture.coordinator.ensureExplicitConnectAdmitted(


### PR DESCRIPTION
An identity-probe stream interrupted during peer shutdown can end without response bytes. Parsing that empty result as malformed JSON imposes a 60-second cooldown on the restarted peer, which has repeatedly blocked the selected-private catalog recovery CI test.

Classify a zero-byte response as an interrupted transport attempt, using the existing exponential retry schedule and cap. Nonempty malformed documents retain their existing cooldown. Admission still requires a valid signed network-identity proof.

Validation: the empty-response regression fails on canary with the 60-second cooldown and passes with this change. All 41 admission/coordinator/retry tests pass. The existing signed-recovery case covers both a transport exception and an empty response; the existing schedule tests retain suppression and exponential-cap coverage. Transport exceptions and empty responses explicitly share one throwing transient-failure helper (`never` return type), so recording backoff and throwing cannot diverge. The original real-libp2p selected-private restart scenario also passes locally (one selected test; its timing race was not forced in that run). Agent build/declarations, lint and SPARQL diff checks pass.

Closes #2507.
