### PR TITLE
fix(agent): source finalized catalog RPC from the chain adapter

### DIFF
--- a/devnet/rfc64-cp2-private-swm-vm-recovery/run.ts
+++ b/devnet/rfc64-cp2-private-swm-vm-recovery/run.ts
@@ -125,24 +125,27 @@ async function execute(): Promise<void> {
         seal,
       });
     }));
-    const finalizedVmConfigJson = JSON.stringify({
+    const finalizedChainConfigJson = JSON.stringify({
       accessPolicy: 1,
-      assets: assets.map(({ seal }) => ({
-        assertionRoot: seal.assertionMerkleRoot,
-        assertionVersion: seal.assertionVersion,
-        authorAddress: seal.authorAddress,
-        kaId: seal.reservedKaId,
-      })),
       contextGraphId: CONTEXT_GRAPH_ID,
       nameHash: ethers.keccak256(ethers.toUtf8Bytes(CONTEXT_GRAPH_ID)).toLowerCase(),
       onChainContextGraphId: ON_CHAIN_CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+      vmInventory: {
+        assets: assets.map(({ seal }) => ({
+          assertionRoot: seal.assertionMerkleRoot,
+          assertionVersion: seal.assertionVersion,
+          authorAddress: seal.authorAddress,
+          kaId: seal.reservedKaId,
+        })),
+      },
     });
     const receiver = spawnGate2HarnessAgentV1({
       role: 'receiver',
       catalogLocalAgentAddress: RECEIVER,
       dataDir: dataDirs.receiver,
       eventTimeoutMs: PROCESS_EVENT_TIMEOUT_MS,
-      finalizedVmConfigJson,
+      finalizedChainConfigJson,
       networkChainId: NETWORK_ID,
       registry,
       repoRoot: REPO_ROOT,
@@ -155,6 +158,8 @@ async function execute(): Promise<void> {
     ]);
     assertGate2HarnessReadyV1(authorReady, 'author', launch.manifest.manifestDigest);
     assertGate2HarnessReadyV1(receiverReady, 'receiver', launch.manifest.manifestDigest);
+    exact(authorReady.finalizedChainRuntime, false, 'author finalized chain runtime');
+    exact(receiverReady.finalizedChainRuntime, true, 'receiver finalized chain runtime');
     exact(authorReady.finalizedVmRuntime, false, 'author finalized VM runtime');
     exact(receiverReady.finalizedVmRuntime, true, 'receiver finalized VM runtime');
     const authorPeerId = requiredString(authorReady.peerId, 'author peer ID');

--- a/devnet/rfc64-cp3-private-provider-failover/run.ts
+++ b/devnet/rfc64-cp3-private-provider-failover/run.ts
@@ -110,17 +110,20 @@ async function execute(): Promise<void> {
         seal: await authorSeal(kaNumber),
       });
     }));
-    const finalizedVmConfigJson = JSON.stringify({
+    const finalizedChainConfigJson = JSON.stringify({
       accessPolicy: 1,
-      assets: assets.map(({ seal }) => ({
-        assertionRoot: seal.assertionMerkleRoot,
-        assertionVersion: seal.assertionVersion,
-        authorAddress: seal.authorAddress,
-        kaId: seal.reservedKaId,
-      })),
       contextGraphId: CONTEXT_GRAPH_ID,
       nameHash: ethers.keccak256(ethers.toUtf8Bytes(CONTEXT_GRAPH_ID)).toLowerCase(),
       onChainContextGraphId: ON_CHAIN_CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR,
+      vmInventory: {
+        assets: assets.map(({ seal }) => ({
+          assertionRoot: seal.assertionMerkleRoot,
+          assertionVersion: seal.assertionVersion,
+          authorAddress: seal.authorAddress,
+          kaId: seal.reservedKaId,
+        })),
+      },
     });
     const common = {
       eventTimeoutMs: PROCESS_EVENT_TIMEOUT_MS,
@@ -141,7 +144,7 @@ async function execute(): Promise<void> {
       role: 'receiver',
       catalogLocalAgentAddress: PROVIDER_A,
       dataDir: dataDirs.providerA,
-      finalizedVmConfigJson,
+      finalizedChainConfigJson,
       masterKeyHex: '3c'.repeat(32),
       bundleServeDelayMs: PROVIDER_A_BUNDLE_DELAY_MS,
     });
@@ -150,7 +153,7 @@ async function execute(): Promise<void> {
       role: 'receiver',
       catalogLocalAgentAddress: PROVIDER_B,
       dataDir: dataDirs.providerB,
-      finalizedVmConfigJson,
+      finalizedChainConfigJson,
       masterKeyHex: '4d'.repeat(32),
     });
     const receiver = spawnGate2HarnessAgentV1({
@@ -158,7 +161,7 @@ async function execute(): Promise<void> {
       role: 'receiver',
       catalogLocalAgentAddress: RECEIVER,
       dataDir: dataDirs.receiver,
-      finalizedVmConfigJson,
+      finalizedChainConfigJson,
     });
     const [authorReady, providerAReady, providerBReady, receiverReady] = await Promise.all([
       author.waitFor('ready'),
@@ -167,8 +170,10 @@ async function execute(): Promise<void> {
       receiver.waitFor('ready'),
     ]);
     assertGate2HarnessReadyV1(authorReady, 'author', launch.manifest.manifestDigest);
+    exact(authorReady.finalizedChainRuntime, false, 'author finalized chain runtime');
     for (const ready of [providerAReady, providerBReady, receiverReady]) {
       assertGate2HarnessReadyV1(ready, 'receiver', launch.manifest.manifestDigest);
+      exact(ready.finalizedChainRuntime, true, 'receiver finalized chain runtime');
       exact(ready.finalizedVmRuntime, true, 'receiver finalized VM runtime');
     }
     const authorPeerId = requiredString(authorReady.peerId, 'author peer ID');

--- a/devnet/rfc64-gate2-multi-asset-completeness/README.md
+++ b/devnet/rfc64-gate2-multi-asset-completeness/README.md
@@ -83,14 +83,22 @@ node --experimental-strip-types src/cli/verify.ts raw.json > verdict.json
 Two identical generator invocations must produce byte-identical raw artifacts;
 two verifier invocations over them must produce byte-identical verdicts.
 
-## M2 public finalized-VM process proof
+## Public catalog finalized-policy process proof
 
-`pnpm live:public-vm` clean-builds the exact repository HEAD, then starts an
-author and receiver as distinct real `DKGAgent` OS processes. The receiver
-learns numeric Context Graph id `14` from a production `ContextGraphCreated`
-poller event, receives one policy-bound public catalog successor over the
-production router, reads one finalized on-chain inventory snapshot, writes the
-exact projection to VM, and only then commits the catalog head. The emitted
-`artifacts/m2-public-vm-result.json` proves exact projection/count, confirmed
-metadata, no synthetic transaction hash, durable head equality, peer/process
-identity separation, and the clean-build runtime manifest.
+`pnpm live:public-finalized-catalog` clean-builds the exact repository HEAD,
+then starts an author and receiver as distinct real `DKGAgent` OS processes.
+The legacy command `pnpm live:public-vm` remains an alias.
+
+The receiver learns numeric Context Graph id `14` from a production
+`ContextGraphCreated` poller event and resolves its current chain authority.
+The author uses that exact policy and ownership scope for its catalog. The
+receiver verifies finalized policy through its adapter-owned loopback RPC
+before committing the public catalog head.
+
+`artifacts/public-finalized-catalog-result.json` proves the exact two-quad SWM
+projection, durable applied-head equality, peer/process identity separation,
+and the clean-build runtime manifest. It also requires zero VM rows and no
+fabricated confirmed VM metadata: public catalog reconciliation is policy-only,
+as specified by the production applied-head coordinator. This proof does not
+claim public VM materialization. Private finalized-VM recovery has its separate
+CP2/CP3 harnesses.

--- a/devnet/rfc64-gate2-multi-asset-completeness/README.md
+++ b/devnet/rfc64-gate2-multi-asset-completeness/README.md
@@ -87,7 +87,10 @@ two verifier invocations over them must produce byte-identical verdicts.
 
 `pnpm live:public-finalized-catalog` clean-builds the exact repository HEAD,
 then starts an author and receiver as distinct real `DKGAgent` OS processes.
-The legacy command `pnpm live:public-vm` remains an alias.
+Both this command and the legacy `pnpm live:public-vm` alias execute
+`launch-public-finalized-catalog.ts`, which loads `public-finalized-catalog.ts`.
+Set `DKG_RFC64_PUBLIC_FINALIZED_CATALOG_ARTIFACT` to override the artifact path;
+the old `DKG_RFC64_M2_PUBLIC_VM_ARTIFACT` variable remains a fallback alias.
 
 The receiver learns numeric Context Graph id `14` from a production
 `ContextGraphCreated` poller event and resolves its current chain authority.

--- a/devnet/rfc64-gate2-multi-asset-completeness/adapter-process.ts
+++ b/devnet/rfc64-gate2-multi-asset-completeness/adapter-process.ts
@@ -47,9 +47,9 @@ import {
 } from './model.js';
 import {
   RFC64_GATE2_DEPLOYMENT,
-  parseFinalizedVmHarnessConfigV1,
-  startFinalizedVmHarnessRuntimeV1,
-  type FinalizedVmHarnessRuntimeV1,
+  parseFinalizedChainHarnessConfigV1,
+  startFinalizedChainHarnessRuntimeV1,
+  type FinalizedChainHarnessRuntimeV1,
 } from './finalized-vm-harness-runtime.ts';
 import { sealGate2ExecutedRuntimeManifestV1 } from './runtime-load-hook.ts';
 import { stagePrivateCatalogBulkPredecessorV1 } from
@@ -60,7 +60,7 @@ const role = process.argv[2];
 const dataDirInput = process.env.DKG_RFC64_GATE2_ADAPTER_DATA_DIR;
 const masterKeyHex = process.env.DKG_RFC64_GATE2_AGENT_MASTER_KEY_HEX;
 const runtimeBuildManifestDigest = process.env.DKG_RFC64_GATE2_RUNTIME_MANIFEST_DIGEST;
-const finalizedVmConfigInput = process.env.DKG_RFC64_GATE2_FINALIZED_VM_CONFIG;
+const finalizedChainConfigInput = process.env.DKG_RFC64_GATE2_FINALIZED_CHAIN_CONFIG;
 const networkChainIdInput = process.env.DKG_RFC64_GATE2_NETWORK_CHAIN_ID;
 const localCatalogAgentAddressInput =
   process.env.DKG_RFC64_GATE2_CATALOG_LOCAL_AGENT_ADDRESS;
@@ -81,7 +81,7 @@ if (!runtimeBuildManifestDigest || !/^0x[0-9a-f]{64}$/u.test(runtimeBuildManifes
 const dataDir = resolve(dataDirInput);
 const pinnedMasterKeyHex = masterKeyHex;
 let agent: DKGAgent | undefined;
-let finalizedVmRuntime: Readonly<FinalizedVmHarnessRuntimeV1> | undefined;
+let finalizedChainRuntime: Readonly<FinalizedChainHarnessRuntimeV1> | undefined;
 let stopping = false;
 let commandTail = Promise.resolve();
 const peerCatalogAgentAddresses = new Map<string, EvmAddressV1>();
@@ -138,11 +138,11 @@ async function ensureDeterministicAgentKey(): Promise<void> {
 
 async function boot(): Promise<void> {
   await ensureDeterministicAgentKey();
-  const finalizedVmConfig = finalizedVmConfigInput === undefined
+  const finalizedChainConfig = finalizedChainConfigInput === undefined
     ? null
-    : parseFinalizedVmHarnessConfigV1(finalizedVmConfigInput);
-  if (finalizedVmConfig !== null && role !== 'receiver') {
-    throw new Error('finalized VM harness runtime is receiver-only');
+    : parseFinalizedChainHarnessConfigV1(finalizedChainConfigInput);
+  if (finalizedChainConfig !== null && role !== 'receiver') {
+    throw new Error('finalized chain harness runtime is receiver-only');
   }
   if (networkChainIdInput !== undefined) {
     assertNetworkIdV1(networkChainIdInput);
@@ -154,15 +154,15 @@ async function boot(): Promise<void> {
         'DKG_RFC64_GATE2_CATALOG_LOCAL_AGENT_ADDRESS',
       );
   if (
-    finalizedVmConfig !== null
+    finalizedChainConfig !== null
     && networkChainIdInput !== RFC64_GATE2_DEPLOYMENT.networkId
   ) {
-    throw new Error('finalized VM harness network chain id differs from its deployment');
+    throw new Error('finalized chain harness network chain id differs from its deployment');
   }
-  if (finalizedVmConfig !== null) {
-    finalizedVmRuntime = await startFinalizedVmHarnessRuntimeV1(finalizedVmConfig);
+  if (finalizedChainConfig !== null) {
+    finalizedChainRuntime = await startFinalizedChainHarnessRuntimeV1(finalizedChainConfig);
   }
-  const networkChainAdapter = finalizedVmRuntime?.chainAdapter
+  const networkChainAdapter = finalizedChainRuntime?.chainAdapter
     ?? (networkChainIdInput === undefined ? undefined : new MockChainAdapter(networkChainIdInput));
   const created = await DKGAgent.create({
     name: `RFC64Gate2${role}`,
@@ -186,16 +186,16 @@ async function boot(): Promise<void> {
       },
     }),
     ...(networkChainAdapter === undefined ? {} : { chainAdapter: networkChainAdapter }),
-    ...(finalizedVmRuntime === undefined ? {} : {
+    ...(finalizedChainRuntime === undefined ? {} : {
       chainConfig: {
-        rpcUrl: finalizedVmRuntime.rpcUrl,
+        rpcUrl: finalizedChainRuntime.rpcUrl,
         hubAddress: '0x3333333333333333333333333333333333333333',
         operationalKeys: [`0x${'12'.repeat(32)}`],
       },
     }),
-    ...(finalizedVmConfig === null ? {} : {
+    ...(finalizedChainConfig === null ? {} : {
       contextGraphSubscriptionStore: createHarnessSubscriptionStore(
-        finalizedVmConfig.contextGraphId,
+        finalizedChainConfig.contextGraphId,
       ),
     }),
   });
@@ -205,7 +205,7 @@ async function boot(): Promise<void> {
   }
   agent = created;
   await created.start();
-  if (finalizedVmConfig !== null) {
+  if (finalizedChainConfig !== null) {
     await created.awaitInitialChainPoll();
   }
   const tcp = created.multiaddrs.find((address) => address.includes('/tcp/'));
@@ -221,7 +221,8 @@ async function boot(): Promise<void> {
     protocolVersion: GATE2_ADAPTER_PROTOCOL_VERSION,
     processId: process.pid,
     runtimeBuildManifestDigest,
-    finalizedVmRuntime: finalizedVmConfig !== null,
+    finalizedChainRuntime: finalizedChainConfig !== null,
+    finalizedVmRuntime: finalizedChainRuntime?.hasVmInventory === true,
     startupRepair: null,
   });
 }
@@ -1108,8 +1109,8 @@ async function stop(exitCode: number, requestId?: string): Promise<never> {
   stopping = true;
   try {
     await agent?.stop();
-    await finalizedVmRuntime?.close();
-    finalizedVmRuntime = undefined;
+    await finalizedChainRuntime?.close();
+    finalizedChainRuntime = undefined;
     if (requestId !== undefined) {
       await emitAndFlush({
         event: 'stopped',

--- a/devnet/rfc64-gate2-multi-asset-completeness/adapter-process.ts
+++ b/devnet/rfc64-gate2-multi-asset-completeness/adapter-process.ts
@@ -50,7 +50,7 @@ import {
   parseFinalizedChainHarnessConfigV1,
   startFinalizedChainHarnessRuntimeV1,
   type FinalizedChainHarnessRuntimeV1,
-} from './finalized-vm-harness-runtime.ts';
+} from './finalized-chain-harness-runtime.ts';
 import { sealGate2ExecutedRuntimeManifestV1 } from './runtime-load-hook.ts';
 import { stagePrivateCatalogBulkPredecessorV1 } from
   '../rfc64-cp2-private-swm-vm-recovery/bulk-predecessor.ts';
@@ -222,7 +222,7 @@ async function boot(): Promise<void> {
     processId: process.pid,
     runtimeBuildManifestDigest,
     finalizedChainRuntime: finalizedChainConfig !== null,
-    finalizedVmRuntime: finalizedChainRuntime?.hasVmInventory === true,
+    finalizedVmRuntime: finalizedChainRuntime?.kind === 'vm',
     startupRepair: null,
   });
 }

--- a/devnet/rfc64-gate2-multi-asset-completeness/adapter-process.ts
+++ b/devnet/rfc64-gate2-multi-asset-completeness/adapter-process.ts
@@ -410,6 +410,16 @@ async function handle(command: Command): Promise<void> {
       emitOperationResult(command, accepted);
       return;
     }
+    case 'reconcileCatalogAccessAuthority': {
+      const input = plainRecord(command.input, 'reconcileCatalogAccessAuthority input');
+      const contextGraphId = requiredString(input.contextGraphId, 'contextGraphId');
+      assertContextGraphIdV1(contextGraphId);
+      await currentAgent.whenRfc64CatalogResponsibilitiesIdleV1();
+      const accepted = await currentAgent.reconcileRfc64CatalogAccessAuthorityV1(contextGraphId);
+      if (accepted === null) throw new Error('Harness could not resolve current catalog authority');
+      emitOperationResult(command, accepted);
+      return;
+    }
     case 'publishGenesis': {
       requireRole('author');
       const output = await currentAgent.publishOpenAuthorCatalogGenesisV1(

--- a/devnet/rfc64-gate2-multi-asset-completeness/finalized-chain-harness-runtime.ts
+++ b/devnet/rfc64-gate2-multi-asset-completeness/finalized-chain-harness-runtime.ts
@@ -10,10 +10,13 @@ import {
 
 import {
   FinalizedChainLoopbackMockChainAdapterV1,
-  FinalizedVmLoopbackMockChainAdapterV1,
   createFinalizedChainLoopbackRpcV1,
-  createFinalizedVmLoopbackRpcV1,
   type FinalizedChainLoopbackFixtureConfigV1,
+  type FinalizedChainLoopbackRpcV1,
+} from '../../packages/agent/test/support/rfc64-finalized-chain-loopback-fixture.js';
+import {
+  FinalizedVmLoopbackMockChainAdapterV1,
+  createFinalizedVmLoopbackRpcV1,
   type FinalizedVmLoopbackFixtureConfigV1,
 } from '../../packages/agent/test/support/rfc64-finalized-vm-loopback-fixture.js';
 
@@ -40,21 +43,29 @@ export interface FinalizedChainHarnessVmInventoryConfigV1 {
 }
 
 /** Finalized chain/CG policy baseline; VM inventory is an explicit extension. */
-export interface FinalizedChainHarnessConfigV1 {
+interface FinalizedChainAuthorityHarnessConfigV1 {
   readonly accessPolicy: 0 | 1;
   readonly contextGraphId: string;
   readonly nameHash: Digest32V1;
   readonly onChainContextGraphId: string;
   readonly ownerAddress: EvmAddressV1;
-  readonly vmInventory?: Readonly<FinalizedChainHarnessVmInventoryConfigV1>;
 }
 
-export interface FinalizedChainHarnessRuntimeV1 {
-  readonly chainAdapter: FinalizedChainLoopbackMockChainAdapterV1;
-  readonly hasVmInventory: boolean;
+export type FinalizedChainHarnessConfigV1 =
+  | Readonly<FinalizedChainAuthorityHarnessConfigV1 & { kind: 'policy' }>
+  | Readonly<FinalizedChainAuthorityHarnessConfigV1 & {
+      kind: 'vm'; vmInventory: Readonly<FinalizedChainHarnessVmInventoryConfigV1>;
+    }>;
+
+interface FinalizedChainHarnessServerV1<T extends FinalizedChainLoopbackMockChainAdapterV1> {
+  readonly chainAdapter: T;
   readonly rpcUrl: string;
   close(): Promise<void>;
 }
+
+export type FinalizedChainHarnessRuntimeV1 =
+  | Readonly<FinalizedChainHarnessServerV1<FinalizedChainLoopbackMockChainAdapterV1> & { kind: 'policy' }>
+  | Readonly<FinalizedChainHarnessServerV1<FinalizedVmLoopbackMockChainAdapterV1> & { kind: 'vm' }>;
 
 const FINALIZED_BLOCK_HASH = `0x${'77'.repeat(32)}`;
 
@@ -72,9 +83,6 @@ export function parseFinalizedChainHarnessConfigV1(
     : canonicalAccessPolicy(parsed.accessPolicy, 'finalizedChain.accessPolicy');
   const nameHash = requiredDigest(parsed.nameHash, 'finalizedChain.nameHash');
   const ownerAddress = canonicalEvmAddress(parsed.ownerAddress, 'finalizedChain.ownerAddress');
-  const vmInventory = parsed.vmInventory === undefined
-    ? undefined
-    : parseVmInventory(parsed.vmInventory);
   const onChainContextGraphId = canonicalDecimalWire(
     parsed.onChainContextGraphId,
     'finalizedChain.onChainContextGraphId',
@@ -82,14 +90,11 @@ export function parseFinalizedChainHarnessConfigV1(
   if (BigInt(onChainContextGraphId) === 0n) {
     throw new TypeError('finalized chain on-chain context graph id must be non-zero');
   }
-  return Object.freeze({
-    accessPolicy,
-    contextGraphId,
-    nameHash,
-    onChainContextGraphId,
-    ownerAddress,
-    ...(vmInventory === undefined ? {} : { vmInventory }),
-  });
+  const authority = { accessPolicy, contextGraphId, nameHash, onChainContextGraphId, ownerAddress };
+  // Normalize the legacy wire shape once; all runtime consumers use the mode.
+  return parsed.vmInventory === undefined
+    ? Object.freeze({ ...authority, kind: 'policy' })
+    : Object.freeze({ ...authority, kind: 'vm', vmInventory: parseVmInventory(parsed.vmInventory) });
 }
 
 function parseVmInventory(value: unknown): Readonly<FinalizedChainHarnessVmInventoryConfigV1> {
@@ -124,7 +129,28 @@ function parseVmInventory(value: unknown): Readonly<FinalizedChainHarnessVmInven
 export async function startFinalizedChainHarnessRuntimeV1(
   config: Readonly<FinalizedChainHarnessConfigV1>,
 ): Promise<Readonly<FinalizedChainHarnessRuntimeV1>> {
-  const baseline = Object.freeze({
+  switch (config.kind) {
+    case 'policy': {
+      const fixture = authorityLoopbackFixture(config);
+      const runtime = await startFinalizedChainHarnessServerV1(config,
+        createFinalizedChainLoopbackRpcV1(fixture),
+        rpcUrl => new FinalizedChainLoopbackMockChainAdapterV1(fixture, rpcUrl));
+      return Object.freeze({ ...runtime, kind: 'policy' });
+    }
+    case 'vm': {
+      const fixture = vmLoopbackFixture(config);
+      const runtime = await startFinalizedChainHarnessServerV1(config,
+        createFinalizedVmLoopbackRpcV1(fixture),
+        rpcUrl => new FinalizedVmLoopbackMockChainAdapterV1(fixture, rpcUrl));
+      return Object.freeze({ ...runtime, kind: 'vm' });
+    }
+  }
+}
+
+function authorityLoopbackFixture(
+  config: FinalizedChainAuthorityHarnessConfigV1,
+): FinalizedChainLoopbackFixtureConfigV1 {
+  return Object.freeze({
     accessPolicy: config.accessPolicy,
     active: true,
     assertedAtChainId: RFC64_GATE2_DEPLOYMENT.assertedAtChainId,
@@ -139,22 +165,26 @@ export async function startFinalizedChainHarnessRuntimeV1(
     ownerAddress: config.ownerAddress,
     publishPolicy: 1,
   } satisfies FinalizedChainLoopbackFixtureConfigV1);
-  const vmFixture = config.vmInventory === undefined
-    ? undefined
-    : Object.freeze({
-        ...baseline,
-        knowledgeAssetStorageAddress: RFC64_GATE2_KNOWLEDGE_ASSET_STORAGE_ADDRESS,
-        assets: Object.freeze(config.vmInventory.assets.map((asset) => Object.freeze({
-          assertionRoot: asset.assertionRoot,
-          assertionVersion: asset.assertionVersion,
-          authorAddress: asset.authorAddress,
-          kaId: asset.kaId,
-          publisherAddress: '0x6666666666666666666666666666666666666666' as EvmAddressV1,
-        }))),
-      } satisfies FinalizedVmLoopbackFixtureConfigV1);
-  const rpcFixture = vmFixture === undefined
-    ? createFinalizedChainLoopbackRpcV1(baseline)
-    : createFinalizedVmLoopbackRpcV1(vmFixture);
+}
+
+function vmLoopbackFixture(
+  config: Extract<FinalizedChainHarnessConfigV1, { kind: 'vm' }>,
+): FinalizedVmLoopbackFixtureConfigV1 {
+  return Object.freeze({
+    ...authorityLoopbackFixture(config),
+    knowledgeAssetStorageAddress: RFC64_GATE2_KNOWLEDGE_ASSET_STORAGE_ADDRESS,
+    assets: Object.freeze(config.vmInventory.assets.map(asset => Object.freeze({
+      ...asset, publisherAddress: '0x6666666666666666666666666666666666666666' as EvmAddressV1,
+    }))),
+  });
+}
+
+/** Shared HTTP ownership and adapter initialization for either explicit composition. */
+async function startFinalizedChainHarnessServerV1<T extends FinalizedChainLoopbackMockChainAdapterV1>(
+  config: FinalizedChainAuthorityHarnessConfigV1,
+  rpcFixture: FinalizedChainLoopbackRpcV1,
+  createAdapter: (rpcUrl: string) => T,
+): Promise<Readonly<FinalizedChainHarnessServerV1<T>>> {
   let activeServer: Server | undefined;
   const server = createServer(async (request, response) => {
     try {
@@ -173,10 +203,10 @@ export async function startFinalizedChainHarnessRuntimeV1(
       }
       const call = plainRecord(
         JSON.parse(Buffer.concat(chunks).toString('utf8')),
-        'finalized VM JSON-RPC call',
+        'finalized chain JSON-RPC call',
       );
-      const method = requiredString(call.method, 'finalized VM JSON-RPC method');
-      const params = plainArray(call.params, 'finalized VM JSON-RPC params');
+      const method = requiredString(call.method, 'finalized chain JSON-RPC method');
+      const params = plainArray(call.params, 'finalized chain JSON-RPC params');
       const result = rpcFixture.respond(method, params);
       sendRpcResponse(response, call.id, { result });
     } catch (error) {
@@ -196,14 +226,12 @@ export async function startFinalizedChainHarnessRuntimeV1(
   const address = server.address() as AddressInfo | null;
   if (address === null) {
     await closeServer(server);
-    throw new Error('finalized VM JSON-RPC server has no address');
+    throw new Error('finalized chain JSON-RPC server has no address');
   }
   const rpcUrl = `http://127.0.0.1:${address.port}`;
-  let chainAdapter: FinalizedChainLoopbackMockChainAdapterV1;
+  let chainAdapter: T;
   try {
-    chainAdapter = vmFixture === undefined
-      ? new FinalizedChainLoopbackMockChainAdapterV1(baseline, rpcUrl)
-      : new FinalizedVmLoopbackMockChainAdapterV1(vmFixture, rpcUrl);
+    chainAdapter = createAdapter(rpcUrl);
     const created = await chainAdapter.createOnChainContextGraph({
       accessPolicy: config.accessPolicy,
       publishPolicy: 1,
@@ -218,7 +246,6 @@ export async function startFinalizedChainHarnessRuntimeV1(
   }
   return Object.freeze({
     chainAdapter,
-    hasVmInventory: vmFixture !== undefined,
     rpcUrl,
     close: async () => {
       const current = activeServer;

--- a/devnet/rfc64-gate2-multi-asset-completeness/finalized-vm-harness-runtime.ts
+++ b/devnet/rfc64-gate2-multi-asset-completeness/finalized-vm-harness-runtime.ts
@@ -137,16 +137,6 @@ export async function startFinalizedVmHarnessRuntimeV1(
     publishPolicy: 1,
   } satisfies FinalizedVmLoopbackFixtureConfigV1);
   const rpcFixture = createFinalizedVmLoopbackRpcV1(fixture);
-  const chainAdapter = new FinalizedVmLoopbackMockChainAdapterV1(fixture);
-  const created = await chainAdapter.createOnChainContextGraph({
-    accessPolicy: config.accessPolicy,
-    publishPolicy: 1,
-    nameHash: config.nameHash,
-  });
-  if (created.contextGraphId.toString() !== config.onChainContextGraphId) {
-    throw new Error('mock chain created a different numeric context graph id');
-  }
-
   let activeServer: Server | undefined;
   const server = createServer(async (request, response) => {
     try {
@@ -190,9 +180,25 @@ export async function startFinalizedVmHarnessRuntimeV1(
     await closeServer(server);
     throw new Error('finalized VM JSON-RPC server has no address');
   }
+  const rpcUrl = `http://127.0.0.1:${address.port}`;
+  let chainAdapter: FinalizedVmLoopbackMockChainAdapterV1;
+  try {
+    chainAdapter = new FinalizedVmLoopbackMockChainAdapterV1(fixture, rpcUrl);
+    const created = await chainAdapter.createOnChainContextGraph({
+      accessPolicy: config.accessPolicy,
+      publishPolicy: 1,
+      nameHash: config.nameHash,
+    });
+    if (created.contextGraphId.toString() !== config.onChainContextGraphId) {
+      throw new Error('mock chain created a different numeric context graph id');
+    }
+  } catch (error) {
+    await closeServer(server);
+    throw error;
+  }
   return Object.freeze({
     chainAdapter,
-    rpcUrl: `http://127.0.0.1:${address.port}`,
+    rpcUrl,
     close: async () => {
       const current = activeServer;
       activeServer = undefined;

--- a/devnet/rfc64-gate2-multi-asset-completeness/finalized-vm-harness-runtime.ts
+++ b/devnet/rfc64-gate2-multi-asset-completeness/finalized-vm-harness-runtime.ts
@@ -9,8 +9,11 @@ import {
 } from '@origintrail-official/dkg-core';
 
 import {
+  FinalizedChainLoopbackMockChainAdapterV1,
   FinalizedVmLoopbackMockChainAdapterV1,
+  createFinalizedChainLoopbackRpcV1,
   createFinalizedVmLoopbackRpcV1,
+  type FinalizedChainLoopbackFixtureConfigV1,
   type FinalizedVmLoopbackFixtureConfigV1,
 } from '../../packages/agent/test/support/rfc64-finalized-vm-loopback-fixture.js';
 
@@ -25,118 +28,133 @@ const RFC64_GATE2_CONTEXT_GRAPH_STORAGE_ADDRESS =
 const RFC64_GATE2_KNOWLEDGE_ASSET_STORAGE_ADDRESS =
   '0x5555555555555555555555555555555555555555' as EvmAddressV1;
 
-export interface FinalizedVmHarnessAssetConfigV1 {
+export interface FinalizedChainHarnessVmAssetConfigV1 {
   readonly assertionRoot: Digest32V1;
   readonly assertionVersion: string;
   readonly authorAddress: EvmAddressV1;
   readonly kaId: string;
 }
 
-export interface FinalizedVmHarnessConfigV1 {
+export interface FinalizedChainHarnessVmInventoryConfigV1 {
+  readonly assets: readonly Readonly<FinalizedChainHarnessVmAssetConfigV1>[];
+}
+
+/** Finalized chain/CG policy baseline; VM inventory is an explicit extension. */
+export interface FinalizedChainHarnessConfigV1 {
   readonly accessPolicy: 0 | 1;
-  readonly assets: readonly Readonly<FinalizedVmHarnessAssetConfigV1>[];
   readonly contextGraphId: string;
   readonly nameHash: Digest32V1;
   readonly onChainContextGraphId: string;
+  readonly ownerAddress: EvmAddressV1;
+  readonly vmInventory?: Readonly<FinalizedChainHarnessVmInventoryConfigV1>;
 }
 
-export interface FinalizedVmHarnessRuntimeV1 {
-  readonly chainAdapter: FinalizedVmLoopbackMockChainAdapterV1;
+export interface FinalizedChainHarnessRuntimeV1 {
+  readonly chainAdapter: FinalizedChainLoopbackMockChainAdapterV1;
+  readonly hasVmInventory: boolean;
   readonly rpcUrl: string;
   close(): Promise<void>;
 }
 
 const FINALIZED_BLOCK_HASH = `0x${'77'.repeat(32)}`;
 
-export function parseFinalizedVmHarnessConfigV1(
+export function parseFinalizedChainHarnessConfigV1(
   input: string,
-): Readonly<FinalizedVmHarnessConfigV1> {
+): Readonly<FinalizedChainHarnessConfigV1> {
   if (Buffer.byteLength(input) > 1_000_000) {
-    throw new TypeError('finalized VM harness config exceeds 1 MiB');
+    throw new TypeError('finalized chain harness config exceeds 1 MiB');
   }
-  const parsed = plainRecord(JSON.parse(input), 'finalized VM harness config');
-  const contextGraphId = requiredString(parsed.contextGraphId, 'finalizedVm.contextGraphId');
+  const parsed = plainRecord(JSON.parse(input), 'finalized chain harness config');
+  const contextGraphId = requiredString(parsed.contextGraphId, 'finalizedChain.contextGraphId');
   assertContextGraphIdV1(contextGraphId);
   const accessPolicy = parsed.accessPolicy === undefined
     ? 0
-    : canonicalAccessPolicy(parsed.accessPolicy, 'finalizedVm.accessPolicy');
-  const nameHash = requiredDigest(parsed.nameHash, 'finalizedVm.nameHash');
-  const assetsInput = parsed.assets === undefined
-    ? [{
-        assertionRoot: parsed.assertionRoot,
-        assertionVersion: parsed.assertionVersion,
-        authorAddress: parsed.authorAddress,
-        kaId: parsed.kaId,
-      }]
-    : plainArray(parsed.assets, 'finalizedVm.assets');
-  if (assetsInput.length === 0) {
-    throw new TypeError('finalizedVm.assets must not be empty');
+    : canonicalAccessPolicy(parsed.accessPolicy, 'finalizedChain.accessPolicy');
+  const nameHash = requiredDigest(parsed.nameHash, 'finalizedChain.nameHash');
+  const ownerAddress = canonicalEvmAddress(parsed.ownerAddress, 'finalizedChain.ownerAddress');
+  const vmInventory = parsed.vmInventory === undefined
+    ? undefined
+    : parseVmInventory(parsed.vmInventory);
+  const onChainContextGraphId = canonicalDecimalWire(
+    parsed.onChainContextGraphId,
+    'finalizedChain.onChainContextGraphId',
+  );
+  if (BigInt(onChainContextGraphId) === 0n) {
+    throw new TypeError('finalized chain on-chain context graph id must be non-zero');
   }
+  return Object.freeze({
+    accessPolicy,
+    contextGraphId,
+    nameHash,
+    onChainContextGraphId,
+    ownerAddress,
+    ...(vmInventory === undefined ? {} : { vmInventory }),
+  });
+}
+
+function parseVmInventory(value: unknown): Readonly<FinalizedChainHarnessVmInventoryConfigV1> {
+  const inventory = plainRecord(value, 'finalizedChain.vmInventory');
+  const assetsInput = plainArray(inventory.assets, 'finalizedChain.vmInventory.assets');
+  if (assetsInput.length === 0) throw new TypeError('finalizedChain.vmInventory.assets must not be empty');
   const assets = assetsInput.map((value, index) => {
-    const asset = plainRecord(value, `finalizedVm.assets[${index}]`);
+    const asset = plainRecord(value, `finalizedChain.vmInventory.assets[${index}]`);
     const assertionVersion = canonicalDecimalWire(
       asset.assertionVersion,
-      `finalizedVm.assets[${index}].assertionVersion`,
+      `finalizedChain.vmInventory.assets[${index}].assertionVersion`,
     );
     if (BigInt(assertionVersion) === 0n) {
-      throw new TypeError(`finalizedVm.assets[${index}].assertionVersion must be non-zero`);
+      throw new TypeError(`finalizedChain.vmInventory.assets[${index}].assertionVersion must be non-zero`);
     }
     return Object.freeze({
       assertionRoot: requiredDigest(
         asset.assertionRoot,
-        `finalizedVm.assets[${index}].assertionRoot`,
+        `finalizedChain.vmInventory.assets[${index}].assertionRoot`,
       ),
       assertionVersion,
       authorAddress: canonicalEvmAddress(
         asset.authorAddress,
-        `finalizedVm.assets[${index}].authorAddress`,
+        `finalizedChain.vmInventory.assets[${index}].authorAddress`,
       ),
-      kaId: canonicalDecimalWire(asset.kaId, `finalizedVm.assets[${index}].kaId`),
+      kaId: canonicalDecimalWire(asset.kaId, `finalizedChain.vmInventory.assets[${index}].kaId`),
     });
   });
-  const onChainContextGraphId = canonicalDecimalWire(
-    parsed.onChainContextGraphId,
-    'finalizedVm.onChainContextGraphId',
-  );
-  if (BigInt(onChainContextGraphId) === 0n) {
-    throw new TypeError('finalized VM on-chain context graph id must be non-zero');
-  }
-  return Object.freeze({
-    accessPolicy,
-    assets: Object.freeze(assets),
-    contextGraphId,
-    nameHash,
-    onChainContextGraphId,
-  });
+  return Object.freeze({ assets: Object.freeze(assets) });
 }
 
-export async function startFinalizedVmHarnessRuntimeV1(
-  config: Readonly<FinalizedVmHarnessConfigV1>,
-): Promise<Readonly<FinalizedVmHarnessRuntimeV1>> {
-  const fixture = Object.freeze({
+export async function startFinalizedChainHarnessRuntimeV1(
+  config: Readonly<FinalizedChainHarnessConfigV1>,
+): Promise<Readonly<FinalizedChainHarnessRuntimeV1>> {
+  const baseline = Object.freeze({
     accessPolicy: config.accessPolicy,
     active: true,
     assertedAtChainId: RFC64_GATE2_DEPLOYMENT.assertedAtChainId,
     assertedAtKav10Address:
       RFC64_GATE2_DEPLOYMENT.assertedAtKav10Address as EvmAddressV1,
-    knowledgeAssetStorageAddress: RFC64_GATE2_KNOWLEDGE_ASSET_STORAGE_ADDRESS,
-    assets: Object.freeze(config.assets.map((asset) => Object.freeze({
-      assertionRoot: asset.assertionRoot,
-      assertionVersion: asset.assertionVersion,
-      authorAddress: asset.authorAddress,
-      kaId: asset.kaId,
-      publisherAddress: '0x6666666666666666666666666666666666666666' as EvmAddressV1,
-    }))),
     blockHash: FINALIZED_BLOCK_HASH as Digest32V1,
     blockNumberQuantity: '0x7b',
     contextGraphStorageAddress: RFC64_GATE2_CONTEXT_GRAPH_STORAGE_ADDRESS,
     nameHash: config.nameHash,
     networkId: RFC64_GATE2_DEPLOYMENT.networkId as NetworkIdV1,
     onChainContextGraphId: config.onChainContextGraphId,
-    ownerAddress: config.assets[0]!.authorAddress,
+    ownerAddress: config.ownerAddress,
     publishPolicy: 1,
-  } satisfies FinalizedVmLoopbackFixtureConfigV1);
-  const rpcFixture = createFinalizedVmLoopbackRpcV1(fixture);
+  } satisfies FinalizedChainLoopbackFixtureConfigV1);
+  const vmFixture = config.vmInventory === undefined
+    ? undefined
+    : Object.freeze({
+        ...baseline,
+        knowledgeAssetStorageAddress: RFC64_GATE2_KNOWLEDGE_ASSET_STORAGE_ADDRESS,
+        assets: Object.freeze(config.vmInventory.assets.map((asset) => Object.freeze({
+          assertionRoot: asset.assertionRoot,
+          assertionVersion: asset.assertionVersion,
+          authorAddress: asset.authorAddress,
+          kaId: asset.kaId,
+          publisherAddress: '0x6666666666666666666666666666666666666666' as EvmAddressV1,
+        }))),
+      } satisfies FinalizedVmLoopbackFixtureConfigV1);
+  const rpcFixture = vmFixture === undefined
+    ? createFinalizedChainLoopbackRpcV1(baseline)
+    : createFinalizedVmLoopbackRpcV1(vmFixture);
   let activeServer: Server | undefined;
   const server = createServer(async (request, response) => {
     try {
@@ -181,9 +199,11 @@ export async function startFinalizedVmHarnessRuntimeV1(
     throw new Error('finalized VM JSON-RPC server has no address');
   }
   const rpcUrl = `http://127.0.0.1:${address.port}`;
-  let chainAdapter: FinalizedVmLoopbackMockChainAdapterV1;
+  let chainAdapter: FinalizedChainLoopbackMockChainAdapterV1;
   try {
-    chainAdapter = new FinalizedVmLoopbackMockChainAdapterV1(fixture, rpcUrl);
+    chainAdapter = vmFixture === undefined
+      ? new FinalizedChainLoopbackMockChainAdapterV1(baseline, rpcUrl)
+      : new FinalizedVmLoopbackMockChainAdapterV1(vmFixture, rpcUrl);
     const created = await chainAdapter.createOnChainContextGraph({
       accessPolicy: config.accessPolicy,
       publishPolicy: 1,
@@ -198,6 +218,7 @@ export async function startFinalizedVmHarnessRuntimeV1(
   }
   return Object.freeze({
     chainAdapter,
+    hasVmInventory: vmFixture !== undefined,
     rpcUrl,
     close: async () => {
       const current = activeServer;

--- a/devnet/rfc64-gate2-multi-asset-completeness/launch-public-finalized-catalog.ts
+++ b/devnet/rfc64-gate2-multi-asset-completeness/launch-public-finalized-catalog.ts
@@ -12,8 +12,8 @@ const sourceCommit = readCleanRepositoryHead(repoRoot);
 runGate2CleanRuntimeBuildV1(repoRoot);
 const headAfterBuild = readCleanRepositoryHead(repoRoot);
 if (headAfterBuild !== sourceCommit) {
-  throw new Error('RFC-64 M2 source HEAD changed during the clean runtime build');
+  throw new Error('RFC-64 public finalized catalog source HEAD changed during the clean runtime build');
 }
 const manifest = buildGate2RuntimeManifestV1(repoRoot, sourceCommit);
 installGate2RuntimeLaunchReceiptV1({ manifest, sourceCommit });
-await import('./public-vm.ts');
+await import('./public-finalized-catalog.ts');

--- a/devnet/rfc64-gate2-multi-asset-completeness/package.json
+++ b/devnet/rfc64-gate2-multi-asset-completeness/package.json
@@ -18,8 +18,8 @@
     "generate": "node --experimental-strip-types src/cli/generate.ts",
     "verify": "node --experimental-strip-types src/cli/verify.ts",
     "live:generate": "node --import tsx run.ts",
-    "live:public-finalized-catalog": "node --import tsx launch-public-vm.ts",
-    "live:public-vm": "node --import tsx launch-public-vm.ts",
+    "live:public-finalized-catalog": "node --import tsx launch-public-finalized-catalog.ts",
+    "live:public-vm": "node --import tsx launch-public-finalized-catalog.ts",
     "live:verify": "node --import tsx verify-live.ts"
   }
 }

--- a/devnet/rfc64-gate2-multi-asset-completeness/package.json
+++ b/devnet/rfc64-gate2-multi-asset-completeness/package.json
@@ -18,6 +18,7 @@
     "generate": "node --experimental-strip-types src/cli/generate.ts",
     "verify": "node --experimental-strip-types src/cli/verify.ts",
     "live:generate": "node --import tsx run.ts",
+    "live:public-finalized-catalog": "node --import tsx launch-public-vm.ts",
     "live:public-vm": "node --import tsx launch-public-vm.ts",
     "live:verify": "node --import tsx verify-live.ts"
   }

--- a/devnet/rfc64-gate2-multi-asset-completeness/public-finalized-catalog.ts
+++ b/devnet/rfc64-gate2-multi-asset-completeness/public-finalized-catalog.ts
@@ -13,10 +13,7 @@ import {
 } from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
 
-import {
-  atomicWriteExactBytes,
-  readCleanRepositoryHead,
-} from '../rfc64-persistence-lifecycle/evidence.js';
+import { atomicWriteExactBytes } from '../rfc64-persistence-lifecycle/evidence.js';
 import {
   ChildProcessRegistry,
   cleanupPreservingPrimaryFailure,
@@ -40,11 +37,10 @@ const REPO_ROOT = resolve(import.meta.dirname, '../..');
 const DEFAULT_ARTIFACT = join(import.meta.dirname, 'artifacts/public-finalized-catalog-result.json');
 const NETWORK_ID = 'otp:20430';
 const CONTEXT_GRAPH_ID =
-  '0x1111111111111111111111111111111111111111/m2-public-vm-process';
+  '0x1111111111111111111111111111111111111111/public-finalized-catalog-process';
 const ON_CHAIN_CONTEXT_GRAPH_ID = '14';
 const CG_STORAGE = '0x3333333333333333333333333333333333333333';
 const KAV10 = '0x4444444444444444444444444444444444444444';
-const KA_STORAGE = '0x5555555555555555555555555555555555555555';
 const AUTHOR_PRIVATE_KEY = `0x${'64'.repeat(32)}`;
 const AUTHOR_WALLET = new ethers.Wallet(AUTHOR_PRIVATE_KEY);
 const AUTHOR_ADDRESS = AUTHOR_WALLET.address.toLowerCase();
@@ -74,7 +70,7 @@ async function execute(): Promise<void> {
     launchReceipt.sourceCommit,
     launchReceipt.manifest,
   );
-  const dataDirs = createGate2TwoAgentDataDirsV1('m2-public-vm');
+  const dataDirs = createGate2TwoAgentDataDirsV1('public-finalized-catalog');
   const children = new ChildProcessRegistry(20_000);
   let operationFailed = true;
   let primaryFailure: unknown;
@@ -122,7 +118,7 @@ async function execute(): Promise<void> {
         && receiverReady.processId !== process.pid,
       'author, receiver, and harness use distinct OS processes',
     );
-    await connectGate2HarnessAgentsV1(author, receiver, authorReady, receiverReady, 'm2-public-vm');
+    await connectGate2HarnessAgentsV1(author, receiver, authorReady, receiverReady, 'public-finalized-catalog');
 
     // Startup has already installed release-native authority from the chain
     // event. Reuse that exact policy instead of overwriting its lineage with a
@@ -164,7 +160,7 @@ async function execute(): Promise<void> {
     });
     const genesis = outputRecord(await author.request(
       'publishCatalogGenesis',
-      'm2-public-vm-genesis-v1',
+      'public-finalized-catalog-genesis-v1',
       'operation-completed',
       {
         scope,
@@ -184,7 +180,7 @@ async function execute(): Promise<void> {
 
     const successor = outputRecord(await author.request(
       'publishCatalogExactSetSuccessor',
-      'm2-public-vm-successor-v1',
+      'public-finalized-catalog-successor-v1',
       'operation-completed',
       {
         previousHead: stagedHead(genesis, 'genesis'),
@@ -194,7 +190,7 @@ async function execute(): Promise<void> {
           'genesis authorization',
         ),
         assets: [{
-          assertionCoordinate: 'm2-public-vm-process-object',
+          assertionCoordinate: 'public-finalized-catalog-process-object',
           projectionNQuads: PROJECTION_NQUADS,
           seal: await authorSeal(),
         }],
@@ -214,13 +210,13 @@ async function execute(): Promise<void> {
     const scopeDigest = computeAuthorCatalogScopeDigestV1(scope as never);
     const applied = outputRecord(await receiver.request(
       'appliedHeadReadback',
-      'm2-public-vm-applied-v1',
+      'public-finalized-catalog-applied-v1',
       'operation-completed',
       { catalogScopeDigest: scopeDigest, authorAddress: AUTHOR_ADDRESS },
     ), 'applied head');
     const terminalFailure = await receiver.request(
       'terminalFailureReadback',
-      'm2-public-vm-failure-v1',
+      'public-finalized-catalog-failure-v1',
       'operation-completed',
       { catalogHeadDigest: successorDigest },
     );
@@ -236,7 +232,7 @@ async function execute(): Promise<void> {
 
     const synchronization = outputRecord(await receiver.request(
       'exactInventoryReadback',
-      'm2-public-vm-inventory-v1',
+      'public-finalized-catalog-inventory-v1',
       'operation-completed',
       { catalogHeadDigest: successorDigest },
     ), 'synchronization evidence');
@@ -246,7 +242,7 @@ async function execute(): Promise<void> {
 
     const numericId = await receiver.request(
       'contextGraphOnChainIdReadback',
-      'm2-public-vm-numeric-id-v1',
+      'public-finalized-catalog-numeric-id-v1',
       'operation-completed',
       { contextGraphId: CONTEXT_GRAPH_ID },
     );
@@ -273,7 +269,7 @@ async function execute(): Promise<void> {
     const metaGraph = contextGraphMetaUri(CONTEXT_GRAPH_ID);
     const vm = outputRecord(await receiver.request(
       'vmGraphReadback',
-      'm2-public-vm-readback-v1',
+      'public-finalized-catalog-readback-v1',
       'operation-completed',
       { vmGraph, metaGraph, ual: KA_UAL },
     ), 'VM readback');
@@ -286,8 +282,8 @@ async function execute(): Promise<void> {
     exact(terminalFailure.output, null, 'receiver terminal failure');
 
     const [receiverBoundary, authorBoundary] = await Promise.all([
-      receiver.stop('m2-public-vm-receiver-stop-v1'),
-      author.stop('m2-public-vm-author-stop-v1'),
+      receiver.stop('public-finalized-catalog-receiver-stop-v1'),
+      author.stop('public-finalized-catalog-author-stop-v1'),
     ]);
     const receiverManifest = executedManifest(receiverBoundary.event, 'receiver');
     const authorManifest = executedManifest(authorBoundary.event, 'author');

--- a/devnet/rfc64-gate2-multi-asset-completeness/public-finalized-catalog.ts
+++ b/devnet/rfc64-gate2-multi-asset-completeness/public-finalized-catalog.ts
@@ -4,11 +4,14 @@ import process from 'node:process';
 
 import {
   MemoryLayer,
+  assertAuthorCatalogScopeV1,
   assertCanonicalGraphScopedAuthorSealV1,
+  assertContextGraphPolicyV1,
   buildAuthorAttestationTypedData,
   computeAuthorCatalogScopeDigestV1,
   contextGraphLayerUri,
   contextGraphMetaUri,
+  type AuthorCatalogScopeV1,
   type CanonicalGraphScopedAuthorSealV1,
 } from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
@@ -84,19 +87,17 @@ async function execute(): Promise<void> {
       runtimeManifestDigest: launchReceipt.manifest.manifestDigest,
       sourceCommit: headBefore,
     });
-    const finalizedVmConfigJson = JSON.stringify({
-      assertionRoot: ASSERTION_ROOT,
-      assertionVersion: ASSERTION_VERSION,
-      authorAddress: AUTHOR_ADDRESS,
+    const finalizedChainConfigJson = JSON.stringify({
+      accessPolicy: 0,
       contextGraphId: CONTEXT_GRAPH_ID,
-      kaId: KA_ID,
       nameHash: ethers.keccak256(ethers.toUtf8Bytes(CONTEXT_GRAPH_ID)).toLowerCase(),
       onChainContextGraphId: ON_CHAIN_CONTEXT_GRAPH_ID,
+      ownerAddress: AUTHOR_ADDRESS,
     });
     const receiver = spawnGate2HarnessAgentV1({
       role: 'receiver',
       dataDir: dataDirs.receiver,
-      finalizedVmConfigJson,
+      finalizedChainConfigJson,
       networkChainId: NETWORK_ID,
       registry: children,
       repoRoot: REPO_ROOT,
@@ -109,8 +110,10 @@ async function execute(): Promise<void> {
     ]);
     assertGate2HarnessReadyV1(authorReady, 'author', launchReceipt.manifest.manifestDigest);
     assertGate2HarnessReadyV1(receiverReady, 'receiver', launchReceipt.manifest.manifestDigest);
+    exact(authorReady.finalizedChainRuntime, false, 'author finalized chain runtime');
+    exact(receiverReady.finalizedChainRuntime, true, 'receiver finalized chain runtime');
     exact(authorReady.finalizedVmRuntime, false, 'author finalized VM runtime');
-    exact(receiverReady.finalizedVmRuntime, true, 'receiver finalized VM runtime');
+    exact(receiverReady.finalizedVmRuntime, false, 'public receiver VM inventory');
     requireCondition(authorReady.peerId !== receiverReady.peerId, 'peer identities are distinct');
     requireCondition(
       authorReady.processId !== receiverReady.processId
@@ -129,7 +132,9 @@ async function execute(): Promise<void> {
       'operation-completed',
       { contextGraphId: CONTEXT_GRAPH_ID },
     ), 'receiver policy');
-    const policy = record(receiverPolicy.policy, 'receiver policy payload');
+    const policyInput = receiverPolicy.policy;
+    assertContextGraphPolicyV1(policyInput);
+    const policy = policyInput;
     const policyDigest = digest(receiverPolicy.policyDigest, 'receiver policy digest');
     exact(record(policy.source, 'policy source').kind, 'finalized-chain', 'policy source');
     exact(policy.networkId, NETWORK_ID, 'policy network');
@@ -146,18 +151,19 @@ async function execute(): Promise<void> {
     ), 'author policy');
     exact(authorPolicy.policyDigest, policyDigest, 'author policy');
 
-    const scope = Object.freeze({
+    const scopeInput = {
       networkId: NETWORK_ID,
       contextGraphId: CONTEXT_GRAPH_ID,
       governanceChainId: '20430',
       governanceContractAddress: CG_STORAGE,
-      ownershipTransitionDigest: policy.ownershipTransitionDigest === null
-        ? null : digest(policy.ownershipTransitionDigest, 'policy ownership transition'),
+      ownershipTransitionDigest: policy.ownershipTransitionDigest,
       subGraphName: null,
       authorAddress: AUTHOR_ADDRESS,
-      era: string(policy.era, 'policy era'),
+      era: policy.era,
       bucketCount: '1',
-    });
+    };
+    assertAuthorCatalogScopeV1(scopeInput);
+    const scope: Readonly<AuthorCatalogScopeV1> = Object.freeze(scopeInput);
     const genesis = outputRecord(await author.request(
       'publishCatalogGenesis',
       'public-finalized-catalog-genesis-v1',
@@ -207,7 +213,7 @@ async function execute(): Promise<void> {
       'successor',
     );
 
-    const scopeDigest = computeAuthorCatalogScopeDigestV1(scope as never);
+    const scopeDigest = computeAuthorCatalogScopeDigestV1(scope);
     const applied = outputRecord(await receiver.request(
       'appliedHeadReadback',
       'public-finalized-catalog-applied-v1',

--- a/devnet/rfc64-gate2-multi-asset-completeness/public-vm.ts
+++ b/devnet/rfc64-gate2-multi-asset-completeness/public-vm.ts
@@ -3,7 +3,6 @@ import { join, resolve } from 'node:path';
 import process from 'node:process';
 
 import {
-  CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
   MemoryLayer,
   assertCanonicalGraphScopedAuthorSealV1,
   buildAuthorAttestationTypedData,
@@ -38,7 +37,7 @@ import {
 } from './two-agent-harness.ts';
 
 const REPO_ROOT = resolve(import.meta.dirname, '../..');
-const DEFAULT_ARTIFACT = join(import.meta.dirname, 'artifacts/m2-public-vm-result.json');
+const DEFAULT_ARTIFACT = join(import.meta.dirname, 'artifacts/public-finalized-catalog-result.json');
 const NETWORK_ID = 'otp:20430';
 const CONTEXT_GRAPH_ID =
   '0x1111111111111111111111111111111111111111/m2-public-vm-process';
@@ -55,7 +54,6 @@ const KA_UAL = `did:dkg:${NETWORK_ID}/${AUTHOR_ADDRESS}/${KA_NUMBER}`;
 const ASSERTION_VERSION = '1';
 const ASSERTION_ROOT =
   '0x8d7a7be6029c98db1a7300bf47008c90084d5de4a3b97a68c043c0ea4773609f';
-const POLICY_DIGEST = `0x${'cd'.repeat(32)}`;
 const PROJECTION_NQUADS =
   '<https://example.org/alice> <https://schema.org/age> '
     + '"42"^^<http://www.w3.org/2001/XMLSchema#integer> .\n'
@@ -65,31 +63,7 @@ const DEPLOYMENT = Object.freeze({
   assertedAtChainId: '20430',
   assertedAtKav10Address: KAV10,
 });
-const POLICY = Object.freeze({
-  networkId: NETWORK_ID,
-  contextGraphId: CONTEXT_GRAPH_ID,
-  governanceChainId: '20430',
-  governanceContractAddress: CG_STORAGE,
-  ownershipTransitionDigest: null,
-  era: '0',
-  version: '0',
-  previousPolicyDigest: null,
-  accessPolicy: 0,
-  publishPolicy: 1,
-  publishAuthority: null,
-  publishAuthorityAccountId: '0',
-  projectionId: CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
-  administrativeDelegationDigest: null,
-  source: {
-    kind: 'finalized-chain',
-    chainId: '20430',
-    contractAddress: CG_STORAGE,
-    blockNumber: '120',
-    blockHash: `0x${'76'.repeat(32)}`,
-  },
-  effectiveAt: '1773900000000',
-  issuedAt: '1773900000000',
-});
+
 
 await execute();
 
@@ -150,37 +124,42 @@ async function execute(): Promise<void> {
     );
     await connectGate2HarnessAgentsV1(author, receiver, authorReady, receiverReady, 'm2-public-vm');
 
-    const acceptedSnapshot = { policy: POLICY, policyDigest: POLICY_DIGEST, roster: null };
-    const [authorPolicy, receiverPolicy] = await Promise.all([
-      author.request(
-        'acceptPolicySnapshot',
-        'author-finalized-policy-v1',
-        'operation-completed',
-        acceptedSnapshot,
-      ),
-      receiver.request(
-        'acceptPolicySnapshot',
-        'receiver-finalized-policy-v1',
-        'operation-completed',
-        acceptedSnapshot,
-      ),
-    ]);
-    exact(outputRecord(authorPolicy, 'author policy').policyDigest, POLICY_DIGEST, 'author policy');
-    exact(
-      outputRecord(receiverPolicy, 'receiver policy').policyDigest,
-      POLICY_DIGEST,
-      'receiver policy',
-    );
+    // Startup has already installed release-native authority from the chain
+    // event. Reuse that exact policy instead of overwriting its lineage with a
+    // hardcoded genesis policy and an unrelated digest.
+    const receiverPolicy = outputRecord(await receiver.request(
+      'reconcileCatalogAccessAuthority',
+      'receiver-finalized-policy-v1',
+      'operation-completed',
+      { contextGraphId: CONTEXT_GRAPH_ID },
+    ), 'receiver policy');
+    const policy = record(receiverPolicy.policy, 'receiver policy payload');
+    const policyDigest = digest(receiverPolicy.policyDigest, 'receiver policy digest');
+    exact(record(policy.source, 'policy source').kind, 'finalized-chain', 'policy source');
+    exact(policy.networkId, NETWORK_ID, 'policy network');
+    exact(policy.contextGraphId, CONTEXT_GRAPH_ID, 'policy context graph');
+    exact(policy.governanceChainId, '20430', 'policy chain');
+    exact(policy.governanceContractAddress, CG_STORAGE, 'policy governance contract');
+    exact(policy.accessPolicy, 0, 'public access policy');
+    exact(receiverPolicy.roster, null, 'public policy roster');
+    const authorPolicy = outputRecord(await author.request(
+      'acceptPolicySnapshot',
+      'author-finalized-policy-v1',
+      'operation-completed',
+      { policy, policyDigest, roster: null },
+    ), 'author policy');
+    exact(authorPolicy.policyDigest, policyDigest, 'author policy');
 
     const scope = Object.freeze({
       networkId: NETWORK_ID,
       contextGraphId: CONTEXT_GRAPH_ID,
       governanceChainId: '20430',
       governanceContractAddress: CG_STORAGE,
-      ownershipTransitionDigest: null,
+      ownershipTransitionDigest: policy.ownershipTransitionDigest === null
+        ? null : digest(policy.ownershipTransitionDigest, 'policy ownership transition'),
       subGraphName: null,
       authorAddress: AUTHOR_ADDRESS,
-      era: '0',
+      era: string(policy.era, 'policy era'),
       bucketCount: '1',
     });
     const genesis = outputRecord(await author.request(
@@ -273,6 +252,18 @@ async function execute(): Promise<void> {
     );
     exact(numericId.output, ON_CHAIN_CONTEXT_GRAPH_ID, 'event-derived numeric context graph id');
 
+    const swmGraph = contextGraphLayerUri(
+      CONTEXT_GRAPH_ID, MemoryLayer.SharedWorkingMemory, AUTHOR_ADDRESS, Number(KA_NUMBER),
+    );
+    const swm = outputRecord(await receiver.request(
+      'semanticGraphReadback',
+      'public-finalized-catalog-swm-v1',
+      'operation-completed',
+      { swmGraph },
+    ), 'SWM readback');
+    exact(swm.activatedQuadCount, 2, 'SWM triple count');
+    exact(swm.projectionNQuads, PROJECTION_NQUADS, 'exact SWM projection');
+
     const vmGraph = contextGraphLayerUri(
       CONTEXT_GRAPH_ID,
       MemoryLayer.VerifiableMemory,
@@ -286,21 +277,11 @@ async function execute(): Promise<void> {
       'operation-completed',
       { vmGraph, metaGraph, ual: KA_UAL },
     ), 'VM readback');
-    exact(vm.tripleCount, 2, 'VM triple count');
-    exact(vm.projectionNQuads, PROJECTION_NQUADS, 'exact VM projection');
-    const metadata = array(vm.metadataBindings, 'VM metadata').map((row, index) =>
-      record(row, `VM metadata row ${index}`));
-    metadataObject(metadata, 'status', '"confirmed"');
-    metadataObject(
-      metadata,
-      'batchId',
-      `"${KA_ID}"^^<http://www.w3.org/2001/XMLSchema#integer>`,
-    );
-    metadataObject(metadata, 'materializedVersion', '"123:0"');
-    requireCondition(
-      metadata.every((row) => !string(row.p, 'metadata predicate').endsWith('transactionHash')),
-      'finalized VM metadata contains no synthetic transaction hash',
-    );
+    // Public catalog synchronization verifies finalized policy while retaining
+    // SWM. VM materialization belongs to the separate chain recovery path.
+    exact(vm.tripleCount, 0, 'public catalog must not manufacture VM rows');
+    const metadata = array(vm.metadataBindings, 'VM metadata');
+    exact(metadata.length, 0, 'public catalog must not manufacture confirmed VM metadata');
 
     exact(terminalFailure.output, null, 'receiver terminal failure');
 
@@ -319,7 +300,7 @@ async function execute(): Promise<void> {
     );
 
     const artifact = Object.freeze({
-      gate: 'OT-RFC-64 M2 public finalized VM separate-process proof',
+      gate: 'OT-RFC-64 public catalog finalized-policy separate-process proof',
       status: 'PASS',
       repository: { testedHeadCommit: headAfter, cleanBeforeAndAfter: true },
       processes: {
@@ -329,7 +310,7 @@ async function execute(): Promise<void> {
         authorPeerId: authorReady.peerId,
         receiverPeerId: receiverReady.peerId,
       },
-      policy: { digest: POLICY_DIGEST, source: 'finalized-chain' },
+      policy: { digest: policyDigest, source: 'finalized-chain' },
       chain: {
         numericContextGraphId: numericId.output,
         finalizedBlockNumber: '123',
@@ -340,6 +321,11 @@ async function execute(): Promise<void> {
         appliedInventoryDigest: applied.appliedInventoryDigest,
         inventoryRowCount: applied.inventoryRowCount,
       },
+      sharedWorkingMemory: {
+        graph: swmGraph,
+        tripleCount: swm.activatedQuadCount,
+        exactProjection: swm.projectionNQuads,
+      },
       verifiableMemory: {
         graph: vmGraph,
         tripleCount: vm.tripleCount,
@@ -348,13 +334,14 @@ async function execute(): Promise<void> {
       },
       runtimeBuildManifestDigest: launchReceipt.manifest.manifestDigest,
     });
-    const artifactPath = process.env.DKG_RFC64_M2_PUBLIC_VM_ARTIFACT ?? DEFAULT_ARTIFACT;
+    const artifactPath = process.env.DKG_RFC64_PUBLIC_FINALIZED_CATALOG_ARTIFACT
+      ?? process.env.DKG_RFC64_M2_PUBLIC_VM_ARTIFACT ?? DEFAULT_ARTIFACT;
     const publication = atomicWriteExactBytes(
       artifactPath,
       new TextEncoder().encode(canonicalDocument(artifact as unknown as CanonicalValue)),
     );
     process.stdout.write(
-      `[rfc64-m2-public-vm] PASS artifact=${artifactPath} sha256=${publication.sha256}\n`,
+      `[rfc64-public-finalized-catalog] PASS artifact=${artifactPath} sha256=${publication.sha256}\n`,
     );
     operationFailed = false;
   } catch (error) {
@@ -369,7 +356,7 @@ async function execute(): Promise<void> {
       }),
       reportSecondaryFailure: (primary, secondary) => {
         process.stderr.write(
-          `[rfc64-m2-public-vm] cleanup failure after ${String(primary)}: ${String(secondary)}\n`,
+          `[rfc64-public-finalized-catalog] cleanup failure after ${String(primary)}: ${String(secondary)}\n`,
         );
       },
     });
@@ -445,17 +432,6 @@ function stagedHead(output: Record<string, unknown>, label: string): Record<stri
       `${label} signature variant digest`,
     ),
   };
-}
-
-function metadataObject(
-  rows: readonly Record<string, unknown>[],
-  predicateSuffix: string,
-  expectedObject: string,
-): void {
-  const matching = rows.filter((row) =>
-    string(row.p, `metadata ${predicateSuffix} predicate`).endsWith(predicateSuffix));
-  exact(matching.length, 1, `metadata ${predicateSuffix} row count`);
-  exact(matching[0]!.o, expectedObject, `metadata ${predicateSuffix} object`);
 }
 
 function executedManifest(event: Gate2AgentEvent, label: string): Gate2ExecutedRuntimeManifestV1 {

--- a/devnet/rfc64-gate2-multi-asset-completeness/two-agent-harness.ts
+++ b/devnet/rfc64-gate2-multi-asset-completeness/two-agent-harness.ts
@@ -60,7 +60,7 @@ export function spawnGate2HarnessAgentV1(input: {
   readonly catalogLocalAgentAddress?: string;
   readonly dataDir: string;
   readonly eventTimeoutMs?: number;
-  readonly finalizedVmConfigJson?: string;
+  readonly finalizedChainConfigJson?: string;
   readonly masterKeyHex?: string;
   /** Harness-only provider delay used to prove mid-transfer failover. */
   readonly bundleServeDelayMs?: number;
@@ -121,9 +121,9 @@ export function spawnGate2HarnessAgentV1(input: {
         ...(input.networkChainId === undefined
           ? {}
           : { DKG_RFC64_GATE2_NETWORK_CHAIN_ID: input.networkChainId }),
-        ...(input.finalizedVmConfigJson === undefined
+        ...(input.finalizedChainConfigJson === undefined
           ? {}
-          : { DKG_RFC64_GATE2_FINALIZED_VM_CONFIG: input.finalizedVmConfigJson }),
+          : { DKG_RFC64_GATE2_FINALIZED_CHAIN_CONFIG: input.finalizedChainConfigJson }),
         NODE_ENV: 'production',
       },
     },

--- a/devnet/rfc64-m0-public-baseline/README.md
+++ b/devnet/rfc64-m0-public-baseline/README.md
@@ -1,7 +1,7 @@
 # RFC-64 M0 current public baseline
 
 M0 is a composed release gate for the public RFC-64 slice already present in
-the repository. It turns the previously separate lifecycle, SWM, finalized-VM,
+the repository. It turns the previously separate lifecycle, SWM, finalized-policy,
 cold-start, failover, and bounded-work proofs into one reproducible command.
 It does not enable RFC-64 features, change node defaults, or claim private
 Context Graph support.
@@ -19,11 +19,17 @@ exact checked-out commit. The root command is only an alias for this suite.
 | --- | --- |
 | Persistence lifecycle | Production `DKGAgent` child process; graceful stop, `SIGKILL`, lease recovery, exact durable object readback |
 | Public SWM policy parity | Distinct author and receiver OS processes; public-open and public-curated; exact N-Quads, content digest, bundle digest, and durable applied head |
-| Finalized public VM | Distinct author and receiver OS processes; finalized chain policy and numeric CG id; exact VM projection and metadata before applied-head commit |
+| Finalized public catalog policy | Distinct author and receiver OS processes; finalized chain policy and numeric CG id; exact SWM projection and durable applied head; zero VM rows or confirmed VM metadata |
 | Automatic cold start and restart | Production catalog bootstrap starts after publication, reaches the exact durable head, and reuses it after receiver restart |
 | Source recovery | An initial provider miss is retried and the later viable provider is selected automatically |
 | Public-curated cold/warm parity | Warm and cold receivers converge to one exact finalized head and retain it across restart |
 | Bounded work | Catalog receiver queue/concurrency bounds, unified backpressure invariants, and reconnect-churn behavior |
+
+The finalized-policy row runs `live:public-finalized-catalog`. Public catalog
+reconciliation verifies policy before committing the applied head and writes
+SWM. This row does **not** certify public VM materialization. The historical
+`live:public-vm` command is a compatibility alias for the same policy proof;
+its name must not be interpreted as VM evidence.
 
 The runtime sub-gates write their existing commit-bound artifacts under:
 
@@ -45,9 +51,12 @@ not substitute fixture data for runtime observations.
 ## What M0 does not prove
 
 M0 is a one-machine reproducible foundation. It does not prove internet/NAT
-reachability, testnet fleet behavior, long-duration soak stability, private
+reachability, testnet fleet behavior, long-duration soak stability, public VM
+materialization, private
 content confidentiality, membership revocation, or private-curated publishing.
 Those remain later milestones and must not be inferred from an M0 pass.
+The separate CP2/CP3 gates exercise private finalized-VM recovery; their scope
+does not establish public VM materialization either.
 
 For release comparison, run the same command in clean worktrees at the exact
 `main` and `testnet-canary` commits and record both SHAs. A green run on one ref

--- a/devnet/rfc64-m0-public-baseline/runner.mjs
+++ b/devnet/rfc64-m0-public-baseline/runner.mjs
@@ -19,10 +19,10 @@ export const M0_ACCEPTANCE_ROWS = Object.freeze([
   commandRow('public-swm-policy-parity', 'Public SWM policy parity', [
     'test:m1:rfc64-public-swm-parity',
   ]),
-  commandRow('finalized-public-vm', 'Finalized public VM', [
+  commandRow('finalized-public-catalog', 'Finalized public catalog policy', [
     '--filter',
     '@devnet/rfc64-gate2-multi-asset-completeness',
-    'live:public-vm',
+    'live:public-finalized-catalog',
   ]),
   ...RFC64_M0_RECOVERY_SCENARIO_MANIFEST.map((scenario) => commandRow(
     scenario.rowId,

--- a/devnet/rfc64-m0-public-baseline/runner.test.mjs
+++ b/devnet/rfc64-m0-public-baseline/runner.test.mjs
@@ -20,12 +20,12 @@ const expectedRows = Object.freeze([
     args: ['test:m1:rfc64-public-swm-parity'],
   },
   {
-    id: 'finalized-public-vm',
-    label: 'Finalized public VM',
+    id: 'finalized-public-catalog',
+    label: 'Finalized public catalog policy',
     args: [
       '--filter',
       '@devnet/rfc64-gate2-multi-asset-completeness',
-      'live:public-vm',
+      'live:public-finalized-catalog',
     ],
   },
   ...RFC64_M0_RECOVERY_SCENARIO_MANIFEST.map((scenario) => ({
@@ -97,7 +97,7 @@ test('fails the composed gate immediately when a child row fails', async () => {
     runM0Rows({
       execute: async (row) => {
         invoked.push(row.id);
-        if (row.id === 'finalized-public-vm') {
+        if (row.id === 'finalized-public-catalog') {
           throw failure;
         }
       },

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -75,6 +75,7 @@
     "./dist/rfc64/inventory-v1/swm-author-inventory-persistence.js": null,
     "./dist/rfc64/inventory-v1/swm-author-inventory-sql-codec.js": null,
     "./dist/rfc64/inventory-v1/swm-author-inventory-contracts.js": null,
+    "./dist/rfc64/finalized-agent-precommits-v1.js": null,
     "./dist/rfc64/finalized-policy-agent-precommit-v1.js": null,
     "./dist/rfc64/finalized-policy-verifier-v1.js": null,
     "./dist/rfc64/finalized-vm-agent-precommit-v1.js": null,

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -277,6 +277,7 @@ const blockedRfc64Modules = [
   'inventory-v1/swm-author-inventory-mutation.js',
   'inventory-v1/swm-author-inventory-persistence.js',
   'inventory-v1/swm-author-inventory-sql-codec.js',
+  'finalized-agent-precommits-v1.js',
   'finalized-policy-agent-precommit-v1.js',
   'finalized-policy-verifier-v1.js',
   'finalized-private-placement-repair-store-v1.js',

--- a/packages/agent/src/dkg-agent-rfc64-catalog.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog.ts
@@ -87,8 +87,7 @@ import {
   Rfc64PublicCatalogNativeReceiverErrorV1,
   Rfc64PublicCatalogNativeReceiverV1,
 } from './rfc64/public-catalog-native-receiver-v1.js';
-import { createRfc64FinalizedPolicyAgentPrecommitV1 } from './rfc64/finalized-policy-agent-precommit-v1.js';
-import { createRfc64FinalizedVmAgentPrecommitV1 } from './rfc64/finalized-vm-agent-precommit-v1.js';
+import { createRfc64FinalizedAgentPrecommitsV1 } from './rfc64/finalized-agent-precommits-v1.js';
 import {
   createRfc64CatalogAppliedHeadCoordinatorV1,
 } from './rfc64/catalog-applied-head-coordinator-v1.js';
@@ -3234,34 +3233,14 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
       resolveScopedReadCapability,
       readResourceStats: () => readNativeResourceStats(),
       createReconciler: (clients: Readonly<Rfc64PublicCatalogReconcilerClientsV1>) => {
-        const createFinalizedSnapshotScope =
-          typeof this.chain.createFinalizedEvmSnapshotScope === 'function'
-            ? () => this.chain.createFinalizedEvmSnapshotScope!('rfc64')
-            : null;
         const acceptedPolicySnapshotForCatalogScope = (scope: AuthorCatalogScopeV1) =>
           this.requireRfc64PublicCatalogServiceV1()
             .acceptedPolicySnapshotForCatalogScope(scope);
-        const finalizedPolicyPrecommit = createRfc64FinalizedPolicyAgentPrecommitV1({
+        const { finalizedPolicyPrecommit, finalizedVmPrecommit } = createRfc64FinalizedAgentPrecommitsV1({
+          chain: this.chain,
           acceptedPolicySnapshotForCatalogScope,
-          createFinalizedSnapshotScope,
           getOnChainContextGraphId: (contextGraphId, signal) =>
             this.getContextGraphOnChainId(contextGraphId, { signal }),
-          getEvmChainId: () => this.chain.getEvmChainId(),
-        });
-        const finalizedVmPrecommit = createRfc64FinalizedVmAgentPrecommitV1({
-          acceptedPolicySnapshotForCatalogScope,
-          createFinalizedSnapshotScope,
-          getOnChainContextGraphId: (contextGraphId, signal) =>
-            this.getContextGraphOnChainId(contextGraphId, { signal }),
-          getEvmChainId: () => this.chain.getEvmChainId(),
-          getKnowledgeAssetStorageAddress: async () => {
-            if (typeof this.chain.getDKGKnowledgeAssetsAddress !== 'function') {
-              throw new Error('RFC-64 finalized VM recovery requires KnowledgeAssetStorage');
-            }
-            return this.chain.getDKGKnowledgeAssetsAddress();
-          },
-          getKnowledgeAssetsLifecycleAddress: () =>
-            this.chain.getKnowledgeAssetsLifecycleAddress(),
           store: this.store,
         });
         const beforeAppliedHeadCommit = createRfc64CatalogAppliedHeadCoordinatorV1({

--- a/packages/agent/src/dkg-agent-rfc64-catalog.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog.ts
@@ -52,7 +52,6 @@ import {
   type SignedAuthorCatalogHeadEnvelopeV1,
 } from '@origintrail-official/dkg-core';
 import {
-  resolveRpcUrls,
   verifyControlEnvelopeIssuerSignatureV1,
   type ContextGraphAuthorityReader,
   type ContextGraphAuthorityReaderCapability,
@@ -3235,24 +3234,20 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
       resolveScopedReadCapability,
       readResourceStats: () => readNativeResourceStats(),
       createReconciler: (clients: Readonly<Rfc64PublicCatalogReconcilerClientsV1>) => {
-        const chainConfig = this.config.chainConfig;
+        const finalizedReadRpcEndpoints = this.chain.getRpcUrls?.() ?? null;
         const acceptedPolicySnapshotForCatalogScope = (scope: AuthorCatalogScopeV1) =>
           this.requireRfc64PublicCatalogServiceV1()
             .acceptedPolicySnapshotForCatalogScope(scope);
         const finalizedPolicyPrecommit = createRfc64FinalizedPolicyAgentPrecommitV1({
           acceptedPolicySnapshotForCatalogScope,
-          rpcEndpoints: chainConfig === undefined
-            ? null
-            : resolveRpcUrls(chainConfig.rpcUrl, chainConfig.rpcUrls),
+          rpcEndpoints: finalizedReadRpcEndpoints,
           getOnChainContextGraphId: (contextGraphId, signal) =>
             this.getContextGraphOnChainId(contextGraphId, { signal }),
           getEvmChainId: () => this.chain.getEvmChainId(),
         });
         const finalizedVmPrecommit = createRfc64FinalizedVmAgentPrecommitV1({
           acceptedPolicySnapshotForCatalogScope,
-          rpcEndpoints: chainConfig === undefined
-            ? null
-            : resolveRpcUrls(chainConfig.rpcUrl, chainConfig.rpcUrls),
+          rpcEndpoints: finalizedReadRpcEndpoints,
           getOnChainContextGraphId: (contextGraphId, signal) =>
             this.getContextGraphOnChainId(contextGraphId, { signal }),
           getEvmChainId: () => this.chain.getEvmChainId(),

--- a/packages/agent/src/dkg-agent-rfc64-catalog.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog.ts
@@ -3234,20 +3234,23 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
       resolveScopedReadCapability,
       readResourceStats: () => readNativeResourceStats(),
       createReconciler: (clients: Readonly<Rfc64PublicCatalogReconcilerClientsV1>) => {
-        const finalizedReadRpcEndpoints = this.chain.getRpcUrls?.() ?? null;
+        const createFinalizedSnapshotScope =
+          typeof this.chain.createFinalizedEvmSnapshotScope === 'function'
+            ? () => this.chain.createFinalizedEvmSnapshotScope!('rfc64')
+            : null;
         const acceptedPolicySnapshotForCatalogScope = (scope: AuthorCatalogScopeV1) =>
           this.requireRfc64PublicCatalogServiceV1()
             .acceptedPolicySnapshotForCatalogScope(scope);
         const finalizedPolicyPrecommit = createRfc64FinalizedPolicyAgentPrecommitV1({
           acceptedPolicySnapshotForCatalogScope,
-          rpcEndpoints: finalizedReadRpcEndpoints,
+          createFinalizedSnapshotScope,
           getOnChainContextGraphId: (contextGraphId, signal) =>
             this.getContextGraphOnChainId(contextGraphId, { signal }),
           getEvmChainId: () => this.chain.getEvmChainId(),
         });
         const finalizedVmPrecommit = createRfc64FinalizedVmAgentPrecommitV1({
           acceptedPolicySnapshotForCatalogScope,
-          rpcEndpoints: finalizedReadRpcEndpoints,
+          createFinalizedSnapshotScope,
           getOnChainContextGraphId: (contextGraphId, signal) =>
             this.getContextGraphOnChainId(contextGraphId, { signal }),
           getEvmChainId: () => this.chain.getEvmChainId(),

--- a/packages/agent/src/rfc64/finalized-agent-precommits-v1.ts
+++ b/packages/agent/src/rfc64/finalized-agent-precommits-v1.ts
@@ -1,0 +1,38 @@
+import type { ChainAdapter } from '@origintrail-official/dkg-chain';
+import type { TripleStore } from '@origintrail-official/dkg-storage';
+import {
+  createRfc64FinalizedPolicyAgentPrecommitV1,
+  type Rfc64FinalizedPolicyAgentPrecommitResolutionOptionsV1,
+} from './finalized-policy-agent-precommit-v1.js';
+import { createRfc64FinalizedVmAgentPrecommitV1 } from './finalized-vm-agent-precommit-v1.js';
+
+interface Rfc64FinalizedAgentPrecommitsOptionsV1 extends Pick<
+  Rfc64FinalizedPolicyAgentPrecommitResolutionOptionsV1,
+  'acceptedPolicySnapshotForCatalogScope' | 'getOnChainContextGraphId'
+> {
+  readonly chain: ChainAdapter;
+  readonly store: TripleStore;
+}
+
+/** Bind both catalog barriers to the adapter and the shared RFC-64 read owner. */
+export function createRfc64FinalizedAgentPrecommitsV1(options: Rfc64FinalizedAgentPrecommitsOptionsV1) {
+  const shared: Rfc64FinalizedPolicyAgentPrecommitResolutionOptionsV1 = {
+    acceptedPolicySnapshotForCatalogScope: options.acceptedPolicySnapshotForCatalogScope,
+    getOnChainContextGraphId: options.getOnChainContextGraphId,
+    createFinalizedReadBinding: () => options.chain.createFinalizedEvmReadBinding('rfc64'),
+  };
+  return Object.freeze({
+    finalizedPolicyPrecommit: createRfc64FinalizedPolicyAgentPrecommitV1(shared),
+    finalizedVmPrecommit: createRfc64FinalizedVmAgentPrecommitV1({
+      ...shared,
+      getKnowledgeAssetStorageAddress: async () => {
+        if (typeof options.chain.getDKGKnowledgeAssetsAddress !== 'function') {
+          throw new Error('RFC-64 finalized VM recovery requires KnowledgeAssetStorage');
+        }
+        return options.chain.getDKGKnowledgeAssetsAddress();
+      },
+      getKnowledgeAssetsLifecycleAddress: () => options.chain.getKnowledgeAssetsLifecycleAddress(),
+      store: options.store,
+    }),
+  });
+}

--- a/packages/agent/src/rfc64/finalized-agent-precommits-v1.ts
+++ b/packages/agent/src/rfc64/finalized-agent-precommits-v1.ts
@@ -1,4 +1,4 @@
-import type { ChainAdapter } from '@origintrail-official/dkg-chain';
+import { bindFinalizedEvmReadBindingProvider, type ChainAdapter } from '@origintrail-official/dkg-chain';
 import type { TripleStore } from '@origintrail-official/dkg-storage';
 import {
   createRfc64FinalizedPolicyAgentPrecommitV1,
@@ -16,10 +16,13 @@ interface Rfc64FinalizedAgentPrecommitsOptionsV1 extends Pick<
 
 /** Bind both catalog barriers to the adapter and the shared RFC-64 read owner. */
 export function createRfc64FinalizedAgentPrecommitsV1(options: Rfc64FinalizedAgentPrecommitsOptionsV1) {
+  const finalizedReads = bindFinalizedEvmReadBindingProvider(options.chain);
   const shared: Rfc64FinalizedPolicyAgentPrecommitResolutionOptionsV1 = {
     acceptedPolicySnapshotForCatalogScope: options.acceptedPolicySnapshotForCatalogScope,
     getOnChainContextGraphId: options.getOnChainContextGraphId,
-    createFinalizedReadBinding: () => options.chain.createFinalizedEvmReadBinding('rfc64'),
+    createFinalizedReadBinding: () => finalizedReads.status === 'supported'
+      ? finalizedReads.provider.createFinalizedEvmReadBinding('rfc64')
+      : Promise.resolve(null),
   };
   return Object.freeze({
     finalizedPolicyPrecommit: createRfc64FinalizedPolicyAgentPrecommitV1(shared),

--- a/packages/agent/src/rfc64/finalized-agent-precommits-v1.ts
+++ b/packages/agent/src/rfc64/finalized-agent-precommits-v1.ts
@@ -20,9 +20,7 @@ export function createRfc64FinalizedAgentPrecommitsV1(options: Rfc64FinalizedAge
   const shared: Rfc64FinalizedPolicyAgentPrecommitResolutionOptionsV1 = {
     acceptedPolicySnapshotForCatalogScope: options.acceptedPolicySnapshotForCatalogScope,
     getOnChainContextGraphId: options.getOnChainContextGraphId,
-    createFinalizedReadBinding: () => finalizedReads.status === 'supported'
-      ? finalizedReads.provider.createFinalizedEvmReadBinding('rfc64')
-      : Promise.resolve(null),
+    finalizedReads,
   };
   return Object.freeze({
     finalizedPolicyPrecommit: createRfc64FinalizedPolicyAgentPrecommitV1(shared),

--- a/packages/agent/src/rfc64/finalized-policy-agent-precommit-v1.ts
+++ b/packages/agent/src/rfc64/finalized-policy-agent-precommit-v1.ts
@@ -12,7 +12,7 @@ import {
   type EvmAddressV1,
   type MemberRosterV1,
 } from '@origintrail-official/dkg-core';
-import { createStrictCurrentFinalizedEvmSnapshotScopeV1 } from '@origintrail-official/dkg-chain';
+import type { StrictCurrentFinalizedEvmSnapshotScopeV1 } from '@origintrail-official/dkg-chain';
 
 import {
   assertAcceptedRfc64CatalogAuthorMembershipV1,
@@ -30,7 +30,10 @@ import type {
 export interface Rfc64FinalizedPolicyAgentPrecommitResolutionOptionsV1 {
   readonly acceptedPolicySnapshotForCatalogScope:
     (scope: Readonly<AuthorCatalogScopeV1>) => AcceptedRfc64CatalogAccessSnapshotV1;
-  readonly rpcEndpoints: readonly string[] | null;
+  readonly createFinalizedSnapshotScope:
+    (() => StrictCurrentFinalizedEvmSnapshotScopeV1
+      | Promise<StrictCurrentFinalizedEvmSnapshotScopeV1 | null>
+      | null) | null;
   readonly getOnChainContextGraphId:
     (contextGraphId: ContextGraphIdV1, signal: AbortSignal) => Promise<string | null>;
   readonly getEvmChainId: () => Promise<bigint>;
@@ -44,7 +47,7 @@ export interface ResolvedRfc64FinalizedPolicyAgentPrecommitV1 {
   readonly chainId: ChainIdV1;
   readonly contextGraphStorageAddress: EvmAddressV1;
   readonly onChainContextGraphId: DecimalU256V1;
-  readonly rpcEndpoints: readonly string[];
+  readonly snapshot: StrictCurrentFinalizedEvmSnapshotScopeV1;
 }
 
 /**
@@ -122,10 +125,10 @@ export async function resolveRfc64FinalizedPolicyAgentPrecommitV1(
   ) {
     throw new Error('RFC-64 finalized precommit source differs from its governance binding');
   }
-  if (options.rpcEndpoints === null || options.rpcEndpoints.length === 0) {
+  const snapshot = await options.createFinalizedSnapshotScope?.() ?? null;
+  if (snapshot === null) {
     throw new Error('RFC-64 finalized precommit requires trusted RPC configuration');
   }
-  const rpcEndpoints = Object.freeze([...options.rpcEndpoints]);
 
   const [untrustedContextGraphId, liveChainId] = await Promise.all([
     options.getOnChainContextGraphId(plan.catalogScope.contextGraphId, signal),
@@ -150,7 +153,7 @@ export async function resolveRfc64FinalizedPolicyAgentPrecommitV1(
     chainId,
     contextGraphStorageAddress,
     onChainContextGraphId: untrustedContextGraphId,
-    rpcEndpoints,
+    snapshot,
   });
 }
 
@@ -173,14 +176,7 @@ export function createRfc64FinalizedPolicyAgentPrecommitV1(
       assertPlanPolicyAndRosterCurrentV1(options, plan);
       return;
     }
-    const snapshot = createStrictCurrentFinalizedEvmSnapshotScopeV1({
-      chainId: resolved.chainId,
-      endpoints: resolved.rpcEndpoints,
-      // One process-wide per-chain gate protects concurrent policy and VM
-      // reads even though each precommit owns its own snapshot scope.
-      owner: 'rfc64',
-    });
-    await snapshot(
+    await resolved.snapshot(
       { chainId: resolved.chainId, signal },
       (session) => resolveAndVerifyRfc64FinalizedPolicyInSnapshotV1(
         {

--- a/packages/agent/src/rfc64/finalized-policy-agent-precommit-v1.ts
+++ b/packages/agent/src/rfc64/finalized-policy-agent-precommit-v1.ts
@@ -12,7 +12,7 @@ import {
   type EvmAddressV1,
   type MemberRosterV1,
 } from '@origintrail-official/dkg-core';
-import type { StrictCurrentFinalizedEvmSnapshotScopeV1 } from '@origintrail-official/dkg-chain';
+import type { FinalizedEvmReadBindingV1, StrictCurrentFinalizedEvmSnapshotScopeV1 } from '@origintrail-official/dkg-chain';
 
 import {
   assertAcceptedRfc64CatalogAuthorMembershipV1,
@@ -30,13 +30,10 @@ import type {
 export interface Rfc64FinalizedPolicyAgentPrecommitResolutionOptionsV1 {
   readonly acceptedPolicySnapshotForCatalogScope:
     (scope: Readonly<AuthorCatalogScopeV1>) => AcceptedRfc64CatalogAccessSnapshotV1;
-  readonly createFinalizedSnapshotScope:
-    (() => StrictCurrentFinalizedEvmSnapshotScopeV1
-      | Promise<StrictCurrentFinalizedEvmSnapshotScopeV1 | null>
-      | null) | null;
+  readonly createFinalizedReadBinding:
+    () => Promise<Readonly<FinalizedEvmReadBindingV1> | null>;
   readonly getOnChainContextGraphId:
     (contextGraphId: ContextGraphIdV1, signal: AbortSignal) => Promise<string | null>;
-  readonly getEvmChainId: () => Promise<bigint>;
 }
 
 export interface Rfc64FinalizedPolicyAgentPrecommitOptionsV1
@@ -125,20 +122,18 @@ export async function resolveRfc64FinalizedPolicyAgentPrecommitV1(
   ) {
     throw new Error('RFC-64 finalized precommit source differs from its governance binding');
   }
-  const snapshot = await options.createFinalizedSnapshotScope?.() ?? null;
-  if (snapshot === null) {
-    throw new Error('RFC-64 finalized precommit requires trusted RPC configuration');
-  }
-
-  const [untrustedContextGraphId, liveChainId] = await Promise.all([
+  const [binding, untrustedContextGraphId] = await Promise.all([
+    options.createFinalizedReadBinding(),
     options.getOnChainContextGraphId(plan.catalogScope.contextGraphId, signal),
-    options.getEvmChainId(),
   ]);
   signal.throwIfAborted();
+  if (binding === null) {
+    throw new Error('RFC-64 finalized precommit requires trusted RPC configuration');
+  }
   if (untrustedContextGraphId === null) {
     throw new Error('RFC-64 finalized precommit could not resolve the numeric context graph id');
   }
-  if (liveChainId.toString() !== chainId) {
+  if (binding.chainId !== chainId) {
     throw new Error('RFC-64 finalized precommit policy differs from the configured chain id');
   }
   assertCanonicalDecimalU256(
@@ -153,7 +148,7 @@ export async function resolveRfc64FinalizedPolicyAgentPrecommitV1(
     chainId,
     contextGraphStorageAddress,
     onChainContextGraphId: untrustedContextGraphId,
-    snapshot,
+    snapshot: binding.snapshot,
   });
 }
 

--- a/packages/agent/src/rfc64/finalized-policy-agent-precommit-v1.ts
+++ b/packages/agent/src/rfc64/finalized-policy-agent-precommit-v1.ts
@@ -12,7 +12,7 @@ import {
   type EvmAddressV1,
   type MemberRosterV1,
 } from '@origintrail-official/dkg-core';
-import type { FinalizedEvmReadBindingV1, StrictCurrentFinalizedEvmSnapshotScopeV1 } from '@origintrail-official/dkg-chain';
+import type { FinalizedEvmReadBindingCapability, StrictCurrentFinalizedEvmSnapshotScopeV1 } from '@origintrail-official/dkg-chain';
 
 import {
   assertAcceptedRfc64CatalogAuthorMembershipV1,
@@ -30,8 +30,7 @@ import type {
 export interface Rfc64FinalizedPolicyAgentPrecommitResolutionOptionsV1 {
   readonly acceptedPolicySnapshotForCatalogScope:
     (scope: Readonly<AuthorCatalogScopeV1>) => AcceptedRfc64CatalogAccessSnapshotV1;
-  readonly createFinalizedReadBinding:
-    () => Promise<Readonly<FinalizedEvmReadBindingV1> | null>;
+  readonly finalizedReads: FinalizedEvmReadBindingCapability;
   readonly getOnChainContextGraphId:
     (contextGraphId: ContextGraphIdV1, signal: AbortSignal) => Promise<string | null>;
 }
@@ -122,14 +121,15 @@ export async function resolveRfc64FinalizedPolicyAgentPrecommitV1(
   ) {
     throw new Error('RFC-64 finalized precommit source differs from its governance binding');
   }
+  const { finalizedReads } = options;
+  if (finalizedReads.status === 'unsupported') {
+    throw new Error('RFC-64 finalized precommit requires trusted RPC configuration');
+  }
   const [binding, untrustedContextGraphId] = await Promise.all([
-    options.createFinalizedReadBinding(),
+    finalizedReads.provider.createFinalizedEvmReadBinding('rfc64'),
     options.getOnChainContextGraphId(plan.catalogScope.contextGraphId, signal),
   ]);
   signal.throwIfAborted();
-  if (binding === null) {
-    throw new Error('RFC-64 finalized precommit requires trusted RPC configuration');
-  }
   if (untrustedContextGraphId === null) {
     throw new Error('RFC-64 finalized precommit could not resolve the numeric context graph id');
   }

--- a/packages/agent/src/rfc64/finalized-vm-agent-precommit-v1.ts
+++ b/packages/agent/src/rfc64/finalized-vm-agent-precommit-v1.ts
@@ -3,7 +3,6 @@ import {
   type AuthorCatalogScopeV1,
   type ContextGraphIdV1,
 } from '@origintrail-official/dkg-core';
-import { createStrictCurrentFinalizedEvmSnapshotScopeV1 } from '@origintrail-official/dkg-chain';
 import type { TripleStore } from '@origintrail-official/dkg-storage';
 
 import type { AcceptedRfc64CatalogAccessSnapshotV1 } from './catalog-access-policy-v1.js';
@@ -14,6 +13,7 @@ import type {
 import {
   assertRfc64FinalizedPolicyAgentPrecommitSnapshotCurrentV1,
   resolveRfc64FinalizedPolicyAgentPrecommitV1,
+  type Rfc64FinalizedPolicyAgentPrecommitOptionsV1,
 } from './finalized-policy-agent-precommit-v1.js';
 import { createFinalizedVmRuntimeV1 } from './finalized-vm-runtime-v1.js';
 import type {
@@ -29,7 +29,8 @@ import {
 export interface Rfc64FinalizedVmAgentPrecommitOptionsV1 {
   readonly acceptedPolicySnapshotForCatalogScope:
     (scope: Readonly<AuthorCatalogScopeV1>) => AcceptedRfc64CatalogAccessSnapshotV1;
-  readonly rpcEndpoints: readonly string[] | null;
+  readonly createFinalizedSnapshotScope:
+    Rfc64FinalizedPolicyAgentPrecommitOptionsV1['createFinalizedSnapshotScope'];
   readonly getOnChainContextGraphId:
     (contextGraphId: ContextGraphIdV1, signal: AbortSignal) => Promise<string | null>;
   readonly getEvmChainId: () => Promise<bigint>;
@@ -131,15 +132,7 @@ export function createRfc64FinalizedVmAgentPrecommitV1(
       contextGraphStorageAddress: resolved.contextGraphStorageAddress,
       knowledgeAssetStorageAddress: canonicalKnowledgeAssetStorageAddress,
       knowledgeAssetsLifecycleAddress: canonicalKnowledgeAssetsLifecycleAddress,
-      snapshot: createStrictCurrentFinalizedEvmSnapshotScopeV1({
-        chainId: resolved.chainId,
-        endpoints: resolved.rpcEndpoints,
-        // This scope is constructed PER precommit invocation, so its admission
-        // must come from the process-wide per-chain registry — a gate private
-        // to this instance would have contended with nothing, and two
-        // concurrent precommits on one chain would both admit.
-        owner: 'rfc64',
-      }),
+      snapshot: resolved.snapshot,
       materialize: materializer,
       verifyExistingMaterialization:
         createFinalizedVmStoreExistingMaterializationVerifierV1({

--- a/packages/agent/src/rfc64/finalized-vm-agent-precommit-v1.ts
+++ b/packages/agent/src/rfc64/finalized-vm-agent-precommit-v1.ts
@@ -1,11 +1,6 @@
-import {
-  assertCanonicalEvmAddress,
-  type AuthorCatalogScopeV1,
-  type ContextGraphIdV1,
-} from '@origintrail-official/dkg-core';
+import { assertCanonicalEvmAddress } from '@origintrail-official/dkg-core';
 import type { TripleStore } from '@origintrail-official/dkg-storage';
 
-import type { AcceptedRfc64CatalogAccessSnapshotV1 } from './catalog-access-policy-v1.js';
 import type {
   Rfc64PublicCatalogNativePrimaryPrecommitHandlerV1,
   Rfc64PublicCatalogNativePrecommitTransactionV1,
@@ -13,7 +8,7 @@ import type {
 import {
   assertRfc64FinalizedPolicyAgentPrecommitSnapshotCurrentV1,
   resolveRfc64FinalizedPolicyAgentPrecommitV1,
-  type Rfc64FinalizedPolicyAgentPrecommitOptionsV1,
+  type Rfc64FinalizedPolicyAgentPrecommitResolutionOptionsV1,
 } from './finalized-policy-agent-precommit-v1.js';
 import { createFinalizedVmRuntimeV1 } from './finalized-vm-runtime-v1.js';
 import type {
@@ -26,14 +21,8 @@ import {
   createFinalizedVmStoreMaterializerV1,
 } from './finalized-vm-store-materializer-v1.js';
 
-export interface Rfc64FinalizedVmAgentPrecommitOptionsV1 {
-  readonly acceptedPolicySnapshotForCatalogScope:
-    (scope: Readonly<AuthorCatalogScopeV1>) => AcceptedRfc64CatalogAccessSnapshotV1;
-  readonly createFinalizedSnapshotScope:
-    Rfc64FinalizedPolicyAgentPrecommitOptionsV1['createFinalizedSnapshotScope'];
-  readonly getOnChainContextGraphId:
-    (contextGraphId: ContextGraphIdV1, signal: AbortSignal) => Promise<string | null>;
-  readonly getEvmChainId: () => Promise<bigint>;
+export interface Rfc64FinalizedVmAgentPrecommitOptionsV1
+  extends Rfc64FinalizedPolicyAgentPrecommitResolutionOptionsV1 {
   readonly getKnowledgeAssetStorageAddress: () => Promise<string>;
   readonly getKnowledgeAssetsLifecycleAddress: () => Promise<string>;
   readonly store: TripleStore;

--- a/packages/agent/test/e2e-join.test.ts
+++ b/packages/agent/test/e2e-join.test.ts
@@ -88,15 +88,6 @@ describe('E2E: cross-node curated-CG join over real libp2p (shared chain)', () =
   });
 
   it('boots two real agents, connects them over libp2p, and registers the requesting agents', async () => {
-    const { rpcUrl, hubAddress } = getSharedContext();
-    // The shared adapter handles transactions; finalized catalog recovery also
-    // needs the trusted RPC/Hub configuration to verify its own chain snapshot.
-    const chainConfig = {
-      rpcUrl,
-      hubAddress,
-      chainId: sharedChain.chainId,
-      operationalKeys: [HARDHAT_KEYS.CORE_OP],
-    };
     const curatorDataDir = await mkdtemp(join(tmpdir(), 'dkg-e2e-join-curator-'));
     const joinerDataDir = await mkdtemp(join(tmpdir(), 'dkg-e2e-join-joiner-'));
     tempDirs.push(curatorDataDir, joinerDataDir);
@@ -107,7 +98,6 @@ describe('E2E: cross-node curated-CG join over real libp2p (shared chain)', () =
       listenPort: 0,
       skills: [],
       chainAdapter: sharedChain,
-      chainConfig,
       nodeRole: 'core',
       dataDir: curatorDataDir,
     });
@@ -118,7 +108,6 @@ describe('E2E: cross-node curated-CG join over real libp2p (shared chain)', () =
       listenPort: 0,
       skills: [],
       chainAdapter: sharedChain,
-      chainConfig,
       nodeRole: 'edge',
       dataDir: joinerDataDir,
       contextGraphSubscriptionStore: {

--- a/packages/agent/test/e2e-join.test.ts
+++ b/packages/agent/test/e2e-join.test.ts
@@ -88,6 +88,15 @@ describe('E2E: cross-node curated-CG join over real libp2p (shared chain)', () =
   });
 
   it('boots two real agents, connects them over libp2p, and registers the requesting agents', async () => {
+    const { rpcUrl, hubAddress } = getSharedContext();
+    // The shared adapter handles transactions; finalized catalog recovery also
+    // needs the trusted RPC/Hub configuration to verify its own chain snapshot.
+    const chainConfig = {
+      rpcUrl,
+      hubAddress,
+      chainId: sharedChain.chainId,
+      operationalKeys: [HARDHAT_KEYS.CORE_OP],
+    };
     const curatorDataDir = await mkdtemp(join(tmpdir(), 'dkg-e2e-join-curator-'));
     const joinerDataDir = await mkdtemp(join(tmpdir(), 'dkg-e2e-join-joiner-'));
     tempDirs.push(curatorDataDir, joinerDataDir);
@@ -98,6 +107,7 @@ describe('E2E: cross-node curated-CG join over real libp2p (shared chain)', () =
       listenPort: 0,
       skills: [],
       chainAdapter: sharedChain,
+      chainConfig,
       nodeRole: 'core',
       dataDir: curatorDataDir,
     });
@@ -108,6 +118,7 @@ describe('E2E: cross-node curated-CG join over real libp2p (shared chain)', () =
       listenPort: 0,
       skills: [],
       chainAdapter: sharedChain,
+      chainConfig,
       nodeRole: 'edge',
       dataDir: joinerDataDir,
       contextGraphSubscriptionStore: {
@@ -193,16 +204,20 @@ describe('E2E: cross-node curated-CG join over real libp2p (shared chain)', () =
           `SELECT ?name WHERE { <${subject}> <http://schema.org/name> ?name . }`,
           CG,
         );
+        const catalog = (await joiner.readRfc64CatalogOperationalStatusV1())
+          .find(status => status.contextGraphId === CG);
         return {
           subscribed: joiner.getSubscribedContextGraphs().get(CG)?.subscribed === true,
           hasData: data.bindings.length > 0,
+          catalogApplied: catalog?.appliedRowCount === '1'
+            && catalog.appliedCatalogHeadDigest !== null,
         };
       },
-      (state) => state.subscribed && state.hasData,
+      (state) => state.subscribed && state.hasData && state.catalogApplied,
       60_000,
     );
 
-    expect(caughtUp).toEqual({ subscribed: true, hasData: true });
+    expect(caughtUp).toEqual({ subscribed: true, hasData: true, catalogApplied: true });
     // The 10.0.16 default installs RFC-64 catalog responsibility for an
     // approved private member. Catch-up must complete without reviving the
     // legacy GossipSub or durable-sync receiver lanes.

--- a/packages/agent/test/finalized-adapter-compatibility.typecheck.ts
+++ b/packages/agent/test/finalized-adapter-compatibility.typecheck.ts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ChainAdapter } from '@origintrail-official/dkg-chain';
+
+// Existing implementations need no finalized-EVM method to remain adapters.
+declare const legacyAdapter: Omit<ChainAdapter, 'createFinalizedEvmReadBinding'>;
+const supportedAdapter: ChainAdapter = legacyAdapter;
+void supportedAdapter;

--- a/packages/agent/test/finalized-adapter-compatibility.typecheck.ts
+++ b/packages/agent/test/finalized-adapter-compatibility.typecheck.ts
@@ -1,8 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ChainAdapter } from '@origintrail-official/dkg-chain';
+import type { ChainAdapter, FinalizedEvmReadBindingProvider, FinalizedEvmReadBindingV1 } from '@origintrail-official/dkg-chain';
 
 // Existing implementations need no finalized-EVM method to remain adapters.
 declare const legacyAdapter: Omit<ChainAdapter, 'createFinalizedEvmReadBinding'>;
 const supportedAdapter: ChainAdapter = legacyAdapter;
 void supportedAdapter;
+
+// Advertising the capability guarantees a binding; refusal is an exception.
+declare const provider: FinalizedEvmReadBindingProvider;
+const binding: Promise<Readonly<FinalizedEvmReadBindingV1>> =
+  provider.createFinalizedEvmReadBinding('rfc64');
+void binding;
+const nullableProvider: FinalizedEvmReadBindingProvider = {
+  // @ts-expect-error A supported provider cannot return an absent binding.
+  createFinalizedEvmReadBinding: async () => null,
+};
+void nullableProvider;

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -112,6 +112,7 @@ import {
   createLoopbackJsonRpcTestHarness,
   sendJsonRpcError,
   sendJsonRpcResult,
+  type LoopbackJsonRpcHandler,
 } from '../../chain/test/loopback-rpc-harness.js';
 import {
   FinalizedVmLoopbackMockChainAdapterV1,
@@ -250,10 +251,7 @@ async function startNativeAgent(
   deployment: CatalogSealDeploymentProfileV1 = NATIVE_DEPLOYMENT,
   existingDataDir?: string,
   accessPolicyAuthority?: Rfc64CatalogAccessPolicyAuthorityConfigV1,
-  finalizedRuntime?: Readonly<{
-    chainAdapter: FinalizedVmLoopbackMockChainAdapterV1;
-    initialSubscription?: ContextGraphIdV1;
-  }>,
+  finalizedRuntime?: NativeAgentStartOptionsV1['finalizedRuntime'],
   autoPublish?: Rfc64PublicCatalogAutoPublishConfigV1,
 ): Promise<DKGAgent> {
   return startNativeAgentWithOptions({
@@ -274,6 +272,7 @@ interface NativeAgentStartOptionsV1 {
   readonly finalizedRuntime?: Readonly<{
     chainAdapter: FinalizedVmLoopbackMockChainAdapterV1;
     initialSubscription?: ContextGraphIdV1;
+    configuredRpcUrl?: string;
   }>;
   readonly autoPublish?: Rfc64PublicCatalogAutoPublishConfigV1;
   readonly bootstrap?: Rfc64PublicCatalogBootstrapConfigV1;
@@ -363,7 +362,7 @@ async function startNativeAgentWithOptions(
       chainAdapter: finalizedRuntime.chainAdapter,
       chainConfig: {
         // The chain config supplies fixture operational keys; the adapter owns RPC.
-        rpcUrl: finalizedRuntime.chainAdapter.getRpcUrls()[0]!,
+        rpcUrl: finalizedRuntime.configuredRpcUrl ?? finalizedRuntime.chainAdapter.getRpcUrls()[0]!,
         hubAddress: CONTEXT_GRAPH_STORAGE,
         operationalKeys: [`0x${'12'.repeat(32)}`],
       },
@@ -8398,7 +8397,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     })).toBeNull();
   }, 60_000);
 
-  it('applies a finalized-policy SWM successor through production wiring without VM writes', async () => {
+  it('applies a finalized-policy SWM successor using the injected adapter RPC when chainConfig points elsewhere', async () => {
     const nameHash = ethers.keccak256(ethers.toUtf8Bytes(CONTEXT_GRAPH_ID)).toLowerCase();
     const fixture = Object.freeze({
       accessPolicy: 0,
@@ -8417,7 +8416,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       publishPolicy: 1,
     } satisfies FinalizedVmLoopbackFixtureConfigV1);
     const finalizedRpc = createFinalizedVmLoopbackRpcV1(fixture);
-    const rpc = await rpcHarness.start((call, response) => {
+    const respond: LoopbackJsonRpcHandler = (call, response) => {
       try {
         sendJsonRpcResult(response, call, finalizedRpc.respond(call.method, call.params));
       } catch (cause) {
@@ -8428,8 +8427,14 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
           cause instanceof Error ? cause.message : String(cause),
         );
       }
+    };
+    const rpc = await rpcHarness.start(respond);
+    const authorRpc = await rpcHarness.start(respond);
+    const configuredRpc = await rpcHarness.start((call, response) => {
+      sendJsonRpcError(response, call, -32603, 'chainConfig RPC must not own finalized catalog reads');
     });
     const receiverChain = new FinalizedVmLoopbackMockChainAdapterV1(fixture, rpc.url);
+    const readBinding = vi.spyOn(receiverChain, 'createFinalizedEvmReadBinding');
     const privateVmDependencyLookup = vi.spyOn(
       receiverChain,
       'getDKGKnowledgeAssetsAddress',
@@ -8447,6 +8452,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       {
         chainAdapter: receiverChain,
         initialSubscription: CONTEXT_GRAPH_ID,
+        configuredRpcUrl: configuredRpc.url,
       },
     );
     const author = await startNativeAgent(
@@ -8455,7 +8461,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       undefined,
       undefined,
       {
-        chainAdapter: new FinalizedVmLoopbackMockChainAdapterV1(fixture, rpc.url),
+        chainAdapter: new FinalizedVmLoopbackMockChainAdapterV1(fixture, authorRpc.url),
       },
       {
         peers: [receiver.peerId],
@@ -8482,6 +8488,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       });
     }
     await connectBothWays(author, receiver);
+    const readsBeforePublication = rpc.calls.length;
 
     const publicQuads = [{
       subject: 'https://example.org/policy-only',
@@ -8514,6 +8521,31 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       published.currentCatalogHeadDigest,
     )).toBeNull();
     expect(privateVmDependencyLookup).not.toHaveBeenCalled();
+    expect(configuredRpc.calls).toEqual([]);
+    expect(readBinding).toHaveBeenCalledWith('rfc64');
+    // Only the receiver uses this endpoint. Require the actual policy read for
+    // numeric CG 14 after publication; startup probes cannot satisfy this check.
+    const policyReadData = new ethers.Interface([
+      'function getContextGraph(uint256 contextGraphId)',
+    ]).encodeFunctionData('getContextGraph', [onChainContextGraphId]);
+    expect(rpc.calls.slice(readsBeforePublication)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        method: 'eth_getBlockByNumber', params: ['finalized', false],
+      }),
+      expect.objectContaining({
+        method: 'eth_call',
+        params: expect.arrayContaining([
+          expect.objectContaining({ to: CONTEXT_GRAPH_STORAGE, data: policyReadData }),
+        ]),
+      }),
+    ]));
+    expect(authority.policy).toMatchObject({
+      accessPolicy: 0,
+      publishPolicy: 1,
+      source: { kind: 'finalized-chain' },
+    });
+    await expect(receiver.getContextGraphOnChainId(CONTEXT_GRAPH_ID))
+      .resolves.toBe(ON_CHAIN_CONTEXT_GRAPH_ID);
     expect(receiver.readRfc64AppliedCatalogHeadV1({
       catalogScopeDigest: computeAuthorCatalogScopeDigestV1(scope),
       authorAddress: AUTHOR,

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -251,7 +251,6 @@ async function startNativeAgent(
   existingDataDir?: string,
   accessPolicyAuthority?: Rfc64CatalogAccessPolicyAuthorityConfigV1,
   finalizedRuntime?: Readonly<{
-    rpcUrl: string;
     chainAdapter: FinalizedVmLoopbackMockChainAdapterV1;
     initialSubscription?: ContextGraphIdV1;
   }>,
@@ -273,7 +272,6 @@ interface NativeAgentStartOptionsV1 {
   readonly existingDataDir?: string;
   readonly accessPolicyAuthority?: Rfc64CatalogAccessPolicyAuthorityConfigV1;
   readonly finalizedRuntime?: Readonly<{
-    rpcUrl: string;
     chainAdapter: FinalizedVmLoopbackMockChainAdapterV1;
     initialSubscription?: ContextGraphIdV1;
   }>;
@@ -364,7 +362,8 @@ async function startNativeAgentWithOptions(
     ...(finalizedRuntime === undefined ? {} : {
       chainAdapter: finalizedRuntime.chainAdapter,
       chainConfig: {
-        rpcUrl: finalizedRuntime.rpcUrl,
+        // The chain config supplies fixture operational keys; the adapter owns RPC.
+        rpcUrl: finalizedRuntime.chainAdapter.getRpcUrls()[0]!,
         hubAddress: CONTEXT_GRAPH_STORAGE,
         operationalKeys: [`0x${'12'.repeat(32)}`],
       },
@@ -7253,7 +7252,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
         );
       }
     });
-    const adapter = new FinalizedVmLoopbackMockChainAdapterV1(fixture);
+    const adapter = new FinalizedVmLoopbackMockChainAdapterV1(fixture, rpcServer.url);
     await adapter.createOnChainContextGraph({ accessPolicy: 1, publishPolicy: 0, nameHash });
 
     const policy: ContextGraphPolicyV1 = {
@@ -7285,7 +7284,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
         localAgentAddress: AUTHOR,
         resolveRemoteAgentAddress: async (peerId) => peerAddresses.get(peerId) ?? null,
       },
-      finalizedRuntime: { rpcUrl: rpcServer.url, chainAdapter: adapter },
+      finalizedRuntime: { chainAdapter: adapter },
     });
     allowAllNetworkAdmissionForTest(provider);
     provider.acceptRfc64CatalogAccessSnapshotV1({ policy, policyDigest, roster });
@@ -8011,7 +8010,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
         resolveRemoteAgentAddress: async (peerId) => authorPeerAddresses.get(peerId) ?? null,
       },
     });
-    const providerAdapter = new FinalizedVmLoopbackMockChainAdapterV1(emptyFixture);
+    const providerAdapter = new FinalizedVmLoopbackMockChainAdapterV1(emptyFixture, providerRpcServer.url);
     await providerAdapter.createOnChainContextGraph({
       accessPolicy: 1,
       publishPolicy: 0,
@@ -8032,7 +8031,6 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
         ),
       },
       finalizedRuntime: {
-        rpcUrl: providerRpcServer.url,
         chainAdapter: providerAdapter,
       },
     });
@@ -8103,7 +8101,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
         );
       }
     });
-    const authorizedAdapter = new FinalizedVmLoopbackMockChainAdapterV1(providerFixture);
+    const authorizedAdapter = new FinalizedVmLoopbackMockChainAdapterV1(providerFixture, authorizedRpcServer.url);
     await authorizedAdapter.createOnChainContextGraph({
       accessPolicy: 1,
       publishPolicy: 0,
@@ -8123,7 +8121,6 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     const authorizedCold = await startNativeAgentWithOptions({
       name: 'private-authorized-cold',
       finalizedRuntime: {
-        rpcUrl: authorizedRpcServer.url,
         chainAdapter: authorizedAdapter,
         initialSubscription: CONTEXT_GRAPH_ID,
       },
@@ -8286,7 +8283,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     expect(deniedUnscopedResult.bindings).toEqual([]);
 
     unboundColdAgentAddress = coldAgentAddress;
-    const coldAdapter = new FinalizedVmLoopbackMockChainAdapterV1(coldFixture);
+    const coldAdapter = new FinalizedVmLoopbackMockChainAdapterV1(coldFixture, coldRpcServer.url);
     await coldAdapter.createOnChainContextGraph({
       accessPolicy: 1,
       publishPolicy: 0,
@@ -8296,7 +8293,6 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     const cold = await startNativeAgentWithOptions({
       name: 'private-incomplete-cold',
       finalizedRuntime: {
-        rpcUrl: coldRpcServer.url,
         chainAdapter: coldAdapter,
         initialSubscription: CONTEXT_GRAPH_ID,
       },
@@ -8424,7 +8420,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
         );
       }
     });
-    const receiverChain = new FinalizedVmLoopbackMockChainAdapterV1(fixture);
+    const receiverChain = new FinalizedVmLoopbackMockChainAdapterV1(fixture, rpc.url);
     const privateVmDependencyLookup = vi.spyOn(
       receiverChain,
       'getDKGKnowledgeAssetsAddress',
@@ -8440,7 +8436,6 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       undefined,
       undefined,
       {
-        rpcUrl: rpc.url,
         chainAdapter: receiverChain,
         initialSubscription: CONTEXT_GRAPH_ID,
       },
@@ -8451,8 +8446,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       undefined,
       undefined,
       {
-        rpcUrl: rpc.url,
-        chainAdapter: new FinalizedVmLoopbackMockChainAdapterV1(fixture),
+        chainAdapter: new FinalizedVmLoopbackMockChainAdapterV1(fixture, rpc.url),
       },
       {
         peers: [receiver.peerId],
@@ -8595,7 +8589,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       storePath: string,
       bootstrapConfig?: Rfc64PublicCatalogBootstrapConfigV1,
     ): Promise<DKGAgent> => {
-      const chainAdapter = new FinalizedVmLoopbackMockChainAdapterV1(fixture);
+      const chainAdapter = new FinalizedVmLoopbackMockChainAdapterV1(fixture, rpc.url);
       await chainAdapter.createOnChainContextGraph({
         accessPolicy: 0,
         publishPolicy: 0,
@@ -8605,7 +8599,6 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
         name,
         existingDataDir: dataDir,
         finalizedRuntime: {
-          rpcUrl: rpc.url,
           chainAdapter,
           initialSubscription: CONTEXT_GRAPH_ID,
         },
@@ -8635,8 +8628,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       undefined,
       undefined,
       {
-        rpcUrl: rpc.url,
-        chainAdapter: new FinalizedVmLoopbackMockChainAdapterV1(fixture),
+        chainAdapter: new FinalizedVmLoopbackMockChainAdapterV1(fixture, rpc.url),
       },
       {
         peers: [warm.peerId],

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -8010,7 +8010,10 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
         resolveRemoteAgentAddress: async (peerId) => authorPeerAddresses.get(peerId) ?? null,
       },
     });
-    const providerAdapter = new FinalizedVmLoopbackMockChainAdapterV1(emptyFixture, providerRpcServer.url);
+    const providerAdapter = new FinalizedVmLoopbackMockChainAdapterV1(
+      emptyFixture,
+      providerRpcServer.url,
+    );
     await providerAdapter.createOnChainContextGraph({
       accessPolicy: 1,
       publishPolicy: 0,
@@ -8101,7 +8104,10 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
         );
       }
     });
-    const authorizedAdapter = new FinalizedVmLoopbackMockChainAdapterV1(providerFixture, authorizedRpcServer.url);
+    const authorizedAdapter = new FinalizedVmLoopbackMockChainAdapterV1(
+      providerFixture,
+      authorizedRpcServer.url,
+    );
     await authorizedAdapter.createOnChainContextGraph({
       accessPolicy: 1,
       publishPolicy: 0,
@@ -8283,7 +8289,10 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     expect(deniedUnscopedResult.bindings).toEqual([]);
 
     unboundColdAgentAddress = coldAgentAddress;
-    const coldAdapter = new FinalizedVmLoopbackMockChainAdapterV1(coldFixture, coldRpcServer.url);
+    const coldAdapter = new FinalizedVmLoopbackMockChainAdapterV1(
+      coldFixture,
+      coldRpcServer.url,
+    );
     await coldAdapter.createOnChainContextGraph({
       accessPolicy: 1,
       publishPolicy: 0,

--- a/packages/agent/test/rfc64-finalized-adapter-compatibility.test.ts
+++ b/packages/agent/test/rfc64-finalized-adapter-compatibility.test.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { MockChainAdapter, NoChainAdapter, type ChainAdapter } from '@origintrail-official/dkg-chain';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { describe, expect, it, vi } from 'vitest';
+import { createRfc64FinalizedAgentPrecommitsV1 } from '../src/rfc64/finalized-agent-precommits-v1.js';
+import { acceptedRfc64VmPolicySnapshot, rfc64FinalizedVmPrecommitPlan } from './support/rfc64-finalized-vm-precommit-fixture.js';
+import { RFC64_VM_AUTHOR, RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID } from './support/rfc64-finalized-vm-placement-fixture.js';
+
+function legacyAdapter(): ChainAdapter {
+  const adapter = new MockChainAdapter();
+  // Model an already compiled custom adapter that predates this capability.
+  Object.defineProperty(adapter, 'createFinalizedEvmReadBinding', { value: undefined });
+  return adapter;
+}
+
+describe('legacy adapters at the finalized catalog composition boundary', () => {
+  it.each(['finalizedPolicyPrecommit', 'finalizedVmPrecommit'] as const)(
+    '%s rejects a missing capability with the controlled configuration error', async kind => {
+      const store = new OxigraphStore();
+      const chain = legacyAdapter();
+      const handlers = createRfc64FinalizedAgentPrecommitsV1({
+        chain, store,
+        acceptedPolicySnapshotForCatalogScope: acceptedRfc64VmPolicySnapshot,
+        getOnChainContextGraphId: async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID,
+      });
+      try {
+        await expect(handlers[kind](rfc64FinalizedVmPrecommitPlan(), new AbortController().signal))
+          .rejects.toThrow('RFC-64 finalized precommit requires trusted RPC configuration');
+        await expect(chain.getIdentityId()).resolves.toBe(0n);
+      } finally {
+        await store.close();
+      }
+    },
+  );
+
+  it.each([legacyAdapter(), new NoChainAdapter()])('keeps owner-signed policies usable without EVM reads', async chain => {
+    const store = new OxigraphStore();
+    const accepted = acceptedRfc64VmPolicySnapshot();
+    const finalizedPlan = rfc64FinalizedVmPrecommitPlan();
+    const resolveOnChain = vi.fn(async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID);
+    const { finalizedPolicyPrecommit } = createRfc64FinalizedAgentPrecommitsV1({
+      chain, store,
+      acceptedPolicySnapshotForCatalogScope: () => ({
+        ...accepted,
+        policy: {
+          ...accepted.policy, governanceChainId: null, governanceContractAddress: null,
+          source: { kind: 'owner-signed-unregistered', ownerAddress: RFC64_VM_AUTHOR, ownerAuthorityEra: accepted.policy.era },
+        },
+      }),
+      getOnChainContextGraphId: resolveOnChain,
+    });
+    try {
+      await expect(finalizedPolicyPrecommit({
+        ...finalizedPlan,
+        catalogScope: { ...finalizedPlan.catalogScope, governanceChainId: null, governanceContractAddress: null },
+      }, new AbortController().signal)).resolves.toBeUndefined();
+      expect(resolveOnChain).not.toHaveBeenCalled();
+    } finally {
+      await store.close();
+    }
+  });
+});

--- a/packages/agent/test/rfc64-finalized-adapter-compatibility.test.ts
+++ b/packages/agent/test/rfc64-finalized-adapter-compatibility.test.ts
@@ -15,10 +15,15 @@ function legacyAdapter(): ChainAdapter {
 }
 
 describe('legacy adapters at the finalized catalog composition boundary', () => {
-  it.each(['finalizedPolicyPrecommit', 'finalizedVmPrecommit'] as const)(
-    '%s rejects a missing capability with the controlled configuration error', async kind => {
+  it.each([
+    ['finalizedPolicyPrecommit', 'legacy', legacyAdapter],
+    ['finalizedVmPrecommit', 'legacy', legacyAdapter],
+    ['finalizedPolicyPrecommit', 'no-chain', () => new NoChainAdapter()],
+    ['finalizedVmPrecommit', 'no-chain', () => new NoChainAdapter()],
+  ] as const)(
+    '%s rejects a missing capability on %s with the controlled configuration error', async (kind, _label, makeChain) => {
       const store = new OxigraphStore();
-      const chain = legacyAdapter();
+      const chain = makeChain();
       const handlers = createRfc64FinalizedAgentPrecommitsV1({
         chain, store,
         acceptedPolicySnapshotForCatalogScope: acceptedRfc64VmPolicySnapshot,
@@ -27,10 +32,28 @@ describe('legacy adapters at the finalized catalog composition boundary', () => 
       try {
         await expect(handlers[kind](rfc64FinalizedVmPrecommitPlan(), new AbortController().signal))
           .rejects.toThrow('RFC-64 finalized precommit requires trusted RPC configuration');
-        await expect(chain.getIdentityId()).resolves.toBe(0n);
       } finally {
         await store.close();
       }
+    },
+  );
+
+  it.each(['finalizedPolicyPrecommit', 'finalizedVmPrecommit'] as const)(
+    '%s preserves a supported provider failure', async kind => {
+      const store = new OxigraphStore();
+      const failure = new Error('adapter-owned endpoint failed');
+      const create = vi.fn(async () => { throw failure; });
+      const chain = Object.assign(new MockChainAdapter(), { createFinalizedEvmReadBinding: create });
+      const handlers = createRfc64FinalizedAgentPrecommitsV1({
+        chain, store,
+        acceptedPolicySnapshotForCatalogScope: acceptedRfc64VmPolicySnapshot,
+        getOnChainContextGraphId: async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID,
+      });
+      try {
+        await expect(handlers[kind](rfc64FinalizedVmPrecommitPlan(), new AbortController().signal))
+          .rejects.toBe(failure);
+        expect(create).toHaveBeenCalledExactlyOnceWith('rfc64');
+      } finally { await store.close(); }
     },
   );
 

--- a/packages/agent/test/rfc64-finalized-chain-harness.test.ts
+++ b/packages/agent/test/rfc64-finalized-chain-harness.test.ts
@@ -1,0 +1,106 @@
+import { ethers } from 'ethers';
+import { describe, expect, it } from 'vitest';
+import {
+  parseFinalizedChainHarnessConfigV1,
+  startFinalizedChainHarnessRuntimeV1,
+  type FinalizedChainHarnessConfigV1,
+} from '../../../devnet/rfc64-gate2-multi-asset-completeness/finalized-chain-harness-runtime.js';
+import {
+  FinalizedChainLoopbackMockChainAdapterV1,
+  FINALIZED_CONTEXT_GRAPH_INTERFACE,
+} from './support/rfc64-finalized-chain-loopback-fixture.js';
+import { FinalizedVmLoopbackMockChainAdapterV1 } from './support/rfc64-finalized-vm-loopback-fixture.js';
+
+const authority = {
+  accessPolicy: 0,
+  contextGraphId: 'finalized-harness',
+  nameHash: `0x${'11'.repeat(32)}`,
+  onChainContextGraphId: '14',
+  ownerAddress: `0x${'22'.repeat(20)}`,
+};
+const cgStorage = `0x${'33'.repeat(20)}`;
+const kaStorage = `0x${'55'.repeat(20)}`;
+const kaInterface = new ethers.Interface([
+  'function getKnowledgeAssetUpdateContext(uint256 id) view returns (uint256 merkleRootsCount, uint256 minted, uint88 byteSize, uint40 endEpoch, uint96 tokenAmount, bool isImmutable, uint32 merkleLeafCount)',
+  'function getLatestMerkleRoot(uint256 id) view returns (bytes32)',
+  'function getLatestMerkleRootAuthor(uint256 id) view returns (address)',
+  'function getLatestMerkleRootPublisher(uint256 id) view returns (address)',
+]);
+
+async function read(rpcUrl: string, abi: ethers.Interface, target: string, method: string, args: readonly unknown[]) {
+  const response = await fetch(rpcUrl, {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'eth_call', params: [
+      { to: target, data: abi.encodeFunctionData(method, args) }, 'finalized',
+    ] }),
+  });
+  const body = await response.json() as { result?: string; error?: { message: string } };
+  if (body.error) throw new Error(body.error.message);
+  if (typeof body.result !== 'string') throw new Error('missing RPC result');
+  return abi.decodeFunctionResult(method, body.result);
+}
+
+// A VM runtime cannot be requested without its inventory at the typed boundary.
+const parsedPolicy = parseFinalizedChainHarnessConfigV1(JSON.stringify(authority));
+// @ts-expect-error VM configuration requires a VM inventory.
+const invalidVm: FinalizedChainHarnessConfigV1 = { ...parsedPolicy, kind: 'vm' };
+void invalidVm;
+
+describe('finalized chain harness compositions', () => {
+  it('serves policy authority and zero inventory without a VM adapter', async () => {
+    const runtime = await startFinalizedChainHarnessRuntimeV1(parsedPolicy);
+    try {
+      expect(runtime.kind).toBe('policy');
+      expect(runtime.chainAdapter.constructor).toBe(FinalizedChainLoopbackMockChainAdapterV1);
+      expect(await read(runtime.rpcUrl, FINALIZED_CONTEXT_GRAPH_INTERFACE, cgStorage, 'getNameHash', [14n]))
+        .toEqual([authority.nameHash]);
+      expect(await read(runtime.rpcUrl, FINALIZED_CONTEXT_GRAPH_INTERFACE, cgStorage, 'getContextGraphKaCount', [14n]))
+        .toEqual([0n]);
+      await expect(read(runtime.rpcUrl, FINALIZED_CONTEXT_GRAPH_INTERFACE, cgStorage, 'getContextGraphKaAt', [14n, 0n]))
+        .rejects.toThrow('empty finalized chain inventory');
+      await expect(read(runtime.rpcUrl, kaInterface, kaStorage, 'getLatestMerkleRoot', [1n]))
+        .rejects.toThrow('unexpected finalized chain eth_call selector');
+    } finally { await runtime.close(); }
+  });
+
+  it('layers all multi-asset inventory responses over the same private authority', async () => {
+    const assets = [1, 2].map(index => ({
+      assertionRoot: `0x${String(index).repeat(64)}`, assertionVersion: String(index + 2),
+      authorAddress: `0x${String(index + 6).repeat(40)}`, kaId: String(index),
+    }));
+    const config = parseFinalizedChainHarnessConfigV1(JSON.stringify({ ...authority, accessPolicy: 1, vmInventory: { assets } }));
+    const runtime = await startFinalizedChainHarnessRuntimeV1(config);
+    try {
+      expect(config.kind).toBe('vm');
+      expect(runtime.kind).toBe('vm');
+      expect(runtime.chainAdapter).toBeInstanceOf(FinalizedVmLoopbackMockChainAdapterV1);
+      expect(await runtime.chainAdapter.getDKGKnowledgeAssetsAddress()).toBe(kaStorage);
+      const cg = await read(runtime.rpcUrl, FINALIZED_CONTEXT_GRAPH_INTERFACE, cgStorage, 'getContextGraph', [14n]);
+      expect(cg.owner.toLowerCase()).toBe(authority.ownerAddress);
+      expect(cg.accessPolicy).toBe(1n);
+      expect(await read(runtime.rpcUrl, FINALIZED_CONTEXT_GRAPH_INTERFACE, cgStorage, 'getContextGraphKaCount', [14n]))
+        .toEqual([2n]);
+      for (const [ordinal, asset] of assets.entries()) {
+        expect(await read(runtime.rpcUrl, FINALIZED_CONTEXT_GRAPH_INTERFACE, cgStorage, 'getContextGraphKaAt', [14n, ordinal]))
+          .toEqual([BigInt(asset.kaId)]);
+        const update = await read(runtime.rpcUrl, kaInterface, kaStorage, 'getKnowledgeAssetUpdateContext', [asset.kaId]);
+        expect(update.merkleRootsCount).toBe(BigInt(asset.assertionVersion));
+        expect(await read(runtime.rpcUrl, kaInterface, kaStorage, 'getLatestMerkleRoot', [asset.kaId]))
+          .toEqual([asset.assertionRoot]);
+        expect((await read(runtime.rpcUrl, kaInterface, kaStorage, 'getLatestMerkleRootAuthor', [asset.kaId]))[0].toLowerCase())
+          .toBe(asset.authorAddress);
+        expect(await read(runtime.rpcUrl, kaInterface, kaStorage, 'getLatestMerkleRootPublisher', [asset.kaId]))
+          .toEqual([`0x${'66'.repeat(20)}`]);
+      }
+      await expect(read(runtime.rpcUrl, FINALIZED_CONTEXT_GRAPH_INTERFACE, cgStorage, 'getContextGraphKaAt', [14n, 2n]))
+        .rejects.toThrow('unknown finalized VM ordinal');
+      await expect(read(runtime.rpcUrl, kaInterface, cgStorage, 'getLatestMerkleRoot', [1n]))
+        .rejects.toThrow('unexpected finalized chain knowledge asset storage target');
+    } finally { await runtime.close(); }
+  });
+
+  it('rejects an explicitly requested empty VM inventory', () => {
+    expect(() => parseFinalizedChainHarnessConfigV1(JSON.stringify({ ...authority, vmInventory: { assets: [] } })))
+      .toThrow('assets must not be empty');
+  });
+});

--- a/packages/agent/test/rfc64-finalized-policy-agent-precommit-v1.test.ts
+++ b/packages/agent/test/rfc64-finalized-policy-agent-precommit-v1.test.ts
@@ -26,7 +26,7 @@ import {
 } from './support/rfc64-finalized-vm-placement-fixture.js';
 import {
   acceptedRfc64VmPolicySnapshot,
-  finalizedSnapshotScopeFactory,
+  finalizedReadBindingFactory,
   rfc64FinalizedVmPrecommitOptions,
   rfc64FinalizedVmPrecommitPlan,
 } from './support/rfc64-finalized-vm-precommit-fixture.js';
@@ -45,9 +45,8 @@ function options() {
   const fixture = rfc64FinalizedVmPrecommitOptions();
   return {
     acceptedPolicySnapshotForCatalogScope: fixture.acceptedPolicySnapshotForCatalogScope,
-    createFinalizedSnapshotScope: fixture.createFinalizedSnapshotScope,
+    createFinalizedReadBinding: fixture.createFinalizedReadBinding,
     getOnChainContextGraphId: fixture.getOnChainContextGraphId,
-    getEvmChainId: fixture.getEvmChainId,
   };
 }
 
@@ -92,7 +91,7 @@ async function liveOptions(
   return {
     options: {
       ...options(),
-      createFinalizedSnapshotScope: finalizedSnapshotScopeFactory([server.url]),
+      createFinalizedReadBinding: finalizedReadBindingFactory([server.url]),
     },
     rpc,
   };
@@ -156,14 +155,37 @@ function privateOwnerPlan(policyDigest = RFC64_VM_POLICY_DIGEST) {
 }
 
 describe('RFC-64 finalized policy agent precommit', () => {
+  it('starts numeric CG resolution while the adapter binding is still pending', async () => {
+    const live = await liveOptions();
+    let releaseBinding!: () => void;
+    const pending = new Promise<void>((resolve) => { releaseBinding = resolve; });
+    const createFinalizedReadBinding = vi.fn(async () => {
+      await pending;
+      return live.options.createFinalizedReadBinding();
+    });
+    const getOnChainContextGraphId = vi.fn(async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID);
+    const handler = createRfc64FinalizedPolicyAgentPrecommitV1({
+      ...live.options, createFinalizedReadBinding, getOnChainContextGraphId,
+    });
+    const running = handler(rfc64FinalizedVmPrecommitPlan(), new AbortController().signal);
+    try {
+      expect(createFinalizedReadBinding).toHaveBeenCalledOnce();
+      expect(getOnChainContextGraphId).toHaveBeenCalledOnce();
+      expect(live.rpc.calls).toHaveLength(0);
+    } finally {
+      releaseBinding();
+      await running;
+    }
+  });
+
   it('accepts a chain-bound SWM catalog without invoking VM materialization', async () => {
     const getOnChainContextGraphId = vi.fn(async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID);
-    const getEvmChainId = vi.fn(async () => BigInt(RFC64_VM_CHAIN_ID));
     const live = await liveOptions();
+    const createFinalizedReadBinding = vi.fn(live.options.createFinalizedReadBinding);
     const handler = createRfc64FinalizedPolicyAgentPrecommitV1({
       ...live.options,
       getOnChainContextGraphId,
-      getEvmChainId,
+      createFinalizedReadBinding,
     });
 
     await expect(handler(
@@ -174,34 +196,33 @@ describe('RFC-64 finalized policy agent precommit', () => {
       RFC64_VM_CONTEXT_GRAPH_NAME,
       expect.any(AbortSignal),
     );
-    expect(getEvmChainId).toHaveBeenCalledOnce();
+    expect(createFinalizedReadBinding).toHaveBeenCalledOnce();
     expect(live.rpc.calls.filter((call) => (
       call.method === 'eth_call'
       && (call.params[0] as { data?: string } | undefined)?.data !== '0x'
     ))).toHaveLength(2);
   });
 
-  it('rejects before chain resolution when trusted RPC endpoints are absent', async () => {
+  it('rejects unavailable finalized reads after resolving the shared binding', async () => {
     const getOnChainContextGraphId = vi.fn(async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID);
-    const getEvmChainId = vi.fn(async () => BigInt(RFC64_VM_CHAIN_ID));
+    const createFinalizedReadBinding = vi.fn(async () => null);
     const handler = createRfc64FinalizedPolicyAgentPrecommitV1({
       ...options(),
-      createFinalizedSnapshotScope: null,
       getOnChainContextGraphId,
-      getEvmChainId,
+      createFinalizedReadBinding,
     });
 
     await expect(handler(
       rfc64FinalizedVmPrecommitPlan(),
       new AbortController().signal,
     )).rejects.toThrow('requires trusted RPC configuration');
-    expect(getOnChainContextGraphId).not.toHaveBeenCalled();
-    expect(getEvmChainId).not.toHaveBeenCalled();
+    expect(getOnChainContextGraphId).toHaveBeenCalledOnce();
+    expect(createFinalizedReadBinding).toHaveBeenCalledOnce();
   });
 
   it('leaves non-finalized owner policy outside the EVM precommit lane', async () => {
     const getOnChainContextGraphId = vi.fn(async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID);
-    const getEvmChainId = vi.fn(async () => BigInt(RFC64_VM_CHAIN_ID));
+    const createFinalizedReadBinding = vi.fn(finalizedReadBindingFactory(['http://127.0.0.1:8545']));
     const handler = createRfc64FinalizedPolicyAgentPrecommitV1({
       ...options(),
       acceptedPolicySnapshotForCatalogScope: () => acceptedPolicyWith({
@@ -214,7 +235,7 @@ describe('RFC-64 finalized policy agent precommit', () => {
         },
       }),
       getOnChainContextGraphId,
-      getEvmChainId,
+      createFinalizedReadBinding,
     });
 
     const finalizedPlan = rfc64FinalizedVmPrecommitPlan();
@@ -230,19 +251,19 @@ describe('RFC-64 finalized policy agent precommit', () => {
       new AbortController().signal,
     )).resolves.toBeUndefined();
     expect(getOnChainContextGraphId).not.toHaveBeenCalled();
-    expect(getEvmChainId).not.toHaveBeenCalled();
+    expect(createFinalizedReadBinding).not.toHaveBeenCalled();
   });
 
   it('accepts a private unregistered SWM catalog only with its exact current roster', async () => {
     const current = privateOwnerSnapshot();
     const acceptedPolicySnapshotForCatalogScope = vi.fn(() => current);
     const getOnChainContextGraphId = vi.fn(async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID);
-    const getEvmChainId = vi.fn(async () => BigInt(RFC64_VM_CHAIN_ID));
+    const createFinalizedReadBinding = vi.fn(finalizedReadBindingFactory(['http://127.0.0.1:8545']));
     const handler = createRfc64FinalizedPolicyAgentPrecommitV1({
       ...options(),
       acceptedPolicySnapshotForCatalogScope,
       getOnChainContextGraphId,
-      getEvmChainId,
+      createFinalizedReadBinding,
     });
 
     await expect(handler(
@@ -251,7 +272,7 @@ describe('RFC-64 finalized policy agent precommit', () => {
     )).resolves.toBeUndefined();
     expect(acceptedPolicySnapshotForCatalogScope).toHaveBeenCalledTimes(2);
     expect(getOnChainContextGraphId).not.toHaveBeenCalled();
-    expect(getEvmChainId).not.toHaveBeenCalled();
+    expect(createFinalizedReadBinding).not.toHaveBeenCalled();
   });
 
   it('rejects private SWM when the roster is missing or the policy changes before commit', async () => {
@@ -288,12 +309,12 @@ describe('RFC-64 finalized policy agent precommit', () => {
       `0x${'b1'.repeat(20)}`,
     ));
     const getOnChainContextGraphId = vi.fn(async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID);
-    const getEvmChainId = vi.fn(async () => BigInt(RFC64_VM_CHAIN_ID));
+    const createFinalizedReadBinding = vi.fn(finalizedReadBindingFactory(['http://127.0.0.1:8545']));
     const handler = createRfc64FinalizedPolicyAgentPrecommitV1({
       ...options(),
       acceptedPolicySnapshotForCatalogScope,
       getOnChainContextGraphId,
-      getEvmChainId,
+      createFinalizedReadBinding,
     });
 
     await expect(handler(
@@ -302,7 +323,7 @@ describe('RFC-64 finalized policy agent precommit', () => {
     )).rejects.toThrow(/author membership/iu);
     expect(acceptedPolicySnapshotForCatalogScope).toHaveBeenCalledOnce();
     expect(getOnChainContextGraphId).not.toHaveBeenCalled();
-    expect(getEvmChainId).not.toHaveBeenCalled();
+    expect(createFinalizedReadBinding).not.toHaveBeenCalled();
   });
 
   it('rejects when the second current snapshot drops the private catalog author', async () => {
@@ -356,7 +377,7 @@ describe('RFC-64 finalized policy agent precommit', () => {
 
     const differentChain = createRfc64FinalizedPolicyAgentPrecommitV1({
       ...options(),
-      getEvmChainId: async () => 1n,
+      createFinalizedReadBinding: finalizedReadBindingFactory(['http://127.0.0.1:8545'], '1'),
     });
     await expect(differentChain(
       rfc64FinalizedVmPrecommitPlan(),
@@ -377,14 +398,14 @@ describe('RFC-64 finalized policy agent precommit', () => {
     }],
   ] as const)('rejects %s before resolving chain state', async (_label, policyOverrides) => {
     const getOnChainContextGraphId = vi.fn(async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID);
-    const getEvmChainId = vi.fn(async () => BigInt(RFC64_VM_CHAIN_ID));
+    const createFinalizedReadBinding = vi.fn(finalizedReadBindingFactory(['http://127.0.0.1:8545']));
     const handler = createRfc64FinalizedPolicyAgentPrecommitV1({
       ...options(),
       acceptedPolicySnapshotForCatalogScope: () => acceptedPolicyWith(
         policyOverrides as Partial<ContextGraphPolicyV1>,
       ),
       getOnChainContextGraphId,
-      getEvmChainId,
+      createFinalizedReadBinding,
     });
 
     await expect(handler(
@@ -392,7 +413,7 @@ describe('RFC-64 finalized policy agent precommit', () => {
       new AbortController().signal,
     )).rejects.toThrow();
     expect(getOnChainContextGraphId).not.toHaveBeenCalled();
-    expect(getEvmChainId).not.toHaveBeenCalled();
+    expect(createFinalizedReadBinding).not.toHaveBeenCalled();
   });
 
   it('rejects a stale accepted policy that differs from live finalized chain state', async () => {

--- a/packages/agent/test/rfc64-finalized-policy-agent-precommit-v1.test.ts
+++ b/packages/agent/test/rfc64-finalized-policy-agent-precommit-v1.test.ts
@@ -26,6 +26,7 @@ import {
 } from './support/rfc64-finalized-vm-placement-fixture.js';
 import {
   acceptedRfc64VmPolicySnapshot,
+  finalizedSnapshotScopeFactory,
   rfc64FinalizedVmPrecommitOptions,
   rfc64FinalizedVmPrecommitPlan,
 } from './support/rfc64-finalized-vm-precommit-fixture.js';
@@ -44,7 +45,7 @@ function options() {
   const fixture = rfc64FinalizedVmPrecommitOptions();
   return {
     acceptedPolicySnapshotForCatalogScope: fixture.acceptedPolicySnapshotForCatalogScope,
-    rpcEndpoints: fixture.rpcEndpoints,
+    createFinalizedSnapshotScope: fixture.createFinalizedSnapshotScope,
     getOnChainContextGraphId: fixture.getOnChainContextGraphId,
     getEvmChainId: fixture.getEvmChainId,
   };
@@ -89,7 +90,10 @@ async function liveOptions(
     }
   });
   return {
-    options: { ...options(), rpcEndpoints: [server.url] },
+    options: {
+      ...options(),
+      createFinalizedSnapshotScope: finalizedSnapshotScopeFactory([server.url]),
+    },
     rpc,
   };
 }
@@ -182,7 +186,7 @@ describe('RFC-64 finalized policy agent precommit', () => {
     const getEvmChainId = vi.fn(async () => BigInt(RFC64_VM_CHAIN_ID));
     const handler = createRfc64FinalizedPolicyAgentPrecommitV1({
       ...options(),
-      rpcEndpoints: [],
+      createFinalizedSnapshotScope: null,
       getOnChainContextGraphId,
       getEvmChainId,
     });

--- a/packages/agent/test/rfc64-finalized-policy-agent-precommit-v1.test.ts
+++ b/packages/agent/test/rfc64-finalized-policy-agent-precommit-v1.test.ts
@@ -1,3 +1,4 @@
+import { supportedFinalizedReads, unavailableFinalizedReads } from './support/rfc64-finalized-vm-precommit-fixture.js';
 import type {
   ContextGraphPolicyV1,
   Digest32V1,
@@ -19,7 +20,6 @@ import {
   RFC64_VM_CHAIN_ID,
   RFC64_VM_CONTEXT_GRAPH_NAME,
   RFC64_VM_KAV10,
-  RFC64_VM_KA_STORAGE,
   RFC64_VM_NETWORK_ID,
   RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID,
   RFC64_VM_POLICY_DIGEST,
@@ -31,9 +31,9 @@ import {
   rfc64FinalizedVmPrecommitPlan,
 } from './support/rfc64-finalized-vm-precommit-fixture.js';
 import {
-  createFinalizedVmLoopbackRpcV1,
-  type FinalizedVmLoopbackFixtureConfigV1,
-} from './support/rfc64-finalized-vm-loopback-fixture.js';
+  createFinalizedChainLoopbackRpcV1,
+  type FinalizedChainLoopbackFixtureConfigV1,
+} from './support/rfc64-finalized-chain-loopback-fixture.js';
 
 const rpcHarness = createLoopbackJsonRpcTestHarness();
 
@@ -45,21 +45,19 @@ function options() {
   const fixture = rfc64FinalizedVmPrecommitOptions();
   return {
     acceptedPolicySnapshotForCatalogScope: fixture.acceptedPolicySnapshotForCatalogScope,
-    createFinalizedReadBinding: fixture.createFinalizedReadBinding,
+    finalizedReads: fixture.finalizedReads,
     getOnChainContextGraphId: fixture.getOnChainContextGraphId,
   };
 }
 
 function finalizedChainFixture(
-  overrides: Partial<FinalizedVmLoopbackFixtureConfigV1> = {},
-): FinalizedVmLoopbackFixtureConfigV1 {
+  overrides: Partial<FinalizedChainLoopbackFixtureConfigV1> = {},
+): FinalizedChainLoopbackFixtureConfigV1 {
   return {
     accessPolicy: 0,
     active: true,
     assertedAtChainId: RFC64_VM_CHAIN_ID,
     assertedAtKav10Address: RFC64_VM_KAV10,
-    knowledgeAssetStorageAddress: RFC64_VM_KA_STORAGE,
-    assets: [],
     blockHash: RFC64_VM_BLOCK_HASH,
     blockNumberQuantity: '0x7c',
     contextGraphStorageAddress: RFC64_VM_CG_STORAGE,
@@ -73,9 +71,9 @@ function finalizedChainFixture(
 }
 
 async function liveOptions(
-  overrides: Partial<FinalizedVmLoopbackFixtureConfigV1> = {},
+  overrides: Partial<FinalizedChainLoopbackFixtureConfigV1> = {},
 ) {
-  const rpc = createFinalizedVmLoopbackRpcV1(finalizedChainFixture(overrides));
+  const rpc = createFinalizedChainLoopbackRpcV1(finalizedChainFixture(overrides));
   const server = await rpcHarness.start((call, response) => {
     try {
       sendJsonRpcResult(response, call, rpc.respond(call.method, call.params));
@@ -91,7 +89,7 @@ async function liveOptions(
   return {
     options: {
       ...options(),
-      createFinalizedReadBinding: finalizedReadBindingFactory([server.url]),
+      finalizedReads: supportedFinalizedReads(finalizedReadBindingFactory([server.url])),
     },
     rpc,
   };
@@ -161,11 +159,11 @@ describe('RFC-64 finalized policy agent precommit', () => {
     const pending = new Promise<void>((resolve) => { releaseBinding = resolve; });
     const createFinalizedReadBinding = vi.fn(async () => {
       await pending;
-      return live.options.createFinalizedReadBinding();
+      return live.options.finalizedReads.provider.createFinalizedEvmReadBinding('rfc64');
     });
     const getOnChainContextGraphId = vi.fn(async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID);
     const handler = createRfc64FinalizedPolicyAgentPrecommitV1({
-      ...live.options, createFinalizedReadBinding, getOnChainContextGraphId,
+      ...live.options, finalizedReads: supportedFinalizedReads(createFinalizedReadBinding), getOnChainContextGraphId,
     });
     const running = handler(rfc64FinalizedVmPrecommitPlan(), new AbortController().signal);
     try {
@@ -181,11 +179,11 @@ describe('RFC-64 finalized policy agent precommit', () => {
   it('accepts a chain-bound SWM catalog without invoking VM materialization', async () => {
     const getOnChainContextGraphId = vi.fn(async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID);
     const live = await liveOptions();
-    const createFinalizedReadBinding = vi.fn(live.options.createFinalizedReadBinding);
+    const createFinalizedReadBinding = vi.fn(() => live.options.finalizedReads.provider.createFinalizedEvmReadBinding('rfc64'));
     const handler = createRfc64FinalizedPolicyAgentPrecommitV1({
       ...live.options,
       getOnChainContextGraphId,
-      createFinalizedReadBinding,
+      finalizedReads: supportedFinalizedReads(createFinalizedReadBinding),
     });
 
     await expect(handler(
@@ -203,21 +201,20 @@ describe('RFC-64 finalized policy agent precommit', () => {
     ))).toHaveLength(2);
   });
 
-  it('rejects unavailable finalized reads after resolving the shared binding', async () => {
+  it('rejects an unsupported finalized-read capability before resolving the numeric CG', async () => {
     const getOnChainContextGraphId = vi.fn(async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID);
-    const createFinalizedReadBinding = vi.fn(async () => null);
+    const finalizedReads = unavailableFinalizedReads;
     const handler = createRfc64FinalizedPolicyAgentPrecommitV1({
       ...options(),
       getOnChainContextGraphId,
-      createFinalizedReadBinding,
+      finalizedReads,
     });
 
     await expect(handler(
       rfc64FinalizedVmPrecommitPlan(),
       new AbortController().signal,
     )).rejects.toThrow('requires trusted RPC configuration');
-    expect(getOnChainContextGraphId).toHaveBeenCalledOnce();
-    expect(createFinalizedReadBinding).toHaveBeenCalledOnce();
+    expect(getOnChainContextGraphId).not.toHaveBeenCalled();
   });
 
   it('leaves non-finalized owner policy outside the EVM precommit lane', async () => {
@@ -235,7 +232,7 @@ describe('RFC-64 finalized policy agent precommit', () => {
         },
       }),
       getOnChainContextGraphId,
-      createFinalizedReadBinding,
+      finalizedReads: supportedFinalizedReads(createFinalizedReadBinding),
     });
 
     const finalizedPlan = rfc64FinalizedVmPrecommitPlan();
@@ -263,7 +260,7 @@ describe('RFC-64 finalized policy agent precommit', () => {
       ...options(),
       acceptedPolicySnapshotForCatalogScope,
       getOnChainContextGraphId,
-      createFinalizedReadBinding,
+      finalizedReads: supportedFinalizedReads(createFinalizedReadBinding),
     });
 
     await expect(handler(
@@ -314,7 +311,7 @@ describe('RFC-64 finalized policy agent precommit', () => {
       ...options(),
       acceptedPolicySnapshotForCatalogScope,
       getOnChainContextGraphId,
-      createFinalizedReadBinding,
+      finalizedReads: supportedFinalizedReads(createFinalizedReadBinding),
     });
 
     await expect(handler(
@@ -377,7 +374,7 @@ describe('RFC-64 finalized policy agent precommit', () => {
 
     const differentChain = createRfc64FinalizedPolicyAgentPrecommitV1({
       ...options(),
-      createFinalizedReadBinding: finalizedReadBindingFactory(['http://127.0.0.1:8545'], '1'),
+      finalizedReads: supportedFinalizedReads(finalizedReadBindingFactory(['http://127.0.0.1:8545'], '1')),
     });
     await expect(differentChain(
       rfc64FinalizedVmPrecommitPlan(),
@@ -405,7 +402,7 @@ describe('RFC-64 finalized policy agent precommit', () => {
         policyOverrides as Partial<ContextGraphPolicyV1>,
       ),
       getOnChainContextGraphId,
-      createFinalizedReadBinding,
+      finalizedReads: supportedFinalizedReads(createFinalizedReadBinding),
     });
 
     await expect(handler(

--- a/packages/agent/test/rfc64-finalized-vm-agent-precommit-v1.test.ts
+++ b/packages/agent/test/rfc64-finalized-vm-agent-precommit-v1.test.ts
@@ -35,6 +35,7 @@ import {
 } from './support/rfc64-finalized-vm-placement-fixture.js';
 import {
   acceptedRfc64VmPolicySnapshot,
+  finalizedSnapshotScopeFactory,
   rfc64FinalizedVmPrecommitOptions as baseOptions,
   rfc64FinalizedVmPrecommitPlan as plan,
 } from './support/rfc64-finalized-vm-precommit-fixture.js';
@@ -151,7 +152,7 @@ describe('RFC-64 finalized VM agent precommit', () => {
     const coldHandler = createRfc64FinalizedVmAgentPrecommitV1({
       ...options,
       acceptedPolicySnapshotForCatalogScope: () => privateFinalizedSnapshot(),
-      rpcEndpoints: [endpoint],
+      createFinalizedSnapshotScope: finalizedSnapshotScopeFactory([endpoint]),
     });
     const newerPlan = Object.freeze({
       ...plan(),
@@ -181,7 +182,7 @@ describe('RFC-64 finalized VM agent precommit', () => {
     const exactHandler = createRfc64FinalizedVmAgentPrecommitV1({
       ...options,
       acceptedPolicySnapshotForCatalogScope: () => privateFinalizedSnapshot(),
-      rpcEndpoints: [endpoint],
+      createFinalizedSnapshotScope: finalizedSnapshotScopeFactory([endpoint]),
     });
     const exactTransaction = await exactHandler(Object.freeze({
       ...plan(),
@@ -193,7 +194,7 @@ describe('RFC-64 finalized VM agent precommit', () => {
     const warmHandler = createRfc64FinalizedVmAgentPrecommitV1({
       ...options,
       acceptedPolicySnapshotForCatalogScope: () => privateFinalizedSnapshot(),
-      rpcEndpoints: [endpoint],
+      createFinalizedSnapshotScope: finalizedSnapshotScopeFactory([endpoint]),
     });
     const warmTransaction = await warmHandler(newerPlan, new AbortController().signal);
     expect(warmTransaction.materializationReceipts).toEqual([]);
@@ -234,7 +235,8 @@ describe('RFC-64 finalized VM agent precommit', () => {
     const handler = createRfc64FinalizedVmAgentPrecommitV1({
       ...options,
       acceptedPolicySnapshotForCatalogScope: () => privateFinalizedSnapshot(),
-      rpcEndpoints: [await liveRpcEndpoint(assertionRoot)],
+      createFinalizedSnapshotScope:
+        finalizedSnapshotScopeFactory([await liveRpcEndpoint(assertionRoot)]),
     });
 
     const transaction = await handler(Object.freeze({
@@ -301,7 +303,7 @@ describe('RFC-64 finalized VM agent precommit', () => {
   it('does not apply the private root-only restriction to a public finalized lane', async () => {
     const handler = createRfc64FinalizedVmAgentPrecommitV1({
       ...baseOptions(),
-      rpcEndpoints: [],
+      createFinalizedSnapshotScope: null,
     });
     const namedPlan = {
       ...plan(),
@@ -335,7 +337,7 @@ describe('RFC-64 finalized VM agent precommit', () => {
     const getKnowledgeAssetStorageAddress = vi.fn(async () => RFC64_VM_KA_STORAGE);
     const handler = createRfc64FinalizedVmAgentPrecommitV1({
       ...baseOptions(),
-      rpcEndpoints: [],
+      createFinalizedSnapshotScope: null,
       getOnChainContextGraphId,
       getEvmChainId,
       getKnowledgeAssetStorageAddress,
@@ -426,7 +428,8 @@ describe('RFC-64 finalized VM agent precommit', () => {
     const handler = createRfc64FinalizedVmAgentPrecommitV1({
       ...options,
       acceptedPolicySnapshotForCatalogScope,
-      rpcEndpoints: [await liveRpcEndpoint(assertionRoot)],
+      createFinalizedSnapshotScope:
+        finalizedSnapshotScopeFactory([await liveRpcEndpoint(assertionRoot)]),
       materialize,
     });
 
@@ -476,7 +479,8 @@ describe('RFC-64 finalized VM agent precommit', () => {
     const handler = createRfc64FinalizedVmAgentPrecommitV1({
       ...baseOptions(),
       acceptedPolicySnapshotForCatalogScope: () => privateFinalizedSnapshot(),
-      rpcEndpoints: [await liveRpcEndpoint(assertionRoot)],
+      createFinalizedSnapshotScope:
+        finalizedSnapshotScopeFactory([await liveRpcEndpoint(assertionRoot)]),
       materialize,
     });
 

--- a/packages/agent/test/rfc64-finalized-vm-agent-precommit-v1.test.ts
+++ b/packages/agent/test/rfc64-finalized-vm-agent-precommit-v1.test.ts
@@ -35,7 +35,7 @@ import {
 } from './support/rfc64-finalized-vm-placement-fixture.js';
 import {
   acceptedRfc64VmPolicySnapshot,
-  finalizedSnapshotScopeFactory,
+  finalizedReadBindingFactory,
   rfc64FinalizedVmPrecommitOptions as baseOptions,
   rfc64FinalizedVmPrecommitPlan as plan,
 } from './support/rfc64-finalized-vm-precommit-fixture.js';
@@ -152,7 +152,7 @@ describe('RFC-64 finalized VM agent precommit', () => {
     const coldHandler = createRfc64FinalizedVmAgentPrecommitV1({
       ...options,
       acceptedPolicySnapshotForCatalogScope: () => privateFinalizedSnapshot(),
-      createFinalizedSnapshotScope: finalizedSnapshotScopeFactory([endpoint]),
+      createFinalizedReadBinding: finalizedReadBindingFactory([endpoint]),
     });
     const newerPlan = Object.freeze({
       ...plan(),
@@ -182,7 +182,7 @@ describe('RFC-64 finalized VM agent precommit', () => {
     const exactHandler = createRfc64FinalizedVmAgentPrecommitV1({
       ...options,
       acceptedPolicySnapshotForCatalogScope: () => privateFinalizedSnapshot(),
-      createFinalizedSnapshotScope: finalizedSnapshotScopeFactory([endpoint]),
+      createFinalizedReadBinding: finalizedReadBindingFactory([endpoint]),
     });
     const exactTransaction = await exactHandler(Object.freeze({
       ...plan(),
@@ -194,7 +194,7 @@ describe('RFC-64 finalized VM agent precommit', () => {
     const warmHandler = createRfc64FinalizedVmAgentPrecommitV1({
       ...options,
       acceptedPolicySnapshotForCatalogScope: () => privateFinalizedSnapshot(),
-      createFinalizedSnapshotScope: finalizedSnapshotScopeFactory([endpoint]),
+      createFinalizedReadBinding: finalizedReadBindingFactory([endpoint]),
     });
     const warmTransaction = await warmHandler(newerPlan, new AbortController().signal);
     expect(warmTransaction.materializationReceipts).toEqual([]);
@@ -235,8 +235,8 @@ describe('RFC-64 finalized VM agent precommit', () => {
     const handler = createRfc64FinalizedVmAgentPrecommitV1({
       ...options,
       acceptedPolicySnapshotForCatalogScope: () => privateFinalizedSnapshot(),
-      createFinalizedSnapshotScope:
-        finalizedSnapshotScopeFactory([await liveRpcEndpoint(assertionRoot)]),
+      createFinalizedReadBinding:
+        finalizedReadBindingFactory([await liveRpcEndpoint(assertionRoot)]),
     });
 
     const transaction = await handler(Object.freeze({
@@ -268,7 +268,7 @@ describe('RFC-64 finalized VM agent precommit', () => {
 
   it('applies the root-only restriction to private finalized recovery', async () => {
     const getOnChainContextGraphId = vi.fn(async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID);
-    const getEvmChainId = vi.fn(async () => BigInt(RFC64_VM_CHAIN_ID));
+    const createFinalizedReadBinding = vi.fn(finalizedReadBindingFactory(['http://127.0.0.1:8545']));
     const getKnowledgeAssetStorageAddress = vi.fn(async () => RFC64_VM_KA_STORAGE);
     const getKnowledgeAssetsLifecycleAddress = vi.fn(async () => RFC64_VM_KA_STORAGE);
     const materialize = Object.assign(vi.fn(), {
@@ -279,7 +279,7 @@ describe('RFC-64 finalized VM agent precommit', () => {
       ...baseOptions(),
       acceptedPolicySnapshotForCatalogScope: () => privateFinalizedSnapshot(),
       getOnChainContextGraphId,
-      getEvmChainId,
+      createFinalizedReadBinding,
       getKnowledgeAssetStorageAddress,
       getKnowledgeAssetsLifecycleAddress,
       materialize,
@@ -294,7 +294,7 @@ describe('RFC-64 finalized VM agent precommit', () => {
       code: 'finalized-vm-composition-input',
     } satisfies Partial<FinalizedVmCompositionErrorV1>);
     expect(getOnChainContextGraphId).not.toHaveBeenCalled();
-    expect(getEvmChainId).not.toHaveBeenCalled();
+    expect(createFinalizedReadBinding).not.toHaveBeenCalled();
     expect(getKnowledgeAssetStorageAddress).not.toHaveBeenCalled();
     expect(getKnowledgeAssetsLifecycleAddress).not.toHaveBeenCalled();
     expect(materialize).not.toHaveBeenCalled();
@@ -303,7 +303,7 @@ describe('RFC-64 finalized VM agent precommit', () => {
   it('does not apply the private root-only restriction to a public finalized lane', async () => {
     const handler = createRfc64FinalizedVmAgentPrecommitV1({
       ...baseOptions(),
-      createFinalizedSnapshotScope: null,
+      createFinalizedReadBinding: async () => null,
     });
     const namedPlan = {
       ...plan(),
@@ -331,30 +331,29 @@ describe('RFC-64 finalized VM agent precommit', () => {
     );
   });
 
-  it('rejects before chain resolution when trusted RPC endpoints are empty', async () => {
+  it('rejects unavailable finalized reads before resolving VM storage', async () => {
     const getOnChainContextGraphId = vi.fn(async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID);
-    const getEvmChainId = vi.fn(async () => BigInt(RFC64_VM_CHAIN_ID));
+    const createFinalizedReadBinding = vi.fn(async () => null);
     const getKnowledgeAssetStorageAddress = vi.fn(async () => RFC64_VM_KA_STORAGE);
     const handler = createRfc64FinalizedVmAgentPrecommitV1({
       ...baseOptions(),
-      createFinalizedSnapshotScope: null,
       getOnChainContextGraphId,
-      getEvmChainId,
+      createFinalizedReadBinding,
       getKnowledgeAssetStorageAddress,
     });
 
     await expect(handler(plan(), new AbortController().signal)).rejects.toThrow(
       'requires trusted RPC configuration',
     );
-    expect(getOnChainContextGraphId).not.toHaveBeenCalled();
-    expect(getEvmChainId).not.toHaveBeenCalled();
+    expect(getOnChainContextGraphId).toHaveBeenCalledOnce();
+    expect(createFinalizedReadBinding).toHaveBeenCalledOnce();
     expect(getKnowledgeAssetStorageAddress).not.toHaveBeenCalled();
   });
 
   it('rejects when the live adapter chain differs from the accepted finalized policy', async () => {
     const handler = createRfc64FinalizedVmAgentPrecommitV1({
       ...baseOptions(),
-      getEvmChainId: async () => 1n,
+      createFinalizedReadBinding: finalizedReadBindingFactory(['http://127.0.0.1:8545'], '1'),
     });
 
     await expect(handler(plan(), new AbortController().signal)).rejects.toThrow(
@@ -428,8 +427,8 @@ describe('RFC-64 finalized VM agent precommit', () => {
     const handler = createRfc64FinalizedVmAgentPrecommitV1({
       ...options,
       acceptedPolicySnapshotForCatalogScope,
-      createFinalizedSnapshotScope:
-        finalizedSnapshotScopeFactory([await liveRpcEndpoint(assertionRoot)]),
+      createFinalizedReadBinding:
+        finalizedReadBindingFactory([await liveRpcEndpoint(assertionRoot)]),
       materialize,
     });
 
@@ -479,8 +478,8 @@ describe('RFC-64 finalized VM agent precommit', () => {
     const handler = createRfc64FinalizedVmAgentPrecommitV1({
       ...baseOptions(),
       acceptedPolicySnapshotForCatalogScope: () => privateFinalizedSnapshot(),
-      createFinalizedSnapshotScope:
-        finalizedSnapshotScopeFactory([await liveRpcEndpoint(assertionRoot)]),
+      createFinalizedReadBinding:
+        finalizedReadBindingFactory([await liveRpcEndpoint(assertionRoot)]),
       materialize,
     });
 

--- a/packages/agent/test/rfc64-finalized-vm-agent-precommit-v1.test.ts
+++ b/packages/agent/test/rfc64-finalized-vm-agent-precommit-v1.test.ts
@@ -1,3 +1,4 @@
+import { supportedFinalizedReads, unavailableFinalizedReads } from './support/rfc64-finalized-vm-precommit-fixture.js';
 import {
   MemoryLayer,
   contextGraphLayerUri,
@@ -152,7 +153,7 @@ describe('RFC-64 finalized VM agent precommit', () => {
     const coldHandler = createRfc64FinalizedVmAgentPrecommitV1({
       ...options,
       acceptedPolicySnapshotForCatalogScope: () => privateFinalizedSnapshot(),
-      createFinalizedReadBinding: finalizedReadBindingFactory([endpoint]),
+      finalizedReads: supportedFinalizedReads(finalizedReadBindingFactory([endpoint])),
     });
     const newerPlan = Object.freeze({
       ...plan(),
@@ -182,7 +183,7 @@ describe('RFC-64 finalized VM agent precommit', () => {
     const exactHandler = createRfc64FinalizedVmAgentPrecommitV1({
       ...options,
       acceptedPolicySnapshotForCatalogScope: () => privateFinalizedSnapshot(),
-      createFinalizedReadBinding: finalizedReadBindingFactory([endpoint]),
+      finalizedReads: supportedFinalizedReads(finalizedReadBindingFactory([endpoint])),
     });
     const exactTransaction = await exactHandler(Object.freeze({
       ...plan(),
@@ -194,7 +195,7 @@ describe('RFC-64 finalized VM agent precommit', () => {
     const warmHandler = createRfc64FinalizedVmAgentPrecommitV1({
       ...options,
       acceptedPolicySnapshotForCatalogScope: () => privateFinalizedSnapshot(),
-      createFinalizedReadBinding: finalizedReadBindingFactory([endpoint]),
+      finalizedReads: supportedFinalizedReads(finalizedReadBindingFactory([endpoint])),
     });
     const warmTransaction = await warmHandler(newerPlan, new AbortController().signal);
     expect(warmTransaction.materializationReceipts).toEqual([]);
@@ -235,8 +236,7 @@ describe('RFC-64 finalized VM agent precommit', () => {
     const handler = createRfc64FinalizedVmAgentPrecommitV1({
       ...options,
       acceptedPolicySnapshotForCatalogScope: () => privateFinalizedSnapshot(),
-      createFinalizedReadBinding:
-        finalizedReadBindingFactory([await liveRpcEndpoint(assertionRoot)]),
+      finalizedReads: supportedFinalizedReads(finalizedReadBindingFactory([await liveRpcEndpoint(assertionRoot)])),
     });
 
     const transaction = await handler(Object.freeze({
@@ -279,7 +279,7 @@ describe('RFC-64 finalized VM agent precommit', () => {
       ...baseOptions(),
       acceptedPolicySnapshotForCatalogScope: () => privateFinalizedSnapshot(),
       getOnChainContextGraphId,
-      createFinalizedReadBinding,
+      finalizedReads: supportedFinalizedReads(createFinalizedReadBinding),
       getKnowledgeAssetStorageAddress,
       getKnowledgeAssetsLifecycleAddress,
       materialize,
@@ -303,7 +303,7 @@ describe('RFC-64 finalized VM agent precommit', () => {
   it('does not apply the private root-only restriction to a public finalized lane', async () => {
     const handler = createRfc64FinalizedVmAgentPrecommitV1({
       ...baseOptions(),
-      createFinalizedReadBinding: async () => null,
+      finalizedReads: unavailableFinalizedReads,
     });
     const namedPlan = {
       ...plan(),
@@ -333,27 +333,26 @@ describe('RFC-64 finalized VM agent precommit', () => {
 
   it('rejects unavailable finalized reads before resolving VM storage', async () => {
     const getOnChainContextGraphId = vi.fn(async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID);
-    const createFinalizedReadBinding = vi.fn(async () => null);
+    const finalizedReads = unavailableFinalizedReads;
     const getKnowledgeAssetStorageAddress = vi.fn(async () => RFC64_VM_KA_STORAGE);
     const handler = createRfc64FinalizedVmAgentPrecommitV1({
       ...baseOptions(),
       getOnChainContextGraphId,
-      createFinalizedReadBinding,
+      finalizedReads,
       getKnowledgeAssetStorageAddress,
     });
 
     await expect(handler(plan(), new AbortController().signal)).rejects.toThrow(
       'requires trusted RPC configuration',
     );
-    expect(getOnChainContextGraphId).toHaveBeenCalledOnce();
-    expect(createFinalizedReadBinding).toHaveBeenCalledOnce();
+    expect(getOnChainContextGraphId).not.toHaveBeenCalled();
     expect(getKnowledgeAssetStorageAddress).not.toHaveBeenCalled();
   });
 
   it('rejects when the live adapter chain differs from the accepted finalized policy', async () => {
     const handler = createRfc64FinalizedVmAgentPrecommitV1({
       ...baseOptions(),
-      createFinalizedReadBinding: finalizedReadBindingFactory(['http://127.0.0.1:8545'], '1'),
+      finalizedReads: supportedFinalizedReads(finalizedReadBindingFactory(['http://127.0.0.1:8545'], '1')),
     });
 
     await expect(handler(plan(), new AbortController().signal)).rejects.toThrow(
@@ -427,8 +426,7 @@ describe('RFC-64 finalized VM agent precommit', () => {
     const handler = createRfc64FinalizedVmAgentPrecommitV1({
       ...options,
       acceptedPolicySnapshotForCatalogScope,
-      createFinalizedReadBinding:
-        finalizedReadBindingFactory([await liveRpcEndpoint(assertionRoot)]),
+      finalizedReads: supportedFinalizedReads(finalizedReadBindingFactory([await liveRpcEndpoint(assertionRoot)])),
       materialize,
     });
 
@@ -478,8 +476,7 @@ describe('RFC-64 finalized VM agent precommit', () => {
     const handler = createRfc64FinalizedVmAgentPrecommitV1({
       ...baseOptions(),
       acceptedPolicySnapshotForCatalogScope: () => privateFinalizedSnapshot(),
-      createFinalizedReadBinding:
-        finalizedReadBindingFactory([await liveRpcEndpoint(assertionRoot)]),
+      finalizedReads: supportedFinalizedReads(finalizedReadBindingFactory([await liveRpcEndpoint(assertionRoot)])),
       materialize,
     });
 

--- a/packages/agent/test/rfc64-finalized-vm-precommit-shipped-pool.test.ts
+++ b/packages/agent/test/rfc64-finalized-vm-precommit-shipped-pool.test.ts
@@ -18,17 +18,17 @@
  * dialled nothing. Both assertions below therefore fail on the unfixed code: the
  * first on the message, the second on an empty dial log.
  */
-import { resolveRpcUrls } from '@origintrail-official/dkg-chain';
+import { EVMChainAdapter, resolveRpcUrls } from '@origintrail-official/dkg-chain';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createRfc64FinalizedVmAgentPrecommitV1 } from '../src/rfc64/finalized-vm-agent-precommit-v1.js';
 import {
-  finalizedSnapshotScopeFactory,
   rfc64FinalizedVmPrecommitOptions,
   rfc64FinalizedVmPrecommitPlan,
 } from './support/rfc64-finalized-vm-precommit-fixture.js';
+import { RFC64_VM_CHAIN_ID } from './support/rfc64-finalized-vm-placement-fixture.js';
 
 const REPO_ROOT = join(import.meta.dirname, '..', '..', '..');
 
@@ -61,10 +61,24 @@ describe('RFC-64 finalized VM precommit on a shipped RPC pool', () => {
       throw new Error('stubbed transport failure');
     });
 
-    // Only the adapter-owned snapshot factory varies — that is the seam under test.
+    const adapter = new EVMChainAdapter({
+      rpcUrl: pool[0]!,
+      rpcUrls: pool.slice(1),
+      privateKey: `0x${'11'.repeat(32)}`,
+      hubAddress: `0x${'22'.repeat(20)}`,
+      chainId: 'evm:31337',
+      staticNetwork: false,
+      allowNoAdminSigner: true,
+    });
+    const getEvmChainId = vi.spyOn(adapter, 'getEvmChainId')
+      .mockResolvedValue(BigInt(RFC64_VM_CHAIN_ID));
+
+    // Only chain-ID resolution and transport are mocked; scope construction is
+    // exercised through the production adapter boundary.
     const precommit = createRfc64FinalizedVmAgentPrecommitV1(
       rfc64FinalizedVmPrecommitOptions({
-        createFinalizedSnapshotScope: finalizedSnapshotScopeFactory(pool),
+        createFinalizedSnapshotScope: () =>
+          adapter.createFinalizedEvmSnapshotScope('rfc64'),
       }),
     );
 
@@ -87,6 +101,7 @@ describe('RFC-64 finalized VM precommit on a shipped RPC pool', () => {
     // the normalizer's spelling rules.
     const href = (url: string) => new URL(url).href;
     expect([...new Set(dialled)]).toEqual([href(pool[0]!), href(pool[1]!)]);
+    expect(getEvmChainId).toHaveBeenCalledOnce();
     // And the third is stranded — stated as a tested fact rather than left as a
     // silent consequence. Selection is health-blind and configuration-ordered,
     // so `base-sepolia.drpc.org` is never reached by a strict finalized read even
@@ -94,4 +109,3 @@ describe('RFC-64 finalized VM precommit on a shipped RPC pool', () => {
     expect(dialled).not.toContain(href(pool[2]!));
   });
 });
-

--- a/packages/agent/test/rfc64-finalized-vm-precommit-shipped-pool.test.ts
+++ b/packages/agent/test/rfc64-finalized-vm-precommit-shipped-pool.test.ts
@@ -77,8 +77,8 @@ describe('RFC-64 finalized VM precommit on a shipped RPC pool', () => {
     // exercised through the production adapter boundary.
     const precommit = createRfc64FinalizedVmAgentPrecommitV1(
       rfc64FinalizedVmPrecommitOptions({
-        createFinalizedSnapshotScope: () =>
-          adapter.createFinalizedEvmSnapshotScope('rfc64'),
+        createFinalizedReadBinding: () =>
+          adapter.createFinalizedEvmReadBinding('rfc64'),
       }),
     );
 

--- a/packages/agent/test/rfc64-finalized-vm-precommit-shipped-pool.test.ts
+++ b/packages/agent/test/rfc64-finalized-vm-precommit-shipped-pool.test.ts
@@ -25,6 +25,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createRfc64FinalizedVmAgentPrecommitV1 } from '../src/rfc64/finalized-vm-agent-precommit-v1.js';
 import {
+  finalizedSnapshotScopeFactory,
   rfc64FinalizedVmPrecommitOptions,
   rfc64FinalizedVmPrecommitPlan,
 } from './support/rfc64-finalized-vm-precommit-fixture.js';
@@ -60,9 +61,11 @@ describe('RFC-64 finalized VM precommit on a shipped RPC pool', () => {
       throw new Error('stubbed transport failure');
     });
 
-    // Only `rpcEndpoints` varies — that is the whole point of this regression.
+    // Only the adapter-owned snapshot factory varies — that is the seam under test.
     const precommit = createRfc64FinalizedVmAgentPrecommitV1(
-      rfc64FinalizedVmPrecommitOptions({ rpcEndpoints: pool }),
+      rfc64FinalizedVmPrecommitOptions({
+        createFinalizedSnapshotScope: finalizedSnapshotScopeFactory(pool),
+      }),
     );
 
     // The precommit still fails — there is no chain behind the stub — but it must
@@ -91,5 +94,4 @@ describe('RFC-64 finalized VM precommit on a shipped RPC pool', () => {
     expect(dialled).not.toContain(href(pool[2]!));
   });
 });
-
 

--- a/packages/agent/test/rfc64-finalized-vm-precommit-shipped-pool.test.ts
+++ b/packages/agent/test/rfc64-finalized-vm-precommit-shipped-pool.test.ts
@@ -1,3 +1,4 @@
+import { supportedFinalizedReads } from './support/rfc64-finalized-vm-precommit-fixture.js';
 /**
  * The integration seam this change exists to fix.
  *
@@ -77,8 +78,8 @@ describe('RFC-64 finalized VM precommit on a shipped RPC pool', () => {
     // exercised through the production adapter boundary.
     const precommit = createRfc64FinalizedVmAgentPrecommitV1(
       rfc64FinalizedVmPrecommitOptions({
-        createFinalizedReadBinding: () =>
-          adapter.createFinalizedEvmReadBinding('rfc64'),
+        finalizedReads: supportedFinalizedReads(() =>
+          adapter.createFinalizedEvmReadBinding('rfc64')),
       }),
     );
 

--- a/packages/agent/test/rfc64-precommit-owner-attribution.test.ts
+++ b/packages/agent/test/rfc64-precommit-owner-attribution.test.ts
@@ -16,6 +16,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import type { AcceptedRfc64CatalogAccessSnapshotV1 } from '../src/rfc64/catalog-access-policy-v1.js';
 import { createRfc64FinalizedVmAgentPrecommitV1 } from '../src/rfc64/finalized-vm-agent-precommit-v1.js';
 import type { Rfc64PublicCatalogNativeBeforeAppliedHeadCommitPlanV1 } from '../src/rfc64/public-catalog-native-receiver-v1.js';
+import { finalizedSnapshotScopeFactory } from './support/rfc64-finalized-vm-precommit-fixture.js';
 import {
   RFC64_VM_AUTHOR,
   RFC64_VM_BLOCK_HASH,
@@ -124,7 +125,7 @@ function plan(): Rfc64PublicCatalogNativeBeforeAppliedHeadCommitPlanV1 {
 async function options(endpoint: string) {
   return {
     acceptedPolicySnapshotForCatalogScope: () => acceptedPolicy(),
-    rpcEndpoints: [endpoint],
+    createFinalizedSnapshotScope: finalizedSnapshotScopeFactory([endpoint]),
     getOnChainContextGraphId: async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID,
     getEvmChainId: async () => BigInt(RFC64_VM_CHAIN_ID),
     getKnowledgeAssetStorageAddress: async () => RFC64_VM_KA_STORAGE,

--- a/packages/agent/test/rfc64-precommit-owner-attribution.test.ts
+++ b/packages/agent/test/rfc64-precommit-owner-attribution.test.ts
@@ -1,141 +1,26 @@
-import { createServer, type Server } from 'node:http';
-import { AddressInfo } from 'node:net';
-
-import {
-  CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
-  type ContextGraphPolicyV1,
-} from '@origintrail-official/dkg-core';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import {
+  EVMChainAdapter,
   acquireFinalizedChainRead,
   finalizedChainReadRegistryDepth,
-  type FinalizedChainReadOwnerV1,
 } from '@origintrail-official/dkg-chain';
-import { afterEach, describe, expect, it } from 'vitest';
-
-import type { AcceptedRfc64CatalogAccessSnapshotV1 } from '../src/rfc64/catalog-access-policy-v1.js';
-import { createRfc64FinalizedVmAgentPrecommitV1 } from '../src/rfc64/finalized-vm-agent-precommit-v1.js';
-import type { Rfc64PublicCatalogNativeBeforeAppliedHeadCommitPlanV1 } from '../src/rfc64/public-catalog-native-receiver-v1.js';
-import { finalizedSnapshotScopeFactory } from './support/rfc64-finalized-vm-precommit-fixture.js';
+import { describe, expect, it, vi } from 'vitest';
+import { createRfc64FinalizedAgentPrecommitsV1 } from '../src/rfc64/finalized-agent-precommits-v1.js';
 import {
-  RFC64_VM_AUTHOR,
-  RFC64_VM_BLOCK_HASH,
-  RFC64_VM_CG_STORAGE,
+  acceptedRfc64VmPolicySnapshot,
+  rfc64FinalizedVmPrecommitPlan,
+} from './support/rfc64-finalized-vm-precommit-fixture.js';
+import {
   RFC64_VM_CHAIN_ID,
-  RFC64_VM_CONTEXT_GRAPH_NAME,
   RFC64_VM_KAV10,
   RFC64_VM_KA_STORAGE,
-  RFC64_VM_NETWORK_ID,
   RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID,
-  RFC64_VM_POLICY_DIGEST,
 } from './support/rfc64-finalized-vm-placement-fixture.js';
 
-/**
- * The production RFC64 precommit passes `owner: 'rfc64'` into the shared
- * finalized-read factory. Until now nothing observed that line: the merge-
- * readiness review showed the label could be changed to `foreground` and the
- * focused precommit and runtime suites stayed 10/10 green, because they fail
- * before the real factory or inject mocks.
- *
- * This drives the REAL `createRfc64FinalizedVmAgentPrecommitV1` against an RPC
- * endpoint that accepts the connection and never answers, so the precommit
- * genuinely takes and holds the process-wide permit. While it is held, another
- * owner probes the registry and is told who the holder is — which is both proof
- * that the production path uses the shared registry at all, and the only test
- * that fails if the label changes.
- */
-const servers: Server[] = [];
-
-afterEach(async () => {
-  await Promise.all(
-    servers.splice(0).map(
-      (server) => new Promise<void>((resolve) => server.close(() => resolve())),
-    ),
-  );
-});
-
-/** Accepts, then never responds. The permit stays held until we abort. */
-async function hangingRpcEndpoint(): Promise<string> {
-  const server = createServer(() => {
-    /* deliberately no response */
-  });
-  servers.push(server);
-  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
-  const { port } = server.address() as AddressInfo;
-  return `http://127.0.0.1:${port}`;
-}
-
-function acceptedPolicy(): AcceptedRfc64CatalogAccessSnapshotV1 {
-  // Same canonical shape the existing precommit suite uses; a thinner fake is
-  // rejected by `snapshotFinalizedVmRuntimeRequest` before the chain is touched.
-  const policy = Object.freeze({
-    networkId: RFC64_VM_NETWORK_ID,
-    contextGraphId: RFC64_VM_CONTEXT_GRAPH_NAME,
-    governanceChainId: RFC64_VM_CHAIN_ID,
-    governanceContractAddress: RFC64_VM_CG_STORAGE,
-    ownershipTransitionDigest: null,
-    era: '0',
-    version: '0',
-    previousPolicyDigest: null,
-    accessPolicy: 0,
-    publishPolicy: 1,
-    publishAuthority: null,
-    publishAuthorityAccountId: '0',
-    projectionId: CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
-    administrativeDelegationDigest: null,
-    source: {
-      kind: 'finalized-chain',
-      chainId: RFC64_VM_CHAIN_ID,
-      contractAddress: RFC64_VM_CG_STORAGE,
-      blockNumber: '123',
-      blockHash: RFC64_VM_BLOCK_HASH,
-    },
-    effectiveAt: '1700000000000',
-    issuedAt: '1700000000000',
-  } satisfies ContextGraphPolicyV1);
-  return Object.freeze({
-    policy,
-    policyDigest: RFC64_VM_POLICY_DIGEST,
-    // Explicitly null, not omitted: the runtime rejects a non-null roster, and
-    // `undefined !== null` fails that guard.
-    roster: null,
-  }) as unknown as AcceptedRfc64CatalogAccessSnapshotV1;
-}
-
-function plan(): Rfc64PublicCatalogNativeBeforeAppliedHeadCommitPlanV1 {
-  return Object.freeze({
-    catalogScope: Object.freeze({
-      networkId: RFC64_VM_NETWORK_ID,
-      contextGraphId: RFC64_VM_CONTEXT_GRAPH_NAME,
-      governanceChainId: RFC64_VM_CHAIN_ID,
-      governanceContractAddress: RFC64_VM_CG_STORAGE,
-      ownershipTransitionDigest: null,
-      subGraphName: null,
-      authorAddress: RFC64_VM_AUTHOR,
-      era: '0',
-      bucketCount: '1',
-    }),
-    policyDigest: RFC64_VM_POLICY_DIGEST,
-    catalogHeadDigest: `0x${'91'.repeat(32)}`,
-    inventoryDigest: `0x${'92'.repeat(32)}`,
-    rows: Object.freeze([]),
-  }) as unknown as Rfc64PublicCatalogNativeBeforeAppliedHeadCommitPlanV1;
-}
-
-async function options(endpoint: string) {
-  return {
-    acceptedPolicySnapshotForCatalogScope: () => acceptedPolicy(),
-    createFinalizedSnapshotScope: finalizedSnapshotScopeFactory([endpoint]),
-    getOnChainContextGraphId: async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID,
-    getEvmChainId: async () => BigInt(RFC64_VM_CHAIN_ID),
-    getKnowledgeAssetStorageAddress: async () => RFC64_VM_KA_STORAGE,
-    getKnowledgeAssetsLifecycleAddress: async () => RFC64_VM_KAV10,
-    store: new OxigraphStore(),
-  } as const;
-}
-
-async function waitForPermit(timeoutMs = 15_000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
+async function waitForPermit(): Promise<void> {
+  const deadline = Date.now() + 15_000;
   while (Date.now() < deadline) {
     if (finalizedChainReadRegistryDepth(RFC64_VM_CHAIN_ID) === 1) return;
     await new Promise((resolve) => setTimeout(resolve, 25));
@@ -143,60 +28,80 @@ async function waitForPermit(timeoutMs = 15_000): Promise<void> {
   throw new Error('production precommit never took the shared finalized-read permit');
 }
 
-describe('RFC-64 production precommit owner attribution', () => {
-  it('takes the SHARED permit and holds it as `rfc64`', async () => {
-    const endpoint = await hangingRpcEndpoint();
-    const handler = createRfc64FinalizedVmAgentPrecommitV1(await options(endpoint));
-    const abort = new AbortController();
+function adapterForEndpoint(endpoint: string) {
+  const adapter = new EVMChainAdapter({
+    rpcUrl: endpoint, privateKey: `0x${'11'.repeat(32)}`,
+    hubAddress: `0x${'22'.repeat(20)}`, chainId: 'evm:20430',
+    staticNetwork: false, allowNoAdminSigner: true,
+  });
+  const getChainId = vi.spyOn(adapter, 'getEvmChainId').mockResolvedValue(BigInt(RFC64_VM_CHAIN_ID));
+  vi.spyOn(adapter, 'getDKGKnowledgeAssetsAddress').mockResolvedValue(RFC64_VM_KA_STORAGE);
+  vi.spyOn(adapter, 'getKnowledgeAssetsLifecycleAddress').mockResolvedValue(RFC64_VM_KAV10);
+  return { adapter, getChainId };
+}
 
-    // Not awaited: the precommit parks inside the pinned read while we observe.
-    const running = handler(plan(), abort.signal).catch(() => undefined);
-    await waitForPermit();
-
-    let holder: FinalizedChainReadOwnerV1 | undefined;
-    await expect(
-      acquireFinalizedChainRead(
-        { chainId: RFC64_VM_CHAIN_ID, owner: 'w2-page' },
-        async () => 'must-not-run',
-        (active, seen) => {
-          holder = seen;
-          return new Error(`saturated:${active}:${seen}`);
-        },
-      ),
-    ).rejects.toThrow('saturated:1:rfc64');
-
-    // THE assertion the review asked for: the production line, observed.
-    expect(holder).toBe('rfc64');
-
-    abort.abort();
-    await running;
-  }, 40_000);
-
-  it('releases the shared permit when the precommit is aborted', async () => {
-    // A production path that leaked the permit would wedge every other caller
-    // on that chain for the life of the process.
-    const endpoint = await hangingRpcEndpoint();
-    const handler = createRfc64FinalizedVmAgentPrecommitV1(await options(endpoint));
-    const abort = new AbortController();
-
-    const running = handler(plan(), abort.signal).catch(() => undefined);
-    await waitForPermit();
-    abort.abort();
-    await running;
-
-    const deadline = Date.now() + 15_000;
-    while (Date.now() < deadline && finalizedChainReadRegistryDepth(RFC64_VM_CHAIN_ID) !== 0) {
-      await new Promise((resolve) => setTimeout(resolve, 25));
-    }
-    expect(finalizedChainReadRegistryDepth(RFC64_VM_CHAIN_ID)).toBe(0);
-
-    // …and the lane is genuinely reusable afterwards.
-    await expect(
-      acquireFinalizedChainRead(
+describe('RFC-64 production catalog precommit owner attribution', () => {
+  it.each(['finalizedPolicyPrecommit', 'finalizedVmPrecommit'] as const)(
+    '%s owns the shared permit as rfc64 and releases it after abort', async (kind) => {
+      // A hanging RPC holds the real permit while another owner observes it.
+      const server = createServer(() => {});
+      await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+      const endpoint = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+      const store = new OxigraphStore();
+      const { adapter, getChainId } = adapterForEndpoint(endpoint);
+      // Spy without replacing the implementation: the production catalog
+      // composition selects the owner, and the real adapter builds the scope.
+      const createBinding = vi.spyOn(adapter, 'createFinalizedEvmReadBinding');
+      const handlers = createRfc64FinalizedAgentPrecommitsV1({
+        chain: adapter, store,
+        acceptedPolicySnapshotForCatalogScope: acceptedRfc64VmPolicySnapshot,
+        getOnChainContextGraphId: async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID,
+      });
+      const abort = new AbortController();
+      const running = handlers[kind](rfc64FinalizedVmPrecommitPlan(), abort.signal).catch(() => undefined);
+      try {
+        await waitForPermit();
+        expect(createBinding).toHaveBeenCalledExactlyOnceWith('rfc64');
+        expect(getChainId).toHaveBeenCalledOnce();
+        await expect(acquireFinalizedChainRead(
+          { chainId: RFC64_VM_CHAIN_ID, owner: 'w2-page' },
+          async () => 'must-not-run',
+          (active, owner) => new Error(`saturated:${active}:${owner}`),
+        )).rejects.toThrow('saturated:1:rfc64');
+      } finally {
+        abort.abort();
+        await running;
+        server.closeAllConnections();
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+        await store.close();
+        vi.restoreAllMocks();
+      }
+      expect(finalizedChainReadRegistryDepth(RFC64_VM_CHAIN_ID)).toBe(0);
+      await expect(acquireFinalizedChainRead(
         { chainId: RFC64_VM_CHAIN_ID, owner: 'w2-page' },
         async () => 'reusable',
         (active) => new Error(`saturated:${active}`),
-      ),
-    ).resolves.toBe('reusable');
-  }, 40_000);
+      )).resolves.toBe('reusable');
+    }, 40_000,
+  );
+
+  it('fails closed when the adapter lacks VM storage address capability', async () => {
+    const { adapter } = adapterForEndpoint('http://127.0.0.1:8545');
+    Object.defineProperty(adapter, 'getDKGKnowledgeAssetsAddress', { value: undefined });
+    const store = new OxigraphStore();
+    const { finalizedVmPrecommit } = createRfc64FinalizedAgentPrecommitsV1({
+      chain: adapter, store,
+      acceptedPolicySnapshotForCatalogScope: acceptedRfc64VmPolicySnapshot,
+      getOnChainContextGraphId: async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID,
+    });
+    try {
+      await expect(finalizedVmPrecommit(
+        rfc64FinalizedVmPrecommitPlan(), new AbortController().signal,
+      )).rejects.toThrow('RFC-64 finalized VM recovery requires KnowledgeAssetStorage');
+      expect(finalizedChainReadRegistryDepth(RFC64_VM_CHAIN_ID)).toBe(0);
+    } finally {
+      vi.restoreAllMocks();
+      await store.close();
+    }
+  });
 });

--- a/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
@@ -2334,7 +2334,7 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
       ),
     );
     const getOnChainContextGraphId = vi.fn(async () => '14');
-    const getEvmChainId = vi.fn(async () => 20_430n);
+    const createFinalizedReadBinding = vi.fn(async () => null);
     const getKnowledgeAssetStorageAddress = vi.fn(async () => KAV10);
     const policy = Object.freeze({
       networkId: NETWORK_ID,
@@ -2367,9 +2367,8 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
         policyDigest: POLICY_DIGEST,
         roster: null,
       }),
-      createFinalizedSnapshotScope: null,
       getOnChainContextGraphId,
-      getEvmChainId,
+      createFinalizedReadBinding,
       getKnowledgeAssetStorageAddress,
       getKnowledgeAssetsLifecycleAddress: async () => KAV10,
       store: fixture.receiverStore,
@@ -2387,8 +2386,8 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
       message: expect.stringContaining('catalog applied-head precommit rejected'),
     });
 
-    expect(getOnChainContextGraphId).not.toHaveBeenCalled();
-    expect(getEvmChainId).not.toHaveBeenCalled();
+    expect(getOnChainContextGraphId).toHaveBeenCalledOnce();
+    expect(createFinalizedReadBinding).toHaveBeenCalledOnce();
     expect(getKnowledgeAssetStorageAddress).not.toHaveBeenCalled();
     expect(compareAndSwapAppliedCatalogHeadV1).not.toHaveBeenCalled();
     expect(fixture.receiverPersistence.inventory.readAppliedCatalogHeadV1(

--- a/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
@@ -2367,7 +2367,7 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
         policyDigest: POLICY_DIGEST,
         roster: null,
       }),
-      rpcEndpoints: [],
+      createFinalizedSnapshotScope: null,
       getOnChainContextGraphId,
       getEvmChainId,
       getKnowledgeAssetStorageAddress,

--- a/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
+++ b/packages/agent/test/rfc64-public-catalog-native-gate1.integration.test.ts
@@ -1,3 +1,4 @@
+import { unavailableFinalizedReads } from './support/rfc64-finalized-vm-precommit-fixture.js';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -2334,7 +2335,7 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
       ),
     );
     const getOnChainContextGraphId = vi.fn(async () => '14');
-    const createFinalizedReadBinding = vi.fn(async () => null);
+    const finalizedReads = unavailableFinalizedReads;
     const getKnowledgeAssetStorageAddress = vi.fn(async () => KAV10);
     const policy = Object.freeze({
       networkId: NETWORK_ID,
@@ -2368,7 +2369,7 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
         roster: null,
       }),
       getOnChainContextGraphId,
-      createFinalizedReadBinding,
+      finalizedReads,
       getKnowledgeAssetStorageAddress,
       getKnowledgeAssetsLifecycleAddress: async () => KAV10,
       store: fixture.receiverStore,
@@ -2386,8 +2387,7 @@ describe('RFC-64 Gate 1 native successor to public SWM', () => {
       message: expect.stringContaining('catalog applied-head precommit rejected'),
     });
 
-    expect(getOnChainContextGraphId).toHaveBeenCalledOnce();
-    expect(createFinalizedReadBinding).toHaveBeenCalledOnce();
+    expect(getOnChainContextGraphId).not.toHaveBeenCalled();
     expect(getKnowledgeAssetStorageAddress).not.toHaveBeenCalled();
     expect(compareAndSwapAppliedCatalogHeadV1).not.toHaveBeenCalled();
     expect(fixture.receiverPersistence.inventory.readAppliedCatalogHeadV1(

--- a/packages/agent/test/support/rfc64-finalized-chain-loopback-fixture.ts
+++ b/packages/agent/test/support/rfc64-finalized-chain-loopback-fixture.ts
@@ -1,0 +1,238 @@
+import {
+  createStrictCurrentFinalizedEvmSnapshotScopeV1,
+  MockChainAdapter,
+  MOCK_DEFAULT_SIGNER,
+  type ContextGraphAuthoritySnapshot,
+  type FinalizedChainReadOwnerV1,
+  type FinalizedEvmReadBindingV1,
+} from '@origintrail-official/dkg-chain';
+import {
+  assertCanonicalChainId,
+  type Digest32V1,
+  type EvmAddressV1,
+  type NetworkIdV1,
+} from '@origintrail-official/dkg-core';
+import { ethers } from 'ethers';
+
+/** Finalized authority inputs needed before any VM inventory is considered. */
+export interface FinalizedChainLoopbackFixtureConfigV1 {
+  readonly accessPolicy: 0 | 1;
+  readonly active: boolean;
+  readonly assertedAtChainId: string;
+  readonly assertedAtKav10Address: EvmAddressV1;
+  readonly blockHash: Digest32V1;
+  readonly blockNumberQuantity: string;
+  readonly contextGraphStorageAddress: EvmAddressV1;
+  readonly nameHash: Digest32V1;
+  readonly networkId: NetworkIdV1;
+  readonly onChainContextGraphId: string;
+  readonly ownerAddress: EvmAddressV1;
+  readonly publishPolicy: 0 | 1;
+}
+
+export interface FinalizedChainLoopbackRpcCallV1 {
+  readonly method: string;
+  readonly params: readonly unknown[];
+}
+
+export interface FinalizedChainLoopbackRpcV1 {
+  readonly calls: readonly FinalizedChainLoopbackRpcCallV1[];
+  respond(method: string, params: readonly unknown[]): unknown;
+}
+
+export const FINALIZED_CONTEXT_GRAPH_INTERFACE = new ethers.Interface([
+  'function getContextGraph(uint256 contextGraphId) view returns (address owner, address[] participantAgents, uint256 metadataBatchId, bool active, uint256 createdAt, uint8 accessPolicy, uint8 publishPolicy, address publishAuthority, uint256 publishAuthorityAccountId)',
+  'function getNameHash(uint256 contextGraphId) view returns (bytes32)',
+  'function isContextGraphActive(uint256 contextGraphId) view returns (bool)',
+  'function getContextGraphKaCount(uint256 contextGraphId) view returns (uint256)',
+  'function getContextGraphKaAt(uint256 contextGraphId, uint256 ordinal) view returns (uint256)',
+]);
+/** Mock adapter whose chain identity matches the loopback finalized-RPC lane. */
+export class FinalizedChainLoopbackMockChainAdapterV1 extends MockChainAdapter {
+  protected readonly fixture: FinalizedChainLoopbackFixtureConfigV1;
+  protected readonly rpcEndpoint: string;
+
+  constructor(fixture: FinalizedChainLoopbackFixtureConfigV1, rpcEndpoint: string) {
+    super(fixture.networkId, MOCK_DEFAULT_SIGNER, {
+      initialContextGraphId: BigInt(fixture.onChainContextGraphId),
+    });
+    if (typeof rpcEndpoint !== 'string' || rpcEndpoint.trim() === '') {
+      throw new Error('Finalized chain loopback adapter requires its RPC endpoint');
+    }
+    this.fixture = fixture;
+    this.rpcEndpoint = rpcEndpoint;
+  }
+
+  async createFinalizedEvmReadBinding(
+    owner: FinalizedChainReadOwnerV1,
+  ): Promise<Readonly<FinalizedEvmReadBindingV1>> {
+    const chainId = this.fixture.assertedAtChainId;
+    assertCanonicalChainId(chainId, 'finalized chain fixture chainId');
+    return Object.freeze({
+      chainId,
+      snapshot: createStrictCurrentFinalizedEvmSnapshotScopeV1({
+        chainId, endpoints: [this.rpcEndpoint], owner,
+      }),
+    });
+  }
+
+  override async getEvmChainId(): Promise<bigint> {
+    return BigInt(this.fixture.assertedAtChainId);
+  }
+
+  override async getKnowledgeAssetsLifecycleAddress(): Promise<string> {
+    return this.fixture.assertedAtKav10Address;
+  }
+
+  override async getContextGraphAuthoritySnapshot(
+    contextGraphId: bigint,
+  ): Promise<ContextGraphAuthoritySnapshot> {
+    if (contextGraphId.toString(10) !== this.fixture.onChainContextGraphId) {
+      throw new Error(`Finalized chain fixture has no Context Graph ${contextGraphId.toString(10)}`);
+    }
+    return Object.freeze({
+      chainId: this.fixture.assertedAtChainId,
+      governanceContract: this.fixture.contextGraphStorageAddress.toLowerCase(),
+      contextGraphId: this.fixture.onChainContextGraphId,
+      owner: this.fixture.ownerAddress.toLowerCase(),
+      active: this.fixture.active,
+      accessPolicy: this.fixture.accessPolicy,
+      publishPolicy: this.fixture.publishPolicy,
+      publishAuthority: this.fixture.publishPolicy === 1
+        ? null
+        : this.fixture.ownerAddress.toLowerCase(),
+      publishAuthorityAccountId: '0',
+      participantAgents: Object.freeze([]),
+      nameHash: this.fixture.nameHash.toLowerCase(),
+      ownershipEra: '0',
+      policyVersion: '0',
+      rosterVersion: '0',
+      sourceBlockNumber: BigInt(this.fixture.blockNumberQuantity).toString(10),
+      sourceBlockHash: this.fixture.blockHash.toLowerCase(),
+    });
+  }
+}
+
+export interface FinalizedChainLoopbackContractCallV1 {
+  readonly target: string;
+  readonly data: string;
+}
+
+/** Shared protocol driver; each composition supplies its complete eth_call handler. */
+export function createFinalizedChainLoopbackRpcDriverV1(
+  fixture: FinalizedChainLoopbackFixtureConfigV1,
+  readContract: (call: FinalizedChainLoopbackContractCallV1) => string,
+): FinalizedChainLoopbackRpcV1 {
+  const calls: FinalizedChainLoopbackRpcCallV1[] = [];
+  return Object.freeze({
+    calls,
+    respond(method: string, params: readonly unknown[]): unknown {
+      calls.push(Object.freeze({ method, params: Object.freeze([...params]) }));
+      switch (method) {
+        case 'eth_chainId': return ethers.toQuantity(BigInt(fixture.assertedAtChainId));
+        case 'eth_getBlockByNumber': return { number: fixture.blockNumberQuantity, hash: fixture.blockHash };
+        case 'eth_getCode': return '0x6000';
+        case 'eth_call': {
+          const call = plainRecord(params[0], 'finalized chain eth_call object');
+          const target = requiredString(call.to, 'finalized chain eth_call target').toLowerCase();
+          const data = requiredString(call.data, 'finalized chain eth_call data');
+          return data === '0x' ? '0x' : readContract({ target, data });
+        }
+        default: throw new Error(`unexpected finalized chain JSON-RPC method ${method}`);
+      }
+    },
+  });
+}
+
+/** Policy-only authority advertises an empty Context Graph inventory. */
+export function createFinalizedChainLoopbackRpcV1(
+  fixture: FinalizedChainLoopbackFixtureConfigV1,
+): FinalizedChainLoopbackRpcV1 {
+  return createFinalizedChainLoopbackRpcDriverV1(fixture, call =>
+    readFinalizedChainAuthorityCallV1(fixture, call));
+}
+
+export function readFinalizedChainAuthorityCallV1(
+  fixture: FinalizedChainLoopbackFixtureConfigV1,
+  { target, data }: FinalizedChainLoopbackContractCallV1,
+): string {
+  const selector = data.slice(0, 10);
+  if (CONTEXT_GRAPH_SELECTORS.has(selector)) {
+    assertFinalizedChainCallTargetV1(target, fixture.contextGraphStorageAddress, 'context graph');
+  }
+  switch (selector) {
+    case FINALIZED_CONTEXT_GRAPH_INTERFACE.getFunction('getContextGraph')!.selector:
+      assertContextGraphCall('getContextGraph', data, fixture.onChainContextGraphId);
+      return FINALIZED_CONTEXT_GRAPH_INTERFACE.encodeFunctionResult('getContextGraph', [
+        fixture.ownerAddress,
+        [],
+        0n,
+        fixture.active,
+        1n,
+        fixture.accessPolicy,
+        fixture.publishPolicy,
+        fixture.publishPolicy === 1 ? ethers.ZeroAddress : fixture.ownerAddress,
+        0n,
+      ]);
+    case FINALIZED_CONTEXT_GRAPH_INTERFACE.getFunction('getNameHash')!.selector:
+      assertContextGraphCall('getNameHash', data, fixture.onChainContextGraphId);
+      return FINALIZED_CONTEXT_GRAPH_INTERFACE.encodeFunctionResult('getNameHash', [fixture.nameHash]);
+    case FINALIZED_CONTEXT_GRAPH_INTERFACE.getFunction('isContextGraphActive')!.selector:
+      assertContextGraphCall('isContextGraphActive', data, fixture.onChainContextGraphId);
+      return FINALIZED_CONTEXT_GRAPH_INTERFACE.encodeFunctionResult(
+        'isContextGraphActive',
+        [fixture.active],
+      );
+    case FINALIZED_CONTEXT_GRAPH_INTERFACE.getFunction('getContextGraphKaCount')!.selector:
+      assertContextGraphCall('getContextGraphKaCount', data, fixture.onChainContextGraphId);
+      return FINALIZED_CONTEXT_GRAPH_INTERFACE.encodeFunctionResult('getContextGraphKaCount', [0n]);
+    case FINALIZED_CONTEXT_GRAPH_INTERFACE.getFunction('getContextGraphKaAt')!.selector: {
+      const [id, ordinal] = FINALIZED_CONTEXT_GRAPH_INTERFACE.decodeFunctionData('getContextGraphKaAt', data);
+      assertFinalizedChainNumericIdV1(id, fixture.onChainContextGraphId, 'context graph');
+      throw new Error(`empty finalized chain inventory has no ordinal ${ordinal}`);
+    }
+    default: throw new Error(`unexpected finalized chain eth_call selector ${selector}`);
+  }
+}
+
+const CONTEXT_GRAPH_SELECTORS = new Set([
+  'getContextGraph', 'getNameHash', 'isContextGraphActive',
+  'getContextGraphKaCount', 'getContextGraphKaAt',
+].map(method => FINALIZED_CONTEXT_GRAPH_INTERFACE.getFunction(method)!.selector));
+
+export function assertFinalizedChainCallTargetV1(actual: string, expected: EvmAddressV1, label: string): void {
+  if (actual !== expected.toLowerCase()) {
+    throw new Error(
+      `unexpected finalized chain ${label} target ${actual}; expected ${expected.toLowerCase()}`,
+    );
+  }
+}
+
+function assertContextGraphCall(
+  method: string,
+  data: string,
+  expectedId: string,
+): void {
+  const [contextGraphId] = FINALIZED_CONTEXT_GRAPH_INTERFACE.decodeFunctionData(method, data);
+  assertFinalizedChainNumericIdV1(contextGraphId, expectedId, 'context graph');
+}
+
+export function assertFinalizedChainNumericIdV1(actual: unknown, expected: string, label: string): void {
+  if (String(actual) !== expected) {
+    throw new Error(`unexpected finalized chain ${label} id ${String(actual)}`);
+  }
+}
+
+function plainRecord(value: unknown, label: string): Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requiredString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0 || value.length > 4096) {
+    throw new TypeError(`${label} must be a bounded non-empty string`);
+  }
+  return value;
+}

--- a/packages/agent/test/support/rfc64-finalized-vm-loopback-fixture.ts
+++ b/packages/agent/test/support/rfc64-finalized-vm-loopback-fixture.ts
@@ -1,12 +1,16 @@
 import {
+  createStrictCurrentFinalizedEvmSnapshotScopeV1,
   MockChainAdapter,
   MOCK_DEFAULT_SIGNER,
   type ContextGraphAuthoritySnapshot,
+  type FinalizedChainReadOwnerV1,
+  type StrictCurrentFinalizedEvmSnapshotScopeV1,
 } from '@origintrail-official/dkg-chain';
-import type {
-  Digest32V1,
-  EvmAddressV1,
-  NetworkIdV1,
+import {
+  assertCanonicalChainId,
+  type Digest32V1,
+  type EvmAddressV1,
+  type NetworkIdV1,
 } from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
 
@@ -62,18 +66,27 @@ const KNOWLEDGE_ASSET_INTERFACE = new ethers.Interface([
 /** Mock adapter whose chain identity matches the loopback finalized-RPC lane. */
 export class FinalizedVmLoopbackMockChainAdapterV1 extends MockChainAdapter {
   readonly #fixture: FinalizedVmLoopbackFixtureConfigV1;
-  readonly #rpcUrl: string;
+  readonly #rpcEndpoint: string | undefined;
 
-  constructor(fixture: FinalizedVmLoopbackFixtureConfigV1, rpcUrl: string) {
+  constructor(fixture: FinalizedVmLoopbackFixtureConfigV1, rpcEndpoint?: string) {
     super(fixture.networkId, MOCK_DEFAULT_SIGNER, {
       initialContextGraphId: BigInt(fixture.onChainContextGraphId),
     });
     this.#fixture = fixture;
-    this.#rpcUrl = rpcUrl;
+    this.#rpcEndpoint = rpcEndpoint;
   }
 
-  getRpcUrls(): string[] {
-    return [this.#rpcUrl];
+  override async createFinalizedEvmSnapshotScope(
+    owner: FinalizedChainReadOwnerV1,
+  ): Promise<StrictCurrentFinalizedEvmSnapshotScopeV1 | null> {
+    if (this.#rpcEndpoint === undefined) return null;
+    const chainId = this.#fixture.assertedAtChainId;
+    assertCanonicalChainId(chainId, 'finalized VM fixture chainId');
+    return createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      chainId,
+      endpoints: [this.#rpcEndpoint],
+      owner,
+    });
   }
 
   override async getEvmChainId(): Promise<bigint> {

--- a/packages/agent/test/support/rfc64-finalized-vm-loopback-fixture.ts
+++ b/packages/agent/test/support/rfc64-finalized-vm-loopback-fixture.ts
@@ -4,7 +4,7 @@ import {
   MOCK_DEFAULT_SIGNER,
   type ContextGraphAuthoritySnapshot,
   type FinalizedChainReadOwnerV1,
-  type StrictCurrentFinalizedEvmSnapshotScopeV1,
+  type FinalizedEvmReadBindingV1,
 } from '@origintrail-official/dkg-chain';
 import {
   assertCanonicalChainId,
@@ -66,26 +66,29 @@ const KNOWLEDGE_ASSET_INTERFACE = new ethers.Interface([
 /** Mock adapter whose chain identity matches the loopback finalized-RPC lane. */
 export class FinalizedVmLoopbackMockChainAdapterV1 extends MockChainAdapter {
   readonly #fixture: FinalizedVmLoopbackFixtureConfigV1;
-  readonly #rpcEndpoint: string | undefined;
+  readonly #rpcEndpoint: string;
 
-  constructor(fixture: FinalizedVmLoopbackFixtureConfigV1, rpcEndpoint?: string) {
+  constructor(fixture: FinalizedVmLoopbackFixtureConfigV1, rpcEndpoint: string) {
     super(fixture.networkId, MOCK_DEFAULT_SIGNER, {
       initialContextGraphId: BigInt(fixture.onChainContextGraphId),
     });
+    if (typeof rpcEndpoint !== 'string' || rpcEndpoint.trim() === '') {
+      throw new Error('Finalized VM loopback adapter requires its RPC endpoint');
+    }
     this.#fixture = fixture;
     this.#rpcEndpoint = rpcEndpoint;
   }
 
-  override async createFinalizedEvmSnapshotScope(
+  override async createFinalizedEvmReadBinding(
     owner: FinalizedChainReadOwnerV1,
-  ): Promise<StrictCurrentFinalizedEvmSnapshotScopeV1 | null> {
-    if (this.#rpcEndpoint === undefined) return null;
+  ): Promise<Readonly<FinalizedEvmReadBindingV1>> {
     const chainId = this.#fixture.assertedAtChainId;
     assertCanonicalChainId(chainId, 'finalized VM fixture chainId');
-    return createStrictCurrentFinalizedEvmSnapshotScopeV1({
+    return Object.freeze({
       chainId,
-      endpoints: [this.#rpcEndpoint],
-      owner,
+      snapshot: createStrictCurrentFinalizedEvmSnapshotScopeV1({
+        chainId, endpoints: [this.#rpcEndpoint], owner,
+      }),
     });
   }
 

--- a/packages/agent/test/support/rfc64-finalized-vm-loopback-fixture.ts
+++ b/packages/agent/test/support/rfc64-finalized-vm-loopback-fixture.ts
@@ -1,18 +1,16 @@
-import {
-  createStrictCurrentFinalizedEvmSnapshotScopeV1,
-  MockChainAdapter,
-  MOCK_DEFAULT_SIGNER,
-  type ContextGraphAuthoritySnapshot,
-  type FinalizedChainReadOwnerV1,
-  type FinalizedEvmReadBindingV1,
-} from '@origintrail-official/dkg-chain';
-import {
-  assertCanonicalChainId,
-  type Digest32V1,
-  type EvmAddressV1,
-  type NetworkIdV1,
-} from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
+import type { Digest32V1, EvmAddressV1 } from '@origintrail-official/dkg-core';
+import {
+  FinalizedChainLoopbackMockChainAdapterV1,
+  FINALIZED_CONTEXT_GRAPH_INTERFACE,
+  createFinalizedChainLoopbackRpcDriverV1,
+  readFinalizedChainAuthorityCallV1,
+  assertFinalizedChainCallTargetV1,
+  assertFinalizedChainNumericIdV1,
+  type FinalizedChainLoopbackFixtureConfigV1,
+  type FinalizedChainLoopbackRpcV1,
+  type FinalizedChainLoopbackContractCallV1,
+} from './rfc64-finalized-chain-loopback-fixture.js';
 
 export interface FinalizedVmLoopbackAssetV1 {
   readonly assertionRoot: Digest32V1;
@@ -22,45 +20,12 @@ export interface FinalizedVmLoopbackAssetV1 {
   readonly publisherAddress: EvmAddressV1;
 }
 
-/** Finalized authority inputs needed before any VM inventory is considered. */
-export interface FinalizedChainLoopbackFixtureConfigV1 {
-  readonly accessPolicy: 0 | 1;
-  readonly active: boolean;
-  readonly assertedAtChainId: string;
-  readonly assertedAtKav10Address: EvmAddressV1;
-  readonly blockHash: Digest32V1;
-  readonly blockNumberQuantity: string;
-  readonly contextGraphStorageAddress: EvmAddressV1;
-  readonly nameHash: Digest32V1;
-  readonly networkId: NetworkIdV1;
-  readonly onChainContextGraphId: string;
-  readonly ownerAddress: EvmAddressV1;
-  readonly publishPolicy: 0 | 1;
-}
-
-/** Optional VM inventory layered over finalized Context Graph authority. */
+/** VM inventory extension layered over finalized Context Graph authority. */
 export interface FinalizedVmLoopbackFixtureConfigV1 extends FinalizedChainLoopbackFixtureConfigV1 {
   readonly knowledgeAssetStorageAddress: EvmAddressV1;
   readonly assets: readonly FinalizedVmLoopbackAssetV1[];
 }
 
-export interface FinalizedVmLoopbackRpcCallV1 {
-  readonly method: string;
-  readonly params: readonly unknown[];
-}
-
-export interface FinalizedVmLoopbackRpcV1 {
-  readonly calls: readonly FinalizedVmLoopbackRpcCallV1[];
-  respond(method: string, params: readonly unknown[]): unknown;
-}
-
-const CONTEXT_GRAPH_INTERFACE = new ethers.Interface([
-  'function getContextGraph(uint256 contextGraphId) view returns (address owner, address[] participantAgents, uint256 metadataBatchId, bool active, uint256 createdAt, uint8 accessPolicy, uint8 publishPolicy, address publishAuthority, uint256 publishAuthorityAccountId)',
-  'function getNameHash(uint256 contextGraphId) view returns (bytes32)',
-  'function isContextGraphActive(uint256 contextGraphId) view returns (bool)',
-  'function getContextGraphKaCount(uint256 contextGraphId) view returns (uint256)',
-  'function getContextGraphKaAt(uint256 contextGraphId, uint256 ordinal) view returns (uint256)',
-]);
 const KNOWLEDGE_ASSET_INTERFACE = new ethers.Interface([
   'function getKnowledgeAssetUpdateContext(uint256 id) view returns (uint256 merkleRootsCount, uint256 minted, uint88 byteSize, uint40 endEpoch, uint96 tokenAmount, bool isImmutable, uint32 merkleLeafCount)',
   'function getLatestMerkleRoot(uint256 id) view returns (bytes32)',
@@ -68,181 +33,49 @@ const KNOWLEDGE_ASSET_INTERFACE = new ethers.Interface([
   'function getLatestMerkleRootPublisher(uint256 id) view returns (address)',
 ]);
 
-/** Mock adapter whose chain identity matches the loopback finalized-RPC lane. */
-export class FinalizedChainLoopbackMockChainAdapterV1 extends MockChainAdapter {
-  protected readonly fixture: FinalizedChainLoopbackFixtureConfigV1;
-  protected readonly rpcEndpoint: string;
-
-  constructor(fixture: FinalizedChainLoopbackFixtureConfigV1, rpcEndpoint: string) {
-    super(fixture.networkId, MOCK_DEFAULT_SIGNER, {
-      initialContextGraphId: BigInt(fixture.onChainContextGraphId),
-    });
-    if (typeof rpcEndpoint !== 'string' || rpcEndpoint.trim() === '') {
-      throw new Error('Finalized VM loopback adapter requires its RPC endpoint');
-    }
-    this.fixture = fixture;
-    this.rpcEndpoint = rpcEndpoint;
-  }
-
-  async createFinalizedEvmReadBinding(
-    owner: FinalizedChainReadOwnerV1,
-  ): Promise<Readonly<FinalizedEvmReadBindingV1>> {
-    const chainId = this.fixture.assertedAtChainId;
-    assertCanonicalChainId(chainId, 'finalized VM fixture chainId');
-    return Object.freeze({
-      chainId,
-      snapshot: createStrictCurrentFinalizedEvmSnapshotScopeV1({
-        chainId, endpoints: [this.rpcEndpoint], owner,
-      }),
-    });
-  }
-
-  override async getEvmChainId(): Promise<bigint> {
-    return BigInt(this.fixture.assertedAtChainId);
-  }
-
-  override async getKnowledgeAssetsLifecycleAddress(): Promise<string> {
-    return this.fixture.assertedAtKav10Address;
-  }
-
-  override async getContextGraphAuthoritySnapshot(
-    contextGraphId: bigint,
-  ): Promise<ContextGraphAuthoritySnapshot> {
-    if (contextGraphId.toString(10) !== this.fixture.onChainContextGraphId) {
-      throw new Error(`Finalized VM fixture has no Context Graph ${contextGraphId.toString(10)}`);
-    }
-    return Object.freeze({
-      chainId: this.fixture.assertedAtChainId,
-      governanceContract: this.fixture.contextGraphStorageAddress.toLowerCase(),
-      contextGraphId: this.fixture.onChainContextGraphId,
-      owner: this.fixture.ownerAddress.toLowerCase(),
-      active: this.fixture.active,
-      accessPolicy: this.fixture.accessPolicy,
-      publishPolicy: this.fixture.publishPolicy,
-      publishAuthority: this.fixture.publishPolicy === 1
-        ? null
-        : this.fixture.ownerAddress.toLowerCase(),
-      publishAuthorityAccountId: '0',
-      participantAgents: Object.freeze([]),
-      nameHash: this.fixture.nameHash.toLowerCase(),
-      ownershipEra: '0',
-      policyVersion: '0',
-      rosterVersion: '0',
-      sourceBlockNumber: BigInt(this.fixture.blockNumberQuantity).toString(10),
-      sourceBlockHash: this.fixture.blockHash.toLowerCase(),
-    });
-  }
-}
-
 export class FinalizedVmLoopbackMockChainAdapterV1 extends FinalizedChainLoopbackMockChainAdapterV1 {
-  constructor(fixture: FinalizedVmLoopbackFixtureConfigV1, rpcEndpoint: string) {
-    super(fixture, rpcEndpoint);
+  constructor(private readonly vmFixture: FinalizedVmLoopbackFixtureConfigV1, rpcEndpoint: string) {
+    super(vmFixture, rpcEndpoint);
   }
 
   override async getDKGKnowledgeAssetsAddress(): Promise<string> {
-    return (this.fixture as FinalizedVmLoopbackFixtureConfigV1).knowledgeAssetStorageAddress;
+    return this.vmFixture.knowledgeAssetStorageAddress;
   }
 }
 
-/**
- * Package-owned protocol-shaped finalized RPC test support shared by the
- * integration suite and separate-process devnet proof. Callers own I/O only.
- */
+/** Extend chain authority with a required, exact VM inventory. */
 export function createFinalizedVmLoopbackRpcV1(
   fixture: FinalizedVmLoopbackFixtureConfigV1,
-): FinalizedVmLoopbackRpcV1 {
-  return createFinalizedLoopbackRpcV1(fixture, fixture);
+): FinalizedChainLoopbackRpcV1 {
+  const assets = new Map(fixture.assets.map(asset => [asset.kaId, asset]));
+  return createFinalizedChainLoopbackRpcDriverV1(fixture, call =>
+    readFinalizedVmInventoryCallV1(fixture, assets, call));
 }
 
-/** Policy-only loopback: Context Graph authority is available; VM inventory is empty. */
-export function createFinalizedChainLoopbackRpcV1(
-  fixture: FinalizedChainLoopbackFixtureConfigV1,
-): FinalizedVmLoopbackRpcV1 {
-  return createFinalizedLoopbackRpcV1(fixture, undefined);
-}
-
-function createFinalizedLoopbackRpcV1(
-  fixture: FinalizedChainLoopbackFixtureConfigV1,
-  vmFixture: FinalizedVmLoopbackFixtureConfigV1 | undefined,
-): FinalizedVmLoopbackRpcV1 {
-  const calls: FinalizedVmLoopbackRpcCallV1[] = [];
-  const assets = new Map((vmFixture?.assets ?? []).map((asset) => [asset.kaId, asset]));
-  const respond = (method: string, params: readonly unknown[]): unknown => {
-    calls.push(Object.freeze({ method, params: Object.freeze([...params]) }));
-    switch (method) {
-      case 'eth_chainId':
-        return ethers.toQuantity(BigInt(fixture.assertedAtChainId));
-      case 'eth_getBlockByNumber':
-        return { number: fixture.blockNumberQuantity, hash: fixture.blockHash };
-      case 'eth_getCode':
-        return '0x6000';
-      case 'eth_call':
-        return finalizedVmEthCallResult(params, fixture, vmFixture, assets);
-      default:
-        throw new Error(`unexpected finalized VM JSON-RPC method ${method}`);
-    }
-  };
-  return Object.freeze({ calls, respond });
-}
-
-function finalizedVmEthCallResult(
-  params: readonly unknown[],
-  fixture: FinalizedChainLoopbackFixtureConfigV1,
-  vmFixture: FinalizedVmLoopbackFixtureConfigV1 | undefined,
+function readFinalizedVmInventoryCallV1(
+  fixture: FinalizedVmLoopbackFixtureConfigV1,
   assets: ReadonlyMap<string, FinalizedVmLoopbackAssetV1>,
+  call: FinalizedChainLoopbackContractCallV1,
 ): string {
-  const call = plainRecord(params[0], 'finalized VM eth_call object');
-  const target = requiredString(call.to, 'finalized VM eth_call target').toLowerCase();
-  const data = requiredString(call.data, 'finalized VM eth_call data');
-  if (data === '0x') return '0x';
+  const { target, data } = call;
   const selector = data.slice(0, 10);
-  if (CONTEXT_GRAPH_SELECTORS.has(selector)) {
-    assertCallTarget(target, fixture.contextGraphStorageAddress, 'context graph');
+  if (VM_CONTEXT_GRAPH_SELECTORS.has(selector)) {
+    assertFinalizedChainCallTargetV1(target, fixture.contextGraphStorageAddress, 'context graph');
   } else if (KNOWLEDGE_ASSET_SELECTORS.has(selector)) {
-    if (vmFixture === undefined) throw new Error('policy-only finalized chain has no VM inventory');
-    assertCallTarget(target, vmFixture.knowledgeAssetStorageAddress, 'knowledge asset storage');
+    assertFinalizedChainCallTargetV1(target, fixture.knowledgeAssetStorageAddress, 'knowledge asset storage');
   }
   switch (selector) {
-    case CONTEXT_GRAPH_INTERFACE.getFunction('getContextGraph')!.selector:
-      assertContextGraphCall('getContextGraph', data, fixture.onChainContextGraphId);
-      return CONTEXT_GRAPH_INTERFACE.encodeFunctionResult('getContextGraph', [
-        fixture.ownerAddress,
-        [],
-        0n,
-        fixture.active,
-        1n,
-        fixture.accessPolicy,
-        fixture.publishPolicy,
-        fixture.publishPolicy === 1 ? ethers.ZeroAddress : fixture.ownerAddress,
-        0n,
-      ]);
-    case CONTEXT_GRAPH_INTERFACE.getFunction('getNameHash')!.selector:
-      assertContextGraphCall('getNameHash', data, fixture.onChainContextGraphId);
-      return CONTEXT_GRAPH_INTERFACE.encodeFunctionResult('getNameHash', [fixture.nameHash]);
-    case CONTEXT_GRAPH_INTERFACE.getFunction('isContextGraphActive')!.selector:
-      assertContextGraphCall('isContextGraphActive', data, fixture.onChainContextGraphId);
-      return CONTEXT_GRAPH_INTERFACE.encodeFunctionResult(
-        'isContextGraphActive',
-        [fixture.active],
-      );
-    case CONTEXT_GRAPH_INTERFACE.getFunction('getContextGraphKaCount')!.selector:
-      assertContextGraphCall('getContextGraphKaCount', data, fixture.onChainContextGraphId);
-      return CONTEXT_GRAPH_INTERFACE.encodeFunctionResult(
-        'getContextGraphKaCount',
-        [BigInt(vmFixture?.assets.length ?? 0)],
-      );
-    case CONTEXT_GRAPH_INTERFACE.getFunction('getContextGraphKaAt')!.selector: {
-      const [contextGraphId, ordinal] = CONTEXT_GRAPH_INTERFACE.decodeFunctionData(
-        'getContextGraphKaAt',
-        data,
-      );
-      assertNumericId(contextGraphId, fixture.onChainContextGraphId, 'context graph');
-      const asset = vmFixture?.assets[Number(ordinal)];
+    case FINALIZED_CONTEXT_GRAPH_INTERFACE.getFunction('getContextGraphKaCount')!.selector: {
+      const [id] = FINALIZED_CONTEXT_GRAPH_INTERFACE.decodeFunctionData('getContextGraphKaCount', data);
+      assertFinalizedChainNumericIdV1(id, fixture.onChainContextGraphId, 'context graph');
+      return FINALIZED_CONTEXT_GRAPH_INTERFACE.encodeFunctionResult('getContextGraphKaCount', [BigInt(fixture.assets.length)]);
+    }
+    case FINALIZED_CONTEXT_GRAPH_INTERFACE.getFunction('getContextGraphKaAt')!.selector: {
+      const [id, ordinal] = FINALIZED_CONTEXT_GRAPH_INTERFACE.decodeFunctionData('getContextGraphKaAt', data);
+      assertFinalizedChainNumericIdV1(id, fixture.onChainContextGraphId, 'context graph');
+      const asset = fixture.assets[Number(ordinal)];
       if (asset === undefined) throw new Error(`unknown finalized VM ordinal ${ordinal}`);
-      return CONTEXT_GRAPH_INTERFACE.encodeFunctionResult(
-        'getContextGraphKaAt',
-        [BigInt(asset.kaId)],
-      );
+      return FINALIZED_CONTEXT_GRAPH_INTERFACE.encodeFunctionResult('getContextGraphKaAt', [BigInt(asset.kaId)]);
     }
     case KNOWLEDGE_ASSET_INTERFACE.getFunction('getKnowledgeAssetUpdateContext')!.selector: {
       const asset = readAssetCall('getKnowledgeAssetUpdateContext', data, assets);
@@ -272,42 +105,16 @@ function finalizedVmEthCallResult(
         [asset.publisherAddress],
       );
     }
-    default:
-      throw new Error(`unexpected finalized VM eth_call selector ${selector}`);
+    default: return readFinalizedChainAuthorityCallV1(fixture, call);
   }
 }
 
-const CONTEXT_GRAPH_SELECTORS = new Set([
-  'getContextGraph',
-  'getNameHash',
-  'isContextGraphActive',
-  'getContextGraphKaCount',
-  'getContextGraphKaAt',
-].map((method) => CONTEXT_GRAPH_INTERFACE.getFunction(method)!.selector));
-
+const VM_CONTEXT_GRAPH_SELECTORS = new Set(['getContextGraphKaCount', 'getContextGraphKaAt']
+  .map(method => FINALIZED_CONTEXT_GRAPH_INTERFACE.getFunction(method)!.selector));
 const KNOWLEDGE_ASSET_SELECTORS = new Set([
-  'getKnowledgeAssetUpdateContext',
-  'getLatestMerkleRoot',
-  'getLatestMerkleRootAuthor',
-  'getLatestMerkleRootPublisher',
-].map((method) => KNOWLEDGE_ASSET_INTERFACE.getFunction(method)!.selector));
-
-function assertCallTarget(actual: string, expected: EvmAddressV1, label: string): void {
-  if (actual !== expected.toLowerCase()) {
-    throw new Error(
-      `unexpected finalized VM ${label} target ${actual}; expected ${expected.toLowerCase()}`,
-    );
-  }
-}
-
-function assertContextGraphCall(
-  method: string,
-  data: string,
-  expectedId: string,
-): void {
-  const [contextGraphId] = CONTEXT_GRAPH_INTERFACE.decodeFunctionData(method, data);
-  assertNumericId(contextGraphId, expectedId, 'context graph');
-}
+  'getKnowledgeAssetUpdateContext', 'getLatestMerkleRoot',
+  'getLatestMerkleRootAuthor', 'getLatestMerkleRootPublisher',
+].map(method => KNOWLEDGE_ASSET_INTERFACE.getFunction(method)!.selector));
 
 function readAssetCall(
   method: string,
@@ -318,24 +125,4 @@ function readAssetCall(
   const asset = assets.get(String(kaId));
   if (asset === undefined) throw new Error(`unknown finalized VM KA ${kaId}`);
   return asset;
-}
-
-function assertNumericId(actual: unknown, expected: string, label: string): void {
-  if (String(actual) !== expected) {
-    throw new Error(`unexpected finalized VM ${label} id ${String(actual)}`);
-  }
-}
-
-function plainRecord(value: unknown, label: string): Record<string, unknown> {
-  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
-    throw new TypeError(`${label} must be an object`);
-  }
-  return value as Record<string, unknown>;
-}
-
-function requiredString(value: unknown, label: string): string {
-  if (typeof value !== 'string' || value.length === 0 || value.length > 4096) {
-    throw new TypeError(`${label} must be a bounded non-empty string`);
-  }
-  return value;
 }

--- a/packages/agent/test/support/rfc64-finalized-vm-loopback-fixture.ts
+++ b/packages/agent/test/support/rfc64-finalized-vm-loopback-fixture.ts
@@ -62,12 +62,18 @@ const KNOWLEDGE_ASSET_INTERFACE = new ethers.Interface([
 /** Mock adapter whose chain identity matches the loopback finalized-RPC lane. */
 export class FinalizedVmLoopbackMockChainAdapterV1 extends MockChainAdapter {
   readonly #fixture: FinalizedVmLoopbackFixtureConfigV1;
+  readonly #rpcUrl: string;
 
-  constructor(fixture: FinalizedVmLoopbackFixtureConfigV1) {
+  constructor(fixture: FinalizedVmLoopbackFixtureConfigV1, rpcUrl: string) {
     super(fixture.networkId, MOCK_DEFAULT_SIGNER, {
       initialContextGraphId: BigInt(fixture.onChainContextGraphId),
     });
     this.#fixture = fixture;
+    this.#rpcUrl = rpcUrl;
+  }
+
+  getRpcUrls(): string[] {
+    return [this.#rpcUrl];
   }
 
   override async getEvmChainId(): Promise<bigint> {

--- a/packages/agent/test/support/rfc64-finalized-vm-loopback-fixture.ts
+++ b/packages/agent/test/support/rfc64-finalized-vm-loopback-fixture.ts
@@ -22,13 +22,12 @@ export interface FinalizedVmLoopbackAssetV1 {
   readonly publisherAddress: EvmAddressV1;
 }
 
-export interface FinalizedVmLoopbackFixtureConfigV1 {
+/** Finalized authority inputs needed before any VM inventory is considered. */
+export interface FinalizedChainLoopbackFixtureConfigV1 {
   readonly accessPolicy: 0 | 1;
   readonly active: boolean;
   readonly assertedAtChainId: string;
   readonly assertedAtKav10Address: EvmAddressV1;
-  readonly knowledgeAssetStorageAddress: EvmAddressV1;
-  readonly assets: readonly FinalizedVmLoopbackAssetV1[];
   readonly blockHash: Digest32V1;
   readonly blockNumberQuantity: string;
   readonly contextGraphStorageAddress: EvmAddressV1;
@@ -37,6 +36,12 @@ export interface FinalizedVmLoopbackFixtureConfigV1 {
   readonly onChainContextGraphId: string;
   readonly ownerAddress: EvmAddressV1;
   readonly publishPolicy: 0 | 1;
+}
+
+/** Optional VM inventory layered over finalized Context Graph authority. */
+export interface FinalizedVmLoopbackFixtureConfigV1 extends FinalizedChainLoopbackFixtureConfigV1 {
+  readonly knowledgeAssetStorageAddress: EvmAddressV1;
+  readonly assets: readonly FinalizedVmLoopbackAssetV1[];
 }
 
 export interface FinalizedVmLoopbackRpcCallV1 {
@@ -64,72 +69,78 @@ const KNOWLEDGE_ASSET_INTERFACE = new ethers.Interface([
 ]);
 
 /** Mock adapter whose chain identity matches the loopback finalized-RPC lane. */
-export class FinalizedVmLoopbackMockChainAdapterV1 extends MockChainAdapter {
-  readonly #fixture: FinalizedVmLoopbackFixtureConfigV1;
-  readonly #rpcEndpoint: string;
+export class FinalizedChainLoopbackMockChainAdapterV1 extends MockChainAdapter {
+  protected readonly fixture: FinalizedChainLoopbackFixtureConfigV1;
+  protected readonly rpcEndpoint: string;
 
-  constructor(fixture: FinalizedVmLoopbackFixtureConfigV1, rpcEndpoint: string) {
+  constructor(fixture: FinalizedChainLoopbackFixtureConfigV1, rpcEndpoint: string) {
     super(fixture.networkId, MOCK_DEFAULT_SIGNER, {
       initialContextGraphId: BigInt(fixture.onChainContextGraphId),
     });
     if (typeof rpcEndpoint !== 'string' || rpcEndpoint.trim() === '') {
       throw new Error('Finalized VM loopback adapter requires its RPC endpoint');
     }
-    this.#fixture = fixture;
-    this.#rpcEndpoint = rpcEndpoint;
+    this.fixture = fixture;
+    this.rpcEndpoint = rpcEndpoint;
   }
 
   override async createFinalizedEvmReadBinding(
     owner: FinalizedChainReadOwnerV1,
   ): Promise<Readonly<FinalizedEvmReadBindingV1>> {
-    const chainId = this.#fixture.assertedAtChainId;
+    const chainId = this.fixture.assertedAtChainId;
     assertCanonicalChainId(chainId, 'finalized VM fixture chainId');
     return Object.freeze({
       chainId,
       snapshot: createStrictCurrentFinalizedEvmSnapshotScopeV1({
-        chainId, endpoints: [this.#rpcEndpoint], owner,
+        chainId, endpoints: [this.rpcEndpoint], owner,
       }),
     });
   }
 
   override async getEvmChainId(): Promise<bigint> {
-    return BigInt(this.#fixture.assertedAtChainId);
+    return BigInt(this.fixture.assertedAtChainId);
   }
 
   override async getKnowledgeAssetsLifecycleAddress(): Promise<string> {
-    return this.#fixture.assertedAtKav10Address;
-  }
-
-  override async getDKGKnowledgeAssetsAddress(): Promise<string> {
-    return this.#fixture.knowledgeAssetStorageAddress;
+    return this.fixture.assertedAtKav10Address;
   }
 
   override async getContextGraphAuthoritySnapshot(
     contextGraphId: bigint,
   ): Promise<ContextGraphAuthoritySnapshot> {
-    if (contextGraphId.toString(10) !== this.#fixture.onChainContextGraphId) {
+    if (contextGraphId.toString(10) !== this.fixture.onChainContextGraphId) {
       throw new Error(`Finalized VM fixture has no Context Graph ${contextGraphId.toString(10)}`);
     }
     return Object.freeze({
-      chainId: this.#fixture.assertedAtChainId,
-      governanceContract: this.#fixture.contextGraphStorageAddress.toLowerCase(),
-      contextGraphId: this.#fixture.onChainContextGraphId,
-      owner: this.#fixture.ownerAddress.toLowerCase(),
-      active: this.#fixture.active,
-      accessPolicy: this.#fixture.accessPolicy,
-      publishPolicy: this.#fixture.publishPolicy,
-      publishAuthority: this.#fixture.publishPolicy === 1
+      chainId: this.fixture.assertedAtChainId,
+      governanceContract: this.fixture.contextGraphStorageAddress.toLowerCase(),
+      contextGraphId: this.fixture.onChainContextGraphId,
+      owner: this.fixture.ownerAddress.toLowerCase(),
+      active: this.fixture.active,
+      accessPolicy: this.fixture.accessPolicy,
+      publishPolicy: this.fixture.publishPolicy,
+      publishAuthority: this.fixture.publishPolicy === 1
         ? null
-        : this.#fixture.ownerAddress.toLowerCase(),
+        : this.fixture.ownerAddress.toLowerCase(),
       publishAuthorityAccountId: '0',
       participantAgents: Object.freeze([]),
-      nameHash: this.#fixture.nameHash.toLowerCase(),
+      nameHash: this.fixture.nameHash.toLowerCase(),
       ownershipEra: '0',
       policyVersion: '0',
       rosterVersion: '0',
-      sourceBlockNumber: BigInt(this.#fixture.blockNumberQuantity).toString(10),
-      sourceBlockHash: this.#fixture.blockHash.toLowerCase(),
+      sourceBlockNumber: BigInt(this.fixture.blockNumberQuantity).toString(10),
+      sourceBlockHash: this.fixture.blockHash.toLowerCase(),
     });
+  }
+}
+
+export class FinalizedVmLoopbackMockChainAdapterV1 extends FinalizedChainLoopbackMockChainAdapterV1 {
+  constructor(fixture: FinalizedVmLoopbackFixtureConfigV1, rpcEndpoint: string) {
+    super(fixture, rpcEndpoint);
+  }
+
+  override async getDKGKnowledgeAssetsAddress(): Promise<string> {
+    return (this.fixture as FinalizedVmLoopbackFixtureConfigV1).knowledgeAssetStorageAddress;
   }
 }
 
@@ -140,8 +151,22 @@ export class FinalizedVmLoopbackMockChainAdapterV1 extends MockChainAdapter {
 export function createFinalizedVmLoopbackRpcV1(
   fixture: FinalizedVmLoopbackFixtureConfigV1,
 ): FinalizedVmLoopbackRpcV1 {
+  return createFinalizedLoopbackRpcV1(fixture, fixture);
+}
+
+/** Policy-only loopback: Context Graph authority is available; VM inventory is empty. */
+export function createFinalizedChainLoopbackRpcV1(
+  fixture: FinalizedChainLoopbackFixtureConfigV1,
+): FinalizedVmLoopbackRpcV1 {
+  return createFinalizedLoopbackRpcV1(fixture, undefined);
+}
+
+function createFinalizedLoopbackRpcV1(
+  fixture: FinalizedChainLoopbackFixtureConfigV1,
+  vmFixture: FinalizedVmLoopbackFixtureConfigV1 | undefined,
+): FinalizedVmLoopbackRpcV1 {
   const calls: FinalizedVmLoopbackRpcCallV1[] = [];
-  const assets = new Map(fixture.assets.map((asset) => [asset.kaId, asset]));
+  const assets = new Map((vmFixture?.assets ?? []).map((asset) => [asset.kaId, asset]));
   const respond = (method: string, params: readonly unknown[]): unknown => {
     calls.push(Object.freeze({ method, params: Object.freeze([...params]) }));
     switch (method) {
@@ -152,7 +177,7 @@ export function createFinalizedVmLoopbackRpcV1(
       case 'eth_getCode':
         return '0x6000';
       case 'eth_call':
-        return finalizedVmEthCallResult(params, fixture, assets);
+        return finalizedVmEthCallResult(params, fixture, vmFixture, assets);
       default:
         throw new Error(`unexpected finalized VM JSON-RPC method ${method}`);
     }
@@ -162,7 +187,8 @@ export function createFinalizedVmLoopbackRpcV1(
 
 function finalizedVmEthCallResult(
   params: readonly unknown[],
-  fixture: FinalizedVmLoopbackFixtureConfigV1,
+  fixture: FinalizedChainLoopbackFixtureConfigV1,
+  vmFixture: FinalizedVmLoopbackFixtureConfigV1 | undefined,
   assets: ReadonlyMap<string, FinalizedVmLoopbackAssetV1>,
 ): string {
   const call = plainRecord(params[0], 'finalized VM eth_call object');
@@ -173,7 +199,8 @@ function finalizedVmEthCallResult(
   if (CONTEXT_GRAPH_SELECTORS.has(selector)) {
     assertCallTarget(target, fixture.contextGraphStorageAddress, 'context graph');
   } else if (KNOWLEDGE_ASSET_SELECTORS.has(selector)) {
-    assertCallTarget(target, fixture.knowledgeAssetStorageAddress, 'knowledge asset storage');
+    if (vmFixture === undefined) throw new Error('policy-only finalized chain has no VM inventory');
+    assertCallTarget(target, vmFixture.knowledgeAssetStorageAddress, 'knowledge asset storage');
   }
   switch (selector) {
     case CONTEXT_GRAPH_INTERFACE.getFunction('getContextGraph')!.selector:
@@ -202,7 +229,7 @@ function finalizedVmEthCallResult(
       assertContextGraphCall('getContextGraphKaCount', data, fixture.onChainContextGraphId);
       return CONTEXT_GRAPH_INTERFACE.encodeFunctionResult(
         'getContextGraphKaCount',
-        [BigInt(fixture.assets.length)],
+        [BigInt(vmFixture?.assets.length ?? 0)],
       );
     case CONTEXT_GRAPH_INTERFACE.getFunction('getContextGraphKaAt')!.selector: {
       const [contextGraphId, ordinal] = CONTEXT_GRAPH_INTERFACE.decodeFunctionData(
@@ -210,7 +237,7 @@ function finalizedVmEthCallResult(
         data,
       );
       assertNumericId(contextGraphId, fixture.onChainContextGraphId, 'context graph');
-      const asset = fixture.assets[Number(ordinal)];
+      const asset = vmFixture?.assets[Number(ordinal)];
       if (asset === undefined) throw new Error(`unknown finalized VM ordinal ${ordinal}`);
       return CONTEXT_GRAPH_INTERFACE.encodeFunctionResult(
         'getContextGraphKaAt',

--- a/packages/agent/test/support/rfc64-finalized-vm-loopback-fixture.ts
+++ b/packages/agent/test/support/rfc64-finalized-vm-loopback-fixture.ts
@@ -84,7 +84,7 @@ export class FinalizedChainLoopbackMockChainAdapterV1 extends MockChainAdapter {
     this.rpcEndpoint = rpcEndpoint;
   }
 
-  override async createFinalizedEvmReadBinding(
+  async createFinalizedEvmReadBinding(
     owner: FinalizedChainReadOwnerV1,
   ): Promise<Readonly<FinalizedEvmReadBindingV1>> {
     const chainId = this.fixture.assertedAtChainId;

--- a/packages/agent/test/support/rfc64-finalized-vm-placement-fixture.ts
+++ b/packages/agent/test/support/rfc64-finalized-vm-placement-fixture.ts
@@ -5,6 +5,8 @@ import {
   AUTHOR_CATALOG_HEAD_OBJECT_TYPE_V1,
   AUTHOR_CATALOG_ISSUER_DELEGATION_OBJECT_TYPE_V1,
   buildAuthorAttestationTypedData,
+  assertCanonicalDecimalU64,
+  assertCanonicalChainId,
   canonicalizeCanonicalGraphScopedAuthorSealBytesV1,
   computeAuthorCatalogScopeDigestV1,
   computeCanonicalGraphScopedAuthorSealDigestV1,
@@ -65,6 +67,10 @@ export async function createRfc64FinalizedVmPlacementFixture(options: {
   readonly assertionVersion?: string;
   readonly publicTripleCount?: number;
 } = {}): Promise<FinalizedVmPlacementEvidenceV1> {
+  const chainId = RFC64_VM_CHAIN_ID;
+  assertCanonicalChainId(chainId);
+  const bucketId = '0';
+  assertCanonicalDecimalU64(bucketId);
   const kaNumber = options.kaNumber ?? 1n;
   const kaId = rfc64VmPackKaId(kaNumber);
   const assertionRoot = options.assertionRoot ?? RFC64_VM_ASSERTION_ROOT;
@@ -159,7 +165,7 @@ export async function createRfc64FinalizedVmPlacementFixture(options: {
     era: '0',
     bucketCount: '1',
     bucketId: '0',
-    rows: [row],
+    rows: [{ ...row, transfer: { ...row.transfer } }],
   };
   const bucket = await signEnvelope({
     issuer: RFC64_VM_CATALOG_ISSUER,
@@ -220,7 +226,7 @@ export async function createRfc64FinalizedVmPlacementFixture(options: {
       catalogHeadSignature: await verifyControlEnvelopeIssuerSignatureV1(head),
       directoryPathEnvelopes: [directory],
       directoryPathSignatures: [await verifyControlEnvelopeIssuerSignatureV1(directory)],
-      directoryPathProof: verifyAuthorCatalogDirectoryPathV1(head, [directory], '0'),
+      directoryPathProof: verifyAuthorCatalogDirectoryPathV1(head, [directory], bucketId),
       catalogBucket: bucket,
       catalogBucketSignature: await verifyControlEnvelopeIssuerSignatureV1(bucket),
       targetKaId: kaId,
@@ -231,7 +237,7 @@ export async function createRfc64FinalizedVmPlacementFixture(options: {
       canonicalizeCanonicalGraphScopedAuthorSealBytesV1(seal),
       {
         networkId: RFC64_VM_NETWORK_ID,
-        assertedAtChainId: RFC64_VM_CHAIN_ID,
+        assertedAtChainId: chainId,
         assertedAtKav10Address: RFC64_VM_KAV10,
       },
     ),

--- a/packages/agent/test/support/rfc64-finalized-vm-precommit-fixture.ts
+++ b/packages/agent/test/support/rfc64-finalized-vm-precommit-fixture.ts
@@ -3,9 +3,9 @@
  *
  * Extracted because two suites need the same plan, accepted-policy snapshot and
  * base options while varying one field each — the shipped-pool regression only
- * varies `rpcEndpoints`. Keeping a second copy meant a change to the plan or
- * policy shape required synchronized edits across files before either suite's
- * actual assertion could run.
+ * varies the adapter-owned snapshot factory. Keeping a second copy meant a
+ * change to the plan or policy shape required synchronized edits across files
+ * before either suite's actual assertion could run.
  *
  * The digests are exported so a caller can assert against them rather than
  * re-deriving the literals.
@@ -16,6 +16,10 @@ import {
   type ContextGraphPolicyV1,
   type Digest32V1,
 } from '@origintrail-official/dkg-core';
+import {
+  createStrictCurrentFinalizedEvmSnapshotScopeV1,
+  type StrictCurrentFinalizedEvmSnapshotScopeV1,
+} from '@origintrail-official/dkg-chain';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 
 import type { AcceptedRfc64CatalogAccessSnapshotV1 } from '../../src/rfc64/catalog-access-policy-v1.js';
@@ -36,6 +40,16 @@ import {
 
 export const RFC64_VM_CATALOG_HEAD_DIGEST = `0x${'91'.repeat(32)}` as Digest32V1;
 export const RFC64_VM_INVENTORY_DIGEST = `0x${'92'.repeat(32)}` as Digest32V1;
+
+export function finalizedSnapshotScopeFactory(
+  endpoints: readonly string[],
+): () => StrictCurrentFinalizedEvmSnapshotScopeV1 {
+  return () => createStrictCurrentFinalizedEvmSnapshotScopeV1({
+    chainId: RFC64_VM_CHAIN_ID,
+    endpoints,
+    owner: 'rfc64',
+  });
+}
 
 /** The before-applied-head commit plan the precommit is driven with. */
 export function rfc64FinalizedVmPrecommitPlan():
@@ -95,7 +109,7 @@ export function acceptedRfc64VmPolicySnapshot(): AcceptedRfc64CatalogAccessSnaps
 
 /**
  * Base precommit options. Each suite overrides the one field it is about — a
- * single resolver for the noncanonical-input cases, `rpcEndpoints` for the
+ * single resolver for the noncanonical-input cases, the snapshot factory for the
  * shipped-pool regression.
  *
  * A fresh `OxigraphStore` per call: sharing one across tests would let state
@@ -110,7 +124,8 @@ export function rfc64FinalizedVmPrecommitOptions(
 ): Rfc64FinalizedVmAgentPrecommitOptionsV1 {
   return {
     acceptedPolicySnapshotForCatalogScope: () => acceptedRfc64VmPolicySnapshot(),
-    rpcEndpoints: ['http://127.0.0.1:8545'],
+    createFinalizedSnapshotScope:
+      finalizedSnapshotScopeFactory(['http://127.0.0.1:8545']),
     getOnChainContextGraphId: async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID,
     getEvmChainId: async () => BigInt(RFC64_VM_CHAIN_ID),
     getKnowledgeAssetStorageAddress: async () => RFC64_VM_KA_STORAGE,

--- a/packages/agent/test/support/rfc64-finalized-vm-precommit-fixture.ts
+++ b/packages/agent/test/support/rfc64-finalized-vm-precommit-fixture.ts
@@ -20,6 +20,8 @@ import {
 import {
   createStrictCurrentFinalizedEvmSnapshotScopeV1,
   type FinalizedEvmReadBindingV1,
+  type FinalizedEvmReadBindingCapability,
+  type FinalizedEvmReadBindingProvider,
 } from '@origintrail-official/dkg-chain';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 
@@ -41,6 +43,16 @@ import {
 
 export const RFC64_VM_CATALOG_HEAD_DIGEST = `0x${'91'.repeat(32)}` as Digest32V1;
 export const RFC64_VM_INVENTORY_DIGEST = `0x${'92'.repeat(32)}` as Digest32V1;
+
+export const unavailableFinalizedReads = Object.freeze({
+  status: 'unsupported' as const, reason: 'finalized-evm-read-binding-unavailable' as const,
+});
+
+export function supportedFinalizedReads(
+  createFinalizedEvmReadBinding: FinalizedEvmReadBindingProvider['createFinalizedEvmReadBinding'],
+): Extract<FinalizedEvmReadBindingCapability, { status: 'supported' }> {
+  return Object.freeze({ status: 'supported', provider: { createFinalizedEvmReadBinding } });
+}
 
 export function finalizedReadBindingFactory(
   endpoints: readonly string[],
@@ -131,8 +143,7 @@ export function rfc64FinalizedVmPrecommitOptions(
 ): Rfc64FinalizedVmAgentPrecommitOptionsV1 {
   return {
     acceptedPolicySnapshotForCatalogScope: () => acceptedRfc64VmPolicySnapshot(),
-    createFinalizedReadBinding:
-      finalizedReadBindingFactory(['http://127.0.0.1:8545']),
+    finalizedReads: supportedFinalizedReads(finalizedReadBindingFactory(['http://127.0.0.1:8545'])),
     getOnChainContextGraphId: async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID,
     getKnowledgeAssetStorageAddress: async () => RFC64_VM_KA_STORAGE,
     getKnowledgeAssetsLifecycleAddress: async () => RFC64_VM_KAV10,

--- a/packages/agent/test/support/rfc64-finalized-vm-precommit-fixture.ts
+++ b/packages/agent/test/support/rfc64-finalized-vm-precommit-fixture.ts
@@ -12,13 +12,14 @@
  */
 import {
   CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
-  type AuthorCatalogScopeV1,
-  type ContextGraphPolicyV1,
+  assertAuthorCatalogScopeV1,
+  assertContextGraphPolicyV1,
+  assertCanonicalChainId,
   type Digest32V1,
 } from '@origintrail-official/dkg-core';
 import {
   createStrictCurrentFinalizedEvmSnapshotScopeV1,
-  type StrictCurrentFinalizedEvmSnapshotScopeV1,
+  type FinalizedEvmReadBindingV1,
 } from '@origintrail-official/dkg-chain';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 
@@ -41,31 +42,36 @@ import {
 export const RFC64_VM_CATALOG_HEAD_DIGEST = `0x${'91'.repeat(32)}` as Digest32V1;
 export const RFC64_VM_INVENTORY_DIGEST = `0x${'92'.repeat(32)}` as Digest32V1;
 
-export function finalizedSnapshotScopeFactory(
+export function finalizedReadBindingFactory(
   endpoints: readonly string[],
-): () => StrictCurrentFinalizedEvmSnapshotScopeV1 {
-  return () => createStrictCurrentFinalizedEvmSnapshotScopeV1({
-    chainId: RFC64_VM_CHAIN_ID,
-    endpoints,
-    owner: 'rfc64',
+  chainId: string = RFC64_VM_CHAIN_ID,
+): () => Promise<Readonly<FinalizedEvmReadBindingV1>> {
+  assertCanonicalChainId(chainId);
+  return async () => Object.freeze({
+    chainId,
+    snapshot: createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      chainId, endpoints, owner: 'rfc64',
+    }),
   });
 }
 
 /** The before-applied-head commit plan the precommit is driven with. */
 export function rfc64FinalizedVmPrecommitPlan():
 Readonly<Rfc64PublicCatalogNativeBeforeAppliedHeadCommitPlanV1> {
+  const catalogScope = Object.freeze({
+    networkId: RFC64_VM_NETWORK_ID,
+    contextGraphId: RFC64_VM_CONTEXT_GRAPH_NAME,
+    governanceChainId: RFC64_VM_CHAIN_ID,
+    governanceContractAddress: RFC64_VM_CG_STORAGE,
+    ownershipTransitionDigest: null,
+    subGraphName: null,
+    authorAddress: RFC64_VM_AUTHOR,
+    era: '0',
+    bucketCount: '1',
+  });
+  assertAuthorCatalogScopeV1(catalogScope);
   return Object.freeze({
-    catalogScope: Object.freeze({
-      networkId: RFC64_VM_NETWORK_ID,
-      contextGraphId: RFC64_VM_CONTEXT_GRAPH_NAME,
-      governanceChainId: RFC64_VM_CHAIN_ID,
-      governanceContractAddress: RFC64_VM_CG_STORAGE,
-      ownershipTransitionDigest: null,
-      subGraphName: null,
-      authorAddress: RFC64_VM_AUTHOR,
-      era: '0',
-      bucketCount: '1',
-    } satisfies AuthorCatalogScopeV1),
+    catalogScope,
     policyDigest: RFC64_VM_POLICY_DIGEST,
     catalogHeadDigest: RFC64_VM_CATALOG_HEAD_DIGEST,
     inventoryDigest: RFC64_VM_INVENTORY_DIGEST,
@@ -99,7 +105,8 @@ export function acceptedRfc64VmPolicySnapshot(): AcceptedRfc64CatalogAccessSnaps
     },
     effectiveAt: '1700000000000',
     issuedAt: '1700000000000',
-  } satisfies ContextGraphPolicyV1);
+  });
+  assertContextGraphPolicyV1(policy);
   return Object.freeze({
     policy,
     policyDigest: RFC64_VM_POLICY_DIGEST,
@@ -124,10 +131,9 @@ export function rfc64FinalizedVmPrecommitOptions(
 ): Rfc64FinalizedVmAgentPrecommitOptionsV1 {
   return {
     acceptedPolicySnapshotForCatalogScope: () => acceptedRfc64VmPolicySnapshot(),
-    createFinalizedSnapshotScope:
-      finalizedSnapshotScopeFactory(['http://127.0.0.1:8545']),
+    createFinalizedReadBinding:
+      finalizedReadBindingFactory(['http://127.0.0.1:8545']),
     getOnChainContextGraphId: async () => RFC64_VM_ON_CHAIN_CONTEXT_GRAPH_ID,
-    getEvmChainId: async () => BigInt(RFC64_VM_CHAIN_ID),
     getKnowledgeAssetStorageAddress: async () => RFC64_VM_KA_STORAGE,
     getKnowledgeAssetsLifecycleAddress: async () => RFC64_VM_KAV10,
     store: new OxigraphStore(),

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -44,6 +44,7 @@ export default defineConfig({
       "test/rfc64-receiver-admission-deferral.test.ts",
       "test/rfc64-precommit-owner-attribution.test.ts",
       "test/rfc64-finalized-adapter-compatibility.test.ts",
+      "test/rfc64-finalized-chain-harness.test.ts",
       "test/exact-assets.test.ts",
       "test/exact-asset-responder.test.ts",
       "test/exact-asset-wire-parse.test.ts",

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
       "test/w2-ual-parity.test.ts",
       "test/rfc64-receiver-admission-deferral.test.ts",
       "test/rfc64-precommit-owner-attribution.test.ts",
+      "test/rfc64-finalized-adapter-compatibility.test.ts",
       "test/exact-assets.test.ts",
       "test/exact-asset-responder.test.ts",
       "test/exact-asset-wire-parse.test.ts",

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -1216,7 +1216,7 @@ export interface ChainAdapter {
   /** Optional adapter-owned EVM reads; bind with bindFinalizedEvmReadBindingProvider. */
   createFinalizedEvmReadBinding?(
     owner: FinalizedChainReadOwnerV1,
-  ): Promise<Readonly<FinalizedEvmReadBindingV1> | null>;
+  ): Promise<Readonly<FinalizedEvmReadBindingV1>>;
 
   // Identity
   registerIdentity(proof: IdentityProof): Promise<bigint>;

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -1213,8 +1213,8 @@ export interface ChainAdapter {
    */
   drainRpcUsage?(): RpcUsageWindow;
 
-  /** Adapter-owned finalized reads; null when the adapter has no such capability. */
-  createFinalizedEvmReadBinding(
+  /** Optional adapter-owned EVM reads; bind with bindFinalizedEvmReadBindingProvider. */
+  createFinalizedEvmReadBinding?(
     owner: FinalizedChainReadOwnerV1,
   ): Promise<Readonly<FinalizedEvmReadBindingV1> | null>;
 

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -1,7 +1,14 @@
 import type { ethers } from 'ethers';
+import type { ChainIdV1 } from '@origintrail-official/dkg-core';
 import type { RpcUsageWindow } from './rpc-usage.js';
 import type { FinalizedChainReadOwnerV1 } from './finalized-chain-read-admission.js';
 import type { StrictCurrentFinalizedEvmSnapshotScopeV1 } from './current-finalized-evm-snapshot.js';
+
+/** Chain identity and strict snapshot access resolved together by one adapter. */
+export interface FinalizedEvmReadBindingV1 {
+  readonly chainId: ChainIdV1;
+  readonly snapshot: StrictCurrentFinalizedEvmSnapshotScopeV1;
+}
 
 /**
  * The Publishing-Conviction-Account read methods the funded-wallet selector
@@ -1206,10 +1213,10 @@ export interface ChainAdapter {
    */
   drainRpcUsage?(): RpcUsageWindow;
 
-  /** Adapter-owned strict finalized-read scope; absent on non-EVM adapters. */
-  createFinalizedEvmSnapshotScope?(
+  /** Adapter-owned finalized reads; null when the adapter has no such capability. */
+  createFinalizedEvmReadBinding(
     owner: FinalizedChainReadOwnerV1,
-  ): Promise<StrictCurrentFinalizedEvmSnapshotScopeV1 | null>;
+  ): Promise<Readonly<FinalizedEvmReadBindingV1> | null>;
 
   // Identity
   registerIdentity(proof: IdentityProof): Promise<bigint>;

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -1,5 +1,7 @@
 import type { ethers } from 'ethers';
 import type { RpcUsageWindow } from './rpc-usage.js';
+import type { FinalizedChainReadOwnerV1 } from './finalized-chain-read-admission.js';
+import type { StrictCurrentFinalizedEvmSnapshotScopeV1 } from './current-finalized-evm-snapshot.js';
 
 /**
  * The Publishing-Conviction-Account read methods the funded-wallet selector
@@ -1204,13 +1206,10 @@ export interface ChainAdapter {
    */
   drainRpcUsage?(): RpcUsageWindow;
 
-  /**
-   * Trusted RPC endpoints owned by this adapter. Consumers that must perform
-   * strict finalized reads outside the adapter's ordinary read facade use this
-   * capability instead of asking callers to repeat an otherwise ignored
-   * `chainConfig` alongside `chainAdapter`.
-   */
-  getRpcUrls?(): string[];
+  /** Adapter-owned strict finalized-read scope; absent on non-EVM adapters. */
+  createFinalizedEvmSnapshotScope?(
+    owner: FinalizedChainReadOwnerV1,
+  ): Promise<StrictCurrentFinalizedEvmSnapshotScopeV1 | null>;
 
   // Identity
   registerIdentity(proof: IdentityProof): Promise<bigint>;

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -1204,6 +1204,14 @@ export interface ChainAdapter {
    */
   drainRpcUsage?(): RpcUsageWindow;
 
+  /**
+   * Trusted RPC endpoints owned by this adapter. Consumers that must perform
+   * strict finalized reads outside the adapter's ordinary read facade use this
+   * capability instead of asking callers to repeat an otherwise ignored
+   * `chainConfig` alongside `chainAdapter`.
+   */
+  getRpcUrls?(): string[];
+
   // Identity
   registerIdentity(proof: IdentityProof): Promise<bigint>;
   getIdentityId(): Promise<bigint>;

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -26,7 +26,12 @@ import type {
 } from './chain-adapter.js';
 import { HubResolutionCache } from './hub-resolution-cache.js';
 import { SignerTxSerializer, type SignerTxLaneState } from './signer-tx-serializer.js';
-import { floorPublishTokenAmount, withSpan, getMetrics } from '@origintrail-official/dkg-core';
+import {
+  assertCanonicalChainId,
+  floorPublishTokenAmount,
+  withSpan,
+  getMetrics,
+} from '@origintrail-official/dkg-core';
 import { loadAbi } from './evm-adapter-abi.js';
 import { errorCode, errorMessage, errorStatus, isTooLowAllowanceError, enrichEvmError, getPcaLogicInterface, HUB_STALE_ERROR_MARKERS, isInsufficientFundsError, InsufficientPublisherFundsError, formatNoFundedPublisherWalletMessage, type PublisherWalletBalance } from './evm-adapter-errors.js';
 import { resolveRpcUrls, boundedRetryFetchRequest, withTimeout, isRetryableRpcError, assertSuccessfulReceipt, sleep } from './evm-adapter-rpc.js';
@@ -35,6 +40,9 @@ import { ChainRpcTransportError } from './chain-rpc-transport-error.js';
 import { RpcFailoverClient, type ReadOpts, type ReceiptLookupOptions } from './rpc-failover-client.js';
 import { waitForReceiptWithDeadline } from './receipt-wait.js';
 import { RpcUsageTracker, createCountingJsonRpcProvider, type RpcUsageWindow } from './rpc-usage.js';
+import { createStrictCurrentFinalizedEvmSnapshotScopeV1 } from './strict-current-finalized-evm-snapshot-factory.js';
+import type { StrictCurrentFinalizedEvmSnapshotScopeV1 } from './current-finalized-evm-snapshot.js';
+import type { FinalizedChainReadOwnerV1 } from './finalized-chain-read-admission.js';
 import { computeApprovalAction, effectivePublishAllowance, V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE } from './evm-adapter-allowance.js';
 import { formatProviderContext } from './evm-adapter-types.js';
 import { ReadThroughTtlCache } from './keyed-ttl-single-flight-cache.js';
@@ -4007,6 +4015,18 @@ export class EVMChainAdapterBase {
 
   getRpcUrls(): string[] {
     return [...this.rpcUrls];
+  }
+
+  async createFinalizedEvmSnapshotScope(
+    owner: FinalizedChainReadOwnerV1,
+  ): Promise<StrictCurrentFinalizedEvmSnapshotScopeV1> {
+    const chainId = (await this.getEvmChainId()).toString(10);
+    assertCanonicalChainId(chainId, 'finalized snapshot chainId');
+    return createStrictCurrentFinalizedEvmSnapshotScopeV1({
+      chainId,
+      endpoints: this.rpcUrls,
+      owner,
+    });
   }
 
   /**

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -41,7 +41,7 @@ import { RpcFailoverClient, type ReadOpts, type ReceiptLookupOptions } from './r
 import { waitForReceiptWithDeadline } from './receipt-wait.js';
 import { RpcUsageTracker, createCountingJsonRpcProvider, type RpcUsageWindow } from './rpc-usage.js';
 import { createStrictCurrentFinalizedEvmSnapshotScopeV1 } from './strict-current-finalized-evm-snapshot-factory.js';
-import type { StrictCurrentFinalizedEvmSnapshotScopeV1 } from './current-finalized-evm-snapshot.js';
+import type { FinalizedEvmReadBindingV1 } from './chain-adapter.js';
 import type { FinalizedChainReadOwnerV1 } from './finalized-chain-read-admission.js';
 import { computeApprovalAction, effectivePublishAllowance, V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE } from './evm-adapter-allowance.js';
 import { formatProviderContext } from './evm-adapter-types.js';
@@ -4017,15 +4017,16 @@ export class EVMChainAdapterBase {
     return [...this.rpcUrls];
   }
 
-  async createFinalizedEvmSnapshotScope(
+  async createFinalizedEvmReadBinding(
     owner: FinalizedChainReadOwnerV1,
-  ): Promise<StrictCurrentFinalizedEvmSnapshotScopeV1> {
+  ): Promise<Readonly<FinalizedEvmReadBindingV1>> {
     const chainId = (await this.getEvmChainId()).toString(10);
     assertCanonicalChainId(chainId, 'finalized snapshot chainId');
-    return createStrictCurrentFinalizedEvmSnapshotScopeV1({
+    return Object.freeze({
       chainId,
-      endpoints: this.rpcUrls,
-      owner,
+      snapshot: createStrictCurrentFinalizedEvmSnapshotScopeV1({
+        chainId, endpoints: this.rpcUrls, owner,
+      }),
     });
   }
 

--- a/packages/chain/src/finalized-evm-read-binding-provider.ts
+++ b/packages/chain/src/finalized-evm-read-binding-provider.ts
@@ -7,7 +7,7 @@ import type { FinalizedChainReadOwnerV1 } from './finalized-chain-read-admission
 export interface FinalizedEvmReadBindingProvider {
   createFinalizedEvmReadBinding(
     owner: FinalizedChainReadOwnerV1,
-  ): Promise<Readonly<FinalizedEvmReadBindingV1> | null>;
+  ): Promise<Readonly<FinalizedEvmReadBindingV1>>;
 }
 
 export type FinalizedEvmReadBindingCapability =

--- a/packages/chain/src/finalized-evm-read-binding-provider.ts
+++ b/packages/chain/src/finalized-evm-read-binding-provider.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ChainAdapter, FinalizedEvmReadBindingV1 } from './chain-adapter.js';
+import type { FinalizedChainReadOwnerV1 } from './finalized-chain-read-admission.js';
+
+/** Optional EVM integration; the adapter owns endpoint selection and identity. */
+export interface FinalizedEvmReadBindingProvider {
+  createFinalizedEvmReadBinding(
+    owner: FinalizedChainReadOwnerV1,
+  ): Promise<Readonly<FinalizedEvmReadBindingV1> | null>;
+}
+
+export type FinalizedEvmReadBindingCapability =
+  | Readonly<{ status: 'supported'; provider: FinalizedEvmReadBindingProvider }>
+  | Readonly<{ status: 'unsupported'; reason: 'finalized-evm-read-binding-unavailable' }>;
+
+const UNSUPPORTED = Object.freeze({
+  status: 'unsupported' as const,
+  reason: 'finalized-evm-read-binding-unavailable' as const,
+});
+
+/** Capture the optional method once, preserving its adapter receiver. */
+export function bindFinalizedEvmReadBindingProvider(adapter: ChainAdapter): FinalizedEvmReadBindingCapability {
+  const createBinding = adapter.createFinalizedEvmReadBinding;
+  if (typeof createBinding !== 'function') return UNSUPPORTED;
+  return Object.freeze({
+    status: 'supported' as const,
+    provider: Object.freeze({
+      createFinalizedEvmReadBinding: (owner: FinalizedChainReadOwnerV1) => createBinding.call(adapter, owner),
+    }),
+  });
+}

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -1,5 +1,10 @@
 export * from './chain-adapter.js';
 export {
+  bindFinalizedEvmReadBindingProvider,
+  type FinalizedEvmReadBindingProvider,
+  type FinalizedEvmReadBindingCapability,
+} from './finalized-evm-read-binding-provider.js';
+export {
   bindContextGraphAuthorityReader,
   type ContextGraphAuthorityReader,
   type ContextGraphAuthorityReaderCapability,

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -38,8 +38,6 @@ import type {
   ContextGraphAuthoritySnapshot,
 } from './chain-adapter.js';
 import type { RpcUsageWindow } from './rpc-usage.js';
-import type { FinalizedChainReadOwnerV1 } from './finalized-chain-read-admission.js';
-import type { FinalizedEvmReadBindingV1 } from './chain-adapter.js';
 import {
   NoEligibleContextGraphError,
   NoEligibleKnowledgeCollectionError,
@@ -265,12 +263,6 @@ export class MockChainAdapter implements ChainAdapter {
 
   getRpcUrls(): string[] {
     return [];
-  }
-
-  async createFinalizedEvmReadBinding(
-    _owner: FinalizedChainReadOwnerV1,
-  ): Promise<Readonly<FinalizedEvmReadBindingV1> | null> {
-    return null;
   }
 
   /** RPC-usage capability: the mock has no RPC transport → always-empty window. */

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -39,7 +39,7 @@ import type {
 } from './chain-adapter.js';
 import type { RpcUsageWindow } from './rpc-usage.js';
 import type { FinalizedChainReadOwnerV1 } from './finalized-chain-read-admission.js';
-import type { StrictCurrentFinalizedEvmSnapshotScopeV1 } from './current-finalized-evm-snapshot.js';
+import type { FinalizedEvmReadBindingV1 } from './chain-adapter.js';
 import {
   NoEligibleContextGraphError,
   NoEligibleKnowledgeCollectionError,
@@ -267,9 +267,9 @@ export class MockChainAdapter implements ChainAdapter {
     return [];
   }
 
-  async createFinalizedEvmSnapshotScope(
+  async createFinalizedEvmReadBinding(
     _owner: FinalizedChainReadOwnerV1,
-  ): Promise<StrictCurrentFinalizedEvmSnapshotScopeV1 | null> {
+  ): Promise<Readonly<FinalizedEvmReadBindingV1> | null> {
     return null;
   }
 

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -38,6 +38,8 @@ import type {
   ContextGraphAuthoritySnapshot,
 } from './chain-adapter.js';
 import type { RpcUsageWindow } from './rpc-usage.js';
+import type { FinalizedChainReadOwnerV1 } from './finalized-chain-read-admission.js';
+import type { StrictCurrentFinalizedEvmSnapshotScopeV1 } from './current-finalized-evm-snapshot.js';
 import {
   NoEligibleContextGraphError,
   NoEligibleKnowledgeCollectionError,
@@ -265,7 +267,9 @@ export class MockChainAdapter implements ChainAdapter {
     return [];
   }
 
-  async createFinalizedEvmSnapshotScope(): Promise<null> {
+  async createFinalizedEvmSnapshotScope(
+    _owner: FinalizedChainReadOwnerV1,
+  ): Promise<StrictCurrentFinalizedEvmSnapshotScopeV1 | null> {
     return null;
   }
 

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -265,6 +265,10 @@ export class MockChainAdapter implements ChainAdapter {
     return [];
   }
 
+  async createFinalizedEvmSnapshotScope(): Promise<null> {
+    return null;
+  }
+
   /** RPC-usage capability: the mock has no RPC transport → always-empty window. */
   drainRpcUsage(): RpcUsageWindow {
     return { byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 0 };

--- a/packages/chain/src/no-chain-adapter.ts
+++ b/packages/chain/src/no-chain-adapter.ts
@@ -12,8 +12,6 @@ import type {
   V10PublishParams,
 } from './chain-adapter.js';
 
-import type { FinalizedChainReadOwnerV1 } from './finalized-chain-read-admission.js';
-
 function noChain(): never {
   throw new Error(
     'No blockchain configured. To use on-chain operations, provide chainConfig ' +
@@ -44,7 +42,6 @@ export class NoChainAdapter implements ChainAdapter {
   async isOperationalWalletRegistered(_identityId: bigint, _address: string): Promise<boolean> { return false; }
   async getKnowledgeAssetsLifecycleAddress(): Promise<string> { noChain(); }
   async getEvmChainId(): Promise<bigint> { noChain(); }
-  async createFinalizedEvmReadBinding(_owner: FinalizedChainReadOwnerV1): Promise<null> { return null; }
   async getKnowledgeAssetOwner(_kaId: bigint): Promise<string> { noChain(); }
   async getPublishingConvictionAccountOwner(_accountId: bigint): Promise<string> { noChain(); }
   // The 7 #519 PCA write+read methods are OMITTED on purpose: they are

--- a/packages/chain/src/no-chain-adapter.ts
+++ b/packages/chain/src/no-chain-adapter.ts
@@ -12,6 +12,8 @@ import type {
   V10PublishParams,
 } from './chain-adapter.js';
 
+import type { FinalizedChainReadOwnerV1 } from './finalized-chain-read-admission.js';
+
 function noChain(): never {
   throw new Error(
     'No blockchain configured. To use on-chain operations, provide chainConfig ' +
@@ -42,6 +44,7 @@ export class NoChainAdapter implements ChainAdapter {
   async isOperationalWalletRegistered(_identityId: bigint, _address: string): Promise<boolean> { return false; }
   async getKnowledgeAssetsLifecycleAddress(): Promise<string> { noChain(); }
   async getEvmChainId(): Promise<bigint> { noChain(); }
+  async createFinalizedEvmReadBinding(_owner: FinalizedChainReadOwnerV1): Promise<null> { return null; }
   async getKnowledgeAssetOwner(_kaId: bigint): Promise<string> { noChain(); }
   async getPublishingConvictionAccountOwner(_accountId: bigint): Promise<string> { noChain(); }
   // The 7 #519 PCA write+read methods are OMITTED on purpose: they are

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1254,6 +1254,19 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(a.getRpcUrls()).toEqual(['https://primary.example', 'https://backup.example']);
   });
 
+  it('owns construction of strict finalized-read scopes', async () => {
+    const a = new EVMChainAdapter(minimalConfig({
+      rpcUrl: 'https://primary.example',
+      rpcUrls: ['https://backup.example'],
+    }));
+    const getEvmChainId = vi.spyOn(a, 'getEvmChainId').mockResolvedValue(31337n);
+
+    const scope = await a.createFinalizedEvmSnapshotScope('rfc64');
+
+    expect(scope).toEqual(expect.any(Function));
+    expect(getEvmChainId).toHaveBeenCalledOnce();
+  });
+
   it('receipt lookup succeeds on backup when primary throws retryable provider error', async () => {
     const a = new EVMChainAdapter(minimalConfig({
       rpcUrl: 'https://primary.example',

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -1261,9 +1261,10 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     }));
     const getEvmChainId = vi.spyOn(a, 'getEvmChainId').mockResolvedValue(31337n);
 
-    const scope = await a.createFinalizedEvmSnapshotScope('rfc64');
+    const binding = await a.createFinalizedEvmReadBinding('rfc64');
 
-    expect(scope).toEqual(expect.any(Function));
+    expect(binding).toEqual({ chainId: '31337', snapshot: expect.any(Function) });
+    expect(Object.isFrozen(binding)).toBe(true);
     expect(getEvmChainId).toHaveBeenCalledOnce();
   });
 

--- a/packages/chain/test/finalized-evm-read-binding-provider.unit.test.ts
+++ b/packages/chain/test/finalized-evm-read-binding-provider.unit.test.ts
@@ -43,12 +43,7 @@ describe('optional finalized EVM binding provider', () => {
     });
   });
 
-  it('preserves a provider refusal and error without substituting another RPC source', async () => {
-    const refused = bindFinalizedEvmReadBindingProvider(Object.assign(new NoChainAdapter(), {
-      createFinalizedEvmReadBinding: async () => null,
-    }));
-    if (refused.status !== 'supported') throw new Error('Expected provider');
-    await expect(refused.provider.createFinalizedEvmReadBinding('rfc64')).resolves.toBeNull();
+  it('preserves a provider error without substituting another RPC source', async () => {
     const failure = new Error('adapter configuration failed');
     const failed = bindFinalizedEvmReadBindingProvider(Object.assign(new NoChainAdapter(), {
       createFinalizedEvmReadBinding: async () => { throw failure; },

--- a/packages/chain/test/finalized-evm-read-binding-provider.unit.test.ts
+++ b/packages/chain/test/finalized-evm-read-binding-provider.unit.test.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { assertCanonicalChainId } from '@origintrail-official/dkg-core';
+import { describe, expect, it, vi } from 'vitest';
+import { bindFinalizedEvmReadBindingProvider } from '../src/finalized-evm-read-binding-provider.js';
+import { NoChainAdapter } from '../src/no-chain-adapter.js';
+import { createStrictCurrentFinalizedEvmSnapshotScopeV1 } from '../src/strict-current-finalized-evm-snapshot-factory.js';
+import type { FinalizedChainReadOwnerV1 } from '../src/finalized-chain-read-admission.js';
+
+describe('optional finalized EVM binding provider', () => {
+  it('captures a provider once and preserves its receiver and read owner', async () => {
+    const chainId = '20430';
+    assertCanonicalChainId(chainId);
+    const binding = Object.freeze({
+      chainId,
+      snapshot: createStrictCurrentFinalizedEvmSnapshotScopeV1({
+        chainId, endpoints: ['http://127.0.0.1:8545'], owner: 'rfc64',
+      }),
+    });
+    const adapter = new NoChainAdapter();
+    const create = vi.fn(function (this: NoChainAdapter, owner: FinalizedChainReadOwnerV1) {
+      expect(this).toBe(adapter);
+      expect(owner).toBe('rfc64');
+      return Promise.resolve(binding);
+    });
+    const read = vi.fn(() => create);
+    Object.defineProperty(adapter, 'createFinalizedEvmReadBinding', { get: read });
+    const capability = bindFinalizedEvmReadBindingProvider(adapter);
+    expect(capability.status).toBe('supported');
+    if (capability.status !== 'supported') throw new Error('Expected provider');
+    await expect(capability.provider.createFinalizedEvmReadBinding('rfc64')).resolves.toBe(binding);
+    expect(read).toHaveBeenCalledOnce();
+    expect(create).toHaveBeenCalledOnce();
+    expect(Object.isFrozen(capability)).toBe(true);
+    expect(Object.isFrozen(capability.provider)).toBe(true);
+  });
+
+  it.each([undefined, null, false])('treats a legacy non-function capability %s as unsupported', method => {
+    const adapter = new NoChainAdapter();
+    Object.defineProperty(adapter, 'createFinalizedEvmReadBinding', { value: method });
+    expect(bindFinalizedEvmReadBindingProvider(adapter)).toEqual({
+      status: 'unsupported', reason: 'finalized-evm-read-binding-unavailable',
+    });
+  });
+
+  it('preserves a provider refusal and error without substituting another RPC source', async () => {
+    const refused = bindFinalizedEvmReadBindingProvider(Object.assign(new NoChainAdapter(), {
+      createFinalizedEvmReadBinding: async () => null,
+    }));
+    if (refused.status !== 'supported') throw new Error('Expected provider');
+    await expect(refused.provider.createFinalizedEvmReadBinding('rfc64')).resolves.toBeNull();
+    const failure = new Error('adapter configuration failed');
+    const failed = bindFinalizedEvmReadBindingProvider(Object.assign(new NoChainAdapter(), {
+      createFinalizedEvmReadBinding: async () => { throw failure; },
+    }));
+    if (failed.status !== 'supported') throw new Error('Expected provider');
+    await expect(failed.provider.createFinalizedEvmReadBinding('rfc64')).rejects.toBe(failure);
+  });
+});

--- a/packages/chain/test/mock-adapter-fixtures.unit.test.ts
+++ b/packages/chain/test/mock-adapter-fixtures.unit.test.ts
@@ -11,8 +11,8 @@ describe('MockChainAdapter explicit fixture seams', () => {
   ] as const)('provides no finalized EVM evidence for the %s adapter', async (_name, adapter: ChainAdapter) => {
     // The optional capability must fail closed for local state: callers cannot
     // mistake a fixture or chain-disabled node for a finalized read source.
-    const snapshot = await adapter.createFinalizedEvmSnapshotScope?.('rfc64') ?? null;
-    expect(snapshot).toBeNull();
+    const binding = await adapter.createFinalizedEvmReadBinding('rfc64');
+    expect(binding).toBeNull();
   });
 
   it('seeds the first numeric context graph id through immutable fixture setup', async () => {

--- a/packages/chain/test/mock-adapter-fixtures.unit.test.ts
+++ b/packages/chain/test/mock-adapter-fixtures.unit.test.ts
@@ -1,8 +1,20 @@
 import { describe, expect, it } from 'vitest';
 
 import { MockChainAdapter, MOCK_DEFAULT_SIGNER } from '../src/mock-adapter.js';
+import type { ChainAdapter } from '../src/chain-adapter.js';
+import { NoChainAdapter } from '../src/no-chain-adapter.js';
 
 describe('MockChainAdapter explicit fixture seams', () => {
+  it.each([
+    ['mock', new MockChainAdapter()],
+    ['no-chain', new NoChainAdapter()],
+  ] as const)('provides no finalized EVM evidence for the %s adapter', async (_name, adapter: ChainAdapter) => {
+    // The optional capability must fail closed for local state: callers cannot
+    // mistake a fixture or chain-disabled node for a finalized read source.
+    const snapshot = await adapter.createFinalizedEvmSnapshotScope?.('rfc64') ?? null;
+    expect(snapshot).toBeNull();
+  });
+
   it('seeds the first numeric context graph id through immutable fixture setup', async () => {
     const mock = new MockChainAdapter('mock:31337', MOCK_DEFAULT_SIGNER, {
       initialContextGraphId: 14n,

--- a/packages/chain/test/mock-adapter-fixtures.unit.test.ts
+++ b/packages/chain/test/mock-adapter-fixtures.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { MockChainAdapter, MOCK_DEFAULT_SIGNER } from '../src/mock-adapter.js';
 import type { ChainAdapter } from '../src/chain-adapter.js';
+import { bindFinalizedEvmReadBindingProvider } from '../src/finalized-evm-read-binding-provider.js';
 import { NoChainAdapter } from '../src/no-chain-adapter.js';
 
 describe('MockChainAdapter explicit fixture seams', () => {
@@ -11,8 +12,10 @@ describe('MockChainAdapter explicit fixture seams', () => {
   ] as const)('provides no finalized EVM evidence for the %s adapter', async (_name, adapter: ChainAdapter) => {
     // The optional capability must fail closed for local state: callers cannot
     // mistake a fixture or chain-disabled node for a finalized read source.
-    const binding = await adapter.createFinalizedEvmReadBinding('rfc64');
-    expect(binding).toBeNull();
+    expect('createFinalizedEvmReadBinding' in adapter).toBe(false);
+    expect(bindFinalizedEvmReadBindingProvider(adapter)).toEqual({
+      status: 'unsupported', reason: 'finalized-evm-read-binding-unavailable',
+    });
   });
 
   it('seeds the first numeric context graph id through immutable fixture setup', async () => {

--- a/packages/chain/test/mock-adapter-parity.test.ts
+++ b/packages/chain/test/mock-adapter-parity.test.ts
@@ -84,6 +84,9 @@ const MOCK_EXEMPT_FROM_EVM = new Set<string>([
   'getBlockNumber',         // the mock exposes its own block counter differently (advanceBlock)
   'getProvider',            // returns a JsonRpcProvider; mock has none
   'getReadProvider',        // @deprecated bare-primary accessor; mock has no RPC provider
+  // Optional ChainAdapter capability backed by the EVM adapter's RPC pool.
+  // Mock/no-chain adapters report unsupported through the capability binder.
+  'createFinalizedEvmReadBinding',
   'getSignerAddress',       // mock exposes `signerAddress` as a field
   'getSignerAddresses',     // pool not applicable to mock
   'getAuthorizedPublisherAddress', // pool-specific signer selection; mock has one signerAddress

--- a/packages/chain/vitest.unit.config.ts
+++ b/packages/chain/vitest.unit.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       'test/filter-error-silencer.test.ts',
       'test/keyed-mutex-observability.test.ts',
       'test/mock-adapter-publishing-conviction-v10.test.ts',
+      'test/mock-adapter-parity.test.ts',
     ],
     exclude: ['**/node_modules/**', '**/dist/**'],
     testTimeout: 30_000,


### PR DESCRIPTION
Finalized catalog recovery depended on extra configured RPC settings even when an injected chain adapter already owned the connection. Both catalog precommit barriers now obtain the chain identity and strict finalized snapshot from that adapter, using the RFC-64 read owner. Each supported binding is resolved once, concurrently with the numeric Context Graph lookup.

The optional adapter method is bound into one supported/unsupported capability. A supported provider returns a binding or throws; the shared precommit resolver handles the unsupported case with the controlled trusted-RPC configuration error. Legacy and no-chain adapters remain usable for non-finalized policies. Provider failures propagate without reconstructing a transport from agent configuration.

The harness now separates finalized chain authority from its VM inventory extension. Policy-only fixtures use general chain types and an authority adapter; VM fixtures require their inventory and storage binding. A shared protocol driver and HTTP server serve both explicit compositions. The harness parser normalizes the legacy wire configuration once into a policy/VM union, and readiness derives from that same mode. The policy-only runtime exposes zero inventory; the VM runtime retains multi-asset ordinal, root, author, publisher, and update-context reads.

Validation:

- Canary integration on `d9931e915`: resolved the chain export-list conflict while retaining both the finalized binding provider and durable authority-history checkpoint types. All 287 selected tests pass across 13 suites: 111 chain authority/binding tests and 176 native catalog, precommit, harness, and adapter-compatibility tests. Agent dependency builds, public type/package checks, lint, and merge simulation pass. New remote CI is pending.
- The earlier revision `979d63607` also passed the validation below. Its separate-process proof was not rerun for this canary merge.

- 204 tests pass: 165 native catalog/precommit integration cases, 11 explicit harness/provider compatibility cases, 5 chain provider tests, and 23 Gate 2 tests. The integration selection includes private VM recovery and multi-asset recovery; direct HTTP tests verify both the empty policy inventory and private VM inventory responses.
- The canonical `live:public-finalized-catalog` command passes as a clean-build separate-process proof: numeric CG 14, one applied inventory row, exact two-quad SWM projection, finalized policy, and zero VM triples/confirmed metadata. Its artifact binds the tested commit and executed runtime manifest. This proves public finalized-policy recovery; it does not certify public VM materialization or a full M0 run. The legacy `live:public-vm` command remains an unchanged alias for this launcher.
- The new public type regression rejects nullable supported providers and fails on the preceding PR head. Legacy adapter assignment remains valid. Runtime dependency builds, public type/package checks, Gate 2 typecheck, lint, the 1,798-file inventory, and canary merge simulation pass.
- The broad strict check reports the same 54 existing diagnostics in three older test files, with no additions. The newly added/expanded capability and harness fixtures are clean. The broad check is not claimed as passing.

Closes #2527.
