### PR TITLE
fix(ui): hide unconfigured local LLM agent

### DIFF
--- a/docs/use-dkg/local-llm.md
+++ b/docs/use-dkg/local-llm.md
@@ -582,7 +582,10 @@ Keep the selected local model server running, then open Node UI and select **DKG
 Local LLM** in the Agents panel. There is no separate provider selector in the
 browser: Node UI uses `DKG_LLM_URL`, `DKG_LLM_MODEL`, and `DKG_LLM_BACKEND`
 from the daemon environment. `DKG_LLM_BACKEND` accepts `ollama`, `llama.cpp`,
-or the backward-compatible default `auto`. The integration remains read-only:
+or the backward-compatible default `auto`. Node UI hides the integration when
+none of those environment overrides is set and no server is reachable at the
+default local endpoint. An explicitly configured server remains visible while
+offline so the panel can report its error. The integration remains read-only:
 the daemon always creates this
 UI runtime with writes disabled. The HTTP surface is also node-admin-only.
 Agent-scoped bearer tokens receive `403` and cannot start, continue, or clear

--- a/packages/cli/src/daemon/local-llm-service.ts
+++ b/packages/cli/src/daemon/local-llm-service.ts
@@ -53,6 +53,8 @@ export class DaemonLocalLlmError extends Error {
 
 export interface DaemonLocalLlmHealth {
   ok: boolean;
+  /** True when the operator supplied at least one local-LLM environment override. */
+  configured: boolean;
   ready: boolean;
   reachable: boolean;
   offline: boolean;
@@ -130,6 +132,7 @@ export function resolveDaemonLocalLlmSettings(
   dkgHome: string,
   env: NodeJS.ProcessEnv = process.env,
 ): {
+  configured: boolean;
   llamaUrl: string;
   model: string;
   probeStrategy: LocalModelEndpointProbeStrategy;
@@ -138,7 +141,15 @@ export function resolveDaemonLocalLlmSettings(
   logDir: string;
 } {
   const probe = resolveProbeStrategy(env.DKG_LLM_BACKEND);
+  const configured = [
+    env.DKG_LLM_URL,
+    env.LLAMA_URL,
+    env.DKG_LLM_MODEL,
+    env.LLAMA_MODEL,
+    env.DKG_LLM_BACKEND,
+  ].some((value) => trimmed(value) !== undefined);
   return {
+    configured,
     llamaUrl: trimmed(env.DKG_LLM_URL)
       ?? trimmed(env.LLAMA_URL)
       ?? 'http://127.0.0.1:8080/v1/chat/completions',
@@ -209,6 +220,7 @@ export function createDaemonLocalLlmService(
       const ready = availability.status === 'ready' && !initFailure && !closed;
       return {
         ok: ready,
+        configured: settings.configured,
         ready,
         reachable,
         offline: !reachable,

--- a/packages/cli/test/daemon-local-llm-service.test.ts
+++ b/packages/cli/test/daemon-local-llm-service.test.ts
@@ -63,12 +63,23 @@ describe('daemon local LLM service', () => {
       DKG_LLM_BACKEND: ' llama-cpp ',
       DKG_PROJECT: ' testing ',
     })).toEqual({
+      configured: true,
       llamaUrl: 'http://127.0.0.1:9090/v1/chat/completions',
       model: 'qwen',
       probeStrategy: { kind: 'llama.cpp' },
       defaultProjectId: 'testing',
       logDir: '/tmp/dkg/logs/local-llm',
     });
+  });
+
+  it('distinguishes an untouched default endpoint from explicit local-LLM configuration', () => {
+    expect(resolveDaemonLocalLlmSettings('/tmp/dkg', {}).configured).toBe(false);
+    expect(resolveDaemonLocalLlmSettings('/tmp/dkg', {
+      DKG_LLM_MODEL: ' local-model ',
+    }).configured).toBe(true);
+    expect(resolveDaemonLocalLlmSettings('/tmp/dkg', {
+      LLAMA_URL: ' http://127.0.0.1:8080/v1/chat/completions ',
+    }).configured).toBe(true);
   });
 
   it('maps an invalid configured backend to structured offline health and chat errors', async () => {
@@ -83,6 +94,7 @@ describe('daemon local LLM service', () => {
 
     expect(await service.health()).toEqual(expect.objectContaining({
       ok: false,
+      configured: true,
       ready: false,
       reachable: false,
       offline: true,
@@ -320,7 +332,7 @@ describe('daemon local LLM service', () => {
       createSession,
     });
     expect(await offline.health()).toEqual(expect.objectContaining({
-      ok: false, reachable: false, offline: true,
+      ok: false, configured: false, reachable: false, offline: true,
     }));
     await expect(offline.chat({ message: 'hello' })).rejects.toMatchObject({
       code: 'LOCAL_LLM_OFFLINE', status: 503,

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1961,6 +1961,7 @@ export type LocalAgentChannelTarget = 'bridge' | 'gateway';
 
 export interface LocalAgentHealthResponse {
   ok: boolean;
+  configured?: boolean;
   ready?: boolean;
   reachable?: boolean;
   offline?: boolean;
@@ -2802,7 +2803,9 @@ function hermesDetail(
   return null;
 }
 
-async function mapLocalAgentIntegrationRecord(record: LocalAgentIntegrationRecord): Promise<LocalAgentIntegration> {
+async function mapLocalAgentIntegrationRecord(
+  record: LocalAgentIntegrationRecord,
+): Promise<LocalAgentIntegration | null> {
   const id = String(record.id ?? '').toLowerCase();
   const surface = LOCAL_AGENT_SURFACES[id];
   const hasChatBridge = record.capabilities?.localChat === true && surface?.chatSupported === true;
@@ -2813,6 +2816,13 @@ async function mapLocalAgentIntegrationRecord(record: LocalAgentIntegrationRecor
   const health = configured && hasChatBridge && surface?.fetchHealth
     ? normalizeLocalAgentHealth(await surface.fetchHealth().catch(() => null))
     : null;
+  // The daemon-owned integration exists in the registry on every node. Keep it
+  // out of the UI when the operator supplied no local-LLM configuration and
+  // the conventional local endpoint was not auto-detected. An explicit but
+  // temporarily offline configuration remains visible so its error is useful.
+  if (id === 'local-llm' && health?.configured === false && health.reachable !== true) {
+    return null;
+  }
   const degraded = isDegradedLocalAgentHealth(runtimeStatus, health);
   const chatReady = health?.ok === true && !degraded;
   const bridgeOnline = chatReady;
@@ -2971,7 +2981,10 @@ export async function fetchRegistryIntegrations(opts: { tier?: RegistryTrustTier
 
 export async function fetchLocalAgentIntegrations(): Promise<{ integrations: LocalAgentIntegration[] }> {
   const response = await get<{ integrations?: LocalAgentIntegrationRecord[] }>('/api/local-agent-integrations');
-  const integrations = await Promise.all((response.integrations ?? []).map(mapLocalAgentIntegrationRecord));
+  const mapped = await Promise.all((response.integrations ?? []).map(mapLocalAgentIntegrationRecord));
+  const integrations = mapped.filter(
+    (integration): integration is LocalAgentIntegration => integration !== null,
+  );
 
   integrations.sort((a, b) => {
     const aPriority = a.id === 'openclaw' ? 0 : 1;

--- a/packages/node-ui/test/local-llm-ui.test.ts
+++ b/packages/node-ui/test/local-llm-ui.test.ts
@@ -40,6 +40,7 @@ describe('DKG Local LLM Node UI surface', () => {
       if (url.endsWith('/api/local-llm/health')) {
         return json({
           ok: false,
+          configured: true,
           ready: false,
           reachable: false,
           offline: true,
@@ -66,6 +67,57 @@ describe('DKG Local LLM Node UI surface', () => {
     await expect(connectLocalAgentIntegration('local-llm')).rejects.toThrow(
       'local connect is not available',
     );
+  });
+
+  it('hides the daemon-owned chat when no local LLM is configured or reachable', async () => {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/api/local-agent-integrations')) {
+        return json({ integrations: [localLlmRecord()] });
+      }
+      if (url.endsWith('/api/local-llm/health')) {
+        return json({
+          ok: false,
+          configured: false,
+          ready: false,
+          reachable: false,
+          offline: true,
+          readOnly: true,
+          error: 'Local LLM server is offline: fetch failed',
+        });
+      }
+      return json({ error: `Unexpected request: ${url}` }, 500);
+    }) as typeof globalThis.fetch;
+
+    await expect(fetchLocalAgentIntegrations()).resolves.toEqual({ integrations: [] });
+  });
+
+  it('shows an auto-detected default local LLM without environment overrides', async () => {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/api/local-agent-integrations')) {
+        return json({ integrations: [localLlmRecord()] });
+      }
+      if (url.endsWith('/api/local-llm/health')) {
+        return json({
+          ok: true,
+          configured: false,
+          ready: true,
+          reachable: true,
+          offline: false,
+          readOnly: true,
+        });
+      }
+      return json({ error: `Unexpected request: ${url}` }, 500);
+    }) as typeof globalThis.fetch;
+
+    const { integrations } = await fetchLocalAgentIntegrations();
+    expect(integrations).toHaveLength(1);
+    expect(integrations[0]).toMatchObject({
+      id: 'local-llm',
+      chatReady: true,
+      status: 'chat_ready',
+    });
   });
 
   it('posts the fixed session and active graph, then emits one final event with DKG metadata', async () => {


### PR DESCRIPTION
## Summary

- report whether local-LLM environment overrides are present without exposing their values
- hide DKG Local LLM when no override is configured and the default endpoint is unreachable
- retain the tab for explicitly configured offline servers and auto-detected reachable default servers
- document the Node UI visibility behavior

## Tests

- `pnpm run build:runtime:packages`
- `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/local-llm-ui.test.ts`
- `pnpm --filter @origintrail-official/dkg exec vitest run --config vitest.unit.config.ts test/daemon-local-llm-service.test.ts`
- `pnpm --filter @origintrail-official/dkg-node-ui run build:ui`
- `pnpm run lint`