### PR TITLE
test(openclaw): preserve literal Unicode escapes in memory search

### DIFF
--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -48,7 +48,8 @@
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.0.18",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "@origintrail-official/dkg-storage": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/adapter-openclaw/src/DkgMemoryPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgMemoryPlugin.ts
@@ -29,6 +29,7 @@
  * `21_TRI_MODAL_MEMORY.md §5`.
  */
 
+import { sparqlString } from '@origintrail-official/dkg-core';
 import type { DkgDaemonClient } from './dkg-client.js';
 import type {
   DkgOpenClawConfig,
@@ -224,7 +225,7 @@ export class DkgMemorySearchManager implements MemorySearchManager {
       return [];
     }
     const filter = keywords
-      .map(k => `CONTAINS(LCASE(STR(?text)), "${escapeSparqlString(k)}")`)
+      .map(k => `CONTAINS(LCASE(STR(?text)), ${sparqlString(k)})`)
       .join(' || ');
 
     // Permissive SPARQL shape: find any subject with any literal object of
@@ -1104,13 +1105,4 @@ function bindingValue(v: unknown): string | undefined {
     return v;
   }
   return String(v);
-}
-
-function escapeSparqlString(value: string): string {
-  return value
-    .replace(/\\/g, '\\\\')
-    .replace(/"/g, '\\"')
-    .replace(/\n/g, '\\n')
-    .replace(/\r/g, '\\r')
-    .replace(/\t/g, '\\t');
 }

--- a/packages/adapter-openclaw/test/memory-search-literal-safety.test.ts
+++ b/packages/adapter-openclaw/test/memory-search-literal-safety.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { DkgMemorySearchManager } from '../src/DkgMemoryPlugin.js';
+import { DkgDaemonClient } from '../src/dkg-client.js';
+
+const searchTerms = [
+  String.raw`\u0022`,
+  String.raw`\U00000022`,
+  String.raw`\u0061`,
+  String.raw`\u005c\u0022`,
+  String.raw`\\u0022`,
+  String.raw`\\\u0022`,
+  String.raw`\u0022)||true||(\u0022`,
+  '")||true||("',
+  'needle"#suffix',
+  String.raw`folder\memory`,
+  'café',
+  'Привет',
+  '🧠📚',
+];
+
+afterEach(() => vi.restoreAllMocks());
+
+it.each(searchTerms)('searches %j as literal text using the real SPARQL parser', async (term) => {
+  const store = new OxigraphStore();
+  const client = new DkgDaemonClient({ baseUrl: 'http://127.0.0.1:1' });
+  const warn = vi.fn();
+  const returnedSubjects: string[][] = [];
+  try {
+    const texts = [
+      ['target', `Matching memory record contains ${term} in ordinary text.`],
+      ['unrelated', 'Unrelated memory record contains a plain " quote and alphabetic text.'],
+    ];
+    // Encode fixture RDF independently of the search expression builder.
+    await store.insert(texts.map(([id, text]) => ({
+      subject: `urn:memory:${id}`, predicate: 'urn:memory:text',
+      object: JSON.stringify(text), graph: '',
+    })));
+    // Keep transport/view routing outside this parser witness; execute every
+    // production-generated search expression against a real isolated dataset.
+    const query = vi.spyOn(client, 'query').mockImplementation(async (sparql) => {
+      const result = await store.query(sparql);
+      if (result.type !== 'bindings') throw new Error('Expected SELECT bindings');
+      returnedSubjects.push(result.bindings.map((row) => row.uri));
+      return { result };
+    });
+    const manager = new DkgMemorySearchManager({
+      client, logger: { warn, info: vi.fn(), debug: vi.fn() },
+      resolver: {
+        getSession: () => ({ agentAddress: 'peer-literal-test' }),
+        getDefaultAgentAddress: () => 'peer-literal-test',
+        listAvailableContextGraphs: () => [],
+      },
+    });
+    const results = await manager.search(term);
+    expect(query).toHaveBeenCalledTimes(3);
+    expect(warn).not.toHaveBeenCalled();
+    expect(returnedSubjects).toEqual(Array.from({ length: 3 }, () => ['urn:memory:target']));
+    expect(results).toHaveLength(1);
+    expect(results[0].snippet).toContain('Matching memory record');
+    expect(results[0].layer).toBe('agent-context-vm');
+  } finally {
+    await store.close();
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -545,6 +545,9 @@ importers:
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      '@origintrail-official/dkg-storage':
+        specifier: workspace:*
+        version: link:../storage
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))


### PR DESCRIPTION
OpenClaw memory search had its own SPARQL string escaper and no parser-level coverage for the Unicode escape sequences raised in #173. Use the existing Core `sparqlString` helper and remove the duplicate escaping implementation.

Thirteen regression cases execute the actual generated search queries against an isolated Oxigraph dataset. They cover literal `\u0022`/`\U00000022`, backslash parity, encoded backslashes, quote/filter/comment payloads and ordinary Unicode. Each search must select only the matching record, preserve the three-layer fan-out and deduplication, and emit no query-error warning. Storage is a test-only workspace dependency.

The preceding implementation already passes these cases: this consolidates escaping and supplies the requested regression coverage; it does not claim a newly reproduced injection vulnerability. Validation uses the real SPARQL parser, with daemon transport/view routing outside this test's scope.

Validation: 96 tests across four memory suites pass, including the 13 new parser cases. Removing backslash doubling makes the targeted witness fail. Adapter build, focused test-fixture type checking, lint, test inventory and SPARQL checks pass.

Closes #173.
