### PR TITLE
fix(agent): park repeated finalization failures

### DIFF
--- a/packages/agent/src/finalization-publisher-authority-observer.ts
+++ b/packages/agent/src/finalization-publisher-authority-observer.ts
@@ -1,0 +1,116 @@
+import { BoundedLruCache } from '@origintrail-official/dkg-core';
+import type {
+  FinalizationRecoveryEntry,
+  FinalizationRecoveryStore,
+} from './finalization-recovery-store.js';
+
+export interface FinalizationPublisherAuthorityProbeIdentity {
+  readonly entryKey: string;
+  readonly generation: number | 'pending';
+  readonly sourcePeerId: string;
+}
+
+export interface FinalizationPublisherAuthorityObservation<Prepared> {
+  readonly prepared?: Prepared;
+}
+
+interface FinalizationPublisherAuthorityObserverOptions<PrepareInput, Prepared> {
+  readonly maxFailedProbes: number;
+  readonly prepare: (input: PrepareInput) => Promise<Prepared | undefined>;
+  readonly log: {
+    info(message: string): void;
+    warn(message: string): void;
+  };
+}
+
+function probeCacheKey(identity: FinalizationPublisherAuthorityProbeIdentity): string {
+  return JSON.stringify([
+    identity.entryKey,
+    identity.generation,
+    identity.sourcePeerId,
+  ]);
+}
+
+function isLiveEntry(entry: FinalizationRecoveryEntry): boolean {
+  return entry.state === 'RECEIVED'
+    || entry.state === 'VERIFIED'
+    || entry.state === 'REORGED';
+}
+
+/** Owns bounded failed-probe state and publisher-authority persistence races. */
+export class FinalizationPublisherAuthorityObserver<
+  PrepareInput,
+  Prepared extends { readonly publisherPeerId: string },
+> {
+  private readonly failedProbes: BoundedLruCache<string, true>;
+
+  constructor(
+    private readonly options: FinalizationPublisherAuthorityObserverOptions<PrepareInput, Prepared>,
+  ) {
+    this.failedProbes = new BoundedLruCache(options.maxFailedProbes);
+  }
+
+  async observe(input: {
+    readonly store: FinalizationRecoveryStore;
+    readonly identity: FinalizationPublisherAuthorityProbeIdentity;
+    readonly ual: string;
+    readonly prepareInput: PrepareInput;
+    readonly entry?: FinalizationRecoveryEntry;
+  }): Promise<FinalizationPublisherAuthorityObservation<Prepared>> {
+    if (input.entry?.trustedPublisherPeerId) return {};
+    const probeKey = probeCacheKey(input.identity);
+    if (this.failedProbes.has(probeKey)) return {};
+
+    let prepared: Prepared | undefined;
+    try {
+      prepared = await this.options.prepare(input.prepareInput);
+    } catch (error) {
+      this.options.log.info(
+        `Finalization recovery deferred publisher authority check for ${input.ual}: `
+          + `${error instanceof Error ? error.message : String(error)}`,
+      );
+      return {};
+    }
+    if (!prepared || input.identity.sourcePeerId !== prepared.publisherPeerId) {
+      this.failedProbes.set(probeKey, true);
+      return { prepared };
+    }
+
+    try {
+      if (input.entry) {
+        if (await input.store.recordTrustedPublisher(
+          input.identity.entryKey,
+          input.entry.generation,
+          prepared.publisherPeerId,
+        )) return { prepared };
+      } else if (await input.store.recordPendingTrustedPublisher(
+        input.identity.entryKey,
+        prepared.publisherPeerId,
+      )) {
+        return { prepared };
+      }
+
+      // Promotion is independent of the per-entry recovery lock. If it moved
+      // the row after admission, preserve the same monotonic evidence there.
+      const promoted = await input.store.get(input.identity.entryKey);
+      if (
+        promoted
+        && isLiveEntry(promoted)
+        && await input.store.recordTrustedPublisher(
+          input.identity.entryKey,
+          promoted.generation,
+          prepared.publisherPeerId,
+        )
+      ) return { prepared };
+      this.options.log.warn(
+        `Finalization recovery inbox refused publisher authority for ${input.ual}`,
+      );
+    } catch (error) {
+      this.options.log.warn(
+        `Finalization recovery pending publisher authority commit failed for ${input.ual}: `
+          + `${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    return { prepared };
+  }
+}

--- a/packages/agent/src/finalization-publisher-authority-observer.ts
+++ b/packages/agent/src/finalization-publisher-authority-observer.ts
@@ -71,7 +71,10 @@ export class FinalizationPublisherAuthorityObserver<
       );
       return {};
     }
-    if (!prepared || input.identity.sourcePeerId !== prepared.publisherPeerId) {
+    // Preparation can be temporarily unavailable while the workspace arrives.
+    // Do not turn that transient absence into a generation-scoped negative probe.
+    if (!prepared) return {};
+    if (input.identity.sourcePeerId !== prepared.publisherPeerId) {
       this.failedProbes.set(probeKey, true);
       return { prepared };
     }

--- a/packages/agent/src/finalization-recovery-sqlite-codec.ts
+++ b/packages/agent/src/finalization-recovery-sqlite-codec.ts
@@ -141,11 +141,7 @@ export function finalizationRecoveryRowToEntry(
     ...(optionalString(row.failure_signature)
       ? { failureSignature: String(row.failure_signature) }
       : {}),
-    // Historical v1/v2 rows are decoded once during exact-schema verification
-    // immediately before the v3 migration adds the durable streak columns.
-    failureStreak: row.failure_streak === undefined
-      ? 0
-      : asSafeInteger(row.failure_streak, 'failure_streak'),
+    failureStreak: asSafeInteger(row.failure_streak, 'failure_streak'),
     ...(row.next_attempt_at === null
       ? {}
       : { nextAttemptAt: asSafeInteger(row.next_attempt_at, 'next_attempt_at') }),

--- a/packages/agent/src/finalization-recovery-sqlite-codec.ts
+++ b/packages/agent/src/finalization-recovery-sqlite-codec.ts
@@ -138,6 +138,14 @@ export function finalizationRecoveryRowToEntry(
     ...(verifiedEvidence ? { verifiedEvidence } : {}),
     generation: asSafeInteger(row.generation, 'generation'),
     attemptCount: asSafeInteger(row.attempt_count, 'attempt_count'),
+    ...(optionalString(row.failure_signature)
+      ? { failureSignature: String(row.failure_signature) }
+      : {}),
+    // Historical v1/v2 rows are decoded once during exact-schema verification
+    // immediately before the v3 migration adds the durable streak columns.
+    failureStreak: row.failure_streak === undefined
+      ? 0
+      : asSafeInteger(row.failure_streak, 'failure_streak'),
     ...(row.next_attempt_at === null
       ? {}
       : { nextAttemptAt: asSafeInteger(row.next_attempt_at, 'next_attempt_at') }),

--- a/packages/agent/src/finalization-recovery-sqlite-schema.ts
+++ b/packages/agent/src/finalization-recovery-sqlite-schema.ts
@@ -237,7 +237,11 @@ function verifySchema(
   }
   database.prepare('SELECT * FROM finalization_inbox_v1')
     .all()
-    .forEach(finalizationRecoveryRowToEntry);
+    .forEach((row) => finalizationRecoveryRowToEntry(
+      userVersion < USER_VERSION
+        ? { ...row, failure_signature: null, failure_streak: 0 }
+        : row,
+    ));
 }
 
 function applyRuntimePragmas(database: DatabaseSync): void {
@@ -301,13 +305,36 @@ function initializeFresh(database: DatabaseSync, path: string): void {
   fsyncOwnedSqliteFileAndDirectoryV1(path);
 }
 
-function migrateLegacyV1(database: DatabaseSync, databasePath: string): void {
+interface FinalizationSchemaMigration {
+  readonly sourceVersion: number;
+  readonly targetVersion: number;
+  readonly ddl: string;
+}
+
+const SCHEMA_MIGRATIONS: ReadonlyMap<number, FinalizationSchemaMigration> = new Map([
+  [LEGACY_USER_VERSION, {
+    sourceVersion: LEGACY_USER_VERSION,
+    targetVersion: DEFERRED_SPOOL_USER_VERSION,
+    ddl: PENDING_DDL_V2,
+  }],
+  [DEFERRED_SPOOL_USER_VERSION, {
+    sourceVersion: DEFERRED_SPOOL_USER_VERSION,
+    targetVersion: USER_VERSION,
+    ddl: FAILURE_STREAK_MIGRATION_V3,
+  }],
+]);
+
+function runDurableMigration(
+  database: DatabaseSync,
+  databasePath: string,
+  migration: FinalizationSchemaMigration,
+): void {
   let transactionOpen = false;
   try {
     database.exec('BEGIN IMMEDIATE');
     transactionOpen = true;
-    database.exec(PENDING_DDL_V2);
-    database.exec(`PRAGMA user_version = ${DEFERRED_SPOOL_USER_VERSION}`);
+    database.exec(migration.ddl);
+    database.exec(`PRAGMA user_version = ${migration.targetVersion}`);
     database.exec('COMMIT');
     transactionOpen = false;
   } catch (error) {
@@ -320,35 +347,24 @@ function migrateLegacyV1(database: DatabaseSync, databasePath: string): void {
   if (String(journalMode?.journal_mode).toLowerCase() === 'wal') {
     const checkpoint = database.prepare('PRAGMA wal_checkpoint(TRUNCATE)').get();
     if (Number(checkpoint?.busy ?? 1) !== 0) {
-      throw new Error('Finalization inbox v1 migration WAL checkpoint remained busy');
+      throw new Error(
+        `Finalization inbox v${migration.sourceVersion} migration WAL checkpoint remained busy`,
+      );
     }
   }
   fsyncOwnedSqliteFileAndDirectoryV1(databasePath);
 }
 
-function migrateDeferredSpoolV2(database: DatabaseSync, databasePath: string): void {
-  let transactionOpen = false;
-  try {
-    database.exec('BEGIN IMMEDIATE');
-    transactionOpen = true;
-    database.exec(FAILURE_STREAK_MIGRATION_V3);
-    database.exec(`PRAGMA user_version = ${USER_VERSION}`);
-    database.exec('COMMIT');
-    transactionOpen = false;
-  } catch (error) {
-    if (transactionOpen) {
-      try { database.exec('ROLLBACK'); } catch { /* retain migration failure */ }
-    }
-    throw error;
+function migrateFromVersion(
+  database: DatabaseSync,
+  databasePath: string,
+  sourceVersion: number,
+): void {
+  const migration = SCHEMA_MIGRATIONS.get(sourceVersion);
+  if (!migration) {
+    throw new Error(`Finalization inbox has no migration from version ${sourceVersion}`);
   }
-  const journalMode = database.prepare('PRAGMA journal_mode').get();
-  if (String(journalMode?.journal_mode).toLowerCase() === 'wal') {
-    const checkpoint = database.prepare('PRAGMA wal_checkpoint(TRUNCATE)').get();
-    if (Number(checkpoint?.busy ?? 1) !== 0) {
-      throw new Error('Finalization inbox v2 migration WAL checkpoint remained busy');
-    }
-  }
-  fsyncOwnedSqliteFileAndDirectoryV1(databasePath);
+  runDurableMigration(database, databasePath, migration);
 }
 
 export async function openFinalizationRecoveryDatabase(
@@ -396,15 +412,15 @@ export async function openFinalizationRecoveryDatabase(
         expectedSchema(sqlite.DatabaseSync, DDL_V1),
         LEGACY_USER_VERSION,
       );
-      migrateLegacyV1(database, databasePath);
-      migrateDeferredSpoolV2(database, databasePath);
+      migrateFromVersion(database, databasePath, LEGACY_USER_VERSION);
+      migrateFromVersion(database, databasePath, DEFERRED_SPOOL_USER_VERSION);
     } else if (recoveredVersion === DEFERRED_SPOOL_USER_VERSION) {
       verifySchema(
         database,
         expectedSchema(sqlite.DatabaseSync, DDL_V2),
         DEFERRED_SPOOL_USER_VERSION,
       );
-      migrateDeferredSpoolV2(database, databasePath);
+      migrateFromVersion(database, databasePath, DEFERRED_SPOOL_USER_VERSION);
     } else if (recoveredVersion !== USER_VERSION) {
       throw new Error('Finalization inbox has a foreign or unsupported recovered version');
     }

--- a/packages/agent/src/finalization-recovery-sqlite-schema.ts
+++ b/packages/agent/src/finalization-recovery-sqlite-schema.ts
@@ -28,7 +28,8 @@ import {
 
 const APPLICATION_ID = 0x444b4649; // DKFI
 const LEGACY_USER_VERSION = 1;
-const USER_VERSION = 2;
+const DEFERRED_SPOOL_USER_VERSION = 2;
+const USER_VERSION = 3;
 
 const DDL_V1 = `
 CREATE TABLE finalization_inbox_v1 (
@@ -133,6 +134,13 @@ CREATE INDEX finalization_pending_peer_v2
 `;
 
 const DDL_V2 = `${DDL_V1}\n${PENDING_DDL_V2}`;
+const FAILURE_STREAK_MIGRATION_V3 = `
+ALTER TABLE finalization_inbox_v1
+  ADD COLUMN failure_signature TEXT;
+ALTER TABLE finalization_inbox_v1
+  ADD COLUMN failure_streak INTEGER NOT NULL DEFAULT 0 CHECK (failure_streak >= 0);
+`;
+const DDL_V3 = `${DDL_V2}\n${FAILURE_STREAK_MIGRATION_V3}`;
 
 export interface OpenedFinalizationRecoveryDatabase {
   databasePath: string;
@@ -274,7 +282,7 @@ function initializeFresh(database: DatabaseSync, path: string): void {
     ) {
       throw new Error('Finalization inbox lost its pristine identity before initialization');
     }
-    database.exec(DDL_V2);
+    database.exec(DDL_V3);
     database.exec(`PRAGMA application_id = ${APPLICATION_ID}`);
     database.exec(`PRAGMA user_version = ${USER_VERSION}`);
     database.exec('COMMIT');
@@ -299,7 +307,7 @@ function migrateLegacyV1(database: DatabaseSync, databasePath: string): void {
     database.exec('BEGIN IMMEDIATE');
     transactionOpen = true;
     database.exec(PENDING_DDL_V2);
-    database.exec(`PRAGMA user_version = ${USER_VERSION}`);
+    database.exec(`PRAGMA user_version = ${DEFERRED_SPOOL_USER_VERSION}`);
     database.exec('COMMIT');
     transactionOpen = false;
   } catch (error) {
@@ -313,6 +321,31 @@ function migrateLegacyV1(database: DatabaseSync, databasePath: string): void {
     const checkpoint = database.prepare('PRAGMA wal_checkpoint(TRUNCATE)').get();
     if (Number(checkpoint?.busy ?? 1) !== 0) {
       throw new Error('Finalization inbox v1 migration WAL checkpoint remained busy');
+    }
+  }
+  fsyncOwnedSqliteFileAndDirectoryV1(databasePath);
+}
+
+function migrateDeferredSpoolV2(database: DatabaseSync, databasePath: string): void {
+  let transactionOpen = false;
+  try {
+    database.exec('BEGIN IMMEDIATE');
+    transactionOpen = true;
+    database.exec(FAILURE_STREAK_MIGRATION_V3);
+    database.exec(`PRAGMA user_version = ${USER_VERSION}`);
+    database.exec('COMMIT');
+    transactionOpen = false;
+  } catch (error) {
+    if (transactionOpen) {
+      try { database.exec('ROLLBACK'); } catch { /* retain migration failure */ }
+    }
+    throw error;
+  }
+  const journalMode = database.prepare('PRAGMA journal_mode').get();
+  if (String(journalMode?.journal_mode).toLowerCase() === 'wal') {
+    const checkpoint = database.prepare('PRAGMA wal_checkpoint(TRUNCATE)').get();
+    if (Number(checkpoint?.busy ?? 1) !== 0) {
+      throw new Error('Finalization inbox v2 migration WAL checkpoint remained busy');
     }
   }
   fsyncOwnedSqliteFileAndDirectoryV1(databasePath);
@@ -333,15 +366,24 @@ export async function openFinalizationRecoveryDatabase(
         'Finalization inbox',
       );
     } catch {
-      // The main-file header can legitimately lag a committed WAL. Accept
-      // exactly the owned v1 header here, then classify from SQLite's recovered
-      // PRAGMA below after the WAL has been replayed.
-      assertOwnedSqliteHeaderIdentityV1(
-        databasePath,
-        APPLICATION_ID,
-        LEGACY_USER_VERSION,
-        'Finalization inbox',
-      );
+      // The main-file header can legitimately lag a committed WAL. Accept an
+      // owned historical header here, then classify from SQLite's recovered
+      // PRAGMA after the WAL has been replayed.
+      try {
+        assertOwnedSqliteHeaderIdentityV1(
+          databasePath,
+          APPLICATION_ID,
+          DEFERRED_SPOOL_USER_VERSION,
+          'Finalization inbox',
+        );
+      } catch {
+        assertOwnedSqliteHeaderIdentityV1(
+          databasePath,
+          APPLICATION_ID,
+          LEGACY_USER_VERSION,
+          'Finalization inbox',
+        );
+      }
     }
   }
   const database = new sqlite.DatabaseSync(databasePath);
@@ -355,10 +397,18 @@ export async function openFinalizationRecoveryDatabase(
         LEGACY_USER_VERSION,
       );
       migrateLegacyV1(database, databasePath);
+      migrateDeferredSpoolV2(database, databasePath);
+    } else if (recoveredVersion === DEFERRED_SPOOL_USER_VERSION) {
+      verifySchema(
+        database,
+        expectedSchema(sqlite.DatabaseSync, DDL_V2),
+        DEFERRED_SPOOL_USER_VERSION,
+      );
+      migrateDeferredSpoolV2(database, databasePath);
     } else if (recoveredVersion !== USER_VERSION) {
       throw new Error('Finalization inbox has a foreign or unsupported recovered version');
     }
-    verifySchema(database, expectedSchema(sqlite.DatabaseSync, DDL_V2));
+    verifySchema(database, expectedSchema(sqlite.DatabaseSync, DDL_V3));
     applyRuntimePragmas(database);
     secureOwnedSqliteFileSetV1(databasePath, 'Finalization inbox');
     return { databasePath, database };

--- a/packages/agent/src/finalization-recovery-sqlite-store.ts
+++ b/packages/agent/src/finalization-recovery-sqlite-store.ts
@@ -775,7 +775,7 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
     key: string,
     generation: number,
     lastError?: string,
-    policy: FinalizationRecoveryAttemptPolicy = {},
+    policy: FinalizationRecoveryAttemptPolicy = { mode: 'ordinary' },
   ): Promise<FinalizationRecoveryAttemptResult> {
     if (this.#closed || this.#closing) return Promise.resolve({ status: 'closed' });
     return this.mutate(() => {

--- a/packages/agent/src/finalization-recovery-sqlite-store.ts
+++ b/packages/agent/src/finalization-recovery-sqlite-store.ts
@@ -3,6 +3,8 @@ import { VerifiedGraphScopedFinalizationEvidenceCodec } from './finalization-gra
 import {
   type FinalizationRecoveryEntry,
   type FinalizationRecoveryHealth,
+  type FinalizationRecoveryAttemptPolicy,
+  type FinalizationRecoveryAttemptResult,
   type FinalizationRecoveryVerifiedEvidenceCommit,
   type FinalizationRecoveryReceiveInput,
   type FinalizationRecoveryReceiveResult,
@@ -11,6 +13,7 @@ import {
   type FinalizationRecoveryStore,
   type FinalizationRecoveryVerifyResult,
   planFinalizationRecoveryVerifiedEvidenceTransition,
+  planFinalizationRecoveryAttempt,
 } from './finalization-recovery-store.js';
 import {
   finalizationEnvelopeFromRow,
@@ -483,6 +486,8 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
               verified_evidence_json = NULL,
               generation = generation + 1,
               attempt_count = 0,
+              failure_signature = NULL,
+              failure_streak = 0,
               next_attempt_at = NULL,
               last_error = ?,
               updated_at = ?
@@ -556,6 +561,8 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
             verified_evidence_json = ?,
             generation = ?,
             attempt_count = ?,
+            failure_signature = ?,
+            failure_streak = ?,
             next_attempt_at = ?,
             last_error = ?,
             updated_at = ?
@@ -571,6 +578,8 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
         JSON.stringify(fields.verifiedEvidence),
         fields.generation,
         fields.attemptCount,
+        fields.failureSignature,
+        fields.failureStreak,
         fields.nextAttemptAt,
         fields.lastError,
         this.#policy.now(),
@@ -617,6 +626,8 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
               verified_evidence_json = NULL,
               generation = generation + 1,
               attempt_count = 0,
+              failure_signature = NULL,
+              failure_streak = 0,
               next_attempt_at = NULL,
               last_error = ?,
               updated_at = ?
@@ -635,6 +646,8 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
       this.database.prepare(`
         UPDATE finalization_inbox_v1
         SET attempt_count = 0,
+            failure_signature = NULL,
+            failure_streak = 0,
             next_attempt_at = NULL,
             last_error = NULL,
             updated_at = ?
@@ -654,6 +667,8 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
           UPDATE finalization_inbox_v1
           SET state = 'REJECTED',
               publisher_upgrade_pending = 0,
+              failure_signature = NULL,
+              failure_streak = 0,
               next_attempt_at = NULL,
               last_error = ?,
               updated_at = ?
@@ -741,6 +756,8 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
           SET state = ?,
               publisher_upgrade_pending = 0,
               attempt_count = CASE WHEN ? = 'SETTLED' THEN 0 ELSE attempt_count END,
+              failure_signature = NULL,
+              failure_streak = 0,
               last_error = ?,
               next_attempt_at = NULL,
               updated_at = ?
@@ -758,34 +775,56 @@ export class SqliteFinalizationRecoveryStore implements FinalizationRecoveryStor
     key: string,
     generation: number,
     lastError?: string,
-    retryDelayMs?: number,
-  ): Promise<void> {
-    if (this.#closed || this.#closing) return Promise.resolve();
+    policy: FinalizationRecoveryAttemptPolicy = {},
+  ): Promise<FinalizationRecoveryAttemptResult> {
+    if (this.#closed || this.#closing) return Promise.resolve({ status: 'closed' });
     return this.mutate(() => {
-      if (this.#closed) return;
+      if (this.#closed) return { status: 'closed' as const };
       const now = this.#policy.now();
-      const nextAttemptAt = retryDelayMs === undefined ? null : now + retryDelayMs;
-      this.database.prepare(`
-        UPDATE finalization_inbox_v1
-        SET attempt_count = attempt_count + 1,
-            last_error = ?,
-            next_attempt_at = CASE
-              WHEN ? IS NULL THEN next_attempt_at
-              WHEN next_attempt_at IS NULL THEN ?
-              ELSE MAX(next_attempt_at, ?)
-            END,
-            updated_at = ?
-        WHERE key = ? AND generation = ?
-          AND state IN ('RECEIVED','VERIFIED','REORGED','SETTLED')
-      `).run(
-        lastError ?? null,
-        nextAttemptAt,
-        nextAttemptAt,
-        nextAttemptAt,
-        now,
-        key,
-        generation,
-      );
+      let outcome: FinalizationRecoveryAttemptResult = { status: 'stale' };
+      this.transaction(() => {
+        const row = this.database.prepare(
+          'SELECT * FROM finalization_inbox_v1 WHERE key = ?',
+        ).get(key);
+        if (!row) return;
+        const current = finalizationRecoveryRowToEntry(row);
+        if (
+          current.generation !== generation
+          || !['RECEIVED', 'VERIFIED', 'REORGED', 'SETTLED'].includes(current.state)
+        ) return;
+        const update = planFinalizationRecoveryAttempt(current, lastError, policy, now);
+        const result = this.database.prepare(`
+          UPDATE finalization_inbox_v1
+          SET attempt_count = ?,
+              last_error = ?,
+              failure_signature = ?,
+              failure_streak = ?,
+              next_attempt_at = ?,
+              updated_at = ?
+          WHERE key = ? AND generation = ?
+            AND state IN ('RECEIVED','VERIFIED','REORGED','SETTLED')
+        `).run(
+          update.attemptCount,
+          update.lastError,
+          update.failureSignature,
+          update.failureStreak,
+          update.nextAttemptAt,
+          now,
+          key,
+          generation,
+        );
+        if (result.changes === 0) return;
+        const updated = this.database.prepare(
+          'SELECT * FROM finalization_inbox_v1 WHERE key = ?',
+        ).get(key);
+        if (updated) {
+          outcome = {
+            status: 'updated',
+            entry: finalizationRecoveryRowToEntry(updated),
+          };
+        }
+      });
+      return outcome;
     });
   }
 

--- a/packages/agent/src/finalization-recovery-store.ts
+++ b/packages/agent/src/finalization-recovery-store.ts
@@ -161,13 +161,18 @@ export type FinalizationRecoverySettledPublisherUpgradeResult =
   | { status: 'conflict' | 'missing' | 'closed' };
 
 export type FinalizationRecoveryFailureCode =
-  | 'processing-deferred'
+  | 'workspace-unavailable'
+  | 'publisher-authority-pending'
+  | 'receipt-pending'
+  | 'context-graph-binding-pending'
+  | 'evidence-commit-pending'
+  | 'apply-deferred'
+  | 'vm-metadata-pending'
   | 'store-scheduler-busy'
   | 'background-chain-unavailable'
   | 'background-binding-pending'
   | 'background-no-match'
   | 'background-replay-failed'
-  | 'receipt-pending'
   | 'settled-upgrade-deferred'
   | 'settled-reorg-deferred';
 

--- a/packages/agent/src/finalization-recovery-store.ts
+++ b/packages/agent/src/finalization-recovery-store.ts
@@ -34,6 +34,8 @@ export interface FinalizationRecoveryEntry {
   verifiedEvidence?: VerifiedGraphScopedFinalizationEvidence;
   generation: number;
   attemptCount: number;
+  failureSignature?: string;
+  failureStreak: number;
   nextAttemptAt?: number;
   lastError?: string;
   createdAt: number;
@@ -88,6 +90,8 @@ export interface FinalizationRecoveryVerifiedEvidenceUpdate {
   attemptCount: number;
   nextAttemptAt: number | null;
   lastError: string | null;
+  failureSignature: string | null;
+  failureStreak: number;
 }
 
 export type FinalizationRecoveryVerifiedEvidenceTransitionPlan =
@@ -142,6 +146,12 @@ export function planFinalizationRecoveryVerifiedEvidenceTransition(
       lastError: commit.placement === 'canonical-moved'
         ? commit.reason
         : current.lastError ?? null,
+      failureSignature: commit.placement === 'canonical-moved'
+        ? null
+        : current.failureSignature ?? null,
+      failureStreak: commit.placement === 'canonical-moved'
+        ? 0
+        : current.failureStreak,
     },
   };
 }
@@ -149,6 +159,63 @@ export function planFinalizationRecoveryVerifiedEvidenceTransition(
 export type FinalizationRecoverySettledPublisherUpgradeResult =
   | { status: 'recorded' | 'existing'; entry: FinalizationRecoveryEntry }
   | { status: 'conflict' | 'missing' | 'closed' };
+
+export interface FinalizationRecoveryAttemptPolicy {
+  retryDelayMs?: number;
+  failureSignature?: string;
+  stableFailureThreshold?: number;
+  stableFailureRetryMs?: number;
+  /** Autonomous poison entries must be reconsidered no later than this time. */
+  retryDeadlineAt?: number;
+}
+
+export type FinalizationRecoveryAttemptResult =
+  | { status: 'updated'; entry: FinalizationRecoveryEntry }
+  | { status: 'stale' | 'closed' };
+
+export interface FinalizationRecoveryAttemptUpdate {
+  attemptCount: number;
+  lastError: string | null;
+  failureSignature: string | null;
+  failureStreak: number;
+  nextAttemptAt: number | null;
+}
+
+/** Pure retry policy over one durable entry snapshot. */
+export function planFinalizationRecoveryAttempt(
+  current: FinalizationRecoveryEntry,
+  lastError: string | undefined,
+  policy: FinalizationRecoveryAttemptPolicy,
+  now: number,
+): FinalizationRecoveryAttemptUpdate {
+  const failureSignature = policy.failureSignature;
+  const failureStreak = failureSignature === undefined
+    ? 0
+    : current.failureSignature === failureSignature
+      ? current.failureStreak + 1
+      : 1;
+  let delayMs = policy.retryDelayMs;
+  if (
+    delayMs !== undefined
+    && failureSignature !== undefined
+    && failureStreak >= (policy.stableFailureThreshold ?? Number.POSITIVE_INFINITY)
+  ) {
+    delayMs = Math.max(delayMs, policy.stableFailureRetryMs ?? 0);
+  }
+  let nextAttemptAt = delayMs === undefined
+    ? current.nextAttemptAt ?? null
+    : Math.max(current.nextAttemptAt ?? 0, now + Math.max(0, delayMs));
+  if (policy.retryDeadlineAt !== undefined && nextAttemptAt !== null) {
+    nextAttemptAt = Math.min(nextAttemptAt, Math.max(now, policy.retryDeadlineAt));
+  }
+  return {
+    attemptCount: current.attemptCount + 1,
+    lastError: lastError ?? null,
+    failureSignature: failureSignature ?? null,
+    failureStreak,
+    nextAttemptAt,
+  };
+}
 
 export interface FinalizationRecoveryHealth {
   available: boolean;
@@ -231,8 +298,8 @@ export interface FinalizationRecoveryStore {
     key: string,
     generation: number,
     lastError?: string,
-    retryDelayMs?: number,
-  ): Promise<void>;
+    policy?: FinalizationRecoveryAttemptPolicy,
+  ): Promise<FinalizationRecoveryAttemptResult>;
   health(): Promise<FinalizationRecoveryHealth>;
   close(): Promise<void>;
 }

--- a/packages/agent/src/finalization-recovery-store.ts
+++ b/packages/agent/src/finalization-recovery-store.ts
@@ -160,14 +160,31 @@ export type FinalizationRecoverySettledPublisherUpgradeResult =
   | { status: 'recorded' | 'existing'; entry: FinalizationRecoveryEntry }
   | { status: 'conflict' | 'missing' | 'closed' };
 
-export interface FinalizationRecoveryAttemptPolicy {
-  retryDelayMs?: number;
-  failureSignature?: string;
-  stableFailureThreshold?: number;
-  stableFailureRetryMs?: number;
-  /** Autonomous poison entries must be reconsidered no later than this time. */
-  retryDeadlineAt?: number;
-}
+export type FinalizationRecoveryFailureCode =
+  | 'processing-deferred'
+  | 'store-scheduler-busy'
+  | 'background-chain-unavailable'
+  | 'background-binding-pending'
+  | 'background-no-match'
+  | 'background-replay-failed'
+  | 'receipt-pending'
+  | 'settled-upgrade-deferred'
+  | 'settled-reorg-deferred';
+
+export type FinalizationRecoveryAttemptPolicy =
+  | {
+      mode: 'ordinary';
+      retryDelayMs?: number;
+    }
+  | {
+      mode: 'stable-failure';
+      retryDelayMs: number;
+      failureCode: FinalizationRecoveryFailureCode;
+      stableFailureThreshold: number;
+      stableFailureRetryMs: number;
+      /** A stable live failure must be reconsidered no later than this time. */
+      retryDeadlineAt: number;
+    };
 
 export type FinalizationRecoveryAttemptResult =
   | { status: 'updated'; entry: FinalizationRecoveryEntry }
@@ -188,7 +205,9 @@ export function planFinalizationRecoveryAttempt(
   policy: FinalizationRecoveryAttemptPolicy,
   now: number,
 ): FinalizationRecoveryAttemptUpdate {
-  const failureSignature = policy.failureSignature;
+  const failureSignature = policy.mode === 'stable-failure'
+    ? policy.failureCode
+    : undefined;
   const failureStreak = failureSignature === undefined
     ? 0
     : current.failureSignature === failureSignature
@@ -196,16 +215,22 @@ export function planFinalizationRecoveryAttempt(
       : 1;
   let delayMs = policy.retryDelayMs;
   if (
-    delayMs !== undefined
-    && failureSignature !== undefined
-    && failureStreak >= (policy.stableFailureThreshold ?? Number.POSITIVE_INFINITY)
+    policy.mode === 'stable-failure'
+    && failureStreak >= policy.stableFailureThreshold
   ) {
-    delayMs = Math.max(delayMs, policy.stableFailureRetryMs ?? 0);
+    delayMs = Math.max(policy.retryDelayMs, policy.stableFailureRetryMs);
   }
   let nextAttemptAt = delayMs === undefined
     ? current.nextAttemptAt ?? null
     : Math.max(current.nextAttemptAt ?? 0, now + Math.max(0, delayMs));
-  if (policy.retryDeadlineAt !== undefined && nextAttemptAt !== null) {
+  if (
+    policy.mode === 'stable-failure'
+    && failureStreak >= policy.stableFailureThreshold
+    && nextAttemptAt !== null
+  ) {
+    // Only stable failures are capped. Once the deadline has elapsed this
+    // immediate due time is safe because replay's next pass terminally rejects
+    // the live entry. Ordinary and SETTLED retries retain their future backoff.
     nextAttemptAt = Math.min(nextAttemptAt, Math.max(now, policy.retryDeadlineAt));
   }
   return {

--- a/packages/agent/src/finalization-recovery.ts
+++ b/packages/agent/src/finalization-recovery.ts
@@ -5,7 +5,6 @@ import type {
   EventFilter,
 } from '@origintrail-official/dkg-chain';
 import {
-  BoundedLruCache,
   decodeFinalizationMessage,
   getMetrics,
   GRAPH_KA_CONTENT_SCOPE_VERSION,
@@ -26,11 +25,21 @@ import type {
   FinalizationRecoverySettledPublisherUpgradeResult,
   FinalizationRecoveryStore,
 } from './finalization-recovery-store.js';
+import { FinalizationPublisherAuthorityObserver } from
+  './finalization-publisher-authority-observer.js';
 
 export type FinalizationRecoveryApplyOutcome =
   | 'applied'
   | 'already-confirmed'
   | 'deferred';
+
+type FinalizationRecoveryMaterializationResult =
+  | { outcome: Exclude<FinalizationRecoveryApplyOutcome, 'deferred'> }
+  | {
+      outcome: 'deferred';
+      failureCode: FinalizationRecoveryFailureCode;
+      detail: string;
+    };
 
 export interface FinalizationRecoveryLiveInput {
   rawMessage: Uint8Array;
@@ -109,6 +118,23 @@ export type FinalizationMaterializationVerification =
       | 'context-graph-binding-pending'
       | 'verified-evidence-commit-failed';
   };
+
+function verificationFailureCode(
+  reason: Extract<FinalizationMaterializationVerification, { status: 'deferred' }>['reason'],
+): FinalizationRecoveryFailureCode {
+  switch (reason) {
+    case 'context-graph-binding-pending':
+      return 'context-graph-binding-pending';
+    case 'verified-evidence-commit-failed':
+      return 'evidence-commit-pending';
+    case 'legacy-verification-pending':
+    case 'canonical-receipt-pending':
+    case 'canonical-receipt-reorged':
+    case 'canonical-receipt-rejected':
+    case 'canonical-receipt-unsupported':
+      return 'receipt-pending';
+  }
+}
 
 interface FinalizationRecoveryLog {
   info(message: string): void;
@@ -248,9 +274,10 @@ export class FinalizationRecovery<
     Promise<FinalizationRecoveryReplayOutcome>
   >();
   private readonly entryLockTails = new Map<string, Promise<void>>();
-  private readonly failedPublisherAuthorityProbes = new BoundedLruCache<string, true>(
-    FAILED_PUBLISHER_AUTHORITY_PROBE_MAX_ENTRIES,
-  );
+  private readonly publisherAuthorityObserver: FinalizationPublisherAuthorityObserver<
+    FinalizationRecoveryLiveInput,
+    Prepared
+  >;
   private readonly store: FinalizationRecoveryStore | undefined;
   private readonly storeSource: FinalizationRecoveryStoreSource | undefined;
   private readonly liveRetryLimit: number;
@@ -282,6 +309,11 @@ export class FinalizationRecovery<
       ),
     );
     this.now = options.now ?? Date.now;
+    this.publisherAuthorityObserver = new FinalizationPublisherAuthorityObserver({
+      maxFailedProbes: FAILED_PUBLISHER_AUTHORITY_PROBE_MAX_ENTRIES,
+      prepare: (input) => this.materializer.prepare(input),
+      log: this.log,
+    });
   }
 
   private getStore(): FinalizationRecoveryStore | undefined {
@@ -369,7 +401,18 @@ export class FinalizationRecovery<
     return this.withEntryLock(key, async () => {
       const received = await this.receiveOutcome(input);
       if (received.status === 'pending') {
-        await this.observePublisherAuthority(store, key, input);
+        if (input.sourcePeerId) {
+          await this.publisherAuthorityObserver.observe({
+            store,
+            identity: {
+              entryKey: key,
+              generation: 'pending',
+              sourcePeerId: input.sourcePeerId,
+            },
+            ual: input.candidate.scope.ual,
+            prepareInput: input,
+          });
+        }
         return { status: 'handled' };
       }
       if (received.status === 'capacity') {
@@ -396,7 +439,19 @@ export class FinalizationRecovery<
       // Every accepted delivery gets one authority-observation phase before
       // retry scheduling. Its prepared workspace result is reused below when
       // the materialization gate is open.
-      const authority = await this.observePublisherAuthority(store, key, input, entry);
+      const authority = input.sourcePeerId
+        ? await this.publisherAuthorityObserver.observe({
+            store,
+            identity: {
+              entryKey: key,
+              generation: entry.generation,
+              sourcePeerId: input.sourcePeerId,
+            },
+            ual: input.candidate.scope.ual,
+            prepareInput: input,
+            entry,
+          })
+        : {};
 
       // The worker and reconciliation paths already honor this durable gate.
       // Live duplicate gossip must do the same: the per-entry lock serializes
@@ -409,19 +464,19 @@ export class FinalizationRecovery<
 
       for (let attempt = 0; attempt < 2; attempt += 1) {
         try {
-          const outcome = await this.materialize(
+          const result = await this.materialize(
             input,
             { kind: 'recovery', entry },
             authority.prepared,
           );
-          if (outcome === 'deferred') {
+          if (result.outcome === 'deferred') {
             await this.recordDeferred(
               entry,
-              'processing-deferred',
-              'finalization processing deferred',
+              result.failureCode,
+              result.detail,
             );
           } else {
-            await this.settleEntry(entry, outcome);
+            await this.settleEntry(entry, result.outcome);
           }
           return { status: 'handled' };
         } catch (error) {
@@ -444,67 +499,6 @@ export class FinalizationRecovery<
       }
       return { status: 'handled' };
     });
-  }
-
-  private async observePublisherAuthority(
-    store: FinalizationRecoveryStore,
-    key: string,
-    input: FinalizationRecoveryLiveInput,
-    entry?: FinalizationRecoveryEntry,
-  ): Promise<{ prepared?: Prepared }> {
-    if (!input.sourcePeerId || entry?.trustedPublisherPeerId) return {};
-    const probeKey = `${key}|${entry?.generation ?? 'pending'}|${input.sourcePeerId}`;
-    if (this.failedPublisherAuthorityProbes.has(probeKey)) return {};
-    let prepared: Prepared | undefined;
-    try {
-      prepared = await this.materializer.prepare(input);
-    } catch (error) {
-      this.log.info(
-        `Finalization recovery deferred publisher authority check for `
-          + `${input.candidate.scope.ual}: `
-          + `${error instanceof Error ? error.message : String(error)}`,
-      );
-      return {};
-    }
-    if (!prepared || input.sourcePeerId !== prepared.publisherPeerId) {
-      this.failedPublisherAuthorityProbes.set(probeKey, true);
-      return { prepared };
-    }
-    try {
-      if (entry) {
-        if (await store.recordTrustedPublisher(
-          key,
-          entry.generation,
-          prepared.publisherPeerId,
-        )) return { prepared };
-      } else if (await store.recordPendingTrustedPublisher(key, prepared.publisherPeerId)) {
-        return { prepared };
-      }
-      // Promotion is serialized by the store but is intentionally independent
-      // of the per-entry recovery lock. If it moved this row between admission
-      // and the authority CAS, preserve the same monotonic evidence on the live row.
-      const promoted = await store.get(key);
-      if (
-        promoted
-        && this.isLiveEntry(promoted)
-        && await store.recordTrustedPublisher(
-          key,
-          promoted.generation,
-          prepared.publisherPeerId,
-        )
-      ) return { prepared };
-      this.log.warn(
-        `Finalization recovery inbox refused publisher authority for `
-          + `${input.candidate.scope.ual}`,
-      );
-    } catch (error) {
-      this.log.warn(
-        `Finalization recovery pending publisher authority commit failed for `
-          + `${input.candidate.scope.ual}: `
-          + `${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
-    return {};
   }
 
   /**
@@ -712,10 +706,11 @@ export class FinalizationRecovery<
   }
 
   /** Processes the compatibility path when no durable inbox can be used. */
-  processUnjournaled(
+  async processUnjournaled(
     input: FinalizationRecoveryLiveInput,
   ): Promise<FinalizationRecoveryApplyOutcome> {
-    return this.materialize(input, { kind: 'live' });
+    const result = await this.materialize(input, { kind: 'live' });
+    return result.outcome;
   }
 
   async receive(
@@ -982,7 +977,7 @@ export class FinalizationRecovery<
     input: FinalizationRecoveryLiveInput,
     context: FinalizationVerificationContext,
     observedPrepared?: Prepared,
-  ): Promise<FinalizationRecoveryApplyOutcome> {
+  ): Promise<FinalizationRecoveryMaterializationResult> {
     const preparationInput = context.kind === 'recovery'
       && context.entry.trustedPublisherPeerId
       ? {
@@ -991,13 +986,25 @@ export class FinalizationRecovery<
         }
       : input;
     const prepared = observedPrepared ?? await this.materializer.prepare(preparationInput);
-    if (!prepared) return 'deferred';
+    if (!prepared) {
+      return {
+        outcome: 'deferred',
+        failureCode: 'workspace-unavailable',
+        detail: 'workspace preparation is unavailable',
+      };
+    }
     if (
       context.kind === 'recovery'
       && input.sourcePeerId !== undefined
       && input.sourcePeerId === prepared.publisherPeerId
       && !await this.recordTrustedPublisher(context.entry, prepared.publisherPeerId)
-    ) return 'deferred';
+    ) {
+      return {
+        outcome: 'deferred',
+        failureCode: 'publisher-authority-pending',
+        detail: 'trusted publisher authority is not durable yet',
+      };
+    }
     const verification = await this.verifyMaterialization(
       input.candidate,
       context,
@@ -1008,9 +1015,13 @@ export class FinalizationRecovery<
         `Finalization verification deferred for ${input.candidate.scope.ual} `
           + `(${verification.reason})`,
       );
-      return 'deferred';
+      return {
+        outcome: 'deferred',
+        failureCode: verificationFailureCode(verification.reason),
+        detail: verification.reason,
+      };
     }
-    return this.materializer.apply({
+    const outcome = await this.materializer.apply({
       prepared,
       blockNumber: verification.blockNumber,
       txIndex: verification.txIndex,
@@ -1018,6 +1029,13 @@ export class FinalizationRecovery<
         ? { authorAddress: verification.authorAddress }
         : {}),
     });
+    return outcome === 'deferred'
+      ? {
+          outcome,
+          failureCode: 'apply-deferred',
+          detail: 'verified materialization apply deferred',
+        }
+      : { outcome };
   }
 
   private async recordTrustedPublisher(
@@ -1820,20 +1838,20 @@ export class FinalizationRecovery<
       reason,
     );
     if (!rearmed) return false;
-    const outcome = await this.materialize(
+    const result = await this.materialize(
       recoveryInput,
       { kind: 'recovery', entry: rearmed },
     );
-    if (outcome === 'deferred') {
+    if (result.outcome === 'deferred') {
       await this.recordDeferred(
         rearmed,
-        'settled-upgrade-deferred',
-        'settled publisher upgrade recovery deferred',
+        result.failureCode,
+        result.detail,
         deferredRetryDelay,
       );
       return false;
     }
-    return this.settleEntry(rearmed, outcome);
+    return this.settleEntry(rearmed, result.outcome);
   }
 
   private async settledMatchesReplayTarget(
@@ -1874,7 +1892,7 @@ export class FinalizationRecovery<
       candidate,
     });
     if (!reorged || reorged.state !== 'REORGED') return false;
-    const outcome = await this.materialize(
+    const result = await this.materialize(
       {
         rawMessage: entry.rawMessage,
         contextGraphId: entry.contextGraphId,
@@ -1883,16 +1901,16 @@ export class FinalizationRecovery<
       },
       { kind: 'recovery', entry: reorged },
     );
-    if (outcome === 'deferred') {
+    if (result.outcome === 'deferred') {
       await this.recordDeferred(
         reorged,
-        'settled-reorg-deferred',
-        'settled reorg recovery deferred',
+        result.failureCode,
+        result.detail,
         deferredRetryDelay,
       );
       return false;
     }
-    return this.settleEntry(reorged, outcome);
+    return this.settleEntry(reorged, result.outcome);
   }
 
   private async replayEntry(
@@ -1931,7 +1949,7 @@ export class FinalizationRecovery<
       const replayEntry = ensured.entry;
       activeEntry = replayEntry;
 
-      let outcome: FinalizationRecoveryApplyOutcome;
+      let result: FinalizationRecoveryMaterializationResult;
       if (ensured.status === 'verified') {
         const { evidence, placement } = ensured;
         const receiptStatus = await this.verifyPersistedReceipt(
@@ -1974,15 +1992,27 @@ export class FinalizationRecovery<
           candidate,
           evidence,
         });
-        outcome = replayOutcome === 'promoted'
-          ? 'applied'
-          : replayOutcome === 'already-confirmed' || replayOutcome === 'stale-target'
-            ? 'already-confirmed'
-            : 'deferred';
+        if (replayOutcome === 'promoted') {
+          result = { outcome: 'applied' };
+        } else if (replayOutcome === 'already-confirmed' || replayOutcome === 'stale-target') {
+          result = { outcome: 'already-confirmed' };
+        } else if (replayOutcome === 'no-swm') {
+          result = {
+            outcome: 'deferred',
+            failureCode: 'workspace-unavailable',
+            detail: 'verified replay has no SWM snapshot',
+          };
+        } else {
+          result = {
+            outcome: 'deferred',
+            failureCode: 'vm-metadata-pending',
+            detail: 'verified VM metadata is pending',
+          };
+        }
       } else {
         const recoverySourcePeerId = replayEntry.trustedPublisherPeerId
           ?? replayEntry.sourcePeerId;
-        outcome = await this.materialize(
+        result = await this.materialize(
           {
             rawMessage: replayEntry.rawMessage,
             contextGraphId: replayEntry.contextGraphId,
@@ -1993,18 +2023,18 @@ export class FinalizationRecovery<
         );
       }
 
-      if (outcome === 'deferred') {
+      if (result.outcome === 'deferred') {
         await this.recordDeferred(
           replayEntry,
-          'processing-deferred',
-          'replay processing deferred',
+          result.failureCode,
+          result.detail,
           deferredRetryDelay,
         );
         return deferredRetryDelay === undefined
           ? 'none' as const
           : 'retry-pending' as const;
       }
-      const settled = await this.settleEntry(replayEntry, outcome);
+      const settled = await this.settleEntry(replayEntry, result.outcome);
       return settled ? 'recovered' as const : 'none' as const;
     } catch (error) {
       if (!this.materializer.isRetryableError(error)) throw error;

--- a/packages/agent/src/finalization-recovery.ts
+++ b/packages/agent/src/finalization-recovery.ts
@@ -5,6 +5,7 @@ import type {
   EventFilter,
 } from '@origintrail-official/dkg-chain';
 import {
+  BoundedLruCache,
   decodeFinalizationMessage,
   getMetrics,
   GRAPH_KA_CONTENT_SCOPE_VERSION,
@@ -21,6 +22,7 @@ import {
 import type {
   FinalizationRecoveryEntry,
   FinalizationRecoveryHealth,
+  FinalizationRecoveryFailureCode,
   FinalizationRecoverySettledPublisherUpgradeResult,
   FinalizationRecoveryStore,
 } from './finalization-recovery-store.js';
@@ -246,7 +248,9 @@ export class FinalizationRecovery<
     Promise<FinalizationRecoveryReplayOutcome>
   >();
   private readonly entryLockTails = new Map<string, Promise<void>>();
-  private readonly failedPublisherAuthorityProbes = new Map<string, true>();
+  private readonly failedPublisherAuthorityProbes = new BoundedLruCache<string, true>(
+    FAILED_PUBLISHER_AUTHORITY_PROBE_MAX_ENTRIES,
+  );
   private readonly store: FinalizationRecoveryStore | undefined;
   private readonly storeSource: FinalizationRecoveryStoreSource | undefined;
   private readonly liveRetryLimit: number;
@@ -413,6 +417,7 @@ export class FinalizationRecovery<
           if (outcome === 'deferred') {
             await this.recordDeferred(
               entry,
+              'processing-deferred',
               'finalization processing deferred',
             );
           } else {
@@ -431,6 +436,7 @@ export class FinalizationRecovery<
           );
           await this.recordDeferred(
             entry,
+            'store-scheduler-busy',
             'store scheduler remained busy',
           );
           return { status: 'handled' };
@@ -461,18 +467,7 @@ export class FinalizationRecovery<
       return {};
     }
     if (!prepared || input.sourcePeerId !== prepared.publisherPeerId) {
-      this.failedPublisherAuthorityProbes.delete(probeKey);
       this.failedPublisherAuthorityProbes.set(probeKey, true);
-      while (
-        this.failedPublisherAuthorityProbes.size
-        > FAILED_PUBLISHER_AUTHORITY_PROBE_MAX_ENTRIES
-      ) {
-        const oldest = this.failedPublisherAuthorityProbes.keys().next().value as
-          | string
-          | undefined;
-        if (oldest === undefined) break;
-        this.failedPublisherAuthorityProbes.delete(oldest);
-      }
       return { prepared };
     }
     try {
@@ -552,6 +547,7 @@ export class FinalizationRecovery<
           );
           await this.recordDeferred(
             entry,
+            'background-replay-failed',
             `background replay failed: ${reason}`,
             deferredRetryDelayMs(entry.attemptCount),
           );
@@ -624,6 +620,7 @@ export class FinalizationRecovery<
     ) {
       await this.recordDeferred(
         entry,
+        'background-chain-unavailable',
         'background replay lacks the matching chain binding capability',
         deferredRetryDelayMs(entry.attemptCount),
       );
@@ -641,6 +638,7 @@ export class FinalizationRecovery<
       ) {
         await this.recordDeferred(
           entry,
+          'background-binding-pending',
           'background replay chain binding is not available yet',
           deferredRetryDelayMs(entry.attemptCount),
         );
@@ -666,6 +664,7 @@ export class FinalizationRecovery<
       if (outcome !== 'none') return outcome;
       await this.recordDeferred(
         entry,
+        'background-no-match',
         'background replay found no canonical finalization match',
         deferredRetryDelayMs(entry.attemptCount),
       );
@@ -677,6 +676,7 @@ export class FinalizationRecovery<
       );
       await this.recordDeferred(
         entry,
+        'background-replay-failed',
         `background replay failed: ${reason}`,
         deferredRetryDelayMs(entry.attemptCount),
       );
@@ -1115,6 +1115,7 @@ export class FinalizationRecovery<
 
   async recordDeferred(
     entry: FinalizationRecoveryEntry,
+    failureCode: FinalizationRecoveryFailureCode,
     reason: string,
     retryDelayMs?: number,
   ): Promise<void> {
@@ -1126,13 +1127,16 @@ export class FinalizationRecovery<
         entry.key,
         entry.generation,
         reason,
-        {
-          retryDelayMs: ordinaryDelay,
-          failureSignature: reason,
-          stableFailureThreshold: FINALIZATION_RECOVERY_STABLE_FAILURE_THRESHOLD,
-          stableFailureRetryMs: FINALIZATION_RECOVERY_STABLE_FAILURE_RETRY_MS,
-          retryDeadlineAt: entry.createdAt + this.liveRetryWindowMs,
-        },
+        entry.state === 'SETTLED'
+          ? { mode: 'ordinary', retryDelayMs: ordinaryDelay }
+          : {
+              mode: 'stable-failure',
+              retryDelayMs: ordinaryDelay,
+              failureCode,
+              stableFailureThreshold: FINALIZATION_RECOVERY_STABLE_FAILURE_THRESHOLD,
+              stableFailureRetryMs: FINALIZATION_RECOVERY_STABLE_FAILURE_RETRY_MS,
+              retryDeadlineAt: entry.createdAt + this.liveRetryWindowMs,
+            },
       );
       if (result.status === 'stale') {
         this.log.info(
@@ -1450,7 +1454,7 @@ export class FinalizationRecovery<
         entry.key,
         entry.generation,
         reason,
-        { retryDelayMs: delayMs },
+        { mode: 'ordinary', retryDelayMs: delayMs },
       );
     } catch (error) {
       this.log.warn(
@@ -1823,6 +1827,7 @@ export class FinalizationRecovery<
     if (outcome === 'deferred') {
       await this.recordDeferred(
         rearmed,
+        'settled-upgrade-deferred',
         'settled publisher upgrade recovery deferred',
         deferredRetryDelay,
       );
@@ -1881,6 +1886,7 @@ export class FinalizationRecovery<
     if (outcome === 'deferred') {
       await this.recordDeferred(
         reorged,
+        'settled-reorg-deferred',
         'settled reorg recovery deferred',
         deferredRetryDelay,
       );
@@ -1949,6 +1955,7 @@ export class FinalizationRecovery<
           } else {
             await this.recordDeferred(
               replayEntry,
+              'receipt-pending',
               `persisted receipt is ${receiptStatus}`,
               deferredRetryDelay,
             );
@@ -1989,6 +1996,7 @@ export class FinalizationRecovery<
       if (outcome === 'deferred') {
         await this.recordDeferred(
           replayEntry,
+          'processing-deferred',
           'replay processing deferred',
           deferredRetryDelay,
         );
@@ -2006,6 +2014,7 @@ export class FinalizationRecovery<
       );
       await this.recordDeferred(
         activeEntry,
+        'store-scheduler-busy',
         'replay store scheduler remained busy',
         deferredRetryDelay,
       );

--- a/packages/agent/src/finalization-recovery.ts
+++ b/packages/agent/src/finalization-recovery.ts
@@ -391,6 +391,17 @@ export class FinalizationRecovery<
       // the autonomous retry budget.
       if (!this.isLiveEntry(entry)) return { status: 'handled' };
 
+      // A relay may win admission before the publisher's own delivery arrives.
+      // Preserve that later authority observation even while an autonomous
+      // retry deadline is parked; it is durable evidence, not a retry attempt.
+      if (
+        !entry.trustedPublisherPeerId
+        && input.sourcePeerId !== undefined
+        && input.sourcePeerId !== entry.sourcePeerId
+      ) {
+        await this.recordPendingPublisherAuthority(store, key, input);
+      }
+
       // The worker and reconciliation paths already honor this durable gate.
       // Live duplicate gossip must do the same: the per-entry lock serializes
       // equivalent deliveries, but without this check every queued duplicate

--- a/packages/agent/src/finalization-recovery.ts
+++ b/packages/agent/src/finalization-recovery.ts
@@ -198,6 +198,8 @@ const SETTLED_RECEIPT_RETRY_MAX_MS = 60_000;
 const SETTLED_NOT_FOUND_RETRY_LIMIT = 5;
 const DEFERRED_RETRY_BASE_MS = 1_000;
 const DEFERRED_RETRY_MAX_MS = 60_000;
+export const FINALIZATION_RECOVERY_STABLE_FAILURE_THRESHOLD = 3;
+export const FINALIZATION_RECOVERY_STABLE_FAILURE_RETRY_MS = 6 * 60 * 60 * 1_000;
 /**
  * At the maximum retry delay this is approximately seven days of autonomous
  * worker attempts. The wall-clock window below must also elapse so duplicate
@@ -248,6 +250,10 @@ export class FinalizationRecovery<
   private readonly liveRetryLimit: number;
   private readonly liveRetryWindowMs: number;
   private readonly now: () => number;
+  private readonly deferredFailureStreaks = new Map<
+    string,
+    { generation: number; reason: string; count: number }
+  >();
 
   constructor(
     store: FinalizationRecoveryStore | FinalizationRecoveryStoreSource | undefined,
@@ -1077,13 +1083,47 @@ export class FinalizationRecovery<
   ): Promise<void> {
     const store = this.getStore();
     if (!store) return;
+    const retryKey = entry.key;
+    const previous = this.deferredFailureStreaks.get(retryKey);
+    const sameInMemoryFailure = previous?.generation === entry.generation
+      && previous.reason === reason;
+    // `lastError` seeds one persisted occurrence after restart. The in-memory
+    // streak then distinguishes consecutive failures from an old high global
+    // attempt count, without widening the durable schema.
+    const failureStreak = sameInMemoryFailure
+      ? previous.count + 1
+      : entry.lastError === reason
+        ? 2
+        : 1;
+    const ordinaryDelay = retryDelayMs ?? deferredRetryDelayMs(entry.attemptCount);
+    let effectiveDelay = failureStreak >= FINALIZATION_RECOVERY_STABLE_FAILURE_THRESHOLD
+      ? Math.max(ordinaryDelay, FINALIZATION_RECOVERY_STABLE_FAILURE_RETRY_MS)
+      : ordinaryDelay;
+    // Parking must not hide an entry past the bounded poison-entry decision.
+    // Once the count budget has been consumed, wake at the wall-clock budget
+    // boundary so replayDueEntryLocked can make the terminal decision.
+    if (
+      entry.attemptCount + 1 >= this.liveRetryLimit
+      && this.liveRetryWindowMs < effectiveDelay
+    ) {
+      const retryWindowRemaining = Math.max(
+        0,
+        entry.createdAt + this.liveRetryWindowMs - this.now(),
+      );
+      effectiveDelay = Math.min(effectiveDelay, retryWindowRemaining);
+    }
     try {
       await store.recordAttempt(
         entry.key,
         entry.generation,
         reason,
-        retryDelayMs,
+        effectiveDelay,
       );
+      this.deferredFailureStreaks.set(retryKey, {
+        generation: entry.generation,
+        reason,
+        count: failureStreak,
+      });
     } catch (error) {
       this.log.warn(
         `Finalization recovery attempt update failed for ${entry.ual}: `
@@ -1602,7 +1642,9 @@ export class FinalizationRecovery<
     const store = this.getStore();
     if (!store) return false;
     try {
-      return await store.transition(entry.key, entry.generation, state, reason);
+      const transitioned = await store.transition(entry.key, entry.generation, state, reason);
+      if (transitioned) this.deferredFailureStreaks.delete(entry.key);
+      return transitioned;
     } catch (error) {
       this.log.warn(
         `Finalization recovery transition to ${state} failed for ${entry.ual}: `

--- a/packages/agent/src/finalization-recovery.ts
+++ b/packages/agent/src/finalization-recovery.ts
@@ -198,6 +198,7 @@ const SETTLED_RECEIPT_RETRY_MAX_MS = 60_000;
 const SETTLED_NOT_FOUND_RETRY_LIMIT = 5;
 const DEFERRED_RETRY_BASE_MS = 1_000;
 const DEFERRED_RETRY_MAX_MS = 60_000;
+const FAILED_PUBLISHER_AUTHORITY_PROBE_MAX_ENTRIES = 4_096;
 export const FINALIZATION_RECOVERY_STABLE_FAILURE_THRESHOLD = 3;
 export const FINALIZATION_RECOVERY_STABLE_FAILURE_RETRY_MS = 6 * 60 * 60 * 1_000;
 /**
@@ -245,15 +246,12 @@ export class FinalizationRecovery<
     Promise<FinalizationRecoveryReplayOutcome>
   >();
   private readonly entryLockTails = new Map<string, Promise<void>>();
+  private readonly failedPublisherAuthorityProbes = new Map<string, true>();
   private readonly store: FinalizationRecoveryStore | undefined;
   private readonly storeSource: FinalizationRecoveryStoreSource | undefined;
   private readonly liveRetryLimit: number;
   private readonly liveRetryWindowMs: number;
   private readonly now: () => number;
-  private readonly deferredFailureStreaks = new Map<
-    string,
-    { generation: number; reason: string; count: number }
-  >();
 
   constructor(
     store: FinalizationRecoveryStore | FinalizationRecoveryStoreSource | undefined,
@@ -367,7 +365,7 @@ export class FinalizationRecovery<
     return this.withEntryLock(key, async () => {
       const received = await this.receiveOutcome(input);
       if (received.status === 'pending') {
-        await this.recordPendingPublisherAuthority(store, key, input);
+        await this.observePublisherAuthority(store, key, input);
         return { status: 'handled' };
       }
       if (received.status === 'capacity') {
@@ -391,16 +389,10 @@ export class FinalizationRecovery<
       // the autonomous retry budget.
       if (!this.isLiveEntry(entry)) return { status: 'handled' };
 
-      // A relay may win admission before the publisher's own delivery arrives.
-      // Preserve that later authority observation even while an autonomous
-      // retry deadline is parked; it is durable evidence, not a retry attempt.
-      if (
-        !entry.trustedPublisherPeerId
-        && input.sourcePeerId !== undefined
-        && input.sourcePeerId !== entry.sourcePeerId
-      ) {
-        await this.recordPendingPublisherAuthority(store, key, input);
-      }
+      // Every accepted delivery gets one authority-observation phase before
+      // retry scheduling. Its prepared workspace result is reused below when
+      // the materialization gate is open.
+      const authority = await this.observePublisherAuthority(store, key, input, entry);
 
       // The worker and reconciliation paths already honor this durable gate.
       // Live duplicate gossip must do the same: the per-entry lock serializes
@@ -413,7 +405,11 @@ export class FinalizationRecovery<
 
       for (let attempt = 0; attempt < 2; attempt += 1) {
         try {
-          const outcome = await this.materialize(input, { kind: 'recovery', entry });
+          const outcome = await this.materialize(
+            input,
+            { kind: 'recovery', entry },
+            authority.prepared,
+          );
           if (outcome === 'deferred') {
             await this.recordDeferred(
               entry,
@@ -444,12 +440,15 @@ export class FinalizationRecovery<
     });
   }
 
-  private async recordPendingPublisherAuthority(
+  private async observePublisherAuthority(
     store: FinalizationRecoveryStore,
     key: string,
     input: FinalizationRecoveryLiveInput,
-  ): Promise<void> {
-    if (!input.sourcePeerId) return;
+    entry?: FinalizationRecoveryEntry,
+  ): Promise<{ prepared?: Prepared }> {
+    if (!input.sourcePeerId || entry?.trustedPublisherPeerId) return {};
+    const probeKey = `${key}|${entry?.generation ?? 'pending'}|${input.sourcePeerId}`;
+    if (this.failedPublisherAuthorityProbes.has(probeKey)) return {};
     let prepared: Prepared | undefined;
     try {
       prepared = await this.materializer.prepare(input);
@@ -459,11 +458,33 @@ export class FinalizationRecovery<
           + `${input.candidate.scope.ual}: `
           + `${error instanceof Error ? error.message : String(error)}`,
       );
-      return;
+      return {};
     }
-    if (!prepared || input.sourcePeerId !== prepared.publisherPeerId) return;
+    if (!prepared || input.sourcePeerId !== prepared.publisherPeerId) {
+      this.failedPublisherAuthorityProbes.delete(probeKey);
+      this.failedPublisherAuthorityProbes.set(probeKey, true);
+      while (
+        this.failedPublisherAuthorityProbes.size
+        > FAILED_PUBLISHER_AUTHORITY_PROBE_MAX_ENTRIES
+      ) {
+        const oldest = this.failedPublisherAuthorityProbes.keys().next().value as
+          | string
+          | undefined;
+        if (oldest === undefined) break;
+        this.failedPublisherAuthorityProbes.delete(oldest);
+      }
+      return { prepared };
+    }
     try {
-      if (await store.recordPendingTrustedPublisher(key, prepared.publisherPeerId)) return;
+      if (entry) {
+        if (await store.recordTrustedPublisher(
+          key,
+          entry.generation,
+          prepared.publisherPeerId,
+        )) return { prepared };
+      } else if (await store.recordPendingTrustedPublisher(key, prepared.publisherPeerId)) {
+        return { prepared };
+      }
       // Promotion is serialized by the store but is intentionally independent
       // of the per-entry recovery lock. If it moved this row between admission
       // and the authority CAS, preserve the same monotonic evidence on the live row.
@@ -476,7 +497,7 @@ export class FinalizationRecovery<
           promoted.generation,
           prepared.publisherPeerId,
         )
-      ) return;
+      ) return { prepared };
       this.log.warn(
         `Finalization recovery inbox refused publisher authority for `
           + `${input.candidate.scope.ual}`,
@@ -488,6 +509,7 @@ export class FinalizationRecovery<
           + `${error instanceof Error ? error.message : String(error)}`,
       );
     }
+    return {};
   }
 
   /**
@@ -578,8 +600,11 @@ export class FinalizationRecovery<
     const liveRetryAgeMs = Math.max(0, this.now() - entry.createdAt);
     if (
       this.isLiveEntry(entry)
-      && entry.attemptCount >= this.liveRetryLimit
       && liveRetryAgeMs >= this.liveRetryWindowMs
+      && (
+        entry.attemptCount >= this.liveRetryLimit
+        || entry.failureStreak >= FINALIZATION_RECOVERY_STABLE_FAILURE_THRESHOLD
+      )
     ) {
       const reason = 'autonomous retry budget exhausted after '
         + `${entry.attemptCount} attempts over ${liveRetryAgeMs}ms`;
@@ -956,6 +981,7 @@ export class FinalizationRecovery<
   private async materialize(
     input: FinalizationRecoveryLiveInput,
     context: FinalizationVerificationContext,
+    observedPrepared?: Prepared,
   ): Promise<FinalizationRecoveryApplyOutcome> {
     const preparationInput = context.kind === 'recovery'
       && context.entry.trustedPublisherPeerId
@@ -964,7 +990,7 @@ export class FinalizationRecovery<
           sourcePeerId: context.entry.trustedPublisherPeerId,
         }
       : input;
-    const prepared = await this.materializer.prepare(preparationInput);
+    const prepared = observedPrepared ?? await this.materializer.prepare(preparationInput);
     if (!prepared) return 'deferred';
     if (
       context.kind === 'recovery'
@@ -1094,47 +1120,25 @@ export class FinalizationRecovery<
   ): Promise<void> {
     const store = this.getStore();
     if (!store) return;
-    const retryKey = entry.key;
-    const previous = this.deferredFailureStreaks.get(retryKey);
-    const sameInMemoryFailure = previous?.generation === entry.generation
-      && previous.reason === reason;
-    // `lastError` seeds one persisted occurrence after restart. The in-memory
-    // streak then distinguishes consecutive failures from an old high global
-    // attempt count, without widening the durable schema.
-    const failureStreak = sameInMemoryFailure
-      ? previous.count + 1
-      : entry.lastError === reason
-        ? 2
-        : 1;
     const ordinaryDelay = retryDelayMs ?? deferredRetryDelayMs(entry.attemptCount);
-    let effectiveDelay = failureStreak >= FINALIZATION_RECOVERY_STABLE_FAILURE_THRESHOLD
-      ? Math.max(ordinaryDelay, FINALIZATION_RECOVERY_STABLE_FAILURE_RETRY_MS)
-      : ordinaryDelay;
-    // Parking must not hide an entry past the bounded poison-entry decision.
-    // Once the count budget has been consumed, wake at the wall-clock budget
-    // boundary so replayDueEntryLocked can make the terminal decision.
-    if (
-      entry.attemptCount + 1 >= this.liveRetryLimit
-      && this.liveRetryWindowMs < effectiveDelay
-    ) {
-      const retryWindowRemaining = Math.max(
-        0,
-        entry.createdAt + this.liveRetryWindowMs - this.now(),
-      );
-      effectiveDelay = Math.min(effectiveDelay, retryWindowRemaining);
-    }
     try {
-      await store.recordAttempt(
+      const result = await store.recordAttempt(
         entry.key,
         entry.generation,
         reason,
-        effectiveDelay,
+        {
+          retryDelayMs: ordinaryDelay,
+          failureSignature: reason,
+          stableFailureThreshold: FINALIZATION_RECOVERY_STABLE_FAILURE_THRESHOLD,
+          stableFailureRetryMs: FINALIZATION_RECOVERY_STABLE_FAILURE_RETRY_MS,
+          retryDeadlineAt: entry.createdAt + this.liveRetryWindowMs,
+        },
       );
-      this.deferredFailureStreaks.set(retryKey, {
-        generation: entry.generation,
-        reason,
-        count: failureStreak,
-      });
+      if (result.status === 'stale') {
+        this.log.info(
+          `Finalization recovery ignored stale attempt update for ${entry.ual}`,
+        );
+      }
     } catch (error) {
       this.log.warn(
         `Finalization recovery attempt update failed for ${entry.ual}: `
@@ -1446,7 +1450,7 @@ export class FinalizationRecovery<
         entry.key,
         entry.generation,
         reason,
-        delayMs,
+        { retryDelayMs: delayMs },
       );
     } catch (error) {
       this.log.warn(
@@ -1653,9 +1657,7 @@ export class FinalizationRecovery<
     const store = this.getStore();
     if (!store) return false;
     try {
-      const transitioned = await store.transition(entry.key, entry.generation, state, reason);
-      if (transitioned) this.deferredFailureStreaks.delete(entry.key);
-      return transitioned;
+      return await store.transition(entry.key, entry.generation, state, reason);
     } catch (error) {
       this.log.warn(
         `Finalization recovery transition to ${state} failed for ${entry.ual}: `

--- a/packages/agent/test/finalization-recovery-sqlite-migration.test.ts
+++ b/packages/agent/test/finalization-recovery-sqlite-migration.test.ts
@@ -115,6 +115,8 @@ async function makeDatabaseV1(databasePath: string): Promise<void> {
     DROP INDEX finalization_pending_graph_v2;
     DROP INDEX finalization_pending_time_v2;
     DROP TABLE finalization_pending_v2;
+    ALTER TABLE finalization_inbox_v1 DROP COLUMN failure_signature;
+    ALTER TABLE finalization_inbox_v1 DROP COLUMN failure_streak;
     PRAGMA user_version = 1;
   `);
   legacy.close();
@@ -130,10 +132,13 @@ describe('SQLite finalization recovery migration and crash recovery', () => {
       const migrated = await openSqliteFinalizationRecoveryStore(directory);
       expect(await migrated.list()).toMatchObject([{ key: 'entry-1', state: 'RECEIVED' }]);
       const schema = new DatabaseSync(databasePath, { readOnly: true });
-      expect(schema.prepare('PRAGMA user_version').get()?.user_version).toBe(2);
+      expect(schema.prepare('PRAGMA user_version').get()?.user_version).toBe(3);
       expect(schema.prepare(
         "SELECT name FROM sqlite_schema WHERE name = 'finalization_pending_v2'",
       ).get()?.name).toBe('finalization_pending_v2');
+      expect(schema.prepare(
+        "SELECT name FROM pragma_table_info('finalization_inbox_v1') WHERE name = 'failure_streak'",
+      ).get()?.name).toBe('failure_streak');
       schema.close();
       await migrated.close();
     } finally {
@@ -153,10 +158,13 @@ describe('SQLite finalization recovery migration and crash recovery', () => {
       const recovered = await openSqliteFinalizationRecoveryStore(directory);
       expect(await recovered.list()).toMatchObject([{ key: 'entry-1', state: 'RECEIVED' }]);
       const schema = new DatabaseSync(databasePath, { readOnly: true });
-      expect(schema.prepare('PRAGMA user_version').get()?.user_version).toBe(2);
+      expect(schema.prepare('PRAGMA user_version').get()?.user_version).toBe(3);
       expect(schema.prepare(
         "SELECT name FROM sqlite_schema WHERE name = 'finalization_pending_v2'",
       ).get()?.name).toBe('finalization_pending_v2');
+      expect(schema.prepare(
+        "SELECT name FROM pragma_table_info('finalization_inbox_v1') WHERE name = 'failure_streak'",
+      ).get()?.name).toBe('failure_streak');
       schema.close();
       await recovered.close();
     } finally {

--- a/packages/agent/test/finalization-recovery-sqlite-migration.test.ts
+++ b/packages/agent/test/finalization-recovery-sqlite-migration.test.ts
@@ -122,6 +122,20 @@ async function makeDatabaseV1(databasePath: string): Promise<void> {
   legacy.close();
 }
 
+async function makeDatabaseV2(databasePath: string): Promise<void> {
+  const initial = await openSqliteFinalizationRecoveryStore(dirname(databasePath));
+  await initial.receive(received());
+  await initial.close();
+
+  const v2 = new DatabaseSync(databasePath);
+  v2.exec(`
+    ALTER TABLE finalization_inbox_v1 DROP COLUMN failure_signature;
+    ALTER TABLE finalization_inbox_v1 DROP COLUMN failure_streak;
+    PRAGMA user_version = 2;
+  `);
+  v2.close();
+}
+
 describe('SQLite finalization recovery migration and crash recovery', () => {
   it('migrates a v1 inbox in place without losing accepted entries', async () => {
     const directory = await temporaryDirectory();
@@ -167,6 +181,28 @@ describe('SQLite finalization recovery migration and crash recovery', () => {
       ).get()?.name).toBe('failure_streak');
       schema.close();
       await recovered.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('migrates a clean persisted v2 inbox and defaults its failure streak', async () => {
+    const directory = await temporaryDirectory();
+    const databasePath = join(directory, FINALIZATION_INBOX_DATABASE_FILENAME);
+    try {
+      await makeDatabaseV2(databasePath);
+      expect((await readFile(databasePath)).readUInt32BE(60)).toBe(2);
+
+      const migrated = await openSqliteFinalizationRecoveryStore(directory);
+      expect(await migrated.list()).toMatchObject([{
+        key: 'entry-1',
+        state: 'RECEIVED',
+        failureStreak: 0,
+      }]);
+      const schema = new DatabaseSync(databasePath, { readOnly: true });
+      expect(schema.prepare('PRAGMA user_version').get()?.user_version).toBe(3);
+      schema.close();
+      await migrated.close();
     } finally {
       await rm(directory, { recursive: true, force: true });
     }

--- a/packages/agent/test/finalization-recovery-sqlite-store.test.ts
+++ b/packages/agent/test/finalization-recovery-sqlite-store.test.ts
@@ -40,7 +40,7 @@ describe('SQLite finalization recovery store', () => {
       await store.receive(received({ key: 'entry-1' }));
       await store.receive(received({ key: 'entry-2' }));
       await store.receive(received({ key: 'entry-3' }));
-      await store.recordAttempt('entry-1', 0, 'busy', 1_000);
+      await store.recordAttempt('entry-1', 0, 'busy', { retryDelayMs: 1_000 });
       await commitOriginalEvidence(store, 'entry-3', 0, evidence());
       await store.transition('entry-3', 0, 'SETTLED');
 
@@ -60,6 +60,37 @@ describe('SQLite finalization recovery store', () => {
     }
   });
 
+  it('reports a lost attempt CAS after a terminal transition', async () => {
+    const directory = await temporaryDirectory();
+    try {
+      const store = await openSqliteFinalizationRecoveryStore(directory);
+      await store.receive(received());
+      await expect(store.transition('entry-1', 0, 'REJECTED', 'terminal'))
+        .resolves.toBe(true);
+
+      await expect(store.recordAttempt(
+        'entry-1',
+        0,
+        'late failure',
+        {
+          retryDelayMs: 1_000,
+          failureSignature: 'late failure',
+          stableFailureThreshold: 3,
+          stableFailureRetryMs: 10_000,
+        },
+      )).resolves.toEqual({ status: 'stale' });
+      await expect(store.get('entry-1')).resolves.toMatchObject({
+        state: 'REJECTED',
+        attemptCount: 0,
+        failureStreak: 0,
+        lastError: 'terminal',
+      });
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it('lists a SETTLED receipt retry only after its persisted deadline', async () => {
     const directory = await temporaryDirectory();
     try {
@@ -70,7 +101,7 @@ describe('SQLite finalization recovery store', () => {
       await store.receive(received());
       await commitOriginalEvidence(store, 'entry-1', 0, evidence());
       await store.transition('entry-1', 0, 'SETTLED');
-      await store.recordAttempt('entry-1', 0, 'receipt pending', 1_000);
+      await store.recordAttempt('entry-1', 0, 'receipt pending', { retryDelayMs: 1_000 });
 
       await expect(store.listDue(16)).resolves.toEqual([]);
       now = 2_000;
@@ -96,7 +127,7 @@ describe('SQLite finalization recovery store', () => {
         oldestDueAgeMs: 0,
       });
 
-      await store.recordAttempt('entry-1', 0, 'long backoff', 10_000);
+      await store.recordAttempt('entry-1', 0, 'long backoff', { retryDelayMs: 10_000 });
       expect(await store.get('entry-1')).toMatchObject({
         nextAttemptAt: 11_000,
       });
@@ -104,12 +135,12 @@ describe('SQLite finalization recovery store', () => {
 
       now = 1_500;
       await store.recordAttempt('entry-1', 0, 'duplicate without delay');
-      await store.recordAttempt('entry-1', 0, 'shorter backoff', 100);
+      await store.recordAttempt('entry-1', 0, 'shorter backoff', { retryDelayMs: 100 });
       expect(await store.get('entry-1')).toMatchObject({
         nextAttemptAt: 11_000,
       });
 
-      await store.recordAttempt('entry-1', 0, 'longer backoff', 20_000);
+      await store.recordAttempt('entry-1', 0, 'longer backoff', { retryDelayMs: 20_000 });
       expect(await store.get('entry-1')).toMatchObject({
         nextAttemptAt: 21_500,
       });
@@ -267,7 +298,7 @@ describe('SQLite finalization recovery store', () => {
       expect((await store.receive(received())).status).toBe('inserted');
       expect((await commitOriginalEvidence(store, 'entry-1', 0, evidence())).status).toBe('verified');
       for (let attempt = 0; attempt < 4; attempt += 1) {
-        await store.recordAttempt('entry-1', 0, 'store scheduler remained busy', 1_000);
+        await store.recordAttempt('entry-1', 0, 'store scheduler remained busy', { retryDelayMs: 1_000 });
       }
       expect(await store.list()).toMatchObject([{
         state: 'VERIFIED',
@@ -390,7 +421,7 @@ describe('SQLite finalization recovery store', () => {
       }))).status).toBe('inserted');
       expect((await commitOriginalEvidence(store, 'entry-1', 0, evidence())).status).toBe('verified');
       expect(await store.transition('entry-1', 0, 'SETTLED')).toBe(true);
-      await store.recordAttempt('entry-1', 0, 'old settled retry', 1_000);
+      await store.recordAttempt('entry-1', 0, 'old settled retry', { retryDelayMs: 1_000 });
 
       await expect(store.recordSettledPublisherUpgrade(
         'entry-1',

--- a/packages/agent/test/finalization-recovery-sqlite-store.test.ts
+++ b/packages/agent/test/finalization-recovery-sqlite-store.test.ts
@@ -40,7 +40,7 @@ describe('SQLite finalization recovery store', () => {
       await store.receive(received({ key: 'entry-1' }));
       await store.receive(received({ key: 'entry-2' }));
       await store.receive(received({ key: 'entry-3' }));
-      await store.recordAttempt('entry-1', 0, 'busy', { retryDelayMs: 1_000 });
+      await store.recordAttempt('entry-1', 0, 'busy', { mode: 'ordinary', retryDelayMs: 1_000 });
       await commitOriginalEvidence(store, 'entry-3', 0, evidence());
       await store.transition('entry-3', 0, 'SETTLED');
 
@@ -73,10 +73,12 @@ describe('SQLite finalization recovery store', () => {
         0,
         'late failure',
         {
+          mode: 'stable-failure',
           retryDelayMs: 1_000,
-          failureSignature: 'late failure',
+          failureCode: 'store-scheduler-busy',
           stableFailureThreshold: 3,
           stableFailureRetryMs: 10_000,
+          retryDeadlineAt: 60_000,
         },
       )).resolves.toEqual({ status: 'stale' });
       await expect(store.get('entry-1')).resolves.toMatchObject({
@@ -101,7 +103,9 @@ describe('SQLite finalization recovery store', () => {
       await store.receive(received());
       await commitOriginalEvidence(store, 'entry-1', 0, evidence());
       await store.transition('entry-1', 0, 'SETTLED');
-      await store.recordAttempt('entry-1', 0, 'receipt pending', { retryDelayMs: 1_000 });
+      await store.recordAttempt('entry-1', 0, 'receipt pending', {
+        mode: 'ordinary', retryDelayMs: 1_000,
+      });
 
       await expect(store.listDue(16)).resolves.toEqual([]);
       now = 2_000;
@@ -127,7 +131,9 @@ describe('SQLite finalization recovery store', () => {
         oldestDueAgeMs: 0,
       });
 
-      await store.recordAttempt('entry-1', 0, 'long backoff', { retryDelayMs: 10_000 });
+      await store.recordAttempt('entry-1', 0, 'long backoff', {
+        mode: 'ordinary', retryDelayMs: 10_000,
+      });
       expect(await store.get('entry-1')).toMatchObject({
         nextAttemptAt: 11_000,
       });
@@ -135,12 +141,16 @@ describe('SQLite finalization recovery store', () => {
 
       now = 1_500;
       await store.recordAttempt('entry-1', 0, 'duplicate without delay');
-      await store.recordAttempt('entry-1', 0, 'shorter backoff', { retryDelayMs: 100 });
+      await store.recordAttempt('entry-1', 0, 'shorter backoff', {
+        mode: 'ordinary', retryDelayMs: 100,
+      });
       expect(await store.get('entry-1')).toMatchObject({
         nextAttemptAt: 11_000,
       });
 
-      await store.recordAttempt('entry-1', 0, 'longer backoff', { retryDelayMs: 20_000 });
+      await store.recordAttempt('entry-1', 0, 'longer backoff', {
+        mode: 'ordinary', retryDelayMs: 20_000,
+      });
       expect(await store.get('entry-1')).toMatchObject({
         nextAttemptAt: 21_500,
       });
@@ -298,7 +308,9 @@ describe('SQLite finalization recovery store', () => {
       expect((await store.receive(received())).status).toBe('inserted');
       expect((await commitOriginalEvidence(store, 'entry-1', 0, evidence())).status).toBe('verified');
       for (let attempt = 0; attempt < 4; attempt += 1) {
-        await store.recordAttempt('entry-1', 0, 'store scheduler remained busy', { retryDelayMs: 1_000 });
+        await store.recordAttempt('entry-1', 0, 'store scheduler remained busy', {
+          mode: 'ordinary', retryDelayMs: 1_000,
+        });
       }
       expect(await store.list()).toMatchObject([{
         state: 'VERIFIED',
@@ -421,7 +433,9 @@ describe('SQLite finalization recovery store', () => {
       }))).status).toBe('inserted');
       expect((await commitOriginalEvidence(store, 'entry-1', 0, evidence())).status).toBe('verified');
       expect(await store.transition('entry-1', 0, 'SETTLED')).toBe(true);
-      await store.recordAttempt('entry-1', 0, 'old settled retry', { retryDelayMs: 1_000 });
+      await store.recordAttempt('entry-1', 0, 'old settled retry', {
+        mode: 'ordinary', retryDelayMs: 1_000,
+      });
 
       await expect(store.recordSettledPublisherUpgrade(
         'entry-1',

--- a/packages/agent/test/finalization-recovery-store.test.ts
+++ b/packages/agent/test/finalization-recovery-store.test.ts
@@ -196,7 +196,7 @@ describe('finalization recovery attempt planner', () => {
   const stablePolicy = {
     mode: 'stable-failure' as const,
     retryDelayMs: 100,
-    failureCode: 'processing-deferred' as const,
+    failureCode: 'apply-deferred' as const,
     stableFailureThreshold: 3,
     stableFailureRetryMs: 10_000,
     retryDeadlineAt: 20_000,
@@ -225,10 +225,10 @@ describe('finalization recovery attempt planner', () => {
       1_200,
     );
 
-    expect(first).toMatchObject({ failureSignature: 'processing-deferred', failureStreak: 1 });
+    expect(first).toMatchObject({ failureSignature: 'apply-deferred', failureStreak: 1 });
     expect(second).toMatchObject({
       lastError: 'equivalent wording after an edit',
-      failureSignature: 'processing-deferred',
+      failureSignature: 'apply-deferred',
       failureStreak: 2,
     });
     expect(changed).toMatchObject({
@@ -249,7 +249,7 @@ describe('finalization recovery attempt planner', () => {
 
     const stable = planFinalizationRecoveryAttempt(
       entry({
-        failureSignature: 'processing-deferred',
+        failureSignature: 'apply-deferred',
         failureStreak: 2,
       }),
       'still deferred',

--- a/packages/agent/test/finalization-recovery-store.test.ts
+++ b/packages/agent/test/finalization-recovery-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  planFinalizationRecoveryAttempt,
   planFinalizationRecoveryVerifiedEvidenceTransition,
   type FinalizationRecoveryEntry,
   type FinalizationRecoveryVerifiedEvidenceCommit,
@@ -9,6 +10,10 @@ import {
   TX_HASH,
   evidence,
 } from './finalization-recovery-sqlite-test-helpers.js';
+import {
+  finalizationEnvelopeSha256,
+  finalizationRecoveryRowToEntry,
+} from '../src/finalization-recovery-sqlite-codec.js';
 
 function entry(
   overrides: Partial<FinalizationRecoveryEntry> = {},
@@ -184,5 +189,124 @@ describe('finalization recovery verified-evidence transition planner', () => {
         placement: 'original',
       },
     ).status).toBe('update');
+  });
+});
+
+describe('finalization recovery attempt planner', () => {
+  const stablePolicy = {
+    mode: 'stable-failure' as const,
+    retryDelayMs: 100,
+    failureCode: 'processing-deferred' as const,
+    stableFailureThreshold: 3,
+    stableFailureRetryMs: 10_000,
+    retryDeadlineAt: 20_000,
+  };
+
+  it('keys consecutive failures by code rather than diagnostic wording', () => {
+    const first = planFinalizationRecoveryAttempt(
+      entry(),
+      'first wording',
+      stablePolicy,
+      1_000,
+    );
+    const second = planFinalizationRecoveryAttempt(
+      entry({ ...first }),
+      'equivalent wording after an edit',
+      stablePolicy,
+      1_100,
+    );
+    const changed = planFinalizationRecoveryAttempt(
+      entry({ ...second }),
+      'unrelated transient failure',
+      {
+        ...stablePolicy,
+        failureCode: 'store-scheduler-busy',
+      },
+      1_200,
+    );
+
+    expect(first).toMatchObject({ failureSignature: 'processing-deferred', failureStreak: 1 });
+    expect(second).toMatchObject({
+      lastError: 'equivalent wording after an edit',
+      failureSignature: 'processing-deferred',
+      failureStreak: 2,
+    });
+    expect(changed).toMatchObject({
+      failureSignature: 'store-scheduler-busy',
+      failureStreak: 1,
+      nextAttemptAt: 1_300,
+    });
+  });
+
+  it('caps only a terminally actionable stable failure at its deadline', () => {
+    const belowThreshold = planFinalizationRecoveryAttempt(
+      entry({ createdAt: 1_000 }),
+      'old but not stable',
+      { ...stablePolicy, retryDeadlineAt: 2_000 },
+      10_000,
+    );
+    expect(belowThreshold.nextAttemptAt).toBe(10_100);
+
+    const stable = planFinalizationRecoveryAttempt(
+      entry({
+        failureSignature: 'processing-deferred',
+        failureStreak: 2,
+      }),
+      'still deferred',
+      {
+        ...stablePolicy,
+        stableFailureRetryMs: 6_000,
+        retryDeadlineAt: 2_000,
+      },
+      1_900,
+    );
+    expect(stable).toMatchObject({ failureStreak: 3, nextAttemptAt: 2_000 });
+  });
+
+  it('preserves future backoff for settled retries after the live window', () => {
+    expect(planFinalizationRecoveryAttempt(
+      entry({ state: 'SETTLED', createdAt: 1_000 }),
+      'receipt still pending',
+      { mode: 'ordinary', retryDelayMs: 1_000 },
+      10_000,
+    )).toMatchObject({
+      failureSignature: null,
+      failureStreak: 0,
+      nextAttemptAt: 11_000,
+    });
+  });
+
+  it('rejects a current-schema row with a missing failure streak', () => {
+    expect(() => finalizationRecoveryRowToEntry({
+      key: 'entry-1',
+      state: 'RECEIVED',
+      chain_id: 'base:84532',
+      context_graph_id: 'graph',
+      source_peer_id: null,
+      trusted_publisher_peer_id: null,
+      publisher_upgrade_pending: 0,
+      ual: entry().ual,
+      tx_hash: TX_HASH,
+      assertion_version: '1',
+      merkle_root: `0x${'01'.repeat(32)}`,
+      ka_id: '7',
+      batch_id: '7',
+      target_context_graph_id: null,
+      block_number: null,
+      block_hash: null,
+      tx_index: null,
+      publisher_address: null,
+      author_address: null,
+      envelope_sha256: finalizationEnvelopeSha256(RAW),
+      raw_envelope: RAW,
+      verified_evidence_json: null,
+      generation: 0,
+      attempt_count: 0,
+      failure_signature: null,
+      next_attempt_at: null,
+      last_error: null,
+      created_at: 1_000,
+      updated_at: 1_000,
+    })).toThrow('invalid failure_streak');
   });
 });

--- a/packages/agent/test/finalization-recovery-store.test.ts
+++ b/packages/agent/test/finalization-recovery-store.test.ts
@@ -31,6 +31,7 @@ function entry(
     rawMessage: RAW,
     generation: 0,
     attemptCount: 0,
+    failureStreak: 0,
     createdAt: 1_000,
     updatedAt: 1_000,
     ...overrides,
@@ -45,6 +46,8 @@ describe('finalization recovery verified-evidence transition planner', () => {
         state: 'REORGED',
         generation: 2,
         attemptCount: 3,
+        failureSignature: 'receipt-pending',
+        failureStreak: 2,
         nextAttemptAt: 5_000,
         lastError: 'receipt lookup pending',
       }),
@@ -57,6 +60,8 @@ describe('finalization recovery verified-evidence transition planner', () => {
         verifiedEvidence,
         generation: 2,
         attemptCount: 3,
+        failureSignature: 'receipt-pending',
+        failureStreak: 2,
         nextAttemptAt: 5_000,
         lastError: 'receipt lookup pending',
       },
@@ -74,6 +79,8 @@ describe('finalization recovery verified-evidence transition planner', () => {
         attemptCount: 3,
         nextAttemptAt: 5_000,
         lastError: 'receipt lookup pending',
+        failureSignature: 'receipt-pending',
+        failureStreak: 2,
       }),
       0,
       {
@@ -90,6 +97,8 @@ describe('finalization recovery verified-evidence transition planner', () => {
         attemptCount: 0,
         nextAttemptAt: null,
         lastError: 'independently recovered canonical receipt moved',
+        failureSignature: null,
+        failureStreak: 0,
       },
     });
   });

--- a/packages/agent/test/finalization-recovery.test.ts
+++ b/packages/agent/test/finalization-recovery.test.ts
@@ -30,7 +30,6 @@ import {
   type VerifiedGraphScopedFinalizationEvidence,
 } from '../src/finalization-graph-envelope.js';
 import {
-  FINALIZATION_RECOVERY_LIVE_RETRY_WINDOW_MS,
   FINALIZATION_RECOVERY_STABLE_FAILURE_RETRY_MS,
   FinalizationRecovery,
 } from '../src/finalization-recovery.js';
@@ -435,7 +434,7 @@ describe('graph-scoped finalization recovery admission', () => {
       [entry] = await store.list();
       expect(entry).toMatchObject({
         attemptCount: 3,
-        failureSignature: 'replay processing deferred',
+        failureSignature: 'processing-deferred',
         failureStreak: 3,
         lastError: 'replay processing deferred',
       });
@@ -463,11 +462,12 @@ describe('graph-scoped finalization recovery admission', () => {
     }
   });
 
-  it('rejects a default-policy parked poison entry at the seven-day boundary', async () => {
+  it('caps a stable retry at the live deadline and rejects it there', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-stable-expiry-'));
     try {
       let now = 1_000;
       const store = await openSqliteFinalizationRecoveryStore(directory, { now: () => now });
+      const liveRetryWindowMs = 5_000;
       const recovery = new FinalizationRecovery(
         store,
         recoveryChain(),
@@ -477,7 +477,7 @@ describe('graph-scoped finalization recovery admission', () => {
           apply: async () => 'deferred' as const,
           replayVerified: async () => 'no-swm' as const,
         },
-        { now: () => now },
+        { now: () => now, liveRetryWindowMs },
       );
       await recovery.receive({
         rawMessage: encodeFinalizationMessage(message()),
@@ -492,8 +492,9 @@ describe('graph-scoped finalization recovery admission', () => {
       }
       const [parked] = await store.list();
       expect(parked).toMatchObject({ attemptCount: 3, failureStreak: 3 });
+      expect(parked!.nextAttemptAt).toBe(parked!.createdAt + liveRetryWindowMs);
 
-      now = parked!.createdAt + FINALIZATION_RECOVERY_LIVE_RETRY_WINDOW_MS;
+      now = parked!.nextAttemptAt!;
       await expect(recovery.processDueBatch(16)).resolves.toBe(1);
       expect(await store.list()).toMatchObject([{
         state: 'REJECTED',
@@ -991,12 +992,20 @@ describe('graph-scoped finalization recovery admission', () => {
       expect(preparedSources).toEqual(['12D3KooWRelayA', '12D3KooWRelayB']);
       expect(receiptCalls).toBe(1);
 
+      // A and B plus 4,095 new relay identities exceed the production 4,096
+      // bound. The oldest failed identity (A) must then be probed again.
+      for (let relay = 0; relay < 4_095; relay += 1) {
+        await recovery.processLive({
+          ...baseInput,
+          sourcePeerId: `12D3KooWRelay-${relay}`,
+        });
+      }
+      await recovery.processLive({ ...baseInput, sourcePeerId: '12D3KooWRelayA' });
+      expect(preparedSources).toHaveLength(4_098);
+      expect(preparedSources.at(-1)).toBe('12D3KooWRelayA');
+
       await recovery.processLive({ ...baseInput, sourcePeerId: '12D3KooWPublisher' });
-      expect(preparedSources).toEqual([
-        '12D3KooWRelayA',
-        '12D3KooWRelayB',
-        '12D3KooWPublisher',
-      ]);
+      expect(preparedSources.at(-1)).toBe('12D3KooWPublisher');
       expect(await store.list()).toMatchObject([{
         trustedPublisherPeerId: '12D3KooWPublisher',
         attemptCount: 1,
@@ -1028,7 +1037,9 @@ describe('graph-scoped finalization recovery admission', () => {
         sourcePeerId: '12D3KooWPublisher',
         candidate: parsedMessage(),
       });
-      await store.recordAttempt(entry!.key, entry!.generation, 'worker busy', { retryDelayMs: 60_000 });
+      await store.recordAttempt(entry!.key, entry!.generation, 'worker busy', {
+        mode: 'ordinary', retryDelayMs: 60_000,
+      });
 
       await expect(recovery.replayMatching({
         chainId: chain.chainId,

--- a/packages/agent/test/finalization-recovery.test.ts
+++ b/packages/agent/test/finalization-recovery.test.ts
@@ -398,7 +398,11 @@ describe('graph-scoped finalization recovery admission', () => {
       });
       const makeRecovery = () => new FinalizationRecovery(
         store,
-        recoveryChain(),
+        recoveryChain({
+          resolveCanonicalFinalizationReceipt: async () => repairReady
+            ? { status: 'confirmed', receipt: confirmedReceipt() }
+            : { status: 'pending' },
+        }),
         { info: () => {}, warn: () => {} },
         {
           ...recoveryMaterializer(),
@@ -421,7 +425,7 @@ describe('graph-scoped finalization recovery admission', () => {
       expect(entry).toMatchObject({
         attemptCount: 1,
         failureStreak: 1,
-        lastError: 'replay processing deferred',
+        lastError: 'canonical-receipt-pending',
       });
       await store.close();
       store = await openSqliteFinalizationRecoveryStore(directory, { now: () => now });
@@ -434,9 +438,9 @@ describe('graph-scoped finalization recovery admission', () => {
       [entry] = await store.list();
       expect(entry).toMatchObject({
         attemptCount: 3,
-        failureSignature: 'processing-deferred',
+        failureSignature: 'receipt-pending',
         failureStreak: 3,
-        lastError: 'replay processing deferred',
+        lastError: 'canonical-receipt-pending',
       });
       expect(entry!.nextAttemptAt).toBe(now + FINALIZATION_RECOVERY_STABLE_FAILURE_RETRY_MS);
 
@@ -462,6 +466,61 @@ describe('graph-scoped finalization recovery admission', () => {
     }
   });
 
+  it('resets the stable streak when recovery advances to a different stage', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-stage-progress-'));
+    try {
+      let now = 1_000;
+      let receiptPending = true;
+      const store = await openSqliteFinalizationRecoveryStore(directory, { now: () => now });
+      const recovery = new FinalizationRecovery(
+        store,
+        recoveryChain({
+          resolveCanonicalFinalizationReceipt: async () => {
+            return receiptPending
+              ? { status: 'pending' as const }
+              : { status: 'confirmed' as const, receipt: confirmedReceipt() };
+          },
+        }),
+        { info: () => {}, warn: () => {} },
+        {
+          ...recoveryMaterializer(),
+          apply: async () => 'deferred' as const,
+        },
+        { now: () => now },
+      );
+      await recovery.receive({
+        rawMessage: encodeFinalizationMessage(message()),
+        contextGraphId: CONTEXT_GRAPH,
+        sourcePeerId: '12D3KooWPublisher',
+        candidate: parsedMessage(),
+      });
+
+      await recovery.processDueBatch(16);
+      let [entry] = await store.list();
+      expect(entry).toMatchObject({ failureSignature: 'receipt-pending', failureStreak: 1 });
+      now = entry!.nextAttemptAt!;
+      await recovery.processDueBatch(16);
+      [entry] = await store.list();
+      expect(entry).toMatchObject({ failureSignature: 'receipt-pending', failureStreak: 2 });
+
+      now = entry!.nextAttemptAt!;
+      receiptPending = false;
+      await recovery.processDueBatch(16);
+      [entry] = await store.list();
+      expect(entry).toMatchObject({
+        state: 'VERIFIED',
+        failureSignature: 'apply-deferred',
+        failureStreak: 1,
+      });
+      expect(entry!.nextAttemptAt).toBeLessThan(
+        now + FINALIZATION_RECOVERY_STABLE_FAILURE_RETRY_MS,
+      );
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it('caps a stable retry at the live deadline and rejects it there', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-stable-expiry-'));
     try {
@@ -470,13 +529,11 @@ describe('graph-scoped finalization recovery admission', () => {
       const liveRetryWindowMs = 5_000;
       const recovery = new FinalizationRecovery(
         store,
-        recoveryChain(),
+        recoveryChain({
+          resolveCanonicalFinalizationReceipt: async () => ({ status: 'pending' }),
+        }),
         { info: () => {}, warn: () => {} },
-        {
-          ...recoveryMaterializer(),
-          apply: async () => 'deferred' as const,
-          replayVerified: async () => 'no-swm' as const,
-        },
+        recoveryMaterializer(),
         { now: () => now, liveRetryWindowMs },
       );
       await recovery.receive({

--- a/packages/agent/test/finalization-recovery.test.ts
+++ b/packages/agent/test/finalization-recovery.test.ts
@@ -279,6 +279,7 @@ describe('graph-scoped finalization recovery admission', () => {
       });
       const preparedSources: Array<string | undefined> = [];
       let appliedAccess: { policy: string; peers: string[] } | undefined;
+      let workspaceAvailable = false;
       const recovery = new FinalizationRecovery(
         store,
         recoveryChain(),
@@ -287,6 +288,7 @@ describe('graph-scoped finalization recovery admission', () => {
           ...recoveryMaterializer(),
           prepare: async (input) => {
             preparedSources.push(input.sourcePeerId);
+            if (!workspaceAvailable) return undefined;
             return {
               onChainContextGraphId: '42',
               localTopicOnChainContextGraphId: '42',
@@ -314,6 +316,11 @@ describe('graph-scoped finalization recovery admission', () => {
         ...baseInput,
         sourcePeerId: '12D3KooWRelay',
       });
+      await recovery.processLiveOutcome({
+        ...baseInput,
+        sourcePeerId: '12D3KooWPublisher',
+      });
+      workspaceAvailable = true;
       await recovery.processLiveOutcome({
         ...baseInput,
         sourcePeerId: '12D3KooWPublisher',

--- a/packages/agent/test/finalization-recovery.test.ts
+++ b/packages/agent/test/finalization-recovery.test.ts
@@ -33,10 +33,14 @@ import {
   FINALIZATION_RECOVERY_STABLE_FAILURE_RETRY_MS,
   FinalizationRecovery,
 } from '../src/finalization-recovery.js';
+import { FinalizationPublisherAuthorityObserver } from '../src/finalization-publisher-authority-observer.js';
 import {
   openSqliteFinalizationRecoveryStore,
 } from '../src/finalization-recovery-sqlite-store.js';
-import type { FinalizationRecoveryStore } from '../src/finalization-recovery-store.js';
+import type {
+  FinalizationRecoveryEntry,
+  FinalizationRecoveryStore,
+} from '../src/finalization-recovery-store.js';
 
 const CONTEXT_GRAPH = 'finalization-recovery-admission';
 const AUTHOR = '0x1111111111111111111111111111111111111111';
@@ -205,6 +209,53 @@ describe('graph-scoped finalization recovery admission', () => {
     }
     expect(processUnjournaled).toHaveBeenCalledOnce();
     expect(processUnjournaled).toHaveBeenCalledWith(input);
+  });
+
+  it('retries publisher authority on a promoted row and reports store refusal', async () => {
+    const prepared = { publisherPeerId: '12D3KooWPublisher' };
+    const promoted = {
+      state: 'REORGED',
+      generation: 7,
+    } as FinalizationRecoveryEntry;
+    const recordPendingTrustedPublisher = vi.fn(async () => false);
+    const recordTrustedPublisher = vi.fn(async () => false);
+    const get = vi.fn(async () => promoted);
+    const warn = vi.fn();
+    const observer = new FinalizationPublisherAuthorityObserver<void, typeof prepared>({
+      maxFailedProbes: 4,
+      prepare: async () => prepared,
+      log: { info: vi.fn(), warn },
+    });
+    const store = {
+      recordPendingTrustedPublisher,
+      recordTrustedPublisher,
+      get,
+    } as unknown as FinalizationRecoveryStore;
+
+    await expect(observer.observe({
+      store,
+      identity: {
+        entryKey: 'promoted-entry',
+        generation: 'pending',
+        sourcePeerId: prepared.publisherPeerId,
+      },
+      ual: UAL,
+      prepareInput: undefined,
+    })).resolves.toEqual({ prepared });
+
+    expect(recordPendingTrustedPublisher).toHaveBeenCalledWith(
+      'promoted-entry',
+      prepared.publisherPeerId,
+    );
+    expect(get).toHaveBeenCalledWith('promoted-entry');
+    expect(recordTrustedPublisher).toHaveBeenCalledWith(
+      'promoted-entry',
+      promoted.generation,
+      prepared.publisherPeerId,
+    );
+    expect(warn).toHaveBeenCalledWith(
+      `Finalization recovery inbox refused publisher authority for ${UAL}`,
+    );
   });
 
   it('preserves publisher authority when a trusted duplicate arrives while deferred', async () => {

--- a/packages/agent/test/finalization-recovery.test.ts
+++ b/packages/agent/test/finalization-recovery.test.ts
@@ -30,6 +30,7 @@ import {
   type VerifiedGraphScopedFinalizationEvidence,
 } from '../src/finalization-graph-envelope.js';
 import {
+  FINALIZATION_RECOVERY_LIVE_RETRY_WINDOW_MS,
   FINALIZATION_RECOVERY_STABLE_FAILURE_RETRY_MS,
   FinalizationRecovery,
 } from '../src/finalization-recovery.js';
@@ -389,13 +390,14 @@ describe('graph-scoped finalization recovery admission', () => {
 
   it('parks a stable deferred failure while chain reconciliation can still wake it', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-stable-failure-'));
+    let store: Awaited<ReturnType<typeof openSqliteFinalizationRecoveryStore>> | undefined;
     try {
       let now = 1_000;
       let repairReady = false;
-      const store = await openSqliteFinalizationRecoveryStore(directory, {
+      store = await openSqliteFinalizationRecoveryStore(directory, {
         now: () => now,
       });
-      const recovery = new FinalizationRecovery(
+      const makeRecovery = () => new FinalizationRecovery(
         store,
         recoveryChain(),
         { info: () => {}, warn: () => {} },
@@ -405,6 +407,7 @@ describe('graph-scoped finalization recovery admission', () => {
           replayVerified: async () => repairReady ? 'promoted' as const : 'no-swm' as const,
         },
       );
+      let recovery = makeRecovery();
       await recovery.receive({
         rawMessage: encodeFinalizationMessage(message()),
         contextGraphId: CONTEXT_GRAPH,
@@ -416,14 +419,26 @@ describe('graph-scoped finalization recovery admission', () => {
       // delay. The third consecutive identical outcome enters the stable park.
       await expect(recovery.processDueBatch(16)).resolves.toBe(1);
       let [entry] = await store.list();
-      expect(entry).toMatchObject({ attemptCount: 1, lastError: 'replay processing deferred' });
+      expect(entry).toMatchObject({
+        attemptCount: 1,
+        failureStreak: 1,
+        lastError: 'replay processing deferred',
+      });
+      await store.close();
+      store = await openSqliteFinalizationRecoveryStore(directory, { now: () => now });
+      recovery = makeRecovery();
       now = entry!.nextAttemptAt!;
       await expect(recovery.processDueBatch(16)).resolves.toBe(1);
       [entry] = await store.list();
       now = entry!.nextAttemptAt!;
       await expect(recovery.processDueBatch(16)).resolves.toBe(1);
       [entry] = await store.list();
-      expect(entry).toMatchObject({ attemptCount: 3, lastError: 'replay processing deferred' });
+      expect(entry).toMatchObject({
+        attemptCount: 3,
+        failureSignature: 'replay processing deferred',
+        failureStreak: 3,
+        lastError: 'replay processing deferred',
+      });
       expect(entry!.nextAttemptAt).toBe(now + FINALIZATION_RECOVERY_STABLE_FAILURE_RETRY_MS);
 
       await expect(recovery.processDueBatch(16)).resolves.toBe(0);
@@ -440,6 +455,50 @@ describe('graph-scoped finalization recovery admission', () => {
         kaId: PACKED_KA_ID.toString(),
       })).resolves.toBe('recovered');
       expect(await store.list()).toMatchObject([{ state: 'SETTLED' }]);
+      await store.close();
+      store = undefined;
+    } finally {
+      await store?.close().catch(() => {});
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a default-policy parked poison entry at the seven-day boundary', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-stable-expiry-'));
+    try {
+      let now = 1_000;
+      const store = await openSqliteFinalizationRecoveryStore(directory, { now: () => now });
+      const recovery = new FinalizationRecovery(
+        store,
+        recoveryChain(),
+        { info: () => {}, warn: () => {} },
+        {
+          ...recoveryMaterializer(),
+          apply: async () => 'deferred' as const,
+          replayVerified: async () => 'no-swm' as const,
+        },
+        { now: () => now },
+      );
+      await recovery.receive({
+        rawMessage: encodeFinalizationMessage(message()),
+        contextGraphId: CONTEXT_GRAPH,
+        sourcePeerId: '12D3KooWPublisher',
+        candidate: parsedMessage(),
+      });
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        await expect(recovery.processDueBatch(16)).resolves.toBe(1);
+        const [entry] = await store.list();
+        now = entry!.nextAttemptAt!;
+      }
+      const [parked] = await store.list();
+      expect(parked).toMatchObject({ attemptCount: 3, failureStreak: 3 });
+
+      now = parked!.createdAt + FINALIZATION_RECOVERY_LIVE_RETRY_WINDOW_MS;
+      await expect(recovery.processDueBatch(16)).resolves.toBe(1);
+      expect(await store.list()).toMatchObject([{
+        state: 'REJECTED',
+        attemptCount: 3,
+      }]);
       await store.close();
     } finally {
       await rm(directory, { recursive: true, force: true });
@@ -894,6 +953,61 @@ describe('graph-scoped finalization recovery admission', () => {
     }
   });
 
+  it('bounds parked alternate-relay probes while recording the publisher immediately', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-authority-probes-'));
+    try {
+      let now = 1_000;
+      let receiptCalls = 0;
+      const preparedSources: Array<string | undefined> = [];
+      const store = await openSqliteFinalizationRecoveryStore(directory, { now: () => now });
+      const recovery = new FinalizationRecovery(
+        store,
+        recoveryChain({
+          resolveCanonicalFinalizationReceipt: async () => {
+            receiptCalls += 1;
+            return { status: 'pending' };
+          },
+        }),
+        { info: () => {}, warn: () => {} },
+        {
+          ...recoveryMaterializer(),
+          prepare: async (input) => {
+            preparedSources.push(input.sourcePeerId);
+            return recoveryMaterializer().prepare();
+          },
+        },
+        { now: () => now },
+      );
+      const baseInput = {
+        rawMessage: encodeFinalizationMessage(message()),
+        contextGraphId: CONTEXT_GRAPH,
+        candidate: parsedMessage(),
+      };
+
+      await recovery.processLive({ ...baseInput, sourcePeerId: '12D3KooWRelayA' });
+      for (let duplicate = 0; duplicate < 5; duplicate += 1) {
+        await recovery.processLive({ ...baseInput, sourcePeerId: '12D3KooWRelayB' });
+      }
+      expect(preparedSources).toEqual(['12D3KooWRelayA', '12D3KooWRelayB']);
+      expect(receiptCalls).toBe(1);
+
+      await recovery.processLive({ ...baseInput, sourcePeerId: '12D3KooWPublisher' });
+      expect(preparedSources).toEqual([
+        '12D3KooWRelayA',
+        '12D3KooWRelayB',
+        '12D3KooWPublisher',
+      ]);
+      expect(await store.list()).toMatchObject([{
+        trustedPublisherPeerId: '12D3KooWPublisher',
+        attemptCount: 1,
+      }]);
+      expect(receiptCalls).toBe(1);
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it('lets chain reconciliation recover an entry before its worker deadline', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-reconcile-deadline-'));
     try {
@@ -914,7 +1028,7 @@ describe('graph-scoped finalization recovery admission', () => {
         sourcePeerId: '12D3KooWPublisher',
         candidate: parsedMessage(),
       });
-      await store.recordAttempt(entry!.key, entry!.generation, 'worker busy', 60_000);
+      await store.recordAttempt(entry!.key, entry!.generation, 'worker busy', { retryDelayMs: 60_000 });
 
       await expect(recovery.replayMatching({
         chainId: chain.chainId,

--- a/packages/agent/test/finalization-recovery.test.ts
+++ b/packages/agent/test/finalization-recovery.test.ts
@@ -30,6 +30,7 @@ import {
   type VerifiedGraphScopedFinalizationEvidence,
 } from '../src/finalization-graph-envelope.js';
 import {
+  FINALIZATION_RECOVERY_STABLE_FAILURE_RETRY_MS,
   FinalizationRecovery,
 } from '../src/finalization-recovery.js';
 import {
@@ -379,6 +380,65 @@ describe('graph-scoped finalization recovery admission', () => {
       busy = false;
       now = deferred.nextAttemptAt!;
       await expect(recovery.processDueBatch(16)).resolves.toBe(1);
+      expect(await store.list()).toMatchObject([{ state: 'SETTLED' }]);
+      await store.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('parks a stable deferred failure while chain reconciliation can still wake it', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-stable-failure-'));
+    try {
+      let now = 1_000;
+      let repairReady = false;
+      const store = await openSqliteFinalizationRecoveryStore(directory, {
+        now: () => now,
+      });
+      const recovery = new FinalizationRecovery(
+        store,
+        recoveryChain(),
+        { info: () => {}, warn: () => {} },
+        {
+          ...recoveryMaterializer(),
+          apply: async () => repairReady ? 'applied' as const : 'deferred' as const,
+          replayVerified: async () => repairReady ? 'promoted' as const : 'no-swm' as const,
+        },
+      );
+      await recovery.receive({
+        rawMessage: encodeFinalizationMessage(message()),
+        contextGraphId: CONTEXT_GRAPH,
+        sourcePeerId: '12D3KooWPublisher',
+        candidate: parsedMessage(),
+      });
+
+      // The first two identical worker outcomes use the ordinary exponential
+      // delay. The third consecutive identical outcome enters the stable park.
+      await expect(recovery.processDueBatch(16)).resolves.toBe(1);
+      let [entry] = await store.list();
+      expect(entry).toMatchObject({ attemptCount: 1, lastError: 'replay processing deferred' });
+      now = entry!.nextAttemptAt!;
+      await expect(recovery.processDueBatch(16)).resolves.toBe(1);
+      [entry] = await store.list();
+      now = entry!.nextAttemptAt!;
+      await expect(recovery.processDueBatch(16)).resolves.toBe(1);
+      [entry] = await store.list();
+      expect(entry).toMatchObject({ attemptCount: 3, lastError: 'replay processing deferred' });
+      expect(entry!.nextAttemptAt).toBe(now + FINALIZATION_RECOVERY_STABLE_FAILURE_RETRY_MS);
+
+      await expect(recovery.processDueBatch(16)).resolves.toBe(0);
+
+      // An authoritative reconciliation is a state-change trigger and does
+      // not wait for the autonomous retry deadline.
+      repairReady = true;
+      await expect(recovery.replayMatching({
+        chainId: 'base:84532',
+        contextGraphId: CONTEXT_GRAPH,
+        onChainCgId: '42',
+        ual: UAL,
+        merkleRoot: `0x${'00'.repeat(32)}`,
+        kaId: PACKED_KA_ID.toString(),
+      })).resolves.toBe('recovered');
       expect(await store.list()).toMatchObject([{ state: 'SETTLED' }]);
       await store.close();
     } finally {
@@ -1943,6 +2003,10 @@ describe('graph-scoped finalization recovery admission', () => {
 
       for (let attempt = 0; attempt < 5; attempt += 1) {
         await recovery.processLive(liveInput);
+        const [current] = await store.list();
+        if (current?.state !== 'SETTLED' && current?.nextAttemptAt !== null) {
+          now = current!.nextAttemptAt!;
+        }
       }
       expect(await store.list()).toMatchObject([{
         state: 'SETTLED',

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -1412,7 +1412,7 @@ describe('graph-scoped finalization handler', () => {
 
       await vi.waitFor(async () => {
         expect(await inbox!.list()).toMatchObject([{ state: 'SETTLED' }]);
-      });
+      }, { timeout: 7_000 });
       expect(await store.countQuads(vmGraph)).toBe(2);
       const health = await inbox.health();
       expect(health.ready).toBe(true);
@@ -1688,6 +1688,11 @@ describe('graph-scoped finalization handler', () => {
       }]);
 
       boundContextGraphId = 42n;
+      const [deferred] = await inbox.list();
+      await new Promise((resolve) => setTimeout(
+        resolve,
+        Math.max(0, (deferred?.nextAttemptAt ?? Date.now()) - Date.now()) + 10,
+      ));
       await recoveryHandler.handleFinalizationMessage(
         encodeFinalizationMessage(message),
         CG,

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -1688,7 +1688,7 @@ describe('graph-scoped finalization handler', () => {
       expect(await inbox.list()).toMatchObject([{
         state: 'RECEIVED',
         attemptCount: 1,
-        lastError: 'finalization processing deferred',
+        lastError: 'context-graph-binding-pending',
       }]);
 
       boundContextGraphId = 42n;
@@ -1745,7 +1745,7 @@ describe('graph-scoped finalization handler', () => {
       expect(await inbox.list()).toMatchObject([{
         state: 'RECEIVED',
         attemptCount: 1,
-        lastError: 'finalization processing deferred',
+        lastError: 'context-graph-binding-pending',
       }]);
     } finally {
       await closeInbox(inbox);

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -1611,7 +1611,7 @@ describe('graph-scoped finalization handler', () => {
         listDue: async () => [],
         listForKnowledgeAsset: async () => [],
         transition: async () => false,
-        recordAttempt: async () => {},
+        recordAttempt: async () => ({ status: 'stale' }),
         health: async () => ({
           available: true,
           closed: false,

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -1246,7 +1246,10 @@ describe('graph-scoped finalization handler', () => {
       );
 
       const query = store.query.bind(store);
-      let busyReads = 2;
+      // Publisher-authority observation now owns the first store probe. Keep
+      // both materialization attempts busy as well so this still exercises the
+      // durable pre-verification timeout path.
+      let busyReads = 3;
       store.query = async (sparql, options) => {
         if (busyReads > 0) {
           busyReads -= 1;
@@ -1370,7 +1373,8 @@ describe('graph-scoped finalization handler', () => {
         chain,
         recoveryOptions(inbox),
       );
-      let busyReads = 2;
+      // One authority probe precedes the two bounded materialization attempts.
+      let busyReads = 3;
       store.query = async (sparql, options) => {
         if (busyReads > 0) {
           busyReads -= 1;


### PR DESCRIPTION
## Summary

The autonomous finalization worker currently reaches a 60-second retry ceiling and can repeat the same deterministic repair forever. That turns one stable bad state into continuous store and RPC load.

## Changes

- Track consecutive deferred outcomes by inbox key, generation, and exact reason.
- After three identical failures, park autonomous retry for at least six hours instead of retrying every minute.
- Seed the streak from durable `lastError` after restart without changing the inbox schema.
- Preserve immediate chain-reconciliation wakeups; authoritative chain activity bypasses the autonomous deadline.
- Cap parking at the existing poison-entry retry-window boundary so terminal rejection is never postponed.
- Clear the streak after a successful terminal transition.

This reduces retry storms while retaining eventual autonomous retry and immediate event-driven recovery.

## Test Plan

- [x] `pnpm --filter @origintrail-official/dkg-agent build`
- [x] `vitest run test/finalization-recovery.test.ts` (34/34)
- [x] Covered stable parking, chain-triggered wakeup, and bounded poison rejection
- [ ] Live canary verification

## Related Issues

Incident follow-up for the SBB/Base finalization recovery storm.
