### PR TITLE
fix(agent): prevent RFC-64 Blazegraph startup timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -562,6 +562,7 @@ jobs:
         run: |
           DKG_REQUIRE_BLAZEGRAPH=1 pnpm test:conformance
           pnpm --filter @origintrail-official/dkg-storage exec vitest run --no-file-parallelism test/blazegraph.integration.test.ts test/term-canon-blazegraph-oracle.test.ts test/rfc64-semantic-read-gateway.blazegraph.integration.test.ts test/rfc64-shared-projection-stream.blazegraph.integration.test.ts
+          pnpm --filter @origintrail-official/dkg-agent exec vitest run --config vitest.blazegraph.config.ts
           DKG_RFC64_GATE1_STORE_BACKEND=blazegraph node --import tsx --test devnet/rfc64-gate1-public-open/rollout-store-fixture.test.ts devnet/rfc64-gate1-public-open/rollout-transition.test.ts
 
       - name: Upload store conformance packet

--- a/packages/agent/src/rfc64/legacy-swm-boundary-v1.ts
+++ b/packages/agent/src/rfc64/legacy-swm-boundary-v1.ts
@@ -6,8 +6,10 @@ import {
   assertCanonicalDeterministicUalV1,
   assertCanonicalDecimalU64,
   assertContextGraphIdV1,
+  assertSafeRdfTerm,
   assertSwmAuthorInventoryShareOperationIdV1,
   contextGraphWorkspaceMetaGraphUri,
+  sparqlIri,
   type CanonicalDeterministicUalV1,
   type ContextGraphIdV1,
   type PositiveDecimalU64V1,
@@ -30,6 +32,8 @@ const RFC64_LEGACY_SWM_CAPTURE_MAX_BYTES_V1 = 64 * 1024 * 1024;
 const RFC64_LEGACY_SWM_REPUBLISHED_MAX_BYTES_V1 = 2 * 1024;
 const RFC64_LEGACY_SWM_META_GRAPH_LIMIT_V1 = 16_384;
 const RFC64_LEGACY_SWM_HEAD_LIMIT_V1 = 100_000;
+const RFC64_LEGACY_SWM_OPERATION_CANDIDATE_LIMIT_V1 = 100_000;
+const RFC64_LEGACY_SWM_HEAD_READ_BATCH_SIZE_V1 = 500;
 const CONTEXT_GRAPH_PREFIX = 'did:dkg:context-graph:';
 const SWM_META_SUFFIX = '/_shared_memory_meta';
 const SWM_HEAD_SUFFIX = '#dkg-swm-head';
@@ -49,6 +53,12 @@ interface Rfc64LegacySwmBoundaryEntryV1 {
 interface Rfc64LegacySwmBoundaryCaptureV1 {
   readonly version: 1;
   readonly entries: readonly Rfc64LegacySwmBoundaryEntryV1[];
+}
+
+interface Rfc64LegacySwmOperationCandidateV1
+  extends Rfc64LegacySwmBoundaryEntryV1 {
+  readonly metaGraph: string;
+  readonly shareOperationTerm: string;
 }
 
 interface Rfc64LegacySwmRepublishedMarkerV1
@@ -401,56 +411,57 @@ async function readRfc64LateLegacySwmBoundaryEntriesV1(
 async function captureRfc64LegacySwmBoundaryV1(
   store: TripleStore,
 ): Promise<Readonly<Rfc64LegacySwmBoundaryCaptureV1>> {
-  // Bind and reject named-subgraph metadata inside the store. URI-only parsing
-  // is ambiguous because a valid Context Graph ID may itself contain slashes;
-  // enumerating every `.../_shared_memory_meta` graph would also let unrelated
-  // named history consume the bounded root-capture budget before classification.
-  // Keep the selective WorkspaceOperation pattern before the SWM head join.
-  // Blazegraph otherwise chooses a plan that scans and joins every candidate
-  // head first, which can exceed the store deadline on an existing node during
-  // the one-time upgrade capture. Source order is therefore an operational part
-  // of this query, even though the two forms are semantically equivalent.
-  const result = await store.query(
-    `SELECT DISTINCT ?metaGraph ?head ?ual ?contextGraphId WHERE { ` +
+  // This first read deliberately contains no head pattern. It creates an
+  // application-level execution boundary that no store optimizer can flatten
+  // or reorder into the expensive legacy-head scan that blocked node startup.
+  // Bind and reject named-subgraph metadata inside the store: URI-only parsing
+  // is ambiguous because a valid Context Graph ID may itself contain slashes.
+  const operationResult = await store.query(
+    `SELECT DISTINCT ?metaGraph ?ual ?shareId ?contextGraphId WHERE { ` +
     `GRAPH ?metaGraph { ` +
     `?operation <${RDF_TYPE}> <${WORKSPACE_OPERATION}> ; ` +
     `<${KA_UAL}> ?ual ; <${SHARE_OPERATION_ID}> ?shareId ; ` +
     `<${CONTEXT_GRAPH_ID}> ?contextGraphId . ` +
-    `FILTER(STR(?metaGraph) = CONCAT(` +
+    `} FILTER(STR(?metaGraph) = CONCAT(` +
     `${JSON.stringify(CONTEXT_GRAPH_PREFIX)}, STR(?contextGraphId), ` +
     `${JSON.stringify(SWM_META_SUFFIX)})) ` +
-    `?head <${KA_UAL}> ?ual ; <${SHARE_OPERATION_ID}> ?shareId . ` +
-    `FILTER(STRENDS(STR(?head), ${JSON.stringify(SWM_HEAD_SUFFIX)})) ` +
-    `} } LIMIT ${RFC64_LEGACY_SWM_HEAD_LIMIT_V1 + 1}`,
+    `} LIMIT ${RFC64_LEGACY_SWM_OPERATION_CANDIDATE_LIMIT_V1 + 1}`,
     {
-      source: 'agent.rfc64.legacySwmBoundary.readHeads',
+      source: 'agent.rfc64.legacySwmBoundary.readOperations',
       priority: 'background',
     },
   );
-  if (result.type !== 'bindings') {
-    throw new Error('RFC-64 legacy SWM boundary query did not return bindings');
-  }
-  if (result.bindings.length > RFC64_LEGACY_SWM_HEAD_LIMIT_V1) {
+  if (operationResult.type !== 'bindings') {
     throw new Error(
-      `RFC-64 legacy SWM boundary exceeds head limit ` +
-      `${RFC64_LEGACY_SWM_HEAD_LIMIT_V1}`,
+      'RFC-64 legacy SWM boundary operation query did not return bindings',
+    );
+  }
+  if (
+    operationResult.bindings.length
+    > RFC64_LEGACY_SWM_OPERATION_CANDIDATE_LIMIT_V1
+  ) {
+    throw new Error(
+      `RFC-64 legacy SWM boundary exceeds operation candidate limit ` +
+      `${RFC64_LEGACY_SWM_OPERATION_CANDIDATE_LIMIT_V1}`,
     );
   }
 
   const rootMetaGraphs = new Set<string>();
-  const entries = new Map<string, Rfc64LegacySwmBoundaryEntryV1>();
-  for (const row of result.bindings) {
+  const candidates = new Map<string, Rfc64LegacySwmOperationCandidateV1>();
+  for (const row of operationResult.bindings) {
     const metaGraph = row['metaGraph'];
-    const head = row['head'];
     const rawUal = row['ual'];
+    const rawShareOperationId = row['shareId'];
     const rawContextGraphId = row['contextGraphId'];
     if (
       metaGraph === undefined
-      || head === undefined
       || rawUal === undefined
+      || rawShareOperationId === undefined
       || rawContextGraphId === undefined
     ) {
-      throw new Error('RFC-64 legacy SWM boundary returned an incomplete head');
+      throw new Error(
+        'RFC-64 legacy SWM boundary returned an incomplete operation',
+      );
     }
     const contextGraphId = decodeRfc64BindingValueV1(rawContextGraphId);
     assertContextGraphIdV1(
@@ -468,13 +479,107 @@ async function captureRfc64LegacySwmBoundaryV1(
       );
     }
     const kaUal = assertCanonicalDeterministicUalV1(rawUal).ual;
-    if (head !== `${kaUal}${SWM_HEAD_SUFFIX}`) {
-      throw new Error(`RFC-64 legacy SWM head identity differs for ${kaUal}`);
+    const shareOperationLiteral = parseRdfLiteralTerm(rawShareOperationId);
+    if (shareOperationLiteral === null) {
+      throw new Error(
+        'RFC-64 legacy SWM boundary contains a malformed share operation ID',
+      );
     }
-    entries.set(`${contextGraphId}\u0000${kaUal}`, Object.freeze({
-      contextGraphId,
-      kaUal,
-    }));
+    assertSwmAuthorInventoryShareOperationIdV1(shareOperationLiteral.value);
+    assertSafeRdfTerm(rawShareOperationId);
+    candidates.set(
+      `${metaGraph}\u0000${kaUal}\u0000${rawShareOperationId}`,
+      Object.freeze({
+        metaGraph,
+        contextGraphId,
+        kaUal,
+        shareOperationTerm: rawShareOperationId,
+      }),
+    );
+  }
+
+  const candidatesByMetaGraph = new Map<
+    string,
+    Rfc64LegacySwmOperationCandidateV1[]
+  >();
+  for (const candidate of candidates.values()) {
+    const graphCandidates = candidatesByMetaGraph.get(candidate.metaGraph);
+    if (graphCandidates === undefined) {
+      candidatesByMetaGraph.set(candidate.metaGraph, [candidate]);
+    } else {
+      graphCandidates.push(candidate);
+    }
+  }
+
+  const entries = new Map<string, Rfc64LegacySwmBoundaryEntryV1>();
+  for (const [metaGraph, graphCandidates] of candidatesByMetaGraph) {
+    for (
+      let offset = 0;
+      offset < graphCandidates.length;
+      offset += RFC64_LEGACY_SWM_HEAD_READ_BATCH_SIZE_V1
+    ) {
+      const batch = graphCandidates.slice(
+        offset,
+        offset + RFC64_LEGACY_SWM_HEAD_READ_BATCH_SIZE_V1,
+      );
+      const values = batch.map((candidate) => (
+        `(${sparqlIri(`${candidate.kaUal}${SWM_HEAD_SUFFIX}`)} ` +
+        `${sparqlIri(candidate.kaUal)} ${candidate.shareOperationTerm})`
+      )).join(' ');
+      // sparql-scan-allow: R2 -- the graph and every head, UAL, and share ID are exact values from the bounded operation read above
+      const headResult = await store.query(
+        `SELECT DISTINCT ?head ?ual WHERE { ` +
+        `VALUES (?head ?ual ?shareId) { ${values} } ` +
+        `GRAPH ${sparqlIri(metaGraph)} { ` +
+        `?head <${KA_UAL}> ?ual ; <${SHARE_OPERATION_ID}> ?shareId . ` +
+        `} } LIMIT ${batch.length + 1}`,
+        {
+          source: 'agent.rfc64.legacySwmBoundary.readHeads',
+          priority: 'background',
+        },
+      );
+      if (headResult.type !== 'bindings') {
+        throw new Error(
+          'RFC-64 legacy SWM boundary head query did not return bindings',
+        );
+      }
+      if (headResult.bindings.length > batch.length) {
+        throw new Error('RFC-64 legacy SWM boundary head query exceeded its batch');
+      }
+      const requestedUals = new Map(
+        batch.map((candidate) => [candidate.kaUal, candidate]),
+      );
+      for (const row of headResult.bindings) {
+        const head = row['head'];
+        const rawUal = row['ual'];
+        if (head === undefined || rawUal === undefined) {
+          throw new Error(
+            'RFC-64 legacy SWM boundary returned an incomplete head',
+          );
+        }
+        const kaUal = assertCanonicalDeterministicUalV1(rawUal).ual;
+        const candidate = requestedUals.get(kaUal);
+        if (candidate === undefined) {
+          throw new Error('RFC-64 legacy SWM boundary returned an unrequested head');
+        }
+        if (head !== `${kaUal}${SWM_HEAD_SUFFIX}`) {
+          throw new Error(`RFC-64 legacy SWM head identity differs for ${kaUal}`);
+        }
+        entries.set(
+          `${candidate.contextGraphId}\u0000${kaUal}`,
+          Object.freeze({
+            contextGraphId: candidate.contextGraphId,
+            kaUal,
+          }),
+        );
+        if (entries.size > RFC64_LEGACY_SWM_HEAD_LIMIT_V1) {
+          throw new Error(
+            `RFC-64 legacy SWM boundary exceeds head limit ` +
+            `${RFC64_LEGACY_SWM_HEAD_LIMIT_V1}`,
+          );
+        }
+      }
+    }
   }
   return Object.freeze({
     version: 1,

--- a/packages/agent/src/rfc64/legacy-swm-boundary-v1.ts
+++ b/packages/agent/src/rfc64/legacy-swm-boundary-v1.ts
@@ -572,12 +572,6 @@ async function captureRfc64LegacySwmBoundaryV1(
             kaUal,
           }),
         );
-        if (entries.size > RFC64_LEGACY_SWM_HEAD_LIMIT_V1) {
-          throw new Error(
-            `RFC-64 legacy SWM boundary exceeds head limit ` +
-            `${RFC64_LEGACY_SWM_HEAD_LIMIT_V1}`,
-          );
-        }
       }
     }
   }

--- a/packages/agent/src/rfc64/legacy-swm-boundary-v1.ts
+++ b/packages/agent/src/rfc64/legacy-swm-boundary-v1.ts
@@ -401,10 +401,12 @@ async function readRfc64LateLegacySwmBoundaryEntriesV1(
 async function captureRfc64LegacySwmBoundaryV1(
   store: TripleStore,
 ): Promise<Readonly<Rfc64LegacySwmBoundaryCaptureV1>> {
-  // Derive each canonical head IRI from the selective operation binding before
-  // reading that exact subject. BIND is an explicit SPARQL algebra boundary,
+  // Derive the head-side UAL from the selective operation binding before
+  // reading suffix-bearing heads. BIND is an explicit SPARQL algebra boundary,
   // unlike textual ordering inside one basic graph pattern, so the store never
-  // needs to begin with the broad legacy-head scan that blocked startup.
+  // needs to begin with the broad legacy-head scan that blocked startup. Keep
+  // the head subject variable so corrupt subject/UAL identities remain visible
+  // to the fail-closed validation below.
   // DISTINCT runs after the exact head/operation share-ID correlation: repeated
   // history collapses and the limits count only fully qualified legacy heads.
   // Reject named-subgraph metadata inside the store: URI-only parsing is
@@ -413,15 +415,15 @@ async function captureRfc64LegacySwmBoundaryV1(
     `SELECT DISTINCT ?metaGraph ?head ?ual ?contextGraphId WHERE { ` +
     `GRAPH ?metaGraph { ` +
     `?operation <${RDF_TYPE}> <${WORKSPACE_OPERATION}> ; ` +
-    `<${KA_UAL}> ?ual ; <${SHARE_OPERATION_ID}> ?shareId ; ` +
+    `<${KA_UAL}> ?operationUal ; <${SHARE_OPERATION_ID}> ?shareId ; ` +
     `<${CONTEXT_GRAPH_ID}> ?contextGraphId . ` +
     `} FILTER(STR(?metaGraph) = CONCAT(` +
     `${JSON.stringify(CONTEXT_GRAPH_PREFIX)}, STR(?contextGraphId), ` +
     `${JSON.stringify(SWM_META_SUFFIX)})) ` +
-    `BIND(IRI(CONCAT(STR(?ual), ${JSON.stringify(SWM_HEAD_SUFFIX)})) AS ?head) ` +
+    `BIND(?operationUal AS ?ual) ` +
     `GRAPH ?metaGraph { ` +
     `?head <${KA_UAL}> ?ual ; <${SHARE_OPERATION_ID}> ?shareId . ` +
-    `} ` +
+    `} FILTER(STRENDS(STR(?head), ${JSON.stringify(SWM_HEAD_SUFFIX)})) ` +
     `} LIMIT ${RFC64_LEGACY_SWM_HEAD_LIMIT_V1 + 1}`,
     {
       source: 'agent.rfc64.legacySwmBoundary.readHeads',

--- a/packages/agent/src/rfc64/legacy-swm-boundary-v1.ts
+++ b/packages/agent/src/rfc64/legacy-swm-boundary-v1.ts
@@ -6,10 +6,10 @@ import {
   assertCanonicalDeterministicUalV1,
   assertCanonicalDecimalU64,
   assertContextGraphIdV1,
-  assertSafeRdfTerm,
   assertSwmAuthorInventoryShareOperationIdV1,
   contextGraphWorkspaceMetaGraphUri,
   sparqlIri,
+  sparqlString,
   type CanonicalDeterministicUalV1,
   type ContextGraphIdV1,
   type PositiveDecimalU64V1,
@@ -32,7 +32,6 @@ const RFC64_LEGACY_SWM_CAPTURE_MAX_BYTES_V1 = 64 * 1024 * 1024;
 const RFC64_LEGACY_SWM_REPUBLISHED_MAX_BYTES_V1 = 2 * 1024;
 const RFC64_LEGACY_SWM_META_GRAPH_LIMIT_V1 = 16_384;
 const RFC64_LEGACY_SWM_HEAD_LIMIT_V1 = 100_000;
-const RFC64_LEGACY_SWM_OPERATION_CANDIDATE_LIMIT_V1 = 100_000;
 const RFC64_LEGACY_SWM_HEAD_READ_BATCH_SIZE_V1 = 500;
 const CONTEXT_GRAPH_PREFIX = 'did:dkg:context-graph:';
 const SWM_META_SUFFIX = '/_shared_memory_meta';
@@ -55,10 +54,10 @@ interface Rfc64LegacySwmBoundaryCaptureV1 {
   readonly entries: readonly Rfc64LegacySwmBoundaryEntryV1[];
 }
 
-interface Rfc64LegacySwmOperationCandidateV1
-  extends Rfc64LegacySwmBoundaryEntryV1 {
+interface Rfc64LegacySwmGraphCapturePlanV1 {
+  readonly contextGraphId: ContextGraphIdV1;
   readonly metaGraph: string;
-  readonly shareOperationTerm: string;
+  readonly headsByUal: Map<CanonicalDeterministicUalV1, string>;
 }
 
 interface Rfc64LegacySwmRepublishedMarkerV1
@@ -411,21 +410,26 @@ async function readRfc64LateLegacySwmBoundaryEntriesV1(
 async function captureRfc64LegacySwmBoundaryV1(
   store: TripleStore,
 ): Promise<Readonly<Rfc64LegacySwmBoundaryCaptureV1>> {
-  // This first read deliberately contains no head pattern. It creates an
-  // application-level execution boundary that no store optimizer can flatten
-  // or reorder into the expensive legacy-head scan that blocked node startup.
-  // Bind and reject named-subgraph metadata inside the store: URI-only parsing
-  // is ambiguous because a valid Context Graph ID may itself contain slashes.
+  // This first read derives each canonical head IRI from a selective operation
+  // binding and uses only that exact IRI in the correlated existence check.
+  // DISTINCT collapses repeated historical operations before the existing head
+  // limit is applied. The separate exact-binding read below then proves that a
+  // current head and an operation share the same share ID. No optimizer can
+  // turn either phase into the broad legacy-head scan that blocked startup.
+  // Reject named-subgraph metadata inside the store: URI-only parsing is
+  // ambiguous because a valid Context Graph ID may itself contain slashes.
   const operationResult = await store.query(
-    `SELECT DISTINCT ?metaGraph ?ual ?shareId ?contextGraphId WHERE { ` +
+    `SELECT DISTINCT ?metaGraph ?head ?ual ?contextGraphId WHERE { ` +
     `GRAPH ?metaGraph { ` +
     `?operation <${RDF_TYPE}> <${WORKSPACE_OPERATION}> ; ` +
-    `<${KA_UAL}> ?ual ; <${SHARE_OPERATION_ID}> ?shareId ; ` +
+    `<${KA_UAL}> ?ual ; <${SHARE_OPERATION_ID}> ?operationShareId ; ` +
     `<${CONTEXT_GRAPH_ID}> ?contextGraphId . ` +
     `} FILTER(STR(?metaGraph) = CONCAT(` +
     `${JSON.stringify(CONTEXT_GRAPH_PREFIX)}, STR(?contextGraphId), ` +
     `${JSON.stringify(SWM_META_SUFFIX)})) ` +
-    `} LIMIT ${RFC64_LEGACY_SWM_OPERATION_CANDIDATE_LIMIT_V1 + 1}`,
+    `BIND(IRI(CONCAT(STR(?ual), ${JSON.stringify(SWM_HEAD_SUFFIX)})) AS ?head) ` +
+    `FILTER EXISTS { GRAPH ?metaGraph { ?head <${KA_UAL}> ?ual } } ` +
+    `} LIMIT ${RFC64_LEGACY_SWM_HEAD_LIMIT_V1 + 1}`,
     {
       source: 'agent.rfc64.legacySwmBoundary.readOperations',
       priority: 'background',
@@ -438,25 +442,24 @@ async function captureRfc64LegacySwmBoundaryV1(
   }
   if (
     operationResult.bindings.length
-    > RFC64_LEGACY_SWM_OPERATION_CANDIDATE_LIMIT_V1
+    > RFC64_LEGACY_SWM_HEAD_LIMIT_V1
   ) {
     throw new Error(
-      `RFC-64 legacy SWM boundary exceeds operation candidate limit ` +
-      `${RFC64_LEGACY_SWM_OPERATION_CANDIDATE_LIMIT_V1}`,
+      `RFC-64 legacy SWM boundary exceeds head limit ` +
+      `${RFC64_LEGACY_SWM_HEAD_LIMIT_V1}`,
     );
   }
 
-  const rootMetaGraphs = new Set<string>();
-  const candidates = new Map<string, Rfc64LegacySwmOperationCandidateV1>();
+  const graphPlans = new Map<string, Rfc64LegacySwmGraphCapturePlanV1>();
   for (const row of operationResult.bindings) {
     const metaGraph = row['metaGraph'];
+    const head = row['head'];
     const rawUal = row['ual'];
-    const rawShareOperationId = row['shareId'];
     const rawContextGraphId = row['contextGraphId'];
     if (
       metaGraph === undefined
+      || head === undefined
       || rawUal === undefined
-      || rawShareOperationId === undefined
       || rawContextGraphId === undefined
     ) {
       throw new Error(
@@ -471,67 +474,53 @@ async function captureRfc64LegacySwmBoundaryV1(
     if (metaGraph !== contextGraphWorkspaceMetaGraphUri(contextGraphId)) {
       continue;
     }
-    rootMetaGraphs.add(metaGraph);
-    if (rootMetaGraphs.size > RFC64_LEGACY_SWM_META_GRAPH_LIMIT_V1) {
-      throw new Error(
-        `RFC-64 legacy SWM boundary exceeds metadata graph limit ` +
-        `${RFC64_LEGACY_SWM_META_GRAPH_LIMIT_V1}`,
-      );
-    }
     const kaUal = assertCanonicalDeterministicUalV1(rawUal).ual;
-    const shareOperationLiteral = parseRdfLiteralTerm(rawShareOperationId);
-    if (shareOperationLiteral === null) {
-      throw new Error(
-        'RFC-64 legacy SWM boundary contains a malformed share operation ID',
-      );
+    if (head !== `${kaUal}${SWM_HEAD_SUFFIX}`) {
+      throw new Error(`RFC-64 legacy SWM head identity differs for ${kaUal}`);
     }
-    assertSwmAuthorInventoryShareOperationIdV1(shareOperationLiteral.value);
-    assertSafeRdfTerm(rawShareOperationId);
-    candidates.set(
-      `${metaGraph}\u0000${kaUal}\u0000${rawShareOperationId}`,
-      Object.freeze({
+    let plan = graphPlans.get(metaGraph);
+    if (plan === undefined) {
+      if (graphPlans.size >= RFC64_LEGACY_SWM_META_GRAPH_LIMIT_V1) {
+        throw new Error(
+          `RFC-64 legacy SWM boundary exceeds metadata graph limit ` +
+          `${RFC64_LEGACY_SWM_META_GRAPH_LIMIT_V1}`,
+        );
+      }
+      plan = {
         metaGraph,
         contextGraphId,
-        kaUal,
-        shareOperationTerm: rawShareOperationId,
-      }),
-    );
-  }
-
-  const candidatesByMetaGraph = new Map<
-    string,
-    Rfc64LegacySwmOperationCandidateV1[]
-  >();
-  for (const candidate of candidates.values()) {
-    const graphCandidates = candidatesByMetaGraph.get(candidate.metaGraph);
-    if (graphCandidates === undefined) {
-      candidatesByMetaGraph.set(candidate.metaGraph, [candidate]);
-    } else {
-      graphCandidates.push(candidate);
+        headsByUal: new Map(),
+      };
+      graphPlans.set(metaGraph, plan);
     }
+    plan.headsByUal.set(kaUal, head);
   }
 
   const entries = new Map<string, Rfc64LegacySwmBoundaryEntryV1>();
-  for (const [metaGraph, graphCandidates] of candidatesByMetaGraph) {
+  for (const plan of graphPlans.values()) {
+    const graphHeads = [...plan.headsByUal.entries()];
     for (
       let offset = 0;
-      offset < graphCandidates.length;
+      offset < graphHeads.length;
       offset += RFC64_LEGACY_SWM_HEAD_READ_BATCH_SIZE_V1
     ) {
-      const batch = graphCandidates.slice(
+      const batch = graphHeads.slice(
         offset,
         offset + RFC64_LEGACY_SWM_HEAD_READ_BATCH_SIZE_V1,
       );
-      const values = batch.map((candidate) => (
-        `(${sparqlIri(`${candidate.kaUal}${SWM_HEAD_SUFFIX}`)} ` +
-        `${sparqlIri(candidate.kaUal)} ${candidate.shareOperationTerm})`
+      const values = batch.map(([kaUal, head]) => (
+        `(${sparqlIri(head)} ${sparqlIri(kaUal)} ` +
+        `${sparqlString(plan.contextGraphId)})`
       )).join(' ');
-      // sparql-scan-allow: R2 -- the graph and every head, UAL, and share ID are exact values from the bounded operation read above
+      // sparql-scan-allow: R2 -- the graph, head, UAL, and context ID are exact values from the bounded candidate read above
       const headResult = await store.query(
         `SELECT DISTINCT ?head ?ual WHERE { ` +
-        `VALUES (?head ?ual ?shareId) { ${values} } ` +
-        `GRAPH ${sparqlIri(metaGraph)} { ` +
+        `VALUES (?head ?ual ?contextGraphId) { ${values} } ` +
+        `GRAPH ${sparqlIri(plan.metaGraph)} { ` +
         `?head <${KA_UAL}> ?ual ; <${SHARE_OPERATION_ID}> ?shareId . ` +
+        `?operation <${RDF_TYPE}> <${WORKSPACE_OPERATION}> ; ` +
+        `<${KA_UAL}> ?ual ; <${SHARE_OPERATION_ID}> ?shareId ; ` +
+        `<${CONTEXT_GRAPH_ID}> ?contextGraphId . ` +
         `} } LIMIT ${batch.length + 1}`,
         {
           source: 'agent.rfc64.legacySwmBoundary.readHeads',
@@ -546,9 +535,7 @@ async function captureRfc64LegacySwmBoundaryV1(
       if (headResult.bindings.length > batch.length) {
         throw new Error('RFC-64 legacy SWM boundary head query exceeded its batch');
       }
-      const requestedUals = new Map(
-        batch.map((candidate) => [candidate.kaUal, candidate]),
-      );
+      const requestedUals = new Set(batch.map(([kaUal]) => kaUal));
       for (const row of headResult.bindings) {
         const head = row['head'];
         const rawUal = row['ual'];
@@ -558,17 +545,16 @@ async function captureRfc64LegacySwmBoundaryV1(
           );
         }
         const kaUal = assertCanonicalDeterministicUalV1(rawUal).ual;
-        const candidate = requestedUals.get(kaUal);
-        if (candidate === undefined) {
+        if (!requestedUals.has(kaUal)) {
           throw new Error('RFC-64 legacy SWM boundary returned an unrequested head');
         }
         if (head !== `${kaUal}${SWM_HEAD_SUFFIX}`) {
           throw new Error(`RFC-64 legacy SWM head identity differs for ${kaUal}`);
         }
         entries.set(
-          `${candidate.contextGraphId}\u0000${kaUal}`,
+          `${plan.contextGraphId}\u0000${kaUal}`,
           Object.freeze({
-            contextGraphId: candidate.contextGraphId,
+            contextGraphId: plan.contextGraphId,
             kaUal,
           }),
         );

--- a/packages/agent/src/rfc64/legacy-swm-boundary-v1.ts
+++ b/packages/agent/src/rfc64/legacy-swm-boundary-v1.ts
@@ -8,8 +8,6 @@ import {
   assertContextGraphIdV1,
   assertSwmAuthorInventoryShareOperationIdV1,
   contextGraphWorkspaceMetaGraphUri,
-  sparqlIri,
-  sparqlString,
   type CanonicalDeterministicUalV1,
   type ContextGraphIdV1,
   type PositiveDecimalU64V1,
@@ -17,7 +15,6 @@ import {
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import { parseRdfLiteralTerm } from '@origintrail-official/dkg-rdf-utils';
 
-import { mapWithConcurrency } from '../map-with-concurrency.js';
 import { createRfc64DurableFileStoreV1 } from './durable-file-store-v1.js';
 
 const RFC64_LEGACY_SWM_CAPTURE_PATH_V1 = 'legacy-swm-boundary-v1/capture.json';
@@ -33,8 +30,6 @@ const RFC64_LEGACY_SWM_CAPTURE_MAX_BYTES_V1 = 64 * 1024 * 1024;
 const RFC64_LEGACY_SWM_REPUBLISHED_MAX_BYTES_V1 = 2 * 1024;
 const RFC64_LEGACY_SWM_META_GRAPH_LIMIT_V1 = 16_384;
 const RFC64_LEGACY_SWM_HEAD_LIMIT_V1 = 100_000;
-const RFC64_LEGACY_SWM_HEAD_READ_BATCH_SIZE_V1 = 500;
-const RFC64_LEGACY_SWM_HEAD_READ_CONCURRENCY_V1 = 4;
 const CONTEXT_GRAPH_PREFIX = 'did:dkg:context-graph:';
 const SWM_META_SUFFIX = '/_shared_memory_meta';
 const SWM_HEAD_SUFFIX = '#dkg-swm-head';
@@ -54,18 +49,6 @@ interface Rfc64LegacySwmBoundaryEntryV1 {
 interface Rfc64LegacySwmBoundaryCaptureV1 {
   readonly version: 1;
   readonly entries: readonly Rfc64LegacySwmBoundaryEntryV1[];
-}
-
-interface Rfc64LegacySwmGraphCapturePlanV1 {
-  readonly contextGraphId: ContextGraphIdV1;
-  readonly metaGraph: string;
-  readonly headsByUal: Map<CanonicalDeterministicUalV1, string>;
-}
-
-interface Rfc64LegacySwmHeadBatchV1 {
-  readonly contextGraphId: ContextGraphIdV1;
-  readonly metaGraph: string;
-  readonly heads: readonly (readonly [CanonicalDeterministicUalV1, string])[];
 }
 
 interface Rfc64LegacySwmRepublishedMarkerV1
@@ -418,17 +401,15 @@ async function readRfc64LateLegacySwmBoundaryEntriesV1(
 async function captureRfc64LegacySwmBoundaryV1(
   store: TripleStore,
 ): Promise<Readonly<Rfc64LegacySwmBoundaryCaptureV1>> {
-  // This first read derives each canonical head IRI from a selective operation
-  // binding and uses only that exact IRI in the correlated existence check.
-  // DISTINCT collapses repeated historical operations only after the exact
-  // current head and operation share ID have been correlated, so the existing
-  // limits count fully qualified legacy heads rather than preliminary rows. A
-  // separate exact-binding read below preserves the physical capture boundary.
-  // No optimizer can turn either phase into the broad legacy-head scan that
-  // blocked startup because the head subject is derived before it is read.
+  // Derive each canonical head IRI from the selective operation binding before
+  // reading that exact subject. BIND is an explicit SPARQL algebra boundary,
+  // unlike textual ordering inside one basic graph pattern, so the store never
+  // needs to begin with the broad legacy-head scan that blocked startup.
+  // DISTINCT runs after the exact head/operation share-ID correlation: repeated
+  // history collapses and the limits count only fully qualified legacy heads.
   // Reject named-subgraph metadata inside the store: URI-only parsing is
   // ambiguous because a valid Context Graph ID may itself contain slashes.
-  const operationResult = await store.query(
+  const result = await store.query(
     `SELECT DISTINCT ?metaGraph ?head ?ual ?contextGraphId WHERE { ` +
     `GRAPH ?metaGraph { ` +
     `?operation <${RDF_TYPE}> <${WORKSPACE_OPERATION}> ; ` +
@@ -443,27 +424,23 @@ async function captureRfc64LegacySwmBoundaryV1(
     `} ` +
     `} LIMIT ${RFC64_LEGACY_SWM_HEAD_LIMIT_V1 + 1}`,
     {
-      source: 'agent.rfc64.legacySwmBoundary.readOperations',
+      source: 'agent.rfc64.legacySwmBoundary.readHeads',
       priority: 'background',
     },
   );
-  if (operationResult.type !== 'bindings') {
-    throw new Error(
-      'RFC-64 legacy SWM boundary operation query did not return bindings',
-    );
+  if (result.type !== 'bindings') {
+    throw new Error('RFC-64 legacy SWM boundary query did not return bindings');
   }
-  if (
-    operationResult.bindings.length
-    > RFC64_LEGACY_SWM_HEAD_LIMIT_V1
-  ) {
+  if (result.bindings.length > RFC64_LEGACY_SWM_HEAD_LIMIT_V1) {
     throw new Error(
       `RFC-64 legacy SWM boundary exceeds head limit ` +
       `${RFC64_LEGACY_SWM_HEAD_LIMIT_V1}`,
     );
   }
 
-  const graphPlans = new Map<string, Rfc64LegacySwmGraphCapturePlanV1>();
-  for (const row of operationResult.bindings) {
+  const rootMetaGraphs = new Set<string>();
+  const entries = new Map<string, Rfc64LegacySwmBoundaryEntryV1>();
+  for (const row of result.bindings) {
     const metaGraph = row['metaGraph'];
     const head = row['head'];
     const rawUal = row['ual'];
@@ -475,7 +452,7 @@ async function captureRfc64LegacySwmBoundaryV1(
       || rawContextGraphId === undefined
     ) {
       throw new Error(
-        'RFC-64 legacy SWM boundary returned an incomplete operation',
+        'RFC-64 legacy SWM boundary returned an incomplete head',
       );
     }
     const contextGraphId = decodeRfc64BindingValueV1(rawContextGraphId);
@@ -486,110 +463,26 @@ async function captureRfc64LegacySwmBoundaryV1(
     if (metaGraph !== contextGraphWorkspaceMetaGraphUri(contextGraphId)) {
       continue;
     }
+    rootMetaGraphs.add(metaGraph);
+    if (rootMetaGraphs.size > RFC64_LEGACY_SWM_META_GRAPH_LIMIT_V1) {
+      throw new Error(
+        `RFC-64 legacy SWM boundary exceeds metadata graph limit ` +
+        `${RFC64_LEGACY_SWM_META_GRAPH_LIMIT_V1}`,
+      );
+    }
     const kaUal = assertCanonicalDeterministicUalV1(rawUal).ual;
     if (head !== `${kaUal}${SWM_HEAD_SUFFIX}`) {
       throw new Error(`RFC-64 legacy SWM head identity differs for ${kaUal}`);
     }
-    let plan = graphPlans.get(metaGraph);
-    if (plan === undefined) {
-      if (graphPlans.size >= RFC64_LEGACY_SWM_META_GRAPH_LIMIT_V1) {
-        throw new Error(
-          `RFC-64 legacy SWM boundary exceeds metadata graph limit ` +
-          `${RFC64_LEGACY_SWM_META_GRAPH_LIMIT_V1}`,
-        );
-      }
-      plan = {
-        metaGraph,
-        contextGraphId,
-        headsByUal: new Map(),
-      };
-      graphPlans.set(metaGraph, plan);
-    }
-    plan.headsByUal.set(kaUal, head);
-  }
-
-  const batches: Rfc64LegacySwmHeadBatchV1[] = [];
-  for (const plan of graphPlans.values()) {
-    const graphHeads = [...plan.headsByUal.entries()];
-    for (
-      let offset = 0;
-      offset < graphHeads.length;
-      offset += RFC64_LEGACY_SWM_HEAD_READ_BATCH_SIZE_V1
-    ) {
-      batches.push(Object.freeze({
-        contextGraphId: plan.contextGraphId,
-        metaGraph: plan.metaGraph,
-        heads: Object.freeze(graphHeads.slice(
-          offset,
-          offset + RFC64_LEGACY_SWM_HEAD_READ_BATCH_SIZE_V1,
-        )),
-      }));
-    }
-  }
-  const verifiedBatches = await mapWithConcurrency(
-    batches,
-    RFC64_LEGACY_SWM_HEAD_READ_CONCURRENCY_V1,
-    async (batch) => readRfc64LegacySwmHeadBatchV1(store, batch),
-  );
-  const entries = new Map<string, Rfc64LegacySwmBoundaryEntryV1>();
-  for (const verified of verifiedBatches) {
-    for (const entry of verified) {
-      entries.set(`${entry.contextGraphId}\u0000${entry.kaUal}`, entry);
-    }
+    entries.set(`${contextGraphId}\u0000${kaUal}`, Object.freeze({
+      contextGraphId,
+      kaUal,
+    }));
   }
   return Object.freeze({
     version: 1,
     entries: Object.freeze([...entries.values()].sort(compareEntries)),
   });
-}
-
-async function readRfc64LegacySwmHeadBatchV1(
-  store: TripleStore,
-  batch: Rfc64LegacySwmHeadBatchV1,
-): Promise<readonly Rfc64LegacySwmBoundaryEntryV1[]> {
-  const values = batch.heads.map(([kaUal, head]) => (
-    `(${sparqlIri(head)} ${sparqlIri(kaUal)} ` +
-    `${sparqlString(batch.contextGraphId)})`
-  )).join(' ');
-  // sparql-scan-allow: R2 -- the graph, head, UAL, and context ID are exact values from the bounded candidate read above
-  const headResult = await store.query(
-    `SELECT DISTINCT ?head ?ual WHERE { ` +
-    `VALUES (?head ?ual ?contextGraphId) { ${values} } ` +
-    `GRAPH ${sparqlIri(batch.metaGraph)} { ` +
-    `?head <${KA_UAL}> ?ual ; <${SHARE_OPERATION_ID}> ?shareId . ` +
-    `?operation <${RDF_TYPE}> <${WORKSPACE_OPERATION}> ; ` +
-    `<${KA_UAL}> ?ual ; <${SHARE_OPERATION_ID}> ?shareId ; ` +
-    `<${CONTEXT_GRAPH_ID}> ?contextGraphId . ` +
-    `} } LIMIT ${batch.heads.length + 1}`,
-    {
-      source: 'agent.rfc64.legacySwmBoundary.readHeads',
-      priority: 'background',
-    },
-  );
-  if (headResult.type !== 'bindings') {
-    throw new Error(
-      'RFC-64 legacy SWM boundary head query did not return bindings',
-    );
-  }
-  if (headResult.bindings.length > batch.heads.length) {
-    throw new Error('RFC-64 legacy SWM boundary head query exceeded its batch');
-  }
-  const requestedUals = new Set(batch.heads.map(([kaUal]) => kaUal));
-  return Object.freeze(headResult.bindings.map((row) => {
-    const head = row['head'];
-    const rawUal = row['ual'];
-    if (head === undefined || rawUal === undefined) {
-      throw new Error('RFC-64 legacy SWM boundary returned an incomplete head');
-    }
-    const kaUal = assertCanonicalDeterministicUalV1(rawUal).ual;
-    if (!requestedUals.has(kaUal)) {
-      throw new Error('RFC-64 legacy SWM boundary returned an unrequested head');
-    }
-    if (head !== `${kaUal}${SWM_HEAD_SUFFIX}`) {
-      throw new Error(`RFC-64 legacy SWM head identity differs for ${kaUal}`);
-    }
-    return Object.freeze({ contextGraphId: batch.contextGraphId, kaUal });
-  }));
 }
 
 function decodeRfc64BindingValueV1(raw: string): string {

--- a/packages/agent/src/rfc64/legacy-swm-boundary-v1.ts
+++ b/packages/agent/src/rfc64/legacy-swm-boundary-v1.ts
@@ -17,6 +17,7 @@ import {
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import { parseRdfLiteralTerm } from '@origintrail-official/dkg-rdf-utils';
 
+import { mapWithConcurrency } from '../map-with-concurrency.js';
 import { createRfc64DurableFileStoreV1 } from './durable-file-store-v1.js';
 
 const RFC64_LEGACY_SWM_CAPTURE_PATH_V1 = 'legacy-swm-boundary-v1/capture.json';
@@ -33,6 +34,7 @@ const RFC64_LEGACY_SWM_REPUBLISHED_MAX_BYTES_V1 = 2 * 1024;
 const RFC64_LEGACY_SWM_META_GRAPH_LIMIT_V1 = 16_384;
 const RFC64_LEGACY_SWM_HEAD_LIMIT_V1 = 100_000;
 const RFC64_LEGACY_SWM_HEAD_READ_BATCH_SIZE_V1 = 500;
+const RFC64_LEGACY_SWM_HEAD_READ_CONCURRENCY_V1 = 4;
 const CONTEXT_GRAPH_PREFIX = 'did:dkg:context-graph:';
 const SWM_META_SUFFIX = '/_shared_memory_meta';
 const SWM_HEAD_SUFFIX = '#dkg-swm-head';
@@ -58,6 +60,12 @@ interface Rfc64LegacySwmGraphCapturePlanV1 {
   readonly contextGraphId: ContextGraphIdV1;
   readonly metaGraph: string;
   readonly headsByUal: Map<CanonicalDeterministicUalV1, string>;
+}
+
+interface Rfc64LegacySwmHeadBatchV1 {
+  readonly contextGraphId: ContextGraphIdV1;
+  readonly metaGraph: string;
+  readonly heads: readonly (readonly [CanonicalDeterministicUalV1, string])[];
 }
 
 interface Rfc64LegacySwmRepublishedMarkerV1
@@ -412,23 +420,27 @@ async function captureRfc64LegacySwmBoundaryV1(
 ): Promise<Readonly<Rfc64LegacySwmBoundaryCaptureV1>> {
   // This first read derives each canonical head IRI from a selective operation
   // binding and uses only that exact IRI in the correlated existence check.
-  // DISTINCT collapses repeated historical operations before the existing head
-  // limit is applied. The separate exact-binding read below then proves that a
-  // current head and an operation share the same share ID. No optimizer can
-  // turn either phase into the broad legacy-head scan that blocked startup.
+  // DISTINCT collapses repeated historical operations only after the exact
+  // current head and operation share ID have been correlated, so the existing
+  // limits count fully qualified legacy heads rather than preliminary rows. A
+  // separate exact-binding read below preserves the physical capture boundary.
+  // No optimizer can turn either phase into the broad legacy-head scan that
+  // blocked startup because the head subject is derived before it is read.
   // Reject named-subgraph metadata inside the store: URI-only parsing is
   // ambiguous because a valid Context Graph ID may itself contain slashes.
   const operationResult = await store.query(
     `SELECT DISTINCT ?metaGraph ?head ?ual ?contextGraphId WHERE { ` +
     `GRAPH ?metaGraph { ` +
     `?operation <${RDF_TYPE}> <${WORKSPACE_OPERATION}> ; ` +
-    `<${KA_UAL}> ?ual ; <${SHARE_OPERATION_ID}> ?operationShareId ; ` +
+    `<${KA_UAL}> ?ual ; <${SHARE_OPERATION_ID}> ?shareId ; ` +
     `<${CONTEXT_GRAPH_ID}> ?contextGraphId . ` +
     `} FILTER(STR(?metaGraph) = CONCAT(` +
     `${JSON.stringify(CONTEXT_GRAPH_PREFIX)}, STR(?contextGraphId), ` +
     `${JSON.stringify(SWM_META_SUFFIX)})) ` +
     `BIND(IRI(CONCAT(STR(?ual), ${JSON.stringify(SWM_HEAD_SUFFIX)})) AS ?head) ` +
-    `FILTER EXISTS { GRAPH ?metaGraph { ?head <${KA_UAL}> ?ual } } ` +
+    `GRAPH ?metaGraph { ` +
+    `?head <${KA_UAL}> ?ual ; <${SHARE_OPERATION_ID}> ?shareId . ` +
+    `} ` +
     `} LIMIT ${RFC64_LEGACY_SWM_HEAD_LIMIT_V1 + 1}`,
     {
       source: 'agent.rfc64.legacySwmBoundary.readOperations',
@@ -496,7 +508,7 @@ async function captureRfc64LegacySwmBoundaryV1(
     plan.headsByUal.set(kaUal, head);
   }
 
-  const entries = new Map<string, Rfc64LegacySwmBoundaryEntryV1>();
+  const batches: Rfc64LegacySwmHeadBatchV1[] = [];
   for (const plan of graphPlans.values()) {
     const graphHeads = [...plan.headsByUal.entries()];
     for (
@@ -504,67 +516,80 @@ async function captureRfc64LegacySwmBoundaryV1(
       offset < graphHeads.length;
       offset += RFC64_LEGACY_SWM_HEAD_READ_BATCH_SIZE_V1
     ) {
-      const batch = graphHeads.slice(
-        offset,
-        offset + RFC64_LEGACY_SWM_HEAD_READ_BATCH_SIZE_V1,
-      );
-      const values = batch.map(([kaUal, head]) => (
-        `(${sparqlIri(head)} ${sparqlIri(kaUal)} ` +
-        `${sparqlString(plan.contextGraphId)})`
-      )).join(' ');
-      // sparql-scan-allow: R2 -- the graph, head, UAL, and context ID are exact values from the bounded candidate read above
-      const headResult = await store.query(
-        `SELECT DISTINCT ?head ?ual WHERE { ` +
-        `VALUES (?head ?ual ?contextGraphId) { ${values} } ` +
-        `GRAPH ${sparqlIri(plan.metaGraph)} { ` +
-        `?head <${KA_UAL}> ?ual ; <${SHARE_OPERATION_ID}> ?shareId . ` +
-        `?operation <${RDF_TYPE}> <${WORKSPACE_OPERATION}> ; ` +
-        `<${KA_UAL}> ?ual ; <${SHARE_OPERATION_ID}> ?shareId ; ` +
-        `<${CONTEXT_GRAPH_ID}> ?contextGraphId . ` +
-        `} } LIMIT ${batch.length + 1}`,
-        {
-          source: 'agent.rfc64.legacySwmBoundary.readHeads',
-          priority: 'background',
-        },
-      );
-      if (headResult.type !== 'bindings') {
-        throw new Error(
-          'RFC-64 legacy SWM boundary head query did not return bindings',
-        );
-      }
-      if (headResult.bindings.length > batch.length) {
-        throw new Error('RFC-64 legacy SWM boundary head query exceeded its batch');
-      }
-      const requestedUals = new Set(batch.map(([kaUal]) => kaUal));
-      for (const row of headResult.bindings) {
-        const head = row['head'];
-        const rawUal = row['ual'];
-        if (head === undefined || rawUal === undefined) {
-          throw new Error(
-            'RFC-64 legacy SWM boundary returned an incomplete head',
-          );
-        }
-        const kaUal = assertCanonicalDeterministicUalV1(rawUal).ual;
-        if (!requestedUals.has(kaUal)) {
-          throw new Error('RFC-64 legacy SWM boundary returned an unrequested head');
-        }
-        if (head !== `${kaUal}${SWM_HEAD_SUFFIX}`) {
-          throw new Error(`RFC-64 legacy SWM head identity differs for ${kaUal}`);
-        }
-        entries.set(
-          `${plan.contextGraphId}\u0000${kaUal}`,
-          Object.freeze({
-            contextGraphId: plan.contextGraphId,
-            kaUal,
-          }),
-        );
-      }
+      batches.push(Object.freeze({
+        contextGraphId: plan.contextGraphId,
+        metaGraph: plan.metaGraph,
+        heads: Object.freeze(graphHeads.slice(
+          offset,
+          offset + RFC64_LEGACY_SWM_HEAD_READ_BATCH_SIZE_V1,
+        )),
+      }));
+    }
+  }
+  const verifiedBatches = await mapWithConcurrency(
+    batches,
+    RFC64_LEGACY_SWM_HEAD_READ_CONCURRENCY_V1,
+    async (batch) => readRfc64LegacySwmHeadBatchV1(store, batch),
+  );
+  const entries = new Map<string, Rfc64LegacySwmBoundaryEntryV1>();
+  for (const verified of verifiedBatches) {
+    for (const entry of verified) {
+      entries.set(`${entry.contextGraphId}\u0000${entry.kaUal}`, entry);
     }
   }
   return Object.freeze({
     version: 1,
     entries: Object.freeze([...entries.values()].sort(compareEntries)),
   });
+}
+
+async function readRfc64LegacySwmHeadBatchV1(
+  store: TripleStore,
+  batch: Rfc64LegacySwmHeadBatchV1,
+): Promise<readonly Rfc64LegacySwmBoundaryEntryV1[]> {
+  const values = batch.heads.map(([kaUal, head]) => (
+    `(${sparqlIri(head)} ${sparqlIri(kaUal)} ` +
+    `${sparqlString(batch.contextGraphId)})`
+  )).join(' ');
+  // sparql-scan-allow: R2 -- the graph, head, UAL, and context ID are exact values from the bounded candidate read above
+  const headResult = await store.query(
+    `SELECT DISTINCT ?head ?ual WHERE { ` +
+    `VALUES (?head ?ual ?contextGraphId) { ${values} } ` +
+    `GRAPH ${sparqlIri(batch.metaGraph)} { ` +
+    `?head <${KA_UAL}> ?ual ; <${SHARE_OPERATION_ID}> ?shareId . ` +
+    `?operation <${RDF_TYPE}> <${WORKSPACE_OPERATION}> ; ` +
+    `<${KA_UAL}> ?ual ; <${SHARE_OPERATION_ID}> ?shareId ; ` +
+    `<${CONTEXT_GRAPH_ID}> ?contextGraphId . ` +
+    `} } LIMIT ${batch.heads.length + 1}`,
+    {
+      source: 'agent.rfc64.legacySwmBoundary.readHeads',
+      priority: 'background',
+    },
+  );
+  if (headResult.type !== 'bindings') {
+    throw new Error(
+      'RFC-64 legacy SWM boundary head query did not return bindings',
+    );
+  }
+  if (headResult.bindings.length > batch.heads.length) {
+    throw new Error('RFC-64 legacy SWM boundary head query exceeded its batch');
+  }
+  const requestedUals = new Set(batch.heads.map(([kaUal]) => kaUal));
+  return Object.freeze(headResult.bindings.map((row) => {
+    const head = row['head'];
+    const rawUal = row['ual'];
+    if (head === undefined || rawUal === undefined) {
+      throw new Error('RFC-64 legacy SWM boundary returned an incomplete head');
+    }
+    const kaUal = assertCanonicalDeterministicUalV1(rawUal).ual;
+    if (!requestedUals.has(kaUal)) {
+      throw new Error('RFC-64 legacy SWM boundary returned an unrequested head');
+    }
+    if (head !== `${kaUal}${SWM_HEAD_SUFFIX}`) {
+      throw new Error(`RFC-64 legacy SWM head identity differs for ${kaUal}`);
+    }
+    return Object.freeze({ contextGraphId: batch.contextGraphId, kaUal });
+  }));
 }
 
 function decodeRfc64BindingValueV1(raw: string): string {

--- a/packages/agent/src/rfc64/legacy-swm-boundary-v1.ts
+++ b/packages/agent/src/rfc64/legacy-swm-boundary-v1.ts
@@ -405,16 +405,21 @@ async function captureRfc64LegacySwmBoundaryV1(
   // is ambiguous because a valid Context Graph ID may itself contain slashes;
   // enumerating every `.../_shared_memory_meta` graph would also let unrelated
   // named history consume the bounded root-capture budget before classification.
+  // Keep the selective WorkspaceOperation pattern before the SWM head join.
+  // Blazegraph otherwise chooses a plan that scans and joins every candidate
+  // head first, which can exceed the store deadline on an existing node during
+  // the one-time upgrade capture. Source order is therefore an operational part
+  // of this query, even though the two forms are semantically equivalent.
   const result = await store.query(
     `SELECT DISTINCT ?metaGraph ?head ?ual ?contextGraphId WHERE { ` +
     `GRAPH ?metaGraph { ` +
-    `?head <${KA_UAL}> ?ual ; <${SHARE_OPERATION_ID}> ?shareId . ` +
     `?operation <${RDF_TYPE}> <${WORKSPACE_OPERATION}> ; ` +
     `<${KA_UAL}> ?ual ; <${SHARE_OPERATION_ID}> ?shareId ; ` +
     `<${CONTEXT_GRAPH_ID}> ?contextGraphId . ` +
     `FILTER(STR(?metaGraph) = CONCAT(` +
     `${JSON.stringify(CONTEXT_GRAPH_PREFIX)}, STR(?contextGraphId), ` +
     `${JSON.stringify(SWM_META_SUFFIX)})) ` +
+    `?head <${KA_UAL}> ?ual ; <${SHARE_OPERATION_ID}> ?shareId . ` +
     `FILTER(STRENDS(STR(?head), ${JSON.stringify(SWM_HEAD_SUFFIX)})) ` +
     `} } LIMIT ${RFC64_LEGACY_SWM_HEAD_LIMIT_V1 + 1}`,
     {

--- a/packages/agent/test-live/rfc64-legacy-swm-boundary-v1.blazegraph.test.ts
+++ b/packages/agent/test-live/rfc64-legacy-swm-boundary-v1.blazegraph.test.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 
 import { contextGraphWorkspaceMetaGraphUri } from '@origintrail-official/dkg-core';
 import { BlazegraphStore, type Quad } from '@origintrail-official/dkg-storage';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import {
   initializeRfc64LegacySwmBoundaryV1,
@@ -19,6 +19,7 @@ const CONTEXT_GRAPH_ID =
   `0x1111111111111111111111111111111111111111/legacy-boundary-live-${RUN}`;
 const META_GRAPH = contextGraphWorkspaceMetaGraphUri(CONTEXT_GRAPH_ID);
 const LEGACY_HEAD_COUNT = 5_000;
+const UNRELATED_HEAD_COUNT = 20_000;
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 const KA_UAL = 'http://dkg.io/ontology/kaUal';
 const SHARE_OPERATION_ID = 'http://dkg.io/ontology/shareOperationId';
@@ -53,6 +54,7 @@ describe('RFC-64 legacy SWM boundary (live Blazegraph)', () => {
   it(
     'completes the first-upgrade capture under the store deadline and reuses it on restart',
     async () => {
+      const querySpy = vi.spyOn(store, 'query');
       const firstOwner = {};
       await initializeRfc64LegacySwmBoundaryV1(
         firstOwner,
@@ -63,9 +65,21 @@ describe('RFC-64 legacy SWM boundary (live Blazegraph)', () => {
         firstOwner,
         CONTEXT_GRAPH_ID,
       )).toBe(LEGACY_HEAD_COUNT);
+      const captureReadCount = (source: string) => querySpy.mock.calls.filter(
+        ([, options]) => options?.source === source,
+      ).length;
+      const firstOperationReadCount = captureReadCount(
+        'agent.rfc64.legacySwmBoundary.readOperations',
+      );
+      const firstHeadReadCount = captureReadCount(
+        'agent.rfc64.legacySwmBoundary.readHeads',
+      );
+      expect(firstOperationReadCount).toBe(1);
+      expect(firstHeadReadCount).toBeGreaterThan(0);
 
       // A second owner represents the next process start. It must load the
-      // durable capture rather than repeat the production-sized head scan.
+      // durable capture rather than repeat either capture query. The late-entry
+      // marker read still runs on every start, so observe the sources directly.
       const restartedOwner = {};
       await initializeRfc64LegacySwmBoundaryV1(
         restartedOwner,
@@ -76,6 +90,12 @@ describe('RFC-64 legacy SWM boundary (live Blazegraph)', () => {
         restartedOwner,
         CONTEXT_GRAPH_ID,
       )).toBe(LEGACY_HEAD_COUNT);
+      expect(captureReadCount(
+        'agent.rfc64.legacySwmBoundary.readOperations',
+      )).toBe(firstOperationReadCount);
+      expect(captureReadCount(
+        'agent.rfc64.legacySwmBoundary.readHeads',
+      )).toBe(firstHeadReadCount);
     },
     30_000,
   );
@@ -115,6 +135,24 @@ function legacyBoundaryFixture(): Quad[] {
         subject: operation,
         predicate: CONTEXT_GRAPH_ID_PREDICATE,
         object: JSON.stringify(CONTEXT_GRAPH_ID),
+      },
+    );
+  }
+  // These look like legacy heads but have no WorkspaceOperation. Keeping the
+  // unrelated population much larger than the capture proves the bounded
+  // second read does not depend on Blazegraph choosing a favorable join order.
+  for (let index = 0; index < UNRELATED_HEAD_COUNT; index += 1) {
+    const kaNumber = LEGACY_HEAD_COUNT + index + 1;
+    const ual =
+      `did:dkg:otp:20430/0x1111111111111111111111111111111111111111/${kaNumber}`;
+    const head = `${ual}#dkg-swm-head`;
+    quads.push(
+      { graph: META_GRAPH, subject: head, predicate: KA_UAL, object: ual },
+      {
+        graph: META_GRAPH,
+        subject: head,
+        predicate: SHARE_OPERATION_ID,
+        object: JSON.stringify(`unrelated-live-boundary-share-${index}`),
       },
     );
   }

--- a/packages/agent/test-live/rfc64-legacy-swm-boundary-v1.blazegraph.test.ts
+++ b/packages/agent/test-live/rfc64-legacy-swm-boundary-v1.blazegraph.test.ts
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { chmod, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { contextGraphWorkspaceMetaGraphUri } from '@origintrail-official/dkg-core';
+import { BlazegraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  initializeRfc64LegacySwmBoundaryV1,
+  readRfc64LegacySwmBoundaryCountV1,
+} from '../src/rfc64/legacy-swm-boundary-v1.js';
+
+const BLAZEGRAPH_URL = process.env.BLAZEGRAPH_TEST_URL;
+const RUN = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+const CONTEXT_GRAPH_ID =
+  `0x1111111111111111111111111111111111111111/legacy-boundary-live-${RUN}`;
+const META_GRAPH = contextGraphWorkspaceMetaGraphUri(CONTEXT_GRAPH_ID);
+const LEGACY_HEAD_COUNT = 5_000;
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const KA_UAL = 'http://dkg.io/ontology/kaUal';
+const SHARE_OPERATION_ID = 'http://dkg.io/ontology/shareOperationId';
+const CONTEXT_GRAPH_ID_PREDICATE = 'http://dkg.io/ontology/contextGraphId';
+const WORKSPACE_OPERATION = 'http://dkg.io/ontology/WorkspaceOperation';
+
+describe('RFC-64 legacy SWM boundary (live Blazegraph)', () => {
+  let store: BlazegraphStore;
+  let persistenceRoot: string;
+
+  beforeAll(async () => {
+    if (!BLAZEGRAPH_URL) {
+      throw new Error('BLAZEGRAPH_TEST_URL is required for the live Blazegraph suite');
+    }
+    store = new BlazegraphStore(BLAZEGRAPH_URL, { timeout: 15_000 });
+    persistenceRoot = await mkdtemp(join(tmpdir(), 'dkg-rfc64-boundary-blazegraph-'));
+    await chmod(persistenceRoot, 0o700);
+    await store.dropGraph(META_GRAPH);
+    await store.insert(legacyBoundaryFixture());
+  }, 60_000);
+
+  afterAll(async () => {
+    if (store) {
+      await store.dropGraph(META_GRAPH).catch(() => {});
+      await store.close().catch(() => {});
+    }
+    if (persistenceRoot) {
+      await rm(persistenceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it(
+    'completes the first-upgrade capture under the store deadline and reuses it on restart',
+    async () => {
+      const firstOwner = {};
+      await initializeRfc64LegacySwmBoundaryV1(
+        firstOwner,
+        persistenceRoot,
+        store,
+      );
+      expect(readRfc64LegacySwmBoundaryCountV1(
+        firstOwner,
+        CONTEXT_GRAPH_ID,
+      )).toBe(LEGACY_HEAD_COUNT);
+
+      // A second owner represents the next process start. It must load the
+      // durable capture rather than repeat the production-sized head scan.
+      const restartedOwner = {};
+      await initializeRfc64LegacySwmBoundaryV1(
+        restartedOwner,
+        persistenceRoot,
+        store,
+      );
+      expect(readRfc64LegacySwmBoundaryCountV1(
+        restartedOwner,
+        CONTEXT_GRAPH_ID,
+      )).toBe(LEGACY_HEAD_COUNT);
+    },
+    30_000,
+  );
+});
+
+function legacyBoundaryFixture(): Quad[] {
+  const quads: Quad[] = [];
+  for (let index = 0; index < LEGACY_HEAD_COUNT; index += 1) {
+    const ual =
+      `did:dkg:otp:20430/0x1111111111111111111111111111111111111111/${index + 1}`;
+    const head = `${ual}#dkg-swm-head`;
+    const operation = `urn:dkg:workspace-operation:live-boundary:${RUN}:${index}`;
+    const shareOperationId = JSON.stringify(`live-boundary-share-${index}`);
+    quads.push(
+      { graph: META_GRAPH, subject: head, predicate: KA_UAL, object: ual },
+      {
+        graph: META_GRAPH,
+        subject: head,
+        predicate: SHARE_OPERATION_ID,
+        object: shareOperationId,
+      },
+      {
+        graph: META_GRAPH,
+        subject: operation,
+        predicate: RDF_TYPE,
+        object: WORKSPACE_OPERATION,
+      },
+      { graph: META_GRAPH, subject: operation, predicate: KA_UAL, object: ual },
+      {
+        graph: META_GRAPH,
+        subject: operation,
+        predicate: SHARE_OPERATION_ID,
+        object: shareOperationId,
+      },
+      {
+        graph: META_GRAPH,
+        subject: operation,
+        predicate: CONTEXT_GRAPH_ID_PREDICATE,
+        object: JSON.stringify(CONTEXT_GRAPH_ID),
+      },
+    );
+  }
+  return quads;
+}

--- a/packages/agent/test-live/rfc64-legacy-swm-boundary-v1.blazegraph.test.ts
+++ b/packages/agent/test-live/rfc64-legacy-swm-boundary-v1.blazegraph.test.ts
@@ -12,6 +12,8 @@ import {
   initializeRfc64LegacySwmBoundaryV1,
   readRfc64LegacySwmBoundaryCountV1,
 } from '../src/rfc64/legacy-swm-boundary-v1.js';
+import { legacySwmBoundaryFixtureQuadsV1 } from
+  '../test/_helpers/legacy-swm-boundary-fixture.js';
 
 const BLAZEGRAPH_URL = process.env.BLAZEGRAPH_TEST_URL;
 const RUN = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
@@ -25,11 +27,6 @@ const HISTORICAL_SHARES_PER_OPERATION = 316;
 const HISTORICAL_OPERATION_ROWS =
   HISTORICAL_OPERATION_SUBJECTS * HISTORICAL_SHARES_PER_OPERATION;
 const FIXTURE_INSERT_BATCH_SIZE = 10_000;
-const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
-const KA_UAL = 'http://dkg.io/ontology/kaUal';
-const SHARE_OPERATION_ID = 'http://dkg.io/ontology/shareOperationId';
-const CONTEXT_GRAPH_ID_PREDICATE = 'http://dkg.io/ontology/contextGraphId';
-const WORKSPACE_OPERATION = 'http://dkg.io/ontology/WorkspaceOperation';
 
 describe('RFC-64 legacy SWM boundary (live Blazegraph)', () => {
   let store: BlazegraphStore;
@@ -125,37 +122,16 @@ function* legacyBoundaryFixture(): Generator<Quad> {
   for (let index = 0; index < LEGACY_HEAD_COUNT; index += 1) {
     const ual =
       `did:dkg:otp:20430/0x1111111111111111111111111111111111111111/${index + 1}`;
-    const head = `${ual}#dkg-swm-head`;
     const operation = `urn:dkg:workspace-operation:live-boundary:${RUN}:${index}`;
-    const shareOperationId = JSON.stringify(`live-boundary-share-${index}`);
-    yield* [
-      { graph: META_GRAPH, subject: head, predicate: KA_UAL, object: ual },
-      {
-        graph: META_GRAPH,
-        subject: head,
-        predicate: SHARE_OPERATION_ID,
-        object: shareOperationId,
-      },
-      {
-        graph: META_GRAPH,
-        subject: operation,
-        predicate: RDF_TYPE,
-        object: WORKSPACE_OPERATION,
-      },
-      { graph: META_GRAPH, subject: operation, predicate: KA_UAL, object: ual },
-      {
-        graph: META_GRAPH,
-        subject: operation,
-        predicate: SHARE_OPERATION_ID,
-        object: shareOperationId,
-      },
-      {
-        graph: META_GRAPH,
-        subject: operation,
-        predicate: CONTEXT_GRAPH_ID_PREDICATE,
-        object: JSON.stringify(CONTEXT_GRAPH_ID),
-      },
-    ];
+    const shareOperationId = `live-boundary-share-${index}`;
+    yield* legacySwmBoundaryFixtureQuadsV1({
+      graph: META_GRAPH,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ual,
+      operation,
+      head: { shareOperationId },
+      operationShareOperationIds: [shareOperationId],
+    });
   }
   // These look like legacy heads and have WorkspaceOperations, but their share
   // IDs do not match. They must not consume either semantic capture limit.
@@ -163,36 +139,19 @@ function* legacyBoundaryFixture(): Generator<Quad> {
     const kaNumber = LEGACY_HEAD_COUNT + index + 1;
     const ual =
       `did:dkg:otp:20430/0x1111111111111111111111111111111111111111/${kaNumber}`;
-    const head = `${ual}#dkg-swm-head`;
     const operation = `urn:dkg:workspace-operation:mismatch:${RUN}:${index}`;
-    yield* [
-      { graph: META_GRAPH, subject: head, predicate: KA_UAL, object: ual },
-      {
-        graph: META_GRAPH,
-        subject: head,
-        predicate: SHARE_OPERATION_ID,
-        object: JSON.stringify(`unrelated-live-boundary-share-${index}`),
+    yield* legacySwmBoundaryFixtureQuadsV1({
+      graph: META_GRAPH,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ual,
+      operation,
+      head: {
+        shareOperationId: `unrelated-live-boundary-share-${index}`,
       },
-      {
-        graph: META_GRAPH,
-        subject: operation,
-        predicate: RDF_TYPE,
-        object: WORKSPACE_OPERATION,
-      },
-      { graph: META_GRAPH, subject: operation, predicate: KA_UAL, object: ual },
-      {
-        graph: META_GRAPH,
-        subject: operation,
-        predicate: SHARE_OPERATION_ID,
-        object: JSON.stringify(`mismatched-operation-share-${index}`),
-      },
-      {
-        graph: META_GRAPH,
-        subject: operation,
-        predicate: CONTEXT_GRAPH_ID_PREDICATE,
-        object: JSON.stringify(CONTEXT_GRAPH_ID),
-      },
-    ];
+      operationShareOperationIds: [
+        `mismatched-operation-share-${index}`,
+      ],
+    });
   }
   // More than 100,000 concrete operation solutions target the first UAL, but
   // every historical share differs from its current head. The exact join must
@@ -206,39 +165,17 @@ function* legacyBoundaryFixture(): Generator<Quad> {
   ) {
     const operation =
       `urn:dkg:workspace-operation:history:${RUN}:${operationIndex}`;
-    yield* [
-      {
-        graph: META_GRAPH,
-        subject: operation,
-        predicate: RDF_TYPE,
-        object: WORKSPACE_OPERATION,
-      },
-      {
-        graph: META_GRAPH,
-        subject: operation,
-        predicate: KA_UAL,
-        object: historicalUal,
-      },
-      {
-        graph: META_GRAPH,
-        subject: operation,
-        predicate: CONTEXT_GRAPH_ID_PREDICATE,
-        object: JSON.stringify(CONTEXT_GRAPH_ID),
-      },
-    ];
-    for (
-      let shareIndex = 0;
-      shareIndex < HISTORICAL_SHARES_PER_OPERATION;
-      shareIndex += 1
-    ) {
-      yield {
-        graph: META_GRAPH,
-        subject: operation,
-        predicate: SHARE_OPERATION_ID,
-        object: JSON.stringify(
-          `historical-share-${operationIndex}-${shareIndex}`,
+    yield* legacySwmBoundaryFixtureQuadsV1({
+      graph: META_GRAPH,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ual: historicalUal,
+      operation,
+      operationShareOperationIds: Array.from(
+        { length: HISTORICAL_SHARES_PER_OPERATION },
+        (_, shareIndex) => (
+          `historical-share-${operationIndex}-${shareIndex}`
         ),
-      };
-    }
+      ),
+    });
   }
 }

--- a/packages/agent/test-live/rfc64-legacy-swm-boundary-v1.blazegraph.test.ts
+++ b/packages/agent/test-live/rfc64-legacy-swm-boundary-v1.blazegraph.test.ts
@@ -75,7 +75,17 @@ describe('RFC-64 legacy SWM boundary (live Blazegraph)', () => {
         'agent.rfc64.legacySwmBoundary.readHeads',
       );
       expect(firstOperationReadCount).toBe(1);
-      expect(firstHeadReadCount).toBeGreaterThan(0);
+      expect(firstHeadReadCount).toBe(10);
+      const headQueries = querySpy.mock.calls.filter(([, options]) => (
+        options?.source === 'agent.rfc64.legacySwmBoundary.readHeads'
+      )).map(([sparql]) => sparql);
+      for (const sparql of headQueries) {
+        const values = /VALUES \(\?head \?ual \?contextGraphId\) \{ (.+) \} GRAPH/s
+          .exec(sparql)?.[1];
+        expect(values).toBeDefined();
+        expect(values!.match(/\(<did:dkg:/g)).toHaveLength(500);
+        expect(sparql).toContain('LIMIT 501');
+      }
 
       // A second owner represents the next process start. It must load the
       // durable capture rather than repeat either capture query. The late-entry

--- a/packages/agent/test-live/rfc64-legacy-swm-boundary-v1.blazegraph.test.ts
+++ b/packages/agent/test-live/rfc64-legacy-swm-boundary-v1.blazegraph.test.ts
@@ -43,16 +43,16 @@ describe('RFC-64 legacy SWM boundary (live Blazegraph)', () => {
     persistenceRoot = await mkdtemp(join(tmpdir(), 'dkg-rfc64-boundary-blazegraph-'));
     await chmod(persistenceRoot, 0o700);
     await store.dropGraph(META_GRAPH);
-    const fixture = legacyBoundaryFixture();
-    for (
-      let offset = 0;
-      offset < fixture.length;
-      offset += FIXTURE_INSERT_BATCH_SIZE
-    ) {
-      await store.insert(fixture.slice(
-        offset,
-        offset + FIXTURE_INSERT_BATCH_SIZE,
-      ));
+    let batch: Quad[] = [];
+    for (const quad of legacyBoundaryFixture()) {
+      batch.push(quad);
+      if (batch.length === FIXTURE_INSERT_BATCH_SIZE) {
+        await store.insert(batch);
+        batch = [];
+      }
+    }
+    if (batch.length > 0) {
+      await store.insert(batch);
     }
   }, 120_000);
 
@@ -93,7 +93,7 @@ describe('RFC-64 legacy SWM boundary (live Blazegraph)', () => {
       )).map(([sparql]) => sparql);
       expect(captureQueries).toHaveLength(1);
       expect(captureQueries[0]).toContain(
-        'BIND(IRI(CONCAT(STR(?ual), "#dkg-swm-head")) AS ?head)',
+        'BIND(?operationUal AS ?ual)',
       );
       expect(captureQueries[0]!.match(
         /<http:\/\/dkg\.io\/ontology\/shareOperationId> \?shareId/g,
@@ -121,15 +121,14 @@ describe('RFC-64 legacy SWM boundary (live Blazegraph)', () => {
   );
 });
 
-function legacyBoundaryFixture(): Quad[] {
-  const quads: Quad[] = [];
+function* legacyBoundaryFixture(): Generator<Quad> {
   for (let index = 0; index < LEGACY_HEAD_COUNT; index += 1) {
     const ual =
       `did:dkg:otp:20430/0x1111111111111111111111111111111111111111/${index + 1}`;
     const head = `${ual}#dkg-swm-head`;
     const operation = `urn:dkg:workspace-operation:live-boundary:${RUN}:${index}`;
     const shareOperationId = JSON.stringify(`live-boundary-share-${index}`);
-    quads.push(
+    yield* [
       { graph: META_GRAPH, subject: head, predicate: KA_UAL, object: ual },
       {
         graph: META_GRAPH,
@@ -156,7 +155,7 @@ function legacyBoundaryFixture(): Quad[] {
         predicate: CONTEXT_GRAPH_ID_PREDICATE,
         object: JSON.stringify(CONTEXT_GRAPH_ID),
       },
-    );
+    ];
   }
   // These look like legacy heads and have WorkspaceOperations, but their share
   // IDs do not match. They must not consume either semantic capture limit.
@@ -166,7 +165,7 @@ function legacyBoundaryFixture(): Quad[] {
       `did:dkg:otp:20430/0x1111111111111111111111111111111111111111/${kaNumber}`;
     const head = `${ual}#dkg-swm-head`;
     const operation = `urn:dkg:workspace-operation:mismatch:${RUN}:${index}`;
-    quads.push(
+    yield* [
       { graph: META_GRAPH, subject: head, predicate: KA_UAL, object: ual },
       {
         graph: META_GRAPH,
@@ -193,7 +192,7 @@ function legacyBoundaryFixture(): Quad[] {
         predicate: CONTEXT_GRAPH_ID_PREDICATE,
         object: JSON.stringify(CONTEXT_GRAPH_ID),
       },
-    );
+    ];
   }
   // More than 100,000 concrete operation solutions target the first UAL, but
   // every historical share differs from its current head. The exact join must
@@ -207,7 +206,7 @@ function legacyBoundaryFixture(): Quad[] {
   ) {
     const operation =
       `urn:dkg:workspace-operation:history:${RUN}:${operationIndex}`;
-    quads.push(
+    yield* [
       {
         graph: META_GRAPH,
         subject: operation,
@@ -226,21 +225,20 @@ function legacyBoundaryFixture(): Quad[] {
         predicate: CONTEXT_GRAPH_ID_PREDICATE,
         object: JSON.stringify(CONTEXT_GRAPH_ID),
       },
-    );
+    ];
     for (
       let shareIndex = 0;
       shareIndex < HISTORICAL_SHARES_PER_OPERATION;
       shareIndex += 1
     ) {
-      quads.push({
+      yield {
         graph: META_GRAPH,
         subject: operation,
         predicate: SHARE_OPERATION_ID,
         object: JSON.stringify(
           `historical-share-${operationIndex}-${shareIndex}`,
         ),
-      });
+      };
     }
   }
-  return quads;
 }

--- a/packages/agent/test-live/rfc64-legacy-swm-boundary-v1.blazegraph.test.ts
+++ b/packages/agent/test-live/rfc64-legacy-swm-boundary-v1.blazegraph.test.ts
@@ -19,7 +19,12 @@ const CONTEXT_GRAPH_ID =
   `0x1111111111111111111111111111111111111111/legacy-boundary-live-${RUN}`;
 const META_GRAPH = contextGraphWorkspaceMetaGraphUri(CONTEXT_GRAPH_ID);
 const LEGACY_HEAD_COUNT = 5_000;
-const UNRELATED_HEAD_COUNT = 20_000;
+const SHARE_MISMATCH_COUNT = 20_000;
+const HISTORICAL_OPERATION_SUBJECTS = 317;
+const HISTORICAL_SHARES_PER_OPERATION = 316;
+const HISTORICAL_OPERATION_ROWS =
+  HISTORICAL_OPERATION_SUBJECTS * HISTORICAL_SHARES_PER_OPERATION;
+const FIXTURE_INSERT_BATCH_SIZE = 10_000;
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 const KA_UAL = 'http://dkg.io/ontology/kaUal';
 const SHARE_OPERATION_ID = 'http://dkg.io/ontology/shareOperationId';
@@ -38,8 +43,18 @@ describe('RFC-64 legacy SWM boundary (live Blazegraph)', () => {
     persistenceRoot = await mkdtemp(join(tmpdir(), 'dkg-rfc64-boundary-blazegraph-'));
     await chmod(persistenceRoot, 0o700);
     await store.dropGraph(META_GRAPH);
-    await store.insert(legacyBoundaryFixture());
-  }, 60_000);
+    const fixture = legacyBoundaryFixture();
+    for (
+      let offset = 0;
+      offset < fixture.length;
+      offset += FIXTURE_INSERT_BATCH_SIZE
+    ) {
+      await store.insert(fixture.slice(
+        offset,
+        offset + FIXTURE_INSERT_BATCH_SIZE,
+      ));
+    }
+  }, 120_000);
 
   afterAll(async () => {
     if (store) {
@@ -68,27 +83,25 @@ describe('RFC-64 legacy SWM boundary (live Blazegraph)', () => {
       const captureReadCount = (source: string) => querySpy.mock.calls.filter(
         ([, options]) => options?.source === source,
       ).length;
-      const firstOperationReadCount = captureReadCount(
-        'agent.rfc64.legacySwmBoundary.readOperations',
-      );
       const firstHeadReadCount = captureReadCount(
         'agent.rfc64.legacySwmBoundary.readHeads',
       );
-      expect(firstOperationReadCount).toBe(1);
-      expect(firstHeadReadCount).toBe(10);
-      const headQueries = querySpy.mock.calls.filter(([, options]) => (
+      expect(HISTORICAL_OPERATION_ROWS).toBeGreaterThan(100_000);
+      expect(firstHeadReadCount).toBe(1);
+      const captureQueries = querySpy.mock.calls.filter(([, options]) => (
         options?.source === 'agent.rfc64.legacySwmBoundary.readHeads'
       )).map(([sparql]) => sparql);
-      for (const sparql of headQueries) {
-        const values = /VALUES \(\?head \?ual \?contextGraphId\) \{ (.+) \} GRAPH/s
-          .exec(sparql)?.[1];
-        expect(values).toBeDefined();
-        expect(values!.match(/\(<did:dkg:/g)).toHaveLength(500);
-        expect(sparql).toContain('LIMIT 501');
-      }
+      expect(captureQueries).toHaveLength(1);
+      expect(captureQueries[0]).toContain(
+        'BIND(IRI(CONCAT(STR(?ual), "#dkg-swm-head")) AS ?head)',
+      );
+      expect(captureQueries[0]!.match(
+        /<http:\/\/dkg\.io\/ontology\/shareOperationId> \?shareId/g,
+      )).toHaveLength(2);
+      expect(captureQueries[0]).toContain('LIMIT 100001');
 
       // A second owner represents the next process start. It must load the
-      // durable capture rather than repeat either capture query. The late-entry
+      // durable capture rather than repeat the capture query. The late-entry
       // marker read still runs on every start, so observe the sources directly.
       const restartedOwner = {};
       await initializeRfc64LegacySwmBoundaryV1(
@@ -100,9 +113,6 @@ describe('RFC-64 legacy SWM boundary (live Blazegraph)', () => {
         restartedOwner,
         CONTEXT_GRAPH_ID,
       )).toBe(LEGACY_HEAD_COUNT);
-      expect(captureReadCount(
-        'agent.rfc64.legacySwmBoundary.readOperations',
-      )).toBe(firstOperationReadCount);
       expect(captureReadCount(
         'agent.rfc64.legacySwmBoundary.readHeads',
       )).toBe(firstHeadReadCount);
@@ -148,14 +158,14 @@ function legacyBoundaryFixture(): Quad[] {
       },
     );
   }
-  // These look like legacy heads but have no WorkspaceOperation. Keeping the
-  // unrelated population much larger than the capture proves the bounded
-  // second read does not depend on Blazegraph choosing a favorable join order.
-  for (let index = 0; index < UNRELATED_HEAD_COUNT; index += 1) {
+  // These look like legacy heads and have WorkspaceOperations, but their share
+  // IDs do not match. They must not consume either semantic capture limit.
+  for (let index = 0; index < SHARE_MISMATCH_COUNT; index += 1) {
     const kaNumber = LEGACY_HEAD_COUNT + index + 1;
     const ual =
       `did:dkg:otp:20430/0x1111111111111111111111111111111111111111/${kaNumber}`;
     const head = `${ual}#dkg-swm-head`;
+    const operation = `urn:dkg:workspace-operation:mismatch:${RUN}:${index}`;
     quads.push(
       { graph: META_GRAPH, subject: head, predicate: KA_UAL, object: ual },
       {
@@ -164,7 +174,73 @@ function legacyBoundaryFixture(): Quad[] {
         predicate: SHARE_OPERATION_ID,
         object: JSON.stringify(`unrelated-live-boundary-share-${index}`),
       },
+      {
+        graph: META_GRAPH,
+        subject: operation,
+        predicate: RDF_TYPE,
+        object: WORKSPACE_OPERATION,
+      },
+      { graph: META_GRAPH, subject: operation, predicate: KA_UAL, object: ual },
+      {
+        graph: META_GRAPH,
+        subject: operation,
+        predicate: SHARE_OPERATION_ID,
+        object: JSON.stringify(`mismatched-operation-share-${index}`),
+      },
+      {
+        graph: META_GRAPH,
+        subject: operation,
+        predicate: CONTEXT_GRAPH_ID_PREDICATE,
+        object: JSON.stringify(CONTEXT_GRAPH_ID),
+      },
     );
+  }
+  // More than 100,000 concrete operation solutions target the first UAL, but
+  // every historical share differs from its current head. The exact join must
+  // discard all of them before DISTINCT and the 100,000-head limit.
+  const historicalUal =
+    'did:dkg:otp:20430/0x1111111111111111111111111111111111111111/1';
+  for (
+    let operationIndex = 0;
+    operationIndex < HISTORICAL_OPERATION_SUBJECTS;
+    operationIndex += 1
+  ) {
+    const operation =
+      `urn:dkg:workspace-operation:history:${RUN}:${operationIndex}`;
+    quads.push(
+      {
+        graph: META_GRAPH,
+        subject: operation,
+        predicate: RDF_TYPE,
+        object: WORKSPACE_OPERATION,
+      },
+      {
+        graph: META_GRAPH,
+        subject: operation,
+        predicate: KA_UAL,
+        object: historicalUal,
+      },
+      {
+        graph: META_GRAPH,
+        subject: operation,
+        predicate: CONTEXT_GRAPH_ID_PREDICATE,
+        object: JSON.stringify(CONTEXT_GRAPH_ID),
+      },
+    );
+    for (
+      let shareIndex = 0;
+      shareIndex < HISTORICAL_SHARES_PER_OPERATION;
+      shareIndex += 1
+    ) {
+      quads.push({
+        graph: META_GRAPH,
+        subject: operation,
+        predicate: SHARE_OPERATION_ID,
+        object: JSON.stringify(
+          `historical-share-${operationIndex}-${shareIndex}`,
+        ),
+      });
+    }
   }
   return quads;
 }

--- a/packages/agent/test/_helpers/legacy-swm-boundary-fixture.ts
+++ b/packages/agent/test/_helpers/legacy-swm-boundary-fixture.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Quad } from '@origintrail-official/dkg-storage';
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const KA_UAL = 'http://dkg.io/ontology/kaUal';
+const SHARE_OPERATION_ID = 'http://dkg.io/ontology/shareOperationId';
+const CONTEXT_GRAPH_ID = 'http://dkg.io/ontology/contextGraphId';
+const WORKSPACE_OPERATION = 'http://dkg.io/ontology/WorkspaceOperation';
+const SWM_HEAD_SUFFIX = '#dkg-swm-head';
+
+export interface LegacySwmBoundaryFixtureV1 {
+  readonly graph: string;
+  readonly contextGraphId: string;
+  readonly ual: string;
+  readonly operation: string;
+  readonly head?: {
+    readonly subject?: string;
+    readonly shareOperationId: string;
+  };
+  readonly operationShareOperationIds: readonly string[];
+}
+
+/** Canonical legacy SWM RDF shape shared by unit and live-backend tests. */
+export function legacySwmBoundaryFixtureQuadsV1(
+  fixture: LegacySwmBoundaryFixtureV1,
+): Quad[] {
+  const quads: Quad[] = [];
+  if (fixture.head !== undefined) {
+    const subject = fixture.head.subject ?? `${fixture.ual}${SWM_HEAD_SUFFIX}`;
+    quads.push(
+      { graph: fixture.graph, subject, predicate: KA_UAL, object: fixture.ual },
+      {
+        graph: fixture.graph,
+        subject,
+        predicate: SHARE_OPERATION_ID,
+        object: JSON.stringify(fixture.head.shareOperationId),
+      },
+    );
+  }
+  quads.push(
+    {
+      graph: fixture.graph,
+      subject: fixture.operation,
+      predicate: RDF_TYPE,
+      object: WORKSPACE_OPERATION,
+    },
+    {
+      graph: fixture.graph,
+      subject: fixture.operation,
+      predicate: KA_UAL,
+      object: fixture.ual,
+    },
+    ...fixture.operationShareOperationIds.map((shareOperationId) => ({
+      graph: fixture.graph,
+      subject: fixture.operation,
+      predicate: SHARE_OPERATION_ID,
+      object: JSON.stringify(shareOperationId),
+    })),
+    {
+      graph: fixture.graph,
+      subject: fixture.operation,
+      predicate: CONTEXT_GRAPH_ID,
+      object: JSON.stringify(fixture.contextGraphId),
+    },
+  );
+  return quads;
+}

--- a/packages/agent/test/rfc64-legacy-swm-boundary-v1.test.ts
+++ b/packages/agent/test/rfc64-legacy-swm-boundary-v1.test.ts
@@ -282,6 +282,28 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
     );
   });
 
+  it('binds the selective workspace operation before joining legacy heads', async () => {
+    const root = await secureTempRoot(roots);
+    const store = fakeStore(new Map([[META_GRAPH, [UAL_ONE]]]));
+
+    await initializeRfc64LegacySwmBoundaryV1({}, root, store);
+
+    const captureQueryCall = vi.mocked(store.query).mock.calls.find(([, options]) => (
+      options?.source === 'agent.rfc64.legacySwmBoundary.readHeads'
+    ));
+    expect(captureQueryCall).toBeDefined();
+    const captureQuery = captureQueryCall![0];
+    const operationPattern = captureQuery.indexOf(
+      '?operation <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
+    );
+    const headPattern = captureQuery.indexOf(
+      '?head <http://dkg.io/ontology/kaUal>',
+    );
+    expect(operationPattern).toBeGreaterThanOrEqual(0);
+    expect(headPattern).toBeGreaterThan(operationPattern);
+    expect(captureQuery).not.toContain('queryHints#');
+  });
+
   it('does not query a named metadata graph that could exhaust the root head cap', async () => {
     const root = await secureTempRoot(roots);
     const rootBinding = {

--- a/packages/agent/test/rfc64-legacy-swm-boundary-v1.test.ts
+++ b/packages/agent/test/rfc64-legacy-swm-boundary-v1.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { chmod, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { chmod, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -10,6 +10,7 @@ import {
 } from '@origintrail-official/dkg-core';
 import {
   OxigraphStore,
+  type Quad,
   type QueryResult,
   type TripleStore,
 } from '@origintrail-official/dkg-storage';
@@ -281,195 +282,45 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
     expect(store.query).toHaveBeenCalledWith(
       expect.stringContaining('GRAPH ?metaGraph'),
       expect.objectContaining({
-        source: 'agent.rfc64.legacySwmBoundary.readOperations',
-      }),
-    );
-  });
-
-  it('uses an explicit bounded operation-to-head read boundary', async () => {
-    const root = await secureTempRoot(roots);
-    const store = fakeStore(new Map([[META_GRAPH, [UAL_ONE]]]));
-
-    await initializeRfc64LegacySwmBoundaryV1({}, root, store);
-
-    const operationQueryCall = vi.mocked(store.query).mock.calls.find(([, options]) => (
-      options?.source === 'agent.rfc64.legacySwmBoundary.readOperations'
-    ));
-    const headQueryCall = vi.mocked(store.query).mock.calls.find(([, options]) => (
-      options?.source === 'agent.rfc64.legacySwmBoundary.readHeads'
-    ));
-    expect(operationQueryCall).toBeDefined();
-    expect(headQueryCall).toBeDefined();
-    expect(operationQueryCall![0]).toContain(
-      '?operation <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
-    );
-    expect(operationQueryCall![0]).toContain(
-      'BIND(IRI(CONCAT(STR(?ual), "#dkg-swm-head")) AS ?head)',
-    );
-    expect(operationQueryCall![0]).toContain(
-      '?head <http://dkg.io/ontology/kaUal> ?ual ; <http://dkg.io/ontology/shareOperationId> ?shareId',
-    );
-    expect(operationQueryCall![0]).toContain('LIMIT 100001');
-    expect(headQueryCall![0]).toContain(
-      'VALUES (?head ?ual ?contextGraphId)',
-    );
-    expect(headQueryCall![0]).toContain(`GRAPH <${META_GRAPH}>`);
-    expect(headQueryCall![0]).not.toContain('GRAPH ?metaGraph');
-    expect(headQueryCall![0]).toContain(
-      '?operation <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
-    );
-    expect(headQueryCall![0]).not.toContain('queryHints#');
-  });
-
-  it('does not let 100001 historical operations for one active head consume the head limit', async () => {
-    const root = await secureTempRoot(roots);
-    const historicalOperationCount = 100_001;
-    const store = {
-      query: vi.fn(async (sparql: string, options?: { source?: string }) => {
-        if (
-          options?.source === 'agent.rfc64.legacySwmBoundary.readOperations'
-        ) {
-          // Model the store's DISTINCT projection over a fully joined current
-          // head. Dropping DISTINCT, projecting shareId, or separating the two
-          // share bindings exposes every historical operation and returns the
-          // over-limit result that caused the startup bug.
-          const exactProjection = sparql.startsWith(
-            'SELECT DISTINCT ?metaGraph ?head ?ual ?contextGraphId WHERE',
-          );
-          const shareBindings = sparql.match(
-            /<http:\/\/dkg\.io\/ontology\/shareOperationId> \?shareId/g,
-          ) ?? [];
-          if (!exactProjection || shareBindings.length !== 2) {
-            return {
-              type: 'bindings' as const,
-              bindings: { length: historicalOperationCount },
-            };
-          }
-          return captureOperationResult();
-        }
-        if (options?.source === 'agent.rfc64.legacySwmBoundary.readHeads') {
-          return { type: 'bindings' as const, bindings: [captureHeadBinding()] };
-        }
-        return { type: 'bindings' as const, bindings: [] };
-      }),
-    } as unknown as TripleStore;
-
-    const owner = {};
-    await initializeRfc64LegacySwmBoundaryV1(owner, root, store);
-
-    expect(historicalOperationCount).toBeGreaterThan(100_000);
-    expect(readRfc64LegacySwmBoundaryCountV1(owner, CONTEXT_GRAPH_ID)).toBe(1);
-  });
-
-  it('does not count 100001 share-mismatched heads across 16385 graphs', async () => {
-    const root = await secureTempRoot(roots);
-    const mismatchedHeadCount = 100_001;
-    const mismatchedGraphCount = 16_385;
-    const store = {
-      query: vi.fn(async (sparql: string, options?: { source?: string }) => {
-        if (
-          options?.source === 'agent.rfc64.legacySwmBoundary.readOperations'
-        ) {
-          const shareBindings = sparql.match(
-            /<http:\/\/dkg\.io\/ontology\/shareOperationId> \?shareId/g,
-          ) ?? [];
-          return shareBindings.length === 2
-            ? { type: 'bindings' as const, bindings: [] }
-            : {
-                type: 'bindings' as const,
-                bindings: { length: mismatchedHeadCount },
-              };
-        }
-        return { type: 'bindings' as const, bindings: [] };
-      }),
-    } as unknown as TripleStore;
-
-    const owner = {};
-    await initializeRfc64LegacySwmBoundaryV1(owner, root, store);
-
-    expect(mismatchedHeadCount).toBeGreaterThan(100_000);
-    expect(mismatchedGraphCount).toBeGreaterThan(16_384);
-    expect(readRfc64LegacySwmBoundaryCountV1(owner, CONTEXT_GRAPH_ID)).toBe(0);
-    expect(store.query).not.toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
         source: 'agent.rfc64.legacySwmBoundary.readHeads',
       }),
     );
   });
 
-  it('runs exact-head batches with bounded concurrency and canonical output', async () => {
+  it('uses one bounded fully correlated capture query', async () => {
     const root = await secureTempRoot(roots);
-    const uals = Array.from({ length: 2_001 }, (_, index) => (
-      `did:dkg:otp:20430/0x1111111111111111111111111111111111111111/${index + 1}`
+    const store = fakeStore(new Map([[META_GRAPH, [UAL_ONE]]]));
+
+    await initializeRfc64LegacySwmBoundaryV1({}, root, store);
+
+    const captureQueryCalls = vi.mocked(store.query).mock.calls.filter(([, options]) => (
+      options?.source === 'agent.rfc64.legacySwmBoundary.readHeads'
     ));
-    let activeHeadReads = 0;
-    let maximumActiveHeadReads = 0;
-    let headReadCount = 0;
-    const store = {
-      query: vi.fn(async (sparql: string, options?: { source?: string }) => {
-        if (
-          options?.source === 'agent.rfc64.legacySwmBoundary.readOperations'
-        ) {
-          return {
-            type: 'bindings' as const,
-            bindings: uals.map((ual) => ({
-              metaGraph: META_GRAPH,
-              head: `${ual}#dkg-swm-head`,
-              ual,
-              contextGraphId: `"${CONTEXT_GRAPH_ID}"`,
-            })),
-          };
-        }
-        if (options?.source === 'agent.rfc64.legacySwmBoundary.readHeads') {
-          headReadCount += 1;
-          activeHeadReads += 1;
-          maximumActiveHeadReads = Math.max(
-            maximumActiveHeadReads,
-            activeHeadReads,
-          );
-          try {
-            await new Promise<void>((resolve) => setImmediate(resolve));
-            const bindings = [...sparql.matchAll(
-              /\(<([^>]+)> <([^>]+)> "(?:[^"\\]|\\.)*"\)/g,
-            )].map((match) => ({ head: match[1]!, ual: match[2]! }));
-            return { type: 'bindings' as const, bindings };
-          } finally {
-            activeHeadReads -= 1;
-          }
-        }
-        return { type: 'bindings' as const, bindings: [] };
-      }),
-    } as unknown as TripleStore;
-
-    const owner = {};
-    await initializeRfc64LegacySwmBoundaryV1(owner, root, store);
-
-    expect(headReadCount).toBe(5);
-    expect(maximumActiveHeadReads).toBe(4);
-    expect(readRfc64LegacySwmBoundaryCountV1(owner, CONTEXT_GRAPH_ID)).toBe(
-      uals.length,
+    expect(captureQueryCalls).toHaveLength(1);
+    const captureQuery = captureQueryCalls[0]![0];
+    expect(captureQuery).toContain(
+      '?operation <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
     );
-    const capture = JSON.parse(await readFile(
-      join(root, 'legacy-swm-boundary-v1/capture.json'),
-      'utf8',
-    )) as { entries: Array<{ contextGraphId: string; kaUal: string }> };
-    expect(capture.entries).toEqual([...capture.entries].sort((left, right) => (
-      left.contextGraphId.localeCompare(right.contextGraphId)
-      || left.kaUal.localeCompare(right.kaUal)
-    )));
+    expect(captureQuery).toContain(
+      'BIND(IRI(CONCAT(STR(?ual), "#dkg-swm-head")) AS ?head)',
+    );
+    expect(captureQuery).toContain(
+      '?head <http://dkg.io/ontology/kaUal> ?ual ; <http://dkg.io/ontology/shareOperationId> ?shareId',
+    );
+    expect(captureQuery).toContain('LIMIT 100001');
+    expect(captureQuery).not.toContain('VALUES');
+    expect(captureQuery).not.toContain('queryHints#');
   });
 
   it.each([
     {
-      name: 'a non-binding operation result',
-      operationResult: { type: 'boolean', value: true } as const,
-      headResult: { type: 'bindings', bindings: [] } as const,
-      error: 'operation query did not return bindings',
+      name: 'a non-binding capture result',
+      captureResult: { type: 'boolean', value: true } as const,
+      error: 'query did not return bindings',
     },
     {
-      name: 'an incomplete operation binding',
-      operationResult: {
+      name: 'an incomplete head binding',
+      captureResult: {
         type: 'bindings',
         bindings: [{
           metaGraph: META_GRAPH,
@@ -477,106 +328,42 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
           contextGraphId: `"${CONTEXT_GRAPH_ID}"`,
         }],
       } as const,
-      headResult: { type: 'bindings', bindings: [] } as const,
-      error: 'returned an incomplete operation',
-    },
-    {
-      name: 'more active-head candidates than the head limit',
-      operationResult: {
-        type: 'bindings',
-        bindings: { length: 100_001 },
-      } as unknown as QueryResult,
-      headResult: { type: 'bindings', bindings: [] } as const,
-      error: 'exceeds head limit 100000',
-    },
-    {
-      name: 'a non-binding exact-head result',
-      operationResult: captureOperationResult(),
-      headResult: { type: 'boolean', value: true } as const,
-      error: 'head query did not return bindings',
-    },
-    {
-      name: 'more exact-head rows than the bounded batch',
-      operationResult: captureOperationResult(),
-      headResult: {
-        type: 'bindings',
-        bindings: [captureHeadBinding(), captureHeadBinding()],
-      } as const,
-      error: 'head query exceeded its batch',
-    },
-    {
-      name: 'an incomplete exact-head binding',
-      operationResult: captureOperationResult(),
-      headResult: {
-        type: 'bindings',
-        bindings: [{ head: `${UAL_ONE}#dkg-swm-head` }],
-      } as const,
       error: 'returned an incomplete head',
     },
-    {
-      name: 'an exact-head binding outside the requested batch',
-      operationResult: captureOperationResult(),
-      headResult: {
-        type: 'bindings',
-        bindings: [{ head: `${UAL_TWO}#dkg-swm-head`, ual: UAL_TWO }],
-      } as const,
-      error: 'returned an unrequested head',
-    },
-  ])('fails closed on $name', async ({ operationResult, headResult, error }) => {
+  ])('fails closed on $name', async ({ captureResult, error }) => {
     const root = await secureTempRoot(roots);
-    const store = scriptedCaptureStore(
-      operationResult as QueryResult,
-      headResult as QueryResult,
-    );
+    const store = scriptedCaptureStore(captureResult as QueryResult);
 
     await expect(
       initializeRfc64LegacySwmBoundaryV1({}, root, store),
     ).rejects.toThrow(error);
   });
 
-  it('does not query a named metadata graph that could exhaust the root head cap', async () => {
+  it('rejects 100001 fully joined heads using valid binding rows', async () => {
     const root = await secureTempRoot(roots);
-    const operationBinding = {
-      metaGraph: META_GRAPH,
-      head: `${UAL_ONE}#dkg-swm-head`,
-      ual: UAL_ONE,
-      contextGraphId: `"${CONTEXT_GRAPH_ID}"`,
-    };
-    const headBinding = {
-      head: `${UAL_ONE}#dkg-swm-head`,
-      ual: UAL_ONE,
-    };
-    const store = {
-      listGraphs: vi.fn(async () => [META_GRAPH, SUBGRAPH_META_GRAPH]),
-      query: vi.fn(async (sparql: string, options?: { source?: string }) => {
-        if (sparql.includes(`GRAPH <${SUBGRAPH_META_GRAPH}>`)) {
-          return {
-            type: 'bindings' as const,
-            // The old per-graph capture rejects this length before iteration.
-            bindings: { length: 100_001 },
-          };
-        }
-        if (
-          options?.source === 'agent.rfc64.legacySwmBoundary.readOperations'
-        ) {
-          return { type: 'bindings' as const, bindings: [operationBinding] };
-        }
-        if (options?.source === 'agent.rfc64.legacySwmBoundary.readHeads') {
-          return { type: 'bindings' as const, bindings: [headBinding] };
-        }
-        return { type: 'bindings' as const, bindings: [] };
-      }),
-    } as unknown as TripleStore;
+    const bindings = Array.from({ length: 100_001 }, (_, index) => {
+      const ual = testUal(index + 1);
+      return captureBinding(CONTEXT_GRAPH_ID, ual);
+    });
+    const store = scriptedCaptureStore({ type: 'bindings', bindings });
 
-    const owner = {};
-    await initializeRfc64LegacySwmBoundaryV1(owner, root, store);
+    await expect(
+      initializeRfc64LegacySwmBoundaryV1({}, root, store),
+    ).rejects.toThrow('exceeds head limit 100000');
+  });
 
-    expect(readRfc64LegacySwmBoundaryCountV1(owner, CONTEXT_GRAPH_ID)).toBe(1);
-    expect(store.listGraphs).not.toHaveBeenCalled();
-    expect(store.query).not.toHaveBeenCalledWith(
-      expect.stringContaining(`GRAPH <${SUBGRAPH_META_GRAPH}>`),
-      expect.anything(),
-    );
+  it('rejects 16385 valid root metadata graphs', async () => {
+    const root = await secureTempRoot(roots);
+    const bindings = Array.from({ length: 16_385 }, (_, index) => {
+      const contextGraphId =
+        `0x1111111111111111111111111111111111111111/graph-limit-${index + 1}`;
+      return captureBinding(contextGraphId, UAL_ONE);
+    });
+    const store = scriptedCaptureStore({ type: 'bindings', bindings });
+
+    await expect(
+      initializeRfc64LegacySwmBoundaryV1({}, root, store),
+    ).rejects.toThrow('exceeds metadata graph limit 16384');
   });
 
   it('captures only fully joined legacy heads through the real Oxigraph query', async () => {
@@ -584,19 +371,13 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
     const store = new OxigraphStore();
     const correctHead = `${UAL_ONE}#dkg-swm-head`;
     const mismatchedHead = `${UAL_TWO}#dkg-swm-head`;
-    await store.insert([
+    const quads: Quad[] = [
       { graph: META_GRAPH, subject: correctHead, predicate: 'http://dkg.io/ontology/kaUal', object: UAL_ONE },
       { graph: META_GRAPH, subject: correctHead, predicate: 'http://dkg.io/ontology/shareOperationId', object: '"share-one"' },
       { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:one', predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/WorkspaceOperation' },
       { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:one', predicate: 'http://dkg.io/ontology/kaUal', object: UAL_ONE },
       { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:one', predicate: 'http://dkg.io/ontology/shareOperationId', object: '"share-one"' },
       { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:one', predicate: 'http://dkg.io/ontology/contextGraphId', object: `"${CONTEXT_GRAPH_ID}"` },
-      // Repeated historical shares for the same UAL collapse in the candidate
-      // phase; only the operation matching the current head may capture it.
-      { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:one-old', predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/WorkspaceOperation' },
-      { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:one-old', predicate: 'http://dkg.io/ontology/kaUal', object: UAL_ONE },
-      { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:one-old', predicate: 'http://dkg.io/ontology/shareOperationId', object: '"share-one-old"' },
-      { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:one-old', predicate: 'http://dkg.io/ontology/contextGraphId', object: `"${CONTEXT_GRAPH_ID}"` },
       // This head looks plausible but its operation carries another share id,
       // so the production join must not classify it as a captured legacy row.
       { graph: META_GRAPH, subject: mismatchedHead, predicate: 'http://dkg.io/ontology/kaUal', object: UAL_TWO },
@@ -605,7 +386,18 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
       { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:two', predicate: 'http://dkg.io/ontology/kaUal', object: UAL_TWO },
       { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:two', predicate: 'http://dkg.io/ontology/shareOperationId', object: '"different-share"' },
       { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:two', predicate: 'http://dkg.io/ontology/contextGraphId', object: `"${CONTEXT_GRAPH_ID}"` },
-    ]);
+    ];
+    // Concrete repeated history exercises the real store's join and DISTINCT
+    // semantics. None of these old share IDs matches the one current head.
+    for (let index = 0; index < 512; index += 1) {
+      quads.push(...legacyOperationQuads(
+        META_GRAPH,
+        UAL_ONE,
+        `one-old-${index}`,
+        `share-one-old-${index}`,
+      ));
+    }
+    await store.insert(quads);
 
     const owner = {};
     await initializeRfc64LegacySwmBoundaryV1(owner, root, store);
@@ -624,7 +416,7 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
     expect(readRfc64LegacySwmBoundaryCountV1(owner, CONTEXT_GRAPH_ID)).toBe(0);
   });
 
-  it('captures and queries two root metadata graphs independently', async () => {
+  it('captures two root metadata graphs in one query', async () => {
     const root = await secureTempRoot(roots);
     const secondContextGraphId =
       '0x1111111111111111111111111111111111111111/legacy-boundary-two';
@@ -657,13 +449,8 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
     const headQueries = querySpy.mock.calls.filter(([, options]) => (
       options?.source === 'agent.rfc64.legacySwmBoundary.readHeads'
     )).map(([sparql]) => sparql);
-    expect(headQueries).toHaveLength(2);
-    expect(headQueries.some((sparql) => (
-      sparql.includes(`GRAPH <${META_GRAPH}>`)
-    ))).toBe(true);
-    expect(headQueries.some((sparql) => (
-      sparql.includes(`GRAPH <${secondMetaGraph}>`)
-    ))).toBe(true);
+    expect(headQueries).toHaveLength(1);
+    expect(headQueries[0]).toContain('GRAPH ?metaGraph');
   });
 });
 
@@ -682,9 +469,7 @@ function fakeStore(
     listGraphs: vi.fn(async () => [...headsByGraph.keys()]),
     query: vi.fn(async (_sparql: string, options?: { source?: string }) => {
       const rootHeads = headsByGraph.get(META_GRAPH) ?? [];
-      if (
-        options?.source === 'agent.rfc64.legacySwmBoundary.readOperations'
-      ) {
+      if (options?.source === 'agent.rfc64.legacySwmBoundary.readHeads') {
         return {
           type: 'bindings' as const,
           bindings: rootHeads.map((ual) => ({
@@ -695,53 +480,39 @@ function fakeStore(
           })),
         };
       }
-      if (options?.source === 'agent.rfc64.legacySwmBoundary.readHeads') {
-        return {
-          type: 'bindings' as const,
-          bindings: rootHeads.map((ual) => ({
-            head: forcedHead ?? `${ual}#dkg-swm-head`,
-            ual,
-          })),
-        };
-      }
       return { type: 'bindings' as const, bindings: [] };
     }),
   } as unknown as TripleStore;
 }
 
-function captureOperationResult(): QueryResult {
+function captureBinding(
+  contextGraphId = CONTEXT_GRAPH_ID,
+  ual = UAL_ONE,
+): Record<string, string> {
   return {
-    type: 'bindings',
-    bindings: [{
-      metaGraph: META_GRAPH,
-      head: `${UAL_ONE}#dkg-swm-head`,
-      ual: UAL_ONE,
-      contextGraphId: `"${CONTEXT_GRAPH_ID}"`,
-    }],
+    metaGraph: contextGraphWorkspaceMetaGraphUri(contextGraphId),
+    head: `${ual}#dkg-swm-head`,
+    ual,
+    contextGraphId: JSON.stringify(contextGraphId),
   };
 }
 
-function captureHeadBinding(): Record<string, string> {
-  return { head: `${UAL_ONE}#dkg-swm-head`, ual: UAL_ONE };
+function scriptedCaptureStore(
+  captureResult: QueryResult,
+): TripleStore {
+  const store = new OxigraphStore();
+  const query = store.query.bind(store);
+  vi.spyOn(store, 'query').mockImplementation(async (sparql, options) => {
+    if (options?.source === 'agent.rfc64.legacySwmBoundary.readHeads') {
+      return captureResult;
+    }
+    return query(sparql, options);
+  });
+  return store;
 }
 
-function scriptedCaptureStore(
-  operationResult: QueryResult,
-  headResult: QueryResult,
-): TripleStore {
-  return {
-    query: vi.fn(async (_sparql: string, options?: { source?: string }) => {
-      if (
-        options?.source === 'agent.rfc64.legacySwmBoundary.readOperations'
-      ) {
-        return operationResult;
-      }
-      if (options?.source === 'agent.rfc64.legacySwmBoundary.readHeads') {
-        return headResult;
-      }
-      return { type: 'bindings' as const, bindings: [] };
-    }),
-  } as unknown as TripleStore;
+function testUal(kaNumber: number): string {
+  return `did:dkg:otp:20430/0x1111111111111111111111111111111111111111/${kaNumber}`;
 }
 
 function legacyHeadQuads(
@@ -749,16 +520,28 @@ function legacyHeadQuads(
   ual: string,
   id: string,
   contextGraphId = CONTEXT_GRAPH_ID,
-) {
+): Quad[] {
   const head = `${ual}#dkg-swm-head`;
-  const operation = `urn:dkg:workspace-operation:${id}`;
   const shareId = `"share-${id}"`;
   return [
     { graph, subject: head, predicate: 'http://dkg.io/ontology/kaUal', object: ual },
     { graph, subject: head, predicate: 'http://dkg.io/ontology/shareOperationId', object: shareId },
+    ...legacyOperationQuads(graph, ual, id, `share-${id}`, contextGraphId),
+  ];
+}
+
+function legacyOperationQuads(
+  graph: string,
+  ual: string,
+  id: string,
+  shareId: string,
+  contextGraphId = CONTEXT_GRAPH_ID,
+): Quad[] {
+  const operation = `urn:dkg:workspace-operation:${id}`;
+  return [
     { graph, subject: operation, predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/WorkspaceOperation' },
     { graph, subject: operation, predicate: 'http://dkg.io/ontology/kaUal', object: ual },
-    { graph, subject: operation, predicate: 'http://dkg.io/ontology/shareOperationId', object: shareId },
+    { graph, subject: operation, predicate: 'http://dkg.io/ontology/shareOperationId', object: JSON.stringify(shareId) },
     { graph, subject: operation, predicate: 'http://dkg.io/ontology/contextGraphId', object: `"${contextGraphId}"` },
   ];
 }

--- a/packages/agent/test/rfc64-legacy-swm-boundary-v1.test.ts
+++ b/packages/agent/test/rfc64-legacy-swm-boundary-v1.test.ts
@@ -277,44 +277,53 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
     expect(store.query).toHaveBeenCalledWith(
       expect.stringContaining('GRAPH ?metaGraph'),
       expect.objectContaining({
-        source: 'agent.rfc64.legacySwmBoundary.readHeads',
+        source: 'agent.rfc64.legacySwmBoundary.readOperations',
       }),
     );
   });
 
-  it('binds the selective workspace operation before joining legacy heads', async () => {
+  it('uses an explicit bounded operation-to-head read boundary', async () => {
     const root = await secureTempRoot(roots);
     const store = fakeStore(new Map([[META_GRAPH, [UAL_ONE]]]));
 
     await initializeRfc64LegacySwmBoundaryV1({}, root, store);
 
-    const captureQueryCall = vi.mocked(store.query).mock.calls.find(([, options]) => (
+    const operationQueryCall = vi.mocked(store.query).mock.calls.find(([, options]) => (
+      options?.source === 'agent.rfc64.legacySwmBoundary.readOperations'
+    ));
+    const headQueryCall = vi.mocked(store.query).mock.calls.find(([, options]) => (
       options?.source === 'agent.rfc64.legacySwmBoundary.readHeads'
     ));
-    expect(captureQueryCall).toBeDefined();
-    const captureQuery = captureQueryCall![0];
-    const operationPattern = captureQuery.indexOf(
+    expect(operationQueryCall).toBeDefined();
+    expect(headQueryCall).toBeDefined();
+    expect(operationQueryCall![0]).toContain(
       '?operation <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
     );
-    const headPattern = captureQuery.indexOf(
+    expect(operationQueryCall![0]).not.toContain(
       '?head <http://dkg.io/ontology/kaUal>',
     );
-    expect(operationPattern).toBeGreaterThanOrEqual(0);
-    expect(headPattern).toBeGreaterThan(operationPattern);
-    expect(captureQuery).not.toContain('queryHints#');
+    expect(headQueryCall![0]).toContain('VALUES (?head ?ual ?shareId)');
+    expect(headQueryCall![0]).toContain(`GRAPH <${META_GRAPH}>`);
+    expect(headQueryCall![0]).not.toContain('GRAPH ?metaGraph');
+    expect(headQueryCall![0]).not.toContain('?operation ');
+    expect(headQueryCall![0]).not.toContain('queryHints#');
   });
 
   it('does not query a named metadata graph that could exhaust the root head cap', async () => {
     const root = await secureTempRoot(roots);
-    const rootBinding = {
+    const operationBinding = {
       metaGraph: META_GRAPH,
+      ual: UAL_ONE,
+      shareId: '"share-one"',
+      contextGraphId: `"${CONTEXT_GRAPH_ID}"`,
+    };
+    const headBinding = {
       head: `${UAL_ONE}#dkg-swm-head`,
       ual: UAL_ONE,
-      contextGraphId: `"${CONTEXT_GRAPH_ID}"`,
     };
     const store = {
       listGraphs: vi.fn(async () => [META_GRAPH, SUBGRAPH_META_GRAPH]),
-      query: vi.fn(async (sparql: string) => {
+      query: vi.fn(async (sparql: string, options?: { source?: string }) => {
         if (sparql.includes(`GRAPH <${SUBGRAPH_META_GRAPH}>`)) {
           return {
             type: 'bindings' as const,
@@ -322,8 +331,13 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
             bindings: { length: 100_001 },
           };
         }
-        if (sparql.includes('GRAPH ?metaGraph')) {
-          return { type: 'bindings' as const, bindings: [rootBinding] };
+        if (
+          options?.source === 'agent.rfc64.legacySwmBoundary.readOperations'
+        ) {
+          return { type: 'bindings' as const, bindings: [operationBinding] };
+        }
+        if (options?.source === 'agent.rfc64.legacySwmBoundary.readHeads') {
+          return { type: 'bindings' as const, bindings: [headBinding] };
         }
         return { type: 'bindings' as const, bindings: [] };
       }),
@@ -393,20 +407,31 @@ function fakeStore(
 ): TripleStore {
   return {
     listGraphs: vi.fn(async () => [...headsByGraph.keys()]),
-    query: vi.fn(async (sparql: string) => {
-      if (!sparql.includes('GRAPH ?metaGraph')) {
-        return { type: 'bindings' as const, bindings: [] };
-      }
+    query: vi.fn(async (_sparql: string, options?: { source?: string }) => {
       const rootHeads = headsByGraph.get(META_GRAPH) ?? [];
-      return {
-        type: 'bindings' as const,
-        bindings: rootHeads.map((ual) => ({
-          metaGraph: META_GRAPH,
-          head: forcedHead ?? `${ual}#dkg-swm-head`,
-          ual,
-          contextGraphId: `"${CONTEXT_GRAPH_ID}"`,
-        })),
-      };
+      if (
+        options?.source === 'agent.rfc64.legacySwmBoundary.readOperations'
+      ) {
+        return {
+          type: 'bindings' as const,
+          bindings: rootHeads.map((ual, index) => ({
+            metaGraph: META_GRAPH,
+            ual,
+            shareId: `"share-${index}"`,
+            contextGraphId: `"${CONTEXT_GRAPH_ID}"`,
+          })),
+        };
+      }
+      if (options?.source === 'agent.rfc64.legacySwmBoundary.readHeads') {
+        return {
+          type: 'bindings' as const,
+          bindings: rootHeads.map((ual) => ({
+            head: forcedHead ?? `${ual}#dkg-swm-head`,
+            ual,
+          })),
+        };
+      }
+      return { type: 'bindings' as const, bindings: [] };
     }),
   } as unknown as TripleStore;
 }

--- a/packages/agent/test/rfc64-legacy-swm-boundary-v1.test.ts
+++ b/packages/agent/test/rfc64-legacy-swm-boundary-v1.test.ts
@@ -8,7 +8,11 @@ import {
   contextGraphSharedMemoryMetaUri,
   contextGraphWorkspaceMetaGraphUri,
 } from '@origintrail-official/dkg-core';
-import { OxigraphStore, type TripleStore } from '@origintrail-official/dkg-storage';
+import {
+  OxigraphStore,
+  type QueryResult,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -309,6 +313,85 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
     expect(headQueryCall![0]).not.toContain('queryHints#');
   });
 
+  it.each([
+    {
+      name: 'a non-binding operation result',
+      operationResult: { type: 'boolean', value: true } as const,
+      headResult: { type: 'bindings', bindings: [] } as const,
+      error: 'operation query did not return bindings',
+    },
+    {
+      name: 'an incomplete operation binding',
+      operationResult: {
+        type: 'bindings',
+        bindings: [{
+          metaGraph: META_GRAPH,
+          ual: UAL_ONE,
+          contextGraphId: `"${CONTEXT_GRAPH_ID}"`,
+        }],
+      } as const,
+      headResult: { type: 'bindings', bindings: [] } as const,
+      error: 'returned an incomplete operation',
+    },
+    {
+      name: 'a malformed share-operation literal',
+      operationResult: {
+        type: 'bindings',
+        bindings: [{
+          metaGraph: META_GRAPH,
+          ual: UAL_ONE,
+          shareId: '"unterminated',
+          contextGraphId: `"${CONTEXT_GRAPH_ID}"`,
+        }],
+      } as const,
+      headResult: { type: 'bindings', bindings: [] } as const,
+      error: 'contains a malformed share operation ID',
+    },
+    {
+      name: 'a non-binding exact-head result',
+      operationResult: captureOperationResult(),
+      headResult: { type: 'boolean', value: true } as const,
+      error: 'head query did not return bindings',
+    },
+    {
+      name: 'more exact-head rows than the bounded batch',
+      operationResult: captureOperationResult(),
+      headResult: {
+        type: 'bindings',
+        bindings: [captureHeadBinding(), captureHeadBinding()],
+      } as const,
+      error: 'head query exceeded its batch',
+    },
+    {
+      name: 'an incomplete exact-head binding',
+      operationResult: captureOperationResult(),
+      headResult: {
+        type: 'bindings',
+        bindings: [{ head: `${UAL_ONE}#dkg-swm-head` }],
+      } as const,
+      error: 'returned an incomplete head',
+    },
+    {
+      name: 'an exact-head binding outside the requested batch',
+      operationResult: captureOperationResult(),
+      headResult: {
+        type: 'bindings',
+        bindings: [{ head: `${UAL_TWO}#dkg-swm-head`, ual: UAL_TWO }],
+      } as const,
+      error: 'returned an unrequested head',
+    },
+  ])('fails closed on $name', async ({ operationResult, headResult, error }) => {
+    const root = await secureTempRoot(roots);
+    const store = scriptedCaptureStore(
+      operationResult as QueryResult,
+      headResult as QueryResult,
+    );
+
+    await expect(
+      initializeRfc64LegacySwmBoundaryV1({}, root, store),
+    ).rejects.toThrow(error);
+  });
+
   it('does not query a named metadata graph that could exhaust the root head cap', async () => {
     const root = await secureTempRoot(roots);
     const operationBinding = {
@@ -430,6 +513,41 @@ function fakeStore(
             ual,
           })),
         };
+      }
+      return { type: 'bindings' as const, bindings: [] };
+    }),
+  } as unknown as TripleStore;
+}
+
+function captureOperationResult(): QueryResult {
+  return {
+    type: 'bindings',
+    bindings: [{
+      metaGraph: META_GRAPH,
+      ual: UAL_ONE,
+      shareId: '"share-one"',
+      contextGraphId: `"${CONTEXT_GRAPH_ID}"`,
+    }],
+  };
+}
+
+function captureHeadBinding(): Record<string, string> {
+  return { head: `${UAL_ONE}#dkg-swm-head`, ual: UAL_ONE };
+}
+
+function scriptedCaptureStore(
+  operationResult: QueryResult,
+  headResult: QueryResult,
+): TripleStore {
+  return {
+    query: vi.fn(async (_sparql: string, options?: { source?: string }) => {
+      if (
+        options?.source === 'agent.rfc64.legacySwmBoundary.readOperations'
+      ) {
+        return operationResult;
+      }
+      if (options?.source === 'agent.rfc64.legacySwmBoundary.readHeads') {
+        return headResult;
       }
       return { type: 'bindings' as const, bindings: [] };
     }),

--- a/packages/agent/test/rfc64-legacy-swm-boundary-v1.test.ts
+++ b/packages/agent/test/rfc64-legacy-swm-boundary-v1.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { chmod, mkdtemp, rm } from 'node:fs/promises';
+import { chmod, mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -307,7 +307,7 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
       'BIND(IRI(CONCAT(STR(?ual), "#dkg-swm-head")) AS ?head)',
     );
     expect(operationQueryCall![0]).toContain(
-      'FILTER EXISTS { GRAPH ?metaGraph { ?head <http://dkg.io/ontology/kaUal> ?ual } }',
+      '?head <http://dkg.io/ontology/kaUal> ?ual ; <http://dkg.io/ontology/shareOperationId> ?shareId',
     );
     expect(operationQueryCall![0]).toContain('LIMIT 100001');
     expect(headQueryCall![0]).toContain(
@@ -329,10 +329,17 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
         if (
           options?.source === 'agent.rfc64.legacySwmBoundary.readOperations'
         ) {
-          // Model the store's DISTINCT projection. Reintroducing shareId into
-          // that projection exposes every historical operation and makes this
-          // fake return the over-limit result that caused the startup bug.
-          if (/SELECT DISTINCT[^{}]*\?shareId/.test(sparql)) {
+          // Model the store's DISTINCT projection over a fully joined current
+          // head. Dropping DISTINCT, projecting shareId, or separating the two
+          // share bindings exposes every historical operation and returns the
+          // over-limit result that caused the startup bug.
+          const exactProjection = sparql.startsWith(
+            'SELECT DISTINCT ?metaGraph ?head ?ual ?contextGraphId WHERE',
+          );
+          const shareBindings = sparql.match(
+            /<http:\/\/dkg\.io\/ontology\/shareOperationId> \?shareId/g,
+          ) ?? [];
+          if (!exactProjection || shareBindings.length !== 2) {
             return {
               type: 'bindings' as const,
               bindings: { length: historicalOperationCount },
@@ -352,6 +359,105 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
 
     expect(historicalOperationCount).toBeGreaterThan(100_000);
     expect(readRfc64LegacySwmBoundaryCountV1(owner, CONTEXT_GRAPH_ID)).toBe(1);
+  });
+
+  it('does not count 100001 share-mismatched heads across 16385 graphs', async () => {
+    const root = await secureTempRoot(roots);
+    const mismatchedHeadCount = 100_001;
+    const mismatchedGraphCount = 16_385;
+    const store = {
+      query: vi.fn(async (sparql: string, options?: { source?: string }) => {
+        if (
+          options?.source === 'agent.rfc64.legacySwmBoundary.readOperations'
+        ) {
+          const shareBindings = sparql.match(
+            /<http:\/\/dkg\.io\/ontology\/shareOperationId> \?shareId/g,
+          ) ?? [];
+          return shareBindings.length === 2
+            ? { type: 'bindings' as const, bindings: [] }
+            : {
+                type: 'bindings' as const,
+                bindings: { length: mismatchedHeadCount },
+              };
+        }
+        return { type: 'bindings' as const, bindings: [] };
+      }),
+    } as unknown as TripleStore;
+
+    const owner = {};
+    await initializeRfc64LegacySwmBoundaryV1(owner, root, store);
+
+    expect(mismatchedHeadCount).toBeGreaterThan(100_000);
+    expect(mismatchedGraphCount).toBeGreaterThan(16_384);
+    expect(readRfc64LegacySwmBoundaryCountV1(owner, CONTEXT_GRAPH_ID)).toBe(0);
+    expect(store.query).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        source: 'agent.rfc64.legacySwmBoundary.readHeads',
+      }),
+    );
+  });
+
+  it('runs exact-head batches with bounded concurrency and canonical output', async () => {
+    const root = await secureTempRoot(roots);
+    const uals = Array.from({ length: 2_001 }, (_, index) => (
+      `did:dkg:otp:20430/0x1111111111111111111111111111111111111111/${index + 1}`
+    ));
+    let activeHeadReads = 0;
+    let maximumActiveHeadReads = 0;
+    let headReadCount = 0;
+    const store = {
+      query: vi.fn(async (sparql: string, options?: { source?: string }) => {
+        if (
+          options?.source === 'agent.rfc64.legacySwmBoundary.readOperations'
+        ) {
+          return {
+            type: 'bindings' as const,
+            bindings: uals.map((ual) => ({
+              metaGraph: META_GRAPH,
+              head: `${ual}#dkg-swm-head`,
+              ual,
+              contextGraphId: `"${CONTEXT_GRAPH_ID}"`,
+            })),
+          };
+        }
+        if (options?.source === 'agent.rfc64.legacySwmBoundary.readHeads') {
+          headReadCount += 1;
+          activeHeadReads += 1;
+          maximumActiveHeadReads = Math.max(
+            maximumActiveHeadReads,
+            activeHeadReads,
+          );
+          try {
+            await new Promise<void>((resolve) => setImmediate(resolve));
+            const bindings = [...sparql.matchAll(
+              /\(<([^>]+)> <([^>]+)> "(?:[^"\\]|\\.)*"\)/g,
+            )].map((match) => ({ head: match[1]!, ual: match[2]! }));
+            return { type: 'bindings' as const, bindings };
+          } finally {
+            activeHeadReads -= 1;
+          }
+        }
+        return { type: 'bindings' as const, bindings: [] };
+      }),
+    } as unknown as TripleStore;
+
+    const owner = {};
+    await initializeRfc64LegacySwmBoundaryV1(owner, root, store);
+
+    expect(headReadCount).toBe(5);
+    expect(maximumActiveHeadReads).toBe(4);
+    expect(readRfc64LegacySwmBoundaryCountV1(owner, CONTEXT_GRAPH_ID)).toBe(
+      uals.length,
+    );
+    const capture = JSON.parse(await readFile(
+      join(root, 'legacy-swm-boundary-v1/capture.json'),
+      'utf8',
+    )) as { entries: Array<{ contextGraphId: string; kaUal: string }> };
+    expect(capture.entries).toEqual([...capture.entries].sort((left, right) => (
+      left.contextGraphId.localeCompare(right.contextGraphId)
+      || left.kaUal.localeCompare(right.kaUal)
+    )));
   });
 
   it.each([

--- a/packages/agent/test/rfc64-legacy-swm-boundary-v1.test.ts
+++ b/packages/agent/test/rfc64-legacy-swm-boundary-v1.test.ts
@@ -236,7 +236,28 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
 
   it('fails closed when a head subject and its canonical UAL differ', async () => {
     const root = await secureTempRoot(roots);
-    const store = fakeStore(new Map([[META_GRAPH, [UAL_ONE]]]), `${UAL_TWO}#dkg-swm-head`);
+    const store = new OxigraphStore();
+    const corruptHead = `${UAL_TWO}#dkg-swm-head`;
+    await store.insert([
+      {
+        graph: META_GRAPH,
+        subject: corruptHead,
+        predicate: 'http://dkg.io/ontology/kaUal',
+        object: UAL_ONE,
+      },
+      {
+        graph: META_GRAPH,
+        subject: corruptHead,
+        predicate: 'http://dkg.io/ontology/shareOperationId',
+        object: '"corrupt-share"',
+      },
+      ...legacyOperationQuads(
+        META_GRAPH,
+        UAL_ONE,
+        'corrupt-head',
+        'corrupt-share',
+      ),
+    ]);
 
     await expect(initializeRfc64LegacySwmBoundaryV1({}, root, store)).rejects.toThrow(
       `RFC-64 legacy SWM head identity differs for ${UAL_ONE}`,
@@ -302,12 +323,15 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
       '?operation <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
     );
     expect(captureQuery).toContain(
-      'BIND(IRI(CONCAT(STR(?ual), "#dkg-swm-head")) AS ?head)',
+      'BIND(?operationUal AS ?ual)',
     );
     expect(captureQuery).toContain(
       '?head <http://dkg.io/ontology/kaUal> ?ual ; <http://dkg.io/ontology/shareOperationId> ?shareId',
     );
     expect(captureQuery).toContain('LIMIT 100001');
+    expect(captureQuery).toContain(
+      'FILTER(STRENDS(STR(?head), "#dkg-swm-head"))',
+    );
     expect(captureQuery).not.toContain('VALUES');
     expect(captureQuery).not.toContain('queryHints#');
   });
@@ -463,7 +487,6 @@ async function secureTempRoot(roots: string[]): Promise<string> {
 
 function fakeStore(
   headsByGraph: Map<string, string[]>,
-  forcedHead?: string,
 ): TripleStore {
   return {
     listGraphs: vi.fn(async () => [...headsByGraph.keys()]),
@@ -474,7 +497,7 @@ function fakeStore(
           type: 'bindings' as const,
           bindings: rootHeads.map((ual) => ({
             metaGraph: META_GRAPH,
-            head: forcedHead ?? `${ual}#dkg-swm-head`,
+            head: `${ual}#dkg-swm-head`,
             ual,
             contextGraphId: `"${CONTEXT_GRAPH_ID}"`,
           })),

--- a/packages/agent/test/rfc64-legacy-swm-boundary-v1.test.ts
+++ b/packages/agent/test/rfc64-legacy-swm-boundary-v1.test.ts
@@ -303,14 +303,55 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
     expect(operationQueryCall![0]).toContain(
       '?operation <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
     );
-    expect(operationQueryCall![0]).not.toContain(
-      '?head <http://dkg.io/ontology/kaUal>',
+    expect(operationQueryCall![0]).toContain(
+      'BIND(IRI(CONCAT(STR(?ual), "#dkg-swm-head")) AS ?head)',
     );
-    expect(headQueryCall![0]).toContain('VALUES (?head ?ual ?shareId)');
+    expect(operationQueryCall![0]).toContain(
+      'FILTER EXISTS { GRAPH ?metaGraph { ?head <http://dkg.io/ontology/kaUal> ?ual } }',
+    );
+    expect(operationQueryCall![0]).toContain('LIMIT 100001');
+    expect(headQueryCall![0]).toContain(
+      'VALUES (?head ?ual ?contextGraphId)',
+    );
     expect(headQueryCall![0]).toContain(`GRAPH <${META_GRAPH}>`);
     expect(headQueryCall![0]).not.toContain('GRAPH ?metaGraph');
-    expect(headQueryCall![0]).not.toContain('?operation ');
+    expect(headQueryCall![0]).toContain(
+      '?operation <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
+    );
     expect(headQueryCall![0]).not.toContain('queryHints#');
+  });
+
+  it('does not let 100001 historical operations for one active head consume the head limit', async () => {
+    const root = await secureTempRoot(roots);
+    const historicalOperationCount = 100_001;
+    const store = {
+      query: vi.fn(async (sparql: string, options?: { source?: string }) => {
+        if (
+          options?.source === 'agent.rfc64.legacySwmBoundary.readOperations'
+        ) {
+          // Model the store's DISTINCT projection. Reintroducing shareId into
+          // that projection exposes every historical operation and makes this
+          // fake return the over-limit result that caused the startup bug.
+          if (/SELECT DISTINCT[^{}]*\?shareId/.test(sparql)) {
+            return {
+              type: 'bindings' as const,
+              bindings: { length: historicalOperationCount },
+            };
+          }
+          return captureOperationResult();
+        }
+        if (options?.source === 'agent.rfc64.legacySwmBoundary.readHeads') {
+          return { type: 'bindings' as const, bindings: [captureHeadBinding()] };
+        }
+        return { type: 'bindings' as const, bindings: [] };
+      }),
+    } as unknown as TripleStore;
+
+    const owner = {};
+    await initializeRfc64LegacySwmBoundaryV1(owner, root, store);
+
+    expect(historicalOperationCount).toBeGreaterThan(100_000);
+    expect(readRfc64LegacySwmBoundaryCountV1(owner, CONTEXT_GRAPH_ID)).toBe(1);
   });
 
   it.each([
@@ -334,18 +375,13 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
       error: 'returned an incomplete operation',
     },
     {
-      name: 'a malformed share-operation literal',
+      name: 'more active-head candidates than the head limit',
       operationResult: {
         type: 'bindings',
-        bindings: [{
-          metaGraph: META_GRAPH,
-          ual: UAL_ONE,
-          shareId: '"unterminated',
-          contextGraphId: `"${CONTEXT_GRAPH_ID}"`,
-        }],
-      } as const,
+        bindings: { length: 100_001 },
+      } as unknown as QueryResult,
       headResult: { type: 'bindings', bindings: [] } as const,
-      error: 'contains a malformed share operation ID',
+      error: 'exceeds head limit 100000',
     },
     {
       name: 'a non-binding exact-head result',
@@ -396,8 +432,8 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
     const root = await secureTempRoot(roots);
     const operationBinding = {
       metaGraph: META_GRAPH,
+      head: `${UAL_ONE}#dkg-swm-head`,
       ual: UAL_ONE,
-      shareId: '"share-one"',
       contextGraphId: `"${CONTEXT_GRAPH_ID}"`,
     };
     const headBinding = {
@@ -449,6 +485,12 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
       { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:one', predicate: 'http://dkg.io/ontology/kaUal', object: UAL_ONE },
       { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:one', predicate: 'http://dkg.io/ontology/shareOperationId', object: '"share-one"' },
       { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:one', predicate: 'http://dkg.io/ontology/contextGraphId', object: `"${CONTEXT_GRAPH_ID}"` },
+      // Repeated historical shares for the same UAL collapse in the candidate
+      // phase; only the operation matching the current head may capture it.
+      { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:one-old', predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/WorkspaceOperation' },
+      { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:one-old', predicate: 'http://dkg.io/ontology/kaUal', object: UAL_ONE },
+      { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:one-old', predicate: 'http://dkg.io/ontology/shareOperationId', object: '"share-one-old"' },
+      { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:one-old', predicate: 'http://dkg.io/ontology/contextGraphId', object: `"${CONTEXT_GRAPH_ID}"` },
       // This head looks plausible but its operation carries another share id,
       // so the production join must not classify it as a captured legacy row.
       { graph: META_GRAPH, subject: mismatchedHead, predicate: 'http://dkg.io/ontology/kaUal', object: UAL_TWO },
@@ -475,6 +517,48 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
     );
     expect(readRfc64LegacySwmBoundaryCountV1(owner, CONTEXT_GRAPH_ID)).toBe(0);
   });
+
+  it('captures and queries two root metadata graphs independently', async () => {
+    const root = await secureTempRoot(roots);
+    const secondContextGraphId =
+      '0x1111111111111111111111111111111111111111/legacy-boundary-two';
+    const secondMetaGraph = contextGraphWorkspaceMetaGraphUri(
+      secondContextGraphId,
+    );
+    const store = new OxigraphStore();
+    await store.insert([
+      ...legacyHeadQuads(META_GRAPH, UAL_ONE, 'root-one'),
+      ...legacyHeadQuads(
+        secondMetaGraph,
+        UAL_TWO,
+        'root-two',
+        secondContextGraphId,
+      ),
+    ]);
+    const querySpy = vi.spyOn(store, 'query');
+
+    const owner = {};
+    await initializeRfc64LegacySwmBoundaryV1(owner, root, store);
+
+    expect(readRfc64LegacySwmBoundaryCountV1(
+      owner,
+      CONTEXT_GRAPH_ID,
+    )).toBe(1);
+    expect(readRfc64LegacySwmBoundaryCountV1(
+      owner,
+      secondContextGraphId,
+    )).toBe(1);
+    const headQueries = querySpy.mock.calls.filter(([, options]) => (
+      options?.source === 'agent.rfc64.legacySwmBoundary.readHeads'
+    )).map(([sparql]) => sparql);
+    expect(headQueries).toHaveLength(2);
+    expect(headQueries.some((sparql) => (
+      sparql.includes(`GRAPH <${META_GRAPH}>`)
+    ))).toBe(true);
+    expect(headQueries.some((sparql) => (
+      sparql.includes(`GRAPH <${secondMetaGraph}>`)
+    ))).toBe(true);
+  });
 });
 
 async function secureTempRoot(roots: string[]): Promise<string> {
@@ -497,10 +581,10 @@ function fakeStore(
       ) {
         return {
           type: 'bindings' as const,
-          bindings: rootHeads.map((ual, index) => ({
+          bindings: rootHeads.map((ual) => ({
             metaGraph: META_GRAPH,
+            head: forcedHead ?? `${ual}#dkg-swm-head`,
             ual,
-            shareId: `"share-${index}"`,
             contextGraphId: `"${CONTEXT_GRAPH_ID}"`,
           })),
         };
@@ -524,8 +608,8 @@ function captureOperationResult(): QueryResult {
     type: 'bindings',
     bindings: [{
       metaGraph: META_GRAPH,
+      head: `${UAL_ONE}#dkg-swm-head`,
       ual: UAL_ONE,
-      shareId: '"share-one"',
       contextGraphId: `"${CONTEXT_GRAPH_ID}"`,
     }],
   };
@@ -554,7 +638,12 @@ function scriptedCaptureStore(
   } as unknown as TripleStore;
 }
 
-function legacyHeadQuads(graph: string, ual: string, id: string) {
+function legacyHeadQuads(
+  graph: string,
+  ual: string,
+  id: string,
+  contextGraphId = CONTEXT_GRAPH_ID,
+) {
   const head = `${ual}#dkg-swm-head`;
   const operation = `urn:dkg:workspace-operation:${id}`;
   const shareId = `"share-${id}"`;
@@ -564,6 +653,6 @@ function legacyHeadQuads(graph: string, ual: string, id: string) {
     { graph, subject: operation, predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/WorkspaceOperation' },
     { graph, subject: operation, predicate: 'http://dkg.io/ontology/kaUal', object: ual },
     { graph, subject: operation, predicate: 'http://dkg.io/ontology/shareOperationId', object: shareId },
-    { graph, subject: operation, predicate: 'http://dkg.io/ontology/contextGraphId', object: `"${CONTEXT_GRAPH_ID}"` },
+    { graph, subject: operation, predicate: 'http://dkg.io/ontology/contextGraphId', object: `"${contextGraphId}"` },
   ];
 }

--- a/packages/agent/test/rfc64-legacy-swm-boundary-v1.test.ts
+++ b/packages/agent/test/rfc64-legacy-swm-boundary-v1.test.ts
@@ -22,6 +22,8 @@ import {
   markRfc64LegacySwmRepublishedV1,
   readRfc64LegacySwmBoundaryCountV1,
 } from '../src/rfc64/legacy-swm-boundary-v1.js';
+import { legacySwmBoundaryFixtureQuadsV1 } from
+  './_helpers/legacy-swm-boundary-fixture.js';
 
 const CONTEXT_GRAPH_ID = '0x1111111111111111111111111111111111111111/legacy-boundary';
 const META_GRAPH = contextGraphWorkspaceMetaGraphUri(CONTEXT_GRAPH_ID);
@@ -238,26 +240,17 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
     const root = await secureTempRoot(roots);
     const store = new OxigraphStore();
     const corruptHead = `${UAL_TWO}#dkg-swm-head`;
-    await store.insert([
-      {
-        graph: META_GRAPH,
+    await store.insert(legacySwmBoundaryFixtureQuadsV1({
+      graph: META_GRAPH,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ual: UAL_ONE,
+      operation: 'urn:dkg:workspace-operation:corrupt-head',
+      head: {
         subject: corruptHead,
-        predicate: 'http://dkg.io/ontology/kaUal',
-        object: UAL_ONE,
+        shareOperationId: 'corrupt-share',
       },
-      {
-        graph: META_GRAPH,
-        subject: corruptHead,
-        predicate: 'http://dkg.io/ontology/shareOperationId',
-        object: '"corrupt-share"',
-      },
-      ...legacyOperationQuads(
-        META_GRAPH,
-        UAL_ONE,
-        'corrupt-head',
-        'corrupt-share',
-      ),
-    ]);
+      operationShareOperationIds: ['corrupt-share'],
+    }));
 
     await expect(initializeRfc64LegacySwmBoundaryV1({}, root, store)).rejects.toThrow(
       `RFC-64 legacy SWM head identity differs for ${UAL_ONE}`,
@@ -268,8 +261,22 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
     const root = await secureTempRoot(roots);
     const store = new OxigraphStore();
     await store.insert([
-      ...legacyHeadQuads(META_GRAPH, UAL_ONE, 'root'),
-      ...legacyHeadQuads(SUBGRAPH_META_GRAPH, UAL_TWO, 'named'),
+      ...legacySwmBoundaryFixtureQuadsV1({
+        graph: META_GRAPH,
+        contextGraphId: CONTEXT_GRAPH_ID,
+        ual: UAL_ONE,
+        operation: 'urn:dkg:workspace-operation:root',
+        head: { shareOperationId: 'share-root' },
+        operationShareOperationIds: ['share-root'],
+      }),
+      ...legacySwmBoundaryFixtureQuadsV1({
+        graph: SUBGRAPH_META_GRAPH,
+        contextGraphId: CONTEXT_GRAPH_ID,
+        ual: UAL_TWO,
+        operation: 'urn:dkg:workspace-operation:named',
+        head: { shareOperationId: 'share-named' },
+        operationShareOperationIds: ['share-named'],
+      }),
     ]);
 
     const owner = {};
@@ -393,33 +400,36 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
   it('captures only fully joined legacy heads through the real Oxigraph query', async () => {
     const root = await secureTempRoot(roots);
     const store = new OxigraphStore();
-    const correctHead = `${UAL_ONE}#dkg-swm-head`;
-    const mismatchedHead = `${UAL_TWO}#dkg-swm-head`;
     const quads: Quad[] = [
-      { graph: META_GRAPH, subject: correctHead, predicate: 'http://dkg.io/ontology/kaUal', object: UAL_ONE },
-      { graph: META_GRAPH, subject: correctHead, predicate: 'http://dkg.io/ontology/shareOperationId', object: '"share-one"' },
-      { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:one', predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/WorkspaceOperation' },
-      { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:one', predicate: 'http://dkg.io/ontology/kaUal', object: UAL_ONE },
-      { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:one', predicate: 'http://dkg.io/ontology/shareOperationId', object: '"share-one"' },
-      { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:one', predicate: 'http://dkg.io/ontology/contextGraphId', object: `"${CONTEXT_GRAPH_ID}"` },
+      ...legacySwmBoundaryFixtureQuadsV1({
+        graph: META_GRAPH,
+        contextGraphId: CONTEXT_GRAPH_ID,
+        ual: UAL_ONE,
+        operation: 'urn:dkg:workspace-operation:one',
+        head: { shareOperationId: 'share-one' },
+        operationShareOperationIds: ['share-one'],
+      }),
       // This head looks plausible but its operation carries another share id,
       // so the production join must not classify it as a captured legacy row.
-      { graph: META_GRAPH, subject: mismatchedHead, predicate: 'http://dkg.io/ontology/kaUal', object: UAL_TWO },
-      { graph: META_GRAPH, subject: mismatchedHead, predicate: 'http://dkg.io/ontology/shareOperationId', object: '"share-two"' },
-      { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:two', predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/WorkspaceOperation' },
-      { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:two', predicate: 'http://dkg.io/ontology/kaUal', object: UAL_TWO },
-      { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:two', predicate: 'http://dkg.io/ontology/shareOperationId', object: '"different-share"' },
-      { graph: META_GRAPH, subject: 'urn:dkg:workspace-operation:two', predicate: 'http://dkg.io/ontology/contextGraphId', object: `"${CONTEXT_GRAPH_ID}"` },
+      ...legacySwmBoundaryFixtureQuadsV1({
+        graph: META_GRAPH,
+        contextGraphId: CONTEXT_GRAPH_ID,
+        ual: UAL_TWO,
+        operation: 'urn:dkg:workspace-operation:two',
+        head: { shareOperationId: 'share-two' },
+        operationShareOperationIds: ['different-share'],
+      }),
     ];
     // Concrete repeated history exercises the real store's join and DISTINCT
     // semantics. None of these old share IDs matches the one current head.
     for (let index = 0; index < 512; index += 1) {
-      quads.push(...legacyOperationQuads(
-        META_GRAPH,
-        UAL_ONE,
-        `one-old-${index}`,
-        `share-one-old-${index}`,
-      ));
+      quads.push(...legacySwmBoundaryFixtureQuadsV1({
+        graph: META_GRAPH,
+        contextGraphId: CONTEXT_GRAPH_ID,
+        ual: UAL_ONE,
+        operation: `urn:dkg:workspace-operation:one-old-${index}`,
+        operationShareOperationIds: [`share-one-old-${index}`],
+      }));
     }
     await store.insert(quads);
 
@@ -449,13 +459,22 @@ describe('RFC-64 10.0.16 legacy SWM boundary', () => {
     );
     const store = new OxigraphStore();
     await store.insert([
-      ...legacyHeadQuads(META_GRAPH, UAL_ONE, 'root-one'),
-      ...legacyHeadQuads(
-        secondMetaGraph,
-        UAL_TWO,
-        'root-two',
-        secondContextGraphId,
-      ),
+      ...legacySwmBoundaryFixtureQuadsV1({
+        graph: META_GRAPH,
+        contextGraphId: CONTEXT_GRAPH_ID,
+        ual: UAL_ONE,
+        operation: 'urn:dkg:workspace-operation:root-one',
+        head: { shareOperationId: 'share-root-one' },
+        operationShareOperationIds: ['share-root-one'],
+      }),
+      ...legacySwmBoundaryFixtureQuadsV1({
+        graph: secondMetaGraph,
+        contextGraphId: secondContextGraphId,
+        ual: UAL_TWO,
+        operation: 'urn:dkg:workspace-operation:root-two',
+        head: { shareOperationId: 'share-root-two' },
+        operationShareOperationIds: ['share-root-two'],
+      }),
     ]);
     const querySpy = vi.spyOn(store, 'query');
 
@@ -536,35 +555,4 @@ function scriptedCaptureStore(
 
 function testUal(kaNumber: number): string {
   return `did:dkg:otp:20430/0x1111111111111111111111111111111111111111/${kaNumber}`;
-}
-
-function legacyHeadQuads(
-  graph: string,
-  ual: string,
-  id: string,
-  contextGraphId = CONTEXT_GRAPH_ID,
-): Quad[] {
-  const head = `${ual}#dkg-swm-head`;
-  const shareId = `"share-${id}"`;
-  return [
-    { graph, subject: head, predicate: 'http://dkg.io/ontology/kaUal', object: ual },
-    { graph, subject: head, predicate: 'http://dkg.io/ontology/shareOperationId', object: shareId },
-    ...legacyOperationQuads(graph, ual, id, `share-${id}`, contextGraphId),
-  ];
-}
-
-function legacyOperationQuads(
-  graph: string,
-  ual: string,
-  id: string,
-  shareId: string,
-  contextGraphId = CONTEXT_GRAPH_ID,
-): Quad[] {
-  const operation = `urn:dkg:workspace-operation:${id}`;
-  return [
-    { graph, subject: operation, predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/WorkspaceOperation' },
-    { graph, subject: operation, predicate: 'http://dkg.io/ontology/kaUal', object: ual },
-    { graph, subject: operation, predicate: 'http://dkg.io/ontology/shareOperationId', object: JSON.stringify(shareId) },
-    { graph, subject: operation, predicate: 'http://dkg.io/ontology/contextGraphId', object: `"${contextGraphId}"` },
-  ];
 }

--- a/packages/agent/vitest.blazegraph.config.ts
+++ b/packages/agent/vitest.blazegraph.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+const SQLITE_EXEC_ARGV = [
+  '--experimental-sqlite',
+  '--no-warnings=ExperimentalWarning',
+];
+
+export default defineConfig({
+  test: {
+    allowOnly: false,
+    include: ['test-live/**/*.test.ts'],
+    testTimeout: 30_000,
+    maxWorkers: 1,
+    pool: 'forks',
+    execArgv: SQLITE_EXEC_ARGV,
+  },
+});

--- a/packages/agent/vitest.blazegraph.config.ts
+++ b/packages/agent/vitest.blazegraph.config.ts
@@ -1,17 +1,10 @@
 import { defineConfig } from 'vitest/config';
 
-const SQLITE_EXEC_ARGV = [
-  '--experimental-sqlite',
-  '--no-warnings=ExperimentalWarning',
-];
-
 export default defineConfig({
   test: {
     allowOnly: false,
     include: ['test-live/**/*.blazegraph.test.ts'],
     testTimeout: 30_000,
     maxWorkers: 1,
-    pool: 'forks',
-    execArgv: SQLITE_EXEC_ARGV,
   },
 });

--- a/packages/agent/vitest.blazegraph.config.ts
+++ b/packages/agent/vitest.blazegraph.config.ts
@@ -8,7 +8,7 @@ const SQLITE_EXEC_ARGV = [
 export default defineConfig({
   test: {
     allowOnly: false,
-    include: ['test-live/**/*.test.ts'],
+    include: ['test-live/**/*.blazegraph.test.ts'],
     testTimeout: 30_000,
     maxWorkers: 1,
     pool: 'forks',

--- a/packages/agent/vitest.rfc64-unit-tests.ts
+++ b/packages/agent/vitest.rfc64-unit-tests.ts
@@ -1,5 +1,6 @@
 export const RFC64_UNIT_TESTS = [
   "test/rfc64-inventory-v1-scalars.test.ts",
+  "test/rfc64-legacy-swm-boundary-v1.test.ts",
   "test/rfc64-inventory-v1-lifecycle.test.ts",
   "test/rfc64-inventory-v1-candidates.test.ts",
   "test/rfc64-inventory-v1-applied-head.test.ts",

--- a/test-policy/test-routes.json
+++ b/test-policy/test-routes.json
@@ -82,6 +82,13 @@
     "command": "DKG_REQUIRE_BLAZEGRAPH=1 pnpm test:conformance"
   },
   {
+    "pattern": "packages/agent/test-live/*.test.ts",
+    "lane": "tornado-blazegraph",
+    "reason": "Live Blazegraph regressions required in the existing Tornado Blazegraph CI lane",
+    "cadence": "required",
+    "command": "pnpm --filter @origintrail-official/dkg-agent exec vitest run --config vitest.blazegraph.config.ts"
+  },
+  {
     "pattern": "tools/observability/w1/*.test.yaml",
     "lane": "prometheus-rules",
     "reason": "Promtool rule regression fixtures; requires Prometheus tools",

--- a/test-policy/test-routes.json
+++ b/test-policy/test-routes.json
@@ -82,7 +82,7 @@
     "command": "DKG_REQUIRE_BLAZEGRAPH=1 pnpm test:conformance"
   },
   {
-    "pattern": "packages/agent/test-live/*.test.ts",
+    "pattern": "packages/agent/test-live/**/*.blazegraph.test.ts",
     "lane": "tornado-blazegraph",
     "reason": "Live Blazegraph regressions required in the existing Tornado Blazegraph CI lane",
     "cadence": "required",


### PR DESCRIPTION
## Summary

- bind the selective RFC-64 workspace-operation pattern before joining legacy SWM heads
- keep the shared query backend-neutral rather than adding a Blazegraph-only optimizer hint
- add a deterministic query-shape guard and a live 5,000-head Blazegraph first-upgrade/restart regression
- run the live regression in the required Tornado Blazegraph CI lane

## Context

On the first v10.0.16 startup, existing mainnet nodes could exceed the 30-second store deadline while capturing the RFC-64 legacy SWM boundary. Blazegraph planned the original source order as a broad head scan before the selective workspace-operation join, causing a startup boot loop.

The reordered query is semantically equivalent. With the production dataset it completed in about 2.9 seconds, while the old order did not finish in five minutes. In the local regression fixture, restoring the old order reproduces the store timeout at 15 seconds; the new order completes the capture and verifies that a restarted owner reuses the durable boundary.

## Validation

- agent build
- RFC-64 legacy boundary unit suite: 11 passed
- live Blazegraph regression: 1 passed
- test inventory: 1,796 files verified
- disabled-test audit: 0 additions
- focused oxlint and git diff --check
