### PR TITLE
fix(agent): stabilize scoped catalog replay snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ A default-responsibility RFC-64 release. For persistent nodes, when RFC-64 contr
 
 ### Fixed
 
+- Scoped catalog replay now acquires the relevant author mutation locks before refreshing its replay snapshot, then revalidates that snapshot before reporting completion. A catalog head that advances while replay is waiting for a lock can therefore be replayed from current durable state instead of leaving an otherwise converged receiver fenced with unavailable expected-head evidence.
 - Omitted-deployment catalog authority and author inventory use the chain adapter's namespaced network identity, matching deterministic KA UALs instead of the unrelated DKG genesis hash; post-commit inventory warnings retain their bounded cause chain for operator diagnosis.
 - Local devnet snapshot storage keeps capacity admission with explicit low-disk watermarks, avoiding dependence on production-scale free-space reserves during release certification.
 - Subscription catch-up re-evaluates RFC-64 responsibility after authoritative metadata lands, so a cold Edge join cannot remain fully synced but absent from the default catalog status until restart.

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -35,6 +35,7 @@
     "./dist/rfc64/swm-catalog-durable-asset-resolver-v1.js": null,
     "./dist/rfc64/abort-v1.js": null,
     "./dist/rfc64/catalog-mutation-runtime-v1.js": null,
+    "./dist/rfc64/catalog-replay-snapshot-runtime-v1.js": null,
     "./dist/rfc64/catalog-runtime-v1.js": null,
     "./dist/rfc64/coalescing-supervisor-v1.js": null,
     "./dist/rfc64/supervisor-status-v1.js": null,

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -318,6 +318,7 @@ const blockedRfc64Modules = [
   'swm-inventory-shadow-runtime-v1.js',
   'abort-v1.js',
   'catalog-mutation-runtime-v1.js',
+  'catalog-replay-snapshot-runtime-v1.js',
   'catalog-runtime-v1.js',
   'coalescing-supervisor-v1.js',
   'supervisor-status-v1.js',

--- a/packages/agent/src/dkg-agent-rfc64-catalog.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog.ts
@@ -519,6 +519,27 @@ function rfc64CatalogReplayMutationScopeKeyV1(
   return `${computeAuthorCatalogScopeDigestV1(scope)}\0${scope.authorAddress}`;
 }
 
+interface Rfc64CatalogReplaySnapshotSessionV1 {
+  readonly entries: readonly Rfc64CatalogReplayHeadV1[];
+  assertUnchanged(): Promise<void>;
+}
+
+interface Rfc64CatalogReplaySnapshotPlanV1 {
+  readonly mutationScopes: readonly Readonly<AuthorCatalogScopeV1>[];
+  openLockedSnapshot(): Promise<Readonly<Rfc64CatalogReplaySnapshotSessionV1>>;
+}
+
+function rfc64CatalogReplayMutationScopesV1(
+  entries: readonly Rfc64CatalogReplayHeadV1[],
+): readonly Readonly<AuthorCatalogScopeV1>[] {
+  return [...new Map(entries.map(({ head }) => {
+    const scope = deriveAuthorCatalogScopeFromHeadV1(head.payload);
+    return [rfc64CatalogReplayMutationScopeKeyV1(scope), scope] as const;
+  })).entries()]
+    .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
+    .map(([, scope]) => scope);
+}
+
 type Rfc64CatalogReplayAdmissionV1 = Readonly<{
   status: 'admitted';
   /** True only for the caller that created and owns the unique completion. */
@@ -2685,6 +2706,83 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
     return runtime.indexByScope;
   }
 
+  private async prepareRfc64CatalogReplaySnapshotPlanV1(
+    this: DKGAgent,
+    persistence: Rfc64PersistenceV1,
+    requestedScope?: Readonly<Rfc64PublicCatalogHeadReplayRequestV1>,
+  ): Promise<Readonly<Rfc64CatalogReplaySnapshotPlanV1>> {
+    if (requestedScope === undefined) {
+      const inventoryFingerprint = rfc64CatalogReplayInventoryFingerprintV1(
+        persistence.inventory.listAppliedCatalogHeadsV1(),
+      );
+      const entries = Object.freeze([
+        ...(await this.readRfc64CatalogReplayIndexV1()).values(),
+      ].flat());
+      return Object.freeze({
+        mutationScopes: Object.freeze(rfc64CatalogReplayMutationScopesV1(entries)),
+        openLockedSnapshot: async () => {
+          if (rfc64CatalogReplayInventoryFingerprintV1(
+            persistence.inventory.listAppliedCatalogHeadsV1(),
+          ) !== inventoryFingerprint) {
+            throw new Error('RFC-64 durable catalog inventory changed before replay snapshot');
+          }
+          return Object.freeze({
+            entries,
+            assertUnchanged: async () => {
+              if (rfc64CatalogReplayInventoryFingerprintV1(
+                persistence.inventory.listAppliedCatalogHeadsV1(),
+              ) !== inventoryFingerprint) {
+                throw new Error('RFC-64 durable catalog inventory changed during replay');
+              }
+            },
+          });
+        },
+      });
+    }
+
+    const replayScopeKey = rfc64CatalogReplayScopeKeyV1(
+      requestedScope.networkId,
+      requestedScope.contextGraphId,
+    );
+    const discoveredEntries = (await this.readRfc64CatalogReplayIndexV1())
+      .get(replayScopeKey) ?? [];
+    const mutationScopes = Object.freeze(
+      rfc64CatalogReplayMutationScopesV1(discoveredEntries),
+    );
+    const lockedScopeKeys = new Set(mutationScopes.map(
+      (scope) => rfc64CatalogReplayMutationScopeKeyV1(scope),
+    ));
+    return Object.freeze({
+      mutationScopes,
+      openLockedSnapshot: async () => {
+        // Discovery identifies the author scopes to lock. Refresh only after
+        // those locks are held so a same-author head advance that raced lock
+        // acquisition is part of this replay snapshot.
+        const entries = (await this.readRfc64CatalogReplayIndexV1())
+          .get(replayScopeKey) ?? [];
+        if (entries.some(({ head }) => !lockedScopeKeys.has(
+          rfc64CatalogReplayMutationScopeKeyV1(
+            deriveAuthorCatalogScopeFromHeadV1(head.payload),
+          ),
+        ))) {
+          throw new Error('RFC-64 scoped catalog inventory changed before replay snapshot');
+        }
+        const entriesFingerprint = rfc64CatalogReplayEntriesFingerprintV1(entries);
+        return Object.freeze({
+          entries,
+          assertUnchanged: async () => {
+            const currentEntries = (await this.readRfc64CatalogReplayIndexV1())
+              .get(replayScopeKey) ?? [];
+            if (rfc64CatalogReplayEntriesFingerprintV1(currentEntries)
+              !== entriesFingerprint) {
+              throw new Error('RFC-64 scoped catalog inventory changed during replay');
+            }
+          },
+        });
+      },
+    });
+  }
+
   async reannounceRfc64CatalogHeadsToPeerV1(
     this: DKGAgent,
     peerId: string,
@@ -2700,35 +2798,15 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
     }
     let announced = 0;
     let failed = 0;
-    const replayInventoryFingerprint = requestedScope === undefined
-      ? rfc64CatalogReplayInventoryFingerprintV1(
-          persistence.inventory.listAppliedCatalogHeadsV1(),
-        )
-      : null;
-    const index = await this.readRfc64CatalogReplayIndexV1();
-    const replayScopeKey = requestedScope === undefined
-      ? null
-      : rfc64CatalogReplayScopeKeyV1(
-          requestedScope.networkId,
-          requestedScope.contextGraphId,
-        );
-    const entries = replayScopeKey === null
-      ? [...index.values()].flat()
-      : index.get(replayScopeKey) ?? [];
-    const replayScopes = [...new Map(entries.map(({ head }) => {
-      const scope = deriveAuthorCatalogScopeFromHeadV1(head.payload);
-      return [
-        rfc64CatalogReplayMutationScopeKeyV1(scope),
-        scope,
-      ] as const;
-    })).entries()]
-      .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
-      .map(([, scope]) => scope);
+    const snapshotPlan = await this.prepareRfc64CatalogReplaySnapshotPlanV1(
+      persistence,
+      requestedScope,
+    );
     const runWithReplayScopesLocked = async <T>(
       scopeIndex: number,
       operation: () => Promise<T>,
     ): Promise<T> => {
-      const scope = replayScopes[scopeIndex];
+      const scope = snapshotPlan.mutationScopes[scopeIndex];
       if (scope === undefined) return operation();
       return this.rfc64CatalogMutationCoordinatorV1.run(
         scope,
@@ -2736,35 +2814,9 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
       );
     };
     return runWithReplayScopesLocked(0, async () => {
-      let replayEntries = entries;
-      let scopedReplayFingerprint: string | null = null;
-      if (replayScopeKey === null) {
-        if (rfc64CatalogReplayInventoryFingerprintV1(
-          persistence.inventory.listAppliedCatalogHeadsV1(),
-        ) !== replayInventoryFingerprint) {
-          throw new Error('RFC-64 durable catalog inventory changed before replay snapshot');
-        }
-      } else {
-        // The first index read discovers the author scopes whose mutation locks
-        // must be held. Once they are held, refresh the requested CG so a head
-        // advance that raced lock acquisition is replayed instead of leaving
-        // the receiver permanently fenced until a later peer event.
-        replayEntries = (await this.readRfc64CatalogReplayIndexV1())
-          .get(replayScopeKey) ?? [];
-        const lockedScopes = new Set(replayScopes.map(
-          (scope) => rfc64CatalogReplayMutationScopeKeyV1(scope),
-        ));
-        if (replayEntries.some(({ head }) => !lockedScopes.has(
-          rfc64CatalogReplayMutationScopeKeyV1(
-            deriveAuthorCatalogScopeFromHeadV1(head.payload),
-          ),
-        ))) {
-          throw new Error('RFC-64 scoped catalog inventory changed before replay snapshot');
-        }
-        scopedReplayFingerprint = rfc64CatalogReplayEntriesFingerprintV1(replayEntries);
-      }
+      const replaySnapshot = await snapshotPlan.openLockedSnapshot();
       const manifest: Rfc64PublicCatalogHeadAnnouncementV1[] = [];
-      for (const { head } of replayEntries) {
+      for (const { head } of replaySnapshot.entries) {
         const servingAuthority = this.resolveRfc64CatalogServingAuthorityV1(
           head.payload.contextGraphId,
         );
@@ -2824,20 +2876,7 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
           failed += 1;
         }
       }
-      if (replayScopeKey === null) {
-        if (rfc64CatalogReplayInventoryFingerprintV1(
-          persistence.inventory.listAppliedCatalogHeadsV1(),
-        ) !== replayInventoryFingerprint) {
-          throw new Error('RFC-64 durable catalog inventory changed during replay');
-        }
-      } else {
-        const currentEntries = (await this.readRfc64CatalogReplayIndexV1())
-          .get(replayScopeKey) ?? [];
-        if (rfc64CatalogReplayEntriesFingerprintV1(currentEntries)
-          !== scopedReplayFingerprint) {
-          throw new Error('RFC-64 scoped catalog inventory changed during replay');
-        }
-      }
+      await replaySnapshot.assertUnchanged();
       return Object.freeze({
         announced,
         failed,

--- a/packages/agent/src/dkg-agent-rfc64-catalog.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog.ts
@@ -500,6 +500,25 @@ function rfc64CatalogReplayInventoryFingerprintV1(
     .join('\n');
 }
 
+function rfc64CatalogReplayEntriesFingerprintV1(
+  entries: readonly Rfc64CatalogReplayHeadV1[],
+): string {
+  return entries
+    .map(({ head }) => [
+      computeAuthorCatalogScopeDigestV1(deriveAuthorCatalogScopeFromHeadV1(head.payload)),
+      head.payload.authorAddress,
+      head.objectDigest,
+    ].join(':'))
+    .sort()
+    .join('\n');
+}
+
+function rfc64CatalogReplayMutationScopeKeyV1(
+  scope: Readonly<AuthorCatalogScopeV1>,
+): string {
+  return `${computeAuthorCatalogScopeDigestV1(scope)}\0${scope.authorAddress}`;
+}
+
 type Rfc64CatalogReplayAdmissionV1 = Readonly<{
   status: 'admitted';
   /** True only for the caller that created and owns the unique completion. */
@@ -2681,20 +2700,25 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
     }
     let announced = 0;
     let failed = 0;
-    const replayInventoryFingerprint = rfc64CatalogReplayInventoryFingerprintV1(
-      persistence.inventory.listAppliedCatalogHeadsV1(),
-    );
+    const replayInventoryFingerprint = requestedScope === undefined
+      ? rfc64CatalogReplayInventoryFingerprintV1(
+          persistence.inventory.listAppliedCatalogHeadsV1(),
+        )
+      : null;
     const index = await this.readRfc64CatalogReplayIndexV1();
-    const entries = requestedScope === undefined
+    const replayScopeKey = requestedScope === undefined
+      ? null
+      : rfc64CatalogReplayScopeKeyV1(
+          requestedScope.networkId,
+          requestedScope.contextGraphId,
+        );
+    const entries = replayScopeKey === null
       ? [...index.values()].flat()
-      : index.get(rfc64CatalogReplayScopeKeyV1(
-        requestedScope.networkId,
-        requestedScope.contextGraphId,
-      )) ?? [];
+      : index.get(replayScopeKey) ?? [];
     const replayScopes = [...new Map(entries.map(({ head }) => {
       const scope = deriveAuthorCatalogScopeFromHeadV1(head.payload);
       return [
-        `${computeAuthorCatalogScopeDigestV1(scope)}\0${scope.authorAddress}`,
+        rfc64CatalogReplayMutationScopeKeyV1(scope),
         scope,
       ] as const;
     })).entries()]
@@ -2712,13 +2736,35 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
       );
     };
     return runWithReplayScopesLocked(0, async () => {
-      if (rfc64CatalogReplayInventoryFingerprintV1(
-        persistence.inventory.listAppliedCatalogHeadsV1(),
-      ) !== replayInventoryFingerprint) {
-        throw new Error('RFC-64 durable catalog inventory changed before replay snapshot');
+      let replayEntries = entries;
+      let scopedReplayFingerprint: string | null = null;
+      if (replayScopeKey === null) {
+        if (rfc64CatalogReplayInventoryFingerprintV1(
+          persistence.inventory.listAppliedCatalogHeadsV1(),
+        ) !== replayInventoryFingerprint) {
+          throw new Error('RFC-64 durable catalog inventory changed before replay snapshot');
+        }
+      } else {
+        // The first index read discovers the author scopes whose mutation locks
+        // must be held. Once they are held, refresh the requested CG so a head
+        // advance that raced lock acquisition is replayed instead of leaving
+        // the receiver permanently fenced until a later peer event.
+        replayEntries = (await this.readRfc64CatalogReplayIndexV1())
+          .get(replayScopeKey) ?? [];
+        const lockedScopes = new Set(replayScopes.map(
+          (scope) => rfc64CatalogReplayMutationScopeKeyV1(scope),
+        ));
+        if (replayEntries.some(({ head }) => !lockedScopes.has(
+          rfc64CatalogReplayMutationScopeKeyV1(
+            deriveAuthorCatalogScopeFromHeadV1(head.payload),
+          ),
+        ))) {
+          throw new Error('RFC-64 scoped catalog inventory changed before replay snapshot');
+        }
+        scopedReplayFingerprint = rfc64CatalogReplayEntriesFingerprintV1(replayEntries);
       }
       const manifest: Rfc64PublicCatalogHeadAnnouncementV1[] = [];
-      for (const { head } of entries) {
+      for (const { head } of replayEntries) {
         const servingAuthority = this.resolveRfc64CatalogServingAuthorityV1(
           head.payload.contextGraphId,
         );
@@ -2778,10 +2824,19 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
           failed += 1;
         }
       }
-      if (rfc64CatalogReplayInventoryFingerprintV1(
-        persistence.inventory.listAppliedCatalogHeadsV1(),
-      ) !== replayInventoryFingerprint) {
-        throw new Error('RFC-64 durable catalog inventory changed during replay');
+      if (replayScopeKey === null) {
+        if (rfc64CatalogReplayInventoryFingerprintV1(
+          persistence.inventory.listAppliedCatalogHeadsV1(),
+        ) !== replayInventoryFingerprint) {
+          throw new Error('RFC-64 durable catalog inventory changed during replay');
+        }
+      } else {
+        const currentEntries = (await this.readRfc64CatalogReplayIndexV1())
+          .get(replayScopeKey) ?? [];
+        if (rfc64CatalogReplayEntriesFingerprintV1(currentEntries)
+          !== scopedReplayFingerprint) {
+          throw new Error('RFC-64 scoped catalog inventory changed during replay');
+        }
       }
       return Object.freeze({
         announced,

--- a/packages/agent/src/dkg-agent-rfc64-catalog.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog.ts
@@ -143,6 +143,12 @@ import {
 } from './rfc64/release-native-catalog-authority-v1.js';
 import { readRfc64LegacySwmBoundaryCountV1 } from
   './rfc64/legacy-swm-boundary-v1.js';
+import {
+  rfc64CatalogReplayInventoryFingerprintV1,
+  rfc64CatalogReplayScopeKeyV1,
+  withLockedRfc64CatalogReplaySnapshotV1,
+  type Rfc64CatalogReplayHeadV1,
+} from './rfc64/catalog-replay-snapshot-runtime-v1.js';
 
 /** Minimal EIP-191 EOA signer (ethers.Wallet-compatible) for author-catalog objects. */
 export interface Rfc64CatalogAuthorSignerV1 {
@@ -466,10 +472,6 @@ export const RFC64_CATALOG_TARGET_MAX_ENTRIES_V1 = 1_024;
 export const RFC64_CATALOG_TARGET_MAX_ENTRIES_PER_CONTEXT_GRAPH_V1 = 64;
 export const RFC64_CATALOG_TARGET_MAX_CONTEXT_OVERFLOWS_V1 = 64;
 
-interface Rfc64CatalogReplayHeadV1 {
-  readonly head: SignedAuthorCatalogHeadEnvelopeV1;
-}
-
 interface Rfc64CatalogReplayRuntimeV1 {
   tail: Promise<void>;
   readonly pending: Map<string, Promise<Readonly<Rfc64CatalogReplayResultV1>>>;
@@ -482,62 +484,6 @@ interface Rfc64CatalogReplayResultV1 {
   readonly announced: number;
   readonly failed: number;
   readonly manifest: readonly Rfc64PublicCatalogHeadAnnouncementV1[];
-}
-
-function rfc64CatalogReplayInventoryFingerprintV1(
-  snapshots: readonly AppliedCatalogHeadSnapshotV1[],
-): string {
-  return snapshots
-    .map((snapshot) => [
-      snapshot.catalogScopeDigest,
-      snapshot.authorAddress,
-      snapshot.currentCatalogHeadDigest,
-      snapshot.appliedInventoryDigest,
-      snapshot.catalogVersion,
-      snapshot.inventoryRowCount,
-    ].join(':'))
-    .sort()
-    .join('\n');
-}
-
-function rfc64CatalogReplayEntriesFingerprintV1(
-  entries: readonly Rfc64CatalogReplayHeadV1[],
-): string {
-  return entries
-    .map(({ head }) => [
-      computeAuthorCatalogScopeDigestV1(deriveAuthorCatalogScopeFromHeadV1(head.payload)),
-      head.payload.authorAddress,
-      head.objectDigest,
-    ].join(':'))
-    .sort()
-    .join('\n');
-}
-
-function rfc64CatalogReplayMutationScopeKeyV1(
-  scope: Readonly<AuthorCatalogScopeV1>,
-): string {
-  return `${computeAuthorCatalogScopeDigestV1(scope)}\0${scope.authorAddress}`;
-}
-
-interface Rfc64CatalogReplaySnapshotSessionV1 {
-  readonly entries: readonly Rfc64CatalogReplayHeadV1[];
-  assertUnchanged(): Promise<void>;
-}
-
-interface Rfc64CatalogReplaySnapshotPlanV1 {
-  readonly mutationScopes: readonly Readonly<AuthorCatalogScopeV1>[];
-  openLockedSnapshot(): Promise<Readonly<Rfc64CatalogReplaySnapshotSessionV1>>;
-}
-
-function rfc64CatalogReplayMutationScopesV1(
-  entries: readonly Rfc64CatalogReplayHeadV1[],
-): readonly Readonly<AuthorCatalogScopeV1>[] {
-  return [...new Map(entries.map(({ head }) => {
-    const scope = deriveAuthorCatalogScopeFromHeadV1(head.payload);
-    return [rfc64CatalogReplayMutationScopeKeyV1(scope), scope] as const;
-  })).entries()]
-    .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
-    .map(([, scope]) => scope);
 }
 
 type Rfc64CatalogReplayAdmissionV1 = Readonly<{
@@ -993,10 +939,6 @@ function rfc64CatalogReplayRuntimeForV1(agent: DKGAgent): Rfc64CatalogReplayRunt
     rfc64CatalogReplayRuntimesV1.set(agent, runtime);
   }
   return runtime;
-}
-
-function rfc64CatalogReplayScopeKeyV1(networkId: string, contextGraphId: string): string {
-  return `${networkId}\0${contextGraphId}`;
 }
 
 function rfc64CatalogTargetScopeKeyV1(input: Readonly<{
@@ -2706,83 +2648,6 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
     return runtime.indexByScope;
   }
 
-  private async prepareRfc64CatalogReplaySnapshotPlanV1(
-    this: DKGAgent,
-    persistence: Rfc64PersistenceV1,
-    requestedScope?: Readonly<Rfc64PublicCatalogHeadReplayRequestV1>,
-  ): Promise<Readonly<Rfc64CatalogReplaySnapshotPlanV1>> {
-    if (requestedScope === undefined) {
-      const inventoryFingerprint = rfc64CatalogReplayInventoryFingerprintV1(
-        persistence.inventory.listAppliedCatalogHeadsV1(),
-      );
-      const entries = Object.freeze([
-        ...(await this.readRfc64CatalogReplayIndexV1()).values(),
-      ].flat());
-      return Object.freeze({
-        mutationScopes: Object.freeze(rfc64CatalogReplayMutationScopesV1(entries)),
-        openLockedSnapshot: async () => {
-          if (rfc64CatalogReplayInventoryFingerprintV1(
-            persistence.inventory.listAppliedCatalogHeadsV1(),
-          ) !== inventoryFingerprint) {
-            throw new Error('RFC-64 durable catalog inventory changed before replay snapshot');
-          }
-          return Object.freeze({
-            entries,
-            assertUnchanged: async () => {
-              if (rfc64CatalogReplayInventoryFingerprintV1(
-                persistence.inventory.listAppliedCatalogHeadsV1(),
-              ) !== inventoryFingerprint) {
-                throw new Error('RFC-64 durable catalog inventory changed during replay');
-              }
-            },
-          });
-        },
-      });
-    }
-
-    const replayScopeKey = rfc64CatalogReplayScopeKeyV1(
-      requestedScope.networkId,
-      requestedScope.contextGraphId,
-    );
-    const discoveredEntries = (await this.readRfc64CatalogReplayIndexV1())
-      .get(replayScopeKey) ?? [];
-    const mutationScopes = Object.freeze(
-      rfc64CatalogReplayMutationScopesV1(discoveredEntries),
-    );
-    const lockedScopeKeys = new Set(mutationScopes.map(
-      (scope) => rfc64CatalogReplayMutationScopeKeyV1(scope),
-    ));
-    return Object.freeze({
-      mutationScopes,
-      openLockedSnapshot: async () => {
-        // Discovery identifies the author scopes to lock. Refresh only after
-        // those locks are held so a same-author head advance that raced lock
-        // acquisition is part of this replay snapshot.
-        const entries = (await this.readRfc64CatalogReplayIndexV1())
-          .get(replayScopeKey) ?? [];
-        if (entries.some(({ head }) => !lockedScopeKeys.has(
-          rfc64CatalogReplayMutationScopeKeyV1(
-            deriveAuthorCatalogScopeFromHeadV1(head.payload),
-          ),
-        ))) {
-          throw new Error('RFC-64 scoped catalog inventory changed before replay snapshot');
-        }
-        const entriesFingerprint = rfc64CatalogReplayEntriesFingerprintV1(entries);
-        return Object.freeze({
-          entries,
-          assertUnchanged: async () => {
-            const currentEntries = (await this.readRfc64CatalogReplayIndexV1())
-              .get(replayScopeKey) ?? [];
-            if (rfc64CatalogReplayEntriesFingerprintV1(currentEntries)
-              !== entriesFingerprint) {
-              throw new Error('RFC-64 scoped catalog inventory changed during replay');
-            }
-          },
-        });
-      },
-    });
-  }
-
   async reannounceRfc64CatalogHeadsToPeerV1(
     this: DKGAgent,
     peerId: string,
@@ -2798,90 +2663,79 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
     }
     let announced = 0;
     let failed = 0;
-    const snapshotPlan = await this.prepareRfc64CatalogReplaySnapshotPlanV1(
+    return withLockedRfc64CatalogReplaySnapshotV1({
       persistence,
+      mutationCoordinator: this.rfc64CatalogMutationCoordinatorV1,
       requestedScope,
-    );
-    const runWithReplayScopesLocked = async <T>(
-      scopeIndex: number,
-      operation: () => Promise<T>,
-    ): Promise<T> => {
-      const scope = snapshotPlan.mutationScopes[scopeIndex];
-      if (scope === undefined) return operation();
-      return this.rfc64CatalogMutationCoordinatorV1.run(
-        scope,
-        () => runWithReplayScopesLocked(scopeIndex + 1, operation),
-      );
-    };
-    return runWithReplayScopesLocked(0, async () => {
-      const replaySnapshot = await snapshotPlan.openLockedSnapshot();
-      const manifest: Rfc64PublicCatalogHeadAnnouncementV1[] = [];
-      for (const { head } of replaySnapshot.entries) {
-        const servingAuthority = this.resolveRfc64CatalogServingAuthorityV1(
-          head.payload.contextGraphId,
-        );
-        const accepted = service.acceptedPolicySnapshot(
-          head.payload.networkId,
-          head.payload.contextGraphId,
-        );
-        if (!servingAuthority.track2Enabled || accepted === null) {
-          if (requestedScope !== undefined) {
-            throw new Error('RFC-64 scoped catalog replay authority is unavailable');
+      readIndex: () => this.readRfc64CatalogReplayIndexV1(),
+      operation: async (replayEntries) => {
+        const manifest: Rfc64PublicCatalogHeadAnnouncementV1[] = [];
+        for (const { head } of replayEntries) {
+          const servingAuthority = this.resolveRfc64CatalogServingAuthorityV1(
+            head.payload.contextGraphId,
+          );
+          const accepted = service.acceptedPolicySnapshot(
+            head.payload.networkId,
+            head.payload.contextGraphId,
+          );
+          if (!servingAuthority.track2Enabled || accepted === null) {
+            if (requestedScope !== undefined) {
+              throw new Error('RFC-64 scoped catalog replay authority is unavailable');
+            }
+            continue;
           }
-          continue;
-        }
-        if (
-          requestedScope !== undefined
-          && accepted.policyDigest !== requestedScope.policyDigest
-        ) {
-          throw new Error('RFC-64 scoped catalog replay policy changed before snapshot');
-        }
-        manifest.push(Object.freeze({
-          kind: RFC64_PUBLIC_CATALOG_HEAD_ANNOUNCEMENT_KIND_V1,
-          networkId: head.payload.networkId,
-          contextGraphId: head.payload.contextGraphId,
-          subGraphName: head.payload.subGraphName,
-          authorAddress: head.payload.authorAddress,
-          catalogEra: head.payload.era,
-          catalogVersion: head.payload.version,
-          policyDigest: accepted.policyDigest,
-          catalogHeadObjectDigest: head.objectDigest as Digest32V1,
-          signatureVariantDigest: computeControlSignatureVariantDigestHex(
-            head.objectDigest,
-            head.signature,
-          ) as Digest32V1,
-        }));
-      }
-      if (manifest.length > RFC64_CATALOG_TARGET_MAX_ENTRIES_PER_CONTEXT_GRAPH_V1) {
-        throw new Error('RFC-64 scoped catalog replay manifest exceeds the per-CG target cap');
-      }
-      manifest.sort((left, right) => {
-        const leftKey = rfc64CatalogTargetExactIdentityKeyV1(left);
-        const rightKey = rfc64CatalogTargetExactIdentityKeyV1(right);
-        return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
-      });
-      const completedManifest: Rfc64PublicCatalogHeadAnnouncementV1[] = [];
-      for (const announcement of manifest) {
-        try {
-          const delivery = await service.announceCatalogHead({
-            announcement,
-            peers: [peerId],
-          });
-          announced += delivery.announcedPeers.length;
-          failed += delivery.failedPeers.length;
-          if (delivery.announcedPeers.length === 1) {
-            completedManifest.push(announcement);
+          if (
+            requestedScope !== undefined
+            && accepted.policyDigest !== requestedScope.policyDigest
+          ) {
+            throw new Error('RFC-64 scoped catalog replay policy changed before snapshot');
           }
-        } catch {
-          failed += 1;
+          manifest.push(Object.freeze({
+            kind: RFC64_PUBLIC_CATALOG_HEAD_ANNOUNCEMENT_KIND_V1,
+            networkId: head.payload.networkId,
+            contextGraphId: head.payload.contextGraphId,
+            subGraphName: head.payload.subGraphName,
+            authorAddress: head.payload.authorAddress,
+            catalogEra: head.payload.era,
+            catalogVersion: head.payload.version,
+            policyDigest: accepted.policyDigest,
+            catalogHeadObjectDigest: head.objectDigest as Digest32V1,
+            signatureVariantDigest: computeControlSignatureVariantDigestHex(
+              head.objectDigest,
+              head.signature,
+            ) as Digest32V1,
+          }));
         }
-      }
-      await replaySnapshot.assertUnchanged();
-      return Object.freeze({
-        announced,
-        failed,
-        manifest: Object.freeze(completedManifest),
-      });
+        if (manifest.length > RFC64_CATALOG_TARGET_MAX_ENTRIES_PER_CONTEXT_GRAPH_V1) {
+          throw new Error('RFC-64 scoped catalog replay manifest exceeds the per-CG target cap');
+        }
+        manifest.sort((left, right) => {
+          const leftKey = rfc64CatalogTargetExactIdentityKeyV1(left);
+          const rightKey = rfc64CatalogTargetExactIdentityKeyV1(right);
+          return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+        });
+        const completedManifest: Rfc64PublicCatalogHeadAnnouncementV1[] = [];
+        for (const announcement of manifest) {
+          try {
+            const delivery = await service.announceCatalogHead({
+              announcement,
+              peers: [peerId],
+            });
+            announced += delivery.announcedPeers.length;
+            failed += delivery.failedPeers.length;
+            if (delivery.announcedPeers.length === 1) {
+              completedManifest.push(announcement);
+            }
+          } catch {
+            failed += 1;
+          }
+        }
+        return Object.freeze({
+          announced,
+          failed,
+          manifest: Object.freeze(completedManifest),
+        });
+      },
     });
   }
 

--- a/packages/agent/src/dkg-agent-rfc64-catalog.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog.ts
@@ -143,11 +143,10 @@ import {
 } from './rfc64/release-native-catalog-authority-v1.js';
 import { readRfc64LegacySwmBoundaryCountV1 } from
   './rfc64/legacy-swm-boundary-v1.js';
+import type { Rfc64CatalogMutationCoordinatorV1 } from
+  './rfc64/catalog-mutation-runtime-v1.js';
 import {
-  rfc64CatalogReplayInventoryFingerprintV1,
-  rfc64CatalogReplayScopeKeyV1,
-  withLockedRfc64CatalogReplaySnapshotV1,
-  type Rfc64CatalogReplayHeadV1,
+  Rfc64CatalogReplaySnapshotRuntimeV1,
 } from './rfc64/catalog-replay-snapshot-runtime-v1.js';
 
 /** Minimal EIP-191 EOA signer (ethers.Wallet-compatible) for author-catalog objects. */
@@ -476,8 +475,11 @@ interface Rfc64CatalogReplayRuntimeV1 {
   tail: Promise<void>;
   readonly pending: Map<string, Promise<Readonly<Rfc64CatalogReplayResultV1>>>;
   readonly pendingByPeer: Map<string, number>;
-  indexFingerprint: string | null;
-  indexByScope: ReadonlyMap<string, readonly Rfc64CatalogReplayHeadV1[]>;
+}
+
+interface Rfc64CatalogReplaySnapshotRuntimeOwnerV1 {
+  readonly persistence: Rfc64PersistenceV1;
+  readonly runtime: Rfc64CatalogReplaySnapshotRuntimeV1;
 }
 
 interface Rfc64CatalogReplayResultV1 {
@@ -496,6 +498,8 @@ type Rfc64CatalogReplayAdmissionV1 = Readonly<{
 }>;
 
 const rfc64CatalogReplayRuntimesV1 = new WeakMap<DKGAgent, Rfc64CatalogReplayRuntimeV1>();
+const rfc64CatalogReplaySnapshotRuntimesV1 =
+  new WeakMap<DKGAgent, Rfc64CatalogReplaySnapshotRuntimeOwnerV1>();
 
 interface Rfc64CatalogReplayProgressV1 {
   readonly policyDigest: Digest32V1;
@@ -933,11 +937,24 @@ function rfc64CatalogReplayRuntimeForV1(agent: DKGAgent): Rfc64CatalogReplayRunt
       tail: Promise.resolve(),
       pending: new Map(),
       pendingByPeer: new Map(),
-      indexFingerprint: null,
-      indexByScope: new Map(),
     };
     rfc64CatalogReplayRuntimesV1.set(agent, runtime);
   }
+  return runtime;
+}
+
+function rfc64CatalogReplaySnapshotRuntimeForV1(
+  agent: DKGAgent,
+  persistence: Rfc64PersistenceV1,
+  mutationCoordinator: Rfc64CatalogMutationCoordinatorV1,
+): Rfc64CatalogReplaySnapshotRuntimeV1 {
+  const owned = rfc64CatalogReplaySnapshotRuntimesV1.get(agent);
+  if (owned?.persistence === persistence) return owned.runtime;
+  const runtime = new Rfc64CatalogReplaySnapshotRuntimeV1(
+    persistence,
+    mutationCoordinator,
+  );
+  rfc64CatalogReplaySnapshotRuntimesV1.set(agent, Object.freeze({ persistence, runtime }));
   return runtime;
 }
 
@@ -2597,57 +2614,6 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
     return Object.freeze({ status: 'admitted', newlyQueued: true, completion: run });
   }
 
-  private async readRfc64CatalogReplayIndexV1(
-    this: DKGAgent,
-  ): Promise<ReadonlyMap<string, readonly Rfc64CatalogReplayHeadV1[]>> {
-    const persistence = this.rfc64PersistenceV1;
-    if (persistence === undefined) return new Map();
-    const runtime = rfc64CatalogReplayRuntimeForV1(this);
-    const snapshots = persistence.inventory.listAppliedCatalogHeadsV1();
-    const fingerprint = rfc64CatalogReplayInventoryFingerprintV1(snapshots);
-    if (runtime.indexFingerprint === fingerprint) return runtime.indexByScope;
-
-    const index = new Map<string, Rfc64CatalogReplayHeadV1[]>();
-    for (const applied of snapshots) {
-      const stored = await persistence.controlObjects.getVerifiedObjectByDigest({
-        objectDigest: applied.currentCatalogHeadDigest,
-        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
-      }).catch(() => null);
-      if (stored === null) {
-        throw new Error('RFC-64 durable catalog head is missing or unverifiable');
-      }
-      try {
-        assertSignedAuthorCatalogHeadEnvelopeV1(stored.envelope);
-        const head = stored.envelope;
-        const scope = deriveAuthorCatalogScopeFromHeadV1(head.payload);
-        if (
-          computeAuthorCatalogScopeDigestV1(scope) !== applied.catalogScopeDigest
-          || head.payload.authorAddress !== applied.authorAddress
-          || head.payload.version !== applied.catalogVersion
-        ) {
-          throw new Error('RFC-64 durable catalog head does not match its applied inventory row');
-        }
-        const key = rfc64CatalogReplayScopeKeyV1(
-          head.payload.networkId,
-          head.payload.contextGraphId,
-        );
-        const entries = index.get(key) ?? [];
-        entries.push(Object.freeze({ head }));
-        index.set(key, entries);
-      } catch (cause) {
-        throw new Error('RFC-64 durable catalog inventory contains an invalid head', {
-          cause,
-        });
-      }
-    }
-    runtime.indexFingerprint = fingerprint;
-    runtime.indexByScope = new Map([...index].map(([key, entries]) => [
-      key,
-      Object.freeze(entries),
-    ]));
-    return runtime.indexByScope;
-  }
-
   async reannounceRfc64CatalogHeadsToPeerV1(
     this: DKGAgent,
     peerId: string,
@@ -2663,11 +2629,13 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
     }
     let announced = 0;
     let failed = 0;
-    return withLockedRfc64CatalogReplaySnapshotV1({
+    const replaySnapshotRuntime = rfc64CatalogReplaySnapshotRuntimeForV1(
+      this,
       persistence,
-      mutationCoordinator: this.rfc64CatalogMutationCoordinatorV1,
+      this.rfc64CatalogMutationCoordinatorV1,
+    );
+    return replaySnapshotRuntime.withSnapshot({
       requestedScope,
-      readIndex: () => this.readRfc64CatalogReplayIndexV1(),
       operation: async (replayEntries) => {
         const manifest: Rfc64PublicCatalogHeadAnnouncementV1[] = [];
         for (const { head } of replayEntries) {

--- a/packages/agent/src/dkg-agent-rfc64-catalog.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog.ts
@@ -951,7 +951,15 @@ function rfc64CatalogReplaySnapshotRuntimeForV1(
   const owned = rfc64CatalogReplaySnapshotRuntimesV1.get(agent);
   if (owned?.persistence === persistence) return owned.runtime;
   const runtime = new Rfc64CatalogReplaySnapshotRuntimeV1(
-    persistence,
+    Object.freeze({
+      listAppliedCatalogHeadsV1: () => persistence.inventory.listAppliedCatalogHeadsV1(),
+      readVerifiedCatalogHeadV1: async (objectDigest: Digest32V1) => (
+        await persistence.controlObjects.getVerifiedObjectByDigest({
+          objectDigest,
+          verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+        }).catch(() => null)
+      )?.envelope ?? null,
+    }),
     mutationCoordinator,
   );
   rfc64CatalogReplaySnapshotRuntimesV1.set(agent, Object.freeze({ persistence, runtime }));
@@ -2635,7 +2643,13 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
       this.rfc64CatalogMutationCoordinatorV1,
     );
     return replaySnapshotRuntime.withSnapshot({
-      requestedScope,
+      selection: requestedScope === undefined
+        ? Object.freeze({ kind: 'all' })
+        : Object.freeze({
+            kind: 'scope',
+            networkId: requestedScope.networkId,
+            contextGraphId: requestedScope.contextGraphId,
+          }),
       operation: async (replayEntries) => {
         const manifest: Rfc64PublicCatalogHeadAnnouncementV1[] = [];
         for (const { head } of replayEntries) {

--- a/packages/agent/src/rfc64/catalog-mutation-runtime-v1.ts
+++ b/packages/agent/src/rfc64/catalog-mutation-runtime-v1.ts
@@ -5,7 +5,13 @@ import {
   type AuthorCatalogScopeV1,
 } from '@origintrail-official/dkg-core';
 
+import {
+  raceRfc64AgainstAbortV1,
+  throwIfRfc64AbortedV1,
+} from './abort-v1.js';
 import { Rfc64SerializedScopeRuntimeV1 } from './serialized-scope-runtime-v1.js';
+
+const RFC64_CATALOG_MUTATION_ABORT_MESSAGE_V1 = 'RFC-64 catalog mutation aborted';
 
 export function rfc64CatalogMutationScopeKeyV1(
   scope: Readonly<AuthorCatalogScopeV1>,
@@ -19,7 +25,7 @@ export function rfc64CatalogMutationScopeKeyV1(
  */
 export class Rfc64CatalogMutationCoordinatorV1 {
   readonly #runtime = new Rfc64SerializedScopeRuntimeV1(
-    'RFC-64 catalog mutation aborted',
+    RFC64_CATALOG_MUTATION_ABORT_MESSAGE_V1,
   );
 
   run<T>(
@@ -43,11 +49,19 @@ export class Rfc64CatalogMutationCoordinatorV1 {
       .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
       .map(([, scope]) => scope);
     const acquire = (scopeIndex: number): Promise<T> => {
+      throwIfRfc64AbortedV1(signal, RFC64_CATALOG_MUTATION_ABORT_MESSAGE_V1);
       const scope = orderedScopes[scopeIndex];
       if (scope === undefined) return operation();
-      return this.run(scope, () => acquire(scopeIndex + 1), signal);
+      // Keep each outer lock chained to the physical completion of every
+      // inner lock and the operation. Only the caller-facing promise races
+      // cancellation; nested lock ownership must never unwind early.
+      return this.run(scope, () => acquire(scopeIndex + 1));
     };
-    return acquire(0);
+    return raceRfc64AgainstAbortV1(
+      () => acquire(0),
+      signal,
+      RFC64_CATALOG_MUTATION_ABORT_MESSAGE_V1,
+    );
   }
 
   reopen(): void {

--- a/packages/agent/src/rfc64/catalog-mutation-runtime-v1.ts
+++ b/packages/agent/src/rfc64/catalog-mutation-runtime-v1.ts
@@ -7,6 +7,12 @@ import {
 
 import { Rfc64SerializedScopeRuntimeV1 } from './serialized-scope-runtime-v1.js';
 
+export function rfc64CatalogMutationScopeKeyV1(
+  scope: Readonly<AuthorCatalogScopeV1>,
+): string {
+  return `${computeAuthorCatalogScopeDigestV1(scope)}\n${scope.authorAddress}`;
+}
+
 /**
  * Explicit agent-owned coordinator shared by local authoring and remote apply.
  * Its lifecycle is drained before the catalog service and persistence close.
@@ -21,8 +27,27 @@ export class Rfc64CatalogMutationCoordinatorV1 {
     operation: () => Promise<T>,
     signal?: AbortSignal,
   ): Promise<T> {
-    const key = `${computeAuthorCatalogScopeDigestV1(scope)}\n${scope.authorAddress}`;
-    return this.#runtime.run(key, operation, signal);
+    return this.#runtime.run(rfc64CatalogMutationScopeKeyV1(scope), operation, signal);
+  }
+
+  /** Acquire a unique scope set in canonical order before starting the operation. */
+  runMany<T>(
+    scopes: readonly Readonly<AuthorCatalogScopeV1>[],
+    operation: () => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    const orderedScopes = [...new Map(scopes.map((scope) => [
+      rfc64CatalogMutationScopeKeyV1(scope),
+      scope,
+    ] as const)).entries()]
+      .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
+      .map(([, scope]) => scope);
+    const acquire = (scopeIndex: number): Promise<T> => {
+      const scope = orderedScopes[scopeIndex];
+      if (scope === undefined) return operation();
+      return this.run(scope, () => acquire(scopeIndex + 1), signal);
+    };
+    return acquire(0);
   }
 
   reopen(): void {

--- a/packages/agent/src/rfc64/catalog-replay-snapshot-runtime-v1.ts
+++ b/packages/agent/src/rfc64/catalog-replay-snapshot-runtime-v1.ts
@@ -5,25 +5,38 @@ import {
   computeAuthorCatalogScopeDigestV1,
   deriveAuthorCatalogScopeFromHeadV1,
   type AuthorCatalogScopeV1,
+  type Digest32V1,
   type SignedAuthorCatalogHeadEnvelopeV1,
+  type SignedControlEnvelopeV1,
 } from '@origintrail-official/dkg-core';
-import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dkg-chain';
 
 import {
   rfc64CatalogMutationScopeKeyV1,
   type Rfc64CatalogMutationCoordinatorV1,
 } from './catalog-mutation-runtime-v1.js';
 import type { AppliedCatalogHeadSnapshotV1 } from './inventory-v1/index.js';
-import type { Rfc64PersistenceV1 } from './persistence-v1.js';
-import type { Rfc64PublicCatalogHeadReplayRequestV1 } from
-  './public-catalog-transport-v1.js';
 
 export interface Rfc64CatalogReplayHeadV1 {
   readonly head: SignedAuthorCatalogHeadEnvelopeV1;
 }
 
+export type Rfc64CatalogReplaySelectionV1 = Readonly<{
+  readonly kind: 'all';
+}> | Readonly<{
+  readonly kind: 'scope';
+  readonly networkId: string;
+  readonly contextGraphId: string;
+}>;
+
+export interface Rfc64CatalogReplaySnapshotStorageV1 {
+  listAppliedCatalogHeadsV1(): readonly AppliedCatalogHeadSnapshotV1[];
+  readVerifiedCatalogHeadV1(
+    objectDigest: Digest32V1,
+  ): Promise<SignedControlEnvelopeV1 | null>;
+}
+
 interface WithRfc64CatalogReplaySnapshotInputV1<T> {
-  readonly requestedScope: Readonly<Rfc64PublicCatalogHeadReplayRequestV1> | undefined;
+  readonly selection: Rfc64CatalogReplaySelectionV1;
   operation(entries: readonly Rfc64CatalogReplayHeadV1[]): Promise<T>;
 }
 
@@ -74,25 +87,25 @@ function rfc64CatalogReplayMutationScopesV1(
 
 /** Own index construction, cache invalidation, and the complete locked snapshot protocol. */
 export class Rfc64CatalogReplaySnapshotRuntimeV1 {
-  readonly #persistence: Rfc64PersistenceV1;
+  readonly #storage: Rfc64CatalogReplaySnapshotStorageV1;
   readonly #mutationCoordinator: Rfc64CatalogMutationCoordinatorV1;
   #indexFingerprint: string | null = null;
   #indexByScope: ReadonlyMap<string, readonly Rfc64CatalogReplayHeadV1[]> = new Map();
 
   constructor(
-    persistence: Rfc64PersistenceV1,
+    storage: Rfc64CatalogReplaySnapshotStorageV1,
     mutationCoordinator: Rfc64CatalogMutationCoordinatorV1,
   ) {
-    this.#persistence = persistence;
+    this.#storage = storage;
     this.#mutationCoordinator = mutationCoordinator;
   }
 
   async withSnapshot<T>(
     input: Readonly<WithRfc64CatalogReplaySnapshotInputV1<T>>,
   ): Promise<T> {
-    if (input.requestedScope === undefined) {
+    if (input.selection.kind === 'all') {
       const inventoryFingerprint = rfc64CatalogReplayInventoryFingerprintV1(
-        this.#persistence.inventory.listAppliedCatalogHeadsV1(),
+        this.#storage.listAppliedCatalogHeadsV1(),
       );
       const entries = Object.freeze([
         ...(await this.#readIndex()).values(),
@@ -101,13 +114,13 @@ export class Rfc64CatalogReplaySnapshotRuntimeV1 {
         rfc64CatalogReplayMutationScopesV1(entries),
         async () => {
           if (rfc64CatalogReplayInventoryFingerprintV1(
-            this.#persistence.inventory.listAppliedCatalogHeadsV1(),
+            this.#storage.listAppliedCatalogHeadsV1(),
           ) !== inventoryFingerprint) {
             throw new Error('RFC-64 durable catalog inventory changed before replay snapshot');
           }
           const result = await input.operation(entries);
           if (rfc64CatalogReplayInventoryFingerprintV1(
-            this.#persistence.inventory.listAppliedCatalogHeadsV1(),
+            this.#storage.listAppliedCatalogHeadsV1(),
           ) !== inventoryFingerprint) {
             throw new Error('RFC-64 durable catalog inventory changed during replay');
           }
@@ -117,8 +130,8 @@ export class Rfc64CatalogReplaySnapshotRuntimeV1 {
     }
 
     const replayScopeKey = rfc64CatalogReplayScopeKeyV1(
-      input.requestedScope.networkId,
-      input.requestedScope.contextGraphId,
+      input.selection.networkId,
+      input.selection.contextGraphId,
     );
     const discoveredEntries = (await this.#readIndex()).get(replayScopeKey) ?? [];
     const mutationScopes = rfc64CatalogReplayMutationScopesV1(discoveredEntries);
@@ -147,22 +160,20 @@ export class Rfc64CatalogReplaySnapshotRuntimeV1 {
   }
 
   async #readIndex(): Promise<ReadonlyMap<string, readonly Rfc64CatalogReplayHeadV1[]>> {
-    const snapshots = this.#persistence.inventory.listAppliedCatalogHeadsV1();
+    const snapshots = this.#storage.listAppliedCatalogHeadsV1();
     const fingerprint = rfc64CatalogReplayInventoryFingerprintV1(snapshots);
     if (this.#indexFingerprint === fingerprint) return this.#indexByScope;
 
     const index = new Map<string, Rfc64CatalogReplayHeadV1[]>();
     for (const applied of snapshots) {
-      const stored = await this.#persistence.controlObjects.getVerifiedObjectByDigest({
-        objectDigest: applied.currentCatalogHeadDigest,
-        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
-      }).catch(() => null);
-      if (stored === null) {
+      const head = await this.#storage.readVerifiedCatalogHeadV1(
+        applied.currentCatalogHeadDigest,
+      ).catch(() => null);
+      if (head === null) {
         throw new Error('RFC-64 durable catalog head is missing or unverifiable');
       }
       try {
-        assertSignedAuthorCatalogHeadEnvelopeV1(stored.envelope);
-        const head = stored.envelope;
+        assertSignedAuthorCatalogHeadEnvelopeV1(head);
         const scope = deriveAuthorCatalogScopeFromHeadV1(head.payload);
         if (
           computeAuthorCatalogScopeDigestV1(scope) !== applied.catalogScopeDigest

--- a/packages/agent/src/rfc64/catalog-replay-snapshot-runtime-v1.ts
+++ b/packages/agent/src/rfc64/catalog-replay-snapshot-runtime-v1.ts
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  assertSignedAuthorCatalogHeadEnvelopeV1,
   computeAuthorCatalogScopeDigestV1,
   deriveAuthorCatalogScopeFromHeadV1,
   type AuthorCatalogScopeV1,
   type SignedAuthorCatalogHeadEnvelopeV1,
 } from '@origintrail-official/dkg-core';
+import { verifyControlEnvelopeIssuerSignatureV1 } from '@origintrail-official/dkg-chain';
 
 import {
   rfc64CatalogMutationScopeKeyV1,
@@ -20,15 +22,12 @@ export interface Rfc64CatalogReplayHeadV1 {
   readonly head: SignedAuthorCatalogHeadEnvelopeV1;
 }
 
-interface WithLockedRfc64CatalogReplaySnapshotInputV1<T> {
-  readonly persistence: Rfc64PersistenceV1;
-  readonly mutationCoordinator: Rfc64CatalogMutationCoordinatorV1;
+interface WithRfc64CatalogReplaySnapshotInputV1<T> {
   readonly requestedScope: Readonly<Rfc64PublicCatalogHeadReplayRequestV1> | undefined;
-  readIndex(): Promise<ReadonlyMap<string, readonly Rfc64CatalogReplayHeadV1[]>>;
   operation(entries: readonly Rfc64CatalogReplayHeadV1[]): Promise<T>;
 }
 
-export function rfc64CatalogReplayInventoryFingerprintV1(
+function rfc64CatalogReplayInventoryFingerprintV1(
   snapshots: readonly AppliedCatalogHeadSnapshotV1[],
 ): string {
   return snapshots
@@ -44,7 +43,7 @@ export function rfc64CatalogReplayInventoryFingerprintV1(
     .join('\n');
 }
 
-export function rfc64CatalogReplayScopeKeyV1(
+function rfc64CatalogReplayScopeKeyV1(
   networkId: string,
   contextGraphId: string,
 ): string {
@@ -73,65 +72,123 @@ function rfc64CatalogReplayMutationScopesV1(
   })).values()];
 }
 
-/**
- * Own the complete replay snapshot protocol so refresh and validation cannot
- * be separated from canonical mutation-lock acquisition by a caller.
- */
-export async function withLockedRfc64CatalogReplaySnapshotV1<T>(
-  input: Readonly<WithLockedRfc64CatalogReplaySnapshotInputV1<T>>,
-): Promise<T> {
-  if (input.requestedScope === undefined) {
-    const inventoryFingerprint = rfc64CatalogReplayInventoryFingerprintV1(
-      input.persistence.inventory.listAppliedCatalogHeadsV1(),
-    );
-    const entries = Object.freeze([
-      ...(await input.readIndex()).values(),
-    ].flat());
-    return input.mutationCoordinator.runMany(
-      rfc64CatalogReplayMutationScopesV1(entries),
-      async () => {
-        if (rfc64CatalogReplayInventoryFingerprintV1(
-          input.persistence.inventory.listAppliedCatalogHeadsV1(),
-        ) !== inventoryFingerprint) {
-          throw new Error('RFC-64 durable catalog inventory changed before replay snapshot');
-        }
-        const result = await input.operation(entries);
-        if (rfc64CatalogReplayInventoryFingerprintV1(
-          input.persistence.inventory.listAppliedCatalogHeadsV1(),
-        ) !== inventoryFingerprint) {
-          throw new Error('RFC-64 durable catalog inventory changed during replay');
-        }
-        return result;
-      },
-    );
+/** Own index construction, cache invalidation, and the complete locked snapshot protocol. */
+export class Rfc64CatalogReplaySnapshotRuntimeV1 {
+  readonly #persistence: Rfc64PersistenceV1;
+  readonly #mutationCoordinator: Rfc64CatalogMutationCoordinatorV1;
+  #indexFingerprint: string | null = null;
+  #indexByScope: ReadonlyMap<string, readonly Rfc64CatalogReplayHeadV1[]> = new Map();
+
+  constructor(
+    persistence: Rfc64PersistenceV1,
+    mutationCoordinator: Rfc64CatalogMutationCoordinatorV1,
+  ) {
+    this.#persistence = persistence;
+    this.#mutationCoordinator = mutationCoordinator;
   }
 
-  const replayScopeKey = rfc64CatalogReplayScopeKeyV1(
-    input.requestedScope.networkId,
-    input.requestedScope.contextGraphId,
-  );
-  const discoveredEntries = (await input.readIndex()).get(replayScopeKey) ?? [];
-  const mutationScopes = rfc64CatalogReplayMutationScopesV1(discoveredEntries);
-  const lockedScopeKeys = new Set(mutationScopes.map(
-    (scope) => rfc64CatalogMutationScopeKeyV1(scope),
-  ));
-  return input.mutationCoordinator.runMany(mutationScopes, async () => {
-    // Refresh only after all discovered author scopes are locked so a
-    // same-author head advance that raced acquisition joins this snapshot.
-    const entries = (await input.readIndex()).get(replayScopeKey) ?? [];
-    if (entries.some(({ head }) => !lockedScopeKeys.has(
-      rfc64CatalogMutationScopeKeyV1(
-        deriveAuthorCatalogScopeFromHeadV1(head.payload),
-      ),
-    ))) {
-      throw new Error('RFC-64 scoped catalog inventory changed before replay snapshot');
+  async withSnapshot<T>(
+    input: Readonly<WithRfc64CatalogReplaySnapshotInputV1<T>>,
+  ): Promise<T> {
+    if (input.requestedScope === undefined) {
+      const inventoryFingerprint = rfc64CatalogReplayInventoryFingerprintV1(
+        this.#persistence.inventory.listAppliedCatalogHeadsV1(),
+      );
+      const entries = Object.freeze([
+        ...(await this.#readIndex()).values(),
+      ].flat());
+      return this.#mutationCoordinator.runMany(
+        rfc64CatalogReplayMutationScopesV1(entries),
+        async () => {
+          if (rfc64CatalogReplayInventoryFingerprintV1(
+            this.#persistence.inventory.listAppliedCatalogHeadsV1(),
+          ) !== inventoryFingerprint) {
+            throw new Error('RFC-64 durable catalog inventory changed before replay snapshot');
+          }
+          const result = await input.operation(entries);
+          if (rfc64CatalogReplayInventoryFingerprintV1(
+            this.#persistence.inventory.listAppliedCatalogHeadsV1(),
+          ) !== inventoryFingerprint) {
+            throw new Error('RFC-64 durable catalog inventory changed during replay');
+          }
+          return result;
+        },
+      );
     }
-    const entriesFingerprint = rfc64CatalogReplayEntriesFingerprintV1(entries);
-    const result = await input.operation(entries);
-    const currentEntries = (await input.readIndex()).get(replayScopeKey) ?? [];
-    if (rfc64CatalogReplayEntriesFingerprintV1(currentEntries) !== entriesFingerprint) {
-      throw new Error('RFC-64 scoped catalog inventory changed during replay');
+
+    const replayScopeKey = rfc64CatalogReplayScopeKeyV1(
+      input.requestedScope.networkId,
+      input.requestedScope.contextGraphId,
+    );
+    const discoveredEntries = (await this.#readIndex()).get(replayScopeKey) ?? [];
+    const mutationScopes = rfc64CatalogReplayMutationScopesV1(discoveredEntries);
+    const lockedScopeKeys = new Set(mutationScopes.map(
+      (scope) => rfc64CatalogMutationScopeKeyV1(scope),
+    ));
+    return this.#mutationCoordinator.runMany(mutationScopes, async () => {
+      // Refresh only after all discovered author scopes are locked so a
+      // same-author head advance that raced acquisition joins this snapshot.
+      const entries = (await this.#readIndex()).get(replayScopeKey) ?? [];
+      if (entries.some(({ head }) => !lockedScopeKeys.has(
+        rfc64CatalogMutationScopeKeyV1(
+          deriveAuthorCatalogScopeFromHeadV1(head.payload),
+        ),
+      ))) {
+        throw new Error('RFC-64 scoped catalog inventory changed before replay snapshot');
+      }
+      const entriesFingerprint = rfc64CatalogReplayEntriesFingerprintV1(entries);
+      const result = await input.operation(entries);
+      const currentEntries = (await this.#readIndex()).get(replayScopeKey) ?? [];
+      if (rfc64CatalogReplayEntriesFingerprintV1(currentEntries) !== entriesFingerprint) {
+        throw new Error('RFC-64 scoped catalog inventory changed during replay');
+      }
+      return result;
+    });
+  }
+
+  async #readIndex(): Promise<ReadonlyMap<string, readonly Rfc64CatalogReplayHeadV1[]>> {
+    const snapshots = this.#persistence.inventory.listAppliedCatalogHeadsV1();
+    const fingerprint = rfc64CatalogReplayInventoryFingerprintV1(snapshots);
+    if (this.#indexFingerprint === fingerprint) return this.#indexByScope;
+
+    const index = new Map<string, Rfc64CatalogReplayHeadV1[]>();
+    for (const applied of snapshots) {
+      const stored = await this.#persistence.controlObjects.getVerifiedObjectByDigest({
+        objectDigest: applied.currentCatalogHeadDigest,
+        verifyIssuerSignature: verifyControlEnvelopeIssuerSignatureV1,
+      }).catch(() => null);
+      if (stored === null) {
+        throw new Error('RFC-64 durable catalog head is missing or unverifiable');
+      }
+      try {
+        assertSignedAuthorCatalogHeadEnvelopeV1(stored.envelope);
+        const head = stored.envelope;
+        const scope = deriveAuthorCatalogScopeFromHeadV1(head.payload);
+        if (
+          computeAuthorCatalogScopeDigestV1(scope) !== applied.catalogScopeDigest
+          || head.payload.authorAddress !== applied.authorAddress
+          || head.payload.version !== applied.catalogVersion
+        ) {
+          throw new Error('RFC-64 durable catalog head does not match its applied inventory row');
+        }
+        const key = rfc64CatalogReplayScopeKeyV1(
+          head.payload.networkId,
+          head.payload.contextGraphId,
+        );
+        const entries = index.get(key) ?? [];
+        entries.push(Object.freeze({ head }));
+        index.set(key, entries);
+      } catch (cause) {
+        throw new Error('RFC-64 durable catalog inventory contains an invalid head', {
+          cause,
+        });
+      }
     }
-    return result;
-  });
+    this.#indexFingerprint = fingerprint;
+    this.#indexByScope = new Map([...index].map(([key, entries]) => [
+      key,
+      Object.freeze(entries),
+    ]));
+    return this.#indexByScope;
+  }
 }

--- a/packages/agent/src/rfc64/catalog-replay-snapshot-runtime-v1.ts
+++ b/packages/agent/src/rfc64/catalog-replay-snapshot-runtime-v1.ts
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  computeAuthorCatalogScopeDigestV1,
+  deriveAuthorCatalogScopeFromHeadV1,
+  type AuthorCatalogScopeV1,
+  type SignedAuthorCatalogHeadEnvelopeV1,
+} from '@origintrail-official/dkg-core';
+
+import {
+  rfc64CatalogMutationScopeKeyV1,
+  type Rfc64CatalogMutationCoordinatorV1,
+} from './catalog-mutation-runtime-v1.js';
+import type { AppliedCatalogHeadSnapshotV1 } from './inventory-v1/index.js';
+import type { Rfc64PersistenceV1 } from './persistence-v1.js';
+import type { Rfc64PublicCatalogHeadReplayRequestV1 } from
+  './public-catalog-transport-v1.js';
+
+export interface Rfc64CatalogReplayHeadV1 {
+  readonly head: SignedAuthorCatalogHeadEnvelopeV1;
+}
+
+interface WithLockedRfc64CatalogReplaySnapshotInputV1<T> {
+  readonly persistence: Rfc64PersistenceV1;
+  readonly mutationCoordinator: Rfc64CatalogMutationCoordinatorV1;
+  readonly requestedScope: Readonly<Rfc64PublicCatalogHeadReplayRequestV1> | undefined;
+  readIndex(): Promise<ReadonlyMap<string, readonly Rfc64CatalogReplayHeadV1[]>>;
+  operation(entries: readonly Rfc64CatalogReplayHeadV1[]): Promise<T>;
+}
+
+export function rfc64CatalogReplayInventoryFingerprintV1(
+  snapshots: readonly AppliedCatalogHeadSnapshotV1[],
+): string {
+  return snapshots
+    .map((snapshot) => [
+      snapshot.catalogScopeDigest,
+      snapshot.authorAddress,
+      snapshot.currentCatalogHeadDigest,
+      snapshot.appliedInventoryDigest,
+      snapshot.catalogVersion,
+      snapshot.inventoryRowCount,
+    ].join(':'))
+    .sort()
+    .join('\n');
+}
+
+export function rfc64CatalogReplayScopeKeyV1(
+  networkId: string,
+  contextGraphId: string,
+): string {
+  return `${networkId}\0${contextGraphId}`;
+}
+
+function rfc64CatalogReplayEntriesFingerprintV1(
+  entries: readonly Rfc64CatalogReplayHeadV1[],
+): string {
+  return entries
+    .map(({ head }) => [
+      computeAuthorCatalogScopeDigestV1(deriveAuthorCatalogScopeFromHeadV1(head.payload)),
+      head.payload.authorAddress,
+      head.objectDigest,
+    ].join(':'))
+    .sort()
+    .join('\n');
+}
+
+function rfc64CatalogReplayMutationScopesV1(
+  entries: readonly Rfc64CatalogReplayHeadV1[],
+): readonly Readonly<AuthorCatalogScopeV1>[] {
+  return [...new Map(entries.map(({ head }) => {
+    const scope = deriveAuthorCatalogScopeFromHeadV1(head.payload);
+    return [rfc64CatalogMutationScopeKeyV1(scope), scope] as const;
+  })).values()];
+}
+
+/**
+ * Own the complete replay snapshot protocol so refresh and validation cannot
+ * be separated from canonical mutation-lock acquisition by a caller.
+ */
+export async function withLockedRfc64CatalogReplaySnapshotV1<T>(
+  input: Readonly<WithLockedRfc64CatalogReplaySnapshotInputV1<T>>,
+): Promise<T> {
+  if (input.requestedScope === undefined) {
+    const inventoryFingerprint = rfc64CatalogReplayInventoryFingerprintV1(
+      input.persistence.inventory.listAppliedCatalogHeadsV1(),
+    );
+    const entries = Object.freeze([
+      ...(await input.readIndex()).values(),
+    ].flat());
+    return input.mutationCoordinator.runMany(
+      rfc64CatalogReplayMutationScopesV1(entries),
+      async () => {
+        if (rfc64CatalogReplayInventoryFingerprintV1(
+          input.persistence.inventory.listAppliedCatalogHeadsV1(),
+        ) !== inventoryFingerprint) {
+          throw new Error('RFC-64 durable catalog inventory changed before replay snapshot');
+        }
+        const result = await input.operation(entries);
+        if (rfc64CatalogReplayInventoryFingerprintV1(
+          input.persistence.inventory.listAppliedCatalogHeadsV1(),
+        ) !== inventoryFingerprint) {
+          throw new Error('RFC-64 durable catalog inventory changed during replay');
+        }
+        return result;
+      },
+    );
+  }
+
+  const replayScopeKey = rfc64CatalogReplayScopeKeyV1(
+    input.requestedScope.networkId,
+    input.requestedScope.contextGraphId,
+  );
+  const discoveredEntries = (await input.readIndex()).get(replayScopeKey) ?? [];
+  const mutationScopes = rfc64CatalogReplayMutationScopesV1(discoveredEntries);
+  const lockedScopeKeys = new Set(mutationScopes.map(
+    (scope) => rfc64CatalogMutationScopeKeyV1(scope),
+  ));
+  return input.mutationCoordinator.runMany(mutationScopes, async () => {
+    // Refresh only after all discovered author scopes are locked so a
+    // same-author head advance that raced acquisition joins this snapshot.
+    const entries = (await input.readIndex()).get(replayScopeKey) ?? [];
+    if (entries.some(({ head }) => !lockedScopeKeys.has(
+      rfc64CatalogMutationScopeKeyV1(
+        deriveAuthorCatalogScopeFromHeadV1(head.payload),
+      ),
+    ))) {
+      throw new Error('RFC-64 scoped catalog inventory changed before replay snapshot');
+    }
+    const entriesFingerprint = rfc64CatalogReplayEntriesFingerprintV1(entries);
+    const result = await input.operation(entries);
+    const currentEntries = (await input.readIndex()).get(replayScopeKey) ?? [];
+    if (rfc64CatalogReplayEntriesFingerprintV1(currentEntries) !== entriesFingerprint) {
+      throw new Error('RFC-64 scoped catalog inventory changed during replay');
+    }
+    return result;
+  });
+}

--- a/packages/agent/test/rfc64-catalog-mutation-runtime-v1.test.ts
+++ b/packages/agent/test/rfc64-catalog-mutation-runtime-v1.test.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  type AuthorCatalogScopeV1,
+} from '@origintrail-official/dkg-core';
+import { describe, expect, it } from 'vitest';
+
+import {
+  Rfc64CatalogMutationCoordinatorV1,
+  rfc64CatalogMutationScopeKeyV1,
+} from '../src/rfc64/catalog-mutation-runtime-v1.js';
+
+const AUTHOR = '0x1111111111111111111111111111111111111111';
+
+function catalogScope(contextGraphId: string): Readonly<AuthorCatalogScopeV1> {
+  return Object.freeze({
+    networkId: 'hardhat1',
+    contextGraphId,
+    governanceChainId: null,
+    governanceContractAddress: null,
+    ownershipTransitionDigest: null,
+    subGraphName: null,
+    authorAddress: AUTHOR,
+    era: '0',
+    bucketCount: '1',
+  }) as AuthorCatalogScopeV1;
+}
+
+class RecordingCatalogMutationCoordinatorV1 extends Rfc64CatalogMutationCoordinatorV1 {
+  readonly admissions: string[] = [];
+
+  override run<T>(
+    scope: Readonly<AuthorCatalogScopeV1>,
+    operation: () => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    this.admissions.push(rfc64CatalogMutationScopeKeyV1(scope));
+    return super.run(scope, operation, signal);
+  }
+}
+
+describe('RFC-64 catalog mutation coordinator', () => {
+  it('deduplicates and acquires multiple scopes in canonical order', async () => {
+    const coordinator = new RecordingCatalogMutationCoordinatorV1();
+    const alpha = catalogScope(`${AUTHOR}/alpha`);
+    const omega = catalogScope(`${AUTHOR}/omega`);
+    const expectedOrder = [
+      rfc64CatalogMutationScopeKeyV1(alpha),
+      rfc64CatalogMutationScopeKeyV1(omega),
+    ].sort();
+
+    await expect(coordinator.runMany(
+      [omega, alpha, omega],
+      async () => 'complete',
+    )).resolves.toBe('complete');
+    expect(coordinator.admissions).toEqual(expectedOrder);
+    expect(coordinator.activeScopeCount).toBe(0);
+  });
+});

--- a/packages/agent/test/rfc64-catalog-mutation-runtime-v1.test.ts
+++ b/packages/agent/test/rfc64-catalog-mutation-runtime-v1.test.ts
@@ -94,4 +94,53 @@ describe('RFC-64 catalog mutation coordinator', () => {
     expect(omegaContenderEntered).toBe(true);
     expect(coordinator.activeScopeCount).toBe(0);
   });
+
+  it('keeps every acquired scope locked after caller cancellation until physical completion', async () => {
+    const coordinator = new Rfc64CatalogMutationCoordinatorV1();
+    const alpha = catalogScope(`${AUTHOR}/alpha`);
+    const omega = catalogScope(`${AUTHOR}/omega`);
+    const controller = new AbortController();
+    const abortReason = new Error('caller stopped waiting');
+    let releaseOperation!: () => void;
+    let markOperationEntered!: () => void;
+    const operationGate = new Promise<void>((resolve) => { releaseOperation = resolve; });
+    const operationEntered = new Promise<void>((resolve) => { markOperationEntered = resolve; });
+    const canceled = coordinator.runMany([omega, alpha], async () => {
+      markOperationEntered();
+      await operationGate;
+    }, controller.signal);
+    await operationEntered;
+
+    controller.abort(abortReason);
+    await expect(canceled).rejects.toBe(abortReason);
+    let alphaContenderEntered = false;
+    let omegaContenderEntered = false;
+    const contenders = [
+      coordinator.run(alpha, async () => { alphaContenderEntered = true; }),
+      coordinator.run(omega, async () => { omegaContenderEntered = true; }),
+    ];
+    await new Promise<void>((resolve) => { setImmediate(resolve); });
+    expect(alphaContenderEntered).toBe(false);
+    expect(omegaContenderEntered).toBe(false);
+
+    releaseOperation();
+    await expect(Promise.all(contenders)).resolves.toEqual([undefined, undefined]);
+    expect(alphaContenderEntered).toBe(true);
+    expect(omegaContenderEntered).toBe(true);
+    expect(coordinator.activeScopeCount).toBe(0);
+  });
+
+  it('does not start an empty-scope operation for an already aborted caller', async () => {
+    const coordinator = new Rfc64CatalogMutationCoordinatorV1();
+    const controller = new AbortController();
+    const abortReason = new Error('caller already stopped');
+    let operationStarted = false;
+    controller.abort(abortReason);
+
+    await expect(coordinator.runMany([], async () => {
+      operationStarted = true;
+    }, controller.signal)).rejects.toBe(abortReason);
+    expect(operationStarted).toBe(false);
+    expect(coordinator.activeScopeCount).toBe(0);
+  });
 });

--- a/packages/agent/test/rfc64-catalog-mutation-runtime-v1.test.ts
+++ b/packages/agent/test/rfc64-catalog-mutation-runtime-v1.test.ts
@@ -2,32 +2,17 @@
 
 import {
   type AuthorCatalogScopeV1,
-  type Digest32V1,
-  type SignedAuthorCatalogHeadEnvelopeV1,
 } from '@origintrail-official/dkg-core';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   Rfc64CatalogMutationCoordinatorV1,
   rfc64CatalogMutationScopeKeyV1,
 } from '../src/rfc64/catalog-mutation-runtime-v1.js';
-import {
-  rfc64CatalogReplayScopeKeyV1,
-  withLockedRfc64CatalogReplaySnapshotV1,
-  type Rfc64CatalogReplayHeadV1,
-} from '../src/rfc64/catalog-replay-snapshot-runtime-v1.js';
-import type { AppliedCatalogHeadSnapshotV1 } from '../src/rfc64/inventory-v1/index.js';
-import type { Rfc64PersistenceV1 } from '../src/rfc64/persistence-v1.js';
 
 const AUTHOR = '0x1111111111111111111111111111111111111111';
-const OTHER_AUTHOR = '0x2222222222222222222222222222222222222222';
-const DIGEST_A = `0x${'aa'.repeat(32)}` as Digest32V1;
-const DIGEST_B = `0x${'bb'.repeat(32)}` as Digest32V1;
 
-function catalogScope(
-  contextGraphId: string,
-  authorAddress = AUTHOR,
-): Readonly<AuthorCatalogScopeV1> {
+function catalogScope(contextGraphId: string): Readonly<AuthorCatalogScopeV1> {
   return Object.freeze({
     networkId: 'hardhat1',
     contextGraphId,
@@ -35,37 +20,10 @@ function catalogScope(
     governanceContractAddress: null,
     ownershipTransitionDigest: null,
     subGraphName: null,
-    authorAddress,
+    authorAddress: AUTHOR,
     era: '0',
     bucketCount: '1',
   }) as AuthorCatalogScopeV1;
-}
-
-function replayHead(
-  scope: Readonly<AuthorCatalogScopeV1>,
-  objectDigest: Digest32V1,
-): Readonly<Rfc64CatalogReplayHeadV1> {
-  const payload = Object.freeze({
-    ...scope,
-    catalogIssuerDelegationDigest: DIGEST_A,
-    version: '0',
-    previousHeadDigest: null,
-    totalRows: '0',
-    directoryHeight: '0',
-    directoryRootDigest: DIGEST_B,
-    issuedAt: '1773900000000',
-  });
-  return Object.freeze({
-    head: Object.freeze({ payload, objectDigest }) as unknown as SignedAuthorCatalogHeadEnvelopeV1,
-  });
-}
-
-function persistenceWithInventory(
-  readInventory: () => readonly AppliedCatalogHeadSnapshotV1[],
-): Rfc64PersistenceV1 {
-  return Object.freeze({
-    inventory: Object.freeze({ listAppliedCatalogHeadsV1: readInventory }),
-  }) as unknown as Rfc64PersistenceV1;
 }
 
 class RecordingCatalogMutationCoordinatorV1 extends Rfc64CatalogMutationCoordinatorV1 {
@@ -98,55 +56,42 @@ describe('RFC-64 catalog mutation coordinator', () => {
     expect(coordinator.admissions).toEqual(expectedOrder);
     expect(coordinator.activeScopeCount).toBe(0);
   });
-});
 
-describe('RFC-64 locked catalog replay snapshots', () => {
-  it('rejects an unscoped replay when durable inventory changes during delivery', async () => {
-    const initial = Object.freeze({
-      catalogScopeDigest: DIGEST_A,
-      authorAddress: AUTHOR,
-      currentCatalogHeadDigest: DIGEST_A,
-      appliedInventoryDigest: DIGEST_B,
-      catalogVersion: '0',
-      inventoryRowCount: '0',
-    }) as AppliedCatalogHeadSnapshotV1;
-    let inventory: readonly AppliedCatalogHeadSnapshotV1[] = [initial];
+  it('holds every requested scope until the multi-scope operation completes', async () => {
+    const coordinator = new RecordingCatalogMutationCoordinatorV1();
+    const alpha = catalogScope(`${AUTHOR}/alpha`);
+    const omega = catalogScope(`${AUTHOR}/omega`);
+    const expectedOrder = [
+      rfc64CatalogMutationScopeKeyV1(alpha),
+      rfc64CatalogMutationScopeKeyV1(omega),
+    ].sort();
+    let releaseOperation!: () => void;
+    let markOperationEntered!: () => void;
+    const operationGate = new Promise<void>((resolve) => { releaseOperation = resolve; });
+    const operationEntered = new Promise<void>((resolve) => { markOperationEntered = resolve; });
+    const runMany = coordinator.runMany([omega, alpha, omega], async () => {
+      markOperationEntered();
+      await operationGate;
+      return 'complete';
+    });
+    await operationEntered;
+    expect(coordinator.admissions).toEqual(expectedOrder);
 
-    await expect(withLockedRfc64CatalogReplaySnapshotV1({
-      persistence: persistenceWithInventory(() => inventory),
-      mutationCoordinator: new Rfc64CatalogMutationCoordinatorV1(),
-      requestedScope: undefined,
-      readIndex: async () => new Map(),
-      operation: async () => {
-        inventory = [Object.freeze({ ...initial, catalogVersion: '1' })];
-        return 'delivered';
-      },
-    })).rejects.toThrow(/durable catalog inventory changed during replay/u);
-  });
+    let alphaContenderEntered = false;
+    let omegaContenderEntered = false;
+    const contenders = [
+      coordinator.run(alpha, async () => { alphaContenderEntered = true; }),
+      coordinator.run(omega, async () => { omegaContenderEntered = true; }),
+    ];
+    await new Promise<void>((resolve) => { setImmediate(resolve); });
+    expect(alphaContenderEntered).toBe(false);
+    expect(omegaContenderEntered).toBe(false);
 
-  it('rejects a scoped replay when a new author scope appears after discovery', async () => {
-    const contextGraphId = `${AUTHOR}/catalog`;
-    const replayScopeKey = rfc64CatalogReplayScopeKeyV1('hardhat1', contextGraphId);
-    const first = replayHead(catalogScope(contextGraphId), DIGEST_A);
-    const late = replayHead(catalogScope(contextGraphId, OTHER_AUTHOR), DIGEST_B);
-    const readIndex = vi.fn()
-      .mockResolvedValueOnce(new Map([[replayScopeKey, [first]]]))
-      .mockResolvedValueOnce(new Map([[replayScopeKey, [first, late]]]));
-    const operation = vi.fn(async () => 'delivered');
-
-    await expect(withLockedRfc64CatalogReplaySnapshotV1({
-      persistence: persistenceWithInventory(() => []),
-      mutationCoordinator: new Rfc64CatalogMutationCoordinatorV1(),
-      requestedScope: Object.freeze({
-        kind: 'Rfc64PublicCatalogHeadReplayV1',
-        networkId: 'hardhat1',
-        contextGraphId,
-        policyDigest: DIGEST_A,
-      }),
-      readIndex,
-      operation,
-    })).rejects.toThrow(/scoped catalog inventory changed before replay snapshot/u);
-    expect(readIndex).toHaveBeenCalledTimes(2);
-    expect(operation).not.toHaveBeenCalled();
+    releaseOperation();
+    await expect(runMany).resolves.toBe('complete');
+    await expect(Promise.all(contenders)).resolves.toEqual([undefined, undefined]);
+    expect(alphaContenderEntered).toBe(true);
+    expect(omegaContenderEntered).toBe(true);
+    expect(coordinator.activeScopeCount).toBe(0);
   });
 });

--- a/packages/agent/test/rfc64-catalog-mutation-runtime-v1.test.ts
+++ b/packages/agent/test/rfc64-catalog-mutation-runtime-v1.test.ts
@@ -2,17 +2,32 @@
 
 import {
   type AuthorCatalogScopeV1,
+  type Digest32V1,
+  type SignedAuthorCatalogHeadEnvelopeV1,
 } from '@origintrail-official/dkg-core';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   Rfc64CatalogMutationCoordinatorV1,
   rfc64CatalogMutationScopeKeyV1,
 } from '../src/rfc64/catalog-mutation-runtime-v1.js';
+import {
+  rfc64CatalogReplayScopeKeyV1,
+  withLockedRfc64CatalogReplaySnapshotV1,
+  type Rfc64CatalogReplayHeadV1,
+} from '../src/rfc64/catalog-replay-snapshot-runtime-v1.js';
+import type { AppliedCatalogHeadSnapshotV1 } from '../src/rfc64/inventory-v1/index.js';
+import type { Rfc64PersistenceV1 } from '../src/rfc64/persistence-v1.js';
 
 const AUTHOR = '0x1111111111111111111111111111111111111111';
+const OTHER_AUTHOR = '0x2222222222222222222222222222222222222222';
+const DIGEST_A = `0x${'aa'.repeat(32)}` as Digest32V1;
+const DIGEST_B = `0x${'bb'.repeat(32)}` as Digest32V1;
 
-function catalogScope(contextGraphId: string): Readonly<AuthorCatalogScopeV1> {
+function catalogScope(
+  contextGraphId: string,
+  authorAddress = AUTHOR,
+): Readonly<AuthorCatalogScopeV1> {
   return Object.freeze({
     networkId: 'hardhat1',
     contextGraphId,
@@ -20,10 +35,37 @@ function catalogScope(contextGraphId: string): Readonly<AuthorCatalogScopeV1> {
     governanceContractAddress: null,
     ownershipTransitionDigest: null,
     subGraphName: null,
-    authorAddress: AUTHOR,
+    authorAddress,
     era: '0',
     bucketCount: '1',
   }) as AuthorCatalogScopeV1;
+}
+
+function replayHead(
+  scope: Readonly<AuthorCatalogScopeV1>,
+  objectDigest: Digest32V1,
+): Readonly<Rfc64CatalogReplayHeadV1> {
+  const payload = Object.freeze({
+    ...scope,
+    catalogIssuerDelegationDigest: DIGEST_A,
+    version: '0',
+    previousHeadDigest: null,
+    totalRows: '0',
+    directoryHeight: '0',
+    directoryRootDigest: DIGEST_B,
+    issuedAt: '1773900000000',
+  });
+  return Object.freeze({
+    head: Object.freeze({ payload, objectDigest }) as unknown as SignedAuthorCatalogHeadEnvelopeV1,
+  });
+}
+
+function persistenceWithInventory(
+  readInventory: () => readonly AppliedCatalogHeadSnapshotV1[],
+): Rfc64PersistenceV1 {
+  return Object.freeze({
+    inventory: Object.freeze({ listAppliedCatalogHeadsV1: readInventory }),
+  }) as unknown as Rfc64PersistenceV1;
 }
 
 class RecordingCatalogMutationCoordinatorV1 extends Rfc64CatalogMutationCoordinatorV1 {
@@ -55,5 +97,56 @@ describe('RFC-64 catalog mutation coordinator', () => {
     )).resolves.toBe('complete');
     expect(coordinator.admissions).toEqual(expectedOrder);
     expect(coordinator.activeScopeCount).toBe(0);
+  });
+});
+
+describe('RFC-64 locked catalog replay snapshots', () => {
+  it('rejects an unscoped replay when durable inventory changes during delivery', async () => {
+    const initial = Object.freeze({
+      catalogScopeDigest: DIGEST_A,
+      authorAddress: AUTHOR,
+      currentCatalogHeadDigest: DIGEST_A,
+      appliedInventoryDigest: DIGEST_B,
+      catalogVersion: '0',
+      inventoryRowCount: '0',
+    }) as AppliedCatalogHeadSnapshotV1;
+    let inventory: readonly AppliedCatalogHeadSnapshotV1[] = [initial];
+
+    await expect(withLockedRfc64CatalogReplaySnapshotV1({
+      persistence: persistenceWithInventory(() => inventory),
+      mutationCoordinator: new Rfc64CatalogMutationCoordinatorV1(),
+      requestedScope: undefined,
+      readIndex: async () => new Map(),
+      operation: async () => {
+        inventory = [Object.freeze({ ...initial, catalogVersion: '1' })];
+        return 'delivered';
+      },
+    })).rejects.toThrow(/durable catalog inventory changed during replay/u);
+  });
+
+  it('rejects a scoped replay when a new author scope appears after discovery', async () => {
+    const contextGraphId = `${AUTHOR}/catalog`;
+    const replayScopeKey = rfc64CatalogReplayScopeKeyV1('hardhat1', contextGraphId);
+    const first = replayHead(catalogScope(contextGraphId), DIGEST_A);
+    const late = replayHead(catalogScope(contextGraphId, OTHER_AUTHOR), DIGEST_B);
+    const readIndex = vi.fn()
+      .mockResolvedValueOnce(new Map([[replayScopeKey, [first]]]))
+      .mockResolvedValueOnce(new Map([[replayScopeKey, [first, late]]]));
+    const operation = vi.fn(async () => 'delivered');
+
+    await expect(withLockedRfc64CatalogReplaySnapshotV1({
+      persistence: persistenceWithInventory(() => []),
+      mutationCoordinator: new Rfc64CatalogMutationCoordinatorV1(),
+      requestedScope: Object.freeze({
+        kind: 'Rfc64PublicCatalogHeadReplayV1',
+        networkId: 'hardhat1',
+        contextGraphId,
+        policyDigest: DIGEST_A,
+      }),
+      readIndex,
+      operation,
+    })).rejects.toThrow(/scoped catalog inventory changed before replay snapshot/u);
+    expect(readIndex).toHaveBeenCalledTimes(2);
+    expect(operation).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent/test/rfc64-catalog-replay-snapshot-runtime-v1.test.ts
+++ b/packages/agent/test/rfc64-catalog-replay-snapshot-runtime-v1.test.ts
@@ -16,10 +16,11 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { Rfc64CatalogMutationCoordinatorV1 } from
   '../src/rfc64/catalog-mutation-runtime-v1.js';
-import { Rfc64CatalogReplaySnapshotRuntimeV1 } from
-  '../src/rfc64/catalog-replay-snapshot-runtime-v1.js';
+import {
+  Rfc64CatalogReplaySnapshotRuntimeV1,
+  type Rfc64CatalogReplaySnapshotStorageV1,
+} from '../src/rfc64/catalog-replay-snapshot-runtime-v1.js';
 import type { AppliedCatalogHeadSnapshotV1 } from '../src/rfc64/inventory-v1/index.js';
-import type { Rfc64PersistenceV1 } from '../src/rfc64/persistence-v1.js';
 
 const NETWORK_ID = 'hardhat1';
 const AUTHOR = '0x1111111111111111111111111111111111111111';
@@ -92,12 +93,11 @@ function appliedSnapshot(
   });
 }
 
-function replayRequest(contextGraphId = CONTEXT_GRAPH_ID) {
+function scopedSelection(contextGraphId = CONTEXT_GRAPH_ID) {
   return Object.freeze({
-    kind: 'Rfc64PublicCatalogHeadReplayV1' as const,
+    kind: 'scope' as const,
     networkId: NETWORK_ID,
     contextGraphId,
-    policyDigest: DELEGATION_DIGEST,
   });
 }
 
@@ -106,27 +106,18 @@ function createReplayFixture(initialHeads: readonly SignedAuthorCatalogHeadEnvel
   const storedHeads = new Map<string, SignedAuthorCatalogHeadEnvelopeV1>(
     initialHeads.map((head) => [head.objectDigest, head]),
   );
-  const getVerifiedObjectByDigest = vi.fn(async (
-    input: Readonly<{ objectDigest: Digest32V1 }>,
-  ) => {
-    const envelope = storedHeads.get(input.objectDigest);
-    if (envelope === undefined) return null;
-    return Object.freeze({
-      envelope,
-      issuerSignature: Object.freeze({}),
-    });
+  const readVerifiedCatalogHeadV1 = vi.fn(async (objectDigest: Digest32V1) => (
+    storedHeads.get(objectDigest) ?? null
+  ));
+  const storage: Rfc64CatalogReplaySnapshotStorageV1 = Object.freeze({
+    listAppliedCatalogHeadsV1: () => inventory,
+    readVerifiedCatalogHeadV1,
   });
-  const persistence = Object.freeze({
-    inventory: Object.freeze({
-      listAppliedCatalogHeadsV1: () => inventory,
-    }),
-    controlObjects: Object.freeze({ getVerifiedObjectByDigest }),
-  }) as unknown as Rfc64PersistenceV1;
   const coordinator = new Rfc64CatalogMutationCoordinatorV1();
-  const runtime = new Rfc64CatalogReplaySnapshotRuntimeV1(persistence, coordinator);
+  const runtime = new Rfc64CatalogReplaySnapshotRuntimeV1(storage, coordinator);
   return Object.freeze({
     coordinator,
-    getVerifiedObjectByDigest,
+    readVerifiedCatalogHeadV1,
     runtime,
     stage(head: SignedAuthorCatalogHeadEnvelopeV1): void {
       storedHeads.set(head.objectDigest, head);
@@ -166,17 +157,17 @@ describe('RFC-64 catalog replay snapshot runtime', () => {
     const successor = signedHead(catalogScope(CONTEXT_GRAPH_ID), '1');
     const fixture = createReplayFixture([initial]);
     const readDigests = async () => fixture.runtime.withSnapshot({
-      requestedScope: replayRequest(),
+      selection: scopedSelection(),
       operation: async (entries) => entries.map(({ head }) => head.objectDigest),
     });
 
     await expect(readDigests()).resolves.toEqual([initial.objectDigest]);
     await expect(readDigests()).resolves.toEqual([initial.objectDigest]);
-    expect(fixture.getVerifiedObjectByDigest).toHaveBeenCalledTimes(1);
+    expect(fixture.readVerifiedCatalogHeadV1).toHaveBeenCalledTimes(1);
 
     fixture.replaceAppliedHeads([successor]);
     await expect(readDigests()).resolves.toEqual([successor.objectDigest]);
-    expect(fixture.getVerifiedObjectByDigest).toHaveBeenCalledTimes(2);
+    expect(fixture.readVerifiedCatalogHeadV1).toHaveBeenCalledTimes(2);
   });
 
   it('rejects an unscoped replay when inventory changes before the locks settle', async () => {
@@ -187,9 +178,12 @@ describe('RFC-64 catalog replay snapshot runtime', () => {
     const held = await holdScope(fixture.coordinator, scope);
     const operation = vi.fn(async () => 'delivered');
 
-    const replay = fixture.runtime.withSnapshot({ requestedScope: undefined, operation });
+    const replay = fixture.runtime.withSnapshot({
+      selection: Object.freeze({ kind: 'all' }),
+      operation,
+    });
     await vi.waitFor(() => {
-      expect(fixture.getVerifiedObjectByDigest).toHaveBeenCalledTimes(1);
+      expect(fixture.readVerifiedCatalogHeadV1).toHaveBeenCalledTimes(1);
     });
     fixture.replaceAppliedHeads([successor]);
     held.release();
@@ -205,7 +199,7 @@ describe('RFC-64 catalog replay snapshot runtime', () => {
     const fixture = createReplayFixture([initial]);
 
     await expect(fixture.runtime.withSnapshot({
-      requestedScope: undefined,
+      selection: Object.freeze({ kind: 'all' }),
       operation: async () => {
         fixture.replaceAppliedHeads([successor]);
         return 'delivered';
@@ -222,11 +216,11 @@ describe('RFC-64 catalog replay snapshot runtime', () => {
     const held = await holdScope(fixture.coordinator, scope);
 
     const replay = fixture.runtime.withSnapshot({
-      requestedScope: replayRequest(),
+      selection: scopedSelection(),
       operation: async (entries) => entries.map(({ head }) => head.objectDigest),
     });
     await vi.waitFor(() => {
-      expect(fixture.getVerifiedObjectByDigest).toHaveBeenCalledTimes(1);
+      expect(fixture.readVerifiedCatalogHeadV1).toHaveBeenCalledTimes(1);
     });
     fixture.replaceAppliedHeads([successor]);
     held.release();
@@ -245,11 +239,11 @@ describe('RFC-64 catalog replay snapshot runtime', () => {
     const operation = vi.fn(async () => 'delivered');
 
     const replay = fixture.runtime.withSnapshot({
-      requestedScope: replayRequest(),
+      selection: scopedSelection(),
       operation,
     });
     await vi.waitFor(() => {
-      expect(fixture.getVerifiedObjectByDigest).toHaveBeenCalledTimes(1);
+      expect(fixture.readVerifiedCatalogHeadV1).toHaveBeenCalledTimes(1);
     });
     fixture.replaceAppliedHeads([initial, late]);
     held.release();
@@ -266,7 +260,7 @@ describe('RFC-64 catalog replay snapshot runtime', () => {
     const fixture = createReplayFixture([initial]);
 
     await expect(fixture.runtime.withSnapshot({
-      requestedScope: replayRequest(),
+      selection: scopedSelection(),
       operation: async () => {
         fixture.replaceAppliedHeads([successor]);
         return 'delivered';
@@ -282,7 +276,7 @@ describe('RFC-64 catalog replay snapshot runtime', () => {
     const fixture = createReplayFixture([requested, unrelated]);
 
     await expect(fixture.runtime.withSnapshot({
-      requestedScope: replayRequest(),
+      selection: scopedSelection(),
       operation: async (entries) => {
         fixture.replaceAppliedHeads([requested, unrelatedSuccessor]);
         return entries.map(({ head }) => head.objectDigest);
@@ -296,14 +290,14 @@ describe('RFC-64 catalog replay snapshot runtime', () => {
     const missingFixture = createReplayFixture([initial]);
     missingFixture.remove(initial.objectDigest);
     await expect(missingFixture.runtime.withSnapshot({
-      requestedScope: replayRequest(),
+      selection: scopedSelection(),
       operation: async () => undefined,
     })).rejects.toThrow(/durable catalog head is missing or unverifiable/u);
 
     const mismatchFixture = createReplayFixture([initial]);
     mismatchFixture.storeAtDigest(initial.objectDigest, mismatched);
     await expect(mismatchFixture.runtime.withSnapshot({
-      requestedScope: replayRequest(),
+      selection: scopedSelection(),
       operation: async () => undefined,
     })).rejects.toThrow(/durable catalog inventory contains an invalid head/u);
   });

--- a/packages/agent/test/rfc64-catalog-replay-snapshot-runtime-v1.test.ts
+++ b/packages/agent/test/rfc64-catalog-replay-snapshot-runtime-v1.test.ts
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
+  assertSignedAuthorCatalogHeadEnvelopeV1,
+  computeAuthorCatalogHeadObjectDigestV1,
+  computeAuthorCatalogScopeDigestV1,
+  deriveAuthorCatalogScopeFromHeadV1,
+  type AuthorCatalogHeadV1,
+  type AuthorCatalogScopeV1,
+  type Digest32V1,
+  type SignedAuthorCatalogHeadEnvelopeV1,
+  type UnsignedControlEnvelopeV1,
+} from '@origintrail-official/dkg-core';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Rfc64CatalogMutationCoordinatorV1 } from
+  '../src/rfc64/catalog-mutation-runtime-v1.js';
+import { Rfc64CatalogReplaySnapshotRuntimeV1 } from
+  '../src/rfc64/catalog-replay-snapshot-runtime-v1.js';
+import type { AppliedCatalogHeadSnapshotV1 } from '../src/rfc64/inventory-v1/index.js';
+import type { Rfc64PersistenceV1 } from '../src/rfc64/persistence-v1.js';
+
+const NETWORK_ID = 'hardhat1';
+const AUTHOR = '0x1111111111111111111111111111111111111111';
+const OTHER_AUTHOR = '0x2222222222222222222222222222222222222222';
+const CONTEXT_GRAPH_ID = `${AUTHOR}/catalog`;
+const OTHER_CONTEXT_GRAPH_ID = `${AUTHOR}/unrelated`;
+const DELEGATION_DIGEST = `0x${'66'.repeat(32)}` as Digest32V1;
+const APPLIED_INVENTORY_DIGEST = `0x${'99'.repeat(32)}` as Digest32V1;
+const SIGNATURE = `0x${'77'.repeat(65)}`;
+
+function catalogScope(
+  contextGraphId: string,
+  authorAddress = AUTHOR,
+): Readonly<AuthorCatalogScopeV1> {
+  return Object.freeze({
+    networkId: NETWORK_ID,
+    contextGraphId,
+    governanceChainId: null,
+    governanceContractAddress: null,
+    ownershipTransitionDigest: null,
+    subGraphName: null,
+    authorAddress,
+    era: '0',
+    bucketCount: '1',
+  }) as AuthorCatalogScopeV1;
+}
+
+function signedHead(
+  scope: Readonly<AuthorCatalogScopeV1>,
+  version: string,
+): SignedAuthorCatalogHeadEnvelopeV1 {
+  const directoryByte = (BigInt(version) + 1n).toString(16).padStart(2, '0');
+  const payload = Object.freeze({
+    ...scope,
+    catalogIssuerDelegationDigest: DELEGATION_DIGEST,
+    version,
+    previousHeadDigest: null,
+    totalRows: '0',
+    directoryHeight: '0',
+    directoryRootDigest: `0x${directoryByte.repeat(32)}`,
+    issuedAt: String(1_773_900_000_000n + BigInt(version)),
+  }) as AuthorCatalogHeadV1;
+  const unsigned = Object.freeze({
+    issuer: scope.authorAddress,
+    objectType: AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
+    payload,
+    signatureEvidence: Object.freeze({ kind: 'none' }),
+    signatureSuite: 'eip191-personal-sign-digest-v1',
+  }) as UnsignedControlEnvelopeV1;
+  const head = Object.freeze({
+    ...unsigned,
+    objectDigest: computeAuthorCatalogHeadObjectDigestV1(unsigned),
+    signature: SIGNATURE,
+  });
+  assertSignedAuthorCatalogHeadEnvelopeV1(head);
+  return head;
+}
+
+function appliedSnapshot(
+  head: Readonly<SignedAuthorCatalogHeadEnvelopeV1>,
+): AppliedCatalogHeadSnapshotV1 {
+  const scope = deriveAuthorCatalogScopeFromHeadV1(head.payload);
+  return Object.freeze({
+    catalogScopeDigest: computeAuthorCatalogScopeDigestV1(scope),
+    authorAddress: head.payload.authorAddress,
+    currentCatalogHeadDigest: head.objectDigest,
+    appliedInventoryDigest: APPLIED_INVENTORY_DIGEST,
+    catalogVersion: head.payload.version,
+    inventoryRowCount: head.payload.totalRows,
+  });
+}
+
+function replayRequest(contextGraphId = CONTEXT_GRAPH_ID) {
+  return Object.freeze({
+    kind: 'Rfc64PublicCatalogHeadReplayV1' as const,
+    networkId: NETWORK_ID,
+    contextGraphId,
+    policyDigest: DELEGATION_DIGEST,
+  });
+}
+
+function createReplayFixture(initialHeads: readonly SignedAuthorCatalogHeadEnvelopeV1[]) {
+  let inventory = initialHeads.map(appliedSnapshot);
+  const storedHeads = new Map<string, SignedAuthorCatalogHeadEnvelopeV1>(
+    initialHeads.map((head) => [head.objectDigest, head]),
+  );
+  const getVerifiedObjectByDigest = vi.fn(async (
+    input: Readonly<{ objectDigest: Digest32V1 }>,
+  ) => {
+    const envelope = storedHeads.get(input.objectDigest);
+    if (envelope === undefined) return null;
+    return Object.freeze({
+      envelope,
+      issuerSignature: Object.freeze({}),
+    });
+  });
+  const persistence = Object.freeze({
+    inventory: Object.freeze({
+      listAppliedCatalogHeadsV1: () => inventory,
+    }),
+    controlObjects: Object.freeze({ getVerifiedObjectByDigest }),
+  }) as unknown as Rfc64PersistenceV1;
+  const coordinator = new Rfc64CatalogMutationCoordinatorV1();
+  const runtime = new Rfc64CatalogReplaySnapshotRuntimeV1(persistence, coordinator);
+  return Object.freeze({
+    coordinator,
+    getVerifiedObjectByDigest,
+    runtime,
+    stage(head: SignedAuthorCatalogHeadEnvelopeV1): void {
+      storedHeads.set(head.objectDigest, head);
+    },
+    storeAtDigest(digest: Digest32V1, head: SignedAuthorCatalogHeadEnvelopeV1): void {
+      storedHeads.set(digest, head);
+    },
+    remove(digest: Digest32V1): void {
+      storedHeads.delete(digest);
+    },
+    replaceAppliedHeads(heads: readonly SignedAuthorCatalogHeadEnvelopeV1[]): void {
+      for (const head of heads) storedHeads.set(head.objectDigest, head);
+      inventory = heads.map(appliedSnapshot);
+    },
+  });
+}
+
+async function holdScope(
+  coordinator: Rfc64CatalogMutationCoordinatorV1,
+  scope: Readonly<AuthorCatalogScopeV1>,
+) {
+  let release!: () => void;
+  let markEntered!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  const entered = new Promise<void>((resolve) => { markEntered = resolve; });
+  const completion = coordinator.run(scope, async () => {
+    markEntered();
+    await gate;
+  });
+  await entered;
+  return Object.freeze({ release, completion });
+}
+
+describe('RFC-64 catalog replay snapshot runtime', () => {
+  it('reuses its index until the durable inventory fingerprint changes', async () => {
+    const initial = signedHead(catalogScope(CONTEXT_GRAPH_ID), '0');
+    const successor = signedHead(catalogScope(CONTEXT_GRAPH_ID), '1');
+    const fixture = createReplayFixture([initial]);
+    const readDigests = async () => fixture.runtime.withSnapshot({
+      requestedScope: replayRequest(),
+      operation: async (entries) => entries.map(({ head }) => head.objectDigest),
+    });
+
+    await expect(readDigests()).resolves.toEqual([initial.objectDigest]);
+    await expect(readDigests()).resolves.toEqual([initial.objectDigest]);
+    expect(fixture.getVerifiedObjectByDigest).toHaveBeenCalledTimes(1);
+
+    fixture.replaceAppliedHeads([successor]);
+    await expect(readDigests()).resolves.toEqual([successor.objectDigest]);
+    expect(fixture.getVerifiedObjectByDigest).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects an unscoped replay when inventory changes before the locks settle', async () => {
+    const scope = catalogScope(CONTEXT_GRAPH_ID);
+    const initial = signedHead(scope, '0');
+    const successor = signedHead(scope, '1');
+    const fixture = createReplayFixture([initial]);
+    const held = await holdScope(fixture.coordinator, scope);
+    const operation = vi.fn(async () => 'delivered');
+
+    const replay = fixture.runtime.withSnapshot({ requestedScope: undefined, operation });
+    await vi.waitFor(() => {
+      expect(fixture.getVerifiedObjectByDigest).toHaveBeenCalledTimes(1);
+    });
+    fixture.replaceAppliedHeads([successor]);
+    held.release();
+    await held.completion;
+
+    await expect(replay).rejects.toThrow(/inventory changed before replay snapshot/u);
+    expect(operation).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unscoped replay when inventory changes during delivery', async () => {
+    const initial = signedHead(catalogScope(CONTEXT_GRAPH_ID), '0');
+    const successor = signedHead(catalogScope(CONTEXT_GRAPH_ID), '1');
+    const fixture = createReplayFixture([initial]);
+
+    await expect(fixture.runtime.withSnapshot({
+      requestedScope: undefined,
+      operation: async () => {
+        fixture.replaceAppliedHeads([successor]);
+        return 'delivered';
+      },
+    })).rejects.toThrow(/durable catalog inventory changed during replay/u);
+  });
+
+  it('refreshes a scoped replay after its current head advances before lock acquisition', async () => {
+    const scope = catalogScope(CONTEXT_GRAPH_ID);
+    const initial = signedHead(scope, '0');
+    const successor = signedHead(scope, '1');
+    const fixture = createReplayFixture([initial]);
+    fixture.stage(successor);
+    const held = await holdScope(fixture.coordinator, scope);
+
+    const replay = fixture.runtime.withSnapshot({
+      requestedScope: replayRequest(),
+      operation: async (entries) => entries.map(({ head }) => head.objectDigest),
+    });
+    await vi.waitFor(() => {
+      expect(fixture.getVerifiedObjectByDigest).toHaveBeenCalledTimes(1);
+    });
+    fixture.replaceAppliedHeads([successor]);
+    held.release();
+    await held.completion;
+
+    await expect(replay).resolves.toEqual([successor.objectDigest]);
+  });
+
+  it('rejects a scoped replay when a new author scope appears after discovery', async () => {
+    const initialScope = catalogScope(CONTEXT_GRAPH_ID);
+    const initial = signedHead(initialScope, '0');
+    const late = signedHead(catalogScope(CONTEXT_GRAPH_ID, OTHER_AUTHOR), '0');
+    const fixture = createReplayFixture([initial]);
+    fixture.stage(late);
+    const held = await holdScope(fixture.coordinator, initialScope);
+    const operation = vi.fn(async () => 'delivered');
+
+    const replay = fixture.runtime.withSnapshot({
+      requestedScope: replayRequest(),
+      operation,
+    });
+    await vi.waitFor(() => {
+      expect(fixture.getVerifiedObjectByDigest).toHaveBeenCalledTimes(1);
+    });
+    fixture.replaceAppliedHeads([initial, late]);
+    held.release();
+    await held.completion;
+
+    await expect(replay).rejects.toThrow(/scoped catalog inventory changed before replay snapshot/u);
+    expect(operation).not.toHaveBeenCalled();
+  });
+
+  it('rejects a scoped replay when its locked snapshot changes during delivery', async () => {
+    const scope = catalogScope(CONTEXT_GRAPH_ID);
+    const initial = signedHead(scope, '0');
+    const successor = signedHead(scope, '1');
+    const fixture = createReplayFixture([initial]);
+
+    await expect(fixture.runtime.withSnapshot({
+      requestedScope: replayRequest(),
+      operation: async () => {
+        fixture.replaceAppliedHeads([successor]);
+        return 'delivered';
+      },
+    })).rejects.toThrow(/scoped catalog inventory changed during replay/u);
+  });
+
+  it('keeps a scoped replay stable when an unrelated catalog changes during delivery', async () => {
+    const requested = signedHead(catalogScope(CONTEXT_GRAPH_ID), '0');
+    const unrelatedScope = catalogScope(OTHER_CONTEXT_GRAPH_ID);
+    const unrelated = signedHead(unrelatedScope, '0');
+    const unrelatedSuccessor = signedHead(unrelatedScope, '1');
+    const fixture = createReplayFixture([requested, unrelated]);
+
+    await expect(fixture.runtime.withSnapshot({
+      requestedScope: replayRequest(),
+      operation: async (entries) => {
+        fixture.replaceAppliedHeads([requested, unrelatedSuccessor]);
+        return entries.map(({ head }) => head.objectDigest);
+      },
+    })).resolves.toEqual([requested.objectDigest]);
+  });
+
+  it('rejects missing and mismatched durable catalog heads', async () => {
+    const initial = signedHead(catalogScope(CONTEXT_GRAPH_ID), '0');
+    const mismatched = signedHead(catalogScope(CONTEXT_GRAPH_ID), '1');
+    const missingFixture = createReplayFixture([initial]);
+    missingFixture.remove(initial.objectDigest);
+    await expect(missingFixture.runtime.withSnapshot({
+      requestedScope: replayRequest(),
+      operation: async () => undefined,
+    })).rejects.toThrow(/durable catalog head is missing or unverifiable/u);
+
+    const mismatchFixture = createReplayFixture([initial]);
+    mismatchFixture.storeAtDigest(initial.objectDigest, mismatched);
+    await expect(mismatchFixture.runtime.withSnapshot({
+      requestedScope: replayRequest(),
+      operation: async () => undefined,
+    })).rejects.toThrow(/durable catalog inventory contains an invalid head/u);
+  });
+});

--- a/packages/agent/test/rfc64-rollout-authority.integration.test.ts
+++ b/packages/agent/test/rfc64-rollout-authority.integration.test.ts
@@ -9,7 +9,6 @@ import {
   computeAuthorCatalogScopeDigestV1,
   createOperationContext,
   deriveCanonicalGraphScopedAuthorSealPlacementV1,
-  encodeCanonicalCgSharedPublicRootProjectionV1,
   projectCanonicalGraphScopedAuthorSealRowsV1,
   SYSTEM_CONTEXT_GRAPHS,
   type AssertionSeal,
@@ -196,53 +195,6 @@ async function startAppliedOpenReplayProvider(name: string) {
     inventoryRowCount: '0',
   }).snapshot;
   return Object.freeze({ provider, persistence, publication, scope, applied });
-}
-
-interface Rfc64CatalogMutationCoordinatorTestViewV1 {
-  run<T>(
-    scope: Readonly<AuthorCatalogScopeV1>,
-    operation: () => Promise<T>,
-    signal?: AbortSignal,
-  ): Promise<T>;
-}
-
-async function holdCatalogMutationUntilNextAdmissionV1(
-  provider: DKGAgent,
-  scope: Readonly<AuthorCatalogScopeV1>,
-): Promise<Readonly<{
-  nextAdmission: Promise<void>;
-  release(): void;
-  completion: Promise<void>;
-}>> {
-  const coordinator = (provider as unknown as {
-    rfc64CatalogMutationCoordinatorV1: Rfc64CatalogMutationCoordinatorTestViewV1;
-  }).rfc64CatalogMutationCoordinatorV1;
-  const originalRun = coordinator.run.bind(coordinator);
-  let admissions = 0;
-  let markNextAdmission!: () => void;
-  const nextAdmission = new Promise<void>((resolve) => { markNextAdmission = resolve; });
-  function runWithAdmissionSignal<T>(
-    admittedScope: Readonly<AuthorCatalogScopeV1>,
-    operation: () => Promise<T>,
-    signal?: AbortSignal,
-  ): Promise<T> {
-    const completion = originalRun(admittedScope, operation, signal);
-    admissions += 1;
-    if (admissions === 2) markNextAdmission();
-    return completion;
-  }
-  vi.spyOn(coordinator, 'run').mockImplementation(runWithAdmissionSignal);
-
-  let release!: () => void;
-  let markEntered!: () => void;
-  const gate = new Promise<void>((resolve) => { release = resolve; });
-  const entered = new Promise<void>((resolve) => { markEntered = resolve; });
-  const completion = coordinator.run(scope, async () => {
-    markEntered();
-    await gate;
-  });
-  await entered;
-  return Object.freeze({ nextAdmission, release, completion });
 }
 
 afterEach(async () => {
@@ -841,224 +793,32 @@ describe('RFC-64 rollout authority integration', () => {
     )).rejects.toThrow(/durable catalog head is missing or unverifiable/u);
   });
 
-  it('rejects a replay snapshot when the durable inventory changes during head loading', async () => {
-    const { provider, persistence, scope, applied } =
-      await startAppliedOpenReplayProvider('replay-inventory-race');
-    vi.spyOn((provider as any).router, 'send').mockResolvedValue(Uint8Array.of(1));
-    await provider.reannounceRfc64CatalogHeadsToPeerV1(
-      '12D3KooWReplayInventoryWarmupPeer',
-    );
-    const heldMutation = await holdCatalogMutationUntilNextAdmissionV1(provider, scope);
+  it('rejects provider replay when durable inventory changes during delivery', async () => {
+    const { provider, persistence, applied } =
+      await startAppliedOpenReplayProvider('replay-delivery-race');
+    let releaseDelivery!: () => void;
+    let markDeliveryEntered!: () => void;
+    const deliveryGate = new Promise<void>((resolve) => { releaseDelivery = resolve; });
+    const deliveryEntered = new Promise<void>((resolve) => { markDeliveryEntered = resolve; });
+    vi.spyOn((provider as any).router, 'send').mockImplementation(async () => {
+      markDeliveryEntered();
+      await deliveryGate;
+      return Uint8Array.of(1);
+    });
 
     const replay = provider.reannounceRfc64CatalogHeadsToPeerV1(
-      '12D3KooWReplayInventoryRacePeer',
+      '12D3KooWReplayDeliveryRacePeer',
     );
-    await heldMutation.nextAdmission;
+    await deliveryEntered;
     persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
       ...applied,
       expectedCurrentCatalogHeadDigest: applied.currentCatalogHeadDigest,
       currentCatalogHeadDigest: `0x${'cd'.repeat(32)}`,
       catalogVersion: '1',
     });
-    heldMutation.release();
-    await heldMutation.completion;
-
-    await expect(replay).rejects.toThrow(/inventory changed before replay snapshot/u);
-  });
-
-  it('refreshes a scoped replay after its current head advances before lock acquisition', async () => {
-    const { provider, persistence, publication, scope, applied } =
-      await startAppliedOpenReplayProvider('scoped-replay-head-race');
-    const signer = Object.freeze({
-      address: AUTHOR,
-      signMessage: (digest: Uint8Array) => AUTHOR_WALLET.signMessage(digest),
-    });
-    const successor = await provider.upsertConfirmedRfc64PublicRootCatalogAssetV1({
-      scope,
-      author: signer,
-      asset: Object.freeze({
-        assertionCoordinate: 'scoped-replay-head-race' as never,
-        projectionBytes: encodeCanonicalCgSharedPublicRootProjectionV1(PROJECTION_QUADS),
-        seal: await authorSeal(101n),
-      }),
-      deployment: DEPLOYMENT,
-      peers: [],
-      catalogIssuerDelegationEffectiveAt: '1773899999000' as TimestampMsV1,
-      catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
-    });
-    persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
-      ...applied,
-      expectedCurrentCatalogHeadDigest: successor.currentCatalogHeadDigest,
-    });
-    vi.spyOn((provider as any).router, 'send').mockResolvedValue(Uint8Array.of(1));
-
-    const heldMutation = await holdCatalogMutationUntilNextAdmissionV1(provider, scope);
-
-    const replay = provider.reannounceRfc64CatalogHeadsToPeerV1(
-      '12D3KooWScopedReplayHeadRacePeer',
-      Object.freeze({
-        kind: RFC64_PUBLIC_CATALOG_HEAD_REPLAY_KIND_V1,
-        networkId: NETWORK_ID,
-        contextGraphId: CONTEXT_GRAPH_ID,
-        policyDigest: publication.announcement.policyDigest,
-      }),
-    );
-    await heldMutation.nextAdmission;
-    persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
-      ...successor,
-      expectedCurrentCatalogHeadDigest: applied.currentCatalogHeadDigest,
-    });
-    heldMutation.release();
-    await heldMutation.completion;
-
-    await expect(replay).resolves.toMatchObject({
-      announced: 1,
-      failed: 0,
-      manifest: [expect.objectContaining({
-        catalogHeadObjectDigest: successor.currentCatalogHeadDigest,
-      })],
-    });
-  });
-
-  it('rejects a scoped replay when its locked snapshot changes during delivery', async () => {
-    const { provider, persistence, publication, scope, applied } =
-      await startAppliedOpenReplayProvider('scoped-replay-delivery-race');
-    const signer = Object.freeze({
-      address: AUTHOR,
-      signMessage: (digest: Uint8Array) => AUTHOR_WALLET.signMessage(digest),
-    });
-    const successor = await provider.upsertConfirmedRfc64PublicRootCatalogAssetV1({
-      scope,
-      author: signer,
-      asset: Object.freeze({
-        assertionCoordinate: 'scoped-replay-delivery-race' as never,
-        projectionBytes: encodeCanonicalCgSharedPublicRootProjectionV1(PROJECTION_QUADS),
-        seal: await authorSeal(102n),
-      }),
-      deployment: DEPLOYMENT,
-      peers: [],
-      catalogIssuerDelegationEffectiveAt: '1773899999000' as TimestampMsV1,
-      catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
-    });
-    persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
-      ...applied,
-      expectedCurrentCatalogHeadDigest: successor.currentCatalogHeadDigest,
-    });
-
-    let releaseDelivery!: () => void;
-    let markDeliveryEntered!: () => void;
-    const deliveryGate = new Promise<void>((resolve) => { releaseDelivery = resolve; });
-    const deliveryEntered = new Promise<void>((resolve) => { markDeliveryEntered = resolve; });
-    vi.spyOn((provider as any).router, 'send').mockImplementation(async () => {
-      markDeliveryEntered();
-      await deliveryGate;
-      return Uint8Array.of(1);
-    });
-
-    const replay = provider.reannounceRfc64CatalogHeadsToPeerV1(
-      '12D3KooWScopedReplayDeliveryRacePeer',
-      Object.freeze({
-        kind: RFC64_PUBLIC_CATALOG_HEAD_REPLAY_KIND_V1,
-        networkId: NETWORK_ID,
-        contextGraphId: CONTEXT_GRAPH_ID,
-        policyDigest: publication.announcement.policyDigest,
-      }),
-    );
-    await deliveryEntered;
-    persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
-      ...successor,
-      expectedCurrentCatalogHeadDigest: applied.currentCatalogHeadDigest,
-    });
     releaseDelivery();
 
-    await expect(replay).rejects.toThrow(/scoped catalog inventory changed during replay/u);
-  });
-
-  it('keeps a scoped replay valid when an unrelated catalog advances during delivery', async () => {
-    const { provider, persistence, publication } =
-      await startAppliedOpenReplayProvider('scoped-replay-unrelated-race');
-    const signer = Object.freeze({
-      address: AUTHOR,
-      signMessage: (digest: Uint8Array) => AUTHOR_WALLET.signMessage(digest),
-    });
-    const unrelatedContextGraphId = `${AUTHOR}/unrelated-replay` as ContextGraphIdV1;
-    const unrelatedPublication = await provider.publishOpenAuthorCatalogGenesisV1({
-      networkId: NETWORK_ID,
-      contextGraphId: unrelatedContextGraphId,
-      author: signer,
-      peers: [],
-      issuedAt: '1773900000100' as TimestampMsV1,
-      catalogIssuerDelegationEffectiveAt: '1773899999000' as TimestampMsV1,
-      catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
-    });
-    const unrelatedScope = Object.freeze({
-      networkId: NETWORK_ID,
-      contextGraphId: unrelatedContextGraphId,
-      governanceChainId: null,
-      governanceContractAddress: null,
-      ownershipTransitionDigest: null,
-      subGraphName: null,
-      authorAddress: AUTHOR,
-      era: '0',
-      bucketCount: '1',
-    }) as AuthorCatalogScopeV1;
-    const unrelatedScopeDigest = computeAuthorCatalogScopeDigestV1(unrelatedScope);
-    persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
-      catalogScopeDigest: unrelatedScopeDigest,
-      authorAddress: AUTHOR,
-      expectedCurrentCatalogHeadDigest: null,
-      currentCatalogHeadDigest: unrelatedPublication.headObjectDigest,
-      appliedInventoryDigest: computeRfc64AppliedInventoryDigestV1({
-        catalogScopeDigest: unrelatedScopeDigest,
-        rows: [],
-      }),
-      catalogVersion: unrelatedPublication.announcement.catalogVersion,
-      inventoryRowCount: '0',
-    });
-
-    let releaseDelivery!: () => void;
-    let markDeliveryEntered!: () => void;
-    const deliveryGate = new Promise<void>((resolve) => { releaseDelivery = resolve; });
-    const deliveryEntered = new Promise<void>((resolve) => { markDeliveryEntered = resolve; });
-    vi.spyOn((provider as any).router, 'send').mockImplementation(async () => {
-      markDeliveryEntered();
-      await deliveryGate;
-      return Uint8Array.of(1);
-    });
-
-    const replay = provider.reannounceRfc64CatalogHeadsToPeerV1(
-      '12D3KooWScopedReplayUnrelatedRacePeer',
-      Object.freeze({
-        kind: RFC64_PUBLIC_CATALOG_HEAD_REPLAY_KIND_V1,
-        networkId: NETWORK_ID,
-        contextGraphId: CONTEXT_GRAPH_ID,
-        policyDigest: publication.announcement.policyDigest,
-      }),
-    );
-    await deliveryEntered;
-    await provider.upsertConfirmedRfc64PublicRootCatalogAssetV1({
-      scope: unrelatedScope,
-      author: signer,
-      asset: Object.freeze({
-        assertionCoordinate: 'scoped-replay-unrelated-race' as never,
-        projectionBytes: encodeCanonicalCgSharedPublicRootProjectionV1(PROJECTION_QUADS),
-        seal: await authorSeal(103n),
-      }),
-      deployment: DEPLOYMENT,
-      peers: [],
-      catalogIssuerDelegationEffectiveAt: '1773899999000' as TimestampMsV1,
-      catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
-    });
-    releaseDelivery();
-
-    await expect(replay).resolves.toMatchObject({
-      announced: 1,
-      failed: 0,
-      manifest: [expect.objectContaining({
-        contextGraphId: CONTEXT_GRAPH_ID,
-        catalogHeadObjectDigest: publication.headObjectDigest,
-      })],
-    });
+    await expect(replay).rejects.toThrow(/durable catalog inventory changed during replay/u);
   });
 
   it('keeps system control graphs on durable sync under default catalog responsibility', async () => {

--- a/packages/agent/test/rfc64-rollout-authority.integration.test.ts
+++ b/packages/agent/test/rfc64-rollout-authority.integration.test.ts
@@ -197,6 +197,53 @@ async function startAppliedOpenReplayProvider(name: string) {
   return Object.freeze({ provider, persistence, publication, scope, applied });
 }
 
+interface Rfc64CatalogMutationCoordinatorTestViewV1 {
+  run<T>(
+    scope: Readonly<AuthorCatalogScopeV1>,
+    operation: () => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<T>;
+}
+
+async function holdCatalogMutationUntilNextAdmissionV1(
+  provider: DKGAgent,
+  scope: Readonly<AuthorCatalogScopeV1>,
+): Promise<Readonly<{
+  nextAdmission: Promise<void>;
+  release(): void;
+  completion: Promise<void>;
+}>> {
+  const coordinator = (provider as unknown as {
+    rfc64CatalogMutationCoordinatorV1: Rfc64CatalogMutationCoordinatorTestViewV1;
+  }).rfc64CatalogMutationCoordinatorV1;
+  const originalRun = coordinator.run.bind(coordinator);
+  let admissions = 0;
+  let markNextAdmission!: () => void;
+  const nextAdmission = new Promise<void>((resolve) => { markNextAdmission = resolve; });
+  function runWithAdmissionSignal<T>(
+    admittedScope: Readonly<AuthorCatalogScopeV1>,
+    operation: () => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    const completion = originalRun(admittedScope, operation, signal);
+    admissions += 1;
+    if (admissions === 2) markNextAdmission();
+    return completion;
+  }
+  vi.spyOn(coordinator, 'run').mockImplementation(runWithAdmissionSignal);
+
+  let release!: () => void;
+  let markEntered!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  const entered = new Promise<void>((resolve) => { markEntered = resolve; });
+  const completion = coordinator.run(scope, async () => {
+    markEntered();
+    await gate;
+  });
+  await entered;
+  return Object.freeze({ nextAdmission, release, completion });
+}
+
 afterEach(async () => {
   await cleanup();
   vi.restoreAllMocks();
@@ -800,31 +847,20 @@ describe('RFC-64 rollout authority integration', () => {
     await provider.reannounceRfc64CatalogHeadsToPeerV1(
       '12D3KooWReplayInventoryWarmupPeer',
     );
-    let releaseMutation!: () => void;
-    let markMutationEntered!: () => void;
-    const mutationGate = new Promise<void>((resolve) => { releaseMutation = resolve; });
-    const mutationEntered = new Promise<void>((resolve) => { markMutationEntered = resolve; });
-    const heldMutation = (provider as any).rfc64CatalogMutationCoordinatorV1.run(
-      scope,
-      async () => {
-        markMutationEntered();
-        await mutationGate;
-      },
-    );
-    await mutationEntered;
+    const heldMutation = await holdCatalogMutationUntilNextAdmissionV1(provider, scope);
 
     const replay = provider.reannounceRfc64CatalogHeadsToPeerV1(
       '12D3KooWReplayInventoryRacePeer',
     );
-    await new Promise<void>((resolve) => setTimeout(resolve, 25));
+    await heldMutation.nextAdmission;
     persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
       ...applied,
       expectedCurrentCatalogHeadDigest: applied.currentCatalogHeadDigest,
       currentCatalogHeadDigest: `0x${'cd'.repeat(32)}`,
       catalogVersion: '1',
     });
-    releaseMutation();
-    await heldMutation;
+    heldMutation.release();
+    await heldMutation.completion;
 
     await expect(replay).rejects.toThrow(/inventory changed before replay snapshot/u);
   });
@@ -855,18 +891,7 @@ describe('RFC-64 rollout authority integration', () => {
     });
     vi.spyOn((provider as any).router, 'send').mockResolvedValue(Uint8Array.of(1));
 
-    let releaseMutation!: () => void;
-    let markMutationEntered!: () => void;
-    const mutationGate = new Promise<void>((resolve) => { releaseMutation = resolve; });
-    const mutationEntered = new Promise<void>((resolve) => { markMutationEntered = resolve; });
-    const heldMutation = (provider as any).rfc64CatalogMutationCoordinatorV1.run(
-      scope,
-      async () => {
-        markMutationEntered();
-        await mutationGate;
-      },
-    );
-    await mutationEntered;
+    const heldMutation = await holdCatalogMutationUntilNextAdmissionV1(provider, scope);
 
     const replay = provider.reannounceRfc64CatalogHeadsToPeerV1(
       '12D3KooWScopedReplayHeadRacePeer',
@@ -877,13 +902,13 @@ describe('RFC-64 rollout authority integration', () => {
         policyDigest: publication.announcement.policyDigest,
       }),
     );
-    await new Promise<void>((resolve) => setTimeout(resolve, 25));
+    await heldMutation.nextAdmission;
     persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
       ...successor,
       expectedCurrentCatalogHeadDigest: applied.currentCatalogHeadDigest,
     });
-    releaseMutation();
-    await heldMutation;
+    heldMutation.release();
+    await heldMutation.completion;
 
     await expect(replay).resolves.toMatchObject({
       announced: 1,
@@ -892,6 +917,60 @@ describe('RFC-64 rollout authority integration', () => {
         catalogHeadObjectDigest: successor.currentCatalogHeadDigest,
       })],
     });
+  });
+
+  it('rejects a scoped replay when its locked snapshot changes during delivery', async () => {
+    const { provider, persistence, publication, scope, applied } =
+      await startAppliedOpenReplayProvider('scoped-replay-delivery-race');
+    const signer = Object.freeze({
+      address: AUTHOR,
+      signMessage: (digest: Uint8Array) => AUTHOR_WALLET.signMessage(digest),
+    });
+    const successor = await provider.upsertConfirmedRfc64PublicRootCatalogAssetV1({
+      scope,
+      author: signer,
+      asset: Object.freeze({
+        assertionCoordinate: 'scoped-replay-delivery-race' as never,
+        projectionBytes: encodeCanonicalCgSharedPublicRootProjectionV1(PROJECTION_QUADS),
+        seal: await authorSeal(102n),
+      }),
+      deployment: DEPLOYMENT,
+      peers: [],
+      catalogIssuerDelegationEffectiveAt: '1773899999000' as TimestampMsV1,
+      catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+    });
+    persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
+      ...applied,
+      expectedCurrentCatalogHeadDigest: successor.currentCatalogHeadDigest,
+    });
+
+    let releaseDelivery!: () => void;
+    let markDeliveryEntered!: () => void;
+    const deliveryGate = new Promise<void>((resolve) => { releaseDelivery = resolve; });
+    const deliveryEntered = new Promise<void>((resolve) => { markDeliveryEntered = resolve; });
+    vi.spyOn((provider as any).router, 'send').mockImplementation(async () => {
+      markDeliveryEntered();
+      await deliveryGate;
+      return Uint8Array.of(1);
+    });
+
+    const replay = provider.reannounceRfc64CatalogHeadsToPeerV1(
+      '12D3KooWScopedReplayDeliveryRacePeer',
+      Object.freeze({
+        kind: RFC64_PUBLIC_CATALOG_HEAD_REPLAY_KIND_V1,
+        networkId: NETWORK_ID,
+        contextGraphId: CONTEXT_GRAPH_ID,
+        policyDigest: publication.announcement.policyDigest,
+      }),
+    );
+    await deliveryEntered;
+    persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
+      ...successor,
+      expectedCurrentCatalogHeadDigest: applied.currentCatalogHeadDigest,
+    });
+    releaseDelivery();
+
+    await expect(replay).rejects.toThrow(/scoped catalog inventory changed during replay/u);
   });
 
   it('keeps system control graphs on durable sync under default catalog responsibility', async () => {

--- a/packages/agent/test/rfc64-rollout-authority.integration.test.ts
+++ b/packages/agent/test/rfc64-rollout-authority.integration.test.ts
@@ -9,6 +9,7 @@ import {
   computeAuthorCatalogScopeDigestV1,
   createOperationContext,
   deriveCanonicalGraphScopedAuthorSealPlacementV1,
+  encodeCanonicalCgSharedPublicRootProjectionV1,
   projectCanonicalGraphScopedAuthorSealRowsV1,
   SYSTEM_CONTEXT_GRAPHS,
   type AssertionSeal,
@@ -791,6 +792,85 @@ describe('RFC-64 rollout authority integration', () => {
     await expect(provider.reannounceRfc64CatalogHeadsToPeerV1(
       '12D3KooWReplayMissingHeadPeer',
     )).rejects.toThrow(/durable catalog head is missing or unverifiable/u);
+  });
+
+  it('refreshes scoped provider replay after its head advances while the scope lock waits', async () => {
+    const { provider, persistence, publication, scope, applied } =
+      await startAppliedOpenReplayProvider('scoped-replay-lock-race');
+    const successor = await provider.publishOpenAuthorCatalogExactSetSuccessorV1({
+      previousHead: {
+        objectDigest: publication.headObjectDigest,
+        signatureVariantDigest: publication.signatureVariantDigest,
+      },
+      author: Object.freeze({
+        address: AUTHOR,
+        signMessage: (digest: Uint8Array) => AUTHOR_WALLET.signMessage(digest),
+      }),
+      catalogIssuerAuthorization: publication.catalogIssuerAuthorization,
+      assets: [{
+        assertionCoordinate: 'scoped-replay-lock-race' as never,
+        projectionBytes: encodeCanonicalCgSharedPublicRootProjectionV1(PROJECTION_QUADS),
+        seal: await authorSeal(91n),
+      }],
+      deployment: DEPLOYMENT,
+      issuedAt: '1773900000001' as TimestampMsV1,
+      peers: [],
+    });
+    const [successorAsset] = successor.assets;
+    if (successorAsset === undefined) throw new Error('successor has no asset evidence');
+
+    const coordinator = (provider as any).rfc64CatalogMutationCoordinatorV1;
+    let releaseScope!: () => void;
+    let markScopeEntered!: () => void;
+    const scopeGate = new Promise<void>((resolve) => { releaseScope = resolve; });
+    const scopeEntered = new Promise<void>((resolve) => { markScopeEntered = resolve; });
+    const heldScope = coordinator.run(scope, async () => {
+      markScopeEntered();
+      await scopeGate;
+    });
+    await scopeEntered;
+
+    const runMany = vi.spyOn(coordinator, 'runMany');
+    const send = vi.spyOn((provider as any).router, 'send')
+      .mockResolvedValue(Uint8Array.of(1));
+    const replay = provider.reannounceRfc64CatalogHeadsToPeerV1(
+      '12D3KooWScopedReplayLockRacePeer',
+      Object.freeze({
+        kind: RFC64_PUBLIC_CATALOG_HEAD_REPLAY_KIND_V1,
+        networkId: NETWORK_ID,
+        contextGraphId: CONTEXT_GRAPH_ID,
+        policyDigest: publication.announcement.policyDigest,
+      }),
+    );
+    try {
+      await vi.waitFor(() => expect(runMany).toHaveBeenCalledTimes(1));
+      persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
+        ...applied,
+        expectedCurrentCatalogHeadDigest: applied.currentCatalogHeadDigest,
+        currentCatalogHeadDigest: successor.headObjectDigest,
+        appliedInventoryDigest: computeRfc64AppliedInventoryDigestV1({
+          catalogScopeDigest: successor.catalogScopeDigest,
+          rows: [successorAsset],
+        }),
+        catalogVersion: successor.announcement.catalogVersion,
+        inventoryRowCount: successor.inventoryRowCount,
+      });
+    } finally {
+      releaseScope();
+    }
+    await heldScope;
+
+    await expect(replay).resolves.toMatchObject({
+      announced: 1,
+      failed: 0,
+      manifest: [{ catalogHeadObjectDigest: successor.headObjectDigest }],
+    });
+    const sentAnnouncements = send.mock.calls
+      .filter(([, protocolId]) => protocolId === RFC64_PUBLIC_CATALOG_HEAD_ANNOUNCEMENT_PROTOCOL_V1)
+      .map(([, , data]) => parseRfc64PublicCatalogHeadAnnouncementV1(data));
+    expect(sentAnnouncements).toMatchObject([
+      { catalogHeadObjectDigest: successor.headObjectDigest },
+    ]);
   });
 
   it('rejects provider replay when durable inventory changes during delivery', async () => {

--- a/packages/agent/test/rfc64-rollout-authority.integration.test.ts
+++ b/packages/agent/test/rfc64-rollout-authority.integration.test.ts
@@ -9,6 +9,7 @@ import {
   computeAuthorCatalogScopeDigestV1,
   createOperationContext,
   deriveCanonicalGraphScopedAuthorSealPlacementV1,
+  encodeCanonicalCgSharedPublicRootProjectionV1,
   projectCanonicalGraphScopedAuthorSealRowsV1,
   SYSTEM_CONTEXT_GRAPHS,
   type AssertionSeal,
@@ -826,6 +827,71 @@ describe('RFC-64 rollout authority integration', () => {
     await heldMutation;
 
     await expect(replay).rejects.toThrow(/inventory changed before replay snapshot/u);
+  });
+
+  it('refreshes a scoped replay after its current head advances before lock acquisition', async () => {
+    const { provider, persistence, publication, scope, applied } =
+      await startAppliedOpenReplayProvider('scoped-replay-head-race');
+    const signer = Object.freeze({
+      address: AUTHOR,
+      signMessage: (digest: Uint8Array) => AUTHOR_WALLET.signMessage(digest),
+    });
+    const successor = await provider.upsertConfirmedRfc64PublicRootCatalogAssetV1({
+      scope,
+      author: signer,
+      asset: Object.freeze({
+        assertionCoordinate: 'scoped-replay-head-race' as never,
+        projectionBytes: encodeCanonicalCgSharedPublicRootProjectionV1(PROJECTION_QUADS),
+        seal: await authorSeal(101n),
+      }),
+      deployment: DEPLOYMENT,
+      peers: [],
+      catalogIssuerDelegationEffectiveAt: '1773899999000' as TimestampMsV1,
+      catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+    });
+    persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
+      ...applied,
+      expectedCurrentCatalogHeadDigest: successor.currentCatalogHeadDigest,
+    });
+    vi.spyOn((provider as any).router, 'send').mockResolvedValue(Uint8Array.of(1));
+
+    let releaseMutation!: () => void;
+    let markMutationEntered!: () => void;
+    const mutationGate = new Promise<void>((resolve) => { releaseMutation = resolve; });
+    const mutationEntered = new Promise<void>((resolve) => { markMutationEntered = resolve; });
+    const heldMutation = (provider as any).rfc64CatalogMutationCoordinatorV1.run(
+      scope,
+      async () => {
+        markMutationEntered();
+        await mutationGate;
+      },
+    );
+    await mutationEntered;
+
+    const replay = provider.reannounceRfc64CatalogHeadsToPeerV1(
+      '12D3KooWScopedReplayHeadRacePeer',
+      Object.freeze({
+        kind: RFC64_PUBLIC_CATALOG_HEAD_REPLAY_KIND_V1,
+        networkId: NETWORK_ID,
+        contextGraphId: CONTEXT_GRAPH_ID,
+        policyDigest: publication.announcement.policyDigest,
+      }),
+    );
+    await new Promise<void>((resolve) => setTimeout(resolve, 25));
+    persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
+      ...successor,
+      expectedCurrentCatalogHeadDigest: applied.currentCatalogHeadDigest,
+    });
+    releaseMutation();
+    await heldMutation;
+
+    await expect(replay).resolves.toMatchObject({
+      announced: 1,
+      failed: 0,
+      manifest: [expect.objectContaining({
+        catalogHeadObjectDigest: successor.currentCatalogHeadDigest,
+      })],
+    });
   });
 
   it('keeps system control graphs on durable sync under default catalog responsibility', async () => {

--- a/packages/agent/test/rfc64-rollout-authority.integration.test.ts
+++ b/packages/agent/test/rfc64-rollout-authority.integration.test.ts
@@ -15,6 +15,7 @@ import {
   type AssertionSeal,
   type AuthorCatalogScopeV1,
   type CanonicalGraphScopedAuthorSealV1,
+  type ContextGraphIdV1,
   type Digest32V1,
   type EvmAddressV1,
   type TimestampMsV1,
@@ -971,6 +972,93 @@ describe('RFC-64 rollout authority integration', () => {
     releaseDelivery();
 
     await expect(replay).rejects.toThrow(/scoped catalog inventory changed during replay/u);
+  });
+
+  it('keeps a scoped replay valid when an unrelated catalog advances during delivery', async () => {
+    const { provider, persistence, publication } =
+      await startAppliedOpenReplayProvider('scoped-replay-unrelated-race');
+    const signer = Object.freeze({
+      address: AUTHOR,
+      signMessage: (digest: Uint8Array) => AUTHOR_WALLET.signMessage(digest),
+    });
+    const unrelatedContextGraphId = `${AUTHOR}/unrelated-replay` as ContextGraphIdV1;
+    const unrelatedPublication = await provider.publishOpenAuthorCatalogGenesisV1({
+      networkId: NETWORK_ID,
+      contextGraphId: unrelatedContextGraphId,
+      author: signer,
+      peers: [],
+      issuedAt: '1773900000100' as TimestampMsV1,
+      catalogIssuerDelegationEffectiveAt: '1773899999000' as TimestampMsV1,
+      catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+    });
+    const unrelatedScope = Object.freeze({
+      networkId: NETWORK_ID,
+      contextGraphId: unrelatedContextGraphId,
+      governanceChainId: null,
+      governanceContractAddress: null,
+      ownershipTransitionDigest: null,
+      subGraphName: null,
+      authorAddress: AUTHOR,
+      era: '0',
+      bucketCount: '1',
+    }) as AuthorCatalogScopeV1;
+    const unrelatedScopeDigest = computeAuthorCatalogScopeDigestV1(unrelatedScope);
+    persistence.inventory.compareAndSwapAppliedCatalogHeadV1({
+      catalogScopeDigest: unrelatedScopeDigest,
+      authorAddress: AUTHOR,
+      expectedCurrentCatalogHeadDigest: null,
+      currentCatalogHeadDigest: unrelatedPublication.headObjectDigest,
+      appliedInventoryDigest: computeRfc64AppliedInventoryDigestV1({
+        catalogScopeDigest: unrelatedScopeDigest,
+        rows: [],
+      }),
+      catalogVersion: unrelatedPublication.announcement.catalogVersion,
+      inventoryRowCount: '0',
+    });
+
+    let releaseDelivery!: () => void;
+    let markDeliveryEntered!: () => void;
+    const deliveryGate = new Promise<void>((resolve) => { releaseDelivery = resolve; });
+    const deliveryEntered = new Promise<void>((resolve) => { markDeliveryEntered = resolve; });
+    vi.spyOn((provider as any).router, 'send').mockImplementation(async () => {
+      markDeliveryEntered();
+      await deliveryGate;
+      return Uint8Array.of(1);
+    });
+
+    const replay = provider.reannounceRfc64CatalogHeadsToPeerV1(
+      '12D3KooWScopedReplayUnrelatedRacePeer',
+      Object.freeze({
+        kind: RFC64_PUBLIC_CATALOG_HEAD_REPLAY_KIND_V1,
+        networkId: NETWORK_ID,
+        contextGraphId: CONTEXT_GRAPH_ID,
+        policyDigest: publication.announcement.policyDigest,
+      }),
+    );
+    await deliveryEntered;
+    await provider.upsertConfirmedRfc64PublicRootCatalogAssetV1({
+      scope: unrelatedScope,
+      author: signer,
+      asset: Object.freeze({
+        assertionCoordinate: 'scoped-replay-unrelated-race' as never,
+        projectionBytes: encodeCanonicalCgSharedPublicRootProjectionV1(PROJECTION_QUADS),
+        seal: await authorSeal(103n),
+      }),
+      deployment: DEPLOYMENT,
+      peers: [],
+      catalogIssuerDelegationEffectiveAt: '1773899999000' as TimestampMsV1,
+      catalogIssuerDelegationExpiresAt: '1893456000000' as TimestampMsV1,
+    });
+    releaseDelivery();
+
+    await expect(replay).resolves.toMatchObject({
+      announced: 1,
+      failed: 0,
+      manifest: [expect.objectContaining({
+        contextGraphId: CONTEXT_GRAPH_ID,
+        catalogHeadObjectDigest: publication.headObjectDigest,
+      })],
+    });
   });
 
   it('keeps system control graphs on durable sync under default catalog responsibility', async () => {


### PR DESCRIPTION
## Summary

- refresh scoped RFC-64 replay entries after acquiring the relevant author mutation locks
- fail closed if a new author scope appears outside the acquired lock set
- verify the requested replay snapshot again after announcement before reporting completion
- preserve the existing global inventory-fingerprint behavior for unscoped compatibility replay
- document the release-blocking fix in the 10.0.16 changelog

## Problem

The strict 10.0.16 public `00` and `01` smoke cells could apply all 50 catalog rows while operational status kept the expected head, inventory, and row-count fields unavailable. A head advance between the provider's pre-lock snapshot and lock acquisition caused replay to fail, and the receiver could remain fenced until another external refresh event.

This is a latent replay race exposed by the 50/50 workload, not evidence that the smoke deadline should be relaxed.

## Fix

Scoped replay now discovers the relevant author scopes, acquires their mutation locks, refreshes the requested Context Graph's replay entries under those locks, and fingerprints that scoped snapshot. It then rechecks the same fingerprint after announcement so it cannot claim completion for stale state. Existing head advances that race lock acquisition are refreshed and replayed; newly appearing unlocked author scopes still fail closed.

## Validation

- `pnpm build`
- `pnpm lint`
- 15 replay-focused integration tests passed across rollout-authority and native-wiring suites
- new regression test advances the current head while scoped replay waits for the mutation lock
- existing unscoped inventory-race regression still rejects the change
- strict black-box cell `00`: PASS, SWM 50/50, VM 50/50, all gates passed
- strict black-box cell `01`: PASS, SWM 50/50, VM 50/50, all gates passed
- DKG under test: `63adaf335df8abeffb46adf7b1c515a5cd717232`
- harness: `a503e294fb5e13ae474770bbf04b9d834386de28`

## Review focus

Please pay particular attention to lock discovery/order, the fail-closed new-author check, scoped versus unscoped replay semantics, and the post-announcement snapshot verification.

No contract or deployment changes are included. This PR should land before the 10.0.16 candidate is promoted from `testnet-canary`.
