### PR TITLE
fix(ui): require local LLM readiness for detection

### DIFF
--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -2818,9 +2818,11 @@ async function mapLocalAgentIntegrationRecord(
     : null;
   // The daemon-owned integration exists in the registry on every node. Keep it
   // out of the UI when the operator supplied no local-LLM configuration and
-  // the conventional local endpoint was not auto-detected. An explicit but
-  // temporarily offline configuration remains visible so its error is useful.
-  if (id === 'local-llm' && health?.configured === false && health.reachable !== true) {
+  // the conventional local endpoint did not pass the LLM readiness probe.
+  // Reachability alone is insufficient: an unrelated HTTP service can occupy
+  // the default port. An explicit but temporarily offline configuration
+  // remains visible so its error is useful.
+  if (id === 'local-llm' && health?.configured === false && health.ready !== true) {
     return null;
   }
   const degraded = isDegradedLocalAgentHealth(runtimeStatus, health);

--- a/packages/node-ui/test/local-llm-ui.test.ts
+++ b/packages/node-ui/test/local-llm-ui.test.ts
@@ -92,6 +92,29 @@ describe('DKG Local LLM Node UI surface', () => {
     await expect(fetchLocalAgentIntegrations()).resolves.toEqual({ integrations: [] });
   });
 
+  it('hides an unconfigured local LLM when an unrelated service answers on the default port', async () => {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/api/local-agent-integrations')) {
+        return json({ integrations: [localLlmRecord()] });
+      }
+      if (url.endsWith('/api/local-llm/health')) {
+        return json({
+          ok: false,
+          configured: false,
+          ready: false,
+          reachable: true,
+          offline: true,
+          readOnly: true,
+          error: 'Local LLM readiness probe returned an unexpected response',
+        });
+      }
+      return json({ error: `Unexpected request: ${url}` }, 500);
+    }) as typeof globalThis.fetch;
+
+    await expect(fetchLocalAgentIntegrations()).resolves.toEqual({ integrations: [] });
+  });
+
   it('shows an auto-detected default local LLM without environment overrides', async () => {
     globalThis.fetch = vi.fn(async (input) => {
       const url = String(input);


### PR DESCRIPTION
## Summary

- hide the daemon-owned DKG Local LLM UI when no LLM is configured and the default endpoint is merely reachable but not ready
- preserve the configured-but-offline entry so operators still see actionable errors
- preserve valid auto-detection when the readiness probe succeeds

## Regression covered

An unrelated HTTP service can occupy the conventional local-LLM port. The health endpoint then reports `configured: false`, `reachable: true`, and `ready: false`. Reachability alone must not expose the DKG Local LLM tab.

## Validation

- `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/local-llm-ui.test.ts` (7/7 passed)
- `pnpm --filter @origintrail-official/dkg-node-ui test:types`
- `pnpm --filter @origintrail-official/dkg-node-ui build:ui`