### PR TITLE
fix(cli): bind MCP persistence to the physical config

### DIFF
--- a/packages/cli/src/integrations/detect-installed.ts
+++ b/packages/cli/src/integrations/detect-installed.ts
@@ -21,7 +21,8 @@
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { detectClients, type ClientTarget } from '../mcp-client-registry.js';
+import { detectClients, selectMcpClientTargets, type ClientTarget } from '../mcp-client-registry.js';
+import type { McpPhysicalConfig } from '../mcp-physical-config.js';
 import { readRegisteredServerKeys, type RegisteredMcpServer, type ServerKeyProbe } from '../mcp-client-config.js';
 import {
   resolveNpmGlobalService,
@@ -76,11 +77,11 @@ export interface DetectDeps {
   /** Defaults to the same client targets `dkg mcp setup` registers into. */
   clients?: ClientTarget[];
   /**
-   * Defaults to probing each client's registered server keys. Returns a
+   * Defaults to probing each selected physical config's registered server keys. Returns a
    * probe result, not a bare list, so "could not read this config" stays
    * distinguishable from "read it, nothing registered".
    */
-  readServerKeys?: (target: ClientTarget) => ServerKeyProbe;
+  readServerKeys?: (target: McpPhysicalConfig) => ServerKeyProbe;
 }
 
 /**
@@ -181,15 +182,16 @@ export async function detectInstalled(
   if (needsMcp) {
     const clients = deps.clients ?? detectClients();
     const readKeys = deps.readServerKeys ?? readRegisteredServerKeys;
-    for (const target of clients) {
-      const probe = readKeys(target);
+    for (const { file, aliases } of selectMcpClientTargets(clients)) {
+      const names = aliases.map(alias => alias.name);
+      const probe = readKeys(file);
       if (!probe.ok) {
-        unreadableClients.push(target.name);
+        unreadableClients.push(...names);
         continue;
       }
       for (const [name, server] of Object.entries(probe.servers)) {
         const list = mcpBlocks.get(name) ?? [];
-        list.push({ client: target.name, server });
+        list.push(...names.map(client => ({ client, server })));
         mcpBlocks.set(name, list);
       }
     }

--- a/packages/cli/src/mcp-client-config.ts
+++ b/packages/cli/src/mcp-client-config.ts
@@ -1,6 +1,8 @@
 import { isDeepStrictEqual } from 'node:util';
-import type { McpConfigSourceSnapshot } from './mcp-config-file.js';
-import type { McpPhysicalConfig } from './mcp-physical-config.js';
+import type {
+  McpPhysicalConfig,
+  McpPhysicalConfigSourceSnapshot,
+} from './mcp-physical-config.js';
 import { tomlDocumentAdapter } from './mcp-toml-document.js';
 import { jsonDocumentAdapter, jsoncDocumentAdapter } from './mcp-json-document.js';
 import { isPlainRecord, type DesiredRegistration, type PersistedRegistration, type RegistrationEdit, type McpConfigDocumentAdapter } from './mcp-config-document.js';
@@ -49,7 +51,7 @@ const documentAdapters: Record<McpPhysicalConfig['shape']['format'], McpConfigDo
 
 function readConfigBody(
   target: McpPhysicalConfig,
-  source: McpConfigSourceSnapshot = target.readSource(),
+  source: McpPhysicalConfigSourceSnapshot = target.readSource(),
 ): Record<string, unknown> {
   try { return documentAdapters[target.shape.format].parse(source.content ?? ''); }
   catch {
@@ -159,7 +161,7 @@ export function readRegisteredServerKeys(target: McpPhysicalConfig): ServerKeyPr
 function applyRegistrationEdit(
   target: McpPhysicalConfig,
   edit: RegistrationEdit,
-  source: McpConfigSourceSnapshot,
+  source: McpPhysicalConfigSourceSnapshot,
 ): void {
   const result = documentAdapters[target.shape.format].applyEdit(source.content ?? '', edit, target.shape.serverContainer);
   if (result.warning) {

--- a/packages/cli/src/mcp-client-config.ts
+++ b/packages/cli/src/mcp-client-config.ts
@@ -1,11 +1,11 @@
 import { isDeepStrictEqual } from 'node:util';
 import type { McpConfigSourceSnapshot } from './mcp-config-file.js';
-import { McpPhysicalConfig } from './mcp-physical-config.js';
+import type { McpPhysicalConfig } from './mcp-physical-config.js';
 import { tomlDocumentAdapter } from './mcp-toml-document.js';
 import { jsonDocumentAdapter, jsoncDocumentAdapter } from './mcp-json-document.js';
 import { isPlainRecord, type DesiredRegistration, type PersistedRegistration, type RegistrationEdit, type McpConfigDocumentAdapter } from './mcp-config-document.js';
 export type { DesiredRegistration, PersistedRegistration, RegistrationEdit } from './mcp-config-document.js';
-import { DKG_SERVER_KEY, selectMcpClientTargets, type ClientTarget } from './mcp-client-registry.js';
+import { DKG_SERVER_KEY } from './mcp-client-registry.js';
 
 export interface McpRegistration {
   command?: string;
@@ -103,8 +103,7 @@ export type ServerKeyProbe =
  * that as "not installed": it would tell a user an integration is missing when
  * the truth is that their config could not be read.
  */
-export function readRegisteredServerKeys(client: ClientTarget | McpPhysicalConfig): ServerKeyProbe {
-  const target = client instanceof McpPhysicalConfig ? client : selectMcpClientTargets([client])[0]!.file;
+export function readRegisteredServerKeys(target: McpPhysicalConfig): ServerKeyProbe {
   let body: Record<string, unknown>;
   try {
     body = readConfigBody(target);

--- a/packages/cli/src/mcp-client-config.ts
+++ b/packages/cli/src/mcp-client-config.ts
@@ -1,13 +1,11 @@
-import { existsSync, mkdirSync } from 'node:fs';
-import { dirname } from 'node:path';
 import { isDeepStrictEqual } from 'node:util';
-import { snapshotMcpConfigSource, writeMcpConfigAtomic, type McpConfigSourceSnapshot } from './mcp-config-file.js';
-import { mcpConfigPersistenceStrategy } from './mcp-config-metadata.js';
+import type { McpConfigSourceSnapshot } from './mcp-config-file.js';
+import { McpPhysicalConfig } from './mcp-physical-config.js';
 import { tomlDocumentAdapter } from './mcp-toml-document.js';
 import { jsonDocumentAdapter, jsoncDocumentAdapter } from './mcp-json-document.js';
 import { isPlainRecord, type DesiredRegistration, type PersistedRegistration, type RegistrationEdit, type McpConfigDocumentAdapter } from './mcp-config-document.js';
 export type { DesiredRegistration, PersistedRegistration, RegistrationEdit } from './mcp-config-document.js';
-import { DKG_SERVER_KEY, tildify, type McpConfigEndpoint } from './mcp-client-registry.js';
+import { DKG_SERVER_KEY, selectMcpClientTargets, type ClientTarget } from './mcp-client-registry.js';
 
 export interface McpRegistration {
   command?: string;
@@ -43,19 +41,19 @@ export function classifyRegistration(current: RegistrationRead, expected: Desire
     && current.registration.dkgHome === expected.env.DKG_HOME ? 'registered' : 'stale';
 }
 
-const documentAdapters: Record<McpConfigEndpoint['format'], McpConfigDocumentAdapter> = {
+const documentAdapters: Record<McpPhysicalConfig['shape']['format'], McpConfigDocumentAdapter> = {
   json: jsonDocumentAdapter,
   jsonc: jsoncDocumentAdapter,
   toml: tomlDocumentAdapter,
 };
 
 function readConfigBody(
-  target: McpConfigEndpoint,
-  source: McpConfigSourceSnapshot = snapshotMcpConfigSource(target.configPath),
+  target: McpPhysicalConfig,
+  source: McpConfigSourceSnapshot = target.readSource(),
 ): Record<string, unknown> {
-  try { return documentAdapters[target.format].parse(source.content ?? ''); }
+  try { return documentAdapters[target.shape.format].parse(source.content ?? ''); }
   catch {
-    throw new Error(`Existing file is not valid ${target.format.toUpperCase()}: ${tildify(target.configPath)}. Move it aside and re-run.`);
+    throw new Error(`Existing file is not valid ${target.shape.format.toUpperCase()}: ${target.displayPath}. Move it aside and re-run.`);
   }
 }
 
@@ -105,7 +103,8 @@ export type ServerKeyProbe =
  * that as "not installed": it would tell a user an integration is missing when
  * the truth is that their config could not be read.
  */
-export function readRegisteredServerKeys(target: McpConfigEndpoint): ServerKeyProbe {
+export function readRegisteredServerKeys(client: ClientTarget | McpPhysicalConfig): ServerKeyProbe {
+  const target = client instanceof McpPhysicalConfig ? client : selectMcpClientTargets([client])[0]!.file;
   let body: Record<string, unknown>;
   try {
     body = readConfigBody(target);
@@ -115,7 +114,7 @@ export function readRegisteredServerKeys(target: McpConfigEndpoint): ServerKeyPr
     if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return { ok: true, servers: {} };
     return { ok: false, reason: `could not read ${target.displayPath}` };
   }
-  const cursor = body[target.serverContainer];
+  const cursor = body[target.shape.serverContainer];
   // Missing container: readable config, nothing registered.
   if (cursor === undefined) return { ok: true, servers: {} };
   // Present but not a KEYED object: malformed exactly where we needed to read.
@@ -159,29 +158,26 @@ export function readRegisteredServerKeys(target: McpConfigEndpoint): ServerKeyPr
 
 /** Serialize the inspected source once, then persist through one transaction boundary. */
 function applyRegistrationEdit(
-  target: McpConfigEndpoint,
+  target: McpPhysicalConfig,
   edit: RegistrationEdit,
   source: McpConfigSourceSnapshot,
 ): void {
-  const result = documentAdapters[target.format].applyEdit(source.content ?? '', edit, target.serverContainer);
+  const result = documentAdapters[target.shape.format].applyEdit(source.content ?? '', edit, target.shape.serverContainer);
   if (result.warning) {
-    process.stderr.write(`[mcp-config] WARNING: ${target.format.toUpperCase()} config at ${tildify(target.configPath)} ${result.warning}\n`);
+    process.stderr.write(`[mcp-config] WARNING: ${target.shape.format.toUpperCase()} config at ${target.displayPath} ${result.warning}\n`);
   }
-  const dir = dirname(target.configPath);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  writeMcpConfigAtomic(target.configPath, result.content,
-    mcpConfigPersistenceStrategy(target.location, source.destination), source);
+  target.write(result.content, source);
 }
 
 /** Inspect only: stale/null entries still count as an owned registration. */
-export function inspectRegistration(target: McpConfigEndpoint): boolean {
+export function inspectRegistration(target: McpPhysicalConfig): boolean {
   const container = readServerContainer(readConfigBody(target), target);
   return container !== undefined && Object.hasOwn(container, DKG_SERVER_KEY);
 }
 
 /** Remove only the owned leaf from one source snapshot. */
-export function removeRegistration(target: McpConfigEndpoint): boolean {
-  const source = snapshotMcpConfigSource(target.configPath);
+export function removeRegistration(target: McpPhysicalConfig): boolean {
+  const source = target.readSource();
   const body = readConfigBody(target, source);
   const container = readServerContainer(body, target);
   if (container === undefined || !Object.hasOwn(container, DKG_SERVER_KEY)) return false;
@@ -190,10 +186,10 @@ export function removeRegistration(target: McpConfigEndpoint): boolean {
 }
 
 export function writeRegistration(
-  target: McpConfigEndpoint,
+  target: McpPhysicalConfig,
   entry: DesiredRegistration,
 ): void {
-  const source = snapshotMcpConfigSource(target.configPath);
+  const source = target.readSource();
   const body = readConfigBody(target, source);
 
   // Codex Round-15 Fix 22 + Round-19 Fix 26: when refreshing an
@@ -224,20 +220,20 @@ export function writeRegistration(
 }
 
 /** Read the owned entry for setup classification; no mutation. */
-export function readRegistration(target: McpConfigEndpoint): RegistrationRead {
+export function readRegistration(target: McpPhysicalConfig): RegistrationRead {
   return normalizeRegistration(readOwnedRegistration(readConfigBody(target), target));
 }
 
-function readOwnedRegistration(body: Record<string, unknown>, target: McpConfigEndpoint): unknown {
+function readOwnedRegistration(body: Record<string, unknown>, target: McpPhysicalConfig): unknown {
   return readServerContainer(body, target)?.[DKG_SERVER_KEY];
 }
 
 function readServerContainer(
   body: Record<string, unknown>,
-  target: McpConfigEndpoint,
+  target: McpPhysicalConfig,
 ): Record<string, unknown> | undefined {
-  if (!Object.hasOwn(body, target.serverContainer)) return undefined;
-  const container = body[target.serverContainer];
+  if (!Object.hasOwn(body, target.shape.serverContainer)) return undefined;
+  const container = body[target.shape.serverContainer];
   if (!isPlainRecord(container)) {
     throw new Error(`Malformed MCP server container in ${target.displayPath}`);
   }

--- a/packages/cli/src/mcp-client-registry.ts
+++ b/packages/cli/src/mcp-client-registry.ts
@@ -99,7 +99,7 @@ export function selectMcpClientTargets(
     let physicalPath: string;
     try { physicalPath = resolveMcpConfigDestination(target.configPath); }
     catch { physicalPath = resolve(target.configPath); }
-    const leaf = JSON.stringify([physicalPath, target.serverContainer, DKG_SERVER_KEY]);
+    const leaf = JSON.stringify([physicalPath, target.format, target.serverContainer, DKG_SERVER_KEY]);
     const group = groups.get(leaf) ?? { path: physicalPath, aliases: [] };
     group.aliases.push(target);
     groups.set(leaf, group);
@@ -109,7 +109,7 @@ export function selectMcpClientTargets(
     const aliases = group.aliases.filter(target => !selector || (target.id === selector.id
       && (!selector.location || target.location === selector.location)));
     if (aliases.length === 0) continue;
-    selected.push({ file: new McpPhysicalConfig(group.path, aliases[0]!, aliases), aliases });
+    selected.push({ file: McpPhysicalConfig.create(aliases), aliases });
   }
   return selected;
 }

--- a/packages/cli/src/mcp-client-registry.ts
+++ b/packages/cli/src/mcp-client-registry.ts
@@ -1,11 +1,13 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
-import { homedir, platform, release as osRelease } from 'node:os';
+import { homedir, platform } from 'node:os';
 import { execSync } from 'node:child_process';
 import { resolveMcpConfigDestination } from './mcp-config-file.js';
+import { McpPhysicalConfig } from './mcp-physical-config.js';
+import { detectMcpRuntime } from './mcp-runtime.js';
 
 
-import { DKG_SERVER_KEY, type McpClientConfigShape } from './mcp-config-document.js';
+import { DKG_SERVER_KEY } from './mcp-config-document.js';
 export { DKG_SERVER_KEY, type McpClientConfigShape } from './mcp-config-document.js';
 export type McpClientLocation = 'native' | 'windows-wsl';
 type WindowsPaths = { USERPROFILE: string | null; APPDATA: string | null };
@@ -77,31 +79,14 @@ export function parseMcpClientSelector(value: string): { id: McpClientId; locati
   return { id: client.target.id, location };
 }
 
-/** Physical storage owns format and persistence, independently of client identity. */
-export type McpConfigEndpoint = McpClientConfigShape & {
-  readonly configPath: string;
-  readonly displayPath: string;
-  readonly location: McpClientLocation;
-};
-
 export interface McpConfigSelection {
-  readonly endpoint: McpConfigEndpoint;
-  readonly destination: string;
+  readonly file: McpPhysicalConfig;
   /** Logical clients selected by the caller; never replaced by a storage alias. */
   readonly aliases: readonly ClientTarget[];
 }
 
 export function mcpConfigClientNames(selection: McpConfigSelection): string {
   return [...new Set(selection.aliases.map(alias => alias.name))].join(', ');
-}
-
-/** Confirmation applies to all selected aliases of the inspected destination. */
-export function assertMcpConfigSelectionCurrent(selection: McpConfigSelection): void {
-  for (const alias of selection.aliases) {
-    if (resolveMcpConfigDestination(alias.configPath) !== selection.destination) {
-      throw new Error(`MCP config path changed since inspection: ${alias.displayPath}. Re-run the command to confirm the current destination.`);
-    }
-  }
 }
 
 /** Select each physical owned leaf once while retaining the selected logical aliases. */
@@ -124,16 +109,7 @@ export function selectMcpClientTargets(
     const aliases = group.aliases.filter(target => !selector || (target.id === selector.id
       && (!selector.location || target.location === selector.location)));
     if (aliases.length === 0) continue;
-    // A selected native alias can still refer to a Windows-backed file. Only
-    // storage fields come from the persistence owner; identity stays in aliases.
-    const storage = group.aliases.find(target => target.location === 'windows-wsl') ?? group.aliases[0]!;
-    const { id: _id, name: _name, ...endpoint } = storage;
-    selected.push({
-      // Keep a selected live path for the atomic transaction's revalidation.
-      endpoint: { ...endpoint, configPath: aliases[0]!.configPath, displayPath: aliases[0]!.displayPath },
-      destination: group.path,
-      aliases,
-    });
+    selected.push({ file: new McpPhysicalConfig(group.path, aliases[0]!, aliases), aliases });
   }
   return selected;
 }
@@ -188,35 +164,6 @@ function appConfigPaths(root: string, ...suffix: string[]) {
  * `dkg mcp setup --print-only`" message.
  */
 /**
- * Codex Round-13 Fix 20: detect WSL2. Linux platform with `microsoft`
- * / `WSL` markers in env, kernel release, or `/proc/version`. WSL
- * users running `dkg mcp setup` from inside their WSL distro need
- * to register Windows-side GUI clients (Claude Desktop, Windsurf,
- * VSCode + Copilot, Cline) AS WELL AS any Linux-native clients —
- * pre-fix they got the Linux-only set and the README's WSL2
- * promise silently failed for the apps users actually run.
- *
- * Multi-signal detection (env first; cheaper than fs reads):
- *   - `WSL_DISTRO_NAME` / `WSL_INTEROP` set by the WSL launcher.
- *   - `os.release()` contains `microsoft` or `wsl` (WSL kernels
- *     identify themselves there).
- *   - `/proc/version` contains the same markers (slower fallback).
- */
-function isWSL(): boolean {
-  if (platform() !== 'linux') return false;
-  if (process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP) return true;
-  try {
-    const release = osRelease().toLowerCase();
-    if (release.includes('microsoft') || release.includes('wsl')) return true;
-  } catch { /* fall through */ }
-  try {
-    const procVersion = readFileSync('/proc/version', 'utf-8').toLowerCase();
-    if (procVersion.includes('microsoft') || procVersion.includes('wsl')) return true;
-  } catch { /* /proc/version not readable; not WSL */ }
-  return false;
-}
-
-/**
  * Resolve a Windows-side env var (e.g. `%USERPROFILE%`,
  * `%APPDATA%`) into a WSL-mounted Linux path (`/mnt/c/...`). Uses
  * `cmd.exe` to read the env var, then `wslpath` to convert. Returns
@@ -266,7 +213,7 @@ export function detectClients(
     location: 'native',
     ...client.nativePaths(home, appConfigRoot),
   }));
-  if (isWSL()) {
+  if (detectMcpRuntime() === 'wsl') {
     const windows = {
       USERPROFILE: resolveWslWindowsEnvPath('USERPROFILE'),
       APPDATA: resolveWslWindowsEnvPath('APPDATA'),

--- a/packages/cli/src/mcp-config-file.ts
+++ b/packages/cli/src/mcp-config-file.ts
@@ -4,9 +4,14 @@ import { basename, dirname, join, resolve } from 'node:path';
 import type { McpConfigPersistenceStrategy } from './mcp-config-metadata.js';
 
 /** The exact source document an edit was derived from. */
+const MCP_CONFIG_SOURCE_SNAPSHOT: unique symbol = Symbol('McpConfigSourceSnapshot');
+
 export interface McpConfigSourceSnapshot {
+  readonly [MCP_CONFIG_SOURCE_SNAPSHOT]: true;
   readonly destination: string;
   readonly content: string | undefined;
+  /** Revalidate every selected path binding and the source bytes. */
+  assertCurrent(): void;
 }
 
 /** Resolve existing links, including parents of a first-time config path. */
@@ -18,20 +23,37 @@ export function resolveMcpConfigDestination(configPath: string): string {
   return join(resolveMcpConfigDestination(dirname(absolute)), basename(absolute));
 }
 
-/** Capture both file identity and bytes before parsing or editing a config. */
-export function snapshotMcpConfigSource(configPath: string): McpConfigSourceSnapshot {
+/** Capture path bindings and bytes as one required transaction snapshot. */
+export function snapshotMcpConfigSource(
+  configPath: string,
+  paths: readonly Readonly<{ configPath: string; displayPath: string }>[],
+): McpConfigSourceSnapshot {
+  if (paths.length === 0) throw new Error('An MCP config transaction requires a path binding');
   const destination = resolveMcpConfigDestination(configPath);
-  return {
-    destination,
-    content: existsSync(destination) ? readFileSync(destination, 'utf8') : undefined,
+  const assertBindingsCurrent = (): void => {
+    for (const path of paths) {
+      if (resolveMcpConfigDestination(path.configPath) !== destination) {
+        throw new Error(`MCP config path changed since inspection: ${path.displayPath}. Re-run the command to confirm the current destination.`);
+      }
+    }
   };
-}
-
-function assertSourceUnchanged(configPath: string, expected: McpConfigSourceSnapshot): void {
-  const current = snapshotMcpConfigSource(configPath);
-  if (current.destination !== expected.destination || current.content !== expected.content) {
-    throw new Error(`MCP config changed while it was being edited: ${configPath}. Re-run the command to apply the edit to the latest version.`);
-  }
+  assertBindingsCurrent();
+  const content = existsSync(destination) ? readFileSync(destination, 'utf8') : undefined;
+  assertBindingsCurrent();
+  return Object.freeze({
+    [MCP_CONFIG_SOURCE_SNAPSHOT]: true as const,
+    destination,
+    content,
+    assertCurrent: () => {
+      assertBindingsCurrent();
+      const currentContent = existsSync(destination)
+        ? readFileSync(destination, 'utf8')
+        : undefined;
+      if (currentContent !== content) {
+        throw new Error(`MCP config changed while it was being edited: ${configPath}. Re-run the command to apply the edit to the latest version.`);
+      }
+    },
+  });
 }
 
 /** Replace a complete client config without exposing a truncated file to readers. */
@@ -40,10 +62,8 @@ export function writeMcpConfigAtomic(
   content: string,
   persistence: McpConfigPersistenceStrategy,
   expectedSource: McpConfigSourceSnapshot,
-  validateDestination: () => void = () => {},
 ): void {
-  validateDestination();
-  assertSourceUnchanged(configPath, expectedSource);
+  expectedSource.assertCurrent();
   const destination = expectedSource.destination;
   const original = existsSync(destination) ? statSync(destination) : undefined;
   const mode = original ? original.mode & 0o7777 : 0o600;
@@ -67,8 +87,7 @@ export function writeMcpConfigAtomic(
     }
     // A client may rewrite its config while this replacement is being
     // prepared. Never publish an edit derived from stale bytes over that work.
-    validateDestination();
-    assertSourceUnchanged(configPath, expectedSource);
+    expectedSource.assertCurrent();
     persistence.publish(replacement);
   } finally {
     rmSync(temporary, { force: true });

--- a/packages/cli/src/mcp-config-file.ts
+++ b/packages/cli/src/mcp-config-file.ts
@@ -40,7 +40,9 @@ export function writeMcpConfigAtomic(
   content: string,
   persistence: McpConfigPersistenceStrategy,
   expectedSource: McpConfigSourceSnapshot,
+  validateDestination: () => void = () => {},
 ): void {
+  validateDestination();
   assertSourceUnchanged(configPath, expectedSource);
   const destination = expectedSource.destination;
   const original = existsSync(destination) ? statSync(destination) : undefined;
@@ -65,6 +67,7 @@ export function writeMcpConfigAtomic(
     }
     // A client may rewrite its config while this replacement is being
     // prepared. Never publish an edit derived from stale bytes over that work.
+    validateDestination();
     assertSourceUnchanged(configPath, expectedSource);
     persistence.publish(replacement);
   } finally {

--- a/packages/cli/src/mcp-config-metadata.ts
+++ b/packages/cli/src/mcp-config-metadata.ts
@@ -1,8 +1,9 @@
 import { win32, posix } from 'node:path';
-import { release } from 'node:os';
-import type { McpClientLocation } from './mcp-client-registry.js';
+import { detectMcpRuntime, type McpRuntime } from './mcp-runtime.js';
 import { execFileSync } from 'node:child_process';
 import { existsSync, fchmodSync, fchownSync, fstatSync, renameSync, rmSync, type Stats } from 'node:fs';
+
+type WindowsExecution = 'native' | 'windows-wsl';
 
 interface McpConfigReplacement {
   configPath: string;
@@ -48,7 +49,7 @@ const WINDOWS_MCP_CONFIG_SCRIPTS: Record<WindowsMcpConfigOperation, string> = {
 };
 
 /** Resolve the OS runtime without searching the working directory or PATH. */
-export function windowsPowerShellExecutable(location: McpClientLocation): string {
+export function windowsPowerShellExecutable(location: WindowsExecution): string {
   // WSL does not forward SystemRoot by default. Non-default Windows installs
   // can supply the inherited Windows SystemRoot explicitly to the Linux process.
   const systemRoot = process.env.SystemRoot ?? process.env.SYSTEMROOT ?? 'C:\\Windows';
@@ -65,7 +66,7 @@ export function windowsPowerShellExecutable(location: McpClientLocation): string
 function runMcpConfigPowerShell(
   operation: WindowsMcpConfigOperation,
   paths: { source: string; destination: string; backup?: string },
-  location: Extract<McpClientLocation, 'native' | 'windows-wsl'>,
+  location: WindowsExecution,
 ): void {
   const executable = windowsPowerShellExecutable(location);
   const windowsPath = (path: string) => location === 'windows-wsl'
@@ -96,7 +97,7 @@ function runMcpConfigPowerShell(
 export function copyWindowsMcpConfigMetadata(
   source: string,
   destination: string,
-  location: Extract<McpClientLocation, 'native' | 'windows-wsl'>,
+  location: WindowsExecution,
 ): void {
   runMcpConfigPowerShell('copy-metadata', { source, destination }, location);
 }
@@ -106,7 +107,7 @@ export function replaceWindowsMcpConfigFile(
   source: string,
   destination: string,
   backup: string,
-  location: Extract<McpClientLocation, 'native' | 'windows-wsl'>,
+  location: WindowsExecution,
 ): void {
   runMcpConfigPowerShell('replace-file', { source, destination, backup }, location);
 }
@@ -190,13 +191,12 @@ function windowsPersistence(
   };
 }
 
-/** Resolve client placement and the physical destination into one write policy. */
+/** Select persistence solely from the runtime and resolved physical destination. */
 export function mcpConfigPersistenceStrategy(
-  location: McpClientLocation,
   destination: string,
+  runtime: McpRuntime = detectMcpRuntime(),
 ): McpConfigPersistenceStrategy {
-  if (process.platform === 'linux'
-      && (process.env.WSL_DISTRO_NAME || /microsoft/i.test(release()))) {
+  if (runtime === 'wsl') {
     // WSL resolves custom drive mounts and UNC shares too. A Linux-backed path
     // is exported through the distro share; every other Windows path uses ACLs.
     const translated = execFileSync('/usr/bin/wslpath', ['-w', destination], { encoding: 'utf8', stdio: 'pipe' }).trim();
@@ -204,7 +204,6 @@ export function mcpConfigPersistenceStrategy(
     return /^\\\\wsl(?:\$|\.localhost)\\/i.test(translated)
       ? posixPersistence('linux') : windowsPersistence('windows-wsl');
   }
-  if (location === 'windows-wsl') return windowsPersistence('windows-wsl');
-  if (process.platform === 'win32') return windowsPersistence('windows-native');
-  return posixPersistence(process.platform === 'linux' ? 'linux' : 'posix');
+  if (runtime === 'windows') return windowsPersistence('windows-native');
+  return posixPersistence(runtime === 'linux' ? 'linux' : 'posix');
 }

--- a/packages/cli/src/mcp-physical-config.ts
+++ b/packages/cli/src/mcp-physical-config.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 import type { McpClientConfigShape } from './mcp-config-document.js';
 import { mcpConfigPersistenceStrategy } from './mcp-config-metadata.js';
-import { resolveMcpConfigDestination, snapshotMcpConfigSource, writeMcpConfigAtomic, type McpConfigSourceSnapshot } from './mcp-config-file.js';
+import { snapshotMcpConfigSource, writeMcpConfigAtomic, type McpConfigSourceSnapshot } from './mcp-config-file.js';
 
 type ConfigPath = Readonly<{ configPath: string; displayPath: string }>;
 
@@ -20,27 +20,15 @@ export class McpPhysicalConfig {
 
   get displayPath(): string { return this.paths[0]!.displayPath; }
 
-  private assertCurrent(): void {
-    for (const path of this.paths) {
-      if (resolveMcpConfigDestination(path.configPath) !== this.destination) {
-        throw new Error(`MCP config path changed since inspection: ${path.displayPath}. Re-run the command to confirm the current destination.`);
-      }
-    }
-  }
-
   readSource(): McpConfigSourceSnapshot {
-    this.assertCurrent();
-    const source = snapshotMcpConfigSource(this.destination);
-    this.assertCurrent();
-    return source;
+    return snapshotMcpConfigSource(this.destination, this.paths);
   }
 
   write(content: string, source: McpConfigSourceSnapshot): void {
-    this.assertCurrent();
     if (source.destination !== this.destination) throw new Error('MCP config source belongs to a different destination');
     const persistence = mcpConfigPersistenceStrategy(this.destination);
     const directory = dirname(this.destination);
     if (!existsSync(directory)) mkdirSync(directory, { recursive: true });
-    writeMcpConfigAtomic(this.destination, content, persistence, source, () => this.assertCurrent());
+    writeMcpConfigAtomic(this.destination, content, persistence, source);
   }
 }

--- a/packages/cli/src/mcp-physical-config.ts
+++ b/packages/cli/src/mcp-physical-config.ts
@@ -2,16 +2,14 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 import type { McpClientConfigShape } from './mcp-config-document.js';
 import { mcpConfigPersistenceStrategy } from './mcp-config-metadata.js';
-import { detectMcpRuntime } from './mcp-runtime.js';
 import { resolveMcpConfigDestination, snapshotMcpConfigSource, writeMcpConfigAtomic, type McpConfigSourceSnapshot } from './mcp-config-file.js';
 
 type ConfigPath = Readonly<{ configPath: string; displayPath: string }>;
 
-/** A selected physical file owns its shape, runtime and live-path validation. */
+/** A selected physical file owns its shape and live-path validation. */
 export class McpPhysicalConfig {
   readonly shape: McpClientConfigShape;
   private readonly paths: readonly ConfigPath[];
-  private readonly runtime = detectMcpRuntime();
 
   constructor(readonly destination: string, shape: McpClientConfigShape, paths: readonly ConfigPath[]) {
     if (paths.length === 0) throw new Error('An MCP config requires a selected path');
@@ -40,7 +38,7 @@ export class McpPhysicalConfig {
   write(content: string, source: McpConfigSourceSnapshot): void {
     this.assertCurrent();
     if (source.destination !== this.destination) throw new Error('MCP config source belongs to a different destination');
-    const persistence = mcpConfigPersistenceStrategy(this.destination, this.runtime);
+    const persistence = mcpConfigPersistenceStrategy(this.destination);
     const directory = dirname(this.destination);
     if (!existsSync(directory)) mkdirSync(directory, { recursive: true });
     writeMcpConfigAtomic(this.destination, content, persistence, source, () => this.assertCurrent());

--- a/packages/cli/src/mcp-physical-config.ts
+++ b/packages/cli/src/mcp-physical-config.ts
@@ -1,0 +1,48 @@
+import { existsSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import type { McpClientConfigShape } from './mcp-config-document.js';
+import { mcpConfigPersistenceStrategy } from './mcp-config-metadata.js';
+import { detectMcpRuntime } from './mcp-runtime.js';
+import { resolveMcpConfigDestination, snapshotMcpConfigSource, writeMcpConfigAtomic, type McpConfigSourceSnapshot } from './mcp-config-file.js';
+
+type ConfigPath = Readonly<{ configPath: string; displayPath: string }>;
+
+/** A selected physical file owns its shape, runtime and live-path validation. */
+export class McpPhysicalConfig {
+  readonly shape: McpClientConfigShape;
+  private readonly paths: readonly ConfigPath[];
+  private readonly runtime = detectMcpRuntime();
+
+  constructor(readonly destination: string, shape: McpClientConfigShape, paths: readonly ConfigPath[]) {
+    if (paths.length === 0) throw new Error('An MCP config requires a selected path');
+    this.shape = Object.freeze({ format: shape.format, serverContainer: shape.serverContainer }) as McpClientConfigShape;
+    this.paths = Object.freeze(paths.map(({ configPath, displayPath }) => Object.freeze({ configPath, displayPath })));
+    Object.freeze(this);
+  }
+
+  get displayPath(): string { return this.paths[0]!.displayPath; }
+
+  private assertCurrent(): void {
+    for (const path of this.paths) {
+      if (resolveMcpConfigDestination(path.configPath) !== this.destination) {
+        throw new Error(`MCP config path changed since inspection: ${path.displayPath}. Re-run the command to confirm the current destination.`);
+      }
+    }
+  }
+
+  readSource(): McpConfigSourceSnapshot {
+    this.assertCurrent();
+    const source = snapshotMcpConfigSource(this.destination);
+    this.assertCurrent();
+    return source;
+  }
+
+  write(content: string, source: McpConfigSourceSnapshot): void {
+    this.assertCurrent();
+    if (source.destination !== this.destination) throw new Error('MCP config source belongs to a different destination');
+    const persistence = mcpConfigPersistenceStrategy(this.destination, this.runtime);
+    const directory = dirname(this.destination);
+    if (!existsSync(directory)) mkdirSync(directory, { recursive: true });
+    writeMcpConfigAtomic(this.destination, content, persistence, source, () => this.assertCurrent());
+  }
+}

--- a/packages/cli/src/mcp-physical-config.ts
+++ b/packages/cli/src/mcp-physical-config.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync } from 'node:fs';
-import { dirname } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import type { McpClientConfigShape } from './mcp-config-document.js';
 import { mcpConfigPersistenceStrategy } from './mcp-config-metadata.js';
 import {
@@ -15,6 +15,18 @@ export type McpPhysicalConfigPath = Readonly<{
 }> & McpClientConfigShape;
 
 const MCP_PHYSICAL_CONFIG_OWNER: unique symbol = Symbol('McpPhysicalConfig owner');
+
+function selectedDestination(configPath: string): string {
+  try {
+    return resolveMcpConfigDestination(configPath);
+  } catch {
+    // Selection must remain possible when a malformed parent (for example, a
+    // regular file where a directory is expected) makes live resolution fail.
+    // readSource() still performs the authoritative live-path validation and
+    // lets the caller isolate that client without aborting all registration.
+    return resolve(configPath);
+  }
+}
 
 /** A source snapshot is a capability owned by exactly one physical selection. */
 export interface McpPhysicalConfigSourceSnapshot extends McpConfigSourceSnapshot {
@@ -37,7 +49,7 @@ export class McpPhysicalConfig {
   static create(paths: readonly McpPhysicalConfigPath[]): McpPhysicalConfig {
     const first = paths[0];
     if (!first) throw new Error('An MCP config requires a selected path');
-    const destination = resolveMcpConfigDestination(first.configPath);
+    const destination = selectedDestination(first.configPath);
     for (const path of paths) {
       if (
         path.format !== first.format
@@ -45,7 +57,7 @@ export class McpPhysicalConfig {
       ) {
         throw new Error('MCP config aliases disagree about their document shape');
       }
-      if (resolveMcpConfigDestination(path.configPath) !== destination) {
+      if (selectedDestination(path.configPath) !== destination) {
         throw new Error('MCP config aliases resolve to different destinations');
       }
     }

--- a/packages/cli/src/mcp-physical-config.ts
+++ b/packages/cli/src/mcp-physical-config.ts
@@ -2,29 +2,69 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 import type { McpClientConfigShape } from './mcp-config-document.js';
 import { mcpConfigPersistenceStrategy } from './mcp-config-metadata.js';
-import { snapshotMcpConfigSource, writeMcpConfigAtomic, type McpConfigSourceSnapshot } from './mcp-config-file.js';
+import {
+  resolveMcpConfigDestination,
+  snapshotMcpConfigSource,
+  writeMcpConfigAtomic,
+  type McpConfigSourceSnapshot,
+} from './mcp-config-file.js';
 
-type ConfigPath = Readonly<{ configPath: string; displayPath: string }>;
+export type McpPhysicalConfigPath = Readonly<{
+  configPath: string;
+  displayPath: string;
+}> & McpClientConfigShape;
+
+const MCP_PHYSICAL_CONFIG_OWNER: unique symbol = Symbol('McpPhysicalConfig owner');
+
+/** A source snapshot is a capability owned by exactly one physical selection. */
+export interface McpPhysicalConfigSourceSnapshot extends McpConfigSourceSnapshot {
+  readonly [MCP_PHYSICAL_CONFIG_OWNER]: symbol;
+}
 
 /** A selected physical file owns its shape and live-path validation. */
 export class McpPhysicalConfig {
   readonly shape: McpClientConfigShape;
-  private readonly paths: readonly ConfigPath[];
+  private readonly paths: readonly McpPhysicalConfigPath[];
+  private readonly ownerToken = Symbol('McpPhysicalConfig owner');
 
-  constructor(readonly destination: string, shape: McpClientConfigShape, paths: readonly ConfigPath[]) {
-    if (paths.length === 0) throw new Error('An MCP config requires a selected path');
+  private constructor(readonly destination: string, shape: McpClientConfigShape, paths: readonly McpPhysicalConfigPath[]) {
     this.shape = Object.freeze({ format: shape.format, serverContainer: shape.serverContainer }) as McpClientConfigShape;
-    this.paths = Object.freeze(paths.map(({ configPath, displayPath }) => Object.freeze({ configPath, displayPath })));
+    this.paths = Object.freeze(paths.map(path => Object.freeze({ ...path })));
     Object.freeze(this);
+  }
+
+  /** Derive path, document shape, and aliases at the only construction boundary. */
+  static create(paths: readonly McpPhysicalConfigPath[]): McpPhysicalConfig {
+    const first = paths[0];
+    if (!first) throw new Error('An MCP config requires a selected path');
+    const destination = resolveMcpConfigDestination(first.configPath);
+    for (const path of paths) {
+      if (
+        path.format !== first.format
+        || path.serverContainer !== first.serverContainer
+      ) {
+        throw new Error('MCP config aliases disagree about their document shape');
+      }
+      if (resolveMcpConfigDestination(path.configPath) !== destination) {
+        throw new Error('MCP config aliases resolve to different destinations');
+      }
+    }
+    return new McpPhysicalConfig(destination, first, paths);
   }
 
   get displayPath(): string { return this.paths[0]!.displayPath; }
 
-  readSource(): McpConfigSourceSnapshot {
-    return snapshotMcpConfigSource(this.destination, this.paths);
+  readSource(): McpPhysicalConfigSourceSnapshot {
+    return Object.freeze({
+      ...snapshotMcpConfigSource(this.destination, this.paths),
+      [MCP_PHYSICAL_CONFIG_OWNER]: this.ownerToken,
+    });
   }
 
-  write(content: string, source: McpConfigSourceSnapshot): void {
+  write(content: string, source: McpPhysicalConfigSourceSnapshot): void {
+    if (source[MCP_PHYSICAL_CONFIG_OWNER] !== this.ownerToken) {
+      throw new Error('MCP config source belongs to a different physical config owner');
+    }
     if (source.destination !== this.destination) throw new Error('MCP config source belongs to a different destination');
     const persistence = mcpConfigPersistenceStrategy(this.destination);
     const directory = dirname(this.destination);

--- a/packages/cli/src/mcp-runtime.ts
+++ b/packages/cli/src/mcp-runtime.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { platform, release } from 'node:os';
+
+export type McpRuntime = 'wsl' | 'linux' | 'windows' | 'posix';
+
+/** One runtime classification for client discovery and physical-file persistence. */
+export function detectMcpRuntime(): McpRuntime {
+  const operatingSystem = platform();
+  if (operatingSystem === 'win32') return 'windows';
+  if (operatingSystem !== 'linux') return 'posix';
+  if (process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP) return 'wsl';
+  try { if (/microsoft|wsl/i.test(release())) return 'wsl'; } catch { /* Try procfs. */ }
+  try { if (/microsoft|wsl/i.test(readFileSync('/proc/version', 'utf8'))) return 'wsl'; } catch { /* Plain Linux. */ }
+  return 'linux';
+}

--- a/packages/cli/src/mcp-setup.ts
+++ b/packages/cli/src/mcp-setup.ts
@@ -1,4 +1,4 @@
-import { detectClients, selectMcpClientTargets, assertMcpConfigSelectionCurrent, mcpConfigClientNames, tildify, clientSkillPath, type ClientTarget, type McpConfigSelection } from './mcp-client-registry.js';
+import { detectClients, selectMcpClientTargets, mcpConfigClientNames, tildify, clientSkillPath, type ClientTarget, type McpConfigSelection } from './mcp-client-registry.js';
 import { readRegistration, classifyRegistration, writeRegistration, type DesiredRegistration } from './mcp-client-config.js';
 /**
  * `dkg mcp setup` — bundled init + daemon-start + MCP-client registration.
@@ -389,7 +389,7 @@ export async function confirmPlan(
       const verb = { register: 'Register', refresh: 'Refresh' }[p.action];
       const ans = (
         await rl.question(
-          `${verb} DKG MCP with ${mcpConfigClientNames(p.s.target)} (${p.s.target.endpoint.displayPath})? [Y/n] `,
+          `${verb} DKG MCP with ${mcpConfigClientNames(p.s.target)} (${p.s.target.file.displayPath})? [Y/n] `,
         )
       )
         .trim()
@@ -505,7 +505,7 @@ function classify(
   target: McpConfigSelection,
   expected: DesiredRegistration,
 ): ClientState {
-  const current = readRegistration(target.endpoint);
+  const current = readRegistration(target.file);
   return { target, state: classifyRegistration(current, expected) };
 }
 
@@ -1032,7 +1032,7 @@ export async function mcpSetupAction(
         : action === 'refresh'
           ? 'will refresh'
           : 'leaving alone';
-    console.log(`  ${mcpConfigClientNames(s.target).padEnd(13)} (${s.target.endpoint.displayPath}) — ${stateLabel}; ${actionLabel}`);
+    console.log(`  ${mcpConfigClientNames(s.target).padEnd(13)} (${s.target.file.displayPath}) — ${stateLabel}; ${actionLabel}`);
   }
 
   // F31: per-client interactive confirm. Skipped on `--yes`, in
@@ -1079,9 +1079,8 @@ export async function mcpSetupAction(
     console.log('');
     for (const { s, action } of writes) {
       try {
-        assertMcpConfigSelectionCurrent(s.target);
-        writeRegistration(s.target.endpoint, expectedEntry);
-        console.log(`  ${action === 'register' ? 'Registered' : 'Refreshed'} ${mcpConfigClientNames(s.target)} → ${s.target.endpoint.displayPath}`);
+        writeRegistration(s.target.file, expectedEntry);
+        console.log(`  ${action === 'register' ? 'Registered' : 'Refreshed'} ${mcpConfigClientNames(s.target)} → ${s.target.file.displayPath}`);
         // RFC-41 §4.5: explicit SKILL.md delivery for Cursor + Claude Code,
         // which don't walk node_modules for skill discovery. Returns null
         // for clients that don't support skill delivery; logs a warning

--- a/packages/cli/src/mcp-uninstall.ts
+++ b/packages/cli/src/mcp-uninstall.ts
@@ -1,4 +1,4 @@
-import { detectClients, parseMcpClientSelector, selectMcpClientTargets, assertMcpConfigSelectionCurrent, mcpConfigClientNames, type McpConfigSelection } from './mcp-client-registry.js';
+import { detectClients, parseMcpClientSelector, selectMcpClientTargets, mcpConfigClientNames, type McpConfigSelection } from './mcp-client-registry.js';
 import { inspectRegistration, removeRegistration } from './mcp-client-config.js';
 
 export interface McpUninstallCliOptions {
@@ -27,7 +27,7 @@ export async function confirmUninstallTargets(
   const confirmed: McpConfigSelection[] = [];
   try {
     for (const target of targets) {
-      const answer = (await rl.question(`Remove DKG MCP from ${mcpConfigClientNames(target)} (${target.endpoint.displayPath})? [Y/n] `)).trim().toLowerCase();
+      const answer = (await rl.question(`Remove DKG MCP from ${mcpConfigClientNames(target)} (${target.file.displayPath})? [Y/n] `)).trim().toLowerCase();
       if (answer !== 'n' && answer !== 'no') confirmed.push(target);
     }
     return confirmed;
@@ -51,9 +51,9 @@ export async function mcpUninstallAction(
   const failures: string[] = [];
   for (const target of selected) {
     try {
-      if (inspectRegistration(target.endpoint)) {
+      if (inspectRegistration(target.file)) {
         planned.push(target);
-        log(`${opts.dryRun ? 'Would remove' : 'Found'} DKG MCP: ${mcpConfigClientNames(target)} (${target.endpoint.displayPath})`);
+        log(`${opts.dryRun ? 'Would remove' : 'Found'} DKG MCP: ${mcpConfigClientNames(target)} (${target.file.displayPath})`);
       }
     } catch (error) {
       failures.push(`${mcpConfigClientNames(target)}: ${error instanceof Error ? error.message : 'Unable to read config'}`);
@@ -67,8 +67,7 @@ export async function mcpUninstallAction(
     const confirmed = await (deps.confirmTargets ?? confirmUninstallTargets)(planned, { yes: opts.yes === true });
     for (const target of confirmed) {
       try {
-        assertMcpConfigSelectionCurrent(target);
-        const removed = removeRegistration(target.endpoint);
+        const removed = removeRegistration(target.file);
         log(`${removed ? 'Removed DKG MCP from' : 'Already unregistered:'} ${mcpConfigClientNames(target)}`);
       } catch (error) {
         failures.push(`${mcpConfigClientNames(target)}: ${error instanceof Error ? error.message : 'Unable to write config'}`);

--- a/packages/cli/test/fixtures/mcp-config-wsl.fixture.ts
+++ b/packages/cli/test/fixtures/mcp-config-wsl.fixture.ts
@@ -1,7 +1,7 @@
 /** Mandatory native WSL fixture; runs the built CLI modules with Linux Node. */
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, lstatSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, readdirSync, rmSync, statSync, symlinkSync, lstatSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import TOML from '@iarna/toml';
 import { windowsPowerShellExecutable } from '../../dist/mcp-config-metadata.js';
@@ -76,7 +76,7 @@ async function main(): Promise<void> {
       ...setupDeps,
       confirmPlan: async (planned) => {
         assert.equal(planned.length, 1, 'one physical leaf must produce one registration write');
-        assert.equal(planned[0]!.s.target.endpoint.location, 'windows-wsl');
+        assert.equal(planned[0]!.s.target.file.destination, realpathSync(path));
         assert.equal(planned[0]!.action, 'refresh');
         registrationPlans += planned.length;
         return [...planned];

--- a/packages/cli/test/integrations-install-service.test.ts
+++ b/packages/cli/test/integrations-install-service.test.ts
@@ -1,5 +1,10 @@
 import type { ClientTarget } from '../src/mcp-client-registry.js';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readRegisteredServerKeys, type ServerKeyProbe } from '../src/mcp-client-config.js';
+import { McpPhysicalConfig } from '../src/mcp-physical-config.js';
 
 import { installService } from '../src/integrations/install-service.js';
 import { detectInstalled, parseGlobalNpmList } from '../src/integrations/detect-installed.js';
@@ -386,13 +391,41 @@ describe('detectInstalled', () => {
     expect(row!.state).toBe('not installed');
   });
 
+  it.each([false, true].flatMap(aliasFirst => ['installed', 'unreadable'].map(outcome => ({ aliasFirst, outcome }))))(
+    'probes shared physical configs once and retains aliases ($outcome, alias first: $aliasFirst)', async ({ aliasFirst, outcome }) => {
+      const directory = mkdtempSync(join(tmpdir(), 'dkg-integration-alias-'));
+      try {
+        const configPath = join(directory, 'config.json');
+        const aliasPath = join(directory, 'alias.json');
+        writeFileSync(configPath, outcome === 'installed'
+          ? JSON.stringify({ mcpServers: { 'mcp-slug': { command: 'npx', args: ['-y', 'p'] } } }) : '{ broken');
+        symlinkSync(configPath, aliasPath);
+        const native: ClientTarget = { id: 'cursor', location: 'native', format: 'json', serverContainer: 'mcpServers',
+          name: 'Cursor native', configPath, displayPath: configPath };
+        const windows: ClientTarget = { ...native, location: 'windows-wsl', name: 'Cursor Windows',
+          configPath: aliasPath, displayPath: aliasPath };
+        const readServerKeys = vi.fn(readRegisteredServerKeys);
+        const [row] = await detectInstalled([entry('mcp-slug', { kind: 'mcp', command: 'npx', args: ['-y', 'p'] })], {
+          clients: aliasFirst ? [windows, native] : [native, windows], readServerKeys,
+        });
+        expect(readServerKeys).toHaveBeenCalledTimes(1);
+        const [file] = readServerKeys.mock.calls[0]!;
+        expect(file).toBeInstanceOf(McpPhysicalConfig);
+        expect(file).toHaveProperty('destination', realpathSync(configPath));
+        expect(row!.state).toBe(outcome === 'installed' ? 'installed' : 'unknown');
+        expect(row!.detail).toContain(native.name);
+        expect(row!.detail).toContain(windows.name);
+      } finally { rmSync(directory, { recursive: true, force: true }); }
+    },
+  );
+
   it('detects an mcp entry across every client that registers it', async () => {
     const rows = await detectInstalled(
       [entry('mcp-slug', { kind: 'mcp', command: 'npx', args: ['-y', 'p'] })],
       {
         clients,
-        readServerKeys: (t) =>
-          t.name === 'Cursor'
+        readServerKeys: (t): ServerKeyProbe =>
+          t.displayPath === '~/cursor.json'
             ? { ok: true as const, servers: { 'mcp-slug': { command: 'npx', args: ['-y', 'p'] }, other: { command: 'npx', args: ['-y', 'p'] } } }
             : { ok: true as const, servers: { 'mcp-slug': { command: 'npx', args: ['-y', 'p'] } } },
       },
@@ -419,8 +452,8 @@ describe('detectInstalled', () => {
       [entry('mcp-slug', { kind: 'mcp', command: 'npx', args: ['-y', 'p'] })],
       {
         clients,
-        readServerKeys: (t) =>
-          t.name === 'Cursor'
+        readServerKeys: (t): ServerKeyProbe =>
+          t.displayPath === '~/cursor.json'
             ? { ok: false as const, reason: 'could not read ~/cursor.json' }
             : { ok: true as const, servers: {} },
       },
@@ -437,8 +470,8 @@ describe('detectInstalled', () => {
       [entry('mcp-slug', { kind: 'mcp', command: 'npx', args: ['-y', 'p'] })],
       {
         clients,
-        readServerKeys: (t) =>
-          t.name === 'Cursor'
+        readServerKeys: (t): ServerKeyProbe =>
+          t.displayPath === '~/cursor.json'
             ? { ok: false as const, reason: 'could not read ~/cursor.json' }
             : { ok: true as const, servers: { 'mcp-slug': { command: 'npx', args: ['-y', 'p'] } } },
       },
@@ -498,14 +531,14 @@ describe('detectInstalled', () => {
       [entry('mcp-slug', { kind: 'mcp', command: 'npx', args: ['-y', 'p'] })],
       {
         clients,
-        readServerKeys: (t) => ({
+        readServerKeys: (t): ServerKeyProbe => ({
           ok: true as const,
           servers: {
             'mcp-slug': {
               command: 'npx',
               args: ['-y', 'p'],
               env:
-                t.name === 'Cursor'
+                t.displayPath === '~/cursor.json'
                   ? { DKG_AUTH_TOKEN: 'dkg_live_abc' }
                   : { DKG_AUTH_TOKEN: '<DKG_AUTH_TOKEN>' },
             },

--- a/packages/cli/test/mcp-client-target.typecheck.ts
+++ b/packages/cli/test/mcp-client-target.typecheck.ts
@@ -19,7 +19,7 @@ const arbitrary: ClientTarget = { ...standard, serverContainer: 'unrelated.setti
 void [standard, vscode, codex, wrongCodex, wrongCursor, unsupportedCodexLocation, unsupportedClaudeLocation, implicit, arbitrary];
 
 // Mutation requires a selected physical config; a logical target cannot bypass it.
-import { writeRegistration, removeRegistration } from '../src/mcp-client-config.js';
+import { readRegisteredServerKeys, writeRegistration, removeRegistration } from '../src/mcp-client-config.js';
 import type { McpPhysicalConfig } from '../src/mcp-physical-config.js';
 declare const selection: McpConfigSelection;
 declare const registration: Parameters<typeof writeRegistration>[1];
@@ -27,6 +27,9 @@ const file: McpPhysicalConfig = selection.file;
 const selectedClient: ClientTarget | undefined = selection.aliases[0];
 writeRegistration(selection.file, registration);
 removeRegistration(selection.file);
+readRegisteredServerKeys(selection.file);
+// @ts-expect-error Readers also require a selected physical config.
+readRegisteredServerKeys(standard);
 // @ts-expect-error A raw logical target cannot bypass destination ownership.
 writeRegistration(standard, registration);
 // @ts-expect-error Removal also requires the physical mutation boundary.

--- a/packages/cli/test/mcp-client-target.typecheck.ts
+++ b/packages/cli/test/mcp-client-target.typecheck.ts
@@ -1,4 +1,4 @@
-import type { ClientTarget, McpConfigEndpoint, McpConfigSelection } from '../src/mcp-client-registry.js';
+import type { ClientTarget, McpConfigSelection } from '../src/mcp-client-registry.js';
 
 declare const paths: Pick<ClientTarget, 'name' | 'configPath' | 'displayPath'>;
 const standard: ClientTarget = { ...paths, id: 'cursor', location: 'native', format: 'json', serverContainer: 'mcpServers' };
@@ -18,12 +18,21 @@ const implicit: ClientTarget = { ...paths, id: 'cursor', location: 'native' };
 const arbitrary: ClientTarget = { ...standard, serverContainer: 'unrelated.setting' };
 void [standard, vscode, codex, wrongCodex, wrongCursor, unsupportedCodexLocation, unsupportedClaudeLocation, implicit, arbitrary];
 
-// Physical persistence and selected logical identities are separate contracts.
+// Mutation requires a selected physical config; a logical target cannot bypass it.
+import { writeRegistration, removeRegistration } from '../src/mcp-client-config.js';
+import type { McpPhysicalConfig } from '../src/mcp-physical-config.js';
 declare const selection: McpConfigSelection;
-const endpoint: McpConfigEndpoint = selection.endpoint;
+declare const registration: Parameters<typeof writeRegistration>[1];
+const file: McpPhysicalConfig = selection.file;
 const selectedClient: ClientTarget | undefined = selection.aliases[0];
-// @ts-expect-error A physical endpoint does not represent a logical client.
-const identity: ClientTarget = selection.endpoint;
-// @ts-expect-error Client identity is not available on the persistence endpoint.
-const endpointId = selection.endpoint.id;
-void [endpoint, selectedClient, identity, endpointId];
+writeRegistration(selection.file, registration);
+removeRegistration(selection.file);
+// @ts-expect-error A raw logical target cannot bypass destination ownership.
+writeRegistration(standard, registration);
+// @ts-expect-error Removal also requires the physical mutation boundary.
+removeRegistration(standard);
+// @ts-expect-error Physical configs carry no synthesized logical location.
+const location = selection.file.location;
+// @ts-expect-error A physical config is not a logical client.
+const identity: ClientTarget = selection.file;
+void [file, selectedClient, location, identity];

--- a/packages/cli/test/mcp-client-target.typecheck.ts
+++ b/packages/cli/test/mcp-client-target.typecheck.ts
@@ -21,6 +21,7 @@ void [standard, vscode, codex, wrongCodex, wrongCursor, unsupportedCodexLocation
 // Mutation requires a selected physical config; a logical target cannot bypass it.
 import { readRegisteredServerKeys, writeRegistration, removeRegistration } from '../src/mcp-client-config.js';
 import type { McpPhysicalConfig } from '../src/mcp-physical-config.js';
+import type { McpConfigSourceSnapshot } from '../src/mcp-config-file.js';
 declare const selection: McpConfigSelection;
 declare const registration: Parameters<typeof writeRegistration>[1];
 const file: McpPhysicalConfig = selection.file;
@@ -39,3 +40,11 @@ const location = selection.file.location;
 // @ts-expect-error A physical config is not a logical client.
 const identity: ClientTarget = selection.file;
 void [file, selectedClient, location, identity];
+
+// @ts-expect-error Transaction snapshots cannot be forged without the factory's path validation.
+const unboundSource: McpConfigSourceSnapshot = {
+  destination: '/tmp/config.json',
+  content: undefined,
+  assertCurrent() {},
+};
+void unboundSource;

--- a/packages/cli/test/mcp-config-document.test.ts
+++ b/packages/cli/test/mcp-config-document.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, realpathSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import TOML from '@iarna/toml';
 import { jsonDocumentAdapter, jsoncDocumentAdapter } from '../src/mcp-json-document.js';
 import { tomlDocumentAdapter } from '../src/mcp-toml-document.js';
 import { readRegisteredServerKeys, removeRegistration, writeRegistration } from '../src/mcp-client-config.js';
-import type { McpConfigEndpoint } from '../src/mcp-client-registry.js';
+import { McpPhysicalConfig } from '../src/mcp-physical-config.js';
 import type { DesiredRegistration, McpConfigDocumentAdapter, PersistedRegistration } from '../src/mcp-config-document.js';
 
 const previous = { command: 'old', args: ['old'], cwd: '/keep', env: { DKG_HOME: '/old', KEEP: 'value' } };
@@ -34,15 +34,15 @@ const formats: {
 ];
 
 const directories: string[] = [];
-function configFile(format: 'json' | 'jsonc' | 'toml', source: string): McpConfigEndpoint {
+function configFile(format: 'json' | 'jsonc' | 'toml', source: string): McpPhysicalConfig {
   const dir = mkdtempSync(join(tmpdir(), 'dkg-mcp-document-'));
   directories.push(dir);
   const configPath = join(dir, `config.${format}`);
   writeFileSync(configPath, source);
-  const paths = { configPath, displayPath: configPath, location: 'native' as const };
-  if (format === 'toml') return { ...paths, format, serverContainer: 'mcp_servers' };
-  if (format === 'jsonc') return { ...paths, format, serverContainer: 'servers' };
-  return { ...paths, format, serverContainer: 'mcpServers' };
+  const paths = [{ configPath, displayPath: configPath }];
+  if (format === 'toml') return new McpPhysicalConfig(realpathSync(configPath), { format, serverContainer: 'mcp_servers' }, paths);
+  if (format === 'jsonc') return new McpPhysicalConfig(realpathSync(configPath), { format, serverContainer: 'servers' }, paths);
+  return new McpPhysicalConfig(realpathSync(configPath), { format, serverContainer: 'mcpServers' }, paths);
 }
 afterEach(() => { for (const dir of directories.splice(0)) rmSync(dir, { recursive: true, force: true }); });
 
@@ -80,9 +80,9 @@ describe.each(formats)('$format document edit contract', ({ format, container, a
   it('merges extension fields and preserves unrelated entries through the coordinator', () => {
     const target = configFile(format, source);
     writeRegistration(target, desired);
-    expect(adapter.parse(readFileSync(target.configPath, 'utf8'))).toEqual({ title: 'keep', [container]: { other, dkg: merged } });
+    expect(adapter.parse(readFileSync(target.destination, 'utf8'))).toEqual({ title: 'keep', [container]: { other, dkg: merged } });
     expect(removeRegistration(target)).toBe(true);
-    expect(adapter.parse(readFileSync(target.configPath, 'utf8'))).toEqual({ title: 'keep', [container]: { other } });
+    expect(adapter.parse(readFileSync(target.destination, 'utf8'))).toEqual({ title: 'keep', [container]: { other } });
     expect(removeRegistration(target)).toBe(false);
   });
 });
@@ -97,7 +97,7 @@ describe.each(formats.filter(({ format }) => format !== 'toml'))('$format record
     expect(readRegisteredServerKeys(target).ok).toBe(false);
     expect(() => writeRegistration(target, desired)).toThrow(/not valid/);
     expect(() => removeRegistration(target)).toThrow(/not valid/);
-    expect(readFileSync(target.configPath, 'utf8')).toBe(source);
+    expect(readFileSync(target.destination, 'utf8')).toBe(source);
     expect(readdirSync(dir)).toEqual(entries);
   });
 

--- a/packages/cli/test/mcp-config-document.test.ts
+++ b/packages/cli/test/mcp-config-document.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, realpathSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import TOML from '@iarna/toml';
@@ -39,10 +39,9 @@ function configFile(format: 'json' | 'jsonc' | 'toml', source: string): McpPhysi
   directories.push(dir);
   const configPath = join(dir, `config.${format}`);
   writeFileSync(configPath, source);
-  const paths = [{ configPath, displayPath: configPath }];
-  if (format === 'toml') return new McpPhysicalConfig(realpathSync(configPath), { format, serverContainer: 'mcp_servers' }, paths);
-  if (format === 'jsonc') return new McpPhysicalConfig(realpathSync(configPath), { format, serverContainer: 'servers' }, paths);
-  return new McpPhysicalConfig(realpathSync(configPath), { format, serverContainer: 'mcpServers' }, paths);
+  if (format === 'toml') return McpPhysicalConfig.create([{ configPath, displayPath: configPath, format, serverContainer: 'mcp_servers' }]);
+  if (format === 'jsonc') return McpPhysicalConfig.create([{ configPath, displayPath: configPath, format, serverContainer: 'servers' }]);
+  return McpPhysicalConfig.create([{ configPath, displayPath: configPath, format, serverContainer: 'mcpServers' }]);
 }
 afterEach(() => { for (const dir of directories.splice(0)) rmSync(dir, { recursive: true, force: true }); });
 

--- a/packages/cli/test/mcp-config-metadata.test.ts
+++ b/packages/cli/test/mcp-config-metadata.test.ts
@@ -4,7 +4,22 @@ import { chmodSync, mkdirSync, existsSync, statSync, copyFileSync, mkdtempSync, 
 import { tmpdir } from 'node:os';
 import { join, win32 } from 'node:path';
 import { snapshotMcpConfigSource, writeMcpConfigAtomic } from '../src/mcp-config-file.js';
+import { detectClients } from '../src/mcp-client-registry.js';
+import { detectMcpRuntime } from '../src/mcp-runtime.js';
 import { copyWindowsMcpConfigMetadata, linuxMetadataCopyCommand, mcpConfigPersistenceStrategy } from '../src/mcp-config-metadata.js';
+
+const runtimeFixture = vi.hoisted(() => ({ release: undefined as string | undefined, proc: undefined as string | undefined }));
+vi.mock('node:os', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return { ...actual, platform: () => process.platform, release: () => runtimeFixture.release ?? actual.release() };
+});
+vi.mock('node:fs', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, readFileSync: ((...args: Parameters<typeof actual.readFileSync>) => {
+    if (args[0] === '/proc/version' && runtimeFixture.proc !== undefined) return runtimeFixture.proc;
+    return actual.readFileSync(...args);
+  }) as typeof actual.readFileSync };
+});
 
 vi.mock('node:child_process', async importOriginal => {
   const actual = await importOriginal<typeof import('node:child_process')>();
@@ -19,21 +34,50 @@ beforeEach(() => {
   path = join(directory, "config 'quoted'.json");
   writeFileSync(path, '{"original":true}\n');
 });
-afterEach(() => { vi.unstubAllEnvs(); vi.mocked(execFileSync).mockReset(); rmSync(directory, { recursive: true, force: true }); });
+afterEach(() => { runtimeFixture.release = undefined; runtimeFixture.proc = undefined; vi.unstubAllEnvs(); vi.mocked(execFileSync).mockReset(); rmSync(directory, { recursive: true, force: true }); });
 
-it.each([
-  ['drive', 'C:\\fixture\\config.json', 'windows-wsl'],
-  ['network share', '\\\\server\\share\\config.json', 'windows-wsl'],
-  ['Linux distro', '\\\\wsl.localhost\\Ubuntu\\home\\user\\config.json', 'linux'],
-  ['legacy Linux distro', '\\\\wsl$\\Ubuntu\\home\\user\\config.json', 'linux'],
-] as const)('selects native WSL persistence from the destination on a %s', (_label, translated, kind) => {
+const signals = [
+  { name: 'distro environment', env: 'WSL_DISTRO_NAME', release: 'generic', proc: 'generic' },
+  { name: 'interop environment', env: 'WSL_INTEROP', release: 'generic', proc: 'generic' },
+  { name: 'Microsoft release', release: '5.15.0-microsoft-standard', proc: 'generic' },
+  { name: 'WSL-only release', release: '5.15.0-wsl2', proc: 'generic' },
+  { name: 'Microsoft procfs', release: 'generic', proc: 'Linux Microsoft kernel' },
+  { name: 'WSL-only procfs', release: 'generic', proc: 'Linux WSL2 kernel' },
+];
+const destinations = [
+  { name: 'drive', translated: 'C:\\fixture\\config.json', kind: 'windows-wsl' },
+  { name: 'network share', translated: '\\\\server\\share\\config.json', kind: 'windows-wsl' },
+  { name: 'Linux distro', translated: '\\\\wsl.localhost\\Ubuntu\\home\\user\\config.json', kind: 'linux' },
+  { name: 'legacy Linux distro', translated: '\\\\wsl$\\Ubuntu\\home\\user\\config.json', kind: 'linux' },
+];
+it.each(signals.flatMap(signal => destinations.map(destination => ({ signal, destination,
+  name: signal.name + ': ' + destination.name }))))('routes a shared runtime signal: $name', ({ signal, destination }) => {
   const platform = Object.getOwnPropertyDescriptor(process, 'platform')!;
-  vi.stubEnv('WSL_DISTRO_NAME', 'Ubuntu');
-  vi.mocked(execFileSync).mockReturnValue(translated);
+  vi.stubEnv('WSL_DISTRO_NAME', undefined);
+  vi.stubEnv('WSL_INTEROP', undefined);
+  if (signal.env) vi.stubEnv(signal.env, 'fixture');
+  runtimeFixture.release = signal.release;
+  runtimeFixture.proc = signal.proc;
+  vi.mocked(execFileSync).mockReturnValue(destination.translated);
   try {
     Object.defineProperty(process, 'platform', { value: 'linux' });
-    expect(mcpConfigPersistenceStrategy('native', path).kind).toBe(kind);
+    expect(detectMcpRuntime()).toBe('wsl');
+    const discoverWindowsPath = vi.fn(() => null);
+    detectClients(discoverWindowsPath);
+    expect(discoverWindowsPath).toHaveBeenCalledWith('USERPROFILE');
+    expect(mcpConfigPersistenceStrategy(path).kind).toBe(destination.kind);
     expect(execFileSync).toHaveBeenCalledWith('/usr/bin/wslpath', ['-w', path], expect.any(Object));
+  } finally { Object.defineProperty(process, 'platform', platform); }
+});
+
+it.each([['darwin', 'posix'], ['win32', 'windows-native']] as const)('ignores WSL markers outside Linux on %s', (operatingSystem, kind) => {
+  const platform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+  vi.stubEnv('WSL_DISTRO_NAME', 'fixture');
+  runtimeFixture.release = 'microsoft-wsl';
+  try {
+    Object.defineProperty(process, 'platform', { value: operatingSystem });
+    expect(mcpConfigPersistenceStrategy(path).kind).toBe(kind);
+    expect(execFileSync).not.toHaveBeenCalled();
   } finally { Object.defineProperty(process, 'platform', platform); }
 });
 
@@ -50,7 +94,7 @@ it('rejects a missing metadata capability before creating files or changing cont
   vi.mocked(execFileSync).mockImplementationOnce(() => { throw new Error('gcp not installed'); });
   try {
     Object.defineProperty(process, 'platform', { value: 'linux' });
-    expect(() => writeMcpConfigAtomic(path, '{}\n', mcpConfigPersistenceStrategy('native', path), snapshotMcpConfigSource(path))).toThrow('apk add coreutils');
+    expect(() => writeMcpConfigAtomic(path, '{}\n', mcpConfigPersistenceStrategy(path), snapshotMcpConfigSource(path))).toThrow('apk add coreutils');
     expect(readFileSync(path, 'utf8')).toBe('{"original":true}\n');
     expect(readdirSync(directory)).toEqual(before);
   } finally { Object.defineProperty(process, 'platform', platform); }
@@ -72,7 +116,7 @@ it.each(['acl', 'replace', 'restore-backup', 'retain-backup'] as const)('preserv
   });
   try {
     Object.defineProperty(process, 'platform', { value: 'win32' });
-    expect(() => writeMcpConfigAtomic(path, '{}\n', mcpConfigPersistenceStrategy('native', path), snapshotMcpConfigSource(path))).toThrow(stage === 'retain-backup' ? 'backup is retained' : 'failed');
+    expect(() => writeMcpConfigAtomic(path, '{}\n', mcpConfigPersistenceStrategy(path), snapshotMcpConfigSource(path))).toThrow(stage === 'retain-backup' ? 'backup is retained' : 'failed');
     expect(readFileSync(path, 'utf8')).toBe('{"original":true}\n');
     const backups = readdirSync(directory).filter(name => name.endsWith('.backup'));
     expect(backups).toHaveLength(stage === 'retain-backup' ? 1 : 0);
@@ -109,7 +153,7 @@ it('rejects first-time creation if a symlinked parent changes after inspection',
   expect(source.content).toBeUndefined();
   unlinkSync(alias);
   symlinkSync(second, alias, 'junction');
-  expect(() => writeMcpConfigAtomic(configPath, '{}\n', mcpConfigPersistenceStrategy('native', source.destination), source))
+  expect(() => writeMcpConfigAtomic(configPath, '{}\n', mcpConfigPersistenceStrategy(source.destination), source))
     .toThrow('changed while it was being edited');
   expect(readdirSync(first)).toEqual([]);
   expect(readdirSync(second)).toEqual([]);
@@ -125,7 +169,7 @@ it.runIf(nativeMetadata && process.platform === 'darwin')('preserves macOS permi
   const { mode, uid, gid } = statSync(path);
   expect(mode & 0o777).toBe(0o640);
   expect(before).toContain('everyone allow read');
-  writeMcpConfigAtomic(path, '{}\n', mcpConfigPersistenceStrategy('native', path), snapshotMcpConfigSource(path));
+  writeMcpConfigAtomic(path, '{}\n', mcpConfigPersistenceStrategy(path), snapshotMcpConfigSource(path));
   expect(acl()).toBe(before);
   expect(statSync(path)).toMatchObject({ mode, uid, gid });
   expect(execFileSync('/usr/bin/xattr', ['-p', 'org.origintrail.fixture', path], { encoding: 'utf8' }).trim()).toBe('retained');
@@ -139,7 +183,7 @@ it.runIf(nativeMetadata && process.platform === 'linux')('preserves Linux ACLs a
   const acl = () => execFileSync('getfacl', ['-cn', path], { encoding: 'utf8' });
   const before = acl();
   expect(before).toContain('user:65534:r--');
-  writeMcpConfigAtomic(path, '{}\n', mcpConfigPersistenceStrategy('native', path), snapshotMcpConfigSource(path));
+  writeMcpConfigAtomic(path, '{}\n', mcpConfigPersistenceStrategy(path), snapshotMcpConfigSource(path));
   expect(acl()).toBe(before);
   expect(execFileSync('getfattr', ['--only-values', '-n', 'user.dkg_fixture', path], { encoding: 'utf8' }).trim()).toBe('retained');
   expect(readdirSync(directory)).toEqual(["config 'quoted'.json"]);
@@ -169,7 +213,7 @@ it.runIf(nativeMetadata && process.platform === 'win32')('preserves a protected 
     expect(readFileSync(marker, 'utf8')).toBe('executed');
     rmSync(marker);
     process.chdir(untrusted);
-    writeMcpConfigAtomic(path, '{"replacement":true}\n', mcpConfigPersistenceStrategy('native', path), snapshotMcpConfigSource(path));
+    writeMcpConfigAtomic(path, '{"replacement":true}\n', mcpConfigPersistenceStrategy(path), snapshotMcpConfigSource(path));
     expect(existsSync(marker)).toBe(false);
   } finally {
     process.chdir(priorCwd);
@@ -181,13 +225,14 @@ it.runIf(nativeMetadata && process.platform === 'win32')('preserves a protected 
   const source = snapshotMcpConfigSource(firstPath);
   expect(source.content).toBeUndefined();
   writeMcpConfigAtomic(firstPath, '{"mcpServers":{"dkg":{"command":"node"}}}\n',
-    mcpConfigPersistenceStrategy('native', source.destination), source);
+    mcpConfigPersistenceStrategy(source.destination), source);
   expect(JSON.parse(readFileSync(firstPath, 'utf8'))).toEqual({ mcpServers: { dkg: { command: 'node' } } });
   expect(readdirSync(directory).sort()).toEqual(["config 'quoted'.json", 'first-time.json', 'untrusted']);
 });
 
 
 it('routes Windows-side WSL replacements through converted paths and Windows security APIs', () => {
+  vi.stubEnv('WSL_DISTRO_NAME', 'Ubuntu');
   const platform = Object.getOwnPropertyDescriptor(process, 'platform')!;
   const converted = new Map<string, string>();
   const systemPowerShell = '/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe';
@@ -215,7 +260,7 @@ it('routes Windows-side WSL replacements through converted paths and Windows sec
   });
   try {
     Object.defineProperty(process, 'platform', { value: 'linux' });
-    writeMcpConfigAtomic(path, '{"wsl":true}\n', mcpConfigPersistenceStrategy('windows-wsl', path), snapshotMcpConfigSource(path));
+    writeMcpConfigAtomic(path, '{"wsl":true}\n', mcpConfigPersistenceStrategy(path), snapshotMcpConfigSource(path));
     expect(scripts).toHaveLength(2);
     expect(scripts[0]).toContain('Get-Acl');
     expect(scripts[1]).toContain('::Replace');

--- a/packages/cli/test/mcp-config-metadata.test.ts
+++ b/packages/cli/test/mcp-config-metadata.test.ts
@@ -3,7 +3,7 @@ import { execFileSync } from 'node:child_process';
 import { chmodSync, mkdirSync, existsSync, statSync, copyFileSync, mkdtempSync, readFileSync, readdirSync, renameSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, win32 } from 'node:path';
-import { snapshotMcpConfigSource, writeMcpConfigAtomic } from '../src/mcp-config-file.js';
+import { snapshotMcpConfigSource as snapshotSourceTransaction, writeMcpConfigAtomic } from '../src/mcp-config-file.js';
 import { detectClients } from '../src/mcp-client-registry.js';
 import { detectMcpRuntime } from '../src/mcp-runtime.js';
 import { copyWindowsMcpConfigMetadata, linuxMetadataCopyCommand, mcpConfigPersistenceStrategy } from '../src/mcp-config-metadata.js';
@@ -27,6 +27,10 @@ vi.mock('node:child_process', async importOriginal => {
 });
 
 const nativeMetadata = process.env.DKG_REQUIRE_NATIVE_MCP_METADATA === '1';
+const snapshotMcpConfigSource = (configPath: string) => snapshotSourceTransaction(
+  configPath,
+  [{ configPath, displayPath: configPath }],
+);
 let directory: string;
 let path: string;
 beforeEach(() => {
@@ -154,7 +158,7 @@ it('rejects first-time creation if a symlinked parent changes after inspection',
   unlinkSync(alias);
   symlinkSync(second, alias, 'junction');
   expect(() => writeMcpConfigAtomic(configPath, '{}\n', mcpConfigPersistenceStrategy(source.destination), source))
-    .toThrow('changed while it was being edited');
+    .toThrow('path changed since inspection');
   expect(readdirSync(first)).toEqual([]);
   expect(readdirSync(second)).toEqual([]);
 });

--- a/packages/cli/test/mcp-physical-config.test.ts
+++ b/packages/cli/test/mcp-physical-config.test.ts
@@ -3,8 +3,14 @@ import { mkdtempSync, readFileSync, realpathSync, readdirSync, rmSync, symlinkSy
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { selectMcpClientTargets, type ClientTarget } from '../src/mcp-client-registry.js';
-import { readRegistration, removeRegistration, writeRegistration } from '../src/mcp-client-config.js';
+import { readRegisteredServerKeys, readRegistration, removeRegistration, writeRegistration } from '../src/mcp-client-config.js';
 import { mcpConfigPersistenceStrategy } from '../src/mcp-config-metadata.js';
+import { detectMcpRuntime } from '../src/mcp-runtime.js';
+
+vi.mock('../src/mcp-runtime.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/mcp-runtime.js')>();
+  return { ...actual, detectMcpRuntime: vi.fn(actual.detectMcpRuntime) };
+});
 
 vi.mock('../src/mcp-config-metadata.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../src/mcp-config-metadata.js')>();
@@ -72,4 +78,19 @@ it('rejects a source snapshot owned by another physical config', () => {
   const source = file.readSource();
   expect(() => file.write('{}', { ...source, destination: join(directory, 'replacement.json') })).toThrow('different destination');
   assertUnchanged();
+});
+
+it('constructs and reads physical configs without detecting process runtime', () => {
+  const { file } = fixture(false);
+  expect(readRegistration(file).kind).toBe('entry');
+  expect(readRegisteredServerKeys(file).ok).toBe(true);
+  expect(detectMcpRuntime).not.toHaveBeenCalled();
+});
+
+it('detects process runtime when persisting a physical config', () => {
+  const { file } = fixture(false);
+  vi.mocked(detectMcpRuntime).mockClear();
+  writeRegistration(file, desired);
+  expect(detectMcpRuntime).toHaveBeenCalledTimes(1);
+  expect(readRegistration(file)).toMatchObject({ kind: 'entry', registration: { command: desired.command } });
 });

--- a/packages/cli/test/mcp-physical-config.test.ts
+++ b/packages/cli/test/mcp-physical-config.test.ts
@@ -80,6 +80,31 @@ it('rejects a source snapshot owned by another physical config', () => {
   assertUnchanged();
 });
 
+it('rejects snapshots exchanged between owners of the same destination', () => {
+  const original = join(directory, 'shared.json');
+  const aliasA = join(directory, 'alias-a.json');
+  const aliasB = join(directory, 'alias-b.json');
+  writeFileSync(original, '{}\n');
+  symlinkSync(original, aliasA);
+  symlinkSync(original, aliasB);
+  const base: ClientTarget = {
+    id: 'cursor', name: 'Cursor', location: 'native', format: 'json',
+    serverContainer: 'mcpServers', configPath: aliasA, displayPath: aliasA,
+  };
+  const first = selectMcpClientTargets([base])[0]!.file;
+  const second = selectMcpClientTargets([{
+    ...base,
+    configPath: aliasB,
+    displayPath: aliasB,
+  }])[0]!.file;
+
+  const firstSource = first.readSource();
+  expect(first.destination).toBe(second.destination);
+  expect(() => second.write('{"changed":true}\n', firstSource))
+    .toThrow('different physical config owner');
+  expect(readFileSync(original, 'utf8')).toBe('{}\n');
+});
+
 it('constructs and reads physical configs without detecting process runtime', () => {
   const { file } = fixture(false);
   expect(readRegistration(file).kind).toBe('entry');

--- a/packages/cli/test/mcp-physical-config.test.ts
+++ b/packages/cli/test/mcp-physical-config.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { mkdtempSync, readFileSync, realpathSync, readdirSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { selectMcpClientTargets, type ClientTarget } from '../src/mcp-client-registry.js';
+import { readRegistration, removeRegistration, writeRegistration } from '../src/mcp-client-config.js';
+import { mcpConfigPersistenceStrategy } from '../src/mcp-config-metadata.js';
+
+vi.mock('../src/mcp-config-metadata.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/mcp-config-metadata.js')>();
+  return { ...actual, mcpConfigPersistenceStrategy: vi.fn(actual.mcpConfigPersistenceStrategy) };
+});
+const actualMetadata = await vi.importActual<typeof import('../src/mcp-config-metadata.js')>('../src/mcp-config-metadata.js');
+const desired = { command: 'node', args: ['dkg.js'], env: { DKG_HOME: '/fixture' } };
+let directory: string;
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), 'dkg-mcp-physical-'));
+  vi.mocked(mcpConfigPersistenceStrategy).mockImplementation(actualMetadata.mcpConfigPersistenceStrategy);
+});
+afterEach(() => { vi.clearAllMocks(); rmSync(directory, { recursive: true, force: true }); });
+
+function fixture(aliasFirst: boolean) {
+  const original = join(directory, 'original.json');
+  const replacement = join(directory, 'replacement.json');
+  const alias = join(directory, 'alias.json');
+  const source = '{"mcpServers":{"dkg":{"command":"old"},"other":{"command":"keep"}}}\n';
+  writeFileSync(original, source);
+  writeFileSync(replacement, source);
+  symlinkSync(original, alias);
+  const target: ClientTarget = { id: 'cursor', name: 'Cursor', location: 'native', format: 'json', serverContainer: 'mcpServers', configPath: original, displayPath: original };
+  const windows: ClientTarget = { ...target, location: 'windows-wsl', configPath: alias, displayPath: alias };
+  const clients = aliasFirst ? [windows, target] : [target, windows];
+  const selections = selectMcpClientTargets(clients);
+  expect(selections).toHaveLength(1);
+  const { file, aliases } = selections[0]!;
+  expect(file.destination).toBe(realpathSync(original));
+  expect(aliases).toEqual(clients);
+  expect(file).not.toHaveProperty('location');
+  const retarget = () => { unlinkSync(alias); symlinkSync(replacement, alias); };
+  const assertUnchanged = () => {
+    expect(readFileSync(original, 'utf8')).toBe(source);
+    expect(readFileSync(replacement, 'utf8')).toBe(source);
+    expect(readdirSync(directory).sort()).toEqual(['alias.json', 'original.json', 'replacement.json']);
+  };
+  return { file, retarget, assertUnchanged };
+}
+
+it.each([false, true].flatMap(aliasFirst => ['write', 'remove'].map(operation => ({ aliasFirst, operation }))))(
+  'rejects $operation after confirmation-time retargeting (alias first: $aliasFirst)', ({ aliasFirst, operation }) => {
+    const { file, retarget, assertUnchanged } = fixture(aliasFirst);
+    expect(readRegistration(file).kind).toBe('entry');
+    retarget();
+    const mutate = () => operation === 'write' ? writeRegistration(file, desired) : removeRegistration(file);
+    expect(mutate).toThrow('changed since inspection');
+    assertUnchanged();
+  },
+);
+
+it.each([false, true])('revalidates every selected alias before publication (alias first: %s)', aliasFirst => {
+  const { file, retarget, assertUnchanged } = fixture(aliasFirst);
+  const native = actualMetadata.mcpConfigPersistenceStrategy(file.destination);
+  vi.mocked(mcpConfigPersistenceStrategy).mockReturnValue({
+    ...native,
+    prepare(replacement) { native.prepare(replacement); retarget(); },
+  });
+  expect(() => writeRegistration(file, desired)).toThrow('changed since inspection');
+  assertUnchanged();
+});
+
+it('rejects a source snapshot owned by another physical config', () => {
+  const { file, assertUnchanged } = fixture(false);
+  const source = file.readSource();
+  expect(() => file.write('{}', { ...source, destination: join(directory, 'replacement.json') })).toThrow('different destination');
+  assertUnchanged();
+});

--- a/packages/cli/test/mcp-registered-server-keys.test.ts
+++ b/packages/cli/test/mcp-registered-server-keys.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { realpathSync } from 'node:fs';
 import { McpPhysicalConfig } from '../src/mcp-physical-config.js';
 
 import {
@@ -34,7 +33,7 @@ async function target(
 ): Promise<McpPhysicalConfig> {
   const configPath = join(dir, filename);
   await writeFile(configPath, body, 'utf8');
-  return new McpPhysicalConfig(realpathSync(configPath), shape, [{ configPath, displayPath: configPath }]);
+  return McpPhysicalConfig.create([{ configPath, displayPath: configPath, ...shape }]);
 }
 
 /** Fails loudly with the probe's own reason instead of a bare undefined. */

--- a/packages/cli/test/mcp-registered-server-keys.test.ts
+++ b/packages/cli/test/mcp-registered-server-keys.test.ts
@@ -1,8 +1,10 @@
-import type { McpClientConfigShape, ClientTarget } from '../src/mcp-client-registry.js';
+import { selectMcpClientTargets, type McpClientConfigShape, type ClientTarget } from '../src/mcp-client-registry.js';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { realpathSync } from 'node:fs';
+import { McpPhysicalConfig } from '../src/mcp-physical-config.js';
 
 import {
   readRegisteredServerKeys,
@@ -29,13 +31,10 @@ async function target(
   filename: string,
   body: string,
   shape: McpClientConfigShape = { format: 'json', serverContainer: 'mcpServers' },
-): Promise<ClientTarget> {
+): Promise<McpPhysicalConfig> {
   const configPath = join(dir, filename);
   await writeFile(configPath, body, 'utf8');
-  const paths = { location: 'native' as const, name: 'Test', configPath, displayPath: configPath };
-  if (shape.format === 'toml') return { ...paths, id: 'codex-cli', ...shape };
-  if (shape.serverContainer === 'servers') return { ...paths, id: 'vscode', format: 'jsonc', serverContainer: 'servers' };
-  return { ...paths, id: 'cursor', format: 'json', serverContainer: 'mcpServers' };
+  return new McpPhysicalConfig(realpathSync(configPath), shape, [{ configPath, displayPath: configPath }]);
 }
 
 /** Fails loudly with the probe's own reason instead of a bare undefined. */
@@ -114,7 +113,7 @@ describe('readRegisteredServerKeys', () => {
       configPath: join(dir, 'nope.json'),
       displayPath: 'nope.json',
     };
-    expect(readRegisteredServerKeys(t)).toEqual({ ok: true, servers: {} });
+    expect(readRegisteredServerKeys(selectMcpClientTargets([t])[0]!.file)).toEqual({ ok: true, servers: {} });
   });
 
   it('treats a missing container as a SUCCESSFUL probe with no servers', async () => {

--- a/packages/cli/test/mcp-setup.test.ts
+++ b/packages/cli/test/mcp-setup.test.ts
@@ -2405,8 +2405,8 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     }));
     expect(plans).toHaveLength(1);
     expect(plans[0]).toHaveLength(1);
-    expect(plans[0][0].destination).toBe(realpathSync(configPath));
-    expect(plans[0][0].endpoint).toMatchObject({ configPath, location: 'windows-wsl' });
+    expect(plans[0][0].file.destination).toBe(realpathSync(configPath));
+    expect(plans[0][0].file.shape).toEqual({ format: 'json', serverContainer: 'mcpServers' });
     expect(plans[0][0].aliases).toEqual(windowsFirst ? [windows, native] : [native, windows]);
     expect(JSON.parse(readFileSync(configPath, 'utf8')).mcpServers.dkg.command).toBe('old');
   });

--- a/packages/cli/test/mcp-uninstall-command.test.ts
+++ b/packages/cli/test/mcp-uninstall-command.test.ts
@@ -35,8 +35,7 @@ vi.mock('../src/mcp-config-file.js', async importOriginal => {
       content: string,
       _persistence: Parameters<typeof actual.writeMcpConfigAtomic>[2],
       expectedSource: Parameters<typeof actual.writeMcpConfigAtomic>[3],
-      validateDestination?: () => void,
-    ) => actual.writeMcpConfigAtomic(path, content, mcpConfigPersistenceStrategy(path, process.platform === 'win32' ? 'windows' : process.platform === 'linux' ? 'linux' : 'posix'), expectedSource, validateDestination)),
+    ) => actual.writeMcpConfigAtomic(path, content, mcpConfigPersistenceStrategy(path, process.platform === 'win32' ? 'windows' : process.platform === 'linux' ? 'linux' : 'posix'), expectedSource)),
   };
 });
 

--- a/packages/cli/test/mcp-uninstall-command.test.ts
+++ b/packages/cli/test/mcp-uninstall-command.test.ts
@@ -35,7 +35,8 @@ vi.mock('../src/mcp-config-file.js', async importOriginal => {
       content: string,
       _persistence: Parameters<typeof actual.writeMcpConfigAtomic>[2],
       expectedSource: Parameters<typeof actual.writeMcpConfigAtomic>[3],
-    ) => actual.writeMcpConfigAtomic(path, content, mcpConfigPersistenceStrategy('native', path), expectedSource)),
+      validateDestination?: () => void,
+    ) => actual.writeMcpConfigAtomic(path, content, mcpConfigPersistenceStrategy(path, process.platform === 'win32' ? 'windows' : process.platform === 'linux' ? 'linux' : 'posix'), expectedSource, validateDestination)),
   };
 });
 

--- a/packages/cli/test/mcp-uninstall.test.ts
+++ b/packages/cli/test/mcp-uninstall.test.ts
@@ -8,7 +8,7 @@ import TOML from '@iarna/toml';
 import { inspectRegistration, removeRegistration, readRegistration, classifyRegistration, writeRegistration } from '../src/mcp-client-config.js';
 import { snapshotMcpConfigSource, writeMcpConfigAtomic, type McpConfigSourceSnapshot } from '../src/mcp-config-file.js';
 import { mcpConfigPersistenceStrategy, type McpConfigPersistenceStrategy } from '../src/mcp-config-metadata.js';
-import { type ClientTarget } from '../src/mcp-client-registry.js';
+import { selectMcpClientTargets, type ClientTarget } from '../src/mcp-client-registry.js';
 import { dkgDir, configPath } from '../src/config.js';
 import { dkgAuthTokenPath } from '@origintrail-official/dkg-core';
 import { mcpUninstallAction } from '../src/mcp-uninstall.js';
@@ -31,7 +31,8 @@ vi.mock('../src/mcp-config-file.js', async importOriginal => {
       content: string,
       _persistence: McpConfigPersistenceStrategy,
       expectedSource: McpConfigSourceSnapshot,
-    ) => actual.writeMcpConfigAtomic(path, content, mcpConfigPersistenceStrategy('native', path), expectedSource)),
+      validateDestination?: () => void,
+    ) => actual.writeMcpConfigAtomic(path, content, mcpConfigPersistenceStrategy(path, process.platform === 'win32' ? 'windows' : process.platform === 'linux' ? 'linux' : 'posix'), expectedSource, validateDestination)),
   };
 });
 
@@ -49,6 +50,7 @@ function target(name: string, container: 'mcpServers' | 'servers' | 'mcp_servers
   const id = ({ 'Claude Code': 'claude-code', 'Claude Desktop': 'claude-desktop', Windsurf: 'windsurf', Cline: 'cline' } as const)[name as 'Claude Code' | 'Claude Desktop' | 'Windsurf' | 'Cline'] ?? 'cursor';
   return { ...paths, id, format: 'json', serverContainer: 'mcpServers' };
 }
+const physical = (client: ClientTarget) => selectMcpClientTargets([client])[0]!.file;
 function seed(client: ClientTarget, onlyDkg = false): void {
   const container = client.serverContainer;
   const body = { setting: 'keep', [container]: {
@@ -74,7 +76,7 @@ describe('MCP registration removal', () => {
       const original = JSON.stringify({ [client.serverContainer]: value, setting: 'keep' }) + '\n';
       writeFileSync(client.configPath, original);
       const writesBefore = vi.mocked(writeMcpConfigAtomic).mock.calls.length;
-      expect(() => writeRegistration(client, { command: 'node', args: ['dkg.js'], env: { DKG_HOME: '/fixture' } }))
+      expect(() => writeRegistration(physical(client), { command: 'node', args: ['dkg.js'], env: { DKG_HOME: '/fixture' } }))
         .toThrow('Malformed MCP server container');
       expect(readFileSync(client.configPath, 'utf8')).toBe(original);
       expect(vi.mocked(writeMcpConfigAtomic).mock.calls).toHaveLength(writesBefore);
@@ -85,7 +87,7 @@ describe('MCP registration removal', () => {
     const client = target('Codex', 'mcp_servers', 'toml');
     writeFileSync(client.configPath, original);
     const writesBefore = vi.mocked(writeMcpConfigAtomic).mock.calls.length;
-    expect(() => writeRegistration(client, { command: 'node', args: ['dkg.js'], env: { DKG_HOME: '/fixture' } }))
+    expect(() => writeRegistration(physical(client), { command: 'node', args: ['dkg.js'], env: { DKG_HOME: '/fixture' } }))
       .toThrow('Malformed MCP server container');
     expect(readFileSync(client.configPath, 'utf8')).toBe(original);
     expect(vi.mocked(writeMcpConfigAtomic).mock.calls).toHaveLength(writesBefore);
@@ -95,7 +97,7 @@ describe('MCP registration removal', () => {
     const client = target('dangling');
     fs.symlinkSync('missing-target.json', client.configPath);
     const entries = fs.readdirSync(root);
-    expect(() => writeMcpConfigAtomic(client.configPath, '{}\n', mcpConfigPersistenceStrategy('native', client.configPath), snapshotMcpConfigSource(client.configPath))).toThrow();
+    expect(() => writeMcpConfigAtomic(client.configPath, '{}\n', mcpConfigPersistenceStrategy(client.configPath), snapshotMcpConfigSource(client.configPath))).toThrow();
     expect(fs.lstatSync(client.configPath).isSymbolicLink()).toBe(true);
     expect(fs.readlinkSync(client.configPath)).toBe('missing-target.json');
     expect(fs.readdirSync(root)).toEqual(entries);
@@ -107,7 +109,7 @@ describe('MCP registration removal', () => {
     seed(real);
     fs.symlinkSync(real.configPath, client.configPath);
     const entries = fs.readdirSync(root);
-    expect(removeRegistration(client)).toBe(true);
+    expect(removeRegistration(physical(client))).toBe(true);
     expect(fs.lstatSync(client.configPath).isSymbolicLink()).toBe(true);
     expect(fs.readlinkSync(client.configPath)).toBe(real.configPath);
     expect(read(real).mcpServers).toEqual({ other: { command: 'other-server', custom: 'keep' } });
@@ -126,7 +128,7 @@ describe('MCP registration removal', () => {
     const path = symlink ? join(root, 'owner-link.json') : real.configPath;
     if (symlink) fs.symlinkSync(real.configPath, path);
     const entries = fs.readdirSync(root);
-    writeMcpConfigAtomic(path, '{}\n', mcpConfigPersistenceStrategy('native', path), snapshotMcpConfigSource(path));
+    writeMcpConfigAtomic(path, '{}\n', mcpConfigPersistenceStrategy(path), snapshotMcpConfigSource(path));
     const after = fs.statSync(real.configPath);
     expect({ uid: after.uid, gid: after.gid, mode: after.mode }).toEqual({ uid: before.uid, gid: before.gid, mode: before.mode });
     expect(readFileSync(real.configPath, 'utf8')).toBe('{}\n');
@@ -149,7 +151,7 @@ describe('MCP registration removal', () => {
       return copied;
     });
     vi.spyOn(fs, 'fchownSync').mockImplementationOnce(() => { throw new Error('ownership preservation denied'); });
-    expect(() => writeMcpConfigAtomic(link, '{}\n', mcpConfigPersistenceStrategy('native', link), snapshotMcpConfigSource(link))).toThrow('ownership preservation denied');
+    expect(() => writeMcpConfigAtomic(link, '{}\n', mcpConfigPersistenceStrategy(link), snapshotMcpConfigSource(link))).toThrow('ownership preservation denied');
     expect(fs.renameSync).not.toHaveBeenCalled();
     expect(readFileSync(client.configPath, 'utf8')).toBe(raw);
     expect(fs.lstatSync(link).isSymbolicLink()).toBe(true);
@@ -165,7 +167,7 @@ describe('MCP registration removal', () => {
     const client = target('lossless');
     const raw = `{\n "clientId":9007199254740993, "ratio":1.2300e+06, "mcpServers":{${servers}}\n}\n`;
     writeFileSync(client.configPath, raw);
-    expect(removeRegistration(client)).toBe(true);
+    expect(removeRegistration(physical(client))).toBe(true);
     const result = readFileSync(client.configPath, 'utf8');
     expect(result).toContain('"clientId":9007199254740993');
     expect(result).toContain('"ratio":1.2300e+06');
@@ -193,7 +195,7 @@ describe('MCP registration removal', () => {
     writeFileSync(client.configPath, raw);
     const expected = parseJsonc(raw);
     delete expected.servers.dkg;
-    expect(removeRegistration(client)).toBe(true);
+    expect(removeRegistration(physical(client))).toBe(true);
     expect(read(client)).toEqual(expected);
     expect(readFileSync(client.configPath, 'utf8')).toContain('/* keep */');
   });
@@ -204,7 +206,7 @@ describe('MCP registration removal', () => {
     const original = readFileSync(client.configPath, 'utf8');
     const files = fs.readdirSync(root);
     const rename = vi.mocked(fs.renameSync).mockImplementationOnce(() => { throw new Error('replacement failed'); });
-    expect(() => removeRegistration(client)).toThrow('replacement failed');
+    expect(() => removeRegistration(physical(client))).toThrow('replacement failed');
     expect(rename).toHaveBeenCalledOnce();
     expect(readFileSync(client.configPath, 'utf8')).toBe(original);
     expect(fs.readdirSync(root)).toEqual(files);
@@ -214,7 +216,7 @@ describe('MCP registration removal', () => {
     const client = target('permissions');
     seed(client);
     fs.chmodSync(client.configPath, 0o640);
-    expect(removeRegistration(client)).toBe(true);
+    expect(removeRegistration(physical(client))).toBe(true);
     if (process.platform !== 'win32') expect(fs.statSync(client.configPath).mode & 0o777).toBe(0o640);
   });
 
@@ -226,10 +228,10 @@ describe('MCP registration removal', () => {
   ] as const)('removes only DKG from %s', (name, container, format) => {
     const client = target(name, container, format);
     seed(client);
-    expect(removeRegistration(client)).toBe(true);
+    expect(removeRegistration(physical(client))).toBe(true);
     expect(read(client)).toEqual({ setting: 'keep', [container]: { other: { command: 'other-server', custom: 'keep' } } });
     const bytes = readFileSync(client.configPath, 'utf8');
-    expect(removeRegistration(client)).toBe(false);
+    expect(removeRegistration(physical(client))).toBe(false);
     expect(readFileSync(client.configPath, 'utf8')).toBe(bytes);
   });
 
@@ -237,7 +239,7 @@ describe('MCP registration removal', () => {
     'preserves the empty %s container', (container, format) => {
       const client = target('only', container, format);
       seed(client, true);
-      expect(removeRegistration(client)).toBe(true);
+      expect(removeRegistration(physical(client))).toBe(true);
       expect(read(client)).toEqual({ setting: 'keep', [container]: {} });
     },
   );
@@ -245,7 +247,7 @@ describe('MCP registration removal', () => {
   it('preserves TOML comments and sibling tables while removing DKG subtables', () => {
     const client = target('Codex CLI', 'mcp_servers', 'toml');
     writeFileSync(client.configPath, '# preferences\nmodel = "example"\n\n[mcp_servers.dkg]\ncommand = "dkg"\n[mcp_servers.dkg.env]\nDKG_HOME = "/fixture"\n\n# unrelated server\n[mcp_servers.other]\ncommand = "other"\n');
-    expect(removeRegistration(client)).toBe(true);
+    expect(removeRegistration(physical(client))).toBe(true);
     const output = readFileSync(client.configPath, 'utf8');
     expect(output).toContain('# preferences\nmodel = "example"');
     expect(output).toContain('# unrelated server\n[mcp_servers.other]\ncommand = "other"');
@@ -255,7 +257,7 @@ describe('MCP registration removal', () => {
   it('handles inline TOML without deleting sibling settings', () => {
     const client = target('Codex CLI', 'mcp_servers', 'toml');
     writeFileSync(client.configPath, 'setting = "keep"\nmcp_servers = { dkg = { command = "dkg" }, other = { command = "other" } }\n');
-    expect(removeRegistration(client)).toBe(true);
+    expect(removeRegistration(physical(client))).toBe(true);
     expect(read(client)).toEqual({ setting: 'keep', mcp_servers: { other: { command: 'other' } } });
   });
 
@@ -274,18 +276,18 @@ this_is_string_content = true
     const expected = TOML.parse(raw);
     delete (expected.mcp_servers as TOML.JsonMap).dkg;
     writeFileSync(client.configPath, raw);
-    expect(removeRegistration(client)).toBe(true);
+    expect(removeRegistration(physical(client))).toBe(true);
     const output = readFileSync(client.configPath, 'utf8');
     expect(TOML.parse(output)).toEqual(expected);
     expect(output.startsWith(prefix)).toBe(true);
     expect(output.endsWith(sibling)).toBe(true);
-    expect(removeRegistration(client)).toBe(false);
+    expect(removeRegistration(physical(client))).toBe(false);
     expect(readFileSync(client.configPath, 'utf8')).toBe(output);
   });
 
   it('does not create a missing config', () => {
     const client = target('absent');
-    expect(removeRegistration(client)).toBe(false);
+    expect(removeRegistration(physical(client))).toBe(false);
     expect(existsSync(client.configPath)).toBe(false);
   });
 
@@ -293,7 +295,7 @@ this_is_string_content = true
     'leaves malformed configuration untouched: %s', (raw) => {
       const client = target('malformed');
       writeFileSync(client.configPath, raw);
-      expect(() => removeRegistration(client)).toThrow();
+      expect(() => removeRegistration(physical(client))).toThrow();
       expect(readFileSync(client.configPath, 'utf8')).toBe(raw);
     },
   );
@@ -301,7 +303,7 @@ this_is_string_content = true
   it('removes a stale DKG entry even when it cannot launch', () => {
     const client = target('stale');
     writeFileSync(client.configPath, '{"mcpServers":{"dkg":null,"other":{"url":"https://example.org/mcp"}}}');
-    expect(removeRegistration(client)).toBe(true);
+    expect(removeRegistration(physical(client))).toBe(true);
     expect(read(client).mcpServers).toEqual({ other: { url: 'https://example.org/mcp' } });
   });
 });
@@ -317,7 +319,7 @@ describe('mcpUninstallAction', () => {
   it('--yes removes every registration without prompting, then reruns as a no-op', async () => {
     const { clients, messages, deps } = fixture();
     await mcpUninstallAction({ yes: true }, deps);
-    expect(clients.every((client) => !inspectRegistration(client))).toBe(true);
+    expect(clients.every((client) => !inspectRegistration(physical(client)))).toBe(true);
     await mcpUninstallAction({ yes: true }, deps);
     expect(messages.at(-1)).toBe('No DKG MCP registrations found.');
   });
@@ -326,16 +328,16 @@ describe('mcpUninstallAction', () => {
     const { clients, deps } = fixture();
     expect(process.stdin.isTTY).toBeFalsy();
     await expect(mcpUninstallAction({}, deps)).rejects.toThrow('requires --yes');
-    expect(clients.every((client) => inspectRegistration(client))).toBe(true);
+    expect(clients.every((client) => inspectRegistration(physical(client)))).toBe(true);
   });
 
   it('--client selects one canonical client name', async () => {
     const { clients, deps } = fixture();
     const untouched = readFileSync(clients[0].configPath, 'utf8');
     await mcpUninstallAction({ yes: true, client: 'claude-code' }, deps);
-    expect(inspectRegistration(clients[1])).toBe(false);
+    expect(inspectRegistration(physical(clients[1]))).toBe(false);
     expect(readFileSync(clients[0].configPath, 'utf8')).toBe(untouched);
-    expect(inspectRegistration(clients[2])).toBe(true);
+    expect(inspectRegistration(physical(clients[2]))).toBe(true);
   });
 
   it('--dry-run reports without prompting, changing bytes, or touching node files', async () => {
@@ -368,7 +370,7 @@ describe('mcpUninstallAction', () => {
       await mcpUninstallAction({}, deps);
       expect(question).toHaveBeenCalledTimes(3);
       expect(close).toHaveBeenCalledTimes(1);
-      expect(clients.map((client) => inspectRegistration(client))).toEqual([true, true, false]);
+      expect(clients.map((client) => inspectRegistration(physical(client)))).toEqual([true, true, false]);
       expect(clients.slice(0, 2).map((client) => readFileSync(client.configPath, 'utf8'))).toEqual(originals.slice(0, 2));
     } finally {
       streams.forEach((stream, index) => {
@@ -389,7 +391,7 @@ describe('mcpUninstallAction', () => {
   it('rejects an unknown client without modifying any registration', async () => {
     const { clients, deps } = fixture();
     await expect(mcpUninstallAction({ yes: true, client: 'typo' }, deps)).rejects.toThrow('Unsupported MCP client selector');
-    expect(clients.every((client) => inspectRegistration(client))).toBe(true);
+    expect(clients.every((client) => inspectRegistration(physical(client)))).toBe(true);
   });
 
   it('continues processing confirmed clients after a config fails during removal', async () => {
@@ -404,7 +406,7 @@ describe('mcpUninstallAction', () => {
       },
     })).rejects.toThrow('Could not remove 1');
     expect(readFileSync(clients[0].configPath, 'utf8')).toBe(original);
-    expect(clients.slice(1).every((client) => !inspectRegistration(client))).toBe(true);
+    expect(clients.slice(1).every((client) => !inspectRegistration(physical(client)))).toBe(true);
   });
 
   it('reports unreadable configuration and still processes other confirmed clients', async () => {
@@ -412,7 +414,7 @@ describe('mcpUninstallAction', () => {
     writeFileSync(clients[0].configPath, '{bad');
     await expect(mcpUninstallAction({ yes: true }, deps)).rejects.toThrow('Could not remove 1');
     expect(readFileSync(clients[0].configPath, 'utf8')).toBe('{bad');
-    expect(clients.slice(1).every((client) => !inspectRegistration(client))).toBe(true);
+    expect(clients.slice(1).every((client) => !inspectRegistration(physical(client)))).toBe(true);
   });
 });
 
@@ -471,11 +473,11 @@ describe('stable client selectors', () => {
     expect(messages.join('\n')).toContain('Claude Desktop');
     expect(messages).toContain('Removed DKG MCP from Claude Desktop');
     expect(messages.some(message => /^Found DKG MCP: Cursor|^Removed DKG MCP from Cursor/.test(message))).toBe(false);
-    expect(inspectRegistration(cursor)).toBe(false);
+    expect(inspectRegistration(physical(cursor))).toBe(false);
     expect(fs.lstatSync(aliasPath).isSymbolicLink()).toBe(true);
   });
 
-  it.each([false, true])('setup writes an aliased WSL leaf once using Windows persistence (symlink: %s)', async (symlink) => {
+  it.each([false, true])('setup writes each aliased physical leaf once (symlink: %s)', async (symlink) => {
     vi.stubEnv('HOME', root);
     vi.stubEnv('USERPROFILE', root);
     const nodeHome = join(root, 'node');
@@ -505,8 +507,8 @@ describe('stable client selectors', () => {
     const writes = vi.mocked(writeMcpConfigAtomic).mock.calls.slice(writesBefore);
     expect(writes).toHaveLength(1);
     expect(writes[0]).toEqual([
-      native.configPath, expect.any(String),
-      expect.objectContaining({ kind: 'windows-wsl' }), expect.any(Object),
+      fs.realpathSync(native.configPath), expect.any(String),
+      expect.objectContaining({ kind: mcpConfigPersistenceStrategy(fs.realpathSync(native.configPath)).kind }), expect.any(Object), expect.any(Function),
     ]);
     expect(read(windows).mcpServers.dkg.command).toBe(process.execPath);
     expect(read(windows).mcpServers.other).toEqual({ command: 'other-server', custom: 'keep' });
@@ -527,12 +529,12 @@ describe('stable client selectors', () => {
     const client = { ...template, name: 'Cursor (Windows-side via WSL)', location: 'windows-wsl' as const };
     seed(client);
     await mcpUninstallAction({ yes: true, client: 'cursor' }, { detectClients: () => [client], log: () => {} });
-    expect(inspectRegistration(client)).toBe(false);
+    expect(inspectRegistration(physical(client))).toBe(false);
     expect(writeMcpConfigAtomic).toHaveBeenCalledWith(
-      client.configPath,
+      fs.realpathSync(client.configPath),
       expect.any(String),
-      expect.objectContaining({ kind: 'windows-wsl' }),
-      expect.any(Object),
+      expect.objectContaining({ kind: mcpConfigPersistenceStrategy(client.configPath).kind }),
+      expect.any(Object), expect.any(Function),
     );
   });
 
@@ -543,11 +545,11 @@ describe('stable client selectors', () => {
     const windows = { ...template, name: 'A renamed Windows display label', location: 'windows-wsl' as const };
     seed(native); seed(windows);
     await mcpUninstallAction({ yes: true, client: selector }, { detectClients: () => [native, windows], log: () => {} });
-    expect(inspectRegistration(native)).toBe(selector === 'cursor:windows-wsl');
-    expect(inspectRegistration(windows)).toBe(selector === 'cursor:native');
+    expect(inspectRegistration(physical(native))).toBe(selector === 'cursor:windows-wsl');
+    expect(inspectRegistration(physical(windows))).toBe(selector === 'cursor:native');
   });
 
-  it('retains Windows persistence metadata when a native selector aliases the same WSL file', async () => {
+  it('uses physical storage when a native selector aliases another logical client', async () => {
     const native = target('Cursor');
     if (native.id !== 'cursor') throw new Error('Expected a Cursor fixture');
     const windows = { ...native, name: 'Cursor (Windows-side via WSL)', location: 'windows-wsl' as const };
@@ -556,13 +558,13 @@ describe('stable client selectors', () => {
     await mcpUninstallAction({ yes: true, client: 'cursor:native' }, {
       detectClients: () => [native, windows], log: () => {},
     });
-    expect(inspectRegistration(native)).toBe(false);
+    expect(inspectRegistration(physical(native))).toBe(false);
     expect(vi.mocked(writeMcpConfigAtomic).mock.calls).toHaveLength(callsBefore + 1);
     expect(writeMcpConfigAtomic).toHaveBeenCalledWith(
-      native.configPath,
+      fs.realpathSync(native.configPath),
       expect.any(String),
-      expect.objectContaining({ kind: 'windows-wsl' }),
-      expect.any(Object),
+      expect.objectContaining({ kind: mcpConfigPersistenceStrategy(native.configPath).kind }),
+      expect.any(Object), expect.any(Function),
     );
   });
 
@@ -591,7 +593,7 @@ describe('typed owned-registration boundary', () => {
   ])('classifies $kind/$state without exposing raw owned fields', ({ value, kind, state }) => {
     const client = target('Cursor');
     writeFileSync(client.configPath, JSON.stringify({ mcpServers: { dkg: value } }));
-    const read = readRegistration(client);
+    const read = readRegistration(physical(client));
     expect(read.kind).toBe(kind);
     expect(classifyRegistration(read, expected)).toBe(state);
   });
@@ -599,11 +601,11 @@ describe('typed owned-registration boundary', () => {
   it.each([{ value: ['array-entry'] }, { value: { command: 'old', env: ['array-env'], cwd: '/keep' } }])('does not merge array indices into owned registration records', ({ value }) => {
     const client = target('Cursor');
     writeFileSync(client.configPath, JSON.stringify({ mcpServers: { dkg: value } }));
-    writeRegistration(client, expected);
+    writeRegistration(physical(client), expected);
     const entry = JSON.parse(readFileSync(client.configPath, 'utf8')).mcpServers.dkg;
     expect(entry).not.toHaveProperty('0');
     expect(entry.env).toEqual(expected.env);
     if (!Array.isArray(value)) expect(entry.cwd).toBe('/keep');
-    expect(classifyRegistration(readRegistration(client), expected)).toBe('registered');
+    expect(classifyRegistration(readRegistration(physical(client)), expected)).toBe('registered');
   });
 });

--- a/packages/cli/test/mcp-uninstall.test.ts
+++ b/packages/cli/test/mcp-uninstall.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import TOML from '@iarna/toml';
 import { inspectRegistration, removeRegistration, readRegistration, classifyRegistration, writeRegistration } from '../src/mcp-client-config.js';
-import { snapshotMcpConfigSource, writeMcpConfigAtomic, type McpConfigSourceSnapshot } from '../src/mcp-config-file.js';
+import { snapshotMcpConfigSource as snapshotSourceTransaction, writeMcpConfigAtomic, type McpConfigSourceSnapshot } from '../src/mcp-config-file.js';
 import { mcpConfigPersistenceStrategy, type McpConfigPersistenceStrategy } from '../src/mcp-config-metadata.js';
 import { selectMcpClientTargets, type ClientTarget } from '../src/mcp-client-registry.js';
 import { dkgDir, configPath } from '../src/config.js';
@@ -31,14 +31,17 @@ vi.mock('../src/mcp-config-file.js', async importOriginal => {
       content: string,
       _persistence: McpConfigPersistenceStrategy,
       expectedSource: McpConfigSourceSnapshot,
-      validateDestination?: () => void,
-    ) => actual.writeMcpConfigAtomic(path, content, mcpConfigPersistenceStrategy(path, process.platform === 'win32' ? 'windows' : process.platform === 'linux' ? 'linux' : 'posix'), expectedSource, validateDestination)),
+    ) => actual.writeMcpConfigAtomic(path, content, mcpConfigPersistenceStrategy(path, process.platform === 'win32' ? 'windows' : process.platform === 'linux' ? 'linux' : 'posix'), expectedSource)),
   };
 });
 
 vi.mock('node:readline/promises', () => ({ createInterface: vi.fn() }));
 
 let root: string;
+const snapshotMcpConfigSource = (configPath: string) => snapshotSourceTransaction(
+  configPath,
+  [{ configPath, displayPath: configPath }],
+);
 beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'dkg-mcp-uninstall-')); });
 afterEach(() => { vi.restoreAllMocks(); vi.mocked(fs.renameSync).mockReset(); vi.unstubAllEnvs(); rmSync(root, { recursive: true, force: true }); });
 
@@ -508,7 +511,7 @@ describe('stable client selectors', () => {
     expect(writes).toHaveLength(1);
     expect(writes[0]).toEqual([
       fs.realpathSync(native.configPath), expect.any(String),
-      expect.objectContaining({ kind: mcpConfigPersistenceStrategy(fs.realpathSync(native.configPath)).kind }), expect.any(Object), expect.any(Function),
+      expect.objectContaining({ kind: mcpConfigPersistenceStrategy(fs.realpathSync(native.configPath)).kind }), expect.any(Object),
     ]);
     expect(read(windows).mcpServers.dkg.command).toBe(process.execPath);
     expect(read(windows).mcpServers.other).toEqual({ command: 'other-server', custom: 'keep' });
@@ -534,7 +537,7 @@ describe('stable client selectors', () => {
       fs.realpathSync(client.configPath),
       expect.any(String),
       expect.objectContaining({ kind: mcpConfigPersistenceStrategy(client.configPath).kind }),
-      expect.any(Object), expect.any(Function),
+      expect.any(Object),
     );
   });
 
@@ -564,7 +567,7 @@ describe('stable client selectors', () => {
       fs.realpathSync(native.configPath),
       expect.any(String),
       expect.objectContaining({ kind: mcpConfigPersistenceStrategy(native.configPath).kind }),
-      expect.any(Object), expect.any(Function),
+      expect.any(Object),
     );
   });
 

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
       ? ['test/daemon-http-behavior-extra.test.ts']
       : [
           'test/mcp-config-document.test.ts',
+          'test/mcp-physical-config.test.ts',
           'test/mcp-config-metadata.test.ts',
           'test/api-client.test.ts',
           'test/live-daemon-isolation.test.ts',


### PR DESCRIPTION
WSL client discovery accepts `WSL_INTEROP`, `wsl`-only kernel releases and `/proc/version` markers, but MCP config persistence did not. A native config on a Windows drive could therefore be replaced using Linux metadata handling. Use one runtime classifier for discovery and persistence, then select Windows or Linux replacement from the translated physical destination.

Setup and uninstall now pass an immutable physical config to registration reads and mutations. It owns the destination, document shape and selected live paths; logical client aliases remain separate. Integration detection uses that same physical boundary, reading shared native/WSL aliases once while preserving every client name in installed and unreadable results. Runtime detection happens lazily during persistence, so construction and read-only inspection do not probe the OS. The writer validates every selected alias when reading and again before publication, including changes during replacement preparation. Callers no longer assemble endpoints or coordinate a separate validation call.

Validation:

- 422 tests pass across ten MCP and integration suites, including native macOS owner/mode/ACL/xattr preservation. The two other native OS cases are left to the mandatory Linux/Windows/WSL workflow.
- 24 routing cases cover all six WSL signals across Windows drives, UNC shares and both Linux-share forms. Eight Windows-backed cases select the wrong strategy with the preceding implementation.
- Direct mutation tests cover both alias orders and confirmation/pre-publication retargeting. Removing final alias validation makes both publication regressions fail. Six additional regressions fail the preceding PR head and cover one read per shared physical config in both alias orders, installed/unreadable attribution, read-only runtime laziness, and write-time detection.
- Publisher, agent and CLI builds, public and strict fixture types, lint, test inventory, SPARQL checks and all 57 changed executable lines pass. Remote CI is pending.

Follow-up to #2499. Closes #425.
