### PR TITLE
perf(chain): scan only new Context Graph authority blocks

### DIFF
--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -5,9 +5,10 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && pnpm run test:types",
     "test": "vitest run",
     "test:unit": "vitest run --config vitest.unit.config.ts",
+    "test:types": "tsc --project tsconfig.type-tests.json",
     "test:coverage": "vitest run --coverage && node ../../scripts/ci/check-coverage.mjs chain",
     "clean": "rm -rf dist tsconfig.tsbuildinfo"
   },

--- a/packages/chain/src/context-graph-authority-history.ts
+++ b/packages/chain/src/context-graph-authority-history.ts
@@ -5,12 +5,15 @@ import { BoundedLruCache } from '@origintrail-official/dkg-core';
 export const CONTEXT_GRAPH_AUTHORITY_HISTORY_MAX_ENTRIES = 1_024;
 
 export interface ContextGraphAuthorityHistoryEvent {
-  readonly name: ContextGraphAuthorityHistoryEventName;
   readonly blockNumber: number;
   readonly blockHash: string;
   readonly index: number;
-  /** Present only on the normalized creation event. */
-  readonly nameHash?: string;
+}
+
+/** Creation is the only history event that must carry the immutable name hash. */
+export interface ContextGraphAuthorityHistoryCreationEvent
+  extends ContextGraphAuthorityHistoryEvent {
+  readonly nameHash: string;
 }
 
 export interface ContextGraphAuthorityHistoryState {
@@ -26,7 +29,6 @@ export interface ContextGraphAuthorityHistoryState {
 }
 
 export type ContextGraphAuthorityHistoryEventName =
-  | 'ContextGraphCreated'
   | 'Transfer'
   | 'PublishPolicyUpdated'
   | 'PublishAuthorityUpdated'
@@ -38,9 +40,41 @@ export interface ContextGraphAuthorityHistoryEventQuery {
   readonly contextGraphId: bigint;
 }
 
-/** Bounded LRU storage for finalized per-contract, per-graph history states. */
+export interface ContextGraphAuthorityHistoryLoadInput {
+  readonly cacheKey: string;
+  readonly contextGraphId: bigint;
+  readonly finalized: Readonly<{ number: number; hash: string }>;
+  readonly pageSize: number;
+  readonly signal?: AbortSignal;
+  readonly loadColdFromBlock: () => Promise<number>;
+  readonly readBlockHash: (blockNumber: number) => Promise<string | null>;
+  readonly readCreationEvents: (
+    contextGraphId: bigint,
+    fromBlock: number,
+    toBlock: number,
+  ) => Promise<readonly ContextGraphAuthorityHistoryCreationEvent[]>;
+  readonly readEvents: (
+    query: ContextGraphAuthorityHistoryEventQuery,
+    fromBlock: number,
+    toBlock: number,
+  ) => Promise<readonly ContextGraphAuthorityHistoryEvent[]>;
+}
+
+export interface ContextGraphAuthorityHistoryResolution {
+  readonly state: ContextGraphAuthorityHistoryState;
+  /** Revalidate and publish only after the matching current state is decoded. */
+  publish(): Promise<void>;
+}
+
+/**
+ * Atomic owner of finalized history loading, publication, and invalidation.
+ * Same-head readers share a scan, an older completion cannot replace a newer
+ * watermark, and clear() invalidates every in-flight publication lease.
+ */
 export class ContextGraphAuthorityHistoryCache {
   readonly #entries: BoundedLruCache<string, ContextGraphAuthorityHistoryState>;
+  readonly #inflight = new Map<string, Promise<ContextGraphAuthorityHistoryState>>();
+  #epoch = 0;
 
   constructor(
     readonly maxEntries: number = CONTEXT_GRAPH_AUTHORITY_HISTORY_MAX_ENTRIES,
@@ -51,47 +85,85 @@ export class ContextGraphAuthorityHistoryCache {
     this.#entries = new BoundedLruCache(maxEntries);
   }
 
-  get(key: string): ContextGraphAuthorityHistoryState | undefined {
-    return this.#entries.get(key);
-  }
-
-  delete(key: string): void {
-    this.#entries.delete(key);
-  }
-
-  set(key: string, value: ContextGraphAuthorityHistoryState): void {
-    this.#entries.set(key, value);
+  async resolve(
+    input: ContextGraphAuthorityHistoryLoadInput,
+  ): Promise<ContextGraphAuthorityHistoryResolution> {
+    const epoch = this.#epoch;
+    const finalizedHash = input.finalized.hash.toLowerCase();
+    const normalizedInput = {
+      ...input,
+      finalized: { number: input.finalized.number, hash: finalizedHash },
+    };
+    const loadKey = `${input.cacheKey}\u0000${input.finalized.number}\u0000${finalizedHash}`;
+    let pending = this.#inflight.get(loadKey);
+    if (pending === undefined) {
+      pending = this.#load(normalizedInput);
+      this.#inflight.set(loadKey, pending);
+      void pending.finally(() => {
+        if (this.#inflight.get(loadKey) === pending) this.#inflight.delete(loadKey);
+      }).catch(() => {});
+    }
+    const state = await pending;
+    return Object.freeze({
+      state,
+      publish: async () => {
+        // This is intentionally the final await: callers invoke publish only
+        // after their concurrent current-state read and every field decode.
+        const stableHash = await input.readBlockHash(input.finalized.number);
+        if (stableHash?.toLowerCase() !== finalizedHash) {
+          throw new Error('finalized Context Graph authority anchor changed during resolution');
+        }
+        if (this.#epoch !== epoch) {
+          throw new Error('Context Graph authority history was invalidated during resolution');
+        }
+        const current = this.#entries.get(input.cacheKey);
+        if (current !== undefined && current.throughBlockNumber > state.throughBlockNumber) return;
+        if (
+          current !== undefined
+          && current.throughBlockNumber === state.throughBlockNumber
+          && current.throughBlockHash === state.throughBlockHash
+        ) return;
+        this.#entries.set(input.cacheKey, state);
+      },
+    });
   }
 
   clear(): void {
+    this.#epoch += 1;
     this.#entries.clear();
+    this.#inflight.clear();
   }
 
   get size(): number {
     return this.#entries.size;
   }
+
+  async #load(
+    input: ContextGraphAuthorityHistoryLoadInput,
+  ): Promise<ContextGraphAuthorityHistoryState> {
+    let previous = this.#entries.get(input.cacheKey);
+    if (previous !== undefined) {
+      const anchorHash = previous.throughBlockNumber === input.finalized.number
+        ? input.finalized.hash
+        : previous.throughBlockNumber < input.finalized.number
+          ? await input.readBlockHash(previous.throughBlockNumber)
+          : null;
+      if (anchorHash?.toLowerCase() !== previous.throughBlockHash) {
+        // Do not let a slow stale-anchor check delete a newer state published
+        // while its RPC request was in flight.
+        if (this.#entries.get(input.cacheKey) === previous) {
+          this.#entries.delete(input.cacheKey);
+        }
+        previous = undefined;
+      }
+    }
+    return loadContextGraphAuthorityHistory({ ...input, previous });
+  }
 }
 
-export interface ResolveContextGraphAuthorityHistoryInput {
+export interface ResolveContextGraphAuthorityHistoryInput
+  extends ContextGraphAuthorityHistoryLoadInput {
   readonly cache: ContextGraphAuthorityHistoryCache;
-  readonly cacheKey: string;
-  readonly contextGraphId: bigint;
-  readonly finalized: Readonly<{ number: number; hash: string }>;
-  readonly pageSize: number;
-  readonly signal?: AbortSignal;
-  readonly loadColdFromBlock: () => Promise<number>;
-  readonly readBlockHash: (blockNumber: number) => Promise<string | null>;
-  readonly readEvents: (
-    query: ContextGraphAuthorityHistoryEventQuery,
-    fromBlock: number,
-    toBlock: number,
-  ) => Promise<readonly ContextGraphAuthorityHistoryEvent[]>;
-}
-
-export interface ContextGraphAuthorityHistoryResolution {
-  readonly state: ContextGraphAuthorityHistoryState;
-  /** Publish only after the matching current-state snapshot is decoded. */
-  commit(): void;
 }
 
 function latestEvent(
@@ -106,19 +178,16 @@ function latestEvent(
 export async function resolveContextGraphAuthorityHistory(
   input: ResolveContextGraphAuthorityHistoryInput,
 ): Promise<ContextGraphAuthorityHistoryResolution> {
-  const finalizedHash = input.finalized.hash.toLowerCase();
-  let previous = input.cache.get(input.cacheKey);
-  if (previous !== undefined) {
-    const anchorHash = previous.throughBlockNumber === input.finalized.number
-      ? finalizedHash
-      : previous.throughBlockNumber < input.finalized.number
-        ? await input.readBlockHash(previous.throughBlockNumber)
-        : null;
-    if (anchorHash?.toLowerCase() !== previous.throughBlockHash) {
-      input.cache.delete(input.cacheKey);
-      previous = undefined;
-    }
-  }
+  const { cache, ...loadInput } = input;
+  return cache.resolve(loadInput);
+}
+
+async function loadContextGraphAuthorityHistory(
+  input: ContextGraphAuthorityHistoryLoadInput & {
+    readonly previous?: ContextGraphAuthorityHistoryState;
+  },
+): Promise<ContextGraphAuthorityHistoryState> {
+  const previous = input.previous;
   const cold = previous === undefined;
   const fromBlock = previous === undefined
     ? await input.loadColdFromBlock()
@@ -134,9 +203,18 @@ export async function resolveContextGraphAuthorityHistory(
     }
     return events;
   };
+  const readCreation = async (): Promise<ContextGraphAuthorityHistoryCreationEvent[]> => {
+    const events: ContextGraphAuthorityHistoryCreationEvent[] = [];
+    for (let lo = fromBlock; lo <= input.finalized.number; lo += input.pageSize) {
+      input.signal?.throwIfAborted();
+      const hi = Math.min(lo + input.pageSize - 1, input.finalized.number);
+      events.push(...await input.readCreationEvents(input.contextGraphId, lo, hi));
+    }
+    return events;
+  };
   const [created, transfers, publishPolicy, publishAuthority, participantAdds,
     participantRemoves] = await Promise.all([
-    cold ? read('ContextGraphCreated') : Promise.resolve([]),
+    cold ? readCreation() : Promise.resolve([]),
     read('Transfer'),
     read('PublishPolicyUpdated'),
     read('PublishAuthorityUpdated'),
@@ -147,10 +225,6 @@ export async function resolveContextGraphAuthorityHistory(
     throw new Error(
       `Context Graph ${input.contextGraphId.toString()} has ${created.length} finalized creation events`,
     );
-  }
-  const stableHash = await input.readBlockHash(input.finalized.number);
-  if (stableHash?.toLowerCase() !== finalizedHash) {
-    throw new Error('finalized Context Graph authority anchor changed during resolution');
   }
   const policySource = latestEvent([
     ...created,
@@ -170,9 +244,9 @@ export async function resolveContextGraphAuthorityHistory(
     throw new Error(`Context Graph ${input.contextGraphId.toString()} creation event has no name hash`);
   }
   const ownershipDelta = transfers.length;
-  const state: ContextGraphAuthorityHistoryState = Object.freeze({
+  return Object.freeze({
     throughBlockNumber: input.finalized.number,
-    throughBlockHash: finalizedHash,
+    throughBlockHash: input.finalized.hash,
     nameHash: previous?.nameHash ?? creationNameHash!,
     ownershipEra: (previous?.ownershipEra ?? 0) + ownershipDelta,
     policyVersion: (previous?.policyVersion ?? 0)
@@ -182,9 +256,5 @@ export async function resolveContextGraphAuthorityHistory(
     sourceBlockNumber,
     sourceBlockHash: sourceBlockHash.toLowerCase(),
     sourceLogIndex,
-  });
-  return Object.freeze({
-    state,
-    commit: () => input.cache.set(input.cacheKey, state),
   });
 }

--- a/packages/chain/src/context-graph-authority-history.ts
+++ b/packages/chain/src/context-graph-authority-history.ts
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export const CONTEXT_GRAPH_AUTHORITY_HISTORY_MAX_ENTRIES = 1_024;
+
+export interface ContextGraphAuthorityHistoryEvent {
+  readonly blockNumber: number;
+  readonly blockHash: string;
+  readonly index: number;
+  readonly args?: readonly unknown[] | Record<string, unknown>;
+}
+
+export interface ContextGraphAuthorityHistoryState {
+  readonly throughBlockNumber: number;
+  readonly throughBlockHash: string;
+  readonly nameHash: string;
+  readonly ownershipEra: number;
+  readonly policyVersion: number;
+  readonly rosterVersion: number;
+  readonly sourceBlockNumber: number;
+  readonly sourceBlockHash: string;
+  readonly sourceLogIndex: number;
+}
+
+export type ContextGraphAuthorityHistoryEventName =
+  | 'ContextGraphCreated'
+  | 'Transfer'
+  | 'PublishPolicyUpdated'
+  | 'PublishAuthorityUpdated'
+  | 'AgentParticipantAdded'
+  | 'AgentParticipantRemoved';
+
+/** Bounded LRU storage for finalized per-contract, per-graph history states. */
+export class ContextGraphAuthorityHistoryCache {
+  readonly #entries = new Map<string, ContextGraphAuthorityHistoryState>();
+
+  constructor(
+    readonly maxEntries: number = CONTEXT_GRAPH_AUTHORITY_HISTORY_MAX_ENTRIES,
+  ) {
+    if (!Number.isSafeInteger(maxEntries) || maxEntries < 1) {
+      throw new Error('Context Graph authority history cache must retain at least one entry');
+    }
+  }
+
+  get(key: string): ContextGraphAuthorityHistoryState | undefined {
+    const value = this.#entries.get(key);
+    if (value === undefined) return undefined;
+    this.#entries.delete(key);
+    this.#entries.set(key, value);
+    return value;
+  }
+
+  delete(key: string): void {
+    this.#entries.delete(key);
+  }
+
+  set(key: string, value: ContextGraphAuthorityHistoryState): void {
+    this.#entries.delete(key);
+    this.#entries.set(key, value);
+    while (this.#entries.size > this.maxEntries) {
+      const oldest = this.#entries.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      this.#entries.delete(oldest);
+    }
+  }
+
+  clear(): void {
+    this.#entries.clear();
+  }
+
+  get size(): number {
+    return this.#entries.size;
+  }
+}
+
+const adapterAuthorityHistoryCaches = new WeakMap<object, ContextGraphAuthorityHistoryCache>();
+
+export function contextGraphAuthorityHistoryCacheFor(
+  owner: object,
+): ContextGraphAuthorityHistoryCache {
+  let cache = adapterAuthorityHistoryCaches.get(owner);
+  if (cache === undefined) {
+    cache = new ContextGraphAuthorityHistoryCache();
+    adapterAuthorityHistoryCaches.set(owner, cache);
+  }
+  return cache;
+}
+
+export function invalidateContextGraphAuthorityHistory(owner: object): void {
+  adapterAuthorityHistoryCaches.get(owner)?.clear();
+  adapterAuthorityHistoryCaches.delete(owner);
+}
+
+export interface ResolveContextGraphAuthorityHistoryInput {
+  readonly cache: ContextGraphAuthorityHistoryCache;
+  readonly cacheKey: string;
+  readonly contextGraphId: bigint;
+  readonly finalized: Readonly<{ number: number; hash: string }>;
+  readonly pageSize: number;
+  readonly signal?: AbortSignal;
+  readonly loadColdFromBlock: () => Promise<number>;
+  readonly readBlockHash: (blockNumber: number) => Promise<string | null>;
+  readonly readEvents: (
+    name: ContextGraphAuthorityHistoryEventName,
+    args: readonly unknown[],
+    fromBlock: number,
+    toBlock: number,
+  ) => Promise<readonly ContextGraphAuthorityHistoryEvent[]>;
+  readonly isOwnershipTransfer: (event: ContextGraphAuthorityHistoryEvent) => boolean;
+  readonly creationNameHash: (event: ContextGraphAuthorityHistoryEvent) => string;
+}
+
+export interface ContextGraphAuthorityHistoryResolution {
+  readonly state: ContextGraphAuthorityHistoryState;
+  /** Publish only after the matching current-state snapshot is decoded. */
+  commit(): void;
+}
+
+function latestEvent(
+  events: readonly ContextGraphAuthorityHistoryEvent[],
+): ContextGraphAuthorityHistoryEvent | undefined {
+  return [...events].sort((left, right) => (
+    left.blockNumber - right.blockNumber || left.index - right.index
+  )).at(-1);
+}
+
+/** Resolve one cold or suffix history scan into a complete generation state. */
+export async function resolveContextGraphAuthorityHistory(
+  input: ResolveContextGraphAuthorityHistoryInput,
+): Promise<ContextGraphAuthorityHistoryResolution> {
+  const finalizedHash = input.finalized.hash.toLowerCase();
+  let previous = input.cache.get(input.cacheKey);
+  if (previous !== undefined) {
+    const anchorHash = previous.throughBlockNumber === input.finalized.number
+      ? finalizedHash
+      : previous.throughBlockNumber < input.finalized.number
+        ? await input.readBlockHash(previous.throughBlockNumber)
+        : null;
+    if (anchorHash?.toLowerCase() !== previous.throughBlockHash) {
+      input.cache.delete(input.cacheKey);
+      previous = undefined;
+    }
+  }
+  const cold = previous === undefined;
+  const fromBlock = previous === undefined
+    ? await input.loadColdFromBlock()
+    : previous.throughBlockNumber + 1;
+  const read = async (
+    name: ContextGraphAuthorityHistoryEventName,
+    args: readonly unknown[],
+  ): Promise<ContextGraphAuthorityHistoryEvent[]> => {
+    const events: ContextGraphAuthorityHistoryEvent[] = [];
+    for (let lo = fromBlock; lo <= input.finalized.number; lo += input.pageSize) {
+      input.signal?.throwIfAborted();
+      const hi = Math.min(lo + input.pageSize - 1, input.finalized.number);
+      events.push(...await input.readEvents(name, args, lo, hi));
+    }
+    return events;
+  };
+  const [created, transfers, publishPolicy, publishAuthority, participantAdds,
+    participantRemoves] = await Promise.all([
+    cold ? read('ContextGraphCreated', [input.contextGraphId]) : Promise.resolve([]),
+    read('Transfer', [null, null, input.contextGraphId]),
+    read('PublishPolicyUpdated', [input.contextGraphId]),
+    read('PublishAuthorityUpdated', [input.contextGraphId]),
+    read('AgentParticipantAdded', [input.contextGraphId]),
+    read('AgentParticipantRemoved', [input.contextGraphId]),
+  ]);
+  if (cold && created.length !== 1) {
+    throw new Error(
+      `Context Graph ${input.contextGraphId.toString()} has ${created.length} finalized creation events`,
+    );
+  }
+  const stableHash = await input.readBlockHash(input.finalized.number);
+  if (stableHash?.toLowerCase() !== finalizedHash) {
+    throw new Error('finalized Context Graph authority anchor changed during resolution');
+  }
+  const ownershipTransfers = transfers.filter(input.isOwnershipTransfer);
+  const policySource = latestEvent([
+    ...created,
+    ...ownershipTransfers,
+    ...publishPolicy,
+    ...publishAuthority,
+  ]);
+  const creation = created[0];
+  if (policySource === undefined && previous === undefined) {
+    throw new Error(`Context Graph ${input.contextGraphId.toString()} has no authority history source`);
+  }
+  const sourceBlockNumber = policySource?.blockNumber ?? previous!.sourceBlockNumber;
+  const sourceBlockHash = policySource?.blockHash ?? previous!.sourceBlockHash;
+  const sourceLogIndex = policySource?.index ?? previous!.sourceLogIndex;
+  const ownershipDelta = ownershipTransfers.length;
+  const state: ContextGraphAuthorityHistoryState = Object.freeze({
+    throughBlockNumber: input.finalized.number,
+    throughBlockHash: finalizedHash,
+    nameHash: previous?.nameHash ?? input.creationNameHash(creation!),
+    ownershipEra: (previous?.ownershipEra ?? 0) + ownershipDelta,
+    policyVersion: (previous?.policyVersion ?? 0)
+      + ownershipDelta + publishPolicy.length + publishAuthority.length,
+    rosterVersion: (previous?.rosterVersion ?? 0)
+      + ownershipDelta + participantAdds.length + participantRemoves.length,
+    sourceBlockNumber,
+    sourceBlockHash: sourceBlockHash.toLowerCase(),
+    sourceLogIndex,
+  });
+  return Object.freeze({
+    state,
+    commit: () => input.cache.set(input.cacheKey, state),
+  });
+}

--- a/packages/chain/src/context-graph-authority-history.ts
+++ b/packages/chain/src/context-graph-authority-history.ts
@@ -25,7 +25,6 @@ export interface ContextGraphAuthorityHistoryState {
   readonly rosterVersion: number;
   readonly sourceBlockNumber: number;
   readonly sourceBlockHash: string;
-  readonly sourceLogIndex: number;
 }
 
 export type ContextGraphAuthorityHistoryEventName =
@@ -212,7 +211,6 @@ async function loadContextGraphAuthorityHistory(
   },
 ): Promise<ContextGraphAuthorityHistoryState> {
   const previous = input.previous;
-  const cold = previous === undefined;
   const fromBlock = previous === undefined
     ? await input.loadColdFromBlock()
     : previous.throughBlockNumber + 1;
@@ -238,47 +236,69 @@ async function loadContextGraphAuthorityHistory(
   };
   const [created, transfers, publishPolicy, publishAuthority, participantAdds,
     participantRemoves] = await Promise.all([
-    cold ? readCreation() : Promise.resolve([]),
+    previous === undefined ? readCreation() : Promise.resolve([]),
     read('Transfer'),
     read('PublishPolicyUpdated'),
     read('PublishAuthorityUpdated'),
     read('AgentParticipantAdded'),
     read('AgentParticipantRemoved'),
   ]);
-  if (cold && created.length !== 1) {
-    throw new Error(
-      `Context Graph ${input.contextGraphId.toString()} has ${created.length} finalized creation events`,
-    );
-  }
+  const baseline: Readonly<{
+    nameHash: string;
+    ownershipEra: number;
+    policyVersion: number;
+    rosterVersion: number;
+    sourceBlockNumber: number;
+    sourceBlockHash: string;
+  }> = previous === undefined
+    ? (() => {
+        const creation = created[0];
+        if (created.length !== 1 || creation === undefined) {
+          throw new Error(
+            `Context Graph ${input.contextGraphId.toString()} has ${created.length} finalized creation events`,
+          );
+        }
+        if (!creation.nameHash) {
+          throw new Error(
+            `Context Graph ${input.contextGraphId.toString()} creation event has no name hash`,
+          );
+        }
+        return {
+          nameHash: creation.nameHash,
+          ownershipEra: 0,
+          policyVersion: 0,
+          rosterVersion: 0,
+          sourceBlockNumber: creation.blockNumber,
+          sourceBlockHash: creation.blockHash,
+        };
+      })()
+    : {
+        nameHash: previous.nameHash,
+        ownershipEra: previous.ownershipEra,
+        policyVersion: previous.policyVersion,
+        rosterVersion: previous.rosterVersion,
+        sourceBlockNumber: previous.sourceBlockNumber,
+        sourceBlockHash: previous.sourceBlockHash,
+      };
   const policySource = latestEvent([
     ...created,
     ...transfers,
     ...publishPolicy,
     ...publishAuthority,
   ]);
-  const creation = created[0];
-  if (policySource === undefined && previous === undefined) {
-    throw new Error(`Context Graph ${input.contextGraphId.toString()} has no authority history source`);
-  }
-  const sourceBlockNumber = policySource?.blockNumber ?? previous!.sourceBlockNumber;
-  const sourceBlockHash = policySource?.blockHash ?? previous!.sourceBlockHash;
-  const sourceLogIndex = policySource?.index ?? previous!.sourceLogIndex;
-  const creationNameHash = creation?.nameHash;
-  if (previous === undefined && !creationNameHash) {
-    throw new Error(`Context Graph ${input.contextGraphId.toString()} creation event has no name hash`);
-  }
+  const sourceBlockNumber = policySource?.blockNumber ?? baseline.sourceBlockNumber;
+  const sourceBlockHash = policySource?.blockHash ?? baseline.sourceBlockHash;
   const ownershipDelta = transfers.length;
   return Object.freeze({
     throughBlockNumber: input.finalized.number,
     throughBlockHash: input.finalized.hash,
-    nameHash: previous?.nameHash ?? creationNameHash!,
-    ownershipEra: (previous?.ownershipEra ?? 0) + ownershipDelta,
-    policyVersion: (previous?.policyVersion ?? 0)
+    nameHash: baseline.nameHash,
+    ownershipEra: baseline.ownershipEra + ownershipDelta,
+    policyVersion: baseline.policyVersion
       + ownershipDelta + publishPolicy.length + publishAuthority.length,
-    rosterVersion: (previous?.rosterVersion ?? 0)
+    rosterVersion: baseline.rosterVersion
       + ownershipDelta + participantAdds.length + participantRemoves.length,
     sourceBlockNumber,
     sourceBlockHash: sourceBlockHash.toLowerCase(),
-    sourceLogIndex,
   });
 }

--- a/packages/chain/src/context-graph-authority-history.ts
+++ b/packages/chain/src/context-graph-authority-history.ts
@@ -42,6 +42,8 @@ export interface ContextGraphAuthorityHistoryEventQuery {
 
 export interface ContextGraphAuthorityHistoryLoadInput {
   readonly cacheKey: string;
+  /** Stable identity of the physical RPC reader used for this provider attempt. */
+  readonly readScope: object;
   readonly contextGraphId: bigint;
   readonly finalized: Readonly<{ number: number; hash: string }>;
   readonly pageSize: number;
@@ -74,6 +76,8 @@ export interface ContextGraphAuthorityHistoryResolution {
 export class ContextGraphAuthorityHistoryCache {
   readonly #entries: BoundedLruCache<string, ContextGraphAuthorityHistoryState>;
   readonly #inflight = new Map<string, Promise<ContextGraphAuthorityHistoryState>>();
+  readonly #identityIds = new WeakMap<object, number>();
+  #nextIdentityId = 1;
   #epoch = 0;
 
   constructor(
@@ -94,7 +98,18 @@ export class ContextGraphAuthorityHistoryCache {
       ...input,
       finalized: { number: input.finalized.number, hash: finalizedHash },
     };
-    const loadKey = `${input.cacheKey}\u0000${input.finalized.number}\u0000${finalizedHash}`;
+    // A failover retry at the same finalized head must be able to leave a
+    // stalled endpoint behind. Likewise, callers with independent abort
+    // signals must not inherit one another's cancellation. Readers only share
+    // work when the logical head, physical endpoint, and cancellation domain
+    // are all compatible.
+    const loadKey = [
+      input.cacheKey,
+      input.finalized.number,
+      finalizedHash,
+      this.#identityId(input.readScope),
+      input.signal === undefined ? 'no-signal' : this.#identityId(input.signal),
+    ].join('\u0000');
     let pending = this.#inflight.get(loadKey);
     if (pending === undefined) {
       pending = this.#load(normalizedInput);
@@ -136,6 +151,15 @@ export class ContextGraphAuthorityHistoryCache {
 
   get size(): number {
     return this.#entries.size;
+  }
+
+  #identityId(identity: object): number {
+    const existing = this.#identityIds.get(identity);
+    if (existing !== undefined) return existing;
+    const assigned = this.#nextIdentityId;
+    this.#nextIdentityId += 1;
+    this.#identityIds.set(identity, assigned);
+    return assigned;
   }
 
   async #load(

--- a/packages/chain/src/context-graph-authority-history.ts
+++ b/packages/chain/src/context-graph-authority-history.ts
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { BoundedLruCache } from '@origintrail-official/dkg-core';
+
 export const CONTEXT_GRAPH_AUTHORITY_HISTORY_MAX_ENTRIES = 1_024;
 
 export interface ContextGraphAuthorityHistoryEvent {
+  readonly name: ContextGraphAuthorityHistoryEventName;
   readonly blockNumber: number;
   readonly blockHash: string;
   readonly index: number;
-  readonly args?: readonly unknown[] | Record<string, unknown>;
+  /** Present only on the normalized creation event. */
+  readonly nameHash?: string;
 }
 
 export interface ContextGraphAuthorityHistoryState {
@@ -29,9 +33,14 @@ export type ContextGraphAuthorityHistoryEventName =
   | 'AgentParticipantAdded'
   | 'AgentParticipantRemoved';
 
+export interface ContextGraphAuthorityHistoryEventQuery {
+  readonly name: ContextGraphAuthorityHistoryEventName;
+  readonly contextGraphId: bigint;
+}
+
 /** Bounded LRU storage for finalized per-contract, per-graph history states. */
 export class ContextGraphAuthorityHistoryCache {
-  readonly #entries = new Map<string, ContextGraphAuthorityHistoryState>();
+  readonly #entries: BoundedLruCache<string, ContextGraphAuthorityHistoryState>;
 
   constructor(
     readonly maxEntries: number = CONTEXT_GRAPH_AUTHORITY_HISTORY_MAX_ENTRIES,
@@ -39,14 +48,11 @@ export class ContextGraphAuthorityHistoryCache {
     if (!Number.isSafeInteger(maxEntries) || maxEntries < 1) {
       throw new Error('Context Graph authority history cache must retain at least one entry');
     }
+    this.#entries = new BoundedLruCache(maxEntries);
   }
 
   get(key: string): ContextGraphAuthorityHistoryState | undefined {
-    const value = this.#entries.get(key);
-    if (value === undefined) return undefined;
-    this.#entries.delete(key);
-    this.#entries.set(key, value);
-    return value;
+    return this.#entries.get(key);
   }
 
   delete(key: string): void {
@@ -54,13 +60,7 @@ export class ContextGraphAuthorityHistoryCache {
   }
 
   set(key: string, value: ContextGraphAuthorityHistoryState): void {
-    this.#entries.delete(key);
     this.#entries.set(key, value);
-    while (this.#entries.size > this.maxEntries) {
-      const oldest = this.#entries.keys().next().value as string | undefined;
-      if (oldest === undefined) break;
-      this.#entries.delete(oldest);
-    }
   }
 
   clear(): void {
@@ -70,24 +70,6 @@ export class ContextGraphAuthorityHistoryCache {
   get size(): number {
     return this.#entries.size;
   }
-}
-
-const adapterAuthorityHistoryCaches = new WeakMap<object, ContextGraphAuthorityHistoryCache>();
-
-export function contextGraphAuthorityHistoryCacheFor(
-  owner: object,
-): ContextGraphAuthorityHistoryCache {
-  let cache = adapterAuthorityHistoryCaches.get(owner);
-  if (cache === undefined) {
-    cache = new ContextGraphAuthorityHistoryCache();
-    adapterAuthorityHistoryCaches.set(owner, cache);
-  }
-  return cache;
-}
-
-export function invalidateContextGraphAuthorityHistory(owner: object): void {
-  adapterAuthorityHistoryCaches.get(owner)?.clear();
-  adapterAuthorityHistoryCaches.delete(owner);
 }
 
 export interface ResolveContextGraphAuthorityHistoryInput {
@@ -100,13 +82,10 @@ export interface ResolveContextGraphAuthorityHistoryInput {
   readonly loadColdFromBlock: () => Promise<number>;
   readonly readBlockHash: (blockNumber: number) => Promise<string | null>;
   readonly readEvents: (
-    name: ContextGraphAuthorityHistoryEventName,
-    args: readonly unknown[],
+    query: ContextGraphAuthorityHistoryEventQuery,
     fromBlock: number,
     toBlock: number,
   ) => Promise<readonly ContextGraphAuthorityHistoryEvent[]>;
-  readonly isOwnershipTransfer: (event: ContextGraphAuthorityHistoryEvent) => boolean;
-  readonly creationNameHash: (event: ContextGraphAuthorityHistoryEvent) => string;
 }
 
 export interface ContextGraphAuthorityHistoryResolution {
@@ -146,24 +125,23 @@ export async function resolveContextGraphAuthorityHistory(
     : previous.throughBlockNumber + 1;
   const read = async (
     name: ContextGraphAuthorityHistoryEventName,
-    args: readonly unknown[],
   ): Promise<ContextGraphAuthorityHistoryEvent[]> => {
     const events: ContextGraphAuthorityHistoryEvent[] = [];
     for (let lo = fromBlock; lo <= input.finalized.number; lo += input.pageSize) {
       input.signal?.throwIfAborted();
       const hi = Math.min(lo + input.pageSize - 1, input.finalized.number);
-      events.push(...await input.readEvents(name, args, lo, hi));
+      events.push(...await input.readEvents({ name, contextGraphId: input.contextGraphId }, lo, hi));
     }
     return events;
   };
   const [created, transfers, publishPolicy, publishAuthority, participantAdds,
     participantRemoves] = await Promise.all([
-    cold ? read('ContextGraphCreated', [input.contextGraphId]) : Promise.resolve([]),
-    read('Transfer', [null, null, input.contextGraphId]),
-    read('PublishPolicyUpdated', [input.contextGraphId]),
-    read('PublishAuthorityUpdated', [input.contextGraphId]),
-    read('AgentParticipantAdded', [input.contextGraphId]),
-    read('AgentParticipantRemoved', [input.contextGraphId]),
+    cold ? read('ContextGraphCreated') : Promise.resolve([]),
+    read('Transfer'),
+    read('PublishPolicyUpdated'),
+    read('PublishAuthorityUpdated'),
+    read('AgentParticipantAdded'),
+    read('AgentParticipantRemoved'),
   ]);
   if (cold && created.length !== 1) {
     throw new Error(
@@ -174,10 +152,9 @@ export async function resolveContextGraphAuthorityHistory(
   if (stableHash?.toLowerCase() !== finalizedHash) {
     throw new Error('finalized Context Graph authority anchor changed during resolution');
   }
-  const ownershipTransfers = transfers.filter(input.isOwnershipTransfer);
   const policySource = latestEvent([
     ...created,
-    ...ownershipTransfers,
+    ...transfers,
     ...publishPolicy,
     ...publishAuthority,
   ]);
@@ -188,11 +165,15 @@ export async function resolveContextGraphAuthorityHistory(
   const sourceBlockNumber = policySource?.blockNumber ?? previous!.sourceBlockNumber;
   const sourceBlockHash = policySource?.blockHash ?? previous!.sourceBlockHash;
   const sourceLogIndex = policySource?.index ?? previous!.sourceLogIndex;
-  const ownershipDelta = ownershipTransfers.length;
+  const creationNameHash = creation?.nameHash;
+  if (previous === undefined && !creationNameHash) {
+    throw new Error(`Context Graph ${input.contextGraphId.toString()} creation event has no name hash`);
+  }
+  const ownershipDelta = transfers.length;
   const state: ContextGraphAuthorityHistoryState = Object.freeze({
     throughBlockNumber: input.finalized.number,
     throughBlockHash: finalizedHash,
-    nameHash: previous?.nameHash ?? input.creationNameHash(creation!),
+    nameHash: previous?.nameHash ?? creationNameHash!,
     ownershipEra: (previous?.ownershipEra ?? 0) + ownershipDelta,
     policyVersion: (previous?.policyVersion ?? 0)
       + ownershipDelta + publishPolicy.length + publishAuthority.length,

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -51,7 +51,7 @@ import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, reso
 } from './evm-adapter-constants.js';
 import { decodeKnowledgeAssetUpdateContext } from './evm-knowledge-asset-update-context.js';
 import { applyTransactionFeeCap, resolveMaxFeePerGasWei } from './evm-fee-cap.js';
-import { invalidateContextGraphAuthorityHistory } from './context-graph-authority-history.js';
+import { ContextGraphAuthorityHistoryCache } from './context-graph-authority-history.js';
 
 export { CG_REGISTRY_MAX_SCAN_PAGES } from './evm-adapter-constants.js';
 
@@ -982,6 +982,9 @@ export class EVMChainAdapterBase {
 
   protected readonly contextGraphRegistryScanCursor: ContextGraphRegistryScanCursor;
 
+  /** Finalized authority scan watermarks owned by this adapter lifecycle. */
+  protected readonly contextGraphAuthorityHistory = new ContextGraphAuthorityHistoryCache();
+
   /**
    * eth_getLogs block-window for the pre-10.0.4 getMaxKaNumberForAuthor fallback
    * scan (adapter-level config `kaHighWaterScanPageSize`; non-integer / `< 1`
@@ -1007,6 +1010,7 @@ export class EVMChainAdapterBase {
     this.cachedContractDeployBlocks.clear();
     this.contextGraphNameHashResolver?.invalidateAll();
     this.contextGraphRegistryScanCursor.clearMemoryCache();
+    this.contextGraphAuthorityHistory.clear();
   }
 
   protected clearIdentityIdForAddress(address: string): void {
@@ -4252,7 +4256,7 @@ export class EVMChainAdapterBase {
     // pure missed-rotation backstop.
     this.resolvedContractAddressCache.invalidateAll();
     if (name === 'ContextGraphStorage') {
-      invalidateContextGraphAuthorityHistory(this);
+      this.contextGraphAuthorityHistory.clear();
     }
     if (name === 'RandomSampling' || name === 'RandomSamplingStorage') {
       this.invalidateRandomSamplingPair();
@@ -4315,7 +4319,6 @@ export class EVMChainAdapterBase {
     // the entire resolved-address memo along with every bound handle.
     this.resolvedContractAddressCache.invalidateAll();
     this.invalidateRandomSamplingPair();
-    invalidateContextGraphAuthorityHistory(this);
     this.initialized = false;
   }
 
@@ -4350,7 +4353,7 @@ export class EVMChainAdapterBase {
    */
   destroy(): void {
     this.hubRotationPoller.stop();
-    invalidateContextGraphAuthorityHistory(this);
+    this.contextGraphAuthorityHistory.clear();
     for (const provider of this.providers) {
       try { provider.destroy(); } catch { /* already destroyed / not destroyable */ }
     }

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -4255,9 +4255,6 @@ export class EVMChainAdapterBase {
     // may have moved; flushing all of them is correct and keeps the 30s TTL as a
     // pure missed-rotation backstop.
     this.resolvedContractAddressCache.invalidateAll();
-    if (name === 'ContextGraphStorage') {
-      this.contextGraphAuthorityHistory.clear();
-    }
     if (name === 'RandomSampling' || name === 'RandomSamplingStorage') {
       this.invalidateRandomSamplingPair();
       return;

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -51,6 +51,7 @@ import { RPC_READ_STALL_TIMEOUT_MS, DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS, reso
 } from './evm-adapter-constants.js';
 import { decodeKnowledgeAssetUpdateContext } from './evm-knowledge-asset-update-context.js';
 import { applyTransactionFeeCap, resolveMaxFeePerGasWei } from './evm-fee-cap.js';
+import { invalidateContextGraphAuthorityHistory } from './context-graph-authority-history.js';
 
 export { CG_REGISTRY_MAX_SCAN_PAGES } from './evm-adapter-constants.js';
 
@@ -4250,6 +4251,9 @@ export class EVMChainAdapterBase {
     // may have moved; flushing all of them is correct and keeps the 30s TTL as a
     // pure missed-rotation backstop.
     this.resolvedContractAddressCache.invalidateAll();
+    if (name === 'ContextGraphStorage') {
+      invalidateContextGraphAuthorityHistory(this);
+    }
     if (name === 'RandomSampling' || name === 'RandomSamplingStorage') {
       this.invalidateRandomSamplingPair();
       return;
@@ -4311,6 +4315,7 @@ export class EVMChainAdapterBase {
     // the entire resolved-address memo along with every bound handle.
     this.resolvedContractAddressCache.invalidateAll();
     this.invalidateRandomSamplingPair();
+    invalidateContextGraphAuthorityHistory(this);
     this.initialized = false;
   }
 
@@ -4345,6 +4350,7 @@ export class EVMChainAdapterBase {
    */
   destroy(): void {
     this.hubRotationPoller.stop();
+    invalidateContextGraphAuthorityHistory(this);
     for (const provider of this.providers) {
       try { provider.destroy(); } catch { /* already destroyed / not destroyable */ }
     }

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -22,6 +22,7 @@ import { ContextGraphChainScanPartialError, type ChainReadOptions, type ContextG
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
 import {
   resolveContextGraphAuthorityHistory,
+  type ContextGraphAuthorityHistoryCreationEvent,
   type ContextGraphAuthorityHistoryEvent,
   type ContextGraphAuthorityHistoryEventQuery,
 } from './context-graph-authority-history.js';
@@ -932,6 +933,22 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         const cache = this.contextGraphAuthorityHistory;
         const cacheKey = `${contractAddress}:${contextGraphId.toString(10)}`;
         const authorityFilters = new Map<string, ethers.DeferredTopicFilter>();
+        const readAuthorityEvents = async (
+          name: 'ContextGraphCreated' | ContextGraphAuthorityHistoryEventQuery['name'],
+          targetContextGraphId: bigint,
+          fromBlock: number,
+          toBlock: number,
+        ): Promise<ethers.EventLog[]> => {
+          let filter = authorityFilters.get(name);
+          if (filter === undefined) {
+            filter = name === 'Transfer'
+              ? filters[name]!(null, null, targetContextGraphId)
+              : filters[name]!(targetContextGraphId);
+            authorityFilters.set(name, filter);
+          }
+          return (await contract.queryFilter(filter, fromBlock, toBlock))
+            .map((rawEvent) => rawEvent as ethers.EventLog);
+        };
         const [current, historyResolution] = await Promise.all([
           (contract as any).getContextGraph.staticCall(
             contextGraphId,
@@ -952,19 +969,30 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
             readBlockHash: async (blockNumber) => (
               (await provider.getBlock(blockNumber))?.hash ?? null
             ),
+            readCreationEvents: async (targetContextGraphId, fromBlock, toBlock) => (
+              readAuthorityEvents(
+                'ContextGraphCreated',
+                targetContextGraphId,
+                fromBlock,
+                toBlock,
+              ).then((events): ContextGraphAuthorityHistoryCreationEvent[] => events.map((event) => ({
+                blockNumber: event.blockNumber,
+                blockHash: event.blockHash,
+                index: event.index,
+                nameHash: String(event.args.nameHash ?? event.args[2]).toLowerCase(),
+              })))
+            ),
             readEvents: async (query: ContextGraphAuthorityHistoryEventQuery, fromBlock, toBlock) => {
               const { name } = query;
-              let filter = authorityFilters.get(name);
-              if (filter === undefined) {
-                filter = name === 'Transfer'
-                  ? filters[name]!(null, null, query.contextGraphId)
-                  : filters[name]!(query.contextGraphId);
-                authorityFilters.set(name, filter);
-              }
-              const rawEvents = await contract.queryFilter(filter, fromBlock, toBlock);
+              const rawEvents = await readAuthorityEvents(
+                name,
+                query.contextGraphId,
+                fromBlock,
+                toBlock,
+              );
               const normalized: ContextGraphAuthorityHistoryEvent[] = [];
               for (const rawEvent of rawEvents) {
-                const event = rawEvent as ethers.EventLog;
+                const event = rawEvent;
                 if (name === 'Transfer') {
                   const from = String(event.args.from ?? event.args[0]).toLowerCase();
                   const to = String(event.args.to ?? event.args[1]).toLowerCase();
@@ -975,13 +1003,9 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
                     || from === to) continue;
                 }
                 normalized.push({
-                  name,
                   blockNumber: event.blockNumber,
                   blockHash: event.blockHash,
                   index: event.index,
-                  ...(name === 'ContextGraphCreated'
-                    ? { nameHash: String(event.args.nameHash ?? event.args[2]).toLowerCase() }
-                    : {}),
                 });
               }
               return normalized;
@@ -998,11 +1022,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         const publishPolicy = Number(BigInt(current.publishPolicy ?? current[6]));
         const authorityRaw = String(current.publishAuthority ?? current[7]).toLowerCase();
         const chainId = (await provider.getNetwork()).chainId.toString(10);
-        // Publish the watermark only after the complete snapshot decoded. A
-        // transient failure in current-state parsing must leave the next call
-        // free to replay the same suffix.
-        historyResolution.commit();
-        return Object.freeze({
+        const snapshot: ContextGraphAuthoritySnapshot = Object.freeze({
           chainId,
           governanceContract: contractAddress,
           contextGraphId: contextGraphId.toString(10),
@@ -1021,6 +1041,10 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           sourceBlockNumber: nextHistory.sourceBlockNumber.toString(10),
           sourceBlockHash: nextHistory.sourceBlockHash,
         });
+        // Publish only after every returned field is decoded, and perform the
+        // final anchor check after the concurrent current-state read settles.
+        await historyResolution.publish();
+        return snapshot;
       },
       { signal: options.signal },
     );

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -21,9 +21,9 @@ import { ethers, Contract, type JsonRpcProvider } from 'ethers';
 import { ContextGraphChainScanPartialError, type ChainReadOptions, type ContextGraphAuthoritySnapshot, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type ContextGraphRegistryScanOptions, type ContextGraphRegistryScanPage, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
 import {
-  contextGraphAuthorityHistoryCacheFor,
   resolveContextGraphAuthorityHistory,
   type ContextGraphAuthorityHistoryEvent,
+  type ContextGraphAuthorityHistoryEventQuery,
 } from './context-graph-authority-history.js';
 
 type ContextGraphRegistryScanPlan =
@@ -929,7 +929,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           (...args: unknown[]) => ethers.DeferredTopicFilter
         >;
         const contractAddress = (await contract.getAddress()).toLowerCase();
-        const cache = contextGraphAuthorityHistoryCacheFor(this);
+        const cache = this.contextGraphAuthorityHistory;
         const cacheKey = `${contractAddress}:${contextGraphId.toString(10)}`;
         const authorityFilters = new Map<string, ethers.DeferredTopicFilter>();
         const [current, historyResolution] = await Promise.all([
@@ -952,29 +952,39 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
             readBlockHash: async (blockNumber) => (
               (await provider.getBlock(blockNumber))?.hash ?? null
             ),
-            readEvents: async (name, args, fromBlock, toBlock) => {
+            readEvents: async (query: ContextGraphAuthorityHistoryEventQuery, fromBlock, toBlock) => {
+              const { name } = query;
               let filter = authorityFilters.get(name);
               if (filter === undefined) {
-                filter = filters[name]!(...args);
+                filter = name === 'Transfer'
+                  ? filters[name]!(null, null, query.contextGraphId)
+                  : filters[name]!(query.contextGraphId);
                 authorityFilters.set(name, filter);
               }
-              return contract.queryFilter(filter, fromBlock, toBlock) as Promise<
-                readonly ContextGraphAuthorityHistoryEvent[]
-              >;
-            },
-            isOwnershipTransfer: (event) => {
-              const transfer = event as ethers.EventLog;
-              const from = String(transfer.args.from ?? transfer.args[0]).toLowerCase();
-              const to = String(transfer.args.to ?? transfer.args[1]).toLowerCase();
-              return ethers.isAddress(from)
-                && ethers.isAddress(to)
-                && from !== ethers.ZeroAddress
-                && to !== ethers.ZeroAddress
-                && from !== to;
-            },
-            creationNameHash: (event) => {
-              const created = event as ethers.EventLog;
-              return String(created.args[2]).toLowerCase();
+              const rawEvents = await contract.queryFilter(filter, fromBlock, toBlock);
+              const normalized: ContextGraphAuthorityHistoryEvent[] = [];
+              for (const rawEvent of rawEvents) {
+                const event = rawEvent as ethers.EventLog;
+                if (name === 'Transfer') {
+                  const from = String(event.args.from ?? event.args[0]).toLowerCase();
+                  const to = String(event.args.to ?? event.args[1]).toLowerCase();
+                  if (!ethers.isAddress(from)
+                    || !ethers.isAddress(to)
+                    || from === ethers.ZeroAddress
+                    || to === ethers.ZeroAddress
+                    || from === to) continue;
+                }
+                normalized.push({
+                  name,
+                  blockNumber: event.blockNumber,
+                  blockHash: event.blockHash,
+                  index: event.index,
+                  ...(name === 'ContextGraphCreated'
+                    ? { nameHash: String(event.args.nameHash ?? event.args[2]).toLowerCase() }
+                    : {}),
+                });
+              }
+              return normalized;
             },
           }),
         ]);

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -20,6 +20,11 @@ import {
 import { ethers, Contract, type JsonRpcProvider } from 'ethers';
 import { ContextGraphChainScanPartialError, type ChainReadOptions, type ContextGraphAuthoritySnapshot, type CreateContextGraphParams, type TxResult, type ContextGraphOnChain, type ContextGraphChainScanOptions, type ContextGraphRegistryScanOptions, type ContextGraphRegistryScanPage, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type VerifyParams, type PublishToContextGraphParams, type OnChainPublishResult } from './chain-adapter.js';
 import { buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1 } from '@origintrail-official/dkg-core';
+import {
+  contextGraphAuthorityHistoryCacheFor,
+  resolveContextGraphAuthorityHistory,
+  type ContextGraphAuthorityHistoryEvent,
+} from './context-graph-authority-history.js';
 
 type ContextGraphRegistryScanPlan =
   | {
@@ -170,26 +175,7 @@ function buildCursorContextGraphRegistryScanPlan(
   throw new Error(`Unsupported ContextGraphNameRegistry scan mode: ${JSON.stringify(exhaustive)}`);
 }
 
-interface ContextGraphAuthorityHistoryCacheEntry {
-  readonly throughBlockNumber: number;
-  readonly throughBlockHash: string;
-  readonly nameHash: string;
-  readonly ownershipEra: number;
-  readonly publishPolicyUpdates: number;
-  readonly publishAuthorityUpdates: number;
-  readonly participantAdds: number;
-  readonly participantRemoves: number;
-  readonly sourceBlockNumber: number;
-  readonly sourceBlockHash: string;
-  readonly sourceLogIndex: number;
-}
-
 export class ContextGraphMethods extends EVMChainAdapterBase {
-  /** Lazily initialized because this class is applied as a mixin. */
-  private contextGraphAuthorityHistoryCache?: Map<
-    string,
-    ContextGraphAuthorityHistoryCacheEntry
-  >;
   /**
    * Legacy cost-independent authorized signer selection. New publish flows use
    * resolvePublisherPublishPlan once byte size is known so signer, lifetime,
@@ -943,119 +929,57 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           (...args: unknown[]) => ethers.DeferredTopicFilter
         >;
         const contractAddress = (await contract.getAddress()).toLowerCase();
-        const cache = this.contextGraphAuthorityHistoryCache ??= new Map();
+        const cache = contextGraphAuthorityHistoryCacheFor(this);
         const cacheKey = `${contractAddress}:${contextGraphId.toString(10)}`;
-        let history = cache.get(cacheKey);
-        if (history) {
-          let anchorMatches = false;
-          if (history.throughBlockNumber === finalized.number) {
-            anchorMatches = history.throughBlockHash === finalized.hash.toLowerCase();
-          } else if (history.throughBlockNumber < finalized.number) {
-            const cachedAnchor = await provider.getBlock(history.throughBlockNumber);
-            anchorMatches = cachedAnchor?.hash?.toLowerCase() === history.throughBlockHash;
-          }
-          if (!anchorMatches) history = undefined;
-        }
-        const fromBlock = history
-          ? history.throughBlockNumber + 1
-          : (await this.resolveContractDeployBlock(
-              contractAddress,
-              'getContextGraphAuthoritySnapshot',
-              'ContextGraphStorage',
-            )).fromBlock;
-        const readLogs = async (name: string, ...args: unknown[]) => {
-          const logs: Array<ethers.EventLog | ethers.Log> = [];
-          if (fromBlock > finalized.number) return logs;
-          const filter = filters[name]!(...args);
-          // Production RPCs commonly cap eth_getLogs ranges. Keep every read
-          // page-bounded while all state and event results remain pinned to
-          // one finalized anchor. After the first complete read, `fromBlock`
-          // advances from the cached finalized watermark instead of the
-          // contract deployment block.
-          for (
-            let lo = fromBlock;
-            lo <= finalized.number;
-            lo += this.cgRegistryScanPageSize
-          ) {
-            options.signal?.throwIfAborted();
-            const hi = Math.min(
-              lo + this.cgRegistryScanPageSize - 1,
-              finalized.number,
-            );
-            logs.push(...await contract.queryFilter(filter, lo, hi));
-          }
-          return logs;
-        };
-        const [
-          current,
-          created,
-          transfers,
-          publishPolicyUpdates,
-          publishAuthorityUpdates,
-          participantAdds,
-          participantRemoves,
-        ] = await Promise.all([
+        const authorityFilters = new Map<string, ethers.DeferredTopicFilter>();
+        const [current, historyResolution] = await Promise.all([
           (contract as any).getContextGraph.staticCall(
             contextGraphId,
             { blockTag: finalized.number },
           ),
-          history ? Promise.resolve([]) : readLogs('ContextGraphCreated', contextGraphId),
-          readLogs('Transfer', null, null, contextGraphId),
-          readLogs('PublishPolicyUpdated', contextGraphId),
-          readLogs('PublishAuthorityUpdated', contextGraphId),
-          readLogs('AgentParticipantAdded', contextGraphId),
-          readLogs('AgentParticipantRemoved', contextGraphId),
+          resolveContextGraphAuthorityHistory({
+            cache,
+            cacheKey,
+            contextGraphId,
+            finalized: { number: finalized.number, hash: finalized.hash },
+            pageSize: this.cgRegistryScanPageSize,
+            signal: options.signal,
+            loadColdFromBlock: async () => (await this.resolveContractDeployBlock(
+              contractAddress,
+              'getContextGraphAuthoritySnapshot',
+              'ContextGraphStorage',
+            )).fromBlock,
+            readBlockHash: async (blockNumber) => (
+              (await provider.getBlock(blockNumber))?.hash ?? null
+            ),
+            readEvents: async (name, args, fromBlock, toBlock) => {
+              let filter = authorityFilters.get(name);
+              if (filter === undefined) {
+                filter = filters[name]!(...args);
+                authorityFilters.set(name, filter);
+              }
+              return contract.queryFilter(filter, fromBlock, toBlock) as Promise<
+                readonly ContextGraphAuthorityHistoryEvent[]
+              >;
+            },
+            isOwnershipTransfer: (event) => {
+              const transfer = event as ethers.EventLog;
+              const from = String(transfer.args.from ?? transfer.args[0]).toLowerCase();
+              const to = String(transfer.args.to ?? transfer.args[1]).toLowerCase();
+              return ethers.isAddress(from)
+                && ethers.isAddress(to)
+                && from !== ethers.ZeroAddress
+                && to !== ethers.ZeroAddress
+                && from !== to;
+            },
+            creationNameHash: (event) => {
+              const created = event as ethers.EventLog;
+              return String(created.args[2]).toLowerCase();
+            },
+          }),
         ]);
         options.signal?.throwIfAborted();
-        if (!history && created.length !== 1) {
-          throw new Error(
-            `Context Graph ${contextGraphId.toString()} has ${created.length} finalized creation events`,
-          );
-        }
-        const post = await provider.getBlock(finalized.number);
-        if (post?.hash?.toLowerCase() !== finalized.hash.toLowerCase()) {
-          throw new Error('finalized Context Graph authority anchor changed during resolution');
-        }
-        const ownershipTransfers = transfers.filter((event) => {
-          const transfer = event as ethers.EventLog;
-          const from = String(transfer.args.from ?? transfer.args[0]).toLowerCase();
-          const to = String(transfer.args.to ?? transfer.args[1]).toLowerCase();
-          return ethers.isAddress(from)
-            && ethers.isAddress(to)
-            && from !== ethers.ZeroAddress
-            && to !== ethers.ZeroAddress
-            && from !== to;
-        });
-        const policyEvents = [...created, ...ownershipTransfers, ...publishPolicyUpdates,
-          ...publishAuthorityUpdates].sort((left, right) => (
-          left.blockNumber - right.blockNumber || left.index - right.index
-        ));
-        const latestPolicyEvent = policyEvents.at(-1);
-        const creationEvent = created[0] as ethers.EventLog | undefined;
-        const sourceBlockNumber = latestPolicyEvent?.blockNumber
-          ?? history?.sourceBlockNumber
-          ?? creationEvent!.blockNumber;
-        const sourceBlockHash = latestPolicyEvent?.blockHash?.toLowerCase()
-          ?? history?.sourceBlockHash
-          ?? creationEvent!.blockHash.toLowerCase();
-        const sourceLogIndex = latestPolicyEvent?.index
-          ?? history?.sourceLogIndex
-          ?? creationEvent!.index;
-        const nextHistory: ContextGraphAuthorityHistoryCacheEntry = Object.freeze({
-          throughBlockNumber: finalized.number,
-          throughBlockHash: finalized.hash.toLowerCase(),
-          nameHash: history?.nameHash ?? String(creationEvent!.args[2]).toLowerCase(),
-          ownershipEra: (history?.ownershipEra ?? 0) + ownershipTransfers.length,
-          publishPolicyUpdates:
-            (history?.publishPolicyUpdates ?? 0) + publishPolicyUpdates.length,
-          publishAuthorityUpdates:
-            (history?.publishAuthorityUpdates ?? 0) + publishAuthorityUpdates.length,
-          participantAdds: (history?.participantAdds ?? 0) + participantAdds.length,
-          participantRemoves: (history?.participantRemoves ?? 0) + participantRemoves.length,
-          sourceBlockNumber,
-          sourceBlockHash,
-          sourceLogIndex,
-        });
+        const nextHistory = historyResolution.state;
         const participantAgents = [...(current.participantAgents ?? current[1] ?? [])]
           .map((address) => String(address).toLowerCase())
           .sort();
@@ -1067,7 +991,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         // Publish the watermark only after the complete snapshot decoded. A
         // transient failure in current-state parsing must leave the next call
         // free to replay the same suffix.
-        cache.set(cacheKey, nextHistory);
+        historyResolution.commit();
         return Object.freeze({
           chainId,
           governanceContract: contractAddress,
@@ -1082,16 +1006,8 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           participantAgents: Object.freeze(participantAgents),
           nameHash: nextHistory.nameHash,
           ownershipEra: nextHistory.ownershipEra.toString(10),
-          policyVersion: (
-            nextHistory.ownershipEra
-              + nextHistory.publishPolicyUpdates
-              + nextHistory.publishAuthorityUpdates
-          ).toString(10),
-          rosterVersion: (
-            nextHistory.ownershipEra
-              + nextHistory.participantAdds
-              + nextHistory.participantRemoves
-          ).toString(10),
+          policyVersion: nextHistory.policyVersion.toString(10),
+          rosterVersion: nextHistory.rosterVersion.toString(10),
           sourceBlockNumber: nextHistory.sourceBlockNumber.toString(10),
           sourceBlockHash: nextHistory.sourceBlockHash,
         });

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -170,7 +170,26 @@ function buildCursorContextGraphRegistryScanPlan(
   throw new Error(`Unsupported ContextGraphNameRegistry scan mode: ${JSON.stringify(exhaustive)}`);
 }
 
+interface ContextGraphAuthorityHistoryCacheEntry {
+  readonly throughBlockNumber: number;
+  readonly throughBlockHash: string;
+  readonly nameHash: string;
+  readonly ownershipEra: number;
+  readonly publishPolicyUpdates: number;
+  readonly publishAuthorityUpdates: number;
+  readonly participantAdds: number;
+  readonly participantRemoves: number;
+  readonly sourceBlockNumber: number;
+  readonly sourceBlockHash: string;
+  readonly sourceLogIndex: number;
+}
+
 export class ContextGraphMethods extends EVMChainAdapterBase {
+  /** Lazily initialized because this class is applied as a mixin. */
+  private contextGraphAuthorityHistoryCache?: Map<
+    string,
+    ContextGraphAuthorityHistoryCacheEntry
+  >;
   /**
    * Legacy cost-independent authorized signer selection. New publish flows use
    * resolvePublisherPublishPlan once byte size is known so signer, lifetime,
@@ -923,19 +942,36 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           string,
           (...args: unknown[]) => ethers.DeferredTopicFilter
         >;
-        const contractAddress = await contract.getAddress();
-        const { fromBlock } = await this.resolveContractDeployBlock(
-          contractAddress,
-          'getContextGraphAuthoritySnapshot',
-          'ContextGraphStorage',
-        );
+        const contractAddress = (await contract.getAddress()).toLowerCase();
+        const cache = this.contextGraphAuthorityHistoryCache ??= new Map();
+        const cacheKey = `${contractAddress}:${contextGraphId.toString(10)}`;
+        let history = cache.get(cacheKey);
+        if (history) {
+          let anchorMatches = false;
+          if (history.throughBlockNumber === finalized.number) {
+            anchorMatches = history.throughBlockHash === finalized.hash.toLowerCase();
+          } else if (history.throughBlockNumber < finalized.number) {
+            const cachedAnchor = await provider.getBlock(history.throughBlockNumber);
+            anchorMatches = cachedAnchor?.hash?.toLowerCase() === history.throughBlockHash;
+          }
+          if (!anchorMatches) history = undefined;
+        }
+        const fromBlock = history
+          ? history.throughBlockNumber + 1
+          : (await this.resolveContractDeployBlock(
+              contractAddress,
+              'getContextGraphAuthoritySnapshot',
+              'ContextGraphStorage',
+            )).fromBlock;
         const readLogs = async (name: string, ...args: unknown[]) => {
-          const filter = filters[name]!(...args);
           const logs: Array<ethers.EventLog | ethers.Log> = [];
+          if (fromBlock > finalized.number) return logs;
+          const filter = filters[name]!(...args);
           // Production RPCs commonly cap eth_getLogs ranges. Keep every read
-          // deployment-anchored and page-bounded while all state and event
-          // results remain pinned to the single finalized anchor selected
-          // above. The exact Context Graph stays encoded in each filter.
+          // page-bounded while all state and event results remain pinned to
+          // one finalized anchor. After the first complete read, `fromBlock`
+          // advances from the cached finalized watermark instead of the
+          // contract deployment block.
           for (
             let lo = fromBlock;
             lo <= finalized.number;
@@ -963,7 +999,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
             contextGraphId,
             { blockTag: finalized.number },
           ),
-          readLogs('ContextGraphCreated', contextGraphId),
+          history ? Promise.resolve([]) : readLogs('ContextGraphCreated', contextGraphId),
           readLogs('Transfer', null, null, contextGraphId),
           readLogs('PublishPolicyUpdated', contextGraphId),
           readLogs('PublishAuthorityUpdated', contextGraphId),
@@ -971,12 +1007,11 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           readLogs('AgentParticipantRemoved', contextGraphId),
         ]);
         options.signal?.throwIfAborted();
-        if (created.length !== 1) {
+        if (!history && created.length !== 1) {
           throw new Error(
             `Context Graph ${contextGraphId.toString()} has ${created.length} finalized creation events`,
           );
         }
-        const creationEvent = created[0] as ethers.EventLog;
         const post = await provider.getBlock(finalized.number);
         if (post?.hash?.toLowerCase() !== finalized.hash.toLowerCase()) {
           throw new Error('finalized Context Graph authority anchor changed during resolution');
@@ -995,7 +1030,32 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           ...publishAuthorityUpdates].sort((left, right) => (
           left.blockNumber - right.blockNumber || left.index - right.index
         ));
-        const source = policyEvents.at(-1)!;
+        const latestPolicyEvent = policyEvents.at(-1);
+        const creationEvent = created[0] as ethers.EventLog | undefined;
+        const sourceBlockNumber = latestPolicyEvent?.blockNumber
+          ?? history?.sourceBlockNumber
+          ?? creationEvent!.blockNumber;
+        const sourceBlockHash = latestPolicyEvent?.blockHash?.toLowerCase()
+          ?? history?.sourceBlockHash
+          ?? creationEvent!.blockHash.toLowerCase();
+        const sourceLogIndex = latestPolicyEvent?.index
+          ?? history?.sourceLogIndex
+          ?? creationEvent!.index;
+        const nextHistory: ContextGraphAuthorityHistoryCacheEntry = Object.freeze({
+          throughBlockNumber: finalized.number,
+          throughBlockHash: finalized.hash.toLowerCase(),
+          nameHash: history?.nameHash ?? String(creationEvent!.args[2]).toLowerCase(),
+          ownershipEra: (history?.ownershipEra ?? 0) + ownershipTransfers.length,
+          publishPolicyUpdates:
+            (history?.publishPolicyUpdates ?? 0) + publishPolicyUpdates.length,
+          publishAuthorityUpdates:
+            (history?.publishAuthorityUpdates ?? 0) + publishAuthorityUpdates.length,
+          participantAdds: (history?.participantAdds ?? 0) + participantAdds.length,
+          participantRemoves: (history?.participantRemoves ?? 0) + participantRemoves.length,
+          sourceBlockNumber,
+          sourceBlockHash,
+          sourceLogIndex,
+        });
         const participantAgents = [...(current.participantAgents ?? current[1] ?? [])]
           .map((address) => String(address).toLowerCase())
           .sort();
@@ -1003,10 +1063,14 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         const accessPolicy = Number(BigInt(current.accessPolicy ?? current[5]));
         const publishPolicy = Number(BigInt(current.publishPolicy ?? current[6]));
         const authorityRaw = String(current.publishAuthority ?? current[7]).toLowerCase();
-        const ownershipEra = ownershipTransfers.length;
+        const chainId = (await provider.getNetwork()).chainId.toString(10);
+        // Publish the watermark only after the complete snapshot decoded. A
+        // transient failure in current-state parsing must leave the next call
+        // free to replay the same suffix.
+        cache.set(cacheKey, nextHistory);
         return Object.freeze({
-          chainId: (await provider.getNetwork()).chainId.toString(10),
-          governanceContract: (await contract.getAddress()).toLowerCase(),
+          chainId,
+          governanceContract: contractAddress,
           contextGraphId: contextGraphId.toString(10),
           owner,
           active: Boolean(current.active ?? current[3]),
@@ -1016,16 +1080,20 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           publishAuthorityAccountId:
             BigInt(current.publishAuthorityAccountId ?? current[8]).toString(10),
           participantAgents: Object.freeze(participantAgents),
-          nameHash: String(creationEvent.args[2]).toLowerCase(),
-          ownershipEra: ownershipEra.toString(10),
+          nameHash: nextHistory.nameHash,
+          ownershipEra: nextHistory.ownershipEra.toString(10),
           policyVersion: (
-            ownershipEra + publishPolicyUpdates.length + publishAuthorityUpdates.length
+            nextHistory.ownershipEra
+              + nextHistory.publishPolicyUpdates
+              + nextHistory.publishAuthorityUpdates
           ).toString(10),
           rosterVersion: (
-            ownershipEra + participantAdds.length + participantRemoves.length
+            nextHistory.ownershipEra
+              + nextHistory.participantAdds
+              + nextHistory.participantRemoves
           ).toString(10),
-          sourceBlockNumber: source.blockNumber.toString(10),
-          sourceBlockHash: source.blockHash.toLowerCase(),
+          sourceBlockNumber: nextHistory.sourceBlockNumber.toString(10),
+          sourceBlockHash: nextHistory.sourceBlockHash,
         });
       },
       { signal: options.signal },

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -957,6 +957,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           resolveContextGraphAuthorityHistory({
             cache,
             cacheKey,
+            readScope: provider,
             contextGraphId,
             finalized: { number: finalized.number, hash: finalized.hash },
             pageSize: this.cgRegistryScanPageSize,

--- a/packages/chain/test/context-graph-authority-history.typecheck.ts
+++ b/packages/chain/test/context-graph-authority-history.typecheck.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ContextGraphAuthorityHistoryCreationEvent } from '../src/context-graph-authority-history.js';
+
+// @ts-expect-error Creation events cannot cross this boundary without nameHash.
+const creationWithoutNameHash: ContextGraphAuthorityHistoryCreationEvent = {
+  blockNumber: 1,
+  blockHash: '0x01',
+  index: 0,
+};
+
+void creationWithoutNameHash;

--- a/packages/chain/test/context-graph-authority-history.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-history.unit.test.ts
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  ContextGraphAuthorityHistoryCache,
+  resolveContextGraphAuthorityHistory,
+  type ContextGraphAuthorityHistoryCreationEvent,
+  type ResolveContextGraphAuthorityHistoryInput,
+} from '../src/context-graph-authority-history.js';
+
+const FINALIZED_HASH = `0x${'55'.repeat(32)}`;
+const NEXT_FINALIZED_HASH = `0x${'56'.repeat(32)}`;
+const NAME_HASH = `0x${'88'.repeat(32)}`;
+const DIRECT_READ_SCOPE = {};
+
+function directHistoryInput(params: Readonly<{
+  cache: ContextGraphAuthorityHistoryCache;
+  cacheKey: string;
+  blockNumber: number;
+  blockHash: string;
+  coldReads?: { count: number };
+  ordinaryRanges?: Array<readonly [number, number]>;
+  blockHashes?: Readonly<Record<number, string>>;
+  creationGate?: Readonly<{ entered(): void; wait: Promise<void> }>;
+  readScope?: object;
+  signal?: AbortSignal;
+  omitCreationNameHash?: boolean;
+}>): ResolveContextGraphAuthorityHistoryInput {
+  return {
+    cache: params.cache,
+    cacheKey: params.cacheKey,
+    readScope: params.readScope ?? DIRECT_READ_SCOPE,
+    contextGraphId: 9n,
+    finalized: { number: params.blockNumber, hash: params.blockHash },
+    pageSize: 100,
+    signal: params.signal,
+    loadColdFromBlock: async () => {
+      if (params.coldReads) params.coldReads.count += 1;
+      return 1;
+    },
+    readBlockHash: async (blockNumber) => params.blockHashes?.[blockNumber]
+      ?? (blockNumber === params.blockNumber ? params.blockHash : null),
+    readCreationEvents: async () => {
+      params.creationGate?.entered();
+      if (params.creationGate) await params.creationGate.wait;
+      return [{
+        blockNumber: 1,
+        blockHash: `0x${'01'.repeat(32)}`,
+        index: 0,
+        ...(params.omitCreationNameHash ? {} : { nameHash: NAME_HASH }),
+      }] as unknown as readonly ContextGraphAuthorityHistoryCreationEvent[];
+    },
+    readEvents: async (_query, fromBlock, toBlock) => {
+      params.ordinaryRanges?.push([fromBlock, toBlock]);
+      return [];
+    },
+  };
+}
+
+describe('ContextGraphAuthorityHistoryCache', () => {
+  it('coalesces overlapping resolutions for the same finalized head', async () => {
+    const cache = new ContextGraphAuthorityHistoryCache();
+    const coldReads = { count: 0 };
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const input = directHistoryInput({
+      cache,
+      cacheKey: 'same-head',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+      coldReads,
+      creationGate: { entered: entered.resolve, wait: release.promise },
+    });
+    const first = resolveContextGraphAuthorityHistory(input);
+    await entered.promise;
+    const second = resolveContextGraphAuthorityHistory(input);
+    release.resolve();
+    const [firstResolution, secondResolution] = await Promise.all([first, second]);
+    expect(coldReads.count).toBe(1);
+    expect(firstResolution.state).toBe(secondResolution.state);
+    await Promise.all([firstResolution.publish(), secondResolution.publish()]);
+  });
+
+  it('does not let a stalled provider attempt capture same-head failover', async () => {
+    const cache = new ContextGraphAuthorityHistoryCache();
+    const stalledScope = {};
+    const healthyScope = {};
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const stalled = resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'provider-failover',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+      readScope: stalledScope,
+      creationGate: { entered: entered.resolve, wait: release.promise },
+    }));
+    await entered.promise;
+
+    const healthy = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'provider-failover',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+      readScope: healthyScope,
+    }));
+    expect(healthy.state.nameHash).toBe(NAME_HASH);
+    await healthy.publish();
+
+    release.resolve();
+    await expect(stalled).resolves.toMatchObject({ state: healthy.state });
+  });
+
+  it('does not let one reader abort an independent same-head reader', async () => {
+    const cache = new ContextGraphAuthorityHistoryCache();
+    const readScope = {};
+    const firstAbort = new AbortController();
+    const secondAbort = new AbortController();
+    firstAbort.abort();
+
+    const cancelled = resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'independent-abort',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+      readScope,
+      signal: firstAbort.signal,
+    }));
+    const healthy = resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'independent-abort',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+      readScope,
+      signal: secondAbort.signal,
+    }));
+
+    await expect(cancelled).rejects.toMatchObject({ name: 'AbortError' });
+    await expect(healthy).resolves.toMatchObject({ state: { nameHash: NAME_HASH } });
+  });
+
+  it('retains a newer watermark when an older load publishes last', async () => {
+    const cache = new ContextGraphAuthorityHistoryCache();
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const older = resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'out-of-order',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+      creationGate: { entered: entered.resolve, wait: release.promise },
+    }));
+    await entered.promise;
+    const newer = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'out-of-order',
+      blockNumber: 35,
+      blockHash: NEXT_FINALIZED_HASH,
+    }));
+    await newer.publish();
+    release.resolve();
+    await (await older).publish();
+
+    const ranges: Array<readonly [number, number]> = [];
+    const next = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'out-of-order',
+      blockNumber: 36,
+      blockHash: `0x${'57'.repeat(32)}`,
+      blockHashes: { 35: NEXT_FINALIZED_HASH },
+      ordinaryRanges: ranges,
+    }));
+    expect(ranges).toEqual(Array(5).fill([36, 36]));
+    await next.publish();
+  });
+
+  it('prevents clear from being undone by an in-flight load', async () => {
+    const cache = new ContextGraphAuthorityHistoryCache();
+    const coldReads = { count: 0 };
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const pending = resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'cleared',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+      coldReads,
+      creationGate: { entered: entered.resolve, wait: release.promise },
+    }));
+    await entered.promise;
+    cache.clear();
+    release.resolve();
+    const stale = await pending;
+    await expect(stale.publish()).rejects.toThrow('invalidated');
+
+    const fresh = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'cleared',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+      coldReads,
+    }));
+    await fresh.publish();
+    expect(coldReads.count).toBe(2);
+  });
+
+  it('bounds authority history with LRU retention', async () => {
+    const cache = new ContextGraphAuthorityHistoryCache(2);
+    const coldReads = new Map<string, { count: number }>();
+    const publish = async (cacheKey: string) => {
+      const counter = coldReads.get(cacheKey) ?? { count: 0 };
+      coldReads.set(cacheKey, counter);
+      const resolution = await resolveContextGraphAuthorityHistory(directHistoryInput({
+        cache,
+        cacheKey,
+        blockNumber: 30,
+        blockHash: FINALIZED_HASH,
+        coldReads: counter,
+      }));
+      await resolution.publish();
+    };
+    await publish('a');
+    await publish('b');
+    await publish('a');
+    await publish('c');
+    expect(cache.size).toBe(2);
+    await publish('b');
+    expect(coldReads.get('a')?.count).toBe(1);
+    expect(coldReads.get('b')?.count).toBe(2);
+    expect(coldReads.get('c')?.count).toBe(1);
+  });
+
+  it('rejects a malformed creation event without a name hash at runtime', async () => {
+    await expect(resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache: new ContextGraphAuthorityHistoryCache(),
+      cacheKey: 'malformed-creation',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+      omitCreationNameHash: true,
+    }))).rejects.toThrow('creation event has no name hash');
+  });
+});

--- a/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
@@ -6,6 +6,10 @@ import { ethers } from 'ethers';
 import type { ContextGraphAuthoritySnapshot } from '../src/chain-adapter.js';
 import { EVMChainAdapter } from '../src/evm-adapter.js';
 import { MockChainAdapter } from '../src/mock-adapter.js';
+import {
+  ContextGraphAuthorityHistoryCache,
+  type ContextGraphAuthorityHistoryState,
+} from '../src/context-graph-authority-history.js';
 
 const OWNER = '0x1111111111111111111111111111111111111111';
 const MEMBER = '0x2222222222222222222222222222222222222222';
@@ -29,7 +33,22 @@ function event(
   return { blockNumber, index, blockHash, args };
 }
 
-function makeEvmAuthorityAdapter(options: { reorg?: boolean } = {}) {
+interface AuthorityEvidence {
+  readonly filters: Array<readonly [string, ...unknown[]]>;
+  readonly ranges: Array<readonly [number, number]>;
+  readonly staticCalls: Array<readonly [bigint, { blockTag: number }]>;
+  readonly deploymentReads: Array<readonly [string, string, string]>;
+}
+
+interface EvmAuthorityHarness {
+  readonly adapter: EVMChainAdapter;
+  readonly evidence: AuthorityEvidence;
+  advanceAuthorityHead(): void;
+  replaceCachedAnchor(): void;
+  rotateContextGraphStorage(): void;
+}
+
+function makeEvmAuthorityAdapter(options: { reorg?: boolean } = {}): EvmAuthorityHarness {
   const adapter: any = new EVMChainAdapter({
     rpcUrl: 'http://127.0.0.1:1',
     hubAddress: GOVERNANCE,
@@ -40,7 +59,7 @@ function makeEvmAuthorityAdapter(options: { reorg?: boolean } = {}) {
   adapter.initialized = true;
   adapter.init = async () => {};
   adapter.cgRegistryScanPageSize = 10;
-  const evidence = {
+  const evidence: AuthorityEvidence = {
     filters: [] as Array<readonly [string, ...unknown[]]>,
     ranges: [] as Array<readonly [number, number]>,
     staticCalls: [] as Array<readonly [bigint, { blockTag: number }]>,
@@ -134,23 +153,28 @@ function makeEvmAuthorityAdapter(options: { reorg?: boolean } = {}) {
     evidence.deploymentReads.push([address, operation, label]);
     return { fromBlock: 7, head: 30, scanProviders: [] };
   };
-  adapter.authorityEvidence = evidence;
-  adapter.advanceAuthorityHead = () => {
+  const advanceAuthorityHead = () => {
     finalizedNumber = 35;
     finalizedHash = NEXT_FINALIZED_HASH;
     logs.PublishPolicyUpdated.push(event(33, 0, NEXT_POLICY_HASH));
     current.publishPolicy = 1n;
     current[6] = 1n;
   };
-  adapter.replaceCachedAnchor = () => {
+  const replaceCachedAnchor = () => {
     cachedAnchorReplaced = true;
   };
-  return adapter as EVMChainAdapter;
+  return {
+    adapter: adapter as EVMChainAdapter,
+    evidence,
+    advanceAuthorityHead,
+    replaceCachedAnchor,
+    rotateContextGraphStorage: () => adapter.applyHubRotationEventName('ContextGraphStorage'),
+  };
 }
 
 describe('RFC-64 Context Graph authority snapshots', () => {
   it('reads one stable finalized EVM generation and derives monotonic epochs', async () => {
-    const adapter = makeEvmAuthorityAdapter();
+    const { adapter, evidence, advanceAuthorityHead } = makeEvmAuthorityAdapter();
     const snapshot = await adapter.getContextGraphAuthoritySnapshot(9n);
 
     expect(snapshot).toEqual({
@@ -173,7 +197,6 @@ describe('RFC-64 Context Graph authority snapshots', () => {
     });
     expect(Object.isFrozen(snapshot)).toBe(true);
     expect(Object.isFrozen(snapshot.participantAgents)).toBe(true);
-    const evidence = (adapter as any).authorityEvidence;
     expect(evidence.staticCalls).toEqual([[9n, { blockTag: 30 }]]);
     expect(evidence.deploymentReads).toEqual([[
       GOVERNANCE,
@@ -205,7 +228,7 @@ describe('RFC-64 Context Graph authority snapshots', () => {
       [9n, { blockTag: 30 }],
     ]);
 
-    (adapter as any).advanceAuthorityHead();
+    advanceAuthorityHead();
     const advanced = await adapter.getContextGraphAuthoritySnapshot(9n);
     expect(advanced).toMatchObject({
       publishPolicy: 1,
@@ -222,31 +245,60 @@ describe('RFC-64 Context Graph authority snapshots', () => {
   });
 
   it('rejects a finalized anchor that changes while the generation is read', async () => {
-    await expect(makeEvmAuthorityAdapter({ reorg: true })
+    await expect(makeEvmAuthorityAdapter({ reorg: true }).adapter
       .getContextGraphAuthoritySnapshot(9n))
       .rejects.toThrow('anchor changed');
   });
 
   it('discards the incremental watermark when its finalized anchor was replaced', async () => {
-    const adapter = makeEvmAuthorityAdapter();
+    const { adapter, evidence, advanceAuthorityHead, replaceCachedAnchor } =
+      makeEvmAuthorityAdapter();
     await adapter.getContextGraphAuthoritySnapshot(9n);
-    (adapter as any).advanceAuthorityHead();
-    (adapter as any).replaceCachedAnchor();
+    advanceAuthorityHead();
+    replaceCachedAnchor();
 
     await expect(adapter.getContextGraphAuthoritySnapshot(9n)).resolves.toMatchObject({
       publishPolicy: 1,
       policyVersion: '4',
     });
-    const evidence = (adapter as any).authorityEvidence as {
-      deploymentReads: unknown[];
-      ranges: Array<readonly [number, number]>;
-    };
     expect(evidence.deploymentReads).toHaveLength(2);
     expect(evidence.ranges.slice(18)).toEqual([
       ...Array(6).fill([7, 16]),
       ...Array(6).fill([17, 26]),
       ...Array(6).fill([27, 35]),
     ]);
+  });
+
+  it('clears cached generations when ContextGraphStorage rotates', async () => {
+    const { adapter, evidence, rotateContextGraphStorage } = makeEvmAuthorityAdapter();
+    await adapter.getContextGraphAuthoritySnapshot(9n);
+    rotateContextGraphStorage();
+    await adapter.getContextGraphAuthoritySnapshot(9n);
+    expect(evidence.deploymentReads).toHaveLength(2);
+    expect(evidence.ranges).toHaveLength(36);
+  });
+
+  it('bounds authority history with LRU retention', () => {
+    const cache = new ContextGraphAuthorityHistoryCache(2);
+    const state = (throughBlockNumber: number): ContextGraphAuthorityHistoryState => ({
+      throughBlockNumber,
+      throughBlockHash: `0x${throughBlockNumber}`,
+      nameHash: NAME_HASH,
+      ownershipEra: 0,
+      policyVersion: 0,
+      rosterVersion: 0,
+      sourceBlockNumber: throughBlockNumber,
+      sourceBlockHash: `0x${throughBlockNumber}`,
+      sourceLogIndex: 0,
+    });
+    cache.set('a', state(1));
+    cache.set('b', state(2));
+    expect(cache.get('a')).toEqual(state(1));
+    cache.set('c', state(3));
+    expect(cache.size).toBe(2);
+    expect(cache.get('b')).toBeUndefined();
+    expect(cache.get('a')).toEqual(state(1));
+    expect(cache.get('c')).toEqual(state(3));
   });
 
   it('provides the same authority surface in offline mock-chain mode', async () => {

--- a/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
@@ -14,8 +14,10 @@ const GOVERNANCE = '0x4444444444444444444444444444444444444444';
 const SECOND_MEMBER = '0x5555555555555555555555555555555555555555';
 const SECOND_AUTHORITY = '0x6666666666666666666666666666666666666666';
 const FINALIZED_HASH = `0x${'55'.repeat(32)}`;
+const NEXT_FINALIZED_HASH = `0x${'56'.repeat(32)}`;
 const CREATION_HASH = `0x${'66'.repeat(32)}`;
 const POLICY_HASH = `0x${'77'.repeat(32)}`;
+const NEXT_POLICY_HASH = `0x${'78'.repeat(32)}`;
 const NAME_HASH = `0x${'88'.repeat(32)}`;
 
 function event(
@@ -45,7 +47,10 @@ function makeEvmAuthorityAdapter(options: { reorg?: boolean } = {}) {
     deploymentReads: [] as Array<readonly [string, string, string]>,
   };
 
-  const logs: Record<string, readonly ReturnType<typeof event>[]> = {
+  let finalizedNumber = 30;
+  let finalizedHash = FINALIZED_HASH;
+  let cachedAnchorReplaced = false;
+  const logs: Record<string, ReturnType<typeof event>[]> = {
     ContextGraphCreated: [event(10, 1, CREATION_HASH, [9n, OWNER, NAME_HASH])],
     Transfer: [
       event(10, 0, CREATION_HASH, [ethers.ZeroAddress, OWNER, 9n]),
@@ -91,16 +96,27 @@ function makeEvmAuthorityAdapter(options: { reorg?: boolean } = {}) {
       staticCall: async (contextGraphId: bigint, readOptions: { blockTag: number }) => {
         evidence.staticCalls.push([contextGraphId, readOptions]);
         expect(contextGraphId).toBe(9n);
-        expect(readOptions).toEqual({ blockTag: 30 });
+        expect(readOptions).toEqual({ blockTag: finalizedNumber });
         return current;
       },
     },
     getAddress: async () => GOVERNANCE,
   };
   const provider = {
-    getBlock: async (tag: string | number) => tag === 'finalized'
-      ? { number: 30, hash: FINALIZED_HASH }
-      : { number: 30, hash: options.reorg ? `0x${'cc'.repeat(32)}` : FINALIZED_HASH },
+    getBlock: async (tag: string | number) => {
+      if (tag === 'finalized') return { number: finalizedNumber, hash: finalizedHash };
+      const historicalHash = tag === 30 && cachedAnchorReplaced
+        ? `0x${'cc'.repeat(32)}`
+        : tag === 30
+          ? FINALIZED_HASH
+          : finalizedHash;
+      return {
+        number: Number(tag),
+        hash: options.reorg && tag === finalizedNumber
+          ? `0x${'cc'.repeat(32)}`
+          : historicalHash,
+      };
+    },
     getNetwork: async () => ({ chainId: 31337n }),
   };
   adapter.contracts = {
@@ -119,6 +135,16 @@ function makeEvmAuthorityAdapter(options: { reorg?: boolean } = {}) {
     return { fromBlock: 7, head: 30, scanProviders: [] };
   };
   adapter.authorityEvidence = evidence;
+  adapter.advanceAuthorityHead = () => {
+    finalizedNumber = 35;
+    finalizedHash = NEXT_FINALIZED_HASH;
+    logs.PublishPolicyUpdated.push(event(33, 0, NEXT_POLICY_HASH));
+    current.publishPolicy = 1n;
+    current[6] = 1n;
+  };
+  adapter.replaceCachedAnchor = () => {
+    cachedAnchorReplaced = true;
+  };
   return adapter as EVMChainAdapter;
 }
 
@@ -168,12 +194,59 @@ describe('RFC-64 Context Graph authority snapshots', () => {
       [17, 26],
       [27, 30],
     ]));
+
+    const repeated = await adapter.getContextGraphAuthoritySnapshot(9n);
+    expect(repeated).toEqual(snapshot);
+    expect(evidence.deploymentReads).toHaveLength(1);
+    expect(evidence.ranges).toHaveLength(18);
+    expect(evidence.filters).toHaveLength(6);
+    expect(evidence.staticCalls).toEqual([
+      [9n, { blockTag: 30 }],
+      [9n, { blockTag: 30 }],
+    ]);
+
+    (adapter as any).advanceAuthorityHead();
+    const advanced = await adapter.getContextGraphAuthoritySnapshot(9n);
+    expect(advanced).toMatchObject({
+      publishPolicy: 1,
+      ownershipEra: '1',
+      policyVersion: '4',
+      rosterVersion: '3',
+      sourceBlockNumber: '33',
+      sourceBlockHash: NEXT_POLICY_HASH,
+    });
+    // Five event types are read once over only the unseen suffix. Creation is
+    // immutable and is never scanned again.
+    expect(evidence.ranges.slice(18)).toEqual(Array(5).fill([31, 35]));
+    expect(evidence.deploymentReads).toHaveLength(1);
   });
 
   it('rejects a finalized anchor that changes while the generation is read', async () => {
     await expect(makeEvmAuthorityAdapter({ reorg: true })
       .getContextGraphAuthoritySnapshot(9n))
       .rejects.toThrow('anchor changed');
+  });
+
+  it('discards the incremental watermark when its finalized anchor was replaced', async () => {
+    const adapter = makeEvmAuthorityAdapter();
+    await adapter.getContextGraphAuthoritySnapshot(9n);
+    (adapter as any).advanceAuthorityHead();
+    (adapter as any).replaceCachedAnchor();
+
+    await expect(adapter.getContextGraphAuthoritySnapshot(9n)).resolves.toMatchObject({
+      publishPolicy: 1,
+      policyVersion: '4',
+    });
+    const evidence = (adapter as any).authorityEvidence as {
+      deploymentReads: unknown[];
+      ranges: Array<readonly [number, number]>;
+    };
+    expect(evidence.deploymentReads).toHaveLength(2);
+    expect(evidence.ranges.slice(18)).toEqual([
+      ...Array(6).fill([7, 16]),
+      ...Array(6).fill([17, 26]),
+      ...Array(6).fill([27, 35]),
+    ]);
   });
 
   it('provides the same authority surface in offline mock-chain mode', async () => {

--- a/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
@@ -8,7 +8,9 @@ import { EVMChainAdapter } from '../src/evm-adapter.js';
 import { MockChainAdapter } from '../src/mock-adapter.js';
 import {
   ContextGraphAuthorityHistoryCache,
-  type ContextGraphAuthorityHistoryState,
+  resolveContextGraphAuthorityHistory,
+  type ContextGraphAuthorityHistoryCreationEvent,
+  type ResolveContextGraphAuthorityHistoryInput,
 } from '../src/context-graph-authority-history.js';
 
 const OWNER = '0x1111111111111111111111111111111111111111';
@@ -33,6 +35,45 @@ function event(
   return { blockNumber, index, blockHash, args };
 }
 
+function directHistoryInput(params: Readonly<{
+  cache: ContextGraphAuthorityHistoryCache;
+  cacheKey: string;
+  blockNumber: number;
+  blockHash: string;
+  coldReads?: { count: number };
+  ordinaryRanges?: Array<readonly [number, number]>;
+  blockHashes?: Readonly<Record<number, string>>;
+  creationGate?: Readonly<{ entered(): void; wait: Promise<void> }>;
+}>): ResolveContextGraphAuthorityHistoryInput {
+  return {
+    cache: params.cache,
+    cacheKey: params.cacheKey,
+    contextGraphId: 9n,
+    finalized: { number: params.blockNumber, hash: params.blockHash },
+    pageSize: 100,
+    loadColdFromBlock: async () => {
+      if (params.coldReads) params.coldReads.count += 1;
+      return 1;
+    },
+    readBlockHash: async (blockNumber) => params.blockHashes?.[blockNumber]
+      ?? (blockNumber === params.blockNumber ? params.blockHash : null),
+    readCreationEvents: async () => {
+      params.creationGate?.entered();
+      if (params.creationGate) await params.creationGate.wait;
+      return [{
+        blockNumber: 1,
+        blockHash: `0x${'01'.repeat(32)}`,
+        index: 0,
+        nameHash: NAME_HASH,
+      }];
+    },
+    readEvents: async (_query, fromBlock, toBlock) => {
+      params.ordinaryRanges?.push([fromBlock, toBlock]);
+      return [];
+    },
+  };
+}
+
 interface AuthorityEvidence {
   readonly filters: Array<readonly [string, ...unknown[]]>;
   readonly ranges: Array<readonly [number, number]>;
@@ -45,6 +86,9 @@ interface EvmAuthorityHarness {
   readonly evidence: AuthorityEvidence;
   advanceAuthorityHead(): void;
   replaceCachedAnchor(): void;
+  replaceFinalizedHead(): void;
+  holdCurrentStateRead(): Readonly<{ entered: Promise<void>; release(): void }>;
+  setPublishAuthorityAccountId(value: unknown): void;
   rotateContextGraphStorage(): void;
 }
 
@@ -69,6 +113,7 @@ function makeEvmAuthorityAdapter(options: { reorg?: boolean } = {}): EvmAuthorit
   let finalizedNumber = 30;
   let finalizedHash = FINALIZED_HASH;
   let cachedAnchorReplaced = false;
+  let currentReadGate: PromiseWithResolvers<void> | undefined;
   const logs: Record<string, ReturnType<typeof event>[]> = {
     ContextGraphCreated: [event(10, 1, CREATION_HASH, [9n, OWNER, NAME_HASH])],
     Transfer: [
@@ -116,6 +161,12 @@ function makeEvmAuthorityAdapter(options: { reorg?: boolean } = {}): EvmAuthorit
         evidence.staticCalls.push([contextGraphId, readOptions]);
         expect(contextGraphId).toBe(9n);
         expect(readOptions).toEqual({ blockTag: finalizedNumber });
+        const gate = currentReadGate;
+        if (gate !== undefined) {
+          currentReadGate = undefined;
+          gate.resolve();
+          await gate.promise;
+        }
         return current;
       },
     },
@@ -168,6 +219,24 @@ function makeEvmAuthorityAdapter(options: { reorg?: boolean } = {}): EvmAuthorit
     evidence,
     advanceAuthorityHead,
     replaceCachedAnchor,
+    replaceFinalizedHead: () => {
+      finalizedHash = `0x${'cc'.repeat(32)}`;
+      cachedAnchorReplaced = true;
+    },
+    holdCurrentStateRead: () => {
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      currentReadGate = {
+        promise: release.promise,
+        resolve: entered.resolve,
+        reject: release.reject,
+      };
+      return { entered: entered.promise, release: release.resolve };
+    },
+    setPublishAuthorityAccountId: (value) => {
+      current.publishAuthorityAccountId = value;
+      current[8] = value;
+    },
     rotateContextGraphStorage: () => adapter.applyHubRotationEventName('ContextGraphStorage'),
   };
 }
@@ -250,6 +319,19 @@ describe('RFC-64 Context Graph authority snapshots', () => {
       .rejects.toThrow('anchor changed');
   });
 
+  it('rechecks the anchor after a delayed concurrent current-state read', async () => {
+    const harness = makeEvmAuthorityAdapter();
+    const gate = harness.holdCurrentStateRead();
+    const pending = harness.adapter.getContextGraphAuthoritySnapshot(9n);
+    await gate.entered;
+    // History can finish while the static call is held. Replacing the anchor
+    // here must still invalidate the combined snapshot and its watermark.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    harness.replaceFinalizedHead();
+    gate.release();
+    await expect(pending).rejects.toThrow('anchor changed');
+  });
+
   it('discards the incremental watermark when its finalized anchor was replaced', async () => {
     const { adapter, evidence, advanceAuthorityHead, replaceCachedAnchor } =
       makeEvmAuthorityAdapter();
@@ -278,27 +360,143 @@ describe('RFC-64 Context Graph authority snapshots', () => {
     expect(evidence.ranges).toHaveLength(36);
   });
 
-  it('bounds authority history with LRU retention', () => {
-    const cache = new ContextGraphAuthorityHistoryCache(2);
-    const state = (throughBlockNumber: number): ContextGraphAuthorityHistoryState => ({
-      throughBlockNumber,
-      throughBlockHash: `0x${throughBlockNumber}`,
-      nameHash: NAME_HASH,
-      ownershipEra: 0,
-      policyVersion: 0,
-      rosterVersion: 0,
-      sourceBlockNumber: throughBlockNumber,
-      sourceBlockHash: `0x${throughBlockNumber}`,
-      sourceLogIndex: 0,
+  it('does not advance the history watermark when a late snapshot field fails to decode', async () => {
+    const harness = makeEvmAuthorityAdapter();
+    await harness.adapter.getContextGraphAuthoritySnapshot(9n);
+    harness.advanceAuthorityHead();
+    harness.setPublishAuthorityAccountId('not-a-uint256');
+    await expect(harness.adapter.getContextGraphAuthoritySnapshot(9n)).rejects.toThrow();
+    harness.setPublishAuthorityAccountId(7n);
+
+    await expect(harness.adapter.getContextGraphAuthoritySnapshot(9n)).resolves.toMatchObject({
+      publishAuthorityAccountId: '7',
+      policyVersion: '4',
     });
-    cache.set('a', state(1));
-    cache.set('b', state(2));
-    expect(cache.get('a')).toEqual(state(1));
-    cache.set('c', state(3));
+    expect(harness.evidence.ranges.slice(18)).toEqual(Array(10).fill([31, 35]));
+  });
+
+  it('coalesces overlapping resolutions for the same finalized head', async () => {
+    const cache = new ContextGraphAuthorityHistoryCache();
+    const coldReads = { count: 0 };
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const input = directHistoryInput({
+      cache,
+      cacheKey: 'same-head',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+      coldReads,
+      creationGate: { entered: entered.resolve, wait: release.promise },
+    });
+    const first = resolveContextGraphAuthorityHistory(input);
+    await entered.promise;
+    const second = resolveContextGraphAuthorityHistory(input);
+    release.resolve();
+    const [firstResolution, secondResolution] = await Promise.all([first, second]);
+    expect(coldReads.count).toBe(1);
+    expect(firstResolution.state).toBe(secondResolution.state);
+    await Promise.all([firstResolution.publish(), secondResolution.publish()]);
+  });
+
+  it('retains a newer watermark when an older load publishes last', async () => {
+    const cache = new ContextGraphAuthorityHistoryCache();
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const older = resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'out-of-order',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+      creationGate: { entered: entered.resolve, wait: release.promise },
+    }));
+    await entered.promise;
+    const newer = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'out-of-order',
+      blockNumber: 35,
+      blockHash: NEXT_FINALIZED_HASH,
+    }));
+    await newer.publish();
+    release.resolve();
+    await (await older).publish();
+
+    const ranges: Array<readonly [number, number]> = [];
+    const next = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'out-of-order',
+      blockNumber: 36,
+      blockHash: `0x${'57'.repeat(32)}`,
+      blockHashes: { 35: NEXT_FINALIZED_HASH },
+      ordinaryRanges: ranges,
+    }));
+    expect(ranges).toEqual(Array(5).fill([36, 36]));
+    await next.publish();
+  });
+
+  it('prevents clear from being undone by an in-flight load', async () => {
+    const cache = new ContextGraphAuthorityHistoryCache();
+    const coldReads = { count: 0 };
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const pending = resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'cleared',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+      coldReads,
+      creationGate: { entered: entered.resolve, wait: release.promise },
+    }));
+    await entered.promise;
+    cache.clear();
+    release.resolve();
+    const stale = await pending;
+    await expect(stale.publish()).rejects.toThrow('invalidated');
+
+    const fresh = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'cleared',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+      coldReads,
+    }));
+    await fresh.publish();
+    expect(coldReads.count).toBe(2);
+  });
+
+  it('bounds authority history with LRU retention', async () => {
+    const cache = new ContextGraphAuthorityHistoryCache(2);
+    const coldReads = new Map<string, { count: number }>();
+    const publish = async (cacheKey: string) => {
+      const counter = coldReads.get(cacheKey) ?? { count: 0 };
+      coldReads.set(cacheKey, counter);
+      const resolution = await resolveContextGraphAuthorityHistory(directHistoryInput({
+        cache,
+        cacheKey,
+        blockNumber: 30,
+        blockHash: FINALIZED_HASH,
+        coldReads: counter,
+      }));
+      await resolution.publish();
+    };
+    await publish('a');
+    await publish('b');
+    await publish('a');
+    await publish('c');
     expect(cache.size).toBe(2);
-    expect(cache.get('b')).toBeUndefined();
-    expect(cache.get('a')).toEqual(state(1));
-    expect(cache.get('c')).toEqual(state(3));
+    await publish('b');
+    expect(coldReads.get('a')?.count).toBe(1);
+    expect(coldReads.get('b')?.count).toBe(2);
+    expect(coldReads.get('c')?.count).toBe(1);
+  });
+
+  it('requires a name hash at the creation-event boundary', () => {
+    // @ts-expect-error Creation events cannot cross this boundary without nameHash.
+    const invalid: ContextGraphAuthorityHistoryCreationEvent = {
+      blockNumber: 1,
+      blockHash: CREATION_HASH,
+      index: 0,
+    };
+    expect(invalid).toBeDefined();
   });
 
   it('provides the same authority surface in offline mock-chain mode', async () => {

--- a/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
@@ -6,12 +6,6 @@ import { ethers } from 'ethers';
 import type { ContextGraphAuthoritySnapshot } from '../src/chain-adapter.js';
 import { EVMChainAdapter } from '../src/evm-adapter.js';
 import { MockChainAdapter } from '../src/mock-adapter.js';
-import {
-  ContextGraphAuthorityHistoryCache,
-  resolveContextGraphAuthorityHistory,
-  type ContextGraphAuthorityHistoryCreationEvent,
-  type ResolveContextGraphAuthorityHistoryInput,
-} from '../src/context-graph-authority-history.js';
 
 const OWNER = '0x1111111111111111111111111111111111111111';
 const MEMBER = '0x2222222222222222222222222222222222222222';
@@ -25,7 +19,6 @@ const CREATION_HASH = `0x${'66'.repeat(32)}`;
 const POLICY_HASH = `0x${'77'.repeat(32)}`;
 const NEXT_POLICY_HASH = `0x${'78'.repeat(32)}`;
 const NAME_HASH = `0x${'88'.repeat(32)}`;
-const DIRECT_READ_SCOPE = {};
 
 function event(
   blockNumber: number,
@@ -34,50 +27,6 @@ function event(
   args: readonly unknown[] = [],
 ) {
   return { blockNumber, index, blockHash, args };
-}
-
-function directHistoryInput(params: Readonly<{
-  cache: ContextGraphAuthorityHistoryCache;
-  cacheKey: string;
-  blockNumber: number;
-  blockHash: string;
-  coldReads?: { count: number };
-  ordinaryRanges?: Array<readonly [number, number]>;
-  blockHashes?: Readonly<Record<number, string>>;
-  creationGate?: Readonly<{ entered(): void; wait: Promise<void> }>;
-  readScope?: object;
-  signal?: AbortSignal;
-  omitCreationNameHash?: boolean;
-}>): ResolveContextGraphAuthorityHistoryInput {
-  return {
-    cache: params.cache,
-    cacheKey: params.cacheKey,
-    readScope: params.readScope ?? DIRECT_READ_SCOPE,
-    contextGraphId: 9n,
-    finalized: { number: params.blockNumber, hash: params.blockHash },
-    pageSize: 100,
-    signal: params.signal,
-    loadColdFromBlock: async () => {
-      if (params.coldReads) params.coldReads.count += 1;
-      return 1;
-    },
-    readBlockHash: async (blockNumber) => params.blockHashes?.[blockNumber]
-      ?? (blockNumber === params.blockNumber ? params.blockHash : null),
-    readCreationEvents: async () => {
-      params.creationGate?.entered();
-      if (params.creationGate) await params.creationGate.wait;
-      return [{
-        blockNumber: 1,
-        blockHash: `0x${'01'.repeat(32)}`,
-        index: 0,
-        ...(params.omitCreationNameHash ? {} : { nameHash: NAME_HASH }),
-      }] as unknown as readonly ContextGraphAuthorityHistoryCreationEvent[];
-    },
-    readEvents: async (_query, fromBlock, toBlock) => {
-      params.ordinaryRanges?.push([fromBlock, toBlock]);
-      return [];
-    },
-  };
 }
 
 interface AuthorityEvidence {
@@ -338,6 +287,67 @@ describe('RFC-64 Context Graph authority snapshots', () => {
     await expect(pending).rejects.toThrow('anchor changed');
   });
 
+  it('lets adapter failover leave a stalled same-head history reader behind', async () => {
+    const { adapter: typedAdapter } = makeEvmAuthorityAdapter();
+    const adapter = typedAdapter as any;
+    const baseContract = adapter.contracts.contextGraphStorage.connect();
+    const historyEntered = Promise.withResolvers<void>();
+    const stalledHistory = new Promise<never>(() => {});
+    const makeProvider = () => ({
+      getBlock: async (tag: string | number) => ({
+        number: tag === 'finalized' ? 30 : Number(tag),
+        hash: FINALIZED_HASH,
+      }),
+      getNetwork: async () => ({ chainId: 31337n }),
+    });
+    const stalledProvider = makeProvider();
+    const healthyProvider = makeProvider();
+    const stalledContract = {
+      ...baseContract,
+      queryFilter: async () => {
+        historyEntered.resolve();
+        return stalledHistory;
+      },
+    };
+    const connectedProviders: object[] = [];
+    adapter.contracts.contextGraphStorage = {
+      connect: (provider: object) => {
+        connectedProviders.push(provider);
+        return provider === stalledProvider ? stalledContract : baseContract;
+      },
+    };
+    adapter.readTipProvider = async (
+      _label: string,
+      read: (provider: object) => Promise<unknown>,
+    ) => {
+      const stalledAttempt = read(stalledProvider);
+      void stalledAttempt.catch(() => {});
+      await historyEntered.promise;
+      return read(healthyProvider);
+    };
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const result = await Promise.race([
+        typedAdapter.getContextGraphAuthoritySnapshot(9n),
+        new Promise<never>((_resolve, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error('healthy authority provider remained captured by stalled reader')),
+            1_000,
+          );
+        }),
+      ]);
+      expect(result).toMatchObject({
+        contextGraphId: '9',
+        nameHash: NAME_HASH,
+        sourceBlockNumber: '21',
+      });
+      expect(connectedProviders).toEqual([stalledProvider, healthyProvider]);
+    } finally {
+      if (timeout !== undefined) clearTimeout(timeout);
+    }
+  });
+
   it('discards the incremental watermark when its finalized anchor was replaced', async () => {
     const { adapter, evidence, advanceAuthorityHead, replaceCachedAnchor } =
       makeEvmAuthorityAdapter();
@@ -379,188 +389,6 @@ describe('RFC-64 Context Graph authority snapshots', () => {
       policyVersion: '4',
     });
     expect(harness.evidence.ranges.slice(18)).toEqual(Array(10).fill([31, 35]));
-  });
-
-  it('coalesces overlapping resolutions for the same finalized head', async () => {
-    const cache = new ContextGraphAuthorityHistoryCache();
-    const coldReads = { count: 0 };
-    const entered = Promise.withResolvers<void>();
-    const release = Promise.withResolvers<void>();
-    const input = directHistoryInput({
-      cache,
-      cacheKey: 'same-head',
-      blockNumber: 30,
-      blockHash: FINALIZED_HASH,
-      coldReads,
-      creationGate: { entered: entered.resolve, wait: release.promise },
-    });
-    const first = resolveContextGraphAuthorityHistory(input);
-    await entered.promise;
-    const second = resolveContextGraphAuthorityHistory(input);
-    release.resolve();
-    const [firstResolution, secondResolution] = await Promise.all([first, second]);
-    expect(coldReads.count).toBe(1);
-    expect(firstResolution.state).toBe(secondResolution.state);
-    await Promise.all([firstResolution.publish(), secondResolution.publish()]);
-  });
-
-  it('does not let a stalled provider attempt capture same-head failover', async () => {
-    const cache = new ContextGraphAuthorityHistoryCache();
-    const stalledScope = {};
-    const healthyScope = {};
-    const entered = Promise.withResolvers<void>();
-    const release = Promise.withResolvers<void>();
-    const stalled = resolveContextGraphAuthorityHistory(directHistoryInput({
-      cache,
-      cacheKey: 'provider-failover',
-      blockNumber: 30,
-      blockHash: FINALIZED_HASH,
-      readScope: stalledScope,
-      creationGate: { entered: entered.resolve, wait: release.promise },
-    }));
-    await entered.promise;
-
-    const healthy = await resolveContextGraphAuthorityHistory(directHistoryInput({
-      cache,
-      cacheKey: 'provider-failover',
-      blockNumber: 30,
-      blockHash: FINALIZED_HASH,
-      readScope: healthyScope,
-    }));
-    expect(healthy.state.nameHash).toBe(NAME_HASH);
-    await healthy.publish();
-
-    release.resolve();
-    await expect(stalled).resolves.toMatchObject({ state: healthy.state });
-  });
-
-  it('does not let one reader abort an independent same-head reader', async () => {
-    const cache = new ContextGraphAuthorityHistoryCache();
-    const readScope = {};
-    const firstAbort = new AbortController();
-    const secondAbort = new AbortController();
-    firstAbort.abort();
-
-    const cancelled = resolveContextGraphAuthorityHistory(directHistoryInput({
-      cache,
-      cacheKey: 'independent-abort',
-      blockNumber: 30,
-      blockHash: FINALIZED_HASH,
-      readScope,
-      signal: firstAbort.signal,
-    }));
-    const healthy = resolveContextGraphAuthorityHistory(directHistoryInput({
-      cache,
-      cacheKey: 'independent-abort',
-      blockNumber: 30,
-      blockHash: FINALIZED_HASH,
-      readScope,
-      signal: secondAbort.signal,
-    }));
-
-    await expect(cancelled).rejects.toMatchObject({ name: 'AbortError' });
-    await expect(healthy).resolves.toMatchObject({ state: { nameHash: NAME_HASH } });
-  });
-
-  it('retains a newer watermark when an older load publishes last', async () => {
-    const cache = new ContextGraphAuthorityHistoryCache();
-    const entered = Promise.withResolvers<void>();
-    const release = Promise.withResolvers<void>();
-    const older = resolveContextGraphAuthorityHistory(directHistoryInput({
-      cache,
-      cacheKey: 'out-of-order',
-      blockNumber: 30,
-      blockHash: FINALIZED_HASH,
-      creationGate: { entered: entered.resolve, wait: release.promise },
-    }));
-    await entered.promise;
-    const newer = await resolveContextGraphAuthorityHistory(directHistoryInput({
-      cache,
-      cacheKey: 'out-of-order',
-      blockNumber: 35,
-      blockHash: NEXT_FINALIZED_HASH,
-    }));
-    await newer.publish();
-    release.resolve();
-    await (await older).publish();
-
-    const ranges: Array<readonly [number, number]> = [];
-    const next = await resolveContextGraphAuthorityHistory(directHistoryInput({
-      cache,
-      cacheKey: 'out-of-order',
-      blockNumber: 36,
-      blockHash: `0x${'57'.repeat(32)}`,
-      blockHashes: { 35: NEXT_FINALIZED_HASH },
-      ordinaryRanges: ranges,
-    }));
-    expect(ranges).toEqual(Array(5).fill([36, 36]));
-    await next.publish();
-  });
-
-  it('prevents clear from being undone by an in-flight load', async () => {
-    const cache = new ContextGraphAuthorityHistoryCache();
-    const coldReads = { count: 0 };
-    const entered = Promise.withResolvers<void>();
-    const release = Promise.withResolvers<void>();
-    const pending = resolveContextGraphAuthorityHistory(directHistoryInput({
-      cache,
-      cacheKey: 'cleared',
-      blockNumber: 30,
-      blockHash: FINALIZED_HASH,
-      coldReads,
-      creationGate: { entered: entered.resolve, wait: release.promise },
-    }));
-    await entered.promise;
-    cache.clear();
-    release.resolve();
-    const stale = await pending;
-    await expect(stale.publish()).rejects.toThrow('invalidated');
-
-    const fresh = await resolveContextGraphAuthorityHistory(directHistoryInput({
-      cache,
-      cacheKey: 'cleared',
-      blockNumber: 30,
-      blockHash: FINALIZED_HASH,
-      coldReads,
-    }));
-    await fresh.publish();
-    expect(coldReads.count).toBe(2);
-  });
-
-  it('bounds authority history with LRU retention', async () => {
-    const cache = new ContextGraphAuthorityHistoryCache(2);
-    const coldReads = new Map<string, { count: number }>();
-    const publish = async (cacheKey: string) => {
-      const counter = coldReads.get(cacheKey) ?? { count: 0 };
-      coldReads.set(cacheKey, counter);
-      const resolution = await resolveContextGraphAuthorityHistory(directHistoryInput({
-        cache,
-        cacheKey,
-        blockNumber: 30,
-        blockHash: FINALIZED_HASH,
-        coldReads: counter,
-      }));
-      await resolution.publish();
-    };
-    await publish('a');
-    await publish('b');
-    await publish('a');
-    await publish('c');
-    expect(cache.size).toBe(2);
-    await publish('b');
-    expect(coldReads.get('a')?.count).toBe(1);
-    expect(coldReads.get('b')?.count).toBe(2);
-    expect(coldReads.get('c')?.count).toBe(1);
-  });
-
-  it('rejects a malformed creation event without a name hash at runtime', async () => {
-    await expect(resolveContextGraphAuthorityHistory(directHistoryInput({
-      cache: new ContextGraphAuthorityHistoryCache(),
-      cacheKey: 'malformed-creation',
-      blockNumber: 30,
-      blockHash: FINALIZED_HASH,
-      omitCreationNameHash: true,
-    }))).rejects.toThrow('creation event has no name hash');
   });
 
   it('provides the same authority surface in offline mock-chain mode', async () => {

--- a/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
@@ -25,6 +25,7 @@ const CREATION_HASH = `0x${'66'.repeat(32)}`;
 const POLICY_HASH = `0x${'77'.repeat(32)}`;
 const NEXT_POLICY_HASH = `0x${'78'.repeat(32)}`;
 const NAME_HASH = `0x${'88'.repeat(32)}`;
+const DIRECT_READ_SCOPE = {};
 
 function event(
   blockNumber: number,
@@ -44,13 +45,18 @@ function directHistoryInput(params: Readonly<{
   ordinaryRanges?: Array<readonly [number, number]>;
   blockHashes?: Readonly<Record<number, string>>;
   creationGate?: Readonly<{ entered(): void; wait: Promise<void> }>;
+  readScope?: object;
+  signal?: AbortSignal;
+  omitCreationNameHash?: boolean;
 }>): ResolveContextGraphAuthorityHistoryInput {
   return {
     cache: params.cache,
     cacheKey: params.cacheKey,
+    readScope: params.readScope ?? DIRECT_READ_SCOPE,
     contextGraphId: 9n,
     finalized: { number: params.blockNumber, hash: params.blockHash },
     pageSize: 100,
+    signal: params.signal,
     loadColdFromBlock: async () => {
       if (params.coldReads) params.coldReads.count += 1;
       return 1;
@@ -64,8 +70,8 @@ function directHistoryInput(params: Readonly<{
         blockNumber: 1,
         blockHash: `0x${'01'.repeat(32)}`,
         index: 0,
-        nameHash: NAME_HASH,
-      }];
+        ...(params.omitCreationNameHash ? {} : { nameHash: NAME_HASH }),
+      }] as unknown as readonly ContextGraphAuthorityHistoryCreationEvent[];
     },
     readEvents: async (_query, fromBlock, toBlock) => {
       params.ordinaryRanges?.push([fromBlock, toBlock]);
@@ -398,6 +404,64 @@ describe('RFC-64 Context Graph authority snapshots', () => {
     await Promise.all([firstResolution.publish(), secondResolution.publish()]);
   });
 
+  it('does not let a stalled provider attempt capture same-head failover', async () => {
+    const cache = new ContextGraphAuthorityHistoryCache();
+    const stalledScope = {};
+    const healthyScope = {};
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const stalled = resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'provider-failover',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+      readScope: stalledScope,
+      creationGate: { entered: entered.resolve, wait: release.promise },
+    }));
+    await entered.promise;
+
+    const healthy = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'provider-failover',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+      readScope: healthyScope,
+    }));
+    expect(healthy.state.nameHash).toBe(NAME_HASH);
+    await healthy.publish();
+
+    release.resolve();
+    await expect(stalled).resolves.toMatchObject({ state: healthy.state });
+  });
+
+  it('does not let one reader abort an independent same-head reader', async () => {
+    const cache = new ContextGraphAuthorityHistoryCache();
+    const readScope = {};
+    const firstAbort = new AbortController();
+    const secondAbort = new AbortController();
+    firstAbort.abort();
+
+    const cancelled = resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'independent-abort',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+      readScope,
+      signal: firstAbort.signal,
+    }));
+    const healthy = resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'independent-abort',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+      readScope,
+      signal: secondAbort.signal,
+    }));
+
+    await expect(cancelled).rejects.toMatchObject({ name: 'AbortError' });
+    await expect(healthy).resolves.toMatchObject({ state: { nameHash: NAME_HASH } });
+  });
+
   it('retains a newer watermark when an older load publishes last', async () => {
     const cache = new ContextGraphAuthorityHistoryCache();
     const entered = Promise.withResolvers<void>();
@@ -489,14 +553,14 @@ describe('RFC-64 Context Graph authority snapshots', () => {
     expect(coldReads.get('c')?.count).toBe(1);
   });
 
-  it('requires a name hash at the creation-event boundary', () => {
-    // @ts-expect-error Creation events cannot cross this boundary without nameHash.
-    const invalid: ContextGraphAuthorityHistoryCreationEvent = {
-      blockNumber: 1,
-      blockHash: CREATION_HASH,
-      index: 0,
-    };
-    expect(invalid).toBeDefined();
+  it('rejects a malformed creation event without a name hash at runtime', async () => {
+    await expect(resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache: new ContextGraphAuthorityHistoryCache(),
+      cacheKey: 'malformed-creation',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+      omitCreationNameHash: true,
+    }))).rejects.toThrow('creation event has no name hash');
   });
 
   it('provides the same authority surface in offline mock-chain mode', async () => {

--- a/packages/chain/tsconfig.type-tests.json
+++ b/packages/chain/tsconfig.type-tests.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "rootDir": ".",
+    "sourceMap": false
+  },
+  "include": ["test/**/*.typecheck.ts"]
+}

--- a/packages/core/src/bounded-lru-cache.ts
+++ b/packages/core/src/bounded-lru-cache.ts
@@ -27,6 +27,14 @@ export class BoundedLruCache<K, V> {
     return value;
   }
 
+  delete(key: K): boolean {
+    return this.entries.delete(key);
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
   set(key: K, value: V): void {
     if (!this.shouldAdmit(key)) return;
     this.entries.delete(key);

--- a/packages/core/test/sparql-operation.test.ts
+++ b/packages/core/test/sparql-operation.test.ts
@@ -145,6 +145,18 @@ describe('bounded SPARQL analysis cache policy', () => {
     expect(cache.has('blocked')).toBe(false);
   });
 
+  it('supports explicit entry and lifecycle invalidation', () => {
+    const cache = createCache();
+    cache.set('first', {});
+    cache.set('second', {});
+    expect(cache.delete('first')).toBe(true);
+    expect(cache.delete('missing')).toBe(false);
+    expect(cache.has('first')).toBe(false);
+    cache.clear();
+    expect(cache.size).toBe(0);
+    expect(cache.has('second')).toBe(false);
+  });
+
   const smallMaxSourceLength = 64 * 1024;
   const largeMaxSourceLength = 2 * 1024 * 1024;
   const largeQuery = (suffix: string, padding = smallMaxSourceLength) => (


### PR DESCRIPTION
## Summary

Every Context Graph authority snapshot currently replays all registry events from contract deployment to the finalized head. Repeated finalization/reconciliation calls therefore amplify into full-history `eth_getLogs` traffic and can exhaust Base RPC quotas.

## Changes

- Cache the last complete finalized authority history per governance contract and Context Graph for the adapter process lifetime.
- On an unchanged finalized head, reuse history without issuing log queries.
- On a newer head, validate the cached anchor hash and scan only the unseen block suffix.
- Skip the immutable creation-event scan after the initial complete read.
- Rebuild from deployment if the finalized anchor moves backward or its hash changes.
- Continue reading current contract state at the selected finalized block and post-validating that same anchor before publishing the cache watermark.

The cache is intentionally in memory. A restart safely performs one full reconstruction, then resumes incremental reads.

## Test Plan

- [x] `pnpm --filter @origintrail-official/dkg-chain build`
- [x] `vitest run test/context-graph-authority-snapshot.unit.test.ts` (5/5)
- [x] Covered same-head reuse, suffix-only advancement, and anchor-replacement rebuild
- [ ] Live canary verification against a real Base provider

## Related Issues

Complementary to PR #2496, which reduces initial RFC-64 catalog bootstrap work. Both touch authority resolution, so whichever merges second may need a small rebase.
