### PR TITLE
fix(agent): journal finalization only for locally stored KAs

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -2697,6 +2697,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
               contextGraphSharedMemoryUri,
               chainId: chainIdForHandler,
               kav10Address: kav10AddressForHandler,
+              workspaceWriteLocks: this.writeLocks,
               ackHandlerDeadlineMs: this.config.storageAckTiming.handlerDeadlineMs,
               // Codex review (round 2) on PR #727: must NOT collapse to a
               // plain `gossipWireIdFor` because `PublishIntent.swmGraphId`

--- a/packages/agent/src/dkg-agent-swm-substrate.ts
+++ b/packages/agent/src/dkg-agent-swm-substrate.ts
@@ -1855,6 +1855,7 @@ export class SwmSubstrateMethods extends DKGAgentBase {
           markContextGraphMetaDirtyFromQuads: (quads) => {
             this.contextGraphMetaProjection.markDirtyFromQuads(quads);
           },
+          workspaceWriteLocks: this.writeLocks,
           retireConfirmedGraphScopedSwmTwinIfOrphaned:
             createRetireConfirmedGraphScopedSwmTwinIfOrphaned({
               store: this.store,

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -554,6 +554,16 @@ export class FinalizationHandler {
     let candidate: ParsedGraphScopedFinalization | undefined;
     if (liveAdmission.status === 'admitted') {
       candidate = liveAdmission.input.candidate;
+      if (!await this.hasLocalGraphScopedRecord(liveAdmission.input)) {
+        const ctx = candidate.msg.operationId
+          ? createOperationContext('gossip', candidate.msg.operationId)
+          : createOperationContext('gossip');
+        this.log.info(
+          ctx,
+          `Finalization: ignoring ${candidate.scope.ual}; this node has no local workspace record`,
+        );
+        return;
+      }
       let recoveryResult: FinalizationRecoveryLiveProcessResult;
       try {
         recoveryResult = await this.recovery.processLiveOutcome(liveAdmission.input);
@@ -624,6 +634,63 @@ export class FinalizationHandler {
         );
         throw error;
       }
+    }
+  }
+
+  /**
+   * A finalization broadcast is a repair trigger for nodes that retained the
+   * corresponding graph-scoped workspace record. Merely hearing the Context
+   * Graph topic does not make this node a recovery owner: journaling every
+   * unrelated finalization lets one busy publisher fill every subscriber's
+   * bounded recovery inbox.
+   *
+   * Test only for the durable head subject, rather than resolving it. A
+   * malformed-but-present head still belongs to this node and must remain
+   * eligible for later repair. Store failures fail open so a transient read
+   * outage cannot make us permanently discard a relevant chain command.
+   */
+  private async hasLocalGraphScopedRecord(
+    input: FinalizationRecoveryLiveInput,
+  ): Promise<boolean> {
+    const { candidate, contextGraphId } = input;
+    const ctx = candidate.msg.operationId
+      ? createOperationContext('gossip', candidate.msg.operationId)
+      : createOperationContext('gossip');
+    try {
+      const graphManager = new GraphManager(this.store);
+      const metaGraph = graphManager.sharedMemoryMetaUri(
+        contextGraphId,
+        candidate.msg.subGraphName || undefined,
+      );
+      const vmMetaGraphs = [contextGraphMetaUri(contextGraphId)];
+      if (candidate.msg.targetContextGraphId) {
+        vmMetaGraphs.push(contextGraphMetaUri(
+          contextGraphId,
+          candidate.msg.targetContextGraphId,
+        ));
+      }
+      // Contract shared with workspace-resolution.ts. The candidate parser
+      // has already validated the canonical UAL before this method runs.
+      const headSubject = `${candidate.scope.ual}#dkg-swm-head`;
+      const vmOwnershipPatterns = vmMetaGraphs.map((vmMetaGraph) => (
+        `{ GRAPH <${assertSafeIri(vmMetaGraph)}> { `
+          + `<${assertSafeIri(candidate.scope.ual)}> ?p ?o . } }`
+      ));
+      const result = await this.store.query(
+        `SELECT ?p WHERE { { GRAPH <${assertSafeIri(metaGraph)}> { `
+          + `<${assertSafeIri(headSubject)}> ?p ?o . } } UNION `
+          + `${vmOwnershipPatterns.join(' UNION ')} } LIMIT 1`,
+        { source: 'agent.finalization.localWorkspaceOwnership' },
+      );
+      return result.type === 'bindings' && result.bindings.length > 0;
+    } catch (error) {
+      this.log.warn(
+        ctx,
+        `Finalization: local workspace ownership probe failed for `
+          + `${candidate.scope.ual}; retaining recovery eligibility: `
+          + `${error instanceof Error ? error.message : String(error)}`,
+      );
+      return true;
     }
   }
 

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -114,6 +114,10 @@ import type {
   RetireConfirmedGraphScopedSwmTwinIfOrphaned,
 } from
   './sync/requester/finalized-swm-twin-reconciliation.js';
+import {
+  createDurableFinalizationRecoveryEligibility,
+  type FinalizationRecoveryEligibility,
+} from './finalization-recovery-eligibility.js';
 
 /**
  * Predicate for the durable per-root keep-root-copy signal the publisher
@@ -321,6 +325,8 @@ export interface FinalizationHandlerOptions {
   lifecycleLogOptions?: FinalizationLifecycleLogOptions;
   recoveryStore?: FinalizationRecoveryStore;
   runtime?: FinalizationRuntime;
+  workspaceWriteLocks?: Map<string, Promise<void>>;
+  finalizationRecoveryEligibility?: FinalizationRecoveryEligibility;
 }
 
 function isLegacyFinalizationEventBus(
@@ -446,6 +452,7 @@ export class FinalizationHandler {
   /** Equivalent finalization/reconcile reads share one promise until it settles. */
   private readonly scanSingleFlights = new Map<string, Promise<unknown>>();
   private readonly recoveryWorker: FinalizationRecoveryWorker;
+  private readonly finalizationRecoveryEligibility: FinalizationRecoveryEligibility;
 
   constructor(
     store: TripleStore,
@@ -485,6 +492,11 @@ export class FinalizationHandler {
       options.retireConfirmedGraphScopedSwmTwinIfOrphaned;
     this.reconcileConfirmedGraphScopedSwmTwin =
       options.reconcileConfirmedGraphScopedSwmTwin;
+    this.finalizationRecoveryEligibility = options.finalizationRecoveryEligibility
+      ?? createDurableFinalizationRecoveryEligibility({
+        store,
+        writeLocks: options.workspaceWriteLocks,
+      });
     this.lifecycle = new FinalizationLifecycleLogger(
       this.log,
       options.runtime ?? options.lifecycleLogOptions,
@@ -553,14 +565,32 @@ export class FinalizationHandler {
     let envelope: DecodedFinalizationEnvelope | undefined;
     let candidate: ParsedGraphScopedFinalization | undefined;
     if (liveAdmission.status === 'admitted') {
-      candidate = liveAdmission.input.candidate;
-      if (!await this.hasLocalGraphScopedRecord(liveAdmission.input)) {
-        const ctx = candidate.msg.operationId
-          ? createOperationContext('gossip', candidate.msg.operationId)
+      const liveCandidate = liveAdmission.input.candidate;
+      candidate = liveCandidate;
+      const recoveryEligible = await this.finalizationRecoveryEligibility({
+        contextGraphId,
+        ual: liveCandidate.scope.ual,
+        subGraphName: liveCandidate.msg.subGraphName || undefined,
+        targetContextGraphId: liveCandidate.msg.targetContextGraphId || undefined,
+        onProbeError: (error) => {
+          const ctx = liveCandidate.msg.operationId
+            ? createOperationContext('gossip', liveCandidate.msg.operationId)
+            : createOperationContext('gossip');
+          this.log.warn(
+            ctx,
+            `Finalization: local workspace ownership probe failed for `
+              + `${liveCandidate.scope.ual}; retaining recovery eligibility: `
+              + `${error instanceof Error ? error.message : String(error)}`,
+          );
+        },
+      });
+      if (!recoveryEligible) {
+        const ctx = liveCandidate.msg.operationId
+          ? createOperationContext('gossip', liveCandidate.msg.operationId)
           : createOperationContext('gossip');
         this.log.info(
           ctx,
-          `Finalization: ignoring ${candidate.scope.ual}; this node has no local workspace record`,
+          `Finalization: ignoring ${liveCandidate.scope.ual}; this node has no local workspace record`,
         );
         return;
       }
@@ -634,63 +664,6 @@ export class FinalizationHandler {
         );
         throw error;
       }
-    }
-  }
-
-  /**
-   * A finalization broadcast is a repair trigger for nodes that retained the
-   * corresponding graph-scoped workspace record. Merely hearing the Context
-   * Graph topic does not make this node a recovery owner: journaling every
-   * unrelated finalization lets one busy publisher fill every subscriber's
-   * bounded recovery inbox.
-   *
-   * Test only for the durable head subject, rather than resolving it. A
-   * malformed-but-present head still belongs to this node and must remain
-   * eligible for later repair. Store failures fail open so a transient read
-   * outage cannot make us permanently discard a relevant chain command.
-   */
-  private async hasLocalGraphScopedRecord(
-    input: FinalizationRecoveryLiveInput,
-  ): Promise<boolean> {
-    const { candidate, contextGraphId } = input;
-    const ctx = candidate.msg.operationId
-      ? createOperationContext('gossip', candidate.msg.operationId)
-      : createOperationContext('gossip');
-    try {
-      const graphManager = new GraphManager(this.store);
-      const metaGraph = graphManager.sharedMemoryMetaUri(
-        contextGraphId,
-        candidate.msg.subGraphName || undefined,
-      );
-      const vmMetaGraphs = [contextGraphMetaUri(contextGraphId)];
-      if (candidate.msg.targetContextGraphId) {
-        vmMetaGraphs.push(contextGraphMetaUri(
-          contextGraphId,
-          candidate.msg.targetContextGraphId,
-        ));
-      }
-      // Contract shared with workspace-resolution.ts. The candidate parser
-      // has already validated the canonical UAL before this method runs.
-      const headSubject = `${candidate.scope.ual}#dkg-swm-head`;
-      const vmOwnershipPatterns = vmMetaGraphs.map((vmMetaGraph) => (
-        `{ GRAPH <${assertSafeIri(vmMetaGraph)}> { `
-          + `<${assertSafeIri(candidate.scope.ual)}> ?p ?o . } }`
-      ));
-      const result = await this.store.query(
-        `SELECT ?p WHERE { { GRAPH <${assertSafeIri(metaGraph)}> { `
-          + `<${assertSafeIri(headSubject)}> ?p ?o . } } UNION `
-          + `${vmOwnershipPatterns.join(' UNION ')} } LIMIT 1`,
-        { source: 'agent.finalization.localWorkspaceOwnership' },
-      );
-      return result.type === 'bindings' && result.bindings.length > 0;
-    } catch (error) {
-      this.log.warn(
-        ctx,
-        `Finalization: local workspace ownership probe failed for `
-          + `${candidate.scope.ual}; retaining recovery eligibility: `
-          + `${error instanceof Error ? error.message : String(error)}`,
-      );
-      return true;
     }
   }
 

--- a/packages/agent/src/finalization-recovery-eligibility.ts
+++ b/packages/agent/src/finalization-recovery-eligibility.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  assertSafeIri,
+  contextGraphMetaUri,
+} from '@origintrail-official/dkg-core';
+import {
+  GraphManager,
+  type TripleStore,
+} from '@origintrail-official/dkg-storage';
+import {
+  swmKaWriteLockKey,
+  withKeyedLocks,
+  workspaceKnowledgeAssetHeadSubject,
+} from '@origintrail-official/dkg-publisher';
+
+export const FINALIZATION_RECOVERY_ELIGIBILITY_QUERY_SOURCE =
+  'agent.finalization.localWorkspaceOwnership';
+
+export interface FinalizationRecoveryEligibilityInput {
+  readonly contextGraphId: string;
+  readonly ual: string;
+  readonly subGraphName?: string;
+  readonly targetContextGraphId?: string;
+  readonly onProbeError?: (error: unknown) => void;
+}
+
+export type FinalizationRecoveryEligibility = (
+  input: FinalizationRecoveryEligibilityInput,
+) => Promise<boolean>;
+
+export interface DurableFinalizationRecoveryEligibilityOptions {
+  readonly store: TripleStore;
+  /** The publisher's canonical SWM per-KA lock domain. */
+  readonly writeLocks?: Map<string, Promise<void>>;
+}
+
+/**
+ * Create the durable-record admission policy used before inbox journaling.
+ * SWM presence is observed under the same per-KA lock as head replacement,
+ * while VM metadata remains an independent durable ownership signal. Store
+ * failures fail open so a transient probe cannot discard a chain command.
+ */
+export function createDurableFinalizationRecoveryEligibility(
+  options: DurableFinalizationRecoveryEligibilityOptions,
+): FinalizationRecoveryEligibility {
+  const graphManager = new GraphManager(options.store);
+  return async (input) => {
+    const probe = async (): Promise<boolean> => {
+      try {
+        const swmMetaGraph = graphManager.sharedMemoryMetaUri(
+          input.contextGraphId,
+          input.subGraphName,
+        );
+        const vmMetaGraphs = [contextGraphMetaUri(input.contextGraphId)];
+        if (input.targetContextGraphId) {
+          vmMetaGraphs.push(contextGraphMetaUri(
+            input.contextGraphId,
+            input.targetContextGraphId,
+          ));
+        }
+        const headSubject = workspaceKnowledgeAssetHeadSubject(input.ual);
+        const vmOwnershipPatterns = vmMetaGraphs.map((vmMetaGraph) => (
+          `{ GRAPH <${assertSafeIri(vmMetaGraph)}> { `
+            + `<${assertSafeIri(input.ual)}> ?p ?o . } }`
+        ));
+        const result = await options.store.query(
+          `SELECT ?p WHERE { { GRAPH <${assertSafeIri(swmMetaGraph)}> { `
+            + `<${assertSafeIri(headSubject)}> ?p ?o . } } UNION `
+            + `${vmOwnershipPatterns.join(' UNION ')} } LIMIT 1`,
+          { source: FINALIZATION_RECOVERY_ELIGIBILITY_QUERY_SOURCE },
+        );
+        return result.type === 'bindings' && result.bindings.length > 0;
+      } catch (error) {
+        input.onProbeError?.(error);
+        return true;
+      }
+    };
+
+    if (!options.writeLocks) return probe();
+    return withKeyedLocks(
+      options.writeLocks,
+      [swmKaWriteLockKey(
+        input.contextGraphId,
+        input.subGraphName,
+        input.ual,
+      )],
+      probe,
+    );
+  };
+}

--- a/packages/agent/test/dkg-agent-finalization-admission-composition.test.ts
+++ b/packages/agent/test/dkg-agent-finalization-admission-composition.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import {
+  swmKaWriteLockKey,
+  withKeyedLocks,
+} from '@origintrail-official/dkg-publisher';
+import { SwmSubstrateMethods } from '../src/dkg-agent-swm-substrate.js';
+
+const CONTEXT_GRAPH_ID = 'agent-admission-composition';
+const UAL = 'did:dkg:otp:20430/0x1111111111111111111111111111111111111111/7';
+
+describe('agent finalization admission composition', () => {
+  it('builds the finalization handler in the agent canonical SWM lock domain', async () => {
+    const store = new OxigraphStore();
+    const writeLocks = new Map<string, Promise<void>>();
+    const fakeAgent = {
+      finalizationHandler: undefined,
+      finalizationRuntime: undefined,
+      store,
+      writeLocks,
+      chain: { chainId: 'none' },
+      eventBus: undefined,
+      getContextGraphOnChainId: vi.fn(async () => undefined),
+      contextGraphMetaProjection: { markDirtyFromQuads: vi.fn() },
+      publisher: { clearPublishedKnowledgeAssetSwm: vi.fn() },
+      retireFinalizedSwmTwinCandidate: vi.fn(),
+      invalidateListContextGraphsCache: vi.fn(),
+      log: { info: vi.fn() },
+    };
+    const handler = SwmSubstrateMethods.prototype.getOrCreateFinalizationHandler.call(
+      fakeAgent as never,
+    );
+    const eligibility = (handler as unknown as {
+      finalizationRecoveryEligibility: (input: {
+        contextGraphId: string;
+        ual: string;
+      }) => Promise<boolean>;
+    }).finalizationRecoveryEligibility;
+
+    let release!: () => void;
+    let entered!: () => void;
+    const blocked = new Promise<void>((resolve) => { release = resolve; });
+    const lockEntered = new Promise<void>((resolve) => { entered = resolve; });
+    const lock = withKeyedLocks(
+      writeLocks,
+      [swmKaWriteLockKey(CONTEXT_GRAPH_ID, undefined, UAL)],
+      async () => {
+        entered();
+        await blocked;
+      },
+    );
+    await lockEntered;
+
+    let settled = false;
+    const probe = eligibility({ contextGraphId: CONTEXT_GRAPH_ID, ual: UAL })
+      .finally(() => { settled = true; });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(settled).toBe(false);
+
+    release();
+    await lock;
+    await expect(probe).resolves.toBe(false);
+  });
+});

--- a/packages/agent/test/finalization-handler.test.ts
+++ b/packages/agent/test/finalization-handler.test.ts
@@ -76,8 +76,15 @@ describe('FinalizationHandler', () => {
     });
     const author = '0x1111111111111111111111111111111111111111';
     const packedKaId = (BigInt(author) << 96n) | 7n;
+    const ual = `did:dkg:otp:20430/${author}/7`;
+    await store.insert([{
+      subject: `${ual}#dkg-swm-head`,
+      predicate: 'http://dkg.io/ontology/assertionVersion',
+      object: '"1"',
+      graph: new GraphManager(store).sharedMemoryMetaUri(CONTEXT_GRAPH),
+    } as Quad]);
     await configured.handleFinalizationMessage(encodeFinalizationMessage({
-      ual: `did:dkg:otp:20430/${author}/7`,
+      ual,
       contextGraphId: CONTEXT_GRAPH,
       kcMerkleRoot: new Uint8Array(32),
       txHash: `0x${'ab'.repeat(32)}`,

--- a/packages/agent/test/finalization-recovery-admission.test.ts
+++ b/packages/agent/test/finalization-recovery-admission.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  GRAPH_KA_CONTENT_SCOPE_VERSION,
+  encodeFinalizationMessage,
+  type FinalizationMessageMsg,
+} from '@origintrail-official/dkg-core';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import type { ChainAdapter } from '@origintrail-official/dkg-chain';
+import { FinalizationHandler } from '../src/finalization-handler.js';
+
+const CONTEXT_GRAPH_ID = 'recovery-admission';
+const AUTHOR = '0x1111111111111111111111111111111111111111';
+const UAL = `did:dkg:otp:20430/${AUTHOR}/7`;
+const PACKED_KA_ID = (BigInt(AUTHOR) << 96n) | 7n;
+
+function message(): FinalizationMessageMsg {
+  return {
+    ual: UAL,
+    contextGraphId: CONTEXT_GRAPH_ID,
+    kcMerkleRoot: new Uint8Array(32),
+    txHash: `0x${'ab'.repeat(32)}`,
+    blockNumber: 123,
+    txIndex: 4,
+    batchId: PACKED_KA_ID,
+    startKAId: PACKED_KA_ID,
+    endKAId: PACKED_KA_ID,
+    publisherAddress: '0x2222222222222222222222222222222222222222',
+    rootEntities: [],
+    timestampMs: Date.now(),
+    operationId: 'recovery-admission-op',
+    targetContextGraphId: '42',
+    contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+    assertionVersion: '1',
+    publicTripleCount: 1,
+    privateTripleCount: 0,
+  };
+}
+
+describe('finalization recovery admission', () => {
+  it('does not consult the chain or journal work rejected by local ownership', async () => {
+    const resolveCanonicalFinalizationReceipt = vi.fn();
+    const recoveryStore = {
+      upsertPending: vi.fn(),
+      markSettled: vi.fn(),
+      markRetryable: vi.fn(),
+      markPermanent: vi.fn(),
+      listRecoverable: vi.fn(async () => []),
+    };
+    const handler = new FinalizationHandler(
+      new OxigraphStore(),
+      {
+        chainId: 'legacy:1',
+        isV10Ready: () => true,
+        resolveCanonicalFinalizationReceipt,
+      } as unknown as ChainAdapter,
+      {
+        recoveryStore: recoveryStore as never,
+        finalizationRecoveryEligibility: async () => false,
+      },
+    );
+
+    await handler.handleFinalizationMessage(
+      encodeFinalizationMessage(message()),
+      CONTEXT_GRAPH_ID,
+      '12D3KooWPublisher',
+    );
+
+    expect(resolveCanonicalFinalizationReceipt).not.toHaveBeenCalled();
+    expect(recoveryStore.upsertPending).not.toHaveBeenCalled();
+    expect(recoveryStore.markSettled).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/test/finalization-recovery-eligibility.test.ts
+++ b/packages/agent/test/finalization-recovery-eligibility.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  contextGraphMetaUri,
+} from '@origintrail-official/dkg-core';
+import {
+  GraphManager,
+  OxigraphStore,
+} from '@origintrail-official/dkg-storage';
+import {
+  workspaceKnowledgeAssetHeadSubject,
+} from '@origintrail-official/dkg-publisher';
+import {
+  createDurableFinalizationRecoveryEligibility,
+} from '../src/finalization-recovery-eligibility.js';
+
+const CONTEXT_GRAPH_ID = 'eligibility-graph';
+const UAL = 'did:dkg:otp:20430/0x1111111111111111111111111111111111111111/7';
+
+describe('durable finalization recovery eligibility', () => {
+  it('recognizes a canonical SWM workspace head', async () => {
+    const store = new OxigraphStore();
+    const graph = new GraphManager(store).sharedMemoryMetaUri(CONTEXT_GRAPH_ID);
+    await store.insert([{
+      subject: workspaceKnowledgeAssetHeadSubject(UAL),
+      predicate: 'http://dkg.io/ontology/shareOperationId',
+      object: '"share-1"',
+      graph,
+    }]);
+
+    await expect(createDurableFinalizationRecoveryEligibility({ store })({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ual: UAL,
+    })).resolves.toBe(true);
+  });
+
+  it('recognizes durable VM metadata without an SWM head', async () => {
+    const store = new OxigraphStore();
+    await store.insert([{
+      subject: UAL,
+      predicate: 'http://dkg.io/ontology/transactionHash',
+      object: `"0x${'ab'.repeat(32)}"`,
+      graph: contextGraphMetaUri(CONTEXT_GRAPH_ID),
+    }]);
+
+    await expect(createDurableFinalizationRecoveryEligibility({ store })({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ual: UAL,
+    })).resolves.toBe(true);
+  });
+
+  it('rejects an absent local durable record', async () => {
+    const store = new OxigraphStore();
+    await expect(createDurableFinalizationRecoveryEligibility({ store })({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ual: UAL,
+    })).resolves.toBe(false);
+  });
+
+  it('fails open and reports probe errors', async () => {
+    const store = new OxigraphStore();
+    store.query = async () => {
+      throw new Error('temporary store outage');
+    };
+    const onProbeError = vi.fn();
+
+    await expect(createDurableFinalizationRecoveryEligibility({ store })({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ual: UAL,
+      onProbeError,
+    })).resolves.toBe(true);
+    expect(onProbeError).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'temporary store outage',
+    }));
+  });
+});

--- a/packages/agent/test/finalization-recovery-eligibility.test.ts
+++ b/packages/agent/test/finalization-recovery-eligibility.test.ts
@@ -48,6 +48,28 @@ describe('durable finalization recovery eligibility', () => {
     })).resolves.toBe(true);
   });
 
+  it('recognizes only the requested target-context VM metadata', async () => {
+    const store = new OxigraphStore();
+    await store.insert([{
+      subject: UAL,
+      predicate: 'http://dkg.io/ontology/transactionHash',
+      object: `"0x${'cd'.repeat(32)}"`,
+      graph: contextGraphMetaUri(CONTEXT_GRAPH_ID, '42'),
+    }]);
+
+    const eligible = createDurableFinalizationRecoveryEligibility({ store });
+    await expect(eligible({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ual: UAL,
+      targetContextGraphId: '42',
+    })).resolves.toBe(true);
+    await expect(eligible({
+      contextGraphId: CONTEXT_GRAPH_ID,
+      ual: UAL,
+      targetContextGraphId: '43',
+    })).resolves.toBe(false);
+  });
+
   it('rejects an absent local durable record', async () => {
     const store = new OxigraphStore();
     await expect(createDurableFinalizationRecoveryEligibility({ store })({

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -1172,6 +1172,107 @@ describe('graph-scoped finalization handler', () => {
     }
   });
 
+  it('retains recovery eligibility when the ownership probe fails once', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-probe-failure-'));
+    let inbox: SqliteFinalizationRecoveryStore | undefined;
+    const query = store.query.bind(store);
+    try {
+      const { message, vmGraph } = await stageGraph();
+      inbox = await openSqliteFinalizationRecoveryStore(directory);
+      const recoveryHandler = new FinalizationHandler(
+        store,
+        legacyFinalizationChain(4, {
+          getKAContextGraphId: async () => 42n,
+          resolveCanonicalFinalizationReceipt: async () => canonicalReceipt(message),
+        }),
+        recoveryOptions(inbox),
+      );
+      let probeFailures = 1;
+      store.query = async (sparql, options) => {
+        if (
+          probeFailures > 0
+          && options?.source === 'agent.finalization.localWorkspaceOwnership'
+        ) {
+          probeFailures -= 1;
+          throw new Error('injected ownership probe failure');
+        }
+        return query(sparql, options);
+      };
+
+      await recoveryHandler.handleFinalizationMessage(
+        encodeFinalizationMessage(message),
+        CG,
+        '12D3KooWPublisher',
+      );
+
+      expect(probeFailures).toBe(0);
+      expect(await store.countQuads(vmGraph)).toBe(2);
+      expect(await inbox.list()).toMatchObject([{ state: 'SETTLED' }]);
+    } finally {
+      store.query = query;
+      await closeInbox(inbox);
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('waits for an in-flight workspace head replacement before admission', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-head-rewrite-'));
+    let inbox: SqliteFinalizationRecoveryStore | undefined;
+    try {
+      const { message, vmGraph } = await stageGraph();
+      const writeLocks = new Map<string, Promise<void>>();
+      inbox = await openSqliteFinalizationRecoveryStore(directory);
+      const recoveryHandler = new FinalizationHandler(
+        store,
+        legacyFinalizationChain(4, {
+          getKAContextGraphId: async () => 42n,
+          resolveCanonicalFinalizationReceipt: async () => canonicalReceipt(message),
+        }),
+        { ...recoveryOptions(inbox), workspaceWriteLocks: writeLocks },
+      );
+      const lockKey = swmKaWriteLockKey(CG, undefined, UAL);
+      let markHeadDeleted!: () => void;
+      let allowReplacement!: () => void;
+      const headDeleted = new Promise<void>((resolve) => { markHeadDeleted = resolve; });
+      const replacementAllowed = new Promise<void>((resolve) => { allowReplacement = resolve; });
+      const replacement = withKeyedLocks(writeLocks, [lockKey], async () => {
+        await store.deleteByPattern({
+          graph: graphManager.sharedMemoryMetaUri(CG),
+          subject: `${UAL}#dkg-swm-head`,
+        });
+        markHeadDeleted();
+        await replacementAllowed;
+        await storeKnowledgeAssetWorkspaceHead({
+          store,
+          graphManager,
+          contextGraphId: CG,
+          shareOperationId: SHARE_ID,
+          kaUal: UAL,
+          assertionVersion: VERSION,
+        });
+      });
+      await headDeleted;
+
+      let handlingSettled = false;
+      const handling = recoveryHandler.handleFinalizationMessage(
+        encodeFinalizationMessage(message),
+        CG,
+        '12D3KooWPublisher',
+      ).finally(() => { handlingSettled = true; });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(handlingSettled).toBe(false);
+
+      allowReplacement();
+      await replacement;
+      await handling;
+      expect(await inbox.list()).toMatchObject([{ state: 'SETTLED' }]);
+      expect(await store.countQuads(vmGraph)).toBe(2);
+    } finally {
+      await closeInbox(inbox);
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it('falls back to legacy live verification when canonical receipts are unsupported', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-unsupported-live-'));
     let inbox: SqliteFinalizationRecoveryStore | undefined;

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -1135,6 +1135,43 @@ describe('graph-scoped finalization handler', () => {
     )).resolves.toMatchObject({ type: 'boolean', value: true });
   });
 
+  it('does not journal finalization for a graph-scoped record this node does not store', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-unowned-'));
+    let inbox: SqliteFinalizationRecoveryStore | undefined;
+    try {
+      const { message, swmGraph, vmGraph } = await stageGraph();
+      await store.dropGraph(swmGraph);
+      await store.dropGraph(graphManager.sharedMemoryMetaUri(CG));
+      let canonicalReceiptCalls = 0;
+      const chain = legacyFinalizationChain(4, {
+        resolveCanonicalFinalizationReceipt: async () => {
+          canonicalReceiptCalls += 1;
+          return canonicalReceipt(message);
+        },
+      });
+      inbox = await openSqliteFinalizationRecoveryStore(directory);
+      const localOnlyHandler = new FinalizationHandler(
+        store,
+        chain,
+        recoveryOptions(inbox),
+      );
+
+      await localOnlyHandler.handleFinalizationMessage(
+        encodeFinalizationMessage(message),
+        CG,
+        '12D3KooWPublisher',
+      );
+
+      expect(await inbox.list()).toEqual([]);
+      expect(canonicalReceiptCalls).toBe(0);
+      // The unrelated pre-existing VM row from the fixture is untouched.
+      expect(await store.countQuads(vmGraph)).toBe(1);
+    } finally {
+      await closeInbox(inbox);
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it('falls back to legacy live verification when canonical receipts are unsupported', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-unsupported-live-'));
     let inbox: SqliteFinalizationRecoveryStore | undefined;
@@ -1185,7 +1222,10 @@ describe('graph-scoped finalization handler', () => {
       const retryingHandler = new FinalizationHandler(store, legacyFinalizationChain());
       let busyReads = 1;
       store.query = async (sparql, options) => {
-        if (busyReads > 0) {
+        if (
+          busyReads > 0
+          && options?.source !== 'agent.finalization.localWorkspaceOwnership'
+        ) {
           busyReads -= 1;
           throw new StoreSchedulerBusyError(
             'queue_wait_timeout',
@@ -1248,7 +1288,10 @@ describe('graph-scoped finalization handler', () => {
       const query = store.query.bind(store);
       let busyReads = 2;
       store.query = async (sparql, options) => {
-        if (busyReads > 0) {
+        if (
+          busyReads > 0
+          && options?.source !== 'agent.finalization.localWorkspaceOwnership'
+        ) {
           busyReads -= 1;
           throw new StoreSchedulerBusyError('queue_wait_timeout', 'normal', 'sparql-http.query');
         }
@@ -1372,7 +1415,10 @@ describe('graph-scoped finalization handler', () => {
       );
       let busyReads = 2;
       store.query = async (sparql, options) => {
-        if (busyReads > 0) {
+        if (
+          busyReads > 0
+          && options?.source !== 'agent.finalization.localWorkspaceOwnership'
+        ) {
           busyReads -= 1;
           throw new StoreSchedulerBusyError(
             'queue_wait_timeout',
@@ -1627,7 +1673,9 @@ describe('graph-scoped finalization handler', () => {
       const query = store.query.bind(store);
       let materializationReads = 0;
       store.query = async (sparql, options) => {
-        materializationReads += 1;
+        if (options?.source !== 'agent.finalization.localWorkspaceOwnership') {
+          materializationReads += 1;
+        }
         return query(sparql, options);
       };
       try {

--- a/packages/agent/test/ka-graph-finalization-handler.test.ts
+++ b/packages/agent/test/ka-graph-finalization-handler.test.ts
@@ -41,6 +41,8 @@ import {
   openSqliteFinalizationRecoveryStore,
   type SqliteFinalizationRecoveryStore,
 } from '../src/finalization-recovery-sqlite-store.js';
+import type { FinalizationRecoveryEligibility } from
+  '../src/finalization-recovery-eligibility.js';
 import type { FinalizationRecoveryStore } from '../src/finalization-recovery-store.js';
 import { protobufScalarToBigInt } from '../src/protobuf-scalars.js';
 import {
@@ -147,10 +149,12 @@ async function closeInbox(inbox: SqliteFinalizationRecoveryStore | undefined): P
 function recoveryOptions(
   recoveryStore: FinalizationRecoveryStore,
   localTopicOnChainContextGraphId = '42',
+  finalizationRecoveryEligibility: FinalizationRecoveryEligibility = async () => true,
 ) {
   return {
     recoveryStore,
     resolveContextGraphOnChainId: async () => localTopicOnChainContextGraphId,
+    finalizationRecoveryEligibility,
   };
 }
 
@@ -1135,144 +1139,6 @@ describe('graph-scoped finalization handler', () => {
     )).resolves.toMatchObject({ type: 'boolean', value: true });
   });
 
-  it('does not journal finalization for a graph-scoped record this node does not store', async () => {
-    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-unowned-'));
-    let inbox: SqliteFinalizationRecoveryStore | undefined;
-    try {
-      const { message, swmGraph, vmGraph } = await stageGraph();
-      await store.dropGraph(swmGraph);
-      await store.dropGraph(graphManager.sharedMemoryMetaUri(CG));
-      let canonicalReceiptCalls = 0;
-      const chain = legacyFinalizationChain(4, {
-        resolveCanonicalFinalizationReceipt: async () => {
-          canonicalReceiptCalls += 1;
-          return canonicalReceipt(message);
-        },
-      });
-      inbox = await openSqliteFinalizationRecoveryStore(directory);
-      const localOnlyHandler = new FinalizationHandler(
-        store,
-        chain,
-        recoveryOptions(inbox),
-      );
-
-      await localOnlyHandler.handleFinalizationMessage(
-        encodeFinalizationMessage(message),
-        CG,
-        '12D3KooWPublisher',
-      );
-
-      expect(await inbox.list()).toEqual([]);
-      expect(canonicalReceiptCalls).toBe(0);
-      // The unrelated pre-existing VM row from the fixture is untouched.
-      expect(await store.countQuads(vmGraph)).toBe(1);
-    } finally {
-      await closeInbox(inbox);
-      await rm(directory, { recursive: true, force: true });
-    }
-  });
-
-  it('retains recovery eligibility when the ownership probe fails once', async () => {
-    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-probe-failure-'));
-    let inbox: SqliteFinalizationRecoveryStore | undefined;
-    const query = store.query.bind(store);
-    try {
-      const { message, vmGraph } = await stageGraph();
-      inbox = await openSqliteFinalizationRecoveryStore(directory);
-      const recoveryHandler = new FinalizationHandler(
-        store,
-        legacyFinalizationChain(4, {
-          getKAContextGraphId: async () => 42n,
-          resolveCanonicalFinalizationReceipt: async () => canonicalReceipt(message),
-        }),
-        recoveryOptions(inbox),
-      );
-      let probeFailures = 1;
-      store.query = async (sparql, options) => {
-        if (
-          probeFailures > 0
-          && options?.source === 'agent.finalization.localWorkspaceOwnership'
-        ) {
-          probeFailures -= 1;
-          throw new Error('injected ownership probe failure');
-        }
-        return query(sparql, options);
-      };
-
-      await recoveryHandler.handleFinalizationMessage(
-        encodeFinalizationMessage(message),
-        CG,
-        '12D3KooWPublisher',
-      );
-
-      expect(probeFailures).toBe(0);
-      expect(await store.countQuads(vmGraph)).toBe(2);
-      expect(await inbox.list()).toMatchObject([{ state: 'SETTLED' }]);
-    } finally {
-      store.query = query;
-      await closeInbox(inbox);
-      await rm(directory, { recursive: true, force: true });
-    }
-  });
-
-  it('waits for an in-flight workspace head replacement before admission', async () => {
-    const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-head-rewrite-'));
-    let inbox: SqliteFinalizationRecoveryStore | undefined;
-    try {
-      const { message, vmGraph } = await stageGraph();
-      const writeLocks = new Map<string, Promise<void>>();
-      inbox = await openSqliteFinalizationRecoveryStore(directory);
-      const recoveryHandler = new FinalizationHandler(
-        store,
-        legacyFinalizationChain(4, {
-          getKAContextGraphId: async () => 42n,
-          resolveCanonicalFinalizationReceipt: async () => canonicalReceipt(message),
-        }),
-        { ...recoveryOptions(inbox), workspaceWriteLocks: writeLocks },
-      );
-      const lockKey = swmKaWriteLockKey(CG, undefined, UAL);
-      let markHeadDeleted!: () => void;
-      let allowReplacement!: () => void;
-      const headDeleted = new Promise<void>((resolve) => { markHeadDeleted = resolve; });
-      const replacementAllowed = new Promise<void>((resolve) => { allowReplacement = resolve; });
-      const replacement = withKeyedLocks(writeLocks, [lockKey], async () => {
-        await store.deleteByPattern({
-          graph: graphManager.sharedMemoryMetaUri(CG),
-          subject: `${UAL}#dkg-swm-head`,
-        });
-        markHeadDeleted();
-        await replacementAllowed;
-        await storeKnowledgeAssetWorkspaceHead({
-          store,
-          graphManager,
-          contextGraphId: CG,
-          shareOperationId: SHARE_ID,
-          kaUal: UAL,
-          assertionVersion: VERSION,
-        });
-      });
-      await headDeleted;
-
-      let handlingSettled = false;
-      const handling = recoveryHandler.handleFinalizationMessage(
-        encodeFinalizationMessage(message),
-        CG,
-        '12D3KooWPublisher',
-      ).finally(() => { handlingSettled = true; });
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      expect(handlingSettled).toBe(false);
-
-      allowReplacement();
-      await replacement;
-      await handling;
-      expect(await inbox.list()).toMatchObject([{ state: 'SETTLED' }]);
-      expect(await store.countQuads(vmGraph)).toBe(2);
-    } finally {
-      await closeInbox(inbox);
-      await rm(directory, { recursive: true, force: true });
-    }
-  });
-
   it('falls back to legacy live verification when canonical receipts are unsupported', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dkg-finalization-unsupported-live-'));
     let inbox: SqliteFinalizationRecoveryStore | undefined;
@@ -1323,10 +1189,7 @@ describe('graph-scoped finalization handler', () => {
       const retryingHandler = new FinalizationHandler(store, legacyFinalizationChain());
       let busyReads = 1;
       store.query = async (sparql, options) => {
-        if (
-          busyReads > 0
-          && options?.source !== 'agent.finalization.localWorkspaceOwnership'
-        ) {
+        if (busyReads > 0) {
           busyReads -= 1;
           throw new StoreSchedulerBusyError(
             'queue_wait_timeout',
@@ -1389,10 +1252,7 @@ describe('graph-scoped finalization handler', () => {
       const query = store.query.bind(store);
       let busyReads = 2;
       store.query = async (sparql, options) => {
-        if (
-          busyReads > 0
-          && options?.source !== 'agent.finalization.localWorkspaceOwnership'
-        ) {
+        if (busyReads > 0) {
           busyReads -= 1;
           throw new StoreSchedulerBusyError('queue_wait_timeout', 'normal', 'sparql-http.query');
         }
@@ -1516,10 +1376,7 @@ describe('graph-scoped finalization handler', () => {
       );
       let busyReads = 2;
       store.query = async (sparql, options) => {
-        if (
-          busyReads > 0
-          && options?.source !== 'agent.finalization.localWorkspaceOwnership'
-        ) {
+        if (busyReads > 0) {
           busyReads -= 1;
           throw new StoreSchedulerBusyError(
             'queue_wait_timeout',
@@ -1774,9 +1631,7 @@ describe('graph-scoped finalization handler', () => {
       const query = store.query.bind(store);
       let materializationReads = 0;
       store.query = async (sparql, options) => {
-        if (options?.source !== 'agent.finalization.localWorkspaceOwnership') {
-          materializationReads += 1;
-        }
+        materializationReads += 1;
         return query(sparql, options);
       };
       try {

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -56,6 +56,7 @@ export {
   KnowledgeAssetWorkspaceHeadCorruptError,
   isKnowledgeAssetWorkspaceHeadCorruptError,
   isDecodableWorkspaceOperationRows,
+  workspaceKnowledgeAssetHeadSubject,
   type KnowledgeAssetWorkspaceHead,
   type PublishedKnowledgeAssetWorkspaceHead,
   type ResolveKnowledgeAssetWorkspaceHeadParams,

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -58,6 +58,7 @@ import { generateKnowledgeAssetShareMetadata } from './metadata.js';
 import { storeKnowledgeAssetWorkspaceHead } from './workspace-resolution.js';
 import { workspacePublicQuadsDigest } from './workspace-snapshot-store.js';
 import { validateCanonicalGraphScopedKnowledgeAssetPayload } from './validation.js';
+import { swmKaWriteLockKey, withKeyedLocks } from './keyed-lock.js';
 import { ethers } from 'ethers';
 
 type PeerId = { toString(): string };
@@ -392,6 +393,8 @@ export interface StorageACKHandlerConfig {
    * of the H5 prefix on the V10 ACK digest.
    */
   kav10Address: string;
+  /** Shared publisher/agent lock domain for graph-scoped SWM KA writes. */
+  workspaceWriteLocks?: Map<string, Promise<void>>;
   /**
    * Optional live confirmation hook. When provided, the handler calls it
    * immediately before signing so removed/unregistered operational keys stop
@@ -892,7 +895,7 @@ export class StorageACKHandler {
       graph: metaGraph,
     });
 
-    const result = await this.runStoreOpOrDecline(cgId, async () => {
+    const persist = async () => this.runStoreOpOrDecline(cgId, async () => {
       if (replaceGraph) {
         const replaced = await tryReplaceGraphAtomically(
           this.store,
@@ -943,6 +946,17 @@ export class StorageACKHandler {
         ackStoreOptions('storage-ack.persistGraphScoped.flush'),
       );
     }, signal);
+    const result = this.config.workspaceWriteLocks
+      ? await withKeyedLocks(
+        this.config.workspaceWriteLocks,
+        [swmKaWriteLockKey(
+          swmGraphId,
+          graphPublish.subGraphName,
+          graphPublish.scope.ual,
+        )],
+        persist,
+      )
+      : await persist();
     return result.ok ? { ok: true } : result;
   }
 

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -1432,7 +1432,8 @@ function workspaceOperationSubject(contextGraphId: string, shareOperationId: str
   return subject;
 }
 
-function workspaceKnowledgeAssetHeadSubject(kaUal: string): string {
+/** Canonical durable SWM head locator shared by writers and recovery admission. */
+export function workspaceKnowledgeAssetHeadSubject(kaUal: string): string {
   const scope = createGraphKnowledgeAssetScope(kaUal, 1);
   const subject = `${scope.ual}#dkg-swm-head`;
   assertSafeIri(subject);

--- a/packages/publisher/test/ka-graph-publish-ack.test.ts
+++ b/packages/publisher/test/ka-graph-publish-ack.test.ts
@@ -23,6 +23,7 @@ import {
   computeFlatKCMerkleLeafCountV10,
   computeFlatKCRootV10,
 } from '../src/merkle.js';
+import { swmKaWriteLockKey, withKeyedLocks } from '../src/keyed-lock.js';
 
 const CONTEXT_GRAPH_ID = '42';
 const AUTHOR = '0x1111111111111111111111111111111111111111';
@@ -63,6 +64,71 @@ function byteSizeFloor(quads: readonly Pick<Quad, 'subject' | 'predicate' | 'obj
 }
 
 describe('graph-scoped publish storage ACKs', () => {
+  it('serializes workspace persistence in the shared per-KA lock domain', async () => {
+    const store = new OxigraphStore();
+    const writeLocks = new Map<string, Promise<void>>();
+    const quads: Quad[] = [{
+      subject: 'urn:asset:locked',
+      predicate: 'urn:p:value',
+      object: '"locked"',
+      graph: SWM_GRAPH,
+    }];
+    await store.insert(quads);
+    const config = handlerConfig(ethers.Wallet.createRandom(), false);
+    const handler = new StorageACKHandler(
+      store,
+      { ...config, workspaceWriteLocks: writeLocks },
+      new TypedEventBus(),
+    );
+    const merkleRoot = computeFlatKCRootV10(quads, []);
+    const intent = encodePublishIntent({
+      merkleRoot,
+      contextGraphId: CONTEXT_GRAPH_ID,
+      publisherPeerId: 'publisher-peer',
+      publicByteSize: byteSizeFloor(quads),
+      isPrivate: false,
+      kaCount: 1,
+      rootEntities: [],
+      merkleLeafCount: computeFlatKCMerkleLeafCountV10(quads, []),
+      contentScopeVersion: GRAPH_KA_CONTENT_SCOPE_VERSION,
+      kaUal: UAL,
+      assertionVersion: '1',
+      publicTripleCount: quads.length,
+      privateTripleCount: 0,
+      accessPolicy: 'public',
+      allowedPeers: [],
+    });
+
+    let release!: () => void;
+    let entered!: () => void;
+    const blocked = new Promise<void>((resolve) => { release = resolve; });
+    const lockEntered = new Promise<void>((resolve) => { entered = resolve; });
+    const lock = withKeyedLocks(
+      writeLocks,
+      [swmKaWriteLockKey(CONTEXT_GRAPH_ID, undefined, UAL)],
+      async () => {
+        entered();
+        await blocked;
+      },
+    );
+    await lockEntered;
+
+    let settled = false;
+    const response = handler.handler(intent, PEER).finally(() => { settled = true; });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(settled).toBe(false);
+
+    release();
+    await lock;
+    await expect(response).resolves.toBeInstanceOf(Uint8Array);
+    await expect(resolveKnowledgeAssetWorkspaceHead({
+      store,
+      graphManager: new GraphManager(store),
+      contextGraphId: CONTEXT_GRAPH_ID,
+      kaUal: UAL,
+    })).resolves.toMatchObject({ kaUal: UAL });
+  });
+
   it.each([
     {
       label: 'content without triples',


### PR DESCRIPTION
## Summary

Graph-scoped finalization is broadcast to every Context Graph subscriber, but only nodes that retained the corresponding KA can repair it. During the SBB incident, unrelated subscribers still journaled these messages and filled their bounded recovery inboxes.

## Changes

- Gate durable graph-scoped finalization admission on local ownership evidence.
- Treat any local SWM head row as ownership, including malformed heads that still need repair.
- Also recognize confirmed VM metadata in the root or on-chain partition metadata graph.
- Fail open on a transient store-read failure so a relevant finalization is never permanently discarded.
- Leave the legacy finalization path unchanged.

The gate runs after graph-envelope admission and before receipt resolution or durable inbox insertion. Storage-ACK participants persist the workspace before ACKing, so a node responsible for the record already has the local evidence checked here.

## Test Plan

- [x] `pnpm --filter @origintrail-official/dkg-agent build`
- [x] `vitest run test/ka-graph-finalization-handler.test.ts` (89/89)
- [ ] Live canary verification

## Related Issues

Incident follow-up for the SBB/Base finalization recovery storm. PR #2532 is adjacent malformed-head work, but does not restrict recovery ownership.
