### PR TITLE
test(agent): await identity admission before restart catalog projection

### DIFF
--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -10,7 +10,6 @@ import {
   MEMBER_ROSTER_OBJECT_TYPE_V1,
   MemoryLayer,
   PROTOCOL_NETWORK_IDENTITY,
-  type ProtocolRouter,
   assertCanonicalGraphScopedAuthorSealV1,
   buildAssertionSealQuads,
   buildAuthorAttestationTypedData,
@@ -68,7 +67,6 @@ import {
   DKGAgent,
   Rfc64CatalogReconciliationTerminalErrorV1,
 } from '../src/index.js';
-import type { NetworkAdmissionService } from '../src/p2p/network-admission.js';
 import { Rfc64SwmRecoveryRuntimeV1 } from
   '../src/dkg-agent-rfc64-swm-recovery-runtime.js';
 import {
@@ -2110,15 +2108,11 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
           providerPeerAddresses.get(peerId) ?? null,
       },
     });
-    const providerRuntime = provider as unknown as {
-      router: ProtocolRouter;
-      networkAdmission: NetworkAdmissionService;
-    };
-    const send = providerRuntime.router.send.bind(providerRuntime.router);
+    const send = provider.router.send.bind(provider.router);
     let interruptedProbe = false;
     // A peer closing during identity negotiation can return no frame. Keep
     // the real admission/backoff owner and all subsequent wire probes live.
-    vi.spyOn(providerRuntime.router, 'send').mockImplementation(async (peer, protocol, data, options) => {
+    vi.spyOn(provider.router, 'send').mockImplementation(async (peer, protocol, data, options) => {
       if (protocol === PROTOCOL_NETWORK_IDENTITY && !interruptedProbe) {
         interruptedProbe = true;
         return new Uint8Array();
@@ -2151,7 +2145,7 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     await connectBothWays(author, provider);
     await vi.waitFor(() => {
       expect(interruptedProbe).toBe(true);
-      expect(providerRuntime.networkAdmission.getRetryableProbeBackoff(author.peerId))
+      expect(provider.networkAdmission.getRetryableProbeBackoff(author.peerId))
         .toMatchObject({ kind: 'transient', failures: 1 });
     }, { timeout: 5_000, interval: 10 });
     const assertionCoordinate = 'private-startup-repair';
@@ -2222,8 +2216,8 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       // await the public API's signed identity admission before publishing.
       await restarted.connectTo(tcpMultiaddr(provider));
       await provider.connectTo(tcpMultiaddr(restarted));
-      expect(providerRuntime.networkAdmission.isAcceptedPeer(restarted.peerId)).toBe(true);
-      expect(providerRuntime.networkAdmission.getRetryableProbeBackoff(restarted.peerId)).toBeUndefined();
+      expect(provider.networkAdmission.isAcceptedPeer(restarted.peerId)).toBe(true);
+      expect(provider.networkAdmission.getRetryableProbeBackoff(restarted.peerId)).toBeUndefined();
     } finally {
       releaseStartupProjection();
     }

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -9,6 +9,8 @@ import {
   CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
   MEMBER_ROSTER_OBJECT_TYPE_V1,
   MemoryLayer,
+  PROTOCOL_NETWORK_IDENTITY,
+  type ProtocolRouter,
   assertCanonicalGraphScopedAuthorSealV1,
   buildAssertionSealQuads,
   buildAuthorAttestationTypedData,
@@ -66,6 +68,7 @@ import {
   DKGAgent,
   Rfc64CatalogReconciliationTerminalErrorV1,
 } from '../src/index.js';
+import type { NetworkAdmissionService } from '../src/p2p/network-admission.js';
 import { Rfc64SwmRecoveryRuntimeV1 } from
   '../src/dkg-agent-rfc64-swm-recovery-runtime.js';
 import {
@@ -2107,6 +2110,21 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
           providerPeerAddresses.get(peerId) ?? null,
       },
     });
+    const providerRuntime = provider as unknown as {
+      router: ProtocolRouter;
+      networkAdmission: NetworkAdmissionService;
+    };
+    const send = providerRuntime.router.send.bind(providerRuntime.router);
+    let interruptedProbe = false;
+    // A peer closing during identity negotiation can return no frame. Keep
+    // the real admission/backoff owner and all subsequent wire probes live.
+    vi.spyOn(providerRuntime.router, 'send').mockImplementation(async (peer, protocol, data, options) => {
+      if (protocol === PROTOCOL_NETWORK_IDENTITY && !interruptedProbe) {
+        interruptedProbe = true;
+        return new Uint8Array();
+      }
+      return send(peer, protocol, data, options);
+    });
     provider.acceptRfc64CatalogAccessSnapshotV1({
       policy: authority.policy,
       policyDigest: authority.policyDigest,
@@ -2130,6 +2148,12 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       },
     });
     providerPeerAddresses.set(author.peerId, AUTHOR);
+    await connectBothWays(author, provider);
+    await vi.waitFor(() => {
+      expect(interruptedProbe).toBe(true);
+      expect(providerRuntime.networkAdmission.getRetryableProbeBackoff(author.peerId))
+        .toMatchObject({ kind: 'transient', failures: 1 });
+    }, { timeout: 5_000, interval: 10 });
     const assertionCoordinate = 'private-startup-repair';
     const shareOperationId = 'private-startup-repair-operation';
     await seedSignedSwmWorkspaceV1(author, {
@@ -2192,8 +2216,17 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     });
     providerPeerAddresses.set(restarted.peerId, AUTHOR);
     await startupProjectionEntered;
-    await connectBothWays(restarted, provider);
-    releaseStartupProjection();
+    expect(restarted.peerId).toBe(authorPeerId);
+    try {
+      // Raw libp2p dial only awaits transport. This controlled reconnect must
+      // await the public API's signed identity admission before publishing.
+      await restarted.connectTo(tcpMultiaddr(provider));
+      await provider.connectTo(tcpMultiaddr(restarted));
+      expect(providerRuntime.networkAdmission.isAcceptedPeer(restarted.peerId)).toBe(true);
+      expect(providerRuntime.networkAdmission.getRetryableProbeBackoff(restarted.peerId)).toBeUndefined();
+    } finally {
+      releaseStartupProjection();
+    }
     await restarted.whenRfc64SwmCatalogProjectionSupervisorIdleV1();
 
     expect(restarted.readRfc64AppliedCatalogHeadV1({

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -9,7 +9,6 @@ import {
   CONTEXT_GRAPH_SHARED_PROJECTION_ID_V1,
   MEMBER_ROSTER_OBJECT_TYPE_V1,
   MemoryLayer,
-  PROTOCOL_NETWORK_IDENTITY,
   assertCanonicalGraphScopedAuthorSealV1,
   buildAssertionSealQuads,
   buildAuthorAttestationTypedData,
@@ -289,6 +288,8 @@ interface NativeAgentStartOptionsV1 {
   readonly operationalPrivateKey?: string;
   readonly omitLegacyDeployment?: boolean;
   readonly beforeStart?: (agent: DKGAgent) => void | Promise<void>;
+  /** Establish live-node test preconditions before automatic graph subscription. */
+  readonly afterStart?: (agent: DKGAgent) => void | Promise<void>;
 }
 
 async function startNativeAgentWithOptions(
@@ -306,6 +307,7 @@ async function startNativeAgentWithOptions(
     activation,
     persistentStorePath,
     beforeStart,
+    afterStart,
     syncContextGraphs,
     operationalPrivateKey,
     omitLegacyDeployment = false,
@@ -379,6 +381,7 @@ async function startNativeAgentWithOptions(
   agents.push(agent);
   await beforeStart?.(agent);
   await agent.start();
+  await afterStart?.(agent);
   const selectedContextGraphs = syncContextGraphs ?? (catalogActivation !== undefined
     && catalogActivation.enabled !== false
     ? catalogActivation.bootstrap?.acceptedPolicies.map(
@@ -2108,17 +2111,6 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
           providerPeerAddresses.get(peerId) ?? null,
       },
     });
-    const send = provider.router.send.bind(provider.router);
-    let interruptedProbe = false;
-    // A peer closing during identity negotiation can return no frame. Keep
-    // the real admission/backoff owner and all subsequent wire probes live.
-    vi.spyOn(provider.router, 'send').mockImplementation(async (peer, protocol, data, options) => {
-      if (protocol === PROTOCOL_NETWORK_IDENTITY && !interruptedProbe) {
-        interruptedProbe = true;
-        return new Uint8Array();
-      }
-      return send(peer, protocol, data, options);
-    });
     provider.acceptRfc64CatalogAccessSnapshotV1({
       policy: authority.policy,
       policyDigest: authority.policyDigest,
@@ -2135,19 +2127,15 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       existingDataDir: dataDir,
       persistentStorePath,
       catalogActivation,
+      afterStart: (agent) => provider.networkAdmission.rememberRetryableProbeFailure(
+        agent.peerId, 'restart fixture transient backoff', 'transient',
+      ),
       beforeStart: (agent) => {
         vi.spyOn(agent, 'getCustodialAgentPrivateKey').mockReturnValue(
           AUTHOR_WALLET.privateKey,
         );
       },
     });
-    providerPeerAddresses.set(author.peerId, AUTHOR);
-    await connectBothWays(author, provider);
-    await vi.waitFor(() => {
-      expect(interruptedProbe).toBe(true);
-      expect(provider.networkAdmission.getRetryableProbeBackoff(author.peerId))
-        .toMatchObject({ kind: 'transient', failures: 1 });
-    }, { timeout: 5_000, interval: 10 });
     const assertionCoordinate = 'private-startup-repair';
     const shareOperationId = 'private-startup-repair-operation';
     await seedSignedSwmWorkspaceV1(author, {
@@ -2170,11 +2158,6 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     const authorPeerId = author.peerId;
     await author.stop();
     agents.splice(agents.indexOf(author), 1);
-    await vi.waitFor(() => {
-      expect(provider.node.libp2p.getConnections().some(
-        ({ remotePeer }) => remotePeer.toString() === authorPeerId,
-      )).toBe(false);
-    }, { timeout: 10_000, interval: 10 });
 
     let markStartupProjectionEntered!: () => void;
     let releaseStartupProjection!: () => void;
@@ -2190,6 +2173,9 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       existingDataDir: dataDir,
       persistentStorePath,
       catalogActivation,
+      afterStart: (agent) => provider.networkAdmission.rememberRetryableProbeFailure(
+        agent.peerId, 'restart fixture transient backoff', 'transient',
+      ),
       beforeStart: (agent) => {
         vi.spyOn(agent, 'getCustodialAgentPrivateKey').mockReturnValue(
           AUTHOR_WALLET.privateKey,
@@ -2214,7 +2200,13 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     try {
       // Raw libp2p dial only awaits transport. This controlled reconnect must
       // await the public API's signed identity admission before publishing.
+      provider.networkAdmission.rememberRetryableProbeFailure(
+        restarted.peerId, 'restart fixture transient backoff', 'transient',
+      );
       await restarted.connectTo(tcpMultiaddr(provider));
+      expect(provider.networkAdmission.getRetryableProbeBackoff(restarted.peerId))
+        .toMatchObject({ kind: 'transient', retryAfterMs: expect.any(Number) });
+      expect(provider.networkAdmission.isAcceptedPeer(restarted.peerId)).toBe(false);
       await provider.connectTo(tcpMultiaddr(restarted));
       expect(provider.networkAdmission.isAcceptedPeer(restarted.peerId)).toBe(true);
       expect(provider.networkAdmission.getRetryableProbeBackoff(restarted.peerId)).toBeUndefined();

--- a/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
+++ b/packages/agent/test/rfc64-dkg-agent-native-wiring.integration.test.ts
@@ -288,8 +288,6 @@ interface NativeAgentStartOptionsV1 {
   readonly operationalPrivateKey?: string;
   readonly omitLegacyDeployment?: boolean;
   readonly beforeStart?: (agent: DKGAgent) => void | Promise<void>;
-  /** Establish live-node test preconditions before automatic graph subscription. */
-  readonly afterStart?: (agent: DKGAgent) => void | Promise<void>;
 }
 
 async function startNativeAgentWithOptions(
@@ -307,7 +305,6 @@ async function startNativeAgentWithOptions(
     activation,
     persistentStorePath,
     beforeStart,
-    afterStart,
     syncContextGraphs,
     operationalPrivateKey,
     omitLegacyDeployment = false,
@@ -381,7 +378,6 @@ async function startNativeAgentWithOptions(
   agents.push(agent);
   await beforeStart?.(agent);
   await agent.start();
-  await afterStart?.(agent);
   const selectedContextGraphs = syncContextGraphs ?? (catalogActivation !== undefined
     && catalogActivation.enabled !== false
     ? catalogActivation.bootstrap?.acceptedPolicies.map(
@@ -2111,6 +2107,17 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
           providerPeerAddresses.get(peerId) ?? null,
       },
     });
+    const seedProviderAdmissionBackoff = (peerId: string) => {
+      provider.networkAdmission.rememberRetryableProbeFailure(
+        peerId, 'restart fixture transient backoff', 'transient',
+      );
+    };
+    const startAuthorWithAdmissionBackoff = async (options: NativeAgentStartOptionsV1) => {
+      const agent = await startNativeAgentWithOptions({ ...options, syncContextGraphs: [] });
+      seedProviderAdmissionBackoff(agent.peerId);
+      agent.subscribeToContextGraph(CONTEXT_GRAPH_ID);
+      return agent;
+    };
     provider.acceptRfc64CatalogAccessSnapshotV1({
       policy: authority.policy,
       policyDigest: authority.policyDigest,
@@ -2122,14 +2129,11 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       authority,
       1_000,
     );
-    const author = await startNativeAgentWithOptions({
+    const author = await startAuthorWithAdmissionBackoff({
       name: 'selected-private-startup-author',
       existingDataDir: dataDir,
       persistentStorePath,
       catalogActivation,
-      afterStart: (agent) => provider.networkAdmission.rememberRetryableProbeFailure(
-        agent.peerId, 'restart fixture transient backoff', 'transient',
-      ),
       beforeStart: (agent) => {
         vi.spyOn(agent, 'getCustodialAgentPrivateKey').mockReturnValue(
           AUTHOR_WALLET.privateKey,
@@ -2168,14 +2172,11 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
       releaseStartupProjection = resolve;
     });
     let announce: ReturnType<typeof vi.spyOn<DKGAgent, 'announceRfc64PublicCatalogHeadV1'>>;
-    const restarted = await startNativeAgentWithOptions({
+    const restarted = await startAuthorWithAdmissionBackoff({
       name: 'selected-private-startup-author-restarted',
       existingDataDir: dataDir,
       persistentStorePath,
       catalogActivation,
-      afterStart: (agent) => provider.networkAdmission.rememberRetryableProbeFailure(
-        agent.peerId, 'restart fixture transient backoff', 'transient',
-      ),
       beforeStart: (agent) => {
         vi.spyOn(agent, 'getCustodialAgentPrivateKey').mockReturnValue(
           AUTHOR_WALLET.privateKey,
@@ -2196,13 +2197,11 @@ ordinaryNativeWiringDescribe('RFC-64 DKGAgent production native catalog wiring',
     });
     providerPeerAddresses.set(restarted.peerId, AUTHOR);
     await startupProjectionEntered;
-    expect(restarted.peerId).toBe(authorPeerId);
     try {
+      expect(restarted.peerId).toBe(authorPeerId);
       // Raw libp2p dial only awaits transport. This controlled reconnect must
       // await the public API's signed identity admission before publishing.
-      provider.networkAdmission.rememberRetryableProbeFailure(
-        restarted.peerId, 'restart fixture transient backoff', 'transient',
-      );
+      seedProviderAdmissionBackoff(restarted.peerId);
       await restarted.connectTo(tcpMultiaddr(provider));
       expect(provider.networkAdmission.getRetryableProbeBackoff(restarted.peerId))
         .toMatchObject({ kind: 'transient', retryAfterMs: expect.any(Number) });


### PR DESCRIPTION
The native catalog restart fixture released startup projection after raw libp2p dial, before the complete provider had necessarily admitted the restarted peer. An active identity-probe backoff could reject the catalog announcement and leave the provider applied head null until the test timed out.

Use the public connection API for the controlled post-restart reconnect. A scenario-local helper starts each author, seeds provider admission backoff, then explicitly subscribes to the selected graph. Immediately before the provider calls connectTo, the test requires an active backoff and an unaccepted restarted peer. The awaited public call must admit the peer and clear backoff before projection is released. The gate-release finally block also covers the restarted peer-ID assertion.

Validation:

- The targeted selected-private restart integration passes in about 1.6 seconds with real identity and catalog transport.
- Forcing the peer-ID assertion to fail still releases the projection gate and allows an awaited restarted.stop() to finish; the complete mutation run exits in 5.09 seconds without a cleanup timeout.
- Lint and SPARQL checks pass. The strict fixture compiler differential retains the same 178 existing diagnostics, with none added or removed.
- Current-head CI and re-review are pending.

Closes #2529. The broader selected-graph restart acceptance work in #2364 remains open.
