### PR TITLE
fix(cli): complete chain-reset wipe result and startup coverage

### DIFF
--- a/packages/cli/src/daemon/chain-reset-wipe.ts
+++ b/packages/cli/src/daemon/chain-reset-wipe.ts
@@ -187,6 +187,36 @@ export type ChainResetWipeResult =
   | ({ status: 'incomplete'; prevMarker: string | null; failedFiles: [ChainResetWipeFailure, ...ChainResetWipeFailure[]]; markerError?: never } & ChainResetWipeEffects)
   | ({ status: 'marker-write-failed'; prevMarker: string | null; failedFiles: []; markerError: string } & ChainResetWipeEffects);
 
+/** Operator-facing summary for reset outcomes that performed a wipe. */
+export function formatChainResetWipeOutcome(
+  result: ChainResetWipeResult,
+  currentMarker: string | undefined,
+): string[] {
+  if (
+    result.status !== 'completed'
+    && result.status !== 'incomplete'
+    && result.status !== 'marker-write-failed'
+  ) return [];
+
+  const outcome = result.status === 'completed' ? 'complete' : result.status;
+  const messages = [
+    `Chain-state auto-wipe ${outcome}: ${result.removedFiles.length} file(s) removed, `
+      + `${result.backedUpFiles.length} backed up `
+      + `(prev marker: ${result.prevMarker ?? '<none>'}, now: ${currentMarker})`,
+  ];
+  if (result.status === 'incomplete') {
+    messages.push(
+      `WARN: ${result.failedFiles.length} wipe target(s) failed; the reset will retry on next boot.`,
+    );
+  } else if (result.status === 'marker-write-failed') {
+    messages.push(
+      `WARN: reset marker could not be saved: ${result.markerError}. `
+        + 'The reset will retry on next boot.',
+    );
+  }
+  return messages;
+}
+
 export interface ChainResetWipeOptions {
   /** Node data directory (e.g. `~/.dkg`). */
   dataDir: string;

--- a/packages/cli/src/daemon/chain-reset-wipe.ts
+++ b/packages/cli/src/daemon/chain-reset-wipe.ts
@@ -160,30 +160,32 @@ interface ChainResetWipeEffects {
    * present (or the rename failed — then the failure is in `failedFiles`).
    */
   backedUpFiles: string[];
-  /**
-   * Files we attempted to wipe but could not remove. When non-empty, the
-   * marker is intentionally not persisted so the wipe retries on next boot.
-   */
-  failedFiles: Array<{ file: string; error: string }>;
 }
+
+interface ChainResetWipeFailure { file: string; error: string }
 
 interface NoChainResetWipeEffects {
   removedFiles: [];
   backedUpFiles: [];
   failedFiles: [];
+  markerError?: never;
 }
 
 /**
  * Inactive means no reset marker is configured; steady means it already matches.
  * A skipped mismatch preserves the old marker so unsetting the opt-out retries.
- * A wiped result records an attempt, which may be partial; failedFiles identifies
- * effects that still need retry.
+ * Completed means all cleanup succeeded and the new marker was saved. Incomplete
+ * cleanup and marker-write failure both retry next boot, but only incomplete
+ * cleanup leaves failedFiles. Every attempted outcome may require re-tagging an
+ * external store whose ownership tag was removed by DROP ALL.
  */
 export type ChainResetWipeResult =
   | ({ status: 'inactive'; prevMarker: null } & NoChainResetWipeEffects)
   | ({ status: 'steady'; prevMarker: string } & NoChainResetWipeEffects)
   | ({ status: 'skipped'; prevMarker: string | null } & NoChainResetWipeEffects)
-  | ({ status: 'wiped'; prevMarker: string | null } & ChainResetWipeEffects);
+  | ({ status: 'completed'; prevMarker: string | null; failedFiles: []; markerError?: never } & ChainResetWipeEffects)
+  | ({ status: 'incomplete'; prevMarker: string | null; failedFiles: [ChainResetWipeFailure, ...ChainResetWipeFailure[]]; markerError?: never } & ChainResetWipeEffects)
+  | ({ status: 'marker-write-failed'; prevMarker: string | null; failedFiles: []; markerError: string } & ChainResetWipeEffects);
 
 export interface ChainResetWipeOptions {
   /** Node data directory (e.g. `~/.dkg`). */
@@ -643,7 +645,6 @@ export async function chainResetWipe(
   let removedFiles: string[] = [];
   let backedUpFiles: string[] = [];
   let failedFiles: Array<{ file: string; error: string }> = [];
-  let markerPersisted = false;
   try {
     ({ removedFiles, backedUpFiles, failedFiles } = performWipe(
       opts.dataDir,
@@ -680,30 +681,28 @@ export async function chainResetWipe(
     }
   }
 
-  if (failedFiles.length === 0) {
-    try {
-      saveState(opts.dataDir, opts.currentMarker);
-      markerPersisted = true;
-    } catch (err) {
-      log(
-        `WARN: failed to persist chain reset marker (${opts.currentMarker}): ${(err as Error).message}. Wipe will retry on next boot.`,
-      );
-    }
-  } else {
+  const firstFailure = failedFiles[0];
+  if (firstFailure) {
     log(
       `WARN: chain-state wipe incomplete (${failedFiles.length} failure${failedFiles.length === 1 ? '' : 's'}). ` +
       'Chain reset marker was not persisted; wipe will retry on next boot.',
     );
-  }
-  if (failedFiles.length === 0 && markerPersisted) {
-    log('Chain-state wipe complete. Continuing boot.');
-  } else if (failedFiles.length === 0) {
-    log('Chain-state wipe complete, but marker was not persisted. Continuing boot; wipe will retry on next boot.');
-  } else {
     log('Chain-state wipe incomplete. Continuing boot so operator can repair filesystem state.');
+    return { status: 'incomplete', prevMarker, removedFiles, backedUpFiles, failedFiles: [firstFailure, ...failedFiles.slice(1)] };
   }
 
-  return { status: 'wiped', prevMarker, removedFiles, backedUpFiles, failedFiles };
+  try {
+    saveState(opts.dataDir, opts.currentMarker);
+  } catch (err) {
+    const markerError = (err as Error).message;
+    log(
+      `WARN: failed to persist chain reset marker (${opts.currentMarker}): ${markerError}. Wipe will retry on next boot.`,
+    );
+    log('Chain-state wipe complete, but marker was not persisted. Continuing boot; wipe will retry on next boot.');
+    return { status: 'marker-write-failed', prevMarker, removedFiles, backedUpFiles, failedFiles: [], markerError };
+  }
+  log('Chain-state wipe complete. Continuing boot.');
+  return { status: 'completed', prevMarker, removedFiles, backedUpFiles, failedFiles: [] };
 }
 
 // =====================================================================

--- a/packages/cli/src/daemon/chain-reset-wipe.ts
+++ b/packages/cli/src/daemon/chain-reset-wipe.ts
@@ -73,7 +73,7 @@ import {
   statSync,
   utimesSync,
 } from 'node:fs';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 import { isExternalBackend, getSparqlEndpoint, CHANGELOG_GRAPH } from '@origintrail-official/dkg-storage';
 
 const STATE_FILE = '.network-state.json';
@@ -150,19 +150,8 @@ const SPARQL_SCOPED_DELETE =
   'WHERE { GRAPH ?g { ?s ?p ?o } ' +
   `FILTER(strstarts(str(?g), "${V10_GRAPH_PREFIX}") || strstarts(str(?g), "${PUBLISHER_GRAPH_PREFIX}") || str(?g) = "${CHANGELOG_GRAPH}") }`;
 
-export interface ChainResetWipeResult {
-  /** True when a wipe was performed. */
-  wiped: boolean;
-  /**
-   * True when a wipe WOULD have run (marker mismatch) but was bypassed
-   * because `skip` was set (`DKG_SKIP_CHAIN_RESET_WIPE=1`). Mutually
-   * exclusive with `wiped`. The marker is deliberately NOT persisted on a
-   * skip, so the wipe re-triggers once the env var is unset.
-   */
-  skipped: boolean;
-  /** The marker we had persisted before this boot, or null on first boot / no persisted state. */
-  prevMarker: string | null;
-  /** Files removed during the wipe (relative to dataDir). Empty when `wiped=false`. */
+interface ChainResetWipeEffects {
+  /** Files removed during the wipe (relative to dataDir). Empty when no wipe ran. */
   removedFiles: string[];
   /**
    * `store.nq` backup filenames created by renaming it instead of deleting it
@@ -177,6 +166,24 @@ export interface ChainResetWipeResult {
    */
   failedFiles: Array<{ file: string; error: string }>;
 }
+
+interface NoChainResetWipeEffects {
+  removedFiles: [];
+  backedUpFiles: [];
+  failedFiles: [];
+}
+
+/**
+ * Inactive means no reset marker is configured; steady means it already matches.
+ * A skipped mismatch preserves the old marker so unsetting the opt-out retries.
+ * A wiped result records an attempt, which may be partial; failedFiles identifies
+ * effects that still need retry.
+ */
+export type ChainResetWipeResult =
+  | ({ status: 'inactive'; prevMarker: null } & NoChainResetWipeEffects)
+  | ({ status: 'steady'; prevMarker: string } & NoChainResetWipeEffects)
+  | ({ status: 'skipped'; prevMarker: string | null } & NoChainResetWipeEffects)
+  | ({ status: 'wiped'; prevMarker: string | null } & ChainResetWipeEffects);
 
 export interface ChainResetWipeOptions {
   /** Node data directory (e.g. `~/.dkg`). */
@@ -547,8 +554,9 @@ function performWipe(
   const walAbs = walPath && walPath.length > 0
     ? walPath
     : join(dataDir, 'random-sampling.wal');
-  const walLabel = walAbs.startsWith(dataDir)
-    ? walAbs.slice(dataDir.length).replace(/^[/\\]+/, '')
+  const dataPrefix = dataDir.endsWith(sep) ? dataDir : dataDir + sep;
+  const walLabel = walAbs.startsWith(dataPrefix)
+    ? walAbs.slice(dataPrefix.length)
     : walAbs;
   wipeAbs(walAbs, walLabel || 'random-sampling.wal');
   for (const suffix of ['', '-journal', '-wal', '-shm']) {
@@ -589,14 +597,14 @@ export async function chainResetWipe(
   // touched so we don't accidentally turn on the protocol later just
   // because some leftover state file made the comparison non-trivial.
   if (opts.currentMarker === undefined) {
-    return { wiped: false, skipped: false, prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [] };
+    return { status: 'inactive', prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [] };
   }
 
   const prev = loadState(opts.dataDir);
   const prevMarker = prev?.chainResetMarker ?? null;
 
   if (prevMarker === opts.currentMarker) {
-    return { wiped: false, skipped: false, prevMarker, removedFiles: [], backedUpFiles: [], failedFiles: [] };
+    return { status: 'steady', prevMarker, removedFiles: [], backedUpFiles: [], failedFiles: [] };
   }
 
   // Dev-loop opt-out. A wipe WOULD run here (marker mismatch, including
@@ -611,7 +619,7 @@ export async function chainResetWipe(
       `Chain reset wipe skipped (DKG_SKIP_CHAIN_RESET_WIPE=1): marker ${prevMarker ?? '<none>'} → ${opts.currentMarker}. ` +
       `Local chain-state preserved; unset the env var to wipe.`,
     );
-    return { wiped: false, skipped: true, prevMarker, removedFiles: [], backedUpFiles: [], failedFiles: [] };
+    return { status: 'skipped', prevMarker, removedFiles: [], backedUpFiles: [], failedFiles: [] };
   }
 
   // Mismatch (including "first boot with marker present"): wipe.
@@ -695,7 +703,7 @@ export async function chainResetWipe(
     log('Chain-state wipe incomplete. Continuing boot so operator can repair filesystem state.');
   }
 
-  return { wiped: true, skipped: false, prevMarker, removedFiles, backedUpFiles, failedFiles };
+  return { status: 'wiped', prevMarker, removedFiles, backedUpFiles, failedFiles };
 }
 
 // =====================================================================

--- a/packages/cli/src/daemon/chain-reset-wipe.ts
+++ b/packages/cli/src/daemon/chain-reset-wipe.ts
@@ -73,7 +73,7 @@ import {
   statSync,
   utimesSync,
 } from 'node:fs';
-import { join, sep } from 'node:path';
+import { isAbsolute, join, relative, sep } from 'node:path';
 import { isExternalBackend, getSparqlEndpoint, CHANGELOG_GRAPH } from '@origintrail-official/dkg-storage';
 
 const STATE_FILE = '.network-state.json';
@@ -590,9 +590,11 @@ function performWipe(
   const walAbs = walPath && walPath.length > 0
     ? walPath
     : join(dataDir, 'random-sampling.wal');
-  const dataPrefix = dataDir.endsWith(sep) ? dataDir : dataDir + sep;
-  const walLabel = walAbs.startsWith(dataPrefix)
-    ? walAbs.slice(dataPrefix.length)
+  const relativeWalPath = relative(dataDir, walAbs);
+  const walLabel = relativeWalPath !== '..'
+    && !relativeWalPath.startsWith(`..${sep}`)
+    && !isAbsolute(relativeWalPath)
+    ? relativeWalPath
     : walAbs;
   wipeAbs(walAbs, walLabel || 'random-sampling.wal');
   for (const suffix of ['', '-journal', '-wal', '-shm']) {

--- a/packages/cli/src/daemon/chain-reset-wipe.ts
+++ b/packages/cli/src/daemon/chain-reset-wipe.ts
@@ -165,10 +165,18 @@ interface ChainResetWipeEffects {
 interface ChainResetWipeFailure { file: string; error: string }
 
 interface NoChainResetWipeEffects {
+  attempted: false;
+  requiresStoreRetag: false;
   removedFiles: [];
   backedUpFiles: [];
   failedFiles: [];
   markerError?: never;
+}
+
+interface AttemptedChainResetWipeEffects extends ChainResetWipeEffects {
+  attempted: true;
+  /** A managed external DROP ALL was sent and may have removed ownership. */
+  requiresStoreRetag: boolean;
 }
 
 /**
@@ -183,20 +191,16 @@ export type ChainResetWipeResult =
   | ({ status: 'inactive'; prevMarker: null } & NoChainResetWipeEffects)
   | ({ status: 'steady'; prevMarker: string } & NoChainResetWipeEffects)
   | ({ status: 'skipped'; prevMarker: string | null } & NoChainResetWipeEffects)
-  | ({ status: 'completed'; prevMarker: string | null; failedFiles: []; markerError?: never } & ChainResetWipeEffects)
-  | ({ status: 'incomplete'; prevMarker: string | null; failedFiles: [ChainResetWipeFailure, ...ChainResetWipeFailure[]]; markerError?: never } & ChainResetWipeEffects)
-  | ({ status: 'marker-write-failed'; prevMarker: string | null; failedFiles: []; markerError: string } & ChainResetWipeEffects);
+  | ({ status: 'completed'; prevMarker: string | null; failedFiles: []; markerError?: never } & AttemptedChainResetWipeEffects)
+  | ({ status: 'incomplete'; prevMarker: string | null; failedFiles: [ChainResetWipeFailure, ...ChainResetWipeFailure[]]; markerError?: never } & AttemptedChainResetWipeEffects)
+  | ({ status: 'marker-write-failed'; prevMarker: string | null; failedFiles: []; markerError: string } & AttemptedChainResetWipeEffects);
 
 /** Operator-facing summary for reset outcomes that performed a wipe. */
 export function formatChainResetWipeOutcome(
   result: ChainResetWipeResult,
   currentMarker: string | undefined,
 ): string[] {
-  if (
-    result.status !== 'completed'
-    && result.status !== 'incomplete'
-    && result.status !== 'marker-write-failed'
-  ) return [];
+  if (!result.attempted) return [];
 
   const outcome = result.status === 'completed' ? 'complete' : result.status;
   const messages = [
@@ -352,7 +356,7 @@ async function performExternalWipe(
   storeConfig: ChainResetWipeStoreConfig,
   fetchImpl: typeof globalThis.fetch,
   log: (msg: string) => void,
-): Promise<{ label: string; ok: boolean; error?: string }> {
+): Promise<{ label: string; ok: boolean; requiresStoreRetag: boolean; error?: string }> {
   const { updateUrl, headers } = getSparqlEndpoint({
     backend: storeConfig.backend,
     options: storeConfig.options,
@@ -382,14 +386,14 @@ async function performExternalWipe(
       const text = await res.text().catch(() => '');
       const error = `${res.status} ${res.statusText}: ${text.slice(0, 200)}`;
       log(`  WARN: external wipe failed: ${error}`);
-      return { label, ok: false, error };
+      return { label, ok: false, requiresStoreRetag: managed, error };
     }
     log(`  removed: ${label}`);
-    return { label, ok: true };
+    return { label, ok: true, requiresStoreRetag: managed };
   } catch (err) {
     const error = (err as Error).message;
     log(`  WARN: external wipe transport error: ${error}`);
-    return { label, ok: false, error };
+    return { label, ok: false, requiresStoreRetag: managed, error };
   }
 }
 
@@ -629,14 +633,14 @@ export async function chainResetWipe(
   // touched so we don't accidentally turn on the protocol later just
   // because some leftover state file made the comparison non-trivial.
   if (opts.currentMarker === undefined) {
-    return { status: 'inactive', prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [] };
+    return { status: 'inactive', attempted: false, requiresStoreRetag: false, prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [] };
   }
 
   const prev = loadState(opts.dataDir);
   const prevMarker = prev?.chainResetMarker ?? null;
 
   if (prevMarker === opts.currentMarker) {
-    return { status: 'steady', prevMarker, removedFiles: [], backedUpFiles: [], failedFiles: [] };
+    return { status: 'steady', attempted: false, requiresStoreRetag: false, prevMarker, removedFiles: [], backedUpFiles: [], failedFiles: [] };
   }
 
   // Dev-loop opt-out. A wipe WOULD run here (marker mismatch, including
@@ -651,7 +655,7 @@ export async function chainResetWipe(
       `Chain reset wipe skipped (DKG_SKIP_CHAIN_RESET_WIPE=1): marker ${prevMarker ?? '<none>'} → ${opts.currentMarker}. ` +
       `Local chain-state preserved; unset the env var to wipe.`,
     );
-    return { status: 'skipped', prevMarker, removedFiles: [], backedUpFiles: [], failedFiles: [] };
+    return { status: 'skipped', attempted: false, requiresStoreRetag: false, prevMarker, removedFiles: [], backedUpFiles: [], failedFiles: [] };
   }
 
   // Mismatch (including "first boot with marker present"): wipe.
@@ -675,6 +679,7 @@ export async function chainResetWipe(
   let removedFiles: string[] = [];
   let backedUpFiles: string[] = [];
   let failedFiles: Array<{ file: string; error: string }> = [];
+  let requiresStoreRetag = false;
   try {
     ({ removedFiles, backedUpFiles, failedFiles } = performWipe(
       opts.dataDir,
@@ -699,6 +704,7 @@ export async function chainResetWipe(
   if (opts.storeConfig && isExternalBackend(opts.storeConfig.backend)) {
     try {
       const result = await performExternalWipe(opts.storeConfig, fetchImpl, log);
+      requiresStoreRetag = result.requiresStoreRetag;
       if (result.ok) {
         removedFiles.push(result.label);
       } else {
@@ -718,7 +724,7 @@ export async function chainResetWipe(
       'Chain reset marker was not persisted; wipe will retry on next boot.',
     );
     log('Chain-state wipe incomplete. Continuing boot so operator can repair filesystem state.');
-    return { status: 'incomplete', prevMarker, removedFiles, backedUpFiles, failedFiles: [firstFailure, ...failedFiles.slice(1)] };
+    return { status: 'incomplete', attempted: true, requiresStoreRetag, prevMarker, removedFiles, backedUpFiles, failedFiles: [firstFailure, ...failedFiles.slice(1)] };
   }
 
   try {
@@ -729,10 +735,10 @@ export async function chainResetWipe(
       `WARN: failed to persist chain reset marker (${opts.currentMarker}): ${markerError}. Wipe will retry on next boot.`,
     );
     log('Chain-state wipe complete, but marker was not persisted. Continuing boot; wipe will retry on next boot.');
-    return { status: 'marker-write-failed', prevMarker, removedFiles, backedUpFiles, failedFiles: [], markerError };
+    return { status: 'marker-write-failed', attempted: true, requiresStoreRetag, prevMarker, removedFiles, backedUpFiles, failedFiles: [], markerError };
   }
   log('Chain-state wipe complete. Continuing boot.');
-  return { status: 'completed', prevMarker, removedFiles, backedUpFiles, failedFiles: [] };
+  return { status: 'completed', attempted: true, requiresStoreRetag, prevMarker, removedFiles, backedUpFiles, failedFiles: [] };
 }
 
 // =====================================================================

--- a/packages/cli/src/daemon/chain-reset-wipe.ts
+++ b/packages/cli/src/daemon/chain-reset-wipe.ts
@@ -719,11 +719,6 @@ export async function chainResetWipe(
 
   const firstFailure = failedFiles[0];
   if (firstFailure) {
-    log(
-      `WARN: chain-state wipe incomplete (${failedFiles.length} failure${failedFiles.length === 1 ? '' : 's'}). ` +
-      'Chain reset marker was not persisted; wipe will retry on next boot.',
-    );
-    log('Chain-state wipe incomplete. Continuing boot so operator can repair filesystem state.');
     return { status: 'incomplete', attempted: true, requiresStoreRetag, prevMarker, removedFiles, backedUpFiles, failedFiles: [firstFailure, ...failedFiles.slice(1)] };
   }
 
@@ -731,13 +726,8 @@ export async function chainResetWipe(
     saveState(opts.dataDir, opts.currentMarker);
   } catch (err) {
     const markerError = (err as Error).message;
-    log(
-      `WARN: failed to persist chain reset marker (${opts.currentMarker}): ${markerError}. Wipe will retry on next boot.`,
-    );
-    log('Chain-state wipe complete, but marker was not persisted. Continuing boot; wipe will retry on next boot.');
     return { status: 'marker-write-failed', attempted: true, requiresStoreRetag, prevMarker, removedFiles, backedUpFiles, failedFiles: [], markerError };
   }
-  log('Chain-state wipe complete. Continuing boot.');
   return { status: 'completed', attempted: true, requiresStoreRetag, prevMarker, removedFiles, backedUpFiles, failedFiles: [] };
 }
 

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -357,6 +357,7 @@ import {
   chainResetWipe,
   detectBackendSwitch,
   detectNetworkSwitch,
+  formatChainResetWipeOutcome,
   skipChainResetWipe,
 } from './chain-reset-wipe.js';
 import {
@@ -1572,18 +1573,10 @@ async function runDaemonInnerWithStartupOwnership(
     storeConfig: runtimeStore,
     log,
   });
+  for (const message of formatChainResetWipeOutcome(wipeResult, network?.chainResetMarker)) {
+    log(message);
+  }
   if (wipeResult.status === 'completed' || wipeResult.status === 'incomplete' || wipeResult.status === 'marker-write-failed') {
-    const outcome = wipeResult.status === 'completed' ? 'complete' : wipeResult.status;
-    log(
-      `Chain-state auto-wipe ${outcome}: ${wipeResult.removedFiles.length} file(s) removed, ` +
-      `${wipeResult.backedUpFiles.length} backed up ` +
-      `(prev marker: ${wipeResult.prevMarker ?? '<none>'}, now: ${network?.chainResetMarker})`,
-    );
-    if (wipeResult.status === 'incomplete') {
-      log(`WARN: ${wipeResult.failedFiles.length} wipe target(s) failed; the reset will retry on next boot.`);
-    } else if (wipeResult.status === 'marker-write-failed') {
-      log(`WARN: reset marker could not be saved: ${wipeResult.markerError}. The reset will retry on next boot.`);
-    }
     // A DKG-managed external wipe uses DROP ALL, which also removes the
     // namespace ownership tag verified above. Re-tag before continuing so
     // this daemon never runs against an unclaimed namespace. This is required

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1576,12 +1576,10 @@ async function runDaemonInnerWithStartupOwnership(
   for (const message of formatChainResetWipeOutcome(wipeResult, network?.chainResetMarker)) {
     log(message);
   }
-  if (wipeResult.status === 'completed' || wipeResult.status === 'incomplete' || wipeResult.status === 'marker-write-failed') {
-    // A DKG-managed external wipe uses DROP ALL, which also removes the
-    // namespace ownership tag verified above. Re-tag before continuing so
-    // this daemon never runs against an unclaimed namespace. This is required
-    // even when a local deletion or marker write failed: DROP ALL can succeed
-    // independently of those steps.
+  if (wipeResult.requiresStoreRetag) {
+    // A DKG-managed DROP ALL may have removed the namespace ownership tag.
+    // Re-tag even when cleanup or marker persistence failed: the remote
+    // request can take effect independently of those local outcomes.
     if (isExternalBackend(runtimeStore?.backend)) {
       const identity = await checkOrSetStoreIdentity({
         storeConfig: runtimeStore,

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1572,15 +1572,23 @@ async function runDaemonInnerWithStartupOwnership(
     storeConfig: runtimeStore,
     log,
   });
-  if (wipeResult.status === 'wiped') {
+  if (wipeResult.status === 'completed' || wipeResult.status === 'incomplete' || wipeResult.status === 'marker-write-failed') {
+    const outcome = wipeResult.status === 'completed' ? 'complete' : wipeResult.status;
     log(
-      `Chain-state auto-wipe complete: ${wipeResult.removedFiles.length} file(s) removed, ` +
+      `Chain-state auto-wipe ${outcome}: ${wipeResult.removedFiles.length} file(s) removed, ` +
       `${wipeResult.backedUpFiles.length} backed up ` +
       `(prev marker: ${wipeResult.prevMarker ?? '<none>'}, now: ${network?.chainResetMarker})`,
     );
+    if (wipeResult.status === 'incomplete') {
+      log(`WARN: ${wipeResult.failedFiles.length} wipe target(s) failed; the reset will retry on next boot.`);
+    } else if (wipeResult.status === 'marker-write-failed') {
+      log(`WARN: reset marker could not be saved: ${wipeResult.markerError}. The reset will retry on next boot.`);
+    }
     // A DKG-managed external wipe uses DROP ALL, which also removes the
     // namespace ownership tag verified above. Re-tag before continuing so
-    // this daemon never runs against an unclaimed namespace.
+    // this daemon never runs against an unclaimed namespace. This is required
+    // even when a local deletion or marker write failed: DROP ALL can succeed
+    // independently of those steps.
     if (isExternalBackend(runtimeStore?.backend)) {
       const identity = await checkOrSetStoreIdentity({
         storeConfig: runtimeStore,

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1538,21 +1538,7 @@ async function runDaemonInnerWithStartupOwnership(
     // namespace silently corrupt each other. Fires BEFORE
     // chainResetWipe so a mismatched tag never triggers a wipe of
     // someone else's data.
-    const identity = await checkOrSetStoreIdentity({
-      storeConfig: runtimeStore,
-      nodeName: config.name,
-    });
-    if (!identity.ok) {
-      if (identity.action === 'mismatch') {
-        log(formatIdentityTagMismatch(identity));
-      } else {
-        log(`[STORE-IDENTITY] failed to verify namespace ownership: ${identity.error}`);
-      }
-      process.exit(1);
-    }
-    if (identity.action === 'tagged') {
-      log(`Tagged triple-store namespace for node "${identity.nodeName}".`);
-    }
+    await ensureStoreIdentityOrExit(runtimeStore, config.name, log, 'startup');
   }
 
   const wipeResult = await chainResetWipe({
@@ -1581,21 +1567,7 @@ async function runDaemonInnerWithStartupOwnership(
     // Re-tag even when cleanup or marker persistence failed: the remote
     // request can take effect independently of those local outcomes.
     if (isExternalBackend(runtimeStore?.backend)) {
-      const identity = await checkOrSetStoreIdentity({
-        storeConfig: runtimeStore,
-        nodeName: config.name,
-      });
-      if (!identity.ok) {
-        if (identity.action === 'mismatch') {
-          log(formatIdentityTagMismatch(identity));
-        } else {
-          log(`[STORE-IDENTITY] failed to re-tag namespace after wipe: ${identity.error}`);
-        }
-        process.exit(1);
-      }
-      if (identity.action === 'tagged') {
-        log(`Re-tagged triple-store namespace for node "${identity.nodeName}" after chain-state wipe.`);
-      }
+      await ensureStoreIdentityOrExit(runtimeStore, config.name, log, 'post-wipe');
     }
   }
 
@@ -3880,4 +3852,28 @@ async function runDaemonInnerWithStartupOwnership(
 
   process.on("SIGINT", () => shutdown(0));
   process.on("SIGTERM", () => shutdown(0));
+}
+type StoreIdentityPhase = 'startup' | 'post-wipe';
+
+async function ensureStoreIdentityOrExit(
+  storeConfig: Parameters<typeof checkOrSetStoreIdentity>[0]['storeConfig'],
+  nodeName: string,
+  log: (message: string) => void,
+  phase: StoreIdentityPhase,
+): Promise<void> {
+  const identity = await checkOrSetStoreIdentity({ storeConfig, nodeName });
+  if (!identity.ok) {
+    if (identity.action === 'mismatch') {
+      log(formatIdentityTagMismatch(identity));
+    } else {
+      const action = phase === 'post-wipe' ? 're-tag' : 'verify namespace ownership';
+      log(`[STORE-IDENTITY] failed to ${action}: ${identity.error}`);
+    }
+    process.exit(1);
+  }
+  if (identity.action === 'tagged') {
+    log(phase === 'post-wipe'
+      ? `Re-tagged triple-store namespace for node "${identity.nodeName}" after chain-state wipe.`
+      : `Tagged triple-store namespace for node "${identity.nodeName}".`);
+  }
 }

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1572,7 +1572,7 @@ async function runDaemonInnerWithStartupOwnership(
     storeConfig: runtimeStore,
     log,
   });
-  if (wipeResult.wiped) {
+  if (wipeResult.status === 'wiped') {
     log(
       `Chain-state auto-wipe complete: ${wipeResult.removedFiles.length} file(s) removed, ` +
       `${wipeResult.backedUpFiles.length} backed up ` +

--- a/packages/cli/test/blazegraph-integration.test.ts
+++ b/packages/cli/test/blazegraph-integration.test.ts
@@ -190,7 +190,7 @@ describe.skipIf(!ENABLED)('Blazegraph end-to-end integration', () => {
         options: { url: provisioned!.url, managedByDkg: false },
       },
     });
-    expect(wipe.status).toBe('wiped');
+    expect(wipe.status).toBe('completed');
     expect(wipe.failedFiles).toEqual([]);
 
     expect(await store!.countQuads(V10_GRAPH)).toBe(0);
@@ -220,7 +220,7 @@ describe.skipIf(!ENABLED)('Blazegraph end-to-end integration', () => {
         options: { url: provisioned!.url, managedByDkg: true },
       },
     });
-    expect(wipe.status).toBe('wiped');
+    expect(wipe.status).toBe('completed');
     expect(wipe.failedFiles).toEqual([]);
 
     // Both graphs gone — DROP ALL is unconditional.

--- a/packages/cli/test/blazegraph-integration.test.ts
+++ b/packages/cli/test/blazegraph-integration.test.ts
@@ -190,7 +190,7 @@ describe.skipIf(!ENABLED)('Blazegraph end-to-end integration', () => {
         options: { url: provisioned!.url, managedByDkg: false },
       },
     });
-    expect(wipe.wiped).toBe(true);
+    expect(wipe.status).toBe('wiped');
     expect(wipe.failedFiles).toEqual([]);
 
     expect(await store!.countQuads(V10_GRAPH)).toBe(0);
@@ -220,7 +220,7 @@ describe.skipIf(!ENABLED)('Blazegraph end-to-end integration', () => {
         options: { url: provisioned!.url, managedByDkg: true },
       },
     });
-    expect(wipe.wiped).toBe(true);
+    expect(wipe.status).toBe('wiped');
     expect(wipe.failedFiles).toEqual([]);
 
     // Both graphs gone — DROP ALL is unconditional.

--- a/packages/cli/test/chain-reset-wipe-backup.test.ts
+++ b/packages/cli/test/chain-reset-wipe-backup.test.ts
@@ -27,6 +27,7 @@ import {
   readdirSync,
   utimesSync,
   statSync,
+  symlinkSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -104,6 +105,26 @@ afterEach(() => {
   rmSync(dataDir, { recursive: true, force: true });
 });
 
+// Windows symlink creation depends on developer mode/privileges; this case
+// specifically proves the POSIX dangling-link stat failure requested in #1441.
+// test-disable-allow: D1 #1441 -- owner=cli lane=bura-cli expires=2026-10-09 POSIX stat-failure case executes in the required Linux CLI unit shards.
+it.skipIf(process.platform === 'win32')('rotates a dangling backup symlink after statSync throws', async () => {
+  const broken = 'store.nq.pre-wipe-broken';
+  const path = join(dataDir, broken);
+  symlinkSync(join(dataDir, 'missing-backup-target'), path);
+  expect(() => statSync(path)).toThrow(/ENOENT/);
+  seedBackup('store.nq.pre-wipe-older', new Date(1000));
+  seedBackup('store.nq.pre-wipe-newer', new Date(2000));
+  writeFileSync(join(dataDir, 'store.nq'), 'CURRENT');
+  const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
+  expect(result.failedFiles).toEqual([]);
+  const backups = readdirSync(dataDir).filter(name => name.startsWith('store.nq.pre-wipe-'));
+  expect(backups).not.toContain(broken);
+  expect(backups.sort()).toEqual([
+    'store.nq.pre-wipe-older', 'store.nq.pre-wipe-newer', ...result.backedUpFiles,
+  ].sort());
+});
+
 describe('chainResetWipe — dev-loop opt-out (skip, #679)', () => {
   it('skip=true bypasses the wipe, preserves local chain-state, and does NOT persist the marker', async () => {
     writeFileSync(
@@ -120,8 +141,7 @@ describe('chainResetWipe — dev-loop opt-out (skip, #679)', () => {
       log: (m) => logs.push(m),
     });
 
-    expect(result.wiped).toBe(false);
-    expect(result.skipped).toBe(true);
+    expect(result.status).toBe('skipped');
     expect(result.prevMarker).toBe(OLD_MARKER);
     expect(result.removedFiles).toEqual([]);
     expect(result.backedUpFiles).toEqual([]);
@@ -142,7 +162,7 @@ describe('chainResetWipe — dev-loop opt-out (skip, #679)', () => {
 
     const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER, skip: true });
 
-    expect(result.skipped).toBe(true);
+    expect(result.status).toBe('skipped');
     expect(result.backedUpFiles).toEqual([]);
     expect(readFileSync(join(dataDir, 'store.nq'), 'utf8')).toBe('ORIGINAL');
     // No pre-wipe sibling was written.
@@ -158,14 +178,14 @@ describe('chainResetWipe — dev-loop opt-out (skip, #679)', () => {
 
     // Boot 1: developer has the opt-out set → store preserved, marker untouched.
     const skipped = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER, skip: true });
-    expect(skipped.skipped).toBe(true);
+    expect(skipped.status).toBe('skipped');
     expect(existsSync(join(dataDir, 'store.nq'))).toBe(true);
     expect(readPersistedMarker(dataDir)).toBe(OLD_MARKER);
 
     // Boot 2: flag unset → the wipe finally runs because the marker never advanced.
     const wiped = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER, skip: false });
-    expect(wiped.wiped).toBe(true);
-    expect(wiped.skipped).toBe(false);
+    expect(wiped.status).toBe('wiped');
+
     expect(existsSync(join(dataDir, 'store.nq'))).toBe(false);
     expect(readPersistedMarker(dataDir)).toBe(NEW_MARKER);
   });
@@ -180,15 +200,14 @@ describe('chainResetWipe — dev-loop opt-out (skip, #679)', () => {
     // Boot 1: opt-out set, first boot (no persisted marker) → store preserved and
     // — crucially — NO state file written.
     const skipped = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER, skip: true });
-    expect(skipped.skipped).toBe(true);
-    expect(skipped.wiped).toBe(false);
+    expect(skipped.status).toBe('skipped');
     expect(existsSync(join(dataDir, 'store.nq'))).toBe(true);
     expect(existsSync(join(dataDir, STATE_FILE))).toBe(false); // marker NOT persisted
     expect(readPersistedMarker(dataDir)).toBeNull();
 
     // Boot 2: flag unset → the wipe finally runs, because the marker never advanced.
     const wiped = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER, skip: false });
-    expect(wiped.wiped).toBe(true);
+    expect(wiped.status).toBe('wiped');
     expect(existsSync(join(dataDir, 'store.nq'))).toBe(false);
     expect(readPersistedMarker(dataDir)).toBe(NEW_MARKER);
   });
@@ -219,8 +238,7 @@ describe('chainResetWipe — dev-loop opt-out (skip, #679)', () => {
       fetch: fn,
     });
 
-    expect(result.skipped).toBe(true);
-    expect(result.wiped).toBe(false);
+    expect(result.status).toBe('skipped');
     expect(fetchCalls).toBe(0); // no external SPARQL request issued
     expect(existsSync(join(dataDir, 'store.nq'))).toBe(true); // local store preserved too
   });
@@ -235,9 +253,9 @@ describe('chainResetWipe — dev-loop opt-out (skip, #679)', () => {
     const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER, skip: true });
 
     // The equal-marker short-circuit returns BEFORE the skip branch, so a match
-    // reports skipped:false (not a bypass — there was simply nothing to bypass).
-    expect(result.wiped).toBe(false);
-    expect(result.skipped).toBe(false);
+    // reports steady: there was no marker mismatch to bypass.
+    expect(result.status).toBe('steady');
+
     expect(result.backedUpFiles).toEqual([]);
     expect(existsSync(join(dataDir, 'store.nq'))).toBe(true);
   });
@@ -258,7 +276,7 @@ describe('chainResetWipe — store.nq backup rename (#679)', () => {
       log: (m) => logs.push(m),
     });
 
-    expect(result.wiped).toBe(true);
+    expect(result.status).toBe('wiped');
     expect(result.removedFiles).not.toContain('store.nq');
     expect(result.backedUpFiles).toHaveLength(1);
     const backup = result.backedUpFiles[0];
@@ -287,7 +305,7 @@ describe('chainResetWipe — store.nq backup rename (#679)', () => {
 
     const result = await chainResetWipe({ dataDir, currentMarker: DIRTY });
 
-    expect(result.wiped).toBe(true);
+    expect(result.status).toBe('wiped');
     expect(result.failedFiles).toEqual([]); // rename did NOT hit a nested-path failure
     expect(result.backedUpFiles).toHaveLength(1);
     // Every non-[A-Za-z0-9._-] char collapsed to `_` (flat filename, no `/`).
@@ -309,7 +327,7 @@ describe('chainResetWipe — store.nq backup rename (#679)', () => {
 
     const result = await chainResetWipe({ dataDir, currentMarker: BIG });
 
-    expect(result.wiped).toBe(true);
+    expect(result.status).toBe('wiped');
     expect(result.failedFiles).toEqual([]);
     expect(result.backedUpFiles).toHaveLength(1);
     const backup = result.backedUpFiles[0];
@@ -324,7 +342,7 @@ describe('chainResetWipe — store.nq backup rename (#679)', () => {
     // Second boot with the same marker = no-op → steady state, no re-wipe loop.
     writeFileSync(join(dataDir, 'store.nq'), 'REGENERATED');
     const second = await chainResetWipe({ dataDir, currentMarker: BIG });
-    expect(second.wiped).toBe(false);
+    expect(second.status).toBe('steady');
     expect(existsSync(join(dataDir, 'store.nq'))).toBe(true);
   });
 
@@ -348,7 +366,7 @@ describe('chainResetWipe — store.nq backup rename (#679)', () => {
     });
 
     // The wipe ran, but the store.nq backup step failed at renameSync...
-    expect(result.wiped).toBe(true);
+    expect(result.status).toBe('wiped');
     expect(result.backedUpFiles).toEqual([]);
     const storeFailure = result.failedFiles.find((f) => f.file === 'store.nq');
     expect(storeFailure).toBeDefined();
@@ -497,7 +515,7 @@ describe('chainResetWipe — retention via rotation (#679)', () => {
 
     const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
 
-    expect(result.wiped).toBe(true);
+    expect(result.status).toBe('wiped');
     const backups = readdirSync(dataDir).filter((f) => f.startsWith('store.nq.pre-wipe-'));
     // fresh (exempt) + newest 2 OTHERS (old4, old3) = 3; old1 + old2 evicted.
     expect(backups).toHaveLength(3);
@@ -531,7 +549,7 @@ describe('chainResetWipe — retention via rotation (#679)', () => {
       log: (m) => logs.push(m),
     });
 
-    expect(result.wiped).toBe(true);
+    expect(result.status).toBe('wiped');
     // A swallowed rotation error is NOT a wipe failure — failedFiles stays empty...
     expect(result.failedFiles).toEqual([]);
     // ...and the marker still advances (no retry-forever).

--- a/packages/cli/test/chain-reset-wipe-backup.test.ts
+++ b/packages/cli/test/chain-reset-wipe-backup.test.ts
@@ -184,7 +184,7 @@ describe('chainResetWipe — dev-loop opt-out (skip, #679)', () => {
 
     // Boot 2: flag unset → the wipe finally runs because the marker never advanced.
     const wiped = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER, skip: false });
-    expect(wiped.status).toBe('wiped');
+    expect(wiped.status).toBe('completed');
 
     expect(existsSync(join(dataDir, 'store.nq'))).toBe(false);
     expect(readPersistedMarker(dataDir)).toBe(NEW_MARKER);
@@ -207,7 +207,7 @@ describe('chainResetWipe — dev-loop opt-out (skip, #679)', () => {
 
     // Boot 2: flag unset → the wipe finally runs, because the marker never advanced.
     const wiped = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER, skip: false });
-    expect(wiped.status).toBe('wiped');
+    expect(wiped.status).toBe('completed');
     expect(existsSync(join(dataDir, 'store.nq'))).toBe(false);
     expect(readPersistedMarker(dataDir)).toBe(NEW_MARKER);
   });
@@ -276,7 +276,7 @@ describe('chainResetWipe — store.nq backup rename (#679)', () => {
       log: (m) => logs.push(m),
     });
 
-    expect(result.status).toBe('wiped');
+    expect(result.status).toBe('completed');
     expect(result.removedFiles).not.toContain('store.nq');
     expect(result.backedUpFiles).toHaveLength(1);
     const backup = result.backedUpFiles[0];
@@ -305,7 +305,7 @@ describe('chainResetWipe — store.nq backup rename (#679)', () => {
 
     const result = await chainResetWipe({ dataDir, currentMarker: DIRTY });
 
-    expect(result.status).toBe('wiped');
+    expect(result.status).toBe('completed');
     expect(result.failedFiles).toEqual([]); // rename did NOT hit a nested-path failure
     expect(result.backedUpFiles).toHaveLength(1);
     // Every non-[A-Za-z0-9._-] char collapsed to `_` (flat filename, no `/`).
@@ -327,7 +327,7 @@ describe('chainResetWipe — store.nq backup rename (#679)', () => {
 
     const result = await chainResetWipe({ dataDir, currentMarker: BIG });
 
-    expect(result.status).toBe('wiped');
+    expect(result.status).toBe('completed');
     expect(result.failedFiles).toEqual([]);
     expect(result.backedUpFiles).toHaveLength(1);
     const backup = result.backedUpFiles[0];
@@ -366,7 +366,7 @@ describe('chainResetWipe — store.nq backup rename (#679)', () => {
     });
 
     // The wipe ran, but the store.nq backup step failed at renameSync...
-    expect(result.status).toBe('wiped');
+    expect(result.status).toBe('incomplete');
     expect(result.backedUpFiles).toEqual([]);
     const storeFailure = result.failedFiles.find((f) => f.file === 'store.nq');
     expect(storeFailure).toBeDefined();
@@ -515,7 +515,7 @@ describe('chainResetWipe — retention via rotation (#679)', () => {
 
     const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
 
-    expect(result.status).toBe('wiped');
+    expect(result.status).toBe('completed');
     const backups = readdirSync(dataDir).filter((f) => f.startsWith('store.nq.pre-wipe-'));
     // fresh (exempt) + newest 2 OTHERS (old4, old3) = 3; old1 + old2 evicted.
     expect(backups).toHaveLength(3);
@@ -549,7 +549,7 @@ describe('chainResetWipe — retention via rotation (#679)', () => {
       log: (m) => logs.push(m),
     });
 
-    expect(result.status).toBe('wiped');
+    expect(result.status).toBe('completed');
     // A swallowed rotation error is NOT a wipe failure — failedFiles stays empty...
     expect(result.failedFiles).toEqual([]);
     // ...and the marker still advances (no retry-forever).

--- a/packages/cli/test/chain-reset-wipe-backup.test.ts
+++ b/packages/cli/test/chain-reset-wipe-backup.test.ts
@@ -375,7 +375,10 @@ describe('chainResetWipe — store.nq backup rename (#679)', () => {
     expect(readFileSync(join(dataDir, 'store.nq'), 'utf8')).toBe('PRECIOUS');
     // Marker NOT persisted — the wipe must retry on the next boot.
     expect(readPersistedMarker(dataDir)).toBe(OLD_MARKER);
-    expect(logs.some((l) => l.includes('marker was not persisted'))).toBe(true);
+    // The low-level wipe keeps the actionable per-file diagnostic; the daemon
+    // lifecycle owns the single terminal summary for the typed outcome.
+    expect(logs.some((l) => l.includes('failed to back up store.nq'))).toBe(true);
+    expect(logs.some((l) => l.includes('marker was not persisted'))).toBe(false);
   });
 
   it('never overwrites an existing backup — appends a counter on a name collision (🔴 OXNZb)', async () => {

--- a/packages/cli/test/chain-reset-wipe-outcome.test.ts
+++ b/packages/cli/test/chain-reset-wipe-outcome.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatChainResetWipeOutcome,
+  type ChainResetWipeResult,
+} from '../src/daemon/chain-reset-wipe.js';
+
+const NEW_MARKER = 'v10-rs-staking-consolidation-2026-04-30';
+const OLD_MARKER = 'v9-mainnet-launch-2025-12-01';
+
+describe('formatChainResetWipeOutcome', () => {
+  const effects = {
+    prevMarker: OLD_MARKER,
+    removedFiles: ['store.nq.tmp'],
+    backedUpFiles: ['store.nq.pre-wipe-old'],
+  };
+
+  it.each([
+    {
+      status: 'completed', attempted: true, requiresStoreRetag: false,
+      ...effects, failedFiles: [],
+    },
+    {
+      status: 'incomplete', attempted: true, requiresStoreRetag: true,
+      ...effects, failedFiles: [{ file: 'publish-journal.blocked', error: 'is a directory' }],
+    },
+    {
+      status: 'marker-write-failed', attempted: true, requiresStoreRetag: true,
+      ...effects, failedFiles: [], markerError: 'state path is a directory',
+    },
+  ] satisfies ChainResetWipeResult[])('formats the $status reset result', (result) => {
+    const messages = formatChainResetWipeOutcome(result, NEW_MARKER);
+    expect(messages[0]).toContain(`Chain-state auto-wipe ${
+      result.status === 'completed' ? 'complete' : result.status
+    }:`);
+    expect(messages[0]).toContain(`prev marker: ${OLD_MARKER}, now: ${NEW_MARKER}`);
+    expect(messages).toHaveLength(result.status === 'completed' ? 1 : 2);
+    if (result.status === 'incomplete') {
+      expect(messages[1]).toContain('1 wipe target(s) failed');
+    } else if (result.status === 'marker-write-failed') {
+      expect(messages[1]).toContain('state path is a directory');
+    }
+  });
+
+  it('stays silent when no wipe was attempted', () => {
+    expect(formatChainResetWipeOutcome({
+      status: 'steady', attempted: false, requiresStoreRetag: false,
+      prevMarker: NEW_MARKER, removedFiles: [], backedUpFiles: [], failedFiles: [],
+    }, NEW_MARKER)).toEqual([]);
+  });
+});

--- a/packages/cli/test/chain-reset-wipe.test.ts
+++ b/packages/cli/test/chain-reset-wipe.test.ts
@@ -71,11 +71,11 @@ describe('chainResetWipe — opt-in protocol', () => {
     seedAllFiles(dataDir);
     const result = await chainResetWipe({ dataDir, currentMarker: undefined });
 
-    expect(result.wiped).toBe(false);
+    expect(result.status).toBe('inactive');
     expect(result.prevMarker).toBeNull();
     expect(result.removedFiles).toEqual([]);
     // New #679 result fields are inert on the no-op path.
-    expect(result.skipped).toBe(false);
+
     expect(result.backedUpFiles).toEqual([]);
     // No state file is created when the protocol isn't active.
     expect(existsSync(join(dataDir, STATE_FILE))).toBe(false);
@@ -96,7 +96,7 @@ describe('chainResetWipe — first boot with marker present', () => {
       log: (msg) => logs.push(msg),
     });
 
-    expect(result.wiped).toBe(true);
+    expect(result.status).toBe('wiped');
     expect(result.prevMarker).toBeNull();
     // Under the default backupStore=true, store.nq is RENAMED (→ backedUpFiles),
     // not hard-deleted; the regenerable files are still removed outright.
@@ -138,7 +138,7 @@ describe('chainResetWipe — first boot with marker present', () => {
   it('still records the marker on a fresh install with no chain-state files yet', async () => {
     const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
 
-    expect(result.wiped).toBe(true);
+    expect(result.status).toBe('wiped');
     expect(result.removedFiles).toEqual([]);
     expect(existsSync(join(dataDir, STATE_FILE))).toBe(true);
   });
@@ -154,11 +154,11 @@ describe('chainResetWipe — same marker (steady state)', () => {
 
     const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
 
-    expect(result.wiped).toBe(false);
+    expect(result.status).toBe('steady');
     expect(result.prevMarker).toBe(NEW_MARKER);
     expect(result.removedFiles).toEqual([]);
     // New #679 result fields are inert on the equal-marker no-op path too.
-    expect(result.skipped).toBe(false);
+
     expect(result.backedUpFiles).toEqual([]);
     expect(existsSync(join(dataDir, 'store.nq'))).toBe(true);
     expect(existsSync(join(dataDir, 'random-sampling.wal'))).toBe(true);
@@ -180,7 +180,7 @@ describe('chainResetWipe — marker changed (chain reset)', () => {
       log: (msg) => logs.push(msg),
     });
 
-    expect(result.wiped).toBe(true);
+    expect(result.status).toBe('wiped');
     expect(result.prevMarker).toBe(OLD_MARKER);
 
     // Wiped:
@@ -225,7 +225,7 @@ describe('chainResetWipe — marker changed (chain reset)', () => {
 
     const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
 
-    expect(result.wiped).toBe(true);
+    expect(result.status).toBe('wiped');
     // store.nq is backed up (renamed), not in removedFiles; nothing else existed.
     expect(result.removedFiles).toEqual([]);
     expect(result.backedUpFiles).toHaveLength(1);
@@ -242,13 +242,13 @@ describe('chainResetWipe — marker changed (chain reset)', () => {
     seedAllFiles(dataDir);
 
     const first = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
-    expect(first.wiped).toBe(true);
+    expect(first.status).toBe('wiped');
 
     // Re-seed the chain-state files to simulate "boot, work, boot again".
     writeFileSync(join(dataDir, 'store.nq'), '<s> <p> <o> .');
 
     const second = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
-    expect(second.wiped).toBe(false);
+    expect(second.status).toBe('steady');
     expect(second.prevMarker).toBe(NEW_MARKER);
     expect(existsSync(join(dataDir, 'store.nq'))).toBe(true);
   });
@@ -261,7 +261,7 @@ describe('chainResetWipe — corrupt state file', () => {
 
     const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
 
-    expect(result.wiped).toBe(true);
+    expect(result.status).toBe('wiped');
     expect(result.prevMarker).toBeNull();
     // State file gets rewritten with the current marker.
     const persisted = JSON.parse(readFileSync(join(dataDir, STATE_FILE), 'utf8'));
@@ -296,8 +296,8 @@ describe('chainResetWipe — operator-mode invariant (#679)', () => {
     // operator guarantee).
     const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER, skip: false });
 
-    expect(result.wiped).toBe(true);
-    expect(result.skipped).toBe(false);
+    expect(result.status).toBe('wiped');
+
     expect(result.prevMarker).toBe(OLD_MARKER);
 
     // Chain-state gone (store.nq via backup, the rest hard-deleted)...
@@ -335,7 +335,7 @@ describe('chainResetWipe — custom random-sampling WAL path (PR #357 feedback)'
       randomSamplingWalPath: customWal,
     });
 
-    expect(result.wiped).toBe(true);
+    expect(result.status).toBe('wiped');
     expect(existsSync(customWal)).toBe(false);
     // Default path untouched: prover never reads it under this config.
     expect(existsSync(join(dataDir, 'random-sampling.wal'))).toBe(true);
@@ -350,7 +350,7 @@ describe('chainResetWipe — custom random-sampling WAL path (PR #357 feedback)'
       randomSamplingWalPath: '',
     });
 
-    expect(result.wiped).toBe(true);
+    expect(result.status).toBe('wiped');
     expect(existsSync(join(dataDir, 'random-sampling.wal'))).toBe(false);
   });
 
@@ -366,7 +366,7 @@ describe('chainResetWipe — custom random-sampling WAL path (PR #357 feedback)'
         randomSamplingWalPath: externalWal,
       });
 
-      expect(result.wiped).toBe(true);
+      expect(result.status).toBe('wiped');
       expect(existsSync(externalWal)).toBe(false);
       // Display label should be the absolute path (informative for operators).
       expect(result.removedFiles.some((f) => f === externalWal)).toBe(true);
@@ -512,7 +512,7 @@ describe('chainResetWipe — external SPARQL wipe', () => {
       fetch: fn,
     });
 
-    expect(result.wiped).toBe(true);
+    expect(result.status).toBe('wiped');
     expect(result.failedFiles).toEqual([]);
     expect(calls).toHaveLength(1);
     expect(calls[0].url).toBe('http://blaze.test/sparql');
@@ -538,7 +538,7 @@ describe('chainResetWipe — external SPARQL wipe', () => {
       fetch: fn,
     });
 
-    expect(result.wiped).toBe(true);
+    expect(result.status).toBe('wiped');
     expect(calls).toHaveLength(1);
     const update = decodeUpdateBody(calls[0].init?.body);
     expect(update).toContain('DELETE');
@@ -572,7 +572,7 @@ describe('chainResetWipe — external SPARQL wipe', () => {
       log: (m) => logs.push(m),
     });
 
-    expect(result.wiped).toBe(true);
+    expect(result.status).toBe('wiped');
     expect(result.failedFiles).toHaveLength(1);
     expect(result.failedFiles[0].file).toContain('scoped-delete');
     expect(result.failedFiles[0].error).toContain('500');
@@ -623,7 +623,7 @@ describe('chainResetWipe — external SPARQL wipe', () => {
       fetch: fn,
     });
 
-    expect(result.wiped).toBe(true);
+    expect(result.status).toBe('wiped');
     expect(calls).toHaveLength(0);
     expect(result.failedFiles).toEqual([]);
   });
@@ -938,4 +938,16 @@ describe('detectNetworkSwitch', () => {
     expect(persisted.lastBackend).toBe('oxigraph-worker');
     expect(persisted.lastNetworkConfig).toBe('mainnet-gnosis');
   });
+});
+
+it('reports an absolute WAL label for a sibling directory sharing the data-directory prefix', async () => {
+  const sibling = `${dataDir}-sibling`;
+  mkdirSync(sibling, { recursive: true });
+  const wal = join(sibling, 'sampling.wal');
+  writeFileSync(wal, 'old chain WAL');
+  try {
+    const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER, randomSamplingWalPath: wal });
+    expect(result.removedFiles).toContain(wal);
+    expect(existsSync(wal)).toBe(false);
+  } finally { rmSync(sibling, { recursive: true, force: true }); }
 });

--- a/packages/cli/test/chain-reset-wipe.test.ts
+++ b/packages/cli/test/chain-reset-wipe.test.ts
@@ -31,8 +31,6 @@ import {
   chainResetWipe,
   detectBackendSwitch,
   detectNetworkSwitch,
-  formatChainResetWipeOutcome,
-  type ChainResetWipeResult,
 } from '../src/daemon/chain-reset-wipe.js';
 
 const STATE_FILE = '.network-state.json';
@@ -70,63 +68,6 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(dataDir, { recursive: true, force: true });
-});
-
-describe('formatChainResetWipeOutcome', () => {
-  const effects = {
-    prevMarker: OLD_MARKER,
-    removedFiles: ['store.nq.tmp'],
-    backedUpFiles: ['store.nq.pre-wipe-old'],
-  };
-
-  it.each([
-    {
-      status: 'completed',
-      attempted: true,
-      requiresStoreRetag: false,
-      ...effects,
-      failedFiles: [],
-    },
-    {
-      status: 'incomplete',
-      attempted: true,
-      requiresStoreRetag: true,
-      ...effects,
-      failedFiles: [{ file: 'publish-journal.blocked', error: 'is a directory' }],
-    },
-    {
-      status: 'marker-write-failed',
-      attempted: true,
-      requiresStoreRetag: true,
-      ...effects,
-      failedFiles: [],
-      markerError: 'state path is a directory',
-    },
-  ] satisfies ChainResetWipeResult[])('formats the $status reset result', (result) => {
-    const messages = formatChainResetWipeOutcome(result, NEW_MARKER);
-    expect(messages[0]).toContain(`Chain-state auto-wipe ${
-      result.status === 'completed' ? 'complete' : result.status
-    }:`);
-    expect(messages[0]).toContain(`prev marker: ${OLD_MARKER}, now: ${NEW_MARKER}`);
-    expect(messages).toHaveLength(result.status === 'completed' ? 1 : 2);
-    if (result.status === 'incomplete') {
-      expect(messages[1]).toContain('1 wipe target(s) failed');
-    } else if (result.status === 'marker-write-failed') {
-      expect(messages[1]).toContain('state path is a directory');
-    }
-  });
-
-  it('stays silent when no wipe was attempted', () => {
-    expect(formatChainResetWipeOutcome({
-      status: 'steady',
-      attempted: false,
-      requiresStoreRetag: false,
-      prevMarker: NEW_MARKER,
-      removedFiles: [],
-      backedUpFiles: [],
-      failedFiles: [],
-    }, NEW_MARKER)).toEqual([]);
-  });
 });
 
 describe('chainResetWipe — opt-in protocol', () => {
@@ -450,11 +391,9 @@ describe('chainResetWipe — FS errors must not crash boot (PR #357 feedback)', 
     // including as root and on Windows; the data files can still be removed.
     mkdirSync(join(dataDir, STATE_FILE));
     writeFileSync(join(dataDir, 'random-sampling.wal'), 'OLD WAL');
-    const logs: string[] = [];
     const result = await chainResetWipe({
       dataDir,
       currentMarker: NEW_MARKER,
-      log: msg => logs.push(msg),
     });
 
     expect(result.status).toBe('marker-write-failed');
@@ -465,7 +404,6 @@ describe('chainResetWipe — FS errors must not crash boot (PR #357 feedback)', 
     expect(result.removedFiles).toContain('random-sampling.wal');
     expect(existsSync(join(dataDir, 'random-sampling.wal'))).toBe(false);
     expect(statSync(join(dataDir, STATE_FILE)).isDirectory()).toBe(true);
-    expect(logs.some(line => line.includes('failed to persist chain reset marker'))).toBe(true);
 
     rmSync(join(dataDir, STATE_FILE), { recursive: true });
     const retry = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
@@ -507,7 +445,7 @@ describe('chainResetWipe — FS errors must not crash boot (PR #357 feedback)', 
 
     const persisted = JSON.parse(readFileSync(join(dataDir, STATE_FILE), 'utf8'));
     expect(persisted.chainResetMarker).toBe(OLD_MARKER);
-    expect(logsCaptured.some((l) => l.includes('marker was not persisted'))).toBe(true);
+    expect(logsCaptured.some((l) => l.includes('failed to back up store.nq'))).toBe(true);
   });
 });
 
@@ -640,7 +578,33 @@ describe('chainResetWipe — external SPARQL wipe', () => {
     // Marker NOT persisted — retry on next boot.
     const persisted = JSON.parse(readFileSync(join(dataDir, STATE_FILE), 'utf8'));
     expect(persisted.chainResetMarker).toBe(OLD_MARKER);
-    expect(logs.some((l) => l.includes('Chain reset marker was not persisted'))).toBe(true);
+    expect(logs.some((l) => l.includes('external wipe failed'))).toBe(true);
+  });
+
+  it('requires namespace re-tagging after an ambiguous managed DROP failure', async () => {
+    writeFileSync(
+      join(dataDir, STATE_FILE),
+      JSON.stringify({ chainResetMarker: OLD_MARKER, savedAt: Date.now() }),
+    );
+    const { fn } = mockFetch(
+      () => new Response('DROP applied but response failed', { status: 500, statusText: 'Server Error' }),
+    );
+
+    const result = await chainResetWipe({
+      dataDir,
+      currentMarker: NEW_MARKER,
+      storeConfig: {
+        backend: 'blazegraph',
+        options: { url: 'http://managed.test/sparql', managedByDkg: true },
+      },
+      fetch: fn,
+    });
+
+    expect(result).toMatchObject({
+      status: 'incomplete',
+      attempted: true,
+      requiresStoreRetag: true,
+    });
   });
 
   it('records transport error in failedFiles', async () => {

--- a/packages/cli/test/chain-reset-wipe.test.ts
+++ b/packages/cli/test/chain-reset-wipe.test.ts
@@ -96,7 +96,7 @@ describe('chainResetWipe — first boot with marker present', () => {
       log: (msg) => logs.push(msg),
     });
 
-    expect(result.status).toBe('wiped');
+    expect(result.status).toBe('completed');
     expect(result.prevMarker).toBeNull();
     // Under the default backupStore=true, store.nq is RENAMED (→ backedUpFiles),
     // not hard-deleted; the regenerable files are still removed outright.
@@ -138,7 +138,7 @@ describe('chainResetWipe — first boot with marker present', () => {
   it('still records the marker on a fresh install with no chain-state files yet', async () => {
     const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
 
-    expect(result.status).toBe('wiped');
+    expect(result.status).toBe('completed');
     expect(result.removedFiles).toEqual([]);
     expect(existsSync(join(dataDir, STATE_FILE))).toBe(true);
   });
@@ -180,7 +180,7 @@ describe('chainResetWipe — marker changed (chain reset)', () => {
       log: (msg) => logs.push(msg),
     });
 
-    expect(result.status).toBe('wiped');
+    expect(result.status).toBe('completed');
     expect(result.prevMarker).toBe(OLD_MARKER);
 
     // Wiped:
@@ -225,7 +225,7 @@ describe('chainResetWipe — marker changed (chain reset)', () => {
 
     const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
 
-    expect(result.status).toBe('wiped');
+    expect(result.status).toBe('completed');
     // store.nq is backed up (renamed), not in removedFiles; nothing else existed.
     expect(result.removedFiles).toEqual([]);
     expect(result.backedUpFiles).toHaveLength(1);
@@ -242,7 +242,7 @@ describe('chainResetWipe — marker changed (chain reset)', () => {
     seedAllFiles(dataDir);
 
     const first = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
-    expect(first.status).toBe('wiped');
+    expect(first.status).toBe('completed');
 
     // Re-seed the chain-state files to simulate "boot, work, boot again".
     writeFileSync(join(dataDir, 'store.nq'), '<s> <p> <o> .');
@@ -261,7 +261,7 @@ describe('chainResetWipe — corrupt state file', () => {
 
     const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
 
-    expect(result.status).toBe('wiped');
+    expect(result.status).toBe('completed');
     expect(result.prevMarker).toBeNull();
     // State file gets rewritten with the current marker.
     const persisted = JSON.parse(readFileSync(join(dataDir, STATE_FILE), 'utf8'));
@@ -296,7 +296,7 @@ describe('chainResetWipe — operator-mode invariant (#679)', () => {
     // operator guarantee).
     const result = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER, skip: false });
 
-    expect(result.status).toBe('wiped');
+    expect(result.status).toBe('completed');
 
     expect(result.prevMarker).toBe(OLD_MARKER);
 
@@ -335,7 +335,7 @@ describe('chainResetWipe — custom random-sampling WAL path (PR #357 feedback)'
       randomSamplingWalPath: customWal,
     });
 
-    expect(result.status).toBe('wiped');
+    expect(result.status).toBe('completed');
     expect(existsSync(customWal)).toBe(false);
     // Default path untouched: prover never reads it under this config.
     expect(existsSync(join(dataDir, 'random-sampling.wal'))).toBe(true);
@@ -350,7 +350,7 @@ describe('chainResetWipe — custom random-sampling WAL path (PR #357 feedback)'
       randomSamplingWalPath: '',
     });
 
-    expect(result.status).toBe('wiped');
+    expect(result.status).toBe('completed');
     expect(existsSync(join(dataDir, 'random-sampling.wal'))).toBe(false);
   });
 
@@ -366,7 +366,7 @@ describe('chainResetWipe — custom random-sampling WAL path (PR #357 feedback)'
         randomSamplingWalPath: externalWal,
       });
 
-      expect(result.status).toBe('wiped');
+      expect(result.status).toBe('completed');
       expect(existsSync(externalWal)).toBe(false);
       // Display label should be the absolute path (informative for operators).
       expect(result.removedFiles.some((f) => f === externalWal)).toBe(true);
@@ -382,41 +382,33 @@ describe('chainResetWipe — FS errors must not crash boot (PR #357 feedback)', 
   // to boot. Crashing here would create a worse failure mode (node down)
   // than the original problem (stale state).
 
-  it('logs and continues when saveState throws (e.g. read-only FS)', async () => {
-    // Make dataDir read-only so writeFileSync on the state file throws.
-    // Skip on platforms where chmod 0o555 doesn't actually deny root or
-    // where tests run as root (CI containers); the scenario we care
-    // about is non-root operator with a misconfigured volume mount.
-    const originalMode = statSync(dataDir).mode;
-    let logsCaptured: string[] = [];
+  it('reports marker-write failure separately and completes after the state path is repaired', async () => {
+    // A directory at the state-file path deterministically prevents writes,
+    // including as root and on Windows; the data files can still be removed.
+    mkdirSync(join(dataDir, STATE_FILE));
+    writeFileSync(join(dataDir, 'random-sampling.wal'), 'OLD WAL');
+    const logs: string[] = [];
+    const result = await chainResetWipe({
+      dataDir,
+      currentMarker: NEW_MARKER,
+      log: msg => logs.push(msg),
+    });
 
-    try {
-      chmodSync(dataDir, 0o555);
+    expect(result.status).toBe('marker-write-failed');
+    if (result.status !== 'marker-write-failed') throw new Error('Expected marker-write failure');
+    expect(result.markerError).toEqual(expect.any(String));
+    expect(result.markerError.length).toBeGreaterThan(0);
+    expect(result.failedFiles).toEqual([]);
+    expect(result.removedFiles).toContain('random-sampling.wal');
+    expect(existsSync(join(dataDir, 'random-sampling.wal'))).toBe(false);
+    expect(statSync(join(dataDir, STATE_FILE)).isDirectory()).toBe(true);
+    expect(logs.some(line => line.includes('failed to persist chain reset marker'))).toBe(true);
 
-      // Quick capability check: if writeFileSync still works (root /
-      // certain FUSE mounts), skip the rest of the assertion — we
-      // can't synthesize the failure deterministically.
-      try {
-        writeFileSync(join(dataDir, '.probe'), 'x');
-        rmSync(join(dataDir, '.probe'), { force: true });
-        return;
-      } catch {
-        // Good: FS denied the write. Now run the wipe.
-      }
-
-      await expect(
-        chainResetWipe({
-          dataDir,
-          currentMarker: NEW_MARKER,
-          log: (msg) => logsCaptured.push(msg),
-        }),
-      ).resolves.toBeDefined();
-
-      // Loud log so operators can find this in journalctl.
-      expect(logsCaptured.some((l) => l.includes('failed to persist chain reset marker'))).toBe(true);
-    } finally {
-      chmodSync(dataDir, originalMode);
-    }
+    rmSync(join(dataDir, STATE_FILE), { recursive: true });
+    const retry = await chainResetWipe({ dataDir, currentMarker: NEW_MARKER });
+    expect(retry.status).toBe('completed');
+    expect(JSON.parse(readFileSync(join(dataDir, STATE_FILE), 'utf8')).chainResetMarker).toBe(NEW_MARKER);
+    expect((await chainResetWipe({ dataDir, currentMarker: NEW_MARKER })).status).toBe('steady');
   });
 
   it('does not save the marker when an individual file wipe throws', async () => {
@@ -443,6 +435,7 @@ describe('chainResetWipe — FS errors must not crash boot (PR #357 feedback)', 
         currentMarker: NEW_MARKER,
         log: (msg) => logsCaptured.push(msg),
       });
+      expect(result.status).toBe('incomplete');
       expect(result.failedFiles.some((f) => f.file === 'store.nq')).toBe(true);
     } finally {
       chmodSync(dataDir, originalMode);
@@ -512,7 +505,7 @@ describe('chainResetWipe — external SPARQL wipe', () => {
       fetch: fn,
     });
 
-    expect(result.status).toBe('wiped');
+    expect(result.status).toBe('completed');
     expect(result.failedFiles).toEqual([]);
     expect(calls).toHaveLength(1);
     expect(calls[0].url).toBe('http://blaze.test/sparql');
@@ -538,7 +531,7 @@ describe('chainResetWipe — external SPARQL wipe', () => {
       fetch: fn,
     });
 
-    expect(result.status).toBe('wiped');
+    expect(result.status).toBe('completed');
     expect(calls).toHaveLength(1);
     const update = decodeUpdateBody(calls[0].init?.body);
     expect(update).toContain('DELETE');
@@ -572,7 +565,8 @@ describe('chainResetWipe — external SPARQL wipe', () => {
       log: (m) => logs.push(m),
     });
 
-    expect(result.status).toBe('wiped');
+    expect(result.status).toBe('incomplete');
+    if (result.status !== 'incomplete') throw new Error('Expected incomplete cleanup');
     expect(result.failedFiles).toHaveLength(1);
     expect(result.failedFiles[0].file).toContain('scoped-delete');
     expect(result.failedFiles[0].error).toContain('500');
@@ -603,6 +597,7 @@ describe('chainResetWipe — external SPARQL wipe', () => {
       fetch: fn,
     });
 
+    expect(result.status).toBe('incomplete');
     expect(result.failedFiles.some((f) => f.error.includes('ECONNREFUSED'))).toBe(true);
   });
 
@@ -623,7 +618,7 @@ describe('chainResetWipe — external SPARQL wipe', () => {
       fetch: fn,
     });
 
-    expect(result.status).toBe('wiped');
+    expect(result.status).toBe('completed');
     expect(calls).toHaveLength(0);
     expect(result.failedFiles).toEqual([]);
   });

--- a/packages/cli/test/chain-reset-wipe.test.ts
+++ b/packages/cli/test/chain-reset-wipe.test.ts
@@ -27,7 +27,13 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, mkdirSync, chmodSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { chainResetWipe, detectBackendSwitch, detectNetworkSwitch } from '../src/daemon/chain-reset-wipe.js';
+import {
+  chainResetWipe,
+  detectBackendSwitch,
+  detectNetworkSwitch,
+  formatChainResetWipeOutcome,
+  type ChainResetWipeResult,
+} from '../src/daemon/chain-reset-wipe.js';
 
 const STATE_FILE = '.network-state.json';
 const NEW_MARKER = 'v10-rs-staking-consolidation-2026-04-30';
@@ -64,6 +70,55 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('formatChainResetWipeOutcome', () => {
+  const effects = {
+    prevMarker: OLD_MARKER,
+    removedFiles: ['store.nq.tmp'],
+    backedUpFiles: ['store.nq.pre-wipe-old'],
+  };
+
+  it.each([
+    {
+      status: 'completed',
+      ...effects,
+      failedFiles: [],
+    },
+    {
+      status: 'incomplete',
+      ...effects,
+      failedFiles: [{ file: 'publish-journal.blocked', error: 'is a directory' }],
+    },
+    {
+      status: 'marker-write-failed',
+      ...effects,
+      failedFiles: [],
+      markerError: 'state path is a directory',
+    },
+  ] satisfies ChainResetWipeResult[])('formats the $status reset result', (result) => {
+    const messages = formatChainResetWipeOutcome(result, NEW_MARKER);
+    expect(messages[0]).toContain(`Chain-state auto-wipe ${
+      result.status === 'completed' ? 'complete' : result.status
+    }:`);
+    expect(messages[0]).toContain(`prev marker: ${OLD_MARKER}, now: ${NEW_MARKER}`);
+    expect(messages).toHaveLength(result.status === 'completed' ? 1 : 2);
+    if (result.status === 'incomplete') {
+      expect(messages[1]).toContain('1 wipe target(s) failed');
+    } else if (result.status === 'marker-write-failed') {
+      expect(messages[1]).toContain('state path is a directory');
+    }
+  });
+
+  it('stays silent when no wipe was attempted', () => {
+    expect(formatChainResetWipeOutcome({
+      status: 'steady',
+      prevMarker: NEW_MARKER,
+      removedFiles: [],
+      backedUpFiles: [],
+      failedFiles: [],
+    }, NEW_MARKER)).toEqual([]);
+  });
 });
 
 describe('chainResetWipe — opt-in protocol', () => {

--- a/packages/cli/test/chain-reset-wipe.test.ts
+++ b/packages/cli/test/chain-reset-wipe.test.ts
@@ -82,16 +82,22 @@ describe('formatChainResetWipeOutcome', () => {
   it.each([
     {
       status: 'completed',
+      attempted: true,
+      requiresStoreRetag: false,
       ...effects,
       failedFiles: [],
     },
     {
       status: 'incomplete',
+      attempted: true,
+      requiresStoreRetag: true,
       ...effects,
       failedFiles: [{ file: 'publish-journal.blocked', error: 'is a directory' }],
     },
     {
       status: 'marker-write-failed',
+      attempted: true,
+      requiresStoreRetag: true,
       ...effects,
       failedFiles: [],
       markerError: 'state path is a directory',
@@ -113,6 +119,8 @@ describe('formatChainResetWipeOutcome', () => {
   it('stays silent when no wipe was attempted', () => {
     expect(formatChainResetWipeOutcome({
       status: 'steady',
+      attempted: false,
+      requiresStoreRetag: false,
       prevMarker: NEW_MARKER,
       removedFiles: [],
       backedUpFiles: [],

--- a/packages/cli/test/chain-reset-wipe.typecheck.ts
+++ b/packages/cli/test/chain-reset-wipe.typecheck.ts
@@ -1,0 +1,17 @@
+import type { ChainResetWipeResult } from '../src/daemon/chain-reset-wipe.js';
+
+// Explicit constructions exercise every supported status and its effect data.
+const statuses: ChainResetWipeResult[] = [
+  { status: 'inactive', prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [] },
+  { status: 'steady', prevMarker: 'same', removedFiles: [], backedUpFiles: [], failedFiles: [] },
+  { status: 'skipped', prevMarker: 'old', removedFiles: [], backedUpFiles: [], failedFiles: [] },
+  { status: 'wiped', prevMarker: 'old', removedFiles: ['sampling.wal'], backedUpFiles: [], failedFiles: [] },
+];
+void statuses;
+// @ts-expect-error Conflicting boolean states are no longer representable.
+const conflicting: ChainResetWipeResult = { wiped: true, skipped: true, prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [] };
+// @ts-expect-error An inactive result cannot report removed files.
+const inactiveWithEffects: ChainResetWipeResult = { status: 'inactive', prevMarker: null, removedFiles: ['store.nq'], backedUpFiles: [], failedFiles: [] };
+// @ts-expect-error A matching marker is necessarily present.
+const steadyWithoutMarker: ChainResetWipeResult = { status: 'steady', prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [] };
+void conflicting; void inactiveWithEffects; void steadyWithoutMarker;

--- a/packages/cli/test/chain-reset-wipe.typecheck.ts
+++ b/packages/cli/test/chain-reset-wipe.typecheck.ts
@@ -2,12 +2,12 @@ import type { ChainResetWipeResult } from '../src/daemon/chain-reset-wipe.js';
 
 // Explicit constructions exercise every supported status and its effect data.
 const statuses: ChainResetWipeResult[] = [
-  { status: 'inactive', prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [] },
-  { status: 'steady', prevMarker: 'same', removedFiles: [], backedUpFiles: [], failedFiles: [] },
-  { status: 'skipped', prevMarker: 'old', removedFiles: [], backedUpFiles: [], failedFiles: [] },
-  { status: 'completed', prevMarker: 'old', removedFiles: ['sampling.wal'], backedUpFiles: [], failedFiles: [] },
-  { status: 'incomplete', prevMarker: 'old', removedFiles: [], backedUpFiles: [], failedFiles: [{ file: 'store.nq', error: 'denied' }] },
-  { status: 'marker-write-failed', prevMarker: 'old', removedFiles: ['sampling.wal'], backedUpFiles: [], failedFiles: [], markerError: 'denied' },
+  { status: 'inactive', attempted: false, requiresStoreRetag: false, prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [] },
+  { status: 'steady', attempted: false, requiresStoreRetag: false, prevMarker: 'same', removedFiles: [], backedUpFiles: [], failedFiles: [] },
+  { status: 'skipped', attempted: false, requiresStoreRetag: false, prevMarker: 'old', removedFiles: [], backedUpFiles: [], failedFiles: [] },
+  { status: 'completed', attempted: true, requiresStoreRetag: false, prevMarker: 'old', removedFiles: ['sampling.wal'], backedUpFiles: [], failedFiles: [] },
+  { status: 'incomplete', attempted: true, requiresStoreRetag: true, prevMarker: 'old', removedFiles: [], backedUpFiles: [], failedFiles: [{ file: 'store.nq', error: 'denied' }] },
+  { status: 'marker-write-failed', attempted: true, requiresStoreRetag: true, prevMarker: 'old', removedFiles: ['sampling.wal'], backedUpFiles: [], failedFiles: [], markerError: 'denied' },
 ];
 void statuses;
 // @ts-expect-error Conflicting boolean states are no longer representable.

--- a/packages/cli/test/chain-reset-wipe.typecheck.ts
+++ b/packages/cli/test/chain-reset-wipe.typecheck.ts
@@ -5,7 +5,9 @@ const statuses: ChainResetWipeResult[] = [
   { status: 'inactive', prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [] },
   { status: 'steady', prevMarker: 'same', removedFiles: [], backedUpFiles: [], failedFiles: [] },
   { status: 'skipped', prevMarker: 'old', removedFiles: [], backedUpFiles: [], failedFiles: [] },
-  { status: 'wiped', prevMarker: 'old', removedFiles: ['sampling.wal'], backedUpFiles: [], failedFiles: [] },
+  { status: 'completed', prevMarker: 'old', removedFiles: ['sampling.wal'], backedUpFiles: [], failedFiles: [] },
+  { status: 'incomplete', prevMarker: 'old', removedFiles: [], backedUpFiles: [], failedFiles: [{ file: 'store.nq', error: 'denied' }] },
+  { status: 'marker-write-failed', prevMarker: 'old', removedFiles: ['sampling.wal'], backedUpFiles: [], failedFiles: [], markerError: 'denied' },
 ];
 void statuses;
 // @ts-expect-error Conflicting boolean states are no longer representable.
@@ -15,3 +17,16 @@ const inactiveWithEffects: ChainResetWipeResult = { status: 'inactive', prevMark
 // @ts-expect-error A matching marker is necessarily present.
 const steadyWithoutMarker: ChainResetWipeResult = { status: 'steady', prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [] };
 void conflicting; void inactiveWithEffects; void steadyWithoutMarker;
+
+// @ts-expect-error A completed wipe cannot contain failed cleanup targets.
+const completedWithFailures: ChainResetWipeResult = { status: 'completed', prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [{ file: 'store.nq', error: 'denied' }] };
+// @ts-expect-error Incomplete cleanup requires at least one failure.
+const incompleteWithoutFailure: ChainResetWipeResult = { status: 'incomplete', prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [] };
+// @ts-expect-error A marker-write failure must carry its persistence error.
+const missingMarkerError: ChainResetWipeResult = { status: 'marker-write-failed', prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [] };
+const contradictoryCompletion: { status: 'completed'; prevMarker: null; removedFiles: []; backedUpFiles: []; failedFiles: []; markerError: string } = {
+  status: 'completed', prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [], markerError: 'write failed',
+};
+// @ts-expect-error Widened variables cannot represent a marker-write failure as completed.
+const completedWithMarkerError: ChainResetWipeResult = contradictoryCompletion;
+void completedWithFailures; void incompleteWithoutFailure; void missingMarkerError; void completedWithMarkerError;

--- a/packages/cli/test/chain-reset-wipe.typecheck.ts
+++ b/packages/cli/test/chain-reset-wipe.typecheck.ts
@@ -11,21 +11,21 @@ const statuses: ChainResetWipeResult[] = [
 ];
 void statuses;
 // @ts-expect-error Conflicting boolean states are no longer representable.
-const conflicting: ChainResetWipeResult = { wiped: true, skipped: true, prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [] };
+const conflicting: ChainResetWipeResult = { status: 'inactive', attempted: false, requiresStoreRetag: false, prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [], wiped: true, skipped: true };
 // @ts-expect-error An inactive result cannot report removed files.
-const inactiveWithEffects: ChainResetWipeResult = { status: 'inactive', prevMarker: null, removedFiles: ['store.nq'], backedUpFiles: [], failedFiles: [] };
+const inactiveWithEffects: ChainResetWipeResult = { status: 'inactive', attempted: false, requiresStoreRetag: false, prevMarker: null, removedFiles: ['store.nq'], backedUpFiles: [], failedFiles: [] };
 // @ts-expect-error A matching marker is necessarily present.
-const steadyWithoutMarker: ChainResetWipeResult = { status: 'steady', prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [] };
+const steadyWithoutMarker: ChainResetWipeResult = { status: 'steady', attempted: false, requiresStoreRetag: false, prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [] };
 void conflicting; void inactiveWithEffects; void steadyWithoutMarker;
 
 // @ts-expect-error A completed wipe cannot contain failed cleanup targets.
-const completedWithFailures: ChainResetWipeResult = { status: 'completed', prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [{ file: 'store.nq', error: 'denied' }] };
+const completedWithFailures: ChainResetWipeResult = { status: 'completed', attempted: true, requiresStoreRetag: false, prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [{ file: 'store.nq', error: 'denied' }] };
 // @ts-expect-error Incomplete cleanup requires at least one failure.
-const incompleteWithoutFailure: ChainResetWipeResult = { status: 'incomplete', prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [] };
+const incompleteWithoutFailure: ChainResetWipeResult = { status: 'incomplete', attempted: true, requiresStoreRetag: false, prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [] };
 // @ts-expect-error A marker-write failure must carry its persistence error.
-const missingMarkerError: ChainResetWipeResult = { status: 'marker-write-failed', prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [] };
-const contradictoryCompletion: { status: 'completed'; prevMarker: null; removedFiles: []; backedUpFiles: []; failedFiles: []; markerError: string } = {
-  status: 'completed', prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [], markerError: 'write failed',
+const missingMarkerError: ChainResetWipeResult = { status: 'marker-write-failed', attempted: true, requiresStoreRetag: true, prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [] };
+const contradictoryCompletion: { status: 'completed'; attempted: true; requiresStoreRetag: false; prevMarker: null; removedFiles: []; backedUpFiles: []; failedFiles: []; markerError: string } = {
+  status: 'completed', attempted: true, requiresStoreRetag: false, prevMarker: null, removedFiles: [], backedUpFiles: [], failedFiles: [], markerError: 'write failed',
 };
 // @ts-expect-error Widened variables cannot represent a marker-write failure as completed.
 const completedWithMarkerError: ChainResetWipeResult = contradictoryCompletion;

--- a/packages/cli/test/daemon-chain-reset-wipe.test.ts
+++ b/packages/cli/test/daemon-chain-reset-wipe.test.ts
@@ -1,7 +1,9 @@
 import { expect, it } from 'vitest';
-import { readFile, readdir, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { startLiveDaemon, stopLiveDaemon, type LiveDaemon } from './helpers/live-daemon.js';
+import { startOxigraphSparqlEndpoint } from '../../storage/test/helpers/oxigraph-sparql-endpoint.js';
+import { checkOrSetStoreIdentity } from '../src/daemon/store-health-check.js';
 
 const SENTINEL = '<urn:reset-test:subject> <urn:reset-test:predicate> "preserve-me" <urn:reset-test:graph> .\n';
 const OLD_MARKER = 'issue-1441-old-chain';
@@ -32,5 +34,73 @@ it.each(['1', undefined] as const)('honors DKG_SKIP_CHAIN_RESET_WIPE=%s through 
       expect(backups).toHaveLength(1);
       expect(await readFile(join(daemon.home, backups[0]), 'utf8')).toBe(SENTINEL);
     }
+  } finally { await stopLiveDaemon(daemon); }
+});
+
+it.each(['completed', 'incomplete', 'marker-write-failed'] as const)(
+  're-tags a managed external namespace after a %s reset', async outcome => {
+    const endpoint = await startOxigraphSparqlEndpoint();
+    const storeConfig = {
+      backend: 'sparql-http',
+      options: { queryEndpoint: endpoint.queryEndpoint, updateEndpoint: endpoint.updateEndpoint, managedByDkg: true },
+    };
+    endpoint.store.update('INSERT DATA { GRAPH <urn:reset-fixture:old-graph> { <urn:s> <urn:p> "old-chain" } }');
+    let daemon: LiveDaemon | undefined;
+    try {
+      daemon = await startLiveDaemon({
+        extraConfig: {
+          networkConfig: 'testnet', chain: { type: 'mock' }, rfc64Catalog: { enabled: false }, store: storeConfig,
+        },
+        env: { DKG_SKIP_CHAIN_RESET_WIPE: undefined },
+        prepareHome: async home => {
+          if (outcome === 'marker-write-failed') {
+            await mkdir(join(home, '.network-state.json'));
+          } else {
+            await writeFile(join(home, '.network-state.json'), JSON.stringify({ chainResetMarker: OLD_MARKER }));
+          }
+          if (outcome === 'incomplete') {
+            // Journal cleanup is deliberately non-recursive. A directory at a
+            // journal path fails on every platform without denying store access.
+            await mkdir(join(home, 'publish-journal.blocked-fixture'));
+          }
+        },
+      });
+      await daemon.owner.stop();
+      const logs = await readFile(join(daemon.home, 'daemon.log'), 'utf8');
+      expect(endpoint.store.query('ASK { GRAPH <urn:reset-fixture:old-graph> { ?s ?p ?o } }')).toBe(false);
+      expect(logs).toContain(`Chain-state auto-wipe ${outcome === 'completed' ? 'complete' : outcome}:`);
+      expect(logs).toContain('Re-tagged triple-store namespace');
+      // A matching result proves the daemon already restored ownership. This
+      // call would report "tagged" if it had to repair the missing tag itself.
+      expect(await checkOrSetStoreIdentity({ storeConfig, nodeName: 'live-daemon-test' })).toMatchObject({ ok: true, action: 'matched' });
+      if (outcome === 'incomplete') {
+        expect(JSON.parse(await readFile(join(daemon.home, '.network-state.json'), 'utf8')).chainResetMarker).toBe(OLD_MARKER);
+      }
+    } finally {
+      await stopLiveDaemon(daemon);
+      await endpoint.close();
+    }
+  },
+);
+
+it('reports a marker-write failure without claiming a completed daemon reset', async () => {
+  let daemon: LiveDaemon | undefined;
+  try {
+    daemon = await startLiveDaemon({
+      extraConfig: { networkConfig: 'testnet', chain: { type: 'mock' }, rfc64Catalog: { enabled: false } },
+      env: { DKG_SKIP_CHAIN_RESET_WIPE: undefined },
+      prepareHome: async home => {
+        await mkdir(join(home, '.network-state.json'));
+        await writeFile(join(home, 'store.nq'), SENTINEL);
+      },
+    });
+    await daemon.owner.stop();
+    const logs = await readFile(join(daemon.home, 'daemon.log'), 'utf8');
+    expect((await stat(join(daemon.home, '.network-state.json'))).isDirectory()).toBe(true);
+    const backups = (await readdir(daemon.home)).filter(name => name.startsWith('store.nq.pre-wipe-'));
+    expect(backups).toHaveLength(1);
+    expect(await readFile(join(daemon.home, backups[0]), 'utf8')).toBe(SENTINEL);
+    expect(logs).toContain('Chain-state auto-wipe marker-write-failed');
+    expect(logs).not.toContain('Chain-state auto-wipe complete:');
   } finally { await stopLiveDaemon(daemon); }
 });

--- a/packages/cli/test/daemon-chain-reset-wipe.test.ts
+++ b/packages/cli/test/daemon-chain-reset-wipe.test.ts
@@ -1,0 +1,36 @@
+import { expect, it } from 'vitest';
+import { readFile, readdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { startLiveDaemon, stopLiveDaemon, type LiveDaemon } from './helpers/live-daemon.js';
+
+const SENTINEL = '<urn:reset-test:subject> <urn:reset-test:predicate> "preserve-me" <urn:reset-test:graph> .\n';
+const OLD_MARKER = 'issue-1441-old-chain';
+
+it.each(['1', undefined] as const)('honors DKG_SKIP_CHAIN_RESET_WIPE=%s through daemon startup', async flag => {
+  const network = JSON.parse(await readFile(new URL('../../../network/testnet.json', import.meta.url), 'utf8'));
+  expect(typeof network.chainResetMarker).toBe('string');
+  expect(network.chainResetMarker).not.toBe(OLD_MARKER);
+  let daemon: LiveDaemon | undefined;
+  try {
+    daemon = await startLiveDaemon({
+      // This tests daemon/file ownership with a mock chain and no publishing.
+      extraConfig: { networkConfig: 'testnet', chain: { type: 'mock' }, rfc64Catalog: { enabled: false } },
+      env: { DKG_SKIP_CHAIN_RESET_WIPE: flag },
+      prepareHome: async home => {
+        await writeFile(join(home, '.network-state.json'), JSON.stringify({ chainResetMarker: OLD_MARKER }));
+        await writeFile(join(home, 'store.nq'), SENTINEL);
+      },
+    });
+    const state = JSON.parse(await readFile(join(daemon.home, '.network-state.json'), 'utf8'));
+    const backups = (await readdir(daemon.home)).filter(name => name.startsWith('store.nq.pre-wipe-'));
+    if (flag === '1') {
+      expect(state.chainResetMarker).toBe(OLD_MARKER);
+      expect(backups).toEqual([]);
+      expect(await readFile(join(daemon.home, 'store.nq'), 'utf8')).toContain('preserve-me');
+    } else {
+      expect(state.chainResetMarker).toBe(network.chainResetMarker);
+      expect(backups).toHaveLength(1);
+      expect(await readFile(join(daemon.home, backups[0]), 'utf8')).toBe(SENTINEL);
+    }
+  } finally { await stopLiveDaemon(daemon); }
+});

--- a/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
+++ b/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
@@ -243,8 +243,9 @@ describe('runDaemonInner StorageACK timing wiring', () => {
     });
     mocks.loadOpWallets.mockResolvedValue({ adminWallet: undefined, wallets: [] });
     mocks.chainResetWipe.mockResolvedValue({
-      wiped: false,
-      skipped: false,
+      status: 'inactive',
+      attempted: false,
+      requiresStoreRetag: false,
       prevMarker: null,
       removedFiles: [],
       backedUpFiles: [],
@@ -316,6 +317,38 @@ describe('runDaemonInner StorageACK timing wiring', () => {
     closeDashboardDbFromAgentCreateArg(createArg);
     return createArg;
   }
+
+  it('re-tags managed store ownership after an incomplete wipe requests it', async () => {
+    mocks.chainResetWipe.mockResolvedValueOnce({
+      status: 'incomplete',
+      attempted: true,
+      requiresStoreRetag: true,
+      prevMarker: 'old-chain',
+      removedFiles: ['<sparql:drop-all http://127.0.0.1:7878/update>'],
+      backedUpFiles: [],
+      failedFiles: [{ file: '<external-wipe>', error: 'response lost after DROP' }],
+    });
+    mocks.checkOrSetStoreIdentity
+      .mockResolvedValueOnce({ ok: true, action: 'matched', nodeName: 'storage-ack-timing-core-test' })
+      .mockResolvedValueOnce({ ok: true, action: 'tagged', nodeName: 'storage-ack-timing-core-test' });
+
+    await captureCreateArg({
+      store: {
+        backend: 'sparql-http',
+        options: {
+          queryEndpoint: 'http://127.0.0.1:7878/query',
+          updateEndpoint: 'http://127.0.0.1:7878/update',
+          managedByDkg: true,
+        },
+      },
+    });
+
+    expect(mocks.checkOrSetStoreIdentity).toHaveBeenCalledTimes(2);
+    expect(mocks.checkOrSetStoreIdentity.mock.calls[1]?.[0]).toMatchObject({
+      nodeName: 'storage-ack-timing-core-test',
+      storeConfig: { options: { managedByDkg: true } },
+    });
+  });
 
   it('round-trips deployment-scoped selected VM cursors through the daemon DashboardDB wiring', async () => {
     const record = {

--- a/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
+++ b/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
@@ -200,6 +200,7 @@ describe('runDaemonInner StorageACK timing wiring', () => {
   let exitListeners: NodeJS.ExitListener[] = [];
   let sigintListeners: NodeJS.SignalsListener[] = [];
   let sigtermListeners: NodeJS.SignalsListener[] = [];
+  let stdoutLines: string[] = [];
 
   beforeEach(async () => {
     tempHome = await mkdtemp(join(tmpdir(), 'dkg-storage-ack-timing-wiring-'));
@@ -212,6 +213,7 @@ describe('runDaemonInner StorageACK timing wiring', () => {
     exitListeners = process.listeners('exit') as NodeJS.ExitListener[];
     sigintListeners = process.listeners('SIGINT') as NodeJS.SignalsListener[];
     sigtermListeners = process.listeners('SIGTERM') as NodeJS.SignalsListener[];
+    stdoutLines = [];
 
     mocks.createServer.mockImplementation(createFakeServer);
     mocks.startPublisherRuntimeWithOutcome.mockResolvedValue({
@@ -252,7 +254,10 @@ describe('runDaemonInner StorageACK timing wiring', () => {
       failedFiles: [],
     });
     mocks.agentCreate.mockRejectedValue(new Error('after-agent-create'));
-    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+      stdoutLines.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
     vi.spyOn(process, 'exit').mockImplementation(((code?: string | number | null) => {
       throw new Error(`process.exit:${code}`);
     }) as never);
@@ -348,6 +353,57 @@ describe('runDaemonInner StorageACK timing wiring', () => {
       nodeName: 'storage-ack-timing-core-test',
       storeConfig: { options: { managedByDkg: true } },
     });
+  });
+
+  it('fails closed when managed store ownership cannot be re-tagged after a wipe', async () => {
+    mocks.chainResetWipe.mockResolvedValueOnce({
+      status: 'incomplete',
+      attempted: true,
+      requiresStoreRetag: true,
+      prevMarker: 'old-chain',
+      removedFiles: ['<sparql:drop-all http://127.0.0.1:7878/update>'],
+      backedUpFiles: [],
+      failedFiles: [{ file: '<external-wipe>', error: 'response lost after DROP' }],
+    });
+    mocks.checkOrSetStoreIdentity
+      .mockResolvedValueOnce({
+        ok: true,
+        action: 'matched',
+        nodeName: 'storage-ack-timing-core-test',
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        action: 'transport-error',
+        error: 'endpoint unavailable',
+      });
+
+    await expect(runDaemonInner(true, {
+      name: 'storage-ack-timing-core-test',
+      networkConfig: 'mainnet-gnosis',
+      listenPort: 0,
+      nodeRole: 'core',
+      chain: {
+        type: 'evm',
+        rpcUrl: 'https://private-rpc.example',
+        hubAddress: '0x1234567890123456789012345678901234567890',
+        chainId: 'evm:100',
+      },
+      store: {
+        backend: 'sparql-http',
+        options: {
+          queryEndpoint: 'http://127.0.0.1:7878/query',
+          updateEndpoint: 'http://127.0.0.1:7878/update',
+          managedByDkg: true,
+        },
+      },
+    } as any, Date.now(), resolveShutdownPolicy(undefined))).rejects.toThrow('process.exit:1');
+
+    expect(mocks.checkOrSetStoreIdentity).toHaveBeenCalledTimes(2);
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(mocks.agentCreate).not.toHaveBeenCalled();
+    expect(stdoutLines.join('')).toContain(
+      '[STORE-IDENTITY] failed to re-tag: endpoint unavailable',
+    );
   });
 
   it('round-trips deployment-scoped selected VM cursors through the daemon DashboardDB wiring', async () => {

--- a/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
+++ b/packages/cli/test/daemon-storage-ack-timing-wiring.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -16,6 +16,8 @@ import {
   createManagedOxigraphRuntimeStoreConfigV1,
 } from '@origintrail-official/dkg-storage';
 import { resolveShutdownPolicy } from '../src/daemon/shutdown-policy.js';
+import type { ChainResetWipeResult } from '../src/daemon/chain-reset-wipe.js';
+import type { StoreIdentityTagResult } from '../src/daemon/store-health-check.js';
 
 const PRIVATE_RFC64_CONTEXT_GRAPH =
   '0x1111111111111111111111111111111111111111/private-daemon-wiring';
@@ -355,56 +357,81 @@ describe('runDaemonInner StorageACK timing wiring', () => {
     });
   });
 
-  it('fails closed when managed store ownership cannot be re-tagged after a wipe', async () => {
-    mocks.chainResetWipe.mockResolvedValueOnce({
-      status: 'incomplete',
-      attempted: true,
-      requiresStoreRetag: true,
-      prevMarker: 'old-chain',
-      removedFiles: ['<sparql:drop-all http://127.0.0.1:7878/update>'],
-      backedUpFiles: [],
-      failedFiles: [{ file: '<external-wipe>', error: 'response lost after DROP' }],
-    });
-    mocks.checkOrSetStoreIdentity
-      .mockResolvedValueOnce({
-        ok: true,
-        action: 'matched',
-        nodeName: 'storage-ack-timing-core-test',
-      })
-      .mockResolvedValueOnce({
-        ok: false,
-        action: 'transport-error',
-        error: 'endpoint unavailable',
-      });
-
-    await expect(runDaemonInner(true, {
-      name: 'storage-ack-timing-core-test',
-      networkConfig: 'mainnet-gnosis',
-      listenPort: 0,
-      nodeRole: 'core',
-      chain: {
-        type: 'evm',
-        rpcUrl: 'https://private-rpc.example',
-        hubAddress: '0x1234567890123456789012345678901234567890',
-        chainId: 'evm:100',
+  it.each([
+    {
+      failure: { ok: false, action: 'transport-error', error: 'endpoint unavailable after DROP' },
+      diagnostic: '[STORE-IDENTITY] failed to re-tag: endpoint unavailable after DROP',
+    },
+    {
+      failure: {
+        ok: false, action: 'mismatch', existingNodeName: 'another-node',
+        expectedNodeName: 'storage-ack-timing-core-test', error: 'ownership changed after DROP',
       },
-      store: {
-        backend: 'sparql-http',
-        options: {
-          queryEndpoint: 'http://127.0.0.1:7878/query',
-          updateEndpoint: 'http://127.0.0.1:7878/update',
-          managedByDkg: true,
-        },
-      },
-    } as any, Date.now(), resolveShutdownPolicy(undefined))).rejects.toThrow('process.exit:1');
+      diagnostic: '[STORE-IDENTITY] external triple-store is owned by a different node.',
+    },
+  ] satisfies Array<{ failure: StoreIdentityTagResult; diagnostic: string }>)(
+    'refuses startup after post-wipe ownership $failure.action',
+    async ({ failure, diagnostic }) => {
+      mocks.chainResetWipe.mockResolvedValueOnce({
+        status: 'incomplete',
+        attempted: true,
+        requiresStoreRetag: true,
+        prevMarker: 'old-chain',
+        removedFiles: [],
+        backedUpFiles: [],
+        failedFiles: [{ file: '<external-wipe>', error: 'response lost after DROP' }],
+      } satisfies ChainResetWipeResult);
+      mocks.checkOrSetStoreIdentity
+        .mockResolvedValueOnce({ ok: true, action: 'matched', nodeName: 'storage-ack-timing-core-test' })
+        .mockResolvedValueOnce(failure);
 
-    expect(mocks.checkOrSetStoreIdentity).toHaveBeenCalledTimes(2);
-    expect(process.exit).toHaveBeenCalledWith(1);
-    expect(mocks.agentCreate).not.toHaveBeenCalled();
-    expect(stdoutLines.join('')).toContain(
-      '[STORE-IDENTITY] failed to re-tag: endpoint unavailable',
-    );
-  });
+      try {
+        await expect(runDaemonInner(true, {
+          name: 'storage-ack-timing-core-test',
+          networkConfig: 'mainnet-gnosis',
+          listenPort: 0,
+          apiPort: 0,
+          nodeRole: 'core',
+          chain: {
+            type: 'evm', rpcUrl: 'https://private-rpc.example',
+            hubAddress: '0x1234567890123456789012345678901234567890',
+            chainId: 'evm:100',
+          },
+          store: {
+            backend: 'sparql-http',
+            options: {
+              queryEndpoint: 'http://127.0.0.1:7878/query',
+              updateEndpoint: 'http://127.0.0.1:7878/update',
+              managedByDkg: true,
+            },
+          },
+        }, Date.now(), resolveShutdownPolicy(undefined))).rejects.toThrow('process.exit:1');
+
+        expect(process.exit).toHaveBeenCalledExactlyOnceWith(1);
+        expect(mocks.chainResetWipe).toHaveBeenCalledTimes(1);
+        expect(mocks.checkOrSetStoreIdentity).toHaveBeenCalledTimes(2);
+        const identityOrder = mocks.checkOrSetStoreIdentity.mock.invocationCallOrder;
+        const wipeOrder = mocks.chainResetWipe.mock.invocationCallOrder[0]!;
+        expect(identityOrder[0]).toBeLessThan(wipeOrder);
+        expect(identityOrder[1]).toBeGreaterThan(wipeOrder);
+        expect(mocks.agentCreate).not.toHaveBeenCalled();
+        expect(mocks.loadOpWallets).not.toHaveBeenCalled();
+        expect(mocks.startPublisherRuntimeWithOutcome).not.toHaveBeenCalled();
+        const log = await readFile(join(tempHome!, 'daemon.log'), 'utf8');
+        expect(log).toContain(diagnostic);
+        expect(stdoutLines.join('')).toContain(diagnostic);
+        expect(log).not.toContain('Re-tagged triple-store namespace');
+        if (failure.action === 'mismatch') {
+          expect(log).toContain(failure.existingNodeName);
+          expect(log).toContain(failure.expectedNodeName);
+        }
+        expect(process.listeners('uncaughtException')).toEqual(uncaughtExceptionListeners);
+        expect(process.listeners('unhandledRejection')).toEqual(unhandledRejectionListeners);
+      } finally {
+        closeDashboardDbFromAgentCreateArg(mocks.agentCreate.mock.calls[0]?.[0]);
+      }
+    },
+  );
 
   it('round-trips deployment-scoped selected VM cursors through the daemon DashboardDB wiring', async () => {
     const record = {
@@ -497,8 +524,9 @@ describe('runDaemonInner StorageACK timing wiring', () => {
         let agent: Awaited<ReturnType<typeof RealDKGAgent.create>> | undefined;
         try {
           agent = await RealDKGAgent.create(createArg);
-          expect(() => new SyncSharedProjectionStoreV1(agent.store)).not.toThrow();
-          expect(() => new SyncSemanticStoreV1(agent.store)).not.toThrow();
+          const store = agent.store;
+          expect(() => new SyncSharedProjectionStoreV1(store)).not.toThrow();
+          expect(() => new SyncSemanticStoreV1(store)).not.toThrow();
           expect(asChangelogReader(agent.store) !== null).toBe(changelog);
         } finally {
           await agent?.stop().catch(() => {});
@@ -757,11 +785,15 @@ describe('runDaemonInner StorageACK timing wiring', () => {
     const realSetTimeout = globalThis.setTimeout;
     vi.spyOn(globalThis, 'setTimeout').mockImplementation(((handler: Parameters<typeof setTimeout>[0], timeout?: number, ...args: any[]) => {
       const handle = realSetTimeout(handler, timeout, ...args);
-      if ((timeout ?? 0) > 0) handle.unref?.();
+      const timer: unknown = handle;
+      if ((timeout ?? 0) > 0 && typeof timer === 'object' && timer !== null
+        && 'unref' in timer && typeof timer.unref === 'function') timer.unref();
       return handle;
     }) as typeof setTimeout);
     const response = new Uint8Array([7]);
-    const sendReliable = vi.fn(async () => ({
+    const sendReliable = vi.fn<(
+      peerId: string, protocol: string, data: Uint8Array, options: { timeoutMs?: number },
+    ) => Promise<{ delivered: boolean; response?: Uint8Array; error?: unknown }>>(async () => ({
       delivered: true,
       response,
     }));

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -132,6 +132,7 @@ export default defineConfig({
           // fast unit lane.
           'test/chain-reset-wipe.test.ts',
           'test/chain-reset-wipe-backup.test.ts',
+          'test/daemon-chain-reset-wipe.test.ts',
           'test/store-health-check.test.ts',
           'test/validate-store-config.test.ts',
           'test/store-wizard.test.ts',

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -131,6 +131,7 @@ export default defineConfig({
           // (mocked fetch + in-memory config); cheap to keep in the
           // fast unit lane.
           'test/chain-reset-wipe.test.ts',
+          'test/chain-reset-wipe-outcome.test.ts',
           'test/chain-reset-wipe-backup.test.ts',
           'test/daemon-chain-reset-wipe.test.ts',
           'test/store-health-check.test.ts',

--- a/packages/storage/test/helpers/oxigraph-sparql-endpoint.ts
+++ b/packages/storage/test/helpers/oxigraph-sparql-endpoint.ts
@@ -79,20 +79,25 @@ export async function startOxigraphSparqlEndpoint(): Promise<OxigraphSparqlEndpo
     req.on('end', () => {
       try {
         const contentType = String(req.headers['content-type'] ?? '');
+        // Daemon reset/ownership requests use SPARQL Protocol form encoding;
+        // the runtime store adapter sends raw SPARQL to the same endpoint.
+        const form = contentType.includes('application/x-www-form-urlencoded')
+          ? new URLSearchParams(body)
+          : undefined;
         if (contentType.includes('text/x-nquads') || contentType.includes('application/n-quads')) {
           store.load(body, { format: 'application/n-quads' });
           res.writeHead(200);
           res.end();
           return;
         }
-        if (req.url?.includes('/update') || contentType.includes('application/sparql-update')) {
-          store.update(body);
+        if (req.url?.includes('/update') || contentType.includes('application/sparql-update') || form?.has('update')) {
+          store.update(form?.get('update') ?? body);
           res.writeHead(204);
           res.end();
           return;
         }
         const accept = String(req.headers['accept'] ?? '');
-        const result = store.query(body);
+        const result = store.query(form?.get('query') ?? body);
 
         if (typeof result === 'boolean') {
           res.writeHead(200, { 'Content-Type': 'application/sparql-results+json' });


### PR DESCRIPTION
Chain-reset wipes now distinguish `inactive`, `steady`, `skipped`, `completed`, `incomplete`, and `marker-write-failed`. A completed result requires successful cleanup and marker persistence. Partial cleanup carries a nonempty failure list; a marker-write failure carries its persistence error. The daemon reports the actual outcome, preserves next-boot retries, and re-tags managed external namespaces after every attempted wipe, including partial cleanup and marker-write failure.

Custom WAL paths in sibling directories retain their absolute display label instead of losing a shared directory-name prefix.

Closes #1441.

Latest review validation:
- 95 related tests pass: 20 daemon wiring cases, 63 reset/backup/outcome cases, and 12 store-identity cases. The final daemon suite was rerun after fixture type corrections.
- Post-wipe transport failure and ownership mismatch both exit with code 1 before wallet loading, publisher startup or agent creation. The real lifecycle entry point performs the first identity check, wipe and second identity check in order, persists the failure diagnostic, and retires startup listeners. The chain, wipe result and identity responses are mocked in these two cases.
- Bypassing only the post-wipe failure gate makes both regression cases fail; production source was restored byte-for-byte. Strict complete-fixture types, lint, inventory (1,801 files), and merge compatibility with canary 6693d84 pass. This follow-up changes tests only.

Earlier implementation validation:
- 58 filesystem/backend tests, six actual CLI daemon startup tests, and 80 SPARQL adapter tests pass. The daemon tests use a mock chain; three exercise managed external namespace deletion and re-tagging over HTTP against embedded Oxigraph.
- A deterministic directory at the marker-file path reproduces the original incorrect result, then proves recovery after repair. A temporary compiled mutation that re-tagged only completed wipes fails both incomplete and marker-write-failed daemon cases; the compiled file was restored byte-for-byte.
- Type tests reject conflicting boolean states, invalid status/effect combinations, completed results with cleanup failures or marker errors, and incomplete results without failures. CLI, agent, and Node UI builds, strict fixture types, lint, the 1,800-file test inventory, SPARQL checks, and merge compatibility pass.
- Scoped wipe-module coverage is 90.59% lines and 91.95% branches; spawned-daemon execution is separate behavioral evidence.

The POSIX dangling-symlink regression executes in the required Linux `bura-cli` lane and self-skips on Windows. Its issue-linked exception follows repository policy and expires on 2026-10-09. Existing opt-in Docker Blazegraph tests migrate their result assertions; they were not run locally. The HTTP test endpoint now also accepts the form-encoded SPARQL used by daemon reset and ownership requests.

