### PR TITLE
fix(agent): require bounded curator peer discovery pages

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -45,6 +45,28 @@ const agents = await agent.findAgents();
 const skills = await agent.findSkills({ skillType: 'sentiment-analysis' });
 ```
 
+## Bounded peer discovery
+
+`DiscoveryClient.findAgentPeerIdsByAddress(wallet, { limit, afterPeerId?, signal? })`
+requires an integer limit from 1 to `MAX_AGENT_PEER_PAGE_SIZE` (1,024). It returns
+`{ peerIds, nextAfterPeerId }`: peer IDs are unique and ordered, the cursor is
+exclusive, and a null continuation means the query found no further row. The
+query retains at most `limit + 1` rows and does not select optional profile fields.
+This replaces the method's earlier optional-limit, array-only result.
+
+Bounded recovery providers must implement the exported `AgentPeerDiscovery`
+contract. Providers that cannot paginate must reject the lookup; bounded recovery
+reports `lookupFailed` and never substitutes `findAgents()`. This also applies to
+registry discovery during its metadata-refresh fallback. Legacy single-curator
+metadata resolution and callers explicitly using the rich profile API retain
+their existing behavior.
+
+A page walk is not a snapshot of a changing registry. Recovery treats tail pages
+as incomplete roster evidence even when a tail page has no continuation. Only a
+fresh first-page query covering the entire bounded roster can support its existing
+absence-proof checks. These local peer IDs do not themselves establish curator
+authority.
+
 ## Internal Dependencies
 
 - `@origintrail-official/dkg-core` — P2P node, crypto, event bus

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -47,12 +47,14 @@ const skills = await agent.findSkills({ skillType: 'sentiment-analysis' });
 
 ## Bounded peer discovery
 
-`DiscoveryClient.findAgentPeerIdsByAddress(wallet, { limit, afterPeerId?, signal? })`
+`DiscoveryClient.findAgentPeerPageByAddress(wallet, { limit, afterPeerId?, signal? })`
 requires an integer limit from 1 to `MAX_AGENT_PEER_PAGE_SIZE` (1,024). It returns
 `{ peerIds, nextAfterPeerId }`: peer IDs are unique and ordered, the cursor is
 exclusive, and a null continuation means the query found no further row. The
 query retains at most `limit + 1` rows and does not select optional profile fields.
-This replaces the method's earlier optional-limit, array-only result.
+The existing `findAgentPeerIdsByAddress(wallet, options?)` remains available as a
+deprecated array-returning facade. It walks bounded pages internally, retaining
+the full result only for callers explicitly using that legacy API.
 
 Bounded recovery providers must implement the exported `AgentPeerDiscovery`
 contract. Providers that cannot paginate must reject the lookup; bounded recovery

--- a/packages/agent/src/agent-peer-discovery.ts
+++ b/packages/agent/src/agent-peer-discovery.ts
@@ -34,29 +34,34 @@ export function validateAgentPeerPageRequest(request: AgentPeerPageRequest): voi
 /** Reject a broken provider contract before treating a page as registry evidence. */
 export function validateAgentPeerPage(page: unknown, request: AgentPeerPageRequest): AgentPeerPage {
   if (page === null || typeof page !== 'object' || Array.isArray(page)) {
-    throw new Error('Peer discovery returned an invalid page');
+    throw new TypeError('Peer discovery returned an invalid page');
   }
-  const record = page as Record<string, unknown>;
-  const peerIds = record.peerIds;
-  const nextAfterPeerId = record.nextAfterPeerId;
-  if (!Array.isArray(peerIds) || peerIds.length > request.limit) {
+  const { peerIds: rawPeerIds, nextAfterPeerId } = page as Record<string, unknown>;
+  if (!Array.isArray(rawPeerIds)) {
     throw new Error('Peer discovery exceeded its page bound');
   }
+  const peerCount = rawPeerIds.length;
+  if (!Number.isSafeInteger(peerCount) || peerCount < 0 || peerCount > request.limit) {
+    throw new Error('Peer discovery exceeded its page bound');
+  }
+  if (nextAfterPeerId !== null && typeof nextAfterPeerId !== 'string') {
+    throw new TypeError('Peer discovery returned an invalid continuation');
+  }
+  const peerIds: string[] = [];
   let previous = request.afterPeerId;
-  for (const peerId of peerIds) {
+  for (let index = 0; index < peerCount; index++) {
+    const peerId: unknown = rawPeerIds[index];
     if (typeof peerId !== 'string' || peerId.length === 0 || (previous !== undefined && peerId <= previous)) {
       throw new Error('Peer discovery returned a non-monotonic page');
     }
+    peerIds.push(peerId);
     previous = peerId;
-  }
-  if (nextAfterPeerId !== null && typeof nextAfterPeerId !== 'string') {
-    throw new Error('Peer discovery returned an invalid continuation');
   }
   if (nextAfterPeerId !== null && (peerIds.length !== request.limit || nextAfterPeerId !== previous)) {
     throw new Error('Peer discovery returned an invalid continuation');
   }
   request.signal?.throwIfAborted();
-  return { peerIds: [...peerIds], nextAfterPeerId };
+  return { peerIds, nextAfterPeerId };
 }
 
 export async function readAgentPeerPage(

--- a/packages/agent/src/agent-peer-discovery.ts
+++ b/packages/agent/src/agent-peer-discovery.ts
@@ -65,9 +65,7 @@ export function validateAgentPeerPage(page: unknown, request: AgentPeerPageReque
 }
 
 export async function readAgentPeerPage(
-  discovery: {
-    findAgentPeerPageByAddress(agentAddress: string, request: AgentPeerPageRequest): Promise<unknown>;
-  },
+  discovery: AgentPeerDiscovery,
   agentAddress: string,
   request: AgentPeerPageRequest,
 ): Promise<AgentPeerPage> {

--- a/packages/agent/src/agent-peer-discovery.ts
+++ b/packages/agent/src/agent-peer-discovery.ts
@@ -32,9 +32,13 @@ export function validateAgentPeerPageRequest(request: AgentPeerPageRequest): voi
 }
 
 /** Reject a broken provider contract before treating a page as registry evidence. */
-export function validateAgentPeerPage(page: AgentPeerPage, request: AgentPeerPageRequest): AgentPeerPage {
-  const peerIds = page.peerIds;
-  const nextAfterPeerId = page.nextAfterPeerId;
+export function validateAgentPeerPage(page: unknown, request: AgentPeerPageRequest): AgentPeerPage {
+  if (page === null || typeof page !== 'object' || Array.isArray(page)) {
+    throw new Error('Peer discovery returned an invalid page');
+  }
+  const record = page as Record<string, unknown>;
+  const peerIds = record.peerIds;
+  const nextAfterPeerId = record.nextAfterPeerId;
   if (!Array.isArray(peerIds) || peerIds.length > request.limit) {
     throw new Error('Peer discovery exceeded its page bound');
   }
@@ -45,6 +49,9 @@ export function validateAgentPeerPage(page: AgentPeerPage, request: AgentPeerPag
     }
     previous = peerId;
   }
+  if (nextAfterPeerId !== null && typeof nextAfterPeerId !== 'string') {
+    throw new Error('Peer discovery returned an invalid continuation');
+  }
   if (nextAfterPeerId !== null && (peerIds.length !== request.limit || nextAfterPeerId !== previous)) {
     throw new Error('Peer discovery returned an invalid continuation');
   }
@@ -53,7 +60,9 @@ export function validateAgentPeerPage(page: AgentPeerPage, request: AgentPeerPag
 }
 
 export async function readAgentPeerPage(
-  discovery: AgentPeerDiscovery,
+  discovery: {
+    findAgentPeerPageByAddress(agentAddress: string, request: AgentPeerPageRequest): Promise<unknown>;
+  },
   agentAddress: string,
   request: AgentPeerPageRequest,
 ): Promise<AgentPeerPage> {

--- a/packages/agent/src/agent-peer-discovery.ts
+++ b/packages/agent/src/agent-peer-discovery.ts
@@ -18,7 +18,7 @@ export interface AgentPeerPage {
 
 /** Required capability for bounded recovery. Unsupported providers must reject. */
 export interface AgentPeerDiscovery {
-  findAgentPeerIdsByAddress(agentAddress: string, request: AgentPeerPageRequest): Promise<AgentPeerPage>;
+  findAgentPeerPageByAddress(agentAddress: string, request: AgentPeerPageRequest): Promise<AgentPeerPage>;
 }
 
 export function validateAgentPeerPageRequest(request: AgentPeerPageRequest): void {
@@ -59,6 +59,6 @@ export async function readAgentPeerPage(
 ): Promise<AgentPeerPage> {
   const boundedRequest = Object.freeze({ ...request });
   validateAgentPeerPageRequest(boundedRequest);
-  const page = await discovery.findAgentPeerIdsByAddress(agentAddress, boundedRequest);
+  const page = await discovery.findAgentPeerPageByAddress(agentAddress, boundedRequest);
   return validateAgentPeerPage(page, boundedRequest);
 }

--- a/packages/agent/src/agent-peer-discovery.ts
+++ b/packages/agent/src/agent-peer-discovery.ts
@@ -1,0 +1,64 @@
+/** Maximum peer IDs in one wallet-registry page, excluding one lookahead row. */
+export const MAX_AGENT_PEER_PAGE_SIZE = 1024;
+
+export interface AgentPeerPageRequest {
+  /** Positive integer, at most MAX_AGENT_PEER_PAGE_SIZE. */
+  readonly limit: number;
+  /** Exclusive lexical peer-ID cursor; omit for the first page. */
+  readonly afterPeerId?: string;
+  readonly signal?: AbortSignal;
+}
+
+export interface AgentPeerPage {
+  /** Strictly increasing, duplicate-free peer IDs; at most request.limit. */
+  readonly peerIds: readonly string[];
+  /** Last returned peer ID when another row exists, otherwise null. */
+  readonly nextAfterPeerId: string | null;
+}
+
+/** Required capability for bounded recovery. Unsupported providers must reject. */
+export interface AgentPeerDiscovery {
+  findAgentPeerIdsByAddress(agentAddress: string, request: AgentPeerPageRequest): Promise<AgentPeerPage>;
+}
+
+export function validateAgentPeerPageRequest(request: AgentPeerPageRequest): void {
+  if (!Number.isSafeInteger(request.limit) || request.limit < 1 || request.limit > MAX_AGENT_PEER_PAGE_SIZE) {
+    throw new RangeError(`Peer page limit must be an integer from 1 to ${MAX_AGENT_PEER_PAGE_SIZE}`);
+  }
+  if (request.afterPeerId !== undefined && (typeof request.afterPeerId !== 'string' || request.afterPeerId.length === 0)) {
+    throw new TypeError('Peer page cursor must be a nonempty string');
+  }
+  request.signal?.throwIfAborted();
+}
+
+/** Reject a broken provider contract before treating a page as registry evidence. */
+export function validateAgentPeerPage(page: AgentPeerPage, request: AgentPeerPageRequest): AgentPeerPage {
+  const peerIds = page.peerIds;
+  const nextAfterPeerId = page.nextAfterPeerId;
+  if (!Array.isArray(peerIds) || peerIds.length > request.limit) {
+    throw new Error('Peer discovery exceeded its page bound');
+  }
+  let previous = request.afterPeerId;
+  for (const peerId of peerIds) {
+    if (typeof peerId !== 'string' || peerId.length === 0 || (previous !== undefined && peerId <= previous)) {
+      throw new Error('Peer discovery returned a non-monotonic page');
+    }
+    previous = peerId;
+  }
+  if (nextAfterPeerId !== null && (peerIds.length !== request.limit || nextAfterPeerId !== previous)) {
+    throw new Error('Peer discovery returned an invalid continuation');
+  }
+  request.signal?.throwIfAborted();
+  return { peerIds: [...peerIds], nextAfterPeerId };
+}
+
+export async function readAgentPeerPage(
+  discovery: AgentPeerDiscovery,
+  agentAddress: string,
+  request: AgentPeerPageRequest,
+): Promise<AgentPeerPage> {
+  const boundedRequest = Object.freeze({ ...request });
+  validateAgentPeerPageRequest(boundedRequest);
+  const page = await discovery.findAgentPeerIdsByAddress(agentAddress, boundedRequest);
+  return validateAgentPeerPage(page, boundedRequest);
+}

--- a/packages/agent/src/bounded-curator-roster-traversal.ts
+++ b/packages/agent/src/bounded-curator-roster-traversal.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  readAgentPeerPage,
+  validateAgentPeerPageRequest,
+  type AgentPeerPageRequest,
+} from './agent-peer-discovery.js';
+
+interface BoundedCuratorRosterProvider {
+  findAgentPeerPageByAddress(agentAddress: string, request: AgentPeerPageRequest): Promise<unknown>;
+}
+
+export type BoundedCuratorRosterTraversal =
+  | { status: 'complete'; peerIds: string[] }
+  | { status: 'continue'; peerIds: string[]; nextAfterPeerId: string }
+  | { status: 'cycle'; peerIds: string[] };
+
+/**
+ * Read one bounded registry page and describe what the recovery owner should do
+ * with its cursor. A tail page can never prove a complete roster: reaching its
+ * end explicitly asks the owner to begin a fresh cycle on its next pass.
+ */
+export async function traverseBoundedCuratorRoster(
+  discovery: BoundedCuratorRosterProvider,
+  curatorAddress: string,
+  options: {
+    maxPeerIds: number;
+    pagePeerIds?: number;
+    afterPeerId?: string;
+    signal?: AbortSignal;
+  },
+): Promise<BoundedCuratorRosterTraversal> {
+  validateAgentPeerPageRequest({ limit: options.maxPeerIds, signal: options.signal });
+  const requestedPageSize = options.pagePeerIds ?? options.maxPeerIds;
+  validateAgentPeerPageRequest({ limit: requestedPageSize, signal: options.signal });
+  const transportPageSize = Math.min(options.maxPeerIds, requestedPageSize);
+  const startedAtBeginning = options.afterPeerId === undefined;
+  const page = await readAgentPeerPage(discovery, curatorAddress, {
+    ...(options.afterPeerId !== undefined ? { afterPeerId: options.afterPeerId } : {}),
+    limit: startedAtBeginning ? options.maxPeerIds : transportPageSize,
+    signal: options.signal,
+  });
+
+  const peerIds = page.peerIds.slice(
+    0,
+    startedAtBeginning && page.nextAfterPeerId === null
+      ? options.maxPeerIds
+      : transportPageSize,
+  );
+  if (!startedAtBeginning && page.nextAfterPeerId === null) {
+    return { status: 'cycle', peerIds };
+  }
+  if (page.nextAfterPeerId === null) {
+    return { status: 'complete', peerIds };
+  }
+  const nextAfterPeerId = peerIds[peerIds.length - 1];
+  if (!nextAfterPeerId) {
+    throw new Error('Peer discovery continuation did not expose a transport cursor');
+  }
+  return { status: 'continue', peerIds, nextAfterPeerId };
+}

--- a/packages/agent/src/bounded-curator-roster-traversal.ts
+++ b/packages/agent/src/bounded-curator-roster-traversal.ts
@@ -10,52 +10,76 @@ interface BoundedCuratorRosterProvider {
   findAgentPeerPageByAddress(agentAddress: string, request: AgentPeerPageRequest): Promise<unknown>;
 }
 
-export type BoundedCuratorRosterTraversal =
-  | { status: 'complete'; peerIds: string[] }
-  | { status: 'continue'; peerIds: string[]; nextAfterPeerId: string }
-  | { status: 'cycle'; peerIds: string[] };
+export type CuratorRosterState =
+  | { readonly status: 'complete' }
+  | { readonly status: 'continue'; readonly nextAfterPeerId: string }
+  | { readonly status: 'cycle' };
 
-/**
- * Read one bounded registry page and describe what the recovery owner should do
- * with its cursor. A tail page can never prove a complete roster: reaching its
- * end explicitly asks the owner to begin a fresh cycle on its next pass.
- */
+export type BoundedCuratorRosterTraversal = CuratorRosterState & { readonly peerIds: string[] };
+
+export interface BoundedCuratorRosterRequest {
+  readonly maxPeerIds: number;
+  readonly pagePeerIds?: number;
+  readonly afterPeerId?: string;
+  readonly signal?: AbortSignal;
+  readonly isCurrent?: () => boolean;
+}
+
+/** Only a complete first page can establish a whole local roster. */
 export async function traverseBoundedCuratorRoster(
   discovery: BoundedCuratorRosterProvider,
-  curatorAddress: string,
-  options: {
-    maxPeerIds: number;
-    pagePeerIds?: number;
-    afterPeerId?: string;
-    signal?: AbortSignal;
-  },
+  wallet: string,
+  request: BoundedCuratorRosterRequest,
 ): Promise<BoundedCuratorRosterTraversal> {
-  validateAgentPeerPageRequest({ limit: options.maxPeerIds, signal: options.signal });
-  const requestedPageSize = options.pagePeerIds ?? options.maxPeerIds;
-  validateAgentPeerPageRequest({ limit: requestedPageSize, signal: options.signal });
-  const transportPageSize = Math.min(options.maxPeerIds, requestedPageSize);
-  const startedAtBeginning = options.afterPeerId === undefined;
-  const page = await readAgentPeerPage(discovery, curatorAddress, {
-    ...(options.afterPeerId !== undefined ? { afterPeerId: options.afterPeerId } : {}),
-    limit: startedAtBeginning ? options.maxPeerIds : transportPageSize,
-    signal: options.signal,
-  });
+  const { maxPeerIds, pagePeerIds = maxPeerIds, afterPeerId, signal, isCurrent } = request;
+  const assertCurrent = (): void => {
+    signal?.throwIfAborted();
+    if (isCurrent?.() === false) throw new DOMException('Curator discovery is no longer current', 'AbortError');
+  };
+  assertCurrent();
+  validateAgentPeerPageRequest({ limit: maxPeerIds, signal });
+  validateAgentPeerPageRequest({ limit: pagePeerIds, signal });
+  const transportPageSize = Math.min(maxPeerIds, pagePeerIds);
+  const readPage = async (limit: number, cursor?: string) => {
+    assertCurrent();
+    const page = await readAgentPeerPage(discovery, wallet, {
+      limit, ...(cursor === undefined ? {} : { afterPeerId: cursor }), signal,
+    });
+    assertCurrent();
+    return page;
+  };
+  const readFirstPage = async (): Promise<BoundedCuratorRosterTraversal> => {
+    const page = await readPage(maxPeerIds);
+    if (page.nextAfterPeerId === null) return { status: 'complete', peerIds: [...page.peerIds] };
+    // A target can spend only one peer attempt per pass. Advance only past
+    // returned transport candidates, even when the proof probe read more.
+    const peerIds = page.peerIds.slice(0, transportPageSize);
+    return { status: 'continue', peerIds, nextAfterPeerId: peerIds[peerIds.length - 1]! };
+  };
+  if (afterPeerId === undefined) return readFirstPage();
+  const tail = await readPage(transportPageSize, afterPeerId);
+  // A saved cursor can become exhausted after churn. Recover immediately with
+  // a fresh bounded first-page probe; do not infer completeness from the tail.
+  if (tail.peerIds.length === 0) return readFirstPage();
+  const peerIds = [...tail.peerIds];
+  return tail.nextAfterPeerId === null
+    ? { status: 'cycle', peerIds }
+    : { status: 'continue', peerIds, nextAfterPeerId: tail.nextAfterPeerId };
+}
 
-  const peerIds = page.peerIds.slice(
-    0,
-    startedAtBeginning && page.nextAfterPeerId === null
-      ? options.maxPeerIds
-      : transportPageSize,
-  );
-  if (!startedAtBeginning && page.nextAfterPeerId === null) {
-    return { status: 'cycle', peerIds };
-  }
-  if (page.nextAfterPeerId === null) {
-    return { status: 'complete', peerIds };
-  }
-  const nextAfterPeerId = peerIds[peerIds.length - 1];
-  if (!nextAfterPeerId) {
-    throw new Error('Peer discovery continuation did not expose a transport cursor');
-  }
-  return { status: 'continue', peerIds, nextAfterPeerId };
+/** Preserve the existing SDK pagination fields beside the explicit traversal. */
+export function curatorRosterResolution(rosterTraversal: BoundedCuratorRosterTraversal): {
+  peerIds: string[];
+  rosterTraversal: BoundedCuratorRosterTraversal;
+  overflowed?: boolean;
+  nextPageAfterPeerId?: string;
+} {
+  const { peerIds } = rosterTraversal;
+  const legacyCursor = rosterTraversal.status === 'continue' ? rosterTraversal.nextAfterPeerId
+    : rosterTraversal.status === 'cycle' ? peerIds[peerIds.length - 1] : undefined;
+  return {
+    peerIds, rosterTraversal,
+    ...(rosterTraversal.status === 'complete' ? {} : { overflowed: true }),
+    ...(legacyCursor === undefined ? {} : { nextPageAfterPeerId: legacyCursor }),
+  };
 }

--- a/packages/agent/src/bounded-curator-roster-traversal.ts
+++ b/packages/agent/src/bounded-curator-roster-traversal.ts
@@ -3,12 +3,8 @@
 import {
   readAgentPeerPage,
   validateAgentPeerPageRequest,
-  type AgentPeerPageRequest,
+  type AgentPeerDiscovery,
 } from './agent-peer-discovery.js';
-
-interface BoundedCuratorRosterProvider {
-  findAgentPeerPageByAddress(agentAddress: string, request: AgentPeerPageRequest): Promise<unknown>;
-}
 
 export type CuratorRosterState =
   | { readonly status: 'complete' }
@@ -16,6 +12,27 @@ export type CuratorRosterState =
   | { readonly status: 'cycle' };
 
 export type BoundedCuratorRosterTraversal = CuratorRosterState & { readonly peerIds: string[] };
+
+/** Canonical public projection: the peer list has exactly one owner. */
+export type BoundedCuratorRosterResolution =
+  | {
+      readonly peerIds: string[];
+      readonly rosterStatus: 'complete';
+      readonly overflowed?: never;
+      readonly nextPageAfterPeerId?: never;
+    }
+  | {
+      readonly peerIds: string[];
+      readonly rosterStatus: 'continue';
+      readonly overflowed: true;
+      readonly nextPageAfterPeerId: string;
+    }
+  | {
+      readonly peerIds: string[];
+      readonly rosterStatus: 'cycle';
+      readonly overflowed: true;
+      readonly nextPageAfterPeerId?: never;
+    };
 
 export interface BoundedCuratorRosterRequest {
   readonly maxPeerIds: number;
@@ -27,7 +44,7 @@ export interface BoundedCuratorRosterRequest {
 
 /** Only a complete first page can establish a whole local roster. */
 export async function traverseBoundedCuratorRoster(
-  discovery: BoundedCuratorRosterProvider,
+  discovery: AgentPeerDiscovery,
   wallet: string,
   request: BoundedCuratorRosterRequest,
 ): Promise<BoundedCuratorRosterTraversal> {
@@ -67,19 +84,19 @@ export async function traverseBoundedCuratorRoster(
     : { status: 'continue', peerIds, nextAfterPeerId: tail.nextAfterPeerId };
 }
 
-/** Preserve the existing SDK pagination fields beside the explicit traversal. */
-export function curatorRosterResolution(rosterTraversal: BoundedCuratorRosterTraversal): {
-  peerIds: string[];
-  rosterTraversal: BoundedCuratorRosterTraversal;
-  overflowed?: boolean;
-  nextPageAfterPeerId?: string;
-} {
+/** Flatten traversal state beside the one canonical transport peer list. */
+export function curatorRosterResolution(
+  rosterTraversal: BoundedCuratorRosterTraversal,
+): BoundedCuratorRosterResolution {
   const { peerIds } = rosterTraversal;
-  const legacyCursor = rosterTraversal.status === 'continue' ? rosterTraversal.nextAfterPeerId
-    : rosterTraversal.status === 'cycle' ? peerIds[peerIds.length - 1] : undefined;
-  return {
-    peerIds, rosterTraversal,
-    ...(rosterTraversal.status === 'complete' ? {} : { overflowed: true }),
-    ...(legacyCursor === undefined ? {} : { nextPageAfterPeerId: legacyCursor }),
-  };
+  if (rosterTraversal.status === 'complete') return { peerIds, rosterStatus: 'complete' };
+  if (rosterTraversal.status === 'continue') {
+    return {
+      peerIds,
+      rosterStatus: 'continue',
+      overflowed: true,
+      nextPageAfterPeerId: rosterTraversal.nextAfterPeerId,
+    };
+  }
+  return { peerIds, rosterStatus: 'cycle', overflowed: true };
 }

--- a/packages/agent/src/curator-meta-refresh.ts
+++ b/packages/agent/src/curator-meta-refresh.ts
@@ -39,8 +39,11 @@ import { stripLiteral } from './dkg-agent-utils.js';
 
 export interface CuratorMetaRefreshOptions {
   signal?: AbortSignal;
-  /** Require bounded peer discovery if resolving a wallet curator through the registry. */
-  registryPageLimit?: number;
+  /** Optional caller-owned resolution policy for choosing the refresh peer. */
+  curatorPeerResolver?: (
+    contextGraphId: string,
+    signal?: AbortSignal,
+  ) => Promise<string | undefined>;
   /**
    * A curator peer whose authority was already established by the caller.
    * The join-approved path uses the authenticated notification sender so
@@ -93,7 +96,7 @@ interface CuratorMetaRefreshAgent {
   invalidateListContextGraphsCache(): void;
   resolveCuratorPeerId(
     contextGraphId: string,
-    options: CuratorMetaRefreshOptions,
+    options: { signal?: AbortSignal },
   ): Promise<string | undefined>;
   fetchSyncPages(
     ctx: OperationContext,
@@ -783,7 +786,9 @@ export async function runCuratorMetaRefresh(
 
   const ctx = createOperationContext('sync');
   const curatorPeerId = options.trustedCuratorPeerId
-    ?? await refreshAgent.resolveCuratorPeerId(contextGraphId, options);
+    ?? await (options.curatorPeerResolver
+      ? options.curatorPeerResolver(contextGraphId, options.signal)
+      : refreshAgent.resolveCuratorPeerId(contextGraphId, { signal: options.signal }));
   throwIfCuratorMetaRefreshAborted(options.signal);
   if (!curatorPeerId || curatorPeerId === refreshAgent.peerId) return false;
   return scheduleCuratorMetaRefresh(

--- a/packages/agent/src/curator-meta-refresh.ts
+++ b/packages/agent/src/curator-meta-refresh.ts
@@ -39,11 +39,6 @@ import { stripLiteral } from './dkg-agent-utils.js';
 
 export interface CuratorMetaRefreshOptions {
   signal?: AbortSignal;
-  /** Optional caller-owned resolution policy for choosing the refresh peer. */
-  curatorPeerResolver?: (
-    contextGraphId: string,
-    signal?: AbortSignal,
-  ) => Promise<string | undefined>;
   /**
    * A curator peer whose authority was already established by the caller.
    * The join-approved path uses the authenticated notification sender so
@@ -768,6 +763,52 @@ function scheduleCuratorMetaRefresh(
   });
 }
 
+function curatorMetaRefreshCoolingDown(
+  agent: CuratorMetaRefreshAgent,
+  contextGraphId: string,
+  force: boolean | undefined,
+): boolean {
+  const lastRefresh = agent.metaRefreshTimestamps.get(contextGraphId) ?? 0;
+  return !force && Date.now() - lastRefresh < META_REFRESH_COOLDOWN_MS;
+}
+
+function runResolvedCuratorMetaRefresh(
+  agent: CuratorMetaRefreshAgent,
+  contextGraphId: string,
+  curatorPeerId: string | undefined,
+  options: CuratorMetaRefreshOptions,
+): Promise<boolean> {
+  throwIfCuratorMetaRefreshAborted(options.signal);
+  if (!curatorPeerId || curatorPeerId === agent.peerId) return Promise.resolve(false);
+  return scheduleCuratorMetaRefresh(
+    agent,
+    contextGraphId,
+    curatorPeerId,
+    options,
+    createOperationContext('sync'),
+  );
+}
+
+/** Refresh through one peer selected by a dedicated caller-owned coordinator. */
+export function runCuratorMetaRefreshFromPeer(
+  agent: object,
+  contextGraphId: string,
+  curatorPeerId: string | undefined,
+  options: CuratorMetaRefreshOptions = {},
+): Promise<boolean> {
+  const refreshAgent = agent as CuratorMetaRefreshAgent;
+  throwIfCuratorMetaRefreshAborted(options.signal);
+  if (curatorMetaRefreshCoolingDown(refreshAgent, contextGraphId, options.force)) {
+    return Promise.resolve(false);
+  }
+  return runResolvedCuratorMetaRefresh(
+    refreshAgent,
+    contextGraphId,
+    curatorPeerId,
+    options,
+  );
+}
+
 /**
  * Resolve, serialize, fetch, validate, and atomically install a curator's
  * authoritative root metadata snapshot.
@@ -779,23 +820,16 @@ export async function runCuratorMetaRefresh(
 ): Promise<boolean> {
   const refreshAgent = agent as CuratorMetaRefreshAgent;
   throwIfCuratorMetaRefreshAborted(options.signal);
-  const lastRefresh = refreshAgent.metaRefreshTimestamps.get(contextGraphId) ?? 0;
-  if (!options.force && Date.now() - lastRefresh < META_REFRESH_COOLDOWN_MS) {
+  if (curatorMetaRefreshCoolingDown(refreshAgent, contextGraphId, options.force)) {
     return false;
   }
 
-  const ctx = createOperationContext('sync');
   const curatorPeerId = options.trustedCuratorPeerId
-    ?? await (options.curatorPeerResolver
-      ? options.curatorPeerResolver(contextGraphId, options.signal)
-      : refreshAgent.resolveCuratorPeerId(contextGraphId, { signal: options.signal }));
-  throwIfCuratorMetaRefreshAborted(options.signal);
-  if (!curatorPeerId || curatorPeerId === refreshAgent.peerId) return false;
-  return scheduleCuratorMetaRefresh(
+    ?? await refreshAgent.resolveCuratorPeerId(contextGraphId, { signal: options.signal });
+  return runResolvedCuratorMetaRefresh(
     refreshAgent,
     contextGraphId,
     curatorPeerId,
     options,
-    ctx,
   );
 }

--- a/packages/agent/src/curator-meta-refresh.ts
+++ b/packages/agent/src/curator-meta-refresh.ts
@@ -39,6 +39,8 @@ import { stripLiteral } from './dkg-agent-utils.js';
 
 export interface CuratorMetaRefreshOptions {
   signal?: AbortSignal;
+  /** Require bounded peer discovery if resolving a wallet curator through the registry. */
+  registryPageLimit?: number;
   /**
    * A curator peer whose authority was already established by the caller.
    * The join-approved path uses the authenticated notification sender so

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -8,6 +8,7 @@ import {
 } from '@origintrail-official/dkg-core';
 import { AGENT_REGISTRY_CONTEXT_GRAPH } from './profile.js';
 import {
+  MAX_AGENT_PEER_PAGE_SIZE,
   validateAgentPeerPage,
   validateAgentPeerPageRequest,
   type AgentPeerDiscovery,
@@ -221,11 +222,39 @@ export class DiscoveryClient implements AgentPeerDiscovery {
   }
 
   /**
+   * @deprecated Use findAgentPeerPageByAddress for bounded page consumption.
+   * Preserves the existing optional-limit array API for explicit legacy callers;
+   * bounded recovery never calls this facade or accumulates this full result.
+   */
+  async findAgentPeerIdsByAddress(
+    agentAddress: string,
+    options: { afterPeerId?: string; limit?: number; signal?: AbortSignal } = {},
+  ): Promise<string[]> {
+    const requestedLimit = options.limit === undefined ? undefined : Math.max(1, Math.floor(options.limit));
+    if (requestedLimit !== undefined && !Number.isSafeInteger(requestedLimit)) {
+      throw new RangeError('Peer lookup limit must be finite');
+    }
+    const signal = options.signal;
+    let afterPeerId = options.afterPeerId || undefined;
+    const peerIds: string[] = [];
+    do {
+      const page = await this.findAgentPeerPageByAddress(agentAddress, {
+        limit: Math.min(MAX_AGENT_PEER_PAGE_SIZE, requestedLimit === undefined ? MAX_AGENT_PEER_PAGE_SIZE : requestedLimit - peerIds.length),
+        afterPeerId,
+        signal,
+      });
+      peerIds.push(...page.peerIds);
+      afterPeerId = page.nextAfterPeerId ?? undefined;
+    } while (afterPeerId !== undefined && (requestedLimit === undefined || peerIds.length < requestedLimit));
+    return peerIds;
+  }
+
+  /**
    * Deterministic, duplicate-free wallet-to-peer lookup for bounded recovery.
    * Rich profile rows are deliberately not selected here: OPTIONAL profile
    * properties can multiply rows before LIMIT and permanently hide a peer.
    */
-  async findAgentPeerIdsByAddress(
+  async findAgentPeerPageByAddress(
     agentAddress: string,
     options: AgentPeerPageRequest,
   ): Promise<AgentPeerPage> {

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -7,6 +7,13 @@ import {
   sparqlIri,
 } from '@origintrail-official/dkg-core';
 import { AGENT_REGISTRY_CONTEXT_GRAPH } from './profile.js';
+import {
+  validateAgentPeerPage,
+  validateAgentPeerPageRequest,
+  type AgentPeerDiscovery,
+  type AgentPeerPage,
+  type AgentPeerPageRequest,
+} from './agent-peer-discovery.js';
 
 const SKILL = 'https://dkg.origintrail.io/skill#';
 const DKG = 'https://dkg.network/ontology#';
@@ -150,7 +157,7 @@ export interface SkillSearchOptions {
  * Discovers agents and skill offerings by querying the local Agent Registry
  * context graph. All queries are strictly local (Spec §1.6 Store Isolation).
  */
-export class DiscoveryClient {
+export class DiscoveryClient implements AgentPeerDiscovery {
   private readonly engine: QueryEngine;
 
   constructor(engine: QueryEngine) {
@@ -220,36 +227,43 @@ export class DiscoveryClient {
    */
   async findAgentPeerIdsByAddress(
     agentAddress: string,
-    options: { afterPeerId?: string; limit?: number; signal?: AbortSignal } = {},
-  ): Promise<string[]> {
+    options: AgentPeerPageRequest,
+  ): Promise<AgentPeerPage> {
+    options = Object.freeze({ ...options });
+    validateAgentPeerPageRequest(options);
     const isEvmAddress = /^0x[0-9a-fA-F]{40}$/.test(agentAddress);
     const addressMatch = isEvmAddress
       ? `?agent <${DKG}agentAddress> ?storedAgentAddress .
         FILTER(LCASE(STR(?storedAgentAddress)) = "${escapeSparqlLiteral(agentAddress.toLowerCase())}")`
       : `?agent <${DKG}agentAddress> "${escapeSparqlLiteral(agentAddress)}" .`;
-    const limit = options.limit === undefined
-      ? undefined
-      : Math.max(1, Math.floor(options.limit));
     const afterFilter = options.afterPeerId
-      ? `FILTER(STR(?peerId) > "${escapeSparqlLiteral(options.afterPeerId)}")`
+      ? `FILTER(STR(?storedPeerId) > "${escapeSparqlLiteral(options.afterPeerId)}")`
       : '';
     const result = await this.engine.query(`
-      SELECT DISTINCT ?peerId WHERE {
+      SELECT DISTINCT (STR(?storedPeerId) AS ?peerId) WHERE {
         ?agent a <${DKG}Agent> ;
-               <${DKG}peerId> ?peerId .
+               <${DKG}peerId> ?storedPeerId .
         ${addressMatch}
+        FILTER(STRLEN(STR(?storedPeerId)) > 0)
         ${afterFilter}
       }
       ORDER BY ASC(STR(?peerId))
-      ${limit === undefined ? '' : `LIMIT ${limit}`}
+      LIMIT ${options.limit + 1}
     `, {
       contextGraphId: AGENT_REGISTRY_CONTEXT_GRAPH,
       signal: options.signal,
     });
 
-    return result.bindings
-      .map((row) => stripQuotes(row['peerId'] ?? ''))
-      .filter((peerId) => peerId.length > 0);
+    options.signal?.throwIfAborted();
+    if (result.bindings.length > options.limit + 1) {
+      throw new Error('Peer registry query exceeded its row limit');
+    }
+    const peerIds = result.bindings.slice(0, options.limit)
+      .map((row) => stripQuotes(row['peerId'] ?? ''));
+    return validateAgentPeerPage({
+      peerIds,
+      nextAfterPeerId: result.bindings.length > options.limit ? peerIds[peerIds.length - 1] : null,
+    }, options);
   }
 
   async findSkillOfferings(options: SkillSearchOptions = {}): Promise<DiscoveredOffering[]> {

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -606,7 +606,7 @@ export async function resolveCuratorSyncPeer(
    */
   bootstrapHints: Map<string, string>,
   contextGraphId: string,
-  options: { signal?: AbortSignal; registryPageLimit?: number } = {},
+  options: { signal?: AbortSignal; registryLookup?: 'legacy' | 'bounded-first-page' } = {},
 ): Promise<SyncPeerResolution> {
   const approvedCuratorPeerId = bootstrapHints.get(contextGraphId);
   const fromHint = (): SyncPeerResolution => (approvedCuratorPeerId
@@ -658,12 +658,12 @@ export async function resolveCuratorSyncPeer(
     if (!resolved) {
       try {
         throwIfSyncAuthAborted(options.signal);
-        const peerId = options.registryPageLimit === undefined
+        const peerId = options.registryLookup !== 'bounded-first-page'
           ? (await agent.discovery.findAgents({ signal: options.signal })).find(
               (candidate) => candidate.agentAddress?.toLowerCase() === curatorIdentifier.toLowerCase(),
             )?.peerId
           : (await readAgentPeerPage(agent.discovery, curatorIdentifier, {
-              limit: options.registryPageLimit,
+              limit: 1,
               signal: options.signal,
             })).peerIds[0];
         throwIfSyncAuthAborted(options.signal);
@@ -2227,7 +2227,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
   public async resolveCuratorPeerId(
     this: DKGAgent,
     contextGraphId: string,
-    options: { signal?: AbortSignal; registryPageLimit?: number } = {},
+    options: { signal?: AbortSignal; registryLookup?: 'legacy' | 'bounded-first-page' } = {},
   ): Promise<string | undefined> {
     return (await resolveCuratorSyncPeer(
       this,

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -9,6 +9,7 @@
  * cross-calls resolve against the composed class.
  */
 
+import { readAgentPeerPage } from './agent-peer-discovery.js';
 import { createHash } from 'node:crypto';
 import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
@@ -605,7 +606,7 @@ export async function resolveCuratorSyncPeer(
    */
   bootstrapHints: Map<string, string>,
   contextGraphId: string,
-  options: { signal?: AbortSignal } = {},
+  options: { signal?: AbortSignal; registryPageLimit?: number } = {},
 ): Promise<SyncPeerResolution> {
   const approvedCuratorPeerId = bootstrapHints.get(contextGraphId);
   const fromHint = (): SyncPeerResolution => (approvedCuratorPeerId
@@ -657,14 +658,17 @@ export async function resolveCuratorSyncPeer(
     if (!resolved) {
       try {
         throwIfSyncAuthAborted(options.signal);
-        const agents = await agent.discovery.findAgents({ signal: options.signal });
+        const peerId = options.registryPageLimit === undefined
+          ? (await agent.discovery.findAgents({ signal: options.signal })).find(
+              (candidate) => candidate.agentAddress?.toLowerCase() === curatorIdentifier.toLowerCase(),
+            )?.peerId
+          : (await readAgentPeerPage(agent.discovery, curatorIdentifier, {
+              limit: options.registryPageLimit,
+              signal: options.signal,
+            })).peerIds[0];
         throwIfSyncAuthAborted(options.signal);
-        const matches = agents.filter(
-          (a) => a.agentAddress?.toLowerCase() === curatorIdentifier.toLowerCase(),
-        );
-        const match = matches[0];
-        if (match) {
-          curatorPeerId = match.peerId;
+        if (peerId) {
+          curatorPeerId = peerId;
           resolved = true;
           // NEVER authoritative, however many matches came back. `findAgents()`
           // queries the LOCAL Agent Registry only, so "one match" means one match
@@ -2223,7 +2227,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
   public async resolveCuratorPeerId(
     this: DKGAgent,
     contextGraphId: string,
-    options: { signal?: AbortSignal } = {},
+    options: { signal?: AbortSignal; registryPageLimit?: number } = {},
   ): Promise<string | undefined> {
     return (await resolveCuratorSyncPeer(
       this,

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -568,6 +568,26 @@ function curatorDidNeedsRegistryResolution(curatorIdentifier: string): boolean {
   return curatorIdentifier.startsWith('0x');
 }
 
+type CuratorWalletRegistryResolver = (
+  agent: DKGAgent,
+  wallet: string,
+  signal: AbortSignal | undefined,
+) => Promise<string | undefined>;
+
+const resolveRichCuratorWalletPeer: CuratorWalletRegistryResolver = async (
+  agent,
+  wallet,
+  signal,
+) => (await agent.discovery.findAgents({ signal })).find(
+  (candidate) => candidate.agentAddress?.toLowerCase() === wallet.toLowerCase(),
+)?.peerId;
+
+const resolveBoundedCuratorWalletPeer: CuratorWalletRegistryResolver = async (
+  agent,
+  wallet,
+  signal,
+) => (await readAgentPeerPage(agent.discovery, wallet, { limit: 1, signal })).peerIds[0];
+
 /**
  * Resolve the curator peer for a Context Graph together with WHERE it came from.
  *
@@ -597,7 +617,7 @@ function curatorDidNeedsRegistryResolution(curatorIdentifier: string): boolean {
  * was echoed back". Only the resolver knows which branch it took.
  */
 
-export async function resolveCuratorSyncPeer(
+async function resolveCuratorSyncPeerWithRegistry(
   agent: DKGAgent,
   /**
    * The agent's `preferredSyncPeers`, passed explicitly because it is both read
@@ -606,7 +626,8 @@ export async function resolveCuratorSyncPeer(
    */
   bootstrapHints: Map<string, string>,
   contextGraphId: string,
-  options: { signal?: AbortSignal; registryLookup?: 'legacy' | 'bounded-first-page' } = {},
+  options: { signal?: AbortSignal },
+  resolveWalletPeer: CuratorWalletRegistryResolver,
 ): Promise<SyncPeerResolution> {
   const approvedCuratorPeerId = bootstrapHints.get(contextGraphId);
   const fromHint = (): SyncPeerResolution => (approvedCuratorPeerId
@@ -658,14 +679,7 @@ export async function resolveCuratorSyncPeer(
     if (!resolved) {
       try {
         throwIfSyncAuthAborted(options.signal);
-        const peerId = options.registryLookup !== 'bounded-first-page'
-          ? (await agent.discovery.findAgents({ signal: options.signal })).find(
-              (candidate) => candidate.agentAddress?.toLowerCase() === curatorIdentifier.toLowerCase(),
-            )?.peerId
-          : (await readAgentPeerPage(agent.discovery, curatorIdentifier, {
-              limit: 1,
-              signal: options.signal,
-            })).peerIds[0];
+        const peerId = await resolveWalletPeer(agent, curatorIdentifier, options.signal);
         throwIfSyncAuthAborted(options.signal);
         if (peerId) {
           curatorPeerId = peerId;
@@ -712,6 +726,37 @@ export async function resolveCuratorSyncPeer(
 
   bootstrapHints.delete(contextGraphId);
   return { peerId: curatorPeerId, provenance };
+}
+
+export function resolveCuratorSyncPeer(
+  agent: DKGAgent,
+  bootstrapHints: Map<string, string>,
+  contextGraphId: string,
+  options: { signal?: AbortSignal } = {},
+): Promise<SyncPeerResolution> {
+  return resolveCuratorSyncPeerWithRegistry(
+    agent,
+    bootstrapHints,
+    contextGraphId,
+    options,
+    resolveRichCuratorWalletPeer,
+  );
+}
+
+/** Resolve one refresh candidate without crossing the bounded page contract. */
+export function resolveBoundedCuratorSyncPeer(
+  agent: DKGAgent,
+  bootstrapHints: Map<string, string>,
+  contextGraphId: string,
+  options: { signal?: AbortSignal } = {},
+): Promise<SyncPeerResolution> {
+  return resolveCuratorSyncPeerWithRegistry(
+    agent,
+    bootstrapHints,
+    contextGraphId,
+    options,
+    resolveBoundedCuratorWalletPeer,
+  );
 }
 
 export class ContextGraphResolveMethods extends DKGAgentBase {
@@ -2227,7 +2272,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
   public async resolveCuratorPeerId(
     this: DKGAgent,
     contextGraphId: string,
-    options: { signal?: AbortSignal; registryLookup?: 'legacy' | 'bounded-first-page' } = {},
+    options: { signal?: AbortSignal } = {},
   ): Promise<string | undefined> {
     return (await resolveCuratorSyncPeer(
       this,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -8,7 +8,10 @@
  * `this: DKGAgent` so cross-calls resolve against the composed class.
  */
 
-import { readAgentPeerPage, validateAgentPeerPageRequest } from './agent-peer-discovery.js';
+import {
+  traverseBoundedCuratorRoster,
+  type BoundedCuratorRosterTraversal,
+} from './bounded-curator-roster-traversal.js';
 import { createHash } from 'node:crypto';
 import { isLegacySyncGraphCandidateV1 } from './sync/legacy-sync-graph-candidate.js';
 import {
@@ -7289,8 +7292,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     curatorIsLocal: boolean;
     legacyTripleResolved: boolean;
     lookupFailed?: boolean;
-    overflowed?: boolean;
-    nextPageAfterPeerId?: string;
+    rosterTraversal?: BoundedCuratorRosterTraversal;
   }> {
     const assertCurrent = (): void => {
       if (options.signal?.aborted || options.isCurrent?.() === false) {
@@ -7307,42 +7309,26 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       const resolve = async (): Promise<{
         peerIds: string[];
         lookupFailed: boolean;
-        overflowed?: boolean;
-        nextPageAfterPeerId?: string;
+        rosterTraversal?: BoundedCuratorRosterTraversal;
       }> => {
         assertCurrent();
         try {
           if (options.maxPeerIds !== undefined) {
-            validateAgentPeerPageRequest({ limit: options.maxPeerIds, signal: options.signal });
-            const requestedPageSize = options.pagePeerIds ?? options.maxPeerIds;
-            validateAgentPeerPageRequest({ limit: requestedPageSize, signal: options.signal });
-            const pagePeerIds = Math.min(options.maxPeerIds, requestedPageSize);
-            const queryPage = (afterPeerId?: string) =>
-              readAgentPeerPage(this.discovery, structuralAgent, {
-                ...(afterPeerId !== undefined ? { afterPeerId } : {}),
-                limit: afterPeerId !== undefined ? pagePeerIds : options.maxPeerIds!,
+            const rosterTraversal = await traverseBoundedCuratorRoster(
+              this.discovery,
+              structuralAgent,
+              {
+                maxPeerIds: options.maxPeerIds,
+                pagePeerIds: options.pagePeerIds,
+                afterPeerId: options.afterPeerId,
                 signal: options.signal,
-              });
-            let pageStartedAtBeginning = options.afterPeerId === undefined;
-            let page = await queryPage(options.afterPeerId);
+              },
+            );
             assertCurrent();
-            if (options.afterPeerId !== undefined && page.peerIds.length === 0) {
-              pageStartedAtBeginning = true;
-              page = await queryPage();
-            }
-            assertCurrent();
-            // Only a complete first-page query can describe a whole roster.
-            // A tail page remains overflowed even if concurrent deletions made
-            // it short; it cannot authorize an absence proof for earlier peers.
-            const overflowed = !pageStartedAtBeginning || page.nextAfterPeerId !== null;
-            const bounded = page.peerIds.slice(0, overflowed ? pagePeerIds : options.maxPeerIds);
             return {
-              peerIds: bounded,
+              peerIds: rosterTraversal.peerIds,
               lookupFailed: false,
-              overflowed,
-              ...(overflowed && bounded[0]
-                ? { nextPageAfterPeerId: bounded[bounded.length - 1] }
-                : {}),
+              rosterTraversal,
             };
           }
 
@@ -7355,7 +7341,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             .filter((a) => a.agentAddress?.toLowerCase() === structuralAgent)
             .map((a) => a.peerId))]
             .sort((left, right) => left.localeCompare(right));
-          return { peerIds, lookupFailed: false, overflowed: false };
+          return { peerIds, lookupFailed: false };
         } catch {
           assertCurrent();
           return { peerIds: [], lookupFailed: true };
@@ -7365,11 +7351,24 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       assertCurrent();
       // A missing/broken bounded capability is a lookup failure, never an
       // invitation to invoke the legacy rich-profile fallback via refresh.
-      if (resolution.peerIds.length === 0 && !(options.maxPeerIds !== undefined && resolution.lookupFailed)) {
+      if (resolution.peerIds.length === 0
+        && resolution.rosterTraversal?.status !== 'cycle'
+        && !(options.maxPeerIds !== undefined && resolution.lookupFailed)) {
         assertCurrent();
         const refreshed = await this.refreshMetaFromCurator(contextGraphId, {
           signal: options.signal,
-          ...(options.maxPeerIds !== undefined ? { registryPageLimit: 1 } : {}),
+          ...(options.maxPeerIds !== undefined
+            ? {
+                curatorPeerResolver: async (cgId: string, signal?: AbortSignal) => (
+                  await resolveCuratorSyncPeer(
+                    this,
+                    this.preferredSyncPeers,
+                    cgId,
+                    { signal, registryLookup: 'bounded-first-page' },
+                  )
+                ).peerId,
+              }
+            : {}),
         }).catch((error) => {
           assertCurrent();
           return false;
@@ -7389,9 +7388,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         curatorIsLocal: false,
         legacyTripleResolved: false,
         ...(resolution.lookupFailed ? { lookupFailed: true } : {}),
-        ...(resolution.overflowed ? { overflowed: true } : {}),
-        ...(resolution.nextPageAfterPeerId
-          ? { nextPageAfterPeerId: resolution.nextPageAfterPeerId }
+        ...(resolution.rosterTraversal
+          ? { rosterTraversal: resolution.rosterTraversal }
           : {}),
       };
     }

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -11,7 +11,7 @@
 import {
   traverseBoundedCuratorRoster,
   curatorRosterResolution,
-  type BoundedCuratorRosterTraversal,
+  type BoundedCuratorRosterResolution,
 } from './bounded-curator-roster-traversal.js';
 import { createHash } from 'node:crypto';
 import { isLegacySyncGraphCandidateV1 } from './sync/legacy-sync-graph-candidate.js';
@@ -631,9 +631,11 @@ import {
 } from './context-graph-subscription-policy.js';
 import {
   authoritativeSyncPeerId,
+  resolveBoundedCuratorSyncPeer,
   resolveCuratorSyncPeer,
   type SyncPeerResolution,
 } from './dkg-agent-cg-resolve.js';
+import { runCuratorMetaRefreshFromPeer } from './curator-meta-refresh.js';
 import {
   normalizePublishContextGraphId,
   isPublishAsyncQuadEnvelope,
@@ -1811,6 +1813,69 @@ function emptySwmRecoveryResult(): RecoverContextGraphSwmResult {
     completed: true,
   };
 }
+
+type NonBoundedCuratorPeerIdsResolution =
+  | {
+      readonly peerIds: [];
+      readonly curatorIsLocal: true;
+      readonly legacyTripleResolved: boolean;
+      readonly lookupFailed?: never;
+      readonly rosterStatus?: never;
+      readonly overflowed?: never;
+      readonly nextPageAfterPeerId?: never;
+    }
+  | {
+      readonly peerIds: string[];
+      readonly curatorIsLocal: false;
+      readonly legacyTripleResolved: true;
+      readonly lookupFailed?: false;
+      readonly rosterStatus?: never;
+      readonly overflowed?: never;
+      readonly nextPageAfterPeerId?: never;
+    }
+  | {
+      readonly peerIds: string[];
+      readonly curatorIsLocal: false;
+      readonly legacyTripleResolved: false;
+      readonly lookupFailed?: false;
+      readonly rosterStatus?: never;
+      readonly overflowed?: never;
+      readonly nextPageAfterPeerId?: never;
+    }
+  | {
+      readonly peerIds: [];
+      readonly curatorIsLocal: false;
+      readonly legacyTripleResolved: false;
+      readonly lookupFailed: true;
+      readonly rosterStatus?: never;
+      readonly overflowed?: never;
+      readonly nextPageAfterPeerId?: never;
+    };
+
+export type CuratorPeerIdsResolution =
+  | NonBoundedCuratorPeerIdsResolution
+  | (BoundedCuratorRosterResolution & {
+      readonly curatorIsLocal: false;
+      readonly legacyTripleResolved: false;
+      readonly lookupFailed?: false;
+    });
+
+type StructuralCuratorPeerLookup =
+  | (BoundedCuratorRosterResolution & { readonly lookupFailed?: false })
+  | {
+      readonly peerIds: string[];
+      readonly lookupFailed?: false;
+      readonly rosterStatus?: never;
+      readonly overflowed?: never;
+      readonly nextPageAfterPeerId?: never;
+    }
+  | {
+      readonly peerIds: [];
+      readonly lookupFailed: true;
+      readonly rosterStatus?: never;
+      readonly overflowed?: never;
+      readonly nextPageAfterPeerId?: never;
+    };
 
 export class LifecycleSyncMethods extends DKGAgentBase {
   async retireFinalizedSwmTwinCandidate(
@@ -7288,17 +7353,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       signal?: AbortSignal;
       isCurrent?: () => boolean;
     } = {},
-  ): Promise<{
-    peerIds: string[];
-    curatorIsLocal: boolean;
-    legacyTripleResolved: boolean;
-    lookupFailed?: boolean;
-    rosterTraversal?: BoundedCuratorRosterTraversal;
-    /** @deprecated Prefer rosterTraversal for bounded roster state. */
-    overflowed?: boolean;
-    /** @deprecated Prefer rosterTraversal for bounded roster state. */
-    nextPageAfterPeerId?: string;
-  }> {
+  ): Promise<CuratorPeerIdsResolution> {
     const assertCurrent = (): void => {
       if (options.signal?.aborted || options.isCurrent?.() === false) {
         throw new DOMException('Curator discovery is no longer current', 'AbortError');
@@ -7311,13 +7366,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       if ([...this.localAgents.keys()].some((addr) => addr.toLowerCase() === structuralAgent)) {
         return { peerIds: [], curatorIsLocal: true, legacyTripleResolved: false };
       }
-      const resolve = async (): Promise<{
-        peerIds: string[];
-        lookupFailed: boolean;
-        rosterTraversal?: BoundedCuratorRosterTraversal;
-        overflowed?: boolean;
-        nextPageAfterPeerId?: string;
-      }> => {
+      const resolve = async (): Promise<StructuralCuratorPeerLookup> => {
         assertCurrent();
         try {
           if (options.maxPeerIds !== undefined) {
@@ -7333,10 +7382,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
               },
             );
             assertCurrent();
-            return {
-              ...curatorRosterResolution(rosterTraversal),
-              lookupFailed: false,
-            };
+            return curatorRosterResolution(rosterTraversal);
           }
 
           const agents = await this.discovery.findAgents({
@@ -7348,7 +7394,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             .filter((a) => a.agentAddress?.toLowerCase() === structuralAgent)
             .map((a) => a.peerId))]
             .sort((left, right) => left.localeCompare(right));
-          return { peerIds, lookupFailed: false };
+          return { peerIds };
         } catch {
           assertCurrent();
           return { peerIds: [], lookupFailed: true };
@@ -7359,27 +7405,33 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       // A missing/broken bounded capability is a lookup failure, never an
       // invitation to invoke the legacy rich-profile fallback via refresh.
       if (resolution.peerIds.length === 0
-        && resolution.rosterTraversal?.status !== 'cycle'
+        && resolution.rosterStatus !== 'cycle'
         && !(options.maxPeerIds !== undefined && resolution.lookupFailed)) {
         assertCurrent();
-        const refreshed = await this.refreshMetaFromCurator(contextGraphId, {
-          signal: options.signal,
-          ...(options.maxPeerIds !== undefined
-            ? {
-                curatorPeerResolver: async (cgId: string, signal?: AbortSignal) => (
-                  await resolveCuratorSyncPeer(
-                    this,
-                    this.preferredSyncPeers,
-                    cgId,
-                    { signal, registryLookup: 'bounded-first-page' },
-                  )
-                ).peerId,
-              }
-            : {}),
-        }).catch((error) => {
+        let refreshed = false;
+        try {
+          if (options.maxPeerIds !== undefined) {
+            const refreshPeer = await resolveBoundedCuratorSyncPeer(
+              this,
+              this.preferredSyncPeers,
+              contextGraphId,
+              { signal: options.signal },
+            );
+            assertCurrent();
+            refreshed = await runCuratorMetaRefreshFromPeer(
+              this,
+              contextGraphId,
+              refreshPeer.peerId,
+              { signal: options.signal },
+            );
+          } else {
+            refreshed = await this.refreshMetaFromCurator(contextGraphId, {
+              signal: options.signal,
+            });
+          }
+        } catch {
           assertCurrent();
-          return false;
-        });
+        }
         assertCurrent();
         resolution = await resolve();
         assertCurrent();
@@ -7387,21 +7439,21 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         // authoritative empty registry. Preserve any caller-side last-known
         // curator roster unless another writer populated the registry.
         if (!refreshed && !resolution.lookupFailed && resolution.peerIds.length === 0) {
-          resolution = { ...resolution, lookupFailed: true };
+          resolution = { peerIds: [], lookupFailed: true };
         }
       }
+      if (resolution.lookupFailed) {
+        return {
+          peerIds: [],
+          curatorIsLocal: false,
+          legacyTripleResolved: false,
+          lookupFailed: true,
+        };
+      }
       return {
-        peerIds: resolution.peerIds,
+        ...resolution,
         curatorIsLocal: false,
         legacyTripleResolved: false,
-        ...(resolution.lookupFailed ? { lookupFailed: true } : {}),
-        ...(resolution.overflowed ? { overflowed: true } : {}),
-        ...(resolution.nextPageAfterPeerId
-          ? { nextPageAfterPeerId: resolution.nextPageAfterPeerId }
-          : {}),
-        ...(resolution.rosterTraversal
-          ? { rosterTraversal: resolution.rosterTraversal }
-          : {}),
       };
     }
     // Legacy non-wallet-scoped CG: fall back to triple-based curator resolution.

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -8,6 +8,7 @@
  * `this: DKGAgent` so cross-calls resolve against the composed class.
  */
 
+import { readAgentPeerPage, validateAgentPeerPageRequest } from './agent-peer-discovery.js';
 import { createHash } from 'node:crypto';
 import { isLegacySyncGraphCandidateV1 } from './sync/legacy-sync-graph-candidate.js';
 import {
@@ -7311,29 +7312,30 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       }> => {
         assertCurrent();
         try {
-          if (options.maxPeerIds !== undefined
-            && typeof this.discovery.findAgentPeerIdsByAddress === 'function') {
-            const pagePeerIds = Math.min(
-              options.maxPeerIds,
-              Math.max(1, Math.floor(options.pagePeerIds ?? options.maxPeerIds)),
-            );
+          if (options.maxPeerIds !== undefined) {
+            validateAgentPeerPageRequest({ limit: options.maxPeerIds, signal: options.signal });
+            const requestedPageSize = options.pagePeerIds ?? options.maxPeerIds;
+            validateAgentPeerPageRequest({ limit: requestedPageSize, signal: options.signal });
+            const pagePeerIds = Math.min(options.maxPeerIds, requestedPageSize);
             const queryPage = (afterPeerId?: string) =>
-              this.discovery.findAgentPeerIdsByAddress(structuralAgent, {
-                ...(afterPeerId ? { afterPeerId } : {}),
-                limit: (afterPeerId ? pagePeerIds : options.maxPeerIds!) + 1,
+              readAgentPeerPage(this.discovery, structuralAgent, {
+                ...(afterPeerId !== undefined ? { afterPeerId } : {}),
+                limit: afterPeerId !== undefined ? pagePeerIds : options.maxPeerIds!,
                 signal: options.signal,
               });
-            let pageStartedAtBeginning = !options.afterPeerId;
-            let peerIds = await queryPage(options.afterPeerId);
+            let pageStartedAtBeginning = options.afterPeerId === undefined;
+            let page = await queryPage(options.afterPeerId);
             assertCurrent();
-            if (options.afterPeerId && peerIds.length === 0) {
+            if (options.afterPeerId !== undefined && page.peerIds.length === 0) {
               pageStartedAtBeginning = true;
-              peerIds = await queryPage();
+              page = await queryPage();
             }
             assertCurrent();
-            const overflowed = !pageStartedAtBeginning
-              || peerIds.length > options.maxPeerIds;
-            const bounded = peerIds.slice(0, overflowed ? pagePeerIds : options.maxPeerIds);
+            // Only a complete first-page query can describe a whole roster.
+            // A tail page remains overflowed even if concurrent deletions made
+            // it short; it cannot authorize an absence proof for earlier peers.
+            const overflowed = !pageStartedAtBeginning || page.nextAfterPeerId !== null;
+            const bounded = page.peerIds.slice(0, overflowed ? pagePeerIds : options.maxPeerIds);
             return {
               peerIds: bounded,
               lookupFailed: false,
@@ -7361,10 +7363,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       };
       let resolution = await resolve();
       assertCurrent();
-      if (resolution.peerIds.length === 0) {
+      // A missing/broken bounded capability is a lookup failure, never an
+      // invitation to invoke the legacy rich-profile fallback via refresh.
+      if (resolution.peerIds.length === 0 && !(options.maxPeerIds !== undefined && resolution.lookupFailed)) {
         assertCurrent();
         const refreshed = await this.refreshMetaFromCurator(contextGraphId, {
           signal: options.signal,
+          ...(options.maxPeerIds !== undefined ? { registryPageLimit: 1 } : {}),
         }).catch((error) => {
           assertCurrent();
           return false;

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -10,6 +10,7 @@
 
 import {
   traverseBoundedCuratorRoster,
+  curatorRosterResolution,
   type BoundedCuratorRosterTraversal,
 } from './bounded-curator-roster-traversal.js';
 import { createHash } from 'node:crypto';
@@ -7293,6 +7294,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     legacyTripleResolved: boolean;
     lookupFailed?: boolean;
     rosterTraversal?: BoundedCuratorRosterTraversal;
+    /** @deprecated Prefer rosterTraversal for bounded roster state. */
+    overflowed?: boolean;
+    /** @deprecated Prefer rosterTraversal for bounded roster state. */
+    nextPageAfterPeerId?: string;
   }> {
     const assertCurrent = (): void => {
       if (options.signal?.aborted || options.isCurrent?.() === false) {
@@ -7310,6 +7315,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         peerIds: string[];
         lookupFailed: boolean;
         rosterTraversal?: BoundedCuratorRosterTraversal;
+        overflowed?: boolean;
+        nextPageAfterPeerId?: string;
       }> => {
         assertCurrent();
         try {
@@ -7322,13 +7329,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
                 pagePeerIds: options.pagePeerIds,
                 afterPeerId: options.afterPeerId,
                 signal: options.signal,
+                isCurrent: options.isCurrent,
               },
             );
             assertCurrent();
             return {
-              peerIds: rosterTraversal.peerIds,
+              ...curatorRosterResolution(rosterTraversal),
               lookupFailed: false,
-              rosterTraversal,
             };
           }
 
@@ -7388,6 +7395,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         curatorIsLocal: false,
         legacyTripleResolved: false,
         ...(resolution.lookupFailed ? { lookupFailed: true } : {}),
+        ...(resolution.overflowed ? { overflowed: true } : {}),
+        ...(resolution.nextPageAfterPeerId
+          ? { nextPageAfterPeerId: resolution.nextPageAfterPeerId }
+          : {}),
         ...(resolution.rosterTraversal
           ? { rosterTraversal: resolution.rosterTraversal }
           : {}),

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -5808,14 +5808,16 @@ export class SwmHostModeMethods extends DKGAgentBase {
         curatorIsLocal: false,
         legacyTripleResolved: false,
         lookupFailed: true,
-        overflowed: false,
-        nextPageAfterPeerId: undefined,
       }));
     if (!isRecoveryCurrent()) return staleRecovery();
     const allResolvedCuratorPeerIds = [...new Set(curatorResolution.peerIds
       .filter((peerId) => peerId && peerId !== this.peerId))]
       .sort((left, right) => left.localeCompare(right));
-    const curatorRosterOverflow = curatorResolution.overflowed === true
+    const curatorRosterTraversal = 'rosterTraversal' in curatorResolution
+      ? curatorResolution.rosterTraversal
+      : undefined;
+    const curatorRosterOverflow = (curatorRosterTraversal !== undefined
+        && curatorRosterTraversal.status !== 'complete')
       || allResolvedCuratorPeerIds.length > DKGAgentBase.VM_RECONCILE_EXACT_ROSTER_MAX;
     if (curatorRosterOverflow) {
       this.log.warn(
@@ -5852,10 +5854,8 @@ export class SwmHostModeMethods extends DKGAgentBase {
         (overflowWindowStart + offset) % overflowTransportUniverse.length
       ]!,
     );
-    const resolvedCuratorPeerIds = curatorRosterOverflow
-      ? curatorResolution.nextPageAfterPeerId
-        ? allResolvedCuratorPeerIds
-        : overflowTransportPeerIds
+    const resolvedCuratorPeerIds = curatorRosterOverflow && allResolvedCuratorPeerIds.length === 0
+      ? overflowTransportPeerIds
       : allResolvedCuratorPeerIds;
     let legacyPreferredPeerId: string | undefined;
     if (resolutionSucceeded && !curatorResolution.curatorIsLocal
@@ -5880,12 +5880,16 @@ export class SwmHostModeMethods extends DKGAgentBase {
     if (resolutionSucceeded) {
       this.vmReconcileCuratorPeersByCg.delete(localCgId);
       this.vmReconcileCuratorPageCursorByCg.delete(localCgId);
-    } else if (curatorResolution.nextPageAfterPeerId) {
+    } else if (curatorRosterTraversal?.status === 'continue') {
       this.vmReconcileCuratorPageCursorByCg.delete(localCgId);
       this.vmReconcileCuratorPageCursorByCg.set(
         localCgId,
-        curatorResolution.nextPageAfterPeerId,
+        curatorRosterTraversal.nextAfterPeerId,
       );
+    } else if (curatorRosterTraversal?.status === 'cycle') {
+      // The recovery owner, not the page reader, decides when to restart. A
+      // cleared cursor makes the next scheduled recovery begin a fresh cycle.
+      this.vmReconcileCuratorPageCursorByCg.delete(localCgId);
     }
     if (!curatorResolution.curatorIsLocal && curatorPeerIds.length > 0) {
       this.vmReconcileCuratorPeersByCg.delete(localCgId);

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -5808,21 +5808,22 @@ export class SwmHostModeMethods extends DKGAgentBase {
         curatorIsLocal: false,
         legacyTripleResolved: false,
         lookupFailed: true,
+        rosterTraversal: undefined,
+        overflowed: false,
+        nextPageAfterPeerId: undefined,
       }));
     if (!isRecoveryCurrent()) return staleRecovery();
     const allResolvedCuratorPeerIds = [...new Set(curatorResolution.peerIds
       .filter((peerId) => peerId && peerId !== this.peerId))]
       .sort((left, right) => left.localeCompare(right));
-    const curatorRosterTraversal = 'rosterTraversal' in curatorResolution
-      ? curatorResolution.rosterTraversal
-      : undefined;
-    const curatorRosterOverflow = (curatorRosterTraversal !== undefined
-        && curatorRosterTraversal.status !== 'complete')
+    const curatorRosterTraversal = curatorResolution.rosterTraversal;
+    const curatorRosterOverflow = (curatorRosterTraversal
+        ? curatorRosterTraversal.status !== 'complete' : curatorResolution.overflowed === true)
       || allResolvedCuratorPeerIds.length > DKGAgentBase.VM_RECONCILE_EXACT_ROSTER_MAX;
     if (curatorRosterOverflow) {
       this.log.warn(
         ctx,
-        `VM exact fetch curator roster for "${localCgId}" exceeds bounded proof capacity `
+        `VM exact fetch curator roster for "${localCgId}" cannot establish a complete bounded roster `
           + `(ordered transport page=${allResolvedCuratorPeerIds.length}, `
           + `proofCap=${DKGAgentBase.VM_RECONCILE_EXACT_ROSTER_MAX}); `
           + 'walking the registry without negative-proof suppression',
@@ -5854,8 +5855,11 @@ export class SwmHostModeMethods extends DKGAgentBase {
         (overflowWindowStart + offset) % overflowTransportUniverse.length
       ]!,
     );
-    const resolvedCuratorPeerIds = curatorRosterOverflow && allResolvedCuratorPeerIds.length === 0
-      ? overflowTransportPeerIds
+    const resolvedCuratorPeerIds = curatorRosterOverflow
+      ? (curatorRosterTraversal?.status === 'continue' || curatorRosterTraversal?.status === 'cycle'
+          || curatorResolution.nextPageAfterPeerId)
+        ? allResolvedCuratorPeerIds
+        : overflowTransportPeerIds
       : allResolvedCuratorPeerIds;
     let legacyPreferredPeerId: string | undefined;
     if (resolutionSucceeded && !curatorResolution.curatorIsLocal
@@ -5890,6 +5894,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // The recovery owner, not the page reader, decides when to restart. A
       // cleared cursor makes the next scheduled recovery begin a fresh cycle.
       this.vmReconcileCuratorPageCursorByCg.delete(localCgId);
+    } else if (curatorRosterTraversal === undefined && curatorResolution.nextPageAfterPeerId) {
+      // Preserve custom SDK implementations that still return the prior fields.
+      this.vmReconcileCuratorPageCursorByCg.delete(localCgId);
+      this.vmReconcileCuratorPageCursorByCg.set(localCgId, curatorResolution.nextPageAfterPeerId);
     }
     if (!curatorResolution.curatorIsLocal && curatorPeerIds.length > 0) {
       this.vmReconcileCuratorPeersByCg.delete(localCgId);

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -507,6 +507,7 @@ import {
 } from './dkg-agent-swm-state.js';
 import { DKGAgentBase } from './dkg-agent-base.js';
 import type { DKGAgent } from './dkg-agent.js';
+import type { CuratorPeerIdsResolution } from './dkg-agent-lifecycle.js';
 import type {
   ContextGraphBindingTarget,
 } from './context-graph-binding-state.js';
@@ -5803,22 +5804,25 @@ export class SwmHostModeMethods extends DKGAgentBase {
       signal,
       isCurrent: isRecoveryCurrent,
     })
-      .catch(() => ({
-        peerIds: [] as string[],
+      .catch((): CuratorPeerIdsResolution => ({
+        peerIds: [] as [],
         curatorIsLocal: false,
         legacyTripleResolved: false,
         lookupFailed: true,
-        rosterTraversal: undefined,
-        overflowed: false,
-        nextPageAfterPeerId: undefined,
       }));
     if (!isRecoveryCurrent()) return staleRecovery();
     const allResolvedCuratorPeerIds = [...new Set(curatorResolution.peerIds
       .filter((peerId) => peerId && peerId !== this.peerId))]
       .sort((left, right) => left.localeCompare(right));
-    const curatorRosterTraversal = curatorResolution.rosterTraversal;
-    const curatorRosterOverflow = (curatorRosterTraversal
-        ? curatorRosterTraversal.status !== 'complete' : curatorResolution.overflowed === true)
+    // Runtime adapter for older custom hosts. The canonical return type below
+    // does not admit pagination without a rosterStatus discriminant.
+    const legacyPagination = curatorResolution as unknown as {
+      overflowed?: boolean;
+      nextPageAfterPeerId?: string;
+    };
+    const curatorRosterStatus = curatorResolution.rosterStatus;
+    const curatorRosterOverflow = (curatorRosterStatus
+        ? curatorRosterStatus !== 'complete' : legacyPagination.overflowed === true)
       || allResolvedCuratorPeerIds.length > DKGAgentBase.VM_RECONCILE_EXACT_ROSTER_MAX;
     if (curatorRosterOverflow) {
       this.log.warn(
@@ -5856,8 +5860,8 @@ export class SwmHostModeMethods extends DKGAgentBase {
       ]!,
     );
     const resolvedCuratorPeerIds = curatorRosterOverflow
-      ? (curatorRosterTraversal?.status === 'continue' || curatorRosterTraversal?.status === 'cycle'
-          || curatorResolution.nextPageAfterPeerId)
+      ? (curatorRosterStatus === 'continue' || curatorRosterStatus === 'cycle'
+          || legacyPagination.nextPageAfterPeerId)
         ? allResolvedCuratorPeerIds
         : overflowTransportPeerIds
       : allResolvedCuratorPeerIds;
@@ -5884,20 +5888,20 @@ export class SwmHostModeMethods extends DKGAgentBase {
     if (resolutionSucceeded) {
       this.vmReconcileCuratorPeersByCg.delete(localCgId);
       this.vmReconcileCuratorPageCursorByCg.delete(localCgId);
-    } else if (curatorRosterTraversal?.status === 'continue') {
+    } else if (curatorRosterStatus === 'continue') {
       this.vmReconcileCuratorPageCursorByCg.delete(localCgId);
       this.vmReconcileCuratorPageCursorByCg.set(
         localCgId,
-        curatorRosterTraversal.nextAfterPeerId,
+        curatorResolution.nextPageAfterPeerId,
       );
-    } else if (curatorRosterTraversal?.status === 'cycle') {
+    } else if (curatorRosterStatus === 'cycle') {
       // The recovery owner, not the page reader, decides when to restart. A
       // cleared cursor makes the next scheduled recovery begin a fresh cycle.
       this.vmReconcileCuratorPageCursorByCg.delete(localCgId);
-    } else if (curatorRosterTraversal === undefined && curatorResolution.nextPageAfterPeerId) {
+    } else if (curatorRosterStatus === undefined && legacyPagination.nextPageAfterPeerId) {
       // Preserve custom SDK implementations that still return the prior fields.
       this.vmReconcileCuratorPageCursorByCg.delete(localCgId);
-      this.vmReconcileCuratorPageCursorByCg.set(localCgId, curatorResolution.nextPageAfterPeerId);
+      this.vmReconcileCuratorPageCursorByCg.set(localCgId, legacyPagination.nextPageAfterPeerId);
     }
     if (!curatorResolution.curatorIsLocal && curatorPeerIds.length > 0) {
       this.vmReconcileCuratorPeersByCg.delete(localCgId);

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -30,6 +30,7 @@ export {
   type AgentPeerPage,
   type AgentPeerPageRequest,
 } from './agent-peer-discovery.js';
+export type { CuratorPeerIdsResolution } from './dkg-agent-lifecycle.js';
 export {
   DiscoveryClient,
   discoveredAgentIdentityKey,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -25,6 +25,12 @@ export {
 } from './profile.js';
 export { ProfileManager } from './profile-manager.js';
 export {
+  MAX_AGENT_PEER_PAGE_SIZE,
+  type AgentPeerDiscovery,
+  type AgentPeerPage,
+  type AgentPeerPageRequest,
+} from './agent-peer-discovery.js';
+export {
   DiscoveryClient,
   discoveredAgentIdentityKey,
   discoveredAgentRowKey,

--- a/packages/agent/test/_helpers/vm-recovery-host.ts
+++ b/packages/agent/test/_helpers/vm-recovery-host.ts
@@ -7,7 +7,7 @@ import type {
   PendingOrdinalRecoveryResult,
 } from '../../src/chain-reconciler.js';
 import type { VmReconcileRotationRecord } from '../../src/dkg-agent-types.js';
-import type { BoundedCuratorRosterTraversal } from '../../src/bounded-curator-roster-traversal.js';
+import type { CuratorPeerIdsResolution } from '../../src/dkg-agent-lifecycle.js';
 import { DKGAgent } from '../../src/index.js';
 import type { ExactAssetSelection } from '../../src/sync/exact-assets.js';
 import type {
@@ -63,13 +63,7 @@ export interface VmRecoveryHostInternals {
       signal?: AbortSignal;
       isCurrent?: () => boolean;
     },
-  ): Promise<{
-    peerIds: string[];
-    curatorIsLocal: boolean;
-    legacyTripleResolved: boolean;
-    lookupFailed?: boolean;
-    rosterTraversal?: BoundedCuratorRosterTraversal;
-  }>;
+  ): Promise<CuratorPeerIdsResolution>;
   ensurePeerConnected(peerId: string, options?: { signal?: AbortSignal }): Promise<void>;
   selectCatchupPeers(peers: TestPeerId[]): TestPeerId[];
   waitForSyncProtocol(peer: TestPeerId, signal?: AbortSignal): Promise<boolean>;

--- a/packages/agent/test/_helpers/vm-recovery-host.ts
+++ b/packages/agent/test/_helpers/vm-recovery-host.ts
@@ -7,6 +7,7 @@ import type {
   PendingOrdinalRecoveryResult,
 } from '../../src/chain-reconciler.js';
 import type { VmReconcileRotationRecord } from '../../src/dkg-agent-types.js';
+import type { BoundedCuratorRosterTraversal } from '../../src/bounded-curator-roster-traversal.js';
 import { DKGAgent } from '../../src/index.js';
 import type { ExactAssetSelection } from '../../src/sync/exact-assets.js';
 import type {
@@ -67,8 +68,7 @@ export interface VmRecoveryHostInternals {
     curatorIsLocal: boolean;
     legacyTripleResolved: boolean;
     lookupFailed?: boolean;
-    overflowed?: boolean;
-    nextPageAfterPeerId?: string;
+    rosterTraversal?: BoundedCuratorRosterTraversal;
   }>;
   ensurePeerConnected(peerId: string, options?: { signal?: AbortSignal }): Promise<void>;
   selectCatchupPeers(peers: TestPeerId[]): TestPeerId[];

--- a/packages/agent/test/agent-peer-discovery.typecheck.ts
+++ b/packages/agent/test/agent-peer-discovery.typecheck.ts
@@ -1,0 +1,19 @@
+import { DiscoveryClient, type AgentPeerDiscovery, type AgentPeerPageRequest } from '../src/index.js';
+
+declare const discovery: DiscoveryClient;
+const required: AgentPeerDiscovery = discovery;
+const provider: AgentPeerDiscovery = {
+  findAgentPeerIdsByAddress: async (_wallet, request) => ({
+    peerIds: request.afterPeerId ? [] : ['peer-001'], nextAfterPeerId: null,
+  }),
+};
+void required; void provider;
+// @ts-expect-error Bounded discovery always requires a page size.
+void discovery.findAgentPeerIdsByAddress('wallet');
+// @ts-expect-error An optional limit does not satisfy the required page contract.
+const unbounded: AgentPeerPageRequest = { afterPeerId: 'peer-001' };
+// @ts-expect-error A rich-profile lookup alone cannot satisfy bounded peer discovery.
+const legacy: AgentPeerDiscovery = { findAgents: async () => [] };
+// @ts-expect-error Pages carry an explicit end/continuation signal, not only peer IDs.
+const ambiguous: AgentPeerDiscovery = { findAgentPeerIdsByAddress: async () => ['peer-001'] };
+void unbounded; void legacy; void ambiguous;

--- a/packages/agent/test/agent-peer-discovery.typecheck.ts
+++ b/packages/agent/test/agent-peer-discovery.typecheck.ts
@@ -3,17 +3,23 @@ import { DiscoveryClient, type AgentPeerDiscovery, type AgentPeerPageRequest } f
 declare const discovery: DiscoveryClient;
 const required: AgentPeerDiscovery = discovery;
 const provider: AgentPeerDiscovery = {
-  findAgentPeerIdsByAddress: async (_wallet, request) => ({
+  findAgentPeerPageByAddress: async (_wallet, request) => ({
     peerIds: request.afterPeerId ? [] : ['peer-001'], nextAfterPeerId: null,
   }),
 };
 void required; void provider;
 // @ts-expect-error Bounded discovery always requires a page size.
-void discovery.findAgentPeerIdsByAddress('wallet');
+void discovery.findAgentPeerPageByAddress('wallet');
 // @ts-expect-error An optional limit does not satisfy the required page contract.
 const unbounded: AgentPeerPageRequest = { afterPeerId: 'peer-001' };
 // @ts-expect-error A rich-profile lookup alone cannot satisfy bounded peer discovery.
 const legacy: AgentPeerDiscovery = { findAgents: async () => [] };
 // @ts-expect-error Pages carry an explicit end/continuation signal, not only peer IDs.
-const ambiguous: AgentPeerDiscovery = { findAgentPeerIdsByAddress: async () => ['peer-001'] };
+const ambiguous: AgentPeerDiscovery = { findAgentPeerPageByAddress: async () => ['peer-001'] };
 void unbounded; void legacy; void ambiguous;
+
+const oldDefault: Promise<string[]> = discovery.findAgentPeerIdsByAddress('wallet');
+const oldBounded: Promise<string[]> = discovery.findAgentPeerIdsByAddress('wallet', { limit: 2, afterPeerId: 'peer-001' });
+// @ts-expect-error An older array provider cannot substitute for bounded page capability.
+const oldOnly: AgentPeerDiscovery = { findAgentPeerIdsByAddress: async () => [] };
+void oldDefault; void oldBounded; void oldOnly;

--- a/packages/agent/test/bounded-curator-discovery.test.ts
+++ b/packages/agent/test/bounded-curator-discovery.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent, type AgentPeerDiscovery, type AgentPeerPage } from '../src/index.js';
 import { readAgentPeerPage } from '../src/agent-peer-discovery.js';
+import { resolveCuratorSyncPeer } from '../src/dkg-agent-cg-resolve.js';
 
 const WALLET = '0x00000000000000000000000000000000000000ab';
 const CG = `${WALLET}/bounded-curator`;
@@ -62,21 +63,37 @@ describe('bounded curator discovery contract', () => {
       .mockResolvedValueOnce({ peerIds: ['peer-001', 'peer-003'], nextAfterPeerId: 'peer-003' })
       .mockResolvedValueOnce({ peerIds: ['peer-004'], nextAfterPeerId: null });
     const first = await agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2 });
-    expect(first).toMatchObject({ overflowed: true, nextPageAfterPeerId: 'peer-003' });
+    expect(first).toMatchObject({
+      rosterTraversal: { status: 'continue', nextAfterPeerId: 'peer-003' },
+    });
     // Earlier peers may have been deleted and new peers inserted before the
     // cursor. This tail query says nothing about those unobserved entries.
-    const tail = await agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2, afterPeerId: first.nextPageAfterPeerId });
-    expect(tail).toMatchObject({ peerIds: ['peer-004'], overflowed: true, nextPageAfterPeerId: 'peer-004' });
+    const nextAfterPeerId = first.rosterTraversal?.status === 'continue'
+      ? first.rosterTraversal.nextAfterPeerId
+      : undefined;
+    const tail = await agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2, afterPeerId: nextAfterPeerId });
+    expect(tail).toMatchObject({
+      peerIds: ['peer-004'],
+      rosterTraversal: { status: 'cycle' },
+    });
     expect(pages).toHaveBeenCalledTimes(2);
   });
 
-  it('wraps an exhausted cursor through a fresh bounded first-page query', async () => {
+  it('returns cursor restart to the recovery owner after an exhausted tail', async () => {
     const agent = await createAgent();
     const pages = vi.spyOn(agent.discovery, 'findAgentPeerPageByAddress')
       .mockResolvedValueOnce(EMPTY)
       .mockResolvedValueOnce({ peerIds: ['peer-002'], nextAfterPeerId: null });
-    const result = await agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2, pagePeerIds: 1, afterPeerId: 'peer-099' });
-    expect(result).toEqual({ peerIds: ['peer-002'], curatorIsLocal: false, legacyTripleResolved: false });
+    const exhausted = await agent.resolveCuratorPeerIdsForCg(CG, {
+      maxPeerIds: 2, pagePeerIds: 1, afterPeerId: 'peer-099',
+    });
+    expect(exhausted).toMatchObject({
+      peerIds: [], rosterTraversal: { status: 'cycle' },
+    });
+    const restarted = await agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2, pagePeerIds: 1 });
+    expect(restarted).toMatchObject({
+      peerIds: ['peer-002'], rosterTraversal: { status: 'complete' },
+    });
     expect(pages.mock.calls.map(([, request]) => request)).toEqual([
       { limit: 1, afterPeerId: 'peer-099', signal: undefined },
       { limit: 2, signal: undefined },
@@ -117,10 +134,32 @@ describe('bounded curator discovery contract', () => {
     { peerIds: ['peer-001', 'peer-002'], nextAfterPeerId: 'peer-999' },
     { peerIds: ['peer-001', 'peer-002'] },
   ])('rejects a provider page outside the bounded monotonic contract: %j', async invalid => {
-    const provider: AgentPeerDiscovery = {
-      findAgentPeerPageByAddress: async () => invalid as AgentPeerPage,
+    const provider = {
+      findAgentPeerPageByAddress: async () => invalid,
     };
     await expect(readAgentPeerPage(provider, WALLET, { limit: 2 })).rejects.toThrow();
+  });
+
+  it('resolves a bounded wallet curator fallback without invoking rich discovery', async () => {
+    const agent = await createAgent();
+    const record = await agent.getCgMeta(CG);
+    vi.spyOn(agent, 'getCgMeta').mockResolvedValue({
+      ...record,
+      curator: `did:dkg:agent:${WALLET}`,
+      curators: [`did:dkg:agent:${WALLET}`],
+      creator: undefined,
+      creators: [],
+    });
+    const pages = vi.spyOn(agent.discovery, 'findAgentPeerPageByAddress')
+      .mockResolvedValue({ peerIds: ['peer-curator'], nextAfterPeerId: null });
+    const rich = vi.spyOn(agent.discovery, 'findAgents')
+      .mockRejectedValue(new Error('unbounded registry query'));
+
+    await expect(resolveCuratorSyncPeer(agent, new Map(), CG, {
+      registryLookup: 'bounded-first-page',
+    })).resolves.toMatchObject({ peerId: 'peer-curator', provenance: 'registry' });
+    expect(pages).toHaveBeenCalledWith(WALLET, { limit: 1, signal: undefined });
+    expect(rich).not.toHaveBeenCalled();
   });
 
   it('rejects a page that repeats the exclusive cursor', async () => {

--- a/packages/agent/test/bounded-curator-discovery.test.ts
+++ b/packages/agent/test/bounded-curator-discovery.test.ts
@@ -29,12 +29,14 @@ describe('bounded curator discovery contract', () => {
     const findAgents = vi.fn(async () => [{ peerId: 'peer-001', agentAddress: WALLET }]);
     // Deliberately model an untyped older integration. The public type fixture
     // separately proves this provider cannot satisfy AgentPeerDiscovery.
-    Object.defineProperty(agent, 'discovery', { value: { findAgents } });
+    const findAgentPeerIdsByAddress = vi.fn(async () => ['peer-001']);
+    Object.defineProperty(agent, 'discovery', { value: { findAgents, findAgentPeerIdsByAddress } });
     const refresh = vi.spyOn(agent, 'refreshMetaFromCurator').mockResolvedValue(false);
     await expect(agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2 })).resolves.toMatchObject({
       peerIds: [], lookupFailed: true,
     });
     expect(findAgents).not.toHaveBeenCalled();
+    expect(findAgentPeerIdsByAddress).not.toHaveBeenCalled();
     expect(refresh).not.toHaveBeenCalled();
   });
 
@@ -44,7 +46,7 @@ describe('bounded curator discovery contract', () => {
     vi.spyOn(agent, 'getCgMeta').mockResolvedValue({
       ...record, curator: `did:dkg:agent:${WALLET}`, curators: [`did:dkg:agent:${WALLET}`],
     });
-    const pages = vi.spyOn(agent.discovery, 'findAgentPeerIdsByAddress').mockResolvedValue(EMPTY);
+    const pages = vi.spyOn(agent.discovery, 'findAgentPeerPageByAddress').mockResolvedValue(EMPTY);
     const rich = vi.spyOn(agent.discovery, 'findAgents').mockRejectedValue(new Error('unbounded registry query'));
     // Run the real refresh/resolution path. No resolved peer means no transport.
     await expect(agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2 })).resolves.toMatchObject({
@@ -56,7 +58,7 @@ describe('bounded curator discovery contract', () => {
 
   it('does not certify a short tail page as a complete roster after registry churn', async () => {
     const agent = await createAgent();
-    const pages = vi.spyOn(agent.discovery, 'findAgentPeerIdsByAddress')
+    const pages = vi.spyOn(agent.discovery, 'findAgentPeerPageByAddress')
       .mockResolvedValueOnce({ peerIds: ['peer-001', 'peer-003'], nextAfterPeerId: 'peer-003' })
       .mockResolvedValueOnce({ peerIds: ['peer-004'], nextAfterPeerId: null });
     const first = await agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2 });
@@ -70,7 +72,7 @@ describe('bounded curator discovery contract', () => {
 
   it('wraps an exhausted cursor through a fresh bounded first-page query', async () => {
     const agent = await createAgent();
-    const pages = vi.spyOn(agent.discovery, 'findAgentPeerIdsByAddress')
+    const pages = vi.spyOn(agent.discovery, 'findAgentPeerPageByAddress')
       .mockResolvedValueOnce(EMPTY)
       .mockResolvedValueOnce({ peerIds: ['peer-002'], nextAfterPeerId: null });
     const result = await agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2, pagePeerIds: 1, afterPeerId: 'peer-099' });
@@ -86,7 +88,7 @@ describe('bounded curator discovery contract', () => {
     vi.spyOn(agent, 'peerId', 'get').mockReturnValue('peer-self');
     vi.spyOn(agent, 'isCuratorOf').mockResolvedValue(false);
     vi.spyOn(agent, 'resolveCuratorPeerId').mockResolvedValue('peer-legacy');
-    const page = vi.spyOn(agent.discovery, 'findAgentPeerIdsByAddress');
+    const page = vi.spyOn(agent.discovery, 'findAgentPeerPageByAddress');
     await expect(agent.resolveCuratorPeerIdsForCg('legacy-label', { maxPeerIds: 2 })).resolves.toEqual({
       peerIds: ['peer-legacy'], curatorIsLocal: false, legacyTripleResolved: true,
     });
@@ -96,7 +98,7 @@ describe('bounded curator discovery contract', () => {
   it('propagates cancellation through a provider that settles after abort', async () => {
     const agent = await createAgent();
     let settle!: (page: AgentPeerPage) => void;
-    vi.spyOn(agent.discovery, 'findAgentPeerIdsByAddress').mockImplementation(() => new Promise(resolve => { settle = resolve; }));
+    vi.spyOn(agent.discovery, 'findAgentPeerPageByAddress').mockImplementation(() => new Promise(resolve => { settle = resolve; }));
     const refresh = vi.spyOn(agent, 'refreshMetaFromCurator');
     const controller = new AbortController();
     const pending = agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2, signal: controller.signal });
@@ -116,22 +118,22 @@ describe('bounded curator discovery contract', () => {
     { peerIds: ['peer-001', 'peer-002'] },
   ])('rejects a provider page outside the bounded monotonic contract: %j', async invalid => {
     const provider: AgentPeerDiscovery = {
-      findAgentPeerIdsByAddress: async () => invalid as AgentPeerPage,
+      findAgentPeerPageByAddress: async () => invalid as AgentPeerPage,
     };
     await expect(readAgentPeerPage(provider, WALLET, { limit: 2 })).rejects.toThrow();
   });
 
   it('rejects a page that repeats the exclusive cursor', async () => {
     const provider: AgentPeerDiscovery = {
-      findAgentPeerIdsByAddress: async () => ({ peerIds: ['peer-001'], nextAfterPeerId: null }),
+      findAgentPeerPageByAddress: async () => ({ peerIds: ['peer-001'], nextAfterPeerId: null }),
     };
     await expect(readAgentPeerPage(provider, WALLET, { limit: 2, afterPeerId: 'peer-001' })).rejects.toThrow('non-monotonic');
   });
 
   it('rejects an empty cursor instead of restarting a supposedly continued walk', async () => {
-    const findAgentPeerIdsByAddress = vi.fn(async () => EMPTY);
-    await expect(readAgentPeerPage({ findAgentPeerIdsByAddress }, WALLET, { limit: 2, afterPeerId: '' }))
+    const findAgentPeerPageByAddress = vi.fn(async () => EMPTY);
+    await expect(readAgentPeerPage({ findAgentPeerPageByAddress }, WALLET, { limit: 2, afterPeerId: '' }))
       .rejects.toThrow('cursor');
-    expect(findAgentPeerIdsByAddress).not.toHaveBeenCalled();
+    expect(findAgentPeerPageByAddress).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent/test/bounded-curator-discovery.test.ts
+++ b/packages/agent/test/bounded-curator-discovery.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent, type AgentPeerDiscovery, type AgentPeerPage } from '../src/index.js';
-import { readAgentPeerPage } from '../src/agent-peer-discovery.js';
-import { resolveCuratorSyncPeer } from '../src/dkg-agent-cg-resolve.js';
+import { readAgentPeerPage, validateAgentPeerPage } from '../src/agent-peer-discovery.js';
+import { traverseBoundedCuratorRoster } from '../src/bounded-curator-roster-traversal.js';
+import { authoritativeSyncPeerId, resolveCuratorSyncPeer } from '../src/dkg-agent-cg-resolve.js';
 
 const WALLET = '0x00000000000000000000000000000000000000ab';
 const CG = `${WALLET}/bounded-curator`;
@@ -64,35 +65,28 @@ describe('bounded curator discovery contract', () => {
       .mockResolvedValueOnce({ peerIds: ['peer-004'], nextAfterPeerId: null });
     const first = await agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2 });
     expect(first).toMatchObject({
-      rosterTraversal: { status: 'continue', nextAfterPeerId: 'peer-003' },
+      overflowed: true, nextPageAfterPeerId: 'peer-003',
+      rosterTraversal: { status: 'continue', peerIds: ['peer-001', 'peer-003'], nextAfterPeerId: 'peer-003' },
     });
     // Earlier peers may have been deleted and new peers inserted before the
     // cursor. This tail query says nothing about those unobserved entries.
-    const nextAfterPeerId = first.rosterTraversal?.status === 'continue'
-      ? first.rosterTraversal.nextAfterPeerId
-      : undefined;
-    const tail = await agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2, afterPeerId: nextAfterPeerId });
+    const tail = await agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2, afterPeerId: first.nextPageAfterPeerId });
     expect(tail).toMatchObject({
-      peerIds: ['peer-004'],
-      rosterTraversal: { status: 'cycle' },
+      peerIds: ['peer-004'], overflowed: true, nextPageAfterPeerId: 'peer-004',
+      rosterTraversal: { status: 'cycle', peerIds: ['peer-004'] },
     });
     expect(pages).toHaveBeenCalledTimes(2);
   });
 
-  it('returns cursor restart to the recovery owner after an exhausted tail', async () => {
+  it('wraps an exhausted cursor through a fresh bounded first-page query', async () => {
     const agent = await createAgent();
     const pages = vi.spyOn(agent.discovery, 'findAgentPeerPageByAddress')
       .mockResolvedValueOnce(EMPTY)
       .mockResolvedValueOnce({ peerIds: ['peer-002'], nextAfterPeerId: null });
-    const exhausted = await agent.resolveCuratorPeerIdsForCg(CG, {
-      maxPeerIds: 2, pagePeerIds: 1, afterPeerId: 'peer-099',
-    });
-    expect(exhausted).toMatchObject({
-      peerIds: [], rosterTraversal: { status: 'cycle' },
-    });
-    const restarted = await agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2, pagePeerIds: 1 });
-    expect(restarted).toMatchObject({
-      peerIds: ['peer-002'], rosterTraversal: { status: 'complete' },
+    const result = await agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2, pagePeerIds: 1, afterPeerId: 'peer-099' });
+    expect(result).toEqual({
+      peerIds: ['peer-002'], curatorIsLocal: false, legacyTripleResolved: false,
+      rosterTraversal: { status: 'complete', peerIds: ['peer-002'] },
     });
     expect(pages.mock.calls.map(([, request]) => request)).toEqual([
       { limit: 1, afterPeerId: 'peer-099', signal: undefined },
@@ -126,6 +120,14 @@ describe('bounded curator discovery contract', () => {
   });
 
   it.each([
+    null,
+    undefined,
+    'page',
+    [],
+    {},
+    { peerIds: 'peer-001', nextAfterPeerId: null },
+    { peerIds: [1], nextAfterPeerId: null },
+    { peerIds: ['peer-001'], nextAfterPeerId: 1 },
     { peerIds: ['peer-001', 'peer-002', 'peer-003'], nextAfterPeerId: null },
     { peerIds: ['peer-002', 'peer-001'], nextAfterPeerId: null },
     { peerIds: ['peer-001', 'peer-001'], nextAfterPeerId: null },
@@ -133,33 +135,65 @@ describe('bounded curator discovery contract', () => {
     { peerIds: ['peer-001'], nextAfterPeerId: 'peer-001' },
     { peerIds: ['peer-001', 'peer-002'], nextAfterPeerId: 'peer-999' },
     { peerIds: ['peer-001', 'peer-002'] },
-  ])('rejects a provider page outside the bounded monotonic contract: %j', async invalid => {
-    const provider = {
-      findAgentPeerPageByAddress: async () => invalid,
-    };
-    await expect(readAgentPeerPage(provider, WALLET, { limit: 2 })).rejects.toThrow();
+  ])('rejects a provider page outside the bounded monotonic contract: %j', invalid => {
+    expect(() => validateAgentPeerPage(invalid, { limit: 2 })).toThrow();
   });
 
-  it('resolves a bounded wallet curator fallback without invoking rich discovery', async () => {
+  it('copies validated peer IDs without consuming a provider-supplied iterator', () => {
+    const peerIds = ['peer-001', 'peer-002'];
+    const iterator = vi.fn(() => { throw new Error('unbounded provider iterator'); });
+    Object.defineProperty(peerIds, Symbol.iterator, { value: iterator });
+    const decoded = validateAgentPeerPage({ peerIds, nextAfterPeerId: null }, { limit: 2 });
+    peerIds[0] = 'changed-after-validation';
+    expect(decoded).toEqual({ peerIds: ['peer-001', 'peer-002'], nextAfterPeerId: null });
+    expect(iterator).not.toHaveBeenCalled();
+  });
+
+  it('returns the bounded wallet registry candidate without assigning authority or using a bootstrap hint', async () => {
     const agent = await createAgent();
     const record = await agent.getCgMeta(CG);
     vi.spyOn(agent, 'getCgMeta').mockResolvedValue({
-      ...record,
-      curator: `did:dkg:agent:${WALLET}`,
-      curators: [`did:dkg:agent:${WALLET}`],
-      creator: undefined,
-      creators: [],
+      ...record, curator: `did:dkg:agent:${WALLET}`, curators: [`did:dkg:agent:${WALLET}`],
+      creator: undefined, creators: [],
     });
-    const pages = vi.spyOn(agent.discovery, 'findAgentPeerPageByAddress')
-      .mockResolvedValue({ peerIds: ['peer-curator'], nextAfterPeerId: null });
-    const rich = vi.spyOn(agent.discovery, 'findAgents')
-      .mockRejectedValue(new Error('unbounded registry query'));
-
-    await expect(resolveCuratorSyncPeer(agent, new Map(), CG, {
-      registryLookup: 'bounded-first-page',
-    })).resolves.toMatchObject({ peerId: 'peer-curator', provenance: 'registry' });
-    expect(pages).toHaveBeenCalledWith(WALLET, { limit: 1, signal: undefined });
+    const pages = vi.spyOn(agent.discovery, 'findAgentPeerPageByAddress').mockResolvedValue({
+      peerIds: ['peer-registry'], nextAfterPeerId: 'peer-registry',
+    });
+    const rich = vi.spyOn(agent.discovery, 'findAgents').mockRejectedValue(new Error('unbounded registry query'));
+    const hints = new Map([[CG, 'peer-bootstrap']]);
+    const controller = new AbortController();
+    const result = await resolveCuratorSyncPeer(agent, hints, CG, { signal: controller.signal, registryLookup: 'bounded-first-page' });
+    expect(result).toEqual({ peerId: 'peer-registry', provenance: 'registry' });
+    expect(authoritativeSyncPeerId(result)).toBeUndefined();
+    expect(hints.has(CG)).toBe(false);
+    expect(pages).toHaveBeenCalledExactlyOnceWith(WALLET, { limit: 1, signal: controller.signal });
     expect(rich).not.toHaveBeenCalled();
+  });
+
+  it('preserves every transport candidate when the proof probe is larger than one attempt', async () => {
+    const pages = vi.fn<AgentPeerDiscovery['findAgentPeerPageByAddress']>()
+      .mockResolvedValueOnce({ peerIds: ['peer-001', 'peer-002'], nextAfterPeerId: 'peer-002' })
+      .mockResolvedValueOnce({ peerIds: ['peer-002'], nextAfterPeerId: 'peer-002' })
+      .mockResolvedValueOnce({ peerIds: ['peer-003'], nextAfterPeerId: null });
+    const discovery = { findAgentPeerPageByAddress: pages };
+    const first = await traverseBoundedCuratorRoster(discovery, WALLET, { maxPeerIds: 2, pagePeerIds: 1 });
+    expect(first).toEqual({ status: 'continue', peerIds: ['peer-001'], nextAfterPeerId: 'peer-001' });
+    const second = await traverseBoundedCuratorRoster(discovery, WALLET, { maxPeerIds: 2, pagePeerIds: 1, afterPeerId: 'peer-001' });
+    expect(second).toEqual({ status: 'continue', peerIds: ['peer-002'], nextAfterPeerId: 'peer-002' });
+    const tail = await traverseBoundedCuratorRoster(discovery, WALLET, { maxPeerIds: 2, pagePeerIds: 1, afterPeerId: 'peer-002' });
+    expect(tail).toEqual({ status: 'cycle', peerIds: ['peer-003'] });
+    expect(pages.mock.calls.map(([, request]) => [request.limit, request.afterPeerId])).toEqual([
+      [2, undefined], [1, 'peer-001'], [1, 'peer-002'],
+    ]);
+  });
+
+  it('does not restart an exhausted cursor after the recovery owner becomes stale', async () => {
+    let current = true;
+    const pages = vi.fn(async () => { current = false; return EMPTY; });
+    await expect(traverseBoundedCuratorRoster({ findAgentPeerPageByAddress: pages }, WALLET, {
+      maxPeerIds: 2, afterPeerId: 'peer-099', isCurrent: () => current,
+    })).rejects.toMatchObject({ name: 'AbortError' });
+    expect(pages).toHaveBeenCalledTimes(1);
   });
 
   it('rejects a page that repeats the exclusive cursor', async () => {

--- a/packages/agent/test/bounded-curator-discovery.test.ts
+++ b/packages/agent/test/bounded-curator-discovery.test.ts
@@ -3,7 +3,10 @@ import { MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent, type AgentPeerDiscovery, type AgentPeerPage } from '../src/index.js';
 import { readAgentPeerPage, validateAgentPeerPage } from '../src/agent-peer-discovery.js';
 import { traverseBoundedCuratorRoster } from '../src/bounded-curator-roster-traversal.js';
-import { authoritativeSyncPeerId, resolveCuratorSyncPeer } from '../src/dkg-agent-cg-resolve.js';
+import {
+  authoritativeSyncPeerId,
+  resolveBoundedCuratorSyncPeer,
+} from '../src/dkg-agent-cg-resolve.js';
 
 const WALLET = '0x00000000000000000000000000000000000000ab';
 const CG = `${WALLET}/bounded-curator`;
@@ -66,14 +69,13 @@ describe('bounded curator discovery contract', () => {
     const first = await agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2 });
     expect(first).toMatchObject({
       overflowed: true, nextPageAfterPeerId: 'peer-003',
-      rosterTraversal: { status: 'continue', peerIds: ['peer-001', 'peer-003'], nextAfterPeerId: 'peer-003' },
+      rosterStatus: 'continue', peerIds: ['peer-001', 'peer-003'],
     });
     // Earlier peers may have been deleted and new peers inserted before the
     // cursor. This tail query says nothing about those unobserved entries.
     const tail = await agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2, afterPeerId: first.nextPageAfterPeerId });
     expect(tail).toMatchObject({
-      peerIds: ['peer-004'], overflowed: true, nextPageAfterPeerId: 'peer-004',
-      rosterTraversal: { status: 'cycle', peerIds: ['peer-004'] },
+      peerIds: ['peer-004'], overflowed: true, rosterStatus: 'cycle',
     });
     expect(pages).toHaveBeenCalledTimes(2);
   });
@@ -86,7 +88,7 @@ describe('bounded curator discovery contract', () => {
     const result = await agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2, pagePeerIds: 1, afterPeerId: 'peer-099' });
     expect(result).toEqual({
       peerIds: ['peer-002'], curatorIsLocal: false, legacyTripleResolved: false,
-      rosterTraversal: { status: 'complete', peerIds: ['peer-002'] },
+      rosterStatus: 'complete',
     });
     expect(pages.mock.calls.map(([, request]) => request)).toEqual([
       { limit: 1, afterPeerId: 'peer-099', signal: undefined },
@@ -162,7 +164,9 @@ describe('bounded curator discovery contract', () => {
     const rich = vi.spyOn(agent.discovery, 'findAgents').mockRejectedValue(new Error('unbounded registry query'));
     const hints = new Map([[CG, 'peer-bootstrap']]);
     const controller = new AbortController();
-    const result = await resolveCuratorSyncPeer(agent, hints, CG, { signal: controller.signal, registryLookup: 'bounded-first-page' });
+    const result = await resolveBoundedCuratorSyncPeer(agent, hints, CG, {
+      signal: controller.signal,
+    });
     expect(result).toEqual({ peerId: 'peer-registry', provenance: 'registry' });
     expect(authoritativeSyncPeerId(result)).toBeUndefined();
     expect(hints.has(CG)).toBe(false);

--- a/packages/agent/test/bounded-curator-discovery.test.ts
+++ b/packages/agent/test/bounded-curator-discovery.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import { DKGAgent, type AgentPeerDiscovery, type AgentPeerPage } from '../src/index.js';
+import { readAgentPeerPage } from '../src/agent-peer-discovery.js';
+
+const WALLET = '0x00000000000000000000000000000000000000ab';
+const CG = `${WALLET}/bounded-curator`;
+const EMPTY: AgentPeerPage = { peerIds: [], nextAfterPeerId: null };
+
+describe('bounded curator discovery contract', () => {
+  const agents: DKGAgent[] = [];
+  afterEach(async () => {
+    for (const agent of agents.splice(0)) {
+      await agent.stop();
+      await agent.store.close();
+    }
+  });
+  async function createAgent() {
+    const agent = await DKGAgent.create({
+      name: 'Bounded curator discovery', listenHost: '127.0.0.1',
+      chainAdapter: new MockChainAdapter(), rfc64CatalogActivation: { enabled: false },
+    });
+    agents.push(agent);
+    return agent;
+  }
+
+  it('never falls back to rich profiles when an older provider lacks pagination', async () => {
+    const agent = await createAgent();
+    const findAgents = vi.fn(async () => [{ peerId: 'peer-001', agentAddress: WALLET }]);
+    // Deliberately model an untyped older integration. The public type fixture
+    // separately proves this provider cannot satisfy AgentPeerDiscovery.
+    Object.defineProperty(agent, 'discovery', { value: { findAgents } });
+    const refresh = vi.spyOn(agent, 'refreshMetaFromCurator').mockResolvedValue(false);
+    await expect(agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2 })).resolves.toMatchObject({
+      peerIds: [], lookupFailed: true,
+    });
+    expect(findAgents).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('keeps metadata refresh bounded after a valid empty first page', async () => {
+    const agent = await createAgent();
+    const record = await agent.getCgMeta(CG);
+    vi.spyOn(agent, 'getCgMeta').mockResolvedValue({
+      ...record, curator: `did:dkg:agent:${WALLET}`, curators: [`did:dkg:agent:${WALLET}`],
+    });
+    const pages = vi.spyOn(agent.discovery, 'findAgentPeerIdsByAddress').mockResolvedValue(EMPTY);
+    const rich = vi.spyOn(agent.discovery, 'findAgents').mockRejectedValue(new Error('unbounded registry query'));
+    // Run the real refresh/resolution path. No resolved peer means no transport.
+    await expect(agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2 })).resolves.toMatchObject({
+      peerIds: [], lookupFailed: true,
+    });
+    expect(pages.mock.calls.map(([, request]) => request.limit)).toEqual([2, 1, 2]);
+    expect(rich).not.toHaveBeenCalled();
+  });
+
+  it('does not certify a short tail page as a complete roster after registry churn', async () => {
+    const agent = await createAgent();
+    const pages = vi.spyOn(agent.discovery, 'findAgentPeerIdsByAddress')
+      .mockResolvedValueOnce({ peerIds: ['peer-001', 'peer-003'], nextAfterPeerId: 'peer-003' })
+      .mockResolvedValueOnce({ peerIds: ['peer-004'], nextAfterPeerId: null });
+    const first = await agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2 });
+    expect(first).toMatchObject({ overflowed: true, nextPageAfterPeerId: 'peer-003' });
+    // Earlier peers may have been deleted and new peers inserted before the
+    // cursor. This tail query says nothing about those unobserved entries.
+    const tail = await agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2, afterPeerId: first.nextPageAfterPeerId });
+    expect(tail).toMatchObject({ peerIds: ['peer-004'], overflowed: true, nextPageAfterPeerId: 'peer-004' });
+    expect(pages).toHaveBeenCalledTimes(2);
+  });
+
+  it('wraps an exhausted cursor through a fresh bounded first-page query', async () => {
+    const agent = await createAgent();
+    const pages = vi.spyOn(agent.discovery, 'findAgentPeerIdsByAddress')
+      .mockResolvedValueOnce(EMPTY)
+      .mockResolvedValueOnce({ peerIds: ['peer-002'], nextAfterPeerId: null });
+    const result = await agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2, pagePeerIds: 1, afterPeerId: 'peer-099' });
+    expect(result).toEqual({ peerIds: ['peer-002'], curatorIsLocal: false, legacyTripleResolved: false });
+    expect(pages.mock.calls.map(([, request]) => request)).toEqual([
+      { limit: 1, afterPeerId: 'peer-099', signal: undefined },
+      { limit: 2, signal: undefined },
+    ]);
+  });
+
+  it('keeps the legacy single-curator triple route independent of page discovery', async () => {
+    const agent = await createAgent();
+    vi.spyOn(agent, 'peerId', 'get').mockReturnValue('peer-self');
+    vi.spyOn(agent, 'isCuratorOf').mockResolvedValue(false);
+    vi.spyOn(agent, 'resolveCuratorPeerId').mockResolvedValue('peer-legacy');
+    const page = vi.spyOn(agent.discovery, 'findAgentPeerIdsByAddress');
+    await expect(agent.resolveCuratorPeerIdsForCg('legacy-label', { maxPeerIds: 2 })).resolves.toEqual({
+      peerIds: ['peer-legacy'], curatorIsLocal: false, legacyTripleResolved: true,
+    });
+    expect(page).not.toHaveBeenCalled();
+  });
+
+  it('propagates cancellation through a provider that settles after abort', async () => {
+    const agent = await createAgent();
+    let settle!: (page: AgentPeerPage) => void;
+    vi.spyOn(agent.discovery, 'findAgentPeerIdsByAddress').mockImplementation(() => new Promise(resolve => { settle = resolve; }));
+    const refresh = vi.spyOn(agent, 'refreshMetaFromCurator');
+    const controller = new AbortController();
+    const pending = agent.resolveCuratorPeerIdsForCg(CG, { maxPeerIds: 2, signal: controller.signal });
+    controller.abort();
+    settle(EMPTY);
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { peerIds: ['peer-001', 'peer-002', 'peer-003'], nextAfterPeerId: null },
+    { peerIds: ['peer-002', 'peer-001'], nextAfterPeerId: null },
+    { peerIds: ['peer-001', 'peer-001'], nextAfterPeerId: null },
+    { peerIds: [''], nextAfterPeerId: null },
+    { peerIds: ['peer-001'], nextAfterPeerId: 'peer-001' },
+    { peerIds: ['peer-001', 'peer-002'], nextAfterPeerId: 'peer-999' },
+    { peerIds: ['peer-001', 'peer-002'] },
+  ])('rejects a provider page outside the bounded monotonic contract: %j', async invalid => {
+    const provider: AgentPeerDiscovery = {
+      findAgentPeerIdsByAddress: async () => invalid as AgentPeerPage,
+    };
+    await expect(readAgentPeerPage(provider, WALLET, { limit: 2 })).rejects.toThrow();
+  });
+
+  it('rejects a page that repeats the exclusive cursor', async () => {
+    const provider: AgentPeerDiscovery = {
+      findAgentPeerIdsByAddress: async () => ({ peerIds: ['peer-001'], nextAfterPeerId: null }),
+    };
+    await expect(readAgentPeerPage(provider, WALLET, { limit: 2, afterPeerId: 'peer-001' })).rejects.toThrow('non-monotonic');
+  });
+
+  it('rejects an empty cursor instead of restarting a supposedly continued walk', async () => {
+    const findAgentPeerIdsByAddress = vi.fn(async () => EMPTY);
+    await expect(readAgentPeerPage({ findAgentPeerIdsByAddress }, WALLET, { limit: 2, afterPeerId: '' }))
+      .rejects.toThrow('cursor');
+    expect(findAgentPeerIdsByAddress).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -2733,7 +2733,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
     expect((internals as any).vmReconcileCuratorPeersByCg.get(localCgId)).toEqual(curators);
   });
 
-  it('rotates a bounded oversized-roster transport window without treating it as absence proof', async () => {
+  it.each(['legacy', 'traversal'] as const)('rotates a bounded oversized-roster transport window using %s state without treating it as absence proof', async (mode) => {
     const rosterDescriptor = Object.getOwnPropertyDescriptor(
       DKGAgentBase,
       'VM_RECONCILE_EXACT_ROSTER_MAX',
@@ -2756,11 +2756,13 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
         },
       };
       let resolutions = 0;
+      const requestedCursors: Array<string | undefined> = [];
       (internals as any).resolveCuratorPeerIdsForCg = async (
         _cgId: string,
         options: { afterPeerId?: string },
       ) => {
         resolutions += 1;
+        requestedCursors.push(options.afterPeerId);
         const previousIndex = options.afterPeerId
           ? overflowPeers.indexOf(options.afterPeerId)
           : -1;
@@ -2769,11 +2771,13 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
           peerIds: [peerId],
           curatorIsLocal: false,
           legacyTripleResolved: false,
-          rosterTraversal: {
-            status: 'continue',
-            peerIds: [peerId],
-            nextAfterPeerId: peerId,
-          },
+          overflowed: true,
+          nextPageAfterPeerId: peerId,
+          ...(mode === 'traversal' ? {
+            rosterTraversal: peerId === overflowPeers[4]
+              ? { status: 'cycle', peerIds: [peerId] }
+              : { status: 'continue', peerIds: [peerId], nextAfterPeerId: peerId },
+          } : {}),
         };
       };
       (internals as any).ensurePeerConnected = async (peerId: string) => {
@@ -2784,12 +2788,15 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       (internals as any).ensurePeerAdmittedForRecovery = async () => true;
       const fetches: string[] = [];
       const target = vmRecoveryTarget(localCgId, 0, 'roster-overflow');
-      const holderPeerId = overflowPeers[4]!;
+      // The first peer gains the asset during the walk. A complete cycle must
+      // return to it; an unconfirmed tail must neither suppress the target nor
+      // leave the owner querying a synthetic cursor after the final peer.
+      const holderPeerId = overflowPeers[0]!;
       let lastPeerId: string | undefined;
       (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async (peerId: string) => {
         fetches.push(peerId);
         lastPeerId = peerId;
-        const found = peerId === holderPeerId;
+        const found = peerId === holderPeerId && resolutions === 6;
         return {
           result: {
             fetchedDataTriples: found ? 1 : 0,
@@ -2801,7 +2808,7 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
         };
       };
       (internals as any).reconcileChainOrdinal = async () => (
-        lastPeerId === holderPeerId
+        lastPeerId === holderPeerId && resolutions === 6
           ? { status: 'reconciled', blockNumber: 100 }
           : { status: 'pending', recovery: target }
       );
@@ -2815,21 +2822,27 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
       );
 
       let result;
-      for (let pass = 0; pass < 5; pass += 1) {
+      for (let pass = 0; pass < 6; pass += 1) {
         result = await internals.recoverVmReconcileBatch(
           localCgId, 1n, [target], 100, () => true,
         );
-        if (pass < 4) {
+        if (pass < 5) {
           const slotKey = (internals as any).vmReconcileRotationSlotKey(target);
           expect((internals as any).vmReconcileRotationState.get(slotKey)).toMatchObject({
             phase: 'collecting', curatorRosterConfirmed: false,
           });
           (internals as any).vmReconcileFetchCooldowns.delete(localCgId);
+          if (mode === 'traversal' && pass === 4) {
+            expect((internals as any).vmReconcileCuratorPageCursorByCg.has(localCgId)).toBe(false);
+          }
         }
       }
 
-      expect(resolutions).toBe(5);
-      expect(fetches).toEqual(overflowPeers);
+      expect(resolutions).toBe(6);
+      expect(fetches).toEqual([...overflowPeers, overflowPeers[0]]);
+      expect(requestedCursors).toEqual([
+        undefined, ...overflowPeers.slice(0, 4), mode === 'traversal' ? undefined : overflowPeers[4],
+      ]);
       expect(result?.outcomes.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
     } finally {
       Object.defineProperty(

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -2767,18 +2767,20 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
           ? overflowPeers.indexOf(options.afterPeerId)
           : -1;
         const peerId = overflowPeers[(previousIndex + 1) % overflowPeers.length]!;
-        return {
+        const baseResolution = {
           peerIds: [peerId],
           curatorIsLocal: false,
           legacyTripleResolved: false,
           overflowed: true,
-          nextPageAfterPeerId: peerId,
-          ...(mode === 'traversal' ? {
-            rosterTraversal: peerId === overflowPeers[4]
-              ? { status: 'cycle', peerIds: [peerId] }
-              : { status: 'continue', peerIds: [peerId], nextAfterPeerId: peerId },
-          } : {}),
         };
+        if (mode === 'legacy') return { ...baseResolution, nextPageAfterPeerId: peerId };
+        return peerId === overflowPeers[4]
+          ? { ...baseResolution, rosterStatus: 'cycle' as const }
+          : {
+              ...baseResolution,
+              rosterStatus: 'continue' as const,
+              nextPageAfterPeerId: peerId,
+            };
       };
       (internals as any).ensurePeerConnected = async (peerId: string) => {
         connectedById.set(peerId, { toString: () => peerId });
@@ -2851,6 +2853,89 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
         rosterDescriptor,
       );
     }
+  });
+
+  it('clears a completed page-cycle cursor before accepting a fresh complete roster', async () => {
+    const chain = new MockChainAdapter();
+    agent = await DKGAgent.create({ name: 'ExactVmRosterCycleRestart', chainAdapter: chain });
+    const internals = agent as unknown as AgentInternals;
+    const localCgId = '0x0000000000000000000000000000000000000001/roster-cycle';
+    const firstPeer = '12D3KooWRosterCycleFirst';
+    const tailPeer = '12D3KooWRosterCycleTail';
+    const connectedById = new Map<string, { toString(): string }>();
+    (internals as any).node = {
+      peerId: '12D3KooWRosterCycleLocal',
+      libp2p: {
+        getConnections: () => [...connectedById.values()].map((remotePeer) => ({ remotePeer })),
+      },
+    };
+    const requestedCursors: Array<string | undefined> = [];
+    const resolutions = [
+      {
+        peerIds: [firstPeer], curatorIsLocal: false, legacyTripleResolved: false,
+        rosterStatus: 'continue', overflowed: true, nextPageAfterPeerId: firstPeer,
+      },
+      {
+        peerIds: [tailPeer], curatorIsLocal: false, legacyTripleResolved: false,
+        rosterStatus: 'cycle', overflowed: true,
+      },
+      {
+        peerIds: [firstPeer, tailPeer], curatorIsLocal: false, legacyTripleResolved: false,
+        rosterStatus: 'complete',
+      },
+    ] as const;
+    let resolutionCalls = 0;
+    (internals as any).resolveCuratorPeerIdsForCg = async (
+      _cgId: string,
+      options: { afterPeerId?: string },
+    ) => {
+      requestedCursors.push(options.afterPeerId);
+      return resolutions[resolutionCalls++]!;
+    };
+    (internals as any).ensurePeerConnected = async (peerId: string) => {
+      connectedById.set(peerId, { toString: () => peerId });
+    };
+    (internals as any).selectCatchupPeers = (peers: Array<{ toString(): string }>) => peers;
+    (internals as any).waitForSyncProtocol = async () => true;
+    (internals as any).ensurePeerAdmittedForRecovery = async () => true;
+    const target = vmRecoveryTarget(localCgId, 0, 'roster-cycle');
+    (internals as any).syncExactKnowledgeAssetsFromPeerDetailed = async () => {
+      const found = resolutionCalls === 3;
+      return {
+        result: {
+          fetchedDataTriples: found ? 1 : 0,
+          fetchedMetaTriples: found ? 8 : 0,
+          insertedTriples: found ? 9 : 0,
+          failedPeers: 0, failedPhases: 0, deferredBackpressure: 0,
+        },
+        disposition: found ? 'found' as const : 'clean-absent' as const,
+      };
+    };
+    (internals as any).reconcileChainOrdinal = async () => (
+      resolutionCalls === 3
+        ? { status: 'reconciled', blockNumber: 100 }
+        : { status: 'pending', recovery: target }
+    );
+
+    let result;
+    for (let pass = 0; pass < 3; pass += 1) {
+      result = await internals.recoverVmReconcileBatch(
+        localCgId, 1n, [target], 100, () => true,
+      );
+      if (pass < 2) {
+        expect((internals as any).vmReconcileRotationState.get(
+          (internals as any).vmReconcileRotationSlotKey(target),
+        )).toMatchObject({ phase: 'collecting', curatorRosterConfirmed: false });
+        (internals as any).vmReconcileFetchCooldowns.delete(localCgId);
+      }
+      if (pass === 1) {
+        expect((internals as any).vmReconcileCuratorPageCursorByCg.has(localCgId))
+          .toBe(false);
+      }
+    }
+
+    expect(requestedCursors).toEqual([undefined, firstPeer, undefined]);
+    expect(result?.outcomes.get(0)).toEqual({ status: 'reconciled', blockNumber: 100 });
   });
 
   it('keeps a successful-empty metadata fallback ahead of the ordinary roster cap', async () => {

--- a/packages/agent/test/core-fills-gap.test.ts
+++ b/packages/agent/test/core-fills-gap.test.ts
@@ -2769,8 +2769,11 @@ describe('Phase D — reconcile gate + core-fill telemetry', () => {
           peerIds: [peerId],
           curatorIsLocal: false,
           legacyTripleResolved: false,
-          overflowed: true,
-          nextPageAfterPeerId: peerId,
+          rosterTraversal: {
+            status: 'continue',
+            peerIds: [peerId],
+            nextAfterPeerId: peerId,
+          },
         };
       };
       (internals as any).ensurePeerConnected = async (peerId: string) => {

--- a/packages/agent/test/curator-peer-resolution.typecheck.ts
+++ b/packages/agent/test/curator-peer-resolution.typecheck.ts
@@ -1,0 +1,24 @@
+import type { CuratorPeerIdsResolution } from '../src/index.js';
+
+const bounded: CuratorPeerIdsResolution = {
+  peerIds: ['peer-a'],
+  curatorIsLocal: false,
+  legacyTripleResolved: false,
+  rosterStatus: 'continue',
+  overflowed: true,
+  nextPageAfterPeerId: 'peer-a',
+};
+
+const contradictory: CuratorPeerIdsResolution = {
+  peerIds: ['peer-a'],
+  curatorIsLocal: false,
+  legacyTripleResolved: false,
+  rosterStatus: 'continue',
+  overflowed: true,
+  nextPageAfterPeerId: 'peer-a',
+  // @ts-expect-error A resolved roster has no second independently valid peer list.
+  rosterTraversal: { status: 'continue', peerIds: ['peer-b'], nextAfterPeerId: 'peer-b' },
+};
+
+void bounded;
+void contradictory;

--- a/packages/agent/test/discovery-peer-pagination.test.ts
+++ b/packages/agent/test/discovery-peer-pagination.test.ts
@@ -24,7 +24,7 @@ describe('DiscoveryClient curator peer pagination', () => {
       ],
     });
 
-    await expect(discovery.findAgentPeerIdsByAddress(
+    await expect(discovery.findAgentPeerPageByAddress(
       '0xabc',
       { afterPeerId: 'peer-010', limit: 2 },
     )).resolves.toEqual({ peerIds: ['peer-011', 'peer-012'], nextAfterPeerId: null });
@@ -50,9 +50,9 @@ describe('DiscoveryClient curator peer pagination', () => {
       await store.insert([...first.quads, ...second.quads]);
       const discovery = new DiscoveryClient(new DKGQueryEngine(store));
 
-      await expect(discovery.findAgentPeerIdsByAddress(curator, { limit: 1 }))
+      await expect(discovery.findAgentPeerPageByAddress(curator, { limit: 1 }))
         .resolves.toEqual({ peerIds: ['peer-001'], nextAfterPeerId: 'peer-001' });
-      await expect(discovery.findAgentPeerIdsByAddress(
+      await expect(discovery.findAgentPeerPageByAddress(
         curator,
         { afterPeerId: 'peer-001', limit: 2 },
       )).resolves.toEqual({ peerIds: ['peer-002'], nextAfterPeerId: null });
@@ -77,7 +77,7 @@ describe('DiscoveryClient curator peer pagination', () => {
       await store.insert(legacyQuads);
       const discovery = new DiscoveryClient(new DKGQueryEngine(store));
 
-      await expect(discovery.findAgentPeerIdsByAddress(lowerAddress, { limit: 1 }))
+      await expect(discovery.findAgentPeerPageByAddress(lowerAddress, { limit: 1 }))
         .resolves.toEqual({ peerIds: ['peer-checksum'], nextAfterPeerId: null });
     } finally {
       await store.close();
@@ -87,7 +87,7 @@ describe('DiscoveryClient curator peer pagination', () => {
     'rejects invalid limit %s before a store query', async limit => {
       const { engine, discovery } = fixture();
       const query = vi.spyOn(engine, 'query');
-      await expect(discovery.findAgentPeerIdsByAddress('curator', { limit })).rejects.toThrow(RangeError);
+      await expect(discovery.findAgentPeerPageByAddress('curator', { limit })).rejects.toThrow(RangeError);
       expect(query).not.toHaveBeenCalled();
     },
   );
@@ -112,7 +112,7 @@ describe('DiscoveryClient curator peer pagination', () => {
     const observed: string[] = [];
     let afterPeerId: string | undefined;
     do {
-      const page = await discovery.findAgentPeerIdsByAddress(wallet, { limit: 7, afterPeerId });
+      const page = await discovery.findAgentPeerPageByAddress(wallet, { limit: 7, afterPeerId });
       expect(page.peerIds.length).toBeLessThanOrEqual(7);
       observed.push(...page.peerIds);
       afterPeerId = page.nextAfterPeerId ?? undefined;
@@ -130,14 +130,14 @@ describe('DiscoveryClient curator peer pagination', () => {
     const controller = new AbortController();
     const query = vi.spyOn(engine, 'query');
     controller.abort();
-    await expect(discovery.findAgentPeerIdsByAddress('curator', { limit: 1, signal: controller.signal }))
+    await expect(discovery.findAgentPeerPageByAddress('curator', { limit: 1, signal: controller.signal }))
       .rejects.toMatchObject({ name: 'AbortError' });
     expect(query).not.toHaveBeenCalled();
 
     const active = new AbortController();
     let settle!: (value: { bindings: Array<Record<string, string>> }) => void;
     query.mockImplementation(() => new Promise(resolve => { settle = resolve; }));
-    const pending = discovery.findAgentPeerIdsByAddress('curator', { limit: 1, signal: active.signal });
+    const pending = discovery.findAgentPeerPageByAddress('curator', { limit: 1, signal: active.signal });
     expect(query.mock.calls[0][1]?.signal).toBe(active.signal);
     active.abort();
     settle({ bindings: [{ peerId: 'peer-001' }] });
@@ -149,7 +149,7 @@ describe('DiscoveryClient curator peer pagination', () => {
     let settle!: (value: { bindings: Array<Record<string, string>> }) => void;
     vi.spyOn(engine, 'query').mockImplementation(() => new Promise(resolve => { settle = resolve; }));
     const request = { limit: 1 };
-    const pending = discovery.findAgentPeerIdsByAddress('curator', request);
+    const pending = discovery.findAgentPeerPageByAddress('curator', request);
     request.limit = 100;
     settle({ bindings: [{ peerId: 'peer-001' }, { peerId: 'peer-002' }] });
     await expect(pending).resolves.toEqual({ peerIds: ['peer-001'], nextAfterPeerId: 'peer-001' });
@@ -160,7 +160,31 @@ describe('DiscoveryClient curator peer pagination', () => {
     vi.spyOn(engine, 'query').mockResolvedValue({ bindings: [
       { peerId: 'peer-001' }, { peerId: 'peer-002' }, { peerId: 'peer-003' },
     ] });
-    await expect(discovery.findAgentPeerIdsByAddress('curator', { limit: 1 })).rejects.toThrow('row limit');
+    await expect(discovery.findAgentPeerPageByAddress('curator', { limit: 1 })).rejects.toThrow('row limit');
+  });
+
+  it('preserves the published optional-limit array API on real registry data', async () => {
+    const { store, discovery } = fixture();
+    const wallet = '0x00000000000000000000000000000000000000ab';
+    for (const peerId of ['peer-001', 'peer-002', 'peer-003']) {
+      await store.insert(buildAgentProfile({ peerId, name: peerId, agentAddress: wallet, skills: [] }).quads);
+    }
+    await expect(discovery.findAgentPeerIdsByAddress(wallet)).resolves.toEqual(['peer-001', 'peer-002', 'peer-003']);
+    await expect(discovery.findAgentPeerIdsByAddress(wallet, { limit: 1, afterPeerId: 'peer-001' }))
+      .resolves.toEqual(['peer-002']);
+  });
+
+  it('preserves legacy limits larger than a page without issuing an oversized page request', async () => {
+    const { discovery } = fixture();
+    const ids = Array.from({ length: MAX_AGENT_PEER_PAGE_SIZE + 100 }, (_, i) => `peer-${String(i).padStart(4, '0')}`);
+    const page = vi.spyOn(discovery, 'findAgentPeerPageByAddress').mockImplementation(async (_wallet, request) => {
+      const after = request.afterPeerId ? ids.indexOf(request.afterPeerId) + 1 : 0;
+      const peerIds = ids.slice(after, after + request.limit);
+      return { peerIds, nextAfterPeerId: after + request.limit < ids.length ? peerIds[peerIds.length - 1] : null };
+    });
+    await expect(discovery.findAgentPeerIdsByAddress('wallet', { limit: MAX_AGENT_PEER_PAGE_SIZE + 50 }))
+      .resolves.toEqual(ids.slice(0, MAX_AGENT_PEER_PAGE_SIZE + 50));
+    expect(page.mock.calls.map(([, request]) => request.limit)).toEqual([MAX_AGENT_PEER_PAGE_SIZE, 50]);
   });
 
 });

--- a/packages/agent/test/discovery-peer-pagination.test.ts
+++ b/packages/agent/test/discovery-peer-pagination.test.ts
@@ -1,30 +1,39 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DKGQueryEngine } from '@origintrail-official/dkg-query';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import { DiscoveryClient } from '../src/discovery.js';
 import { buildAgentProfile } from '../src/profile.js';
+import { MAX_AGENT_PEER_PAGE_SIZE } from '../src/agent-peer-discovery.js';
+import { MAX_CONTEXT_GRAPH_PARTICIPANT_AGENTS } from '../src/dkg-agent-constants.js';
 
 describe('DiscoveryClient curator peer pagination', () => {
+  const stores: OxigraphStore[] = [];
+  afterEach(async () => { await Promise.all(stores.splice(0).map(store => store.close())); });
+  function fixture() {
+    const store = new OxigraphStore();
+    stores.push(store);
+    const engine = new DKGQueryEngine(store);
+    return { store, engine, discovery: new DiscoveryClient(engine) };
+  }
   it('queries distinct peer IDs in deterministic exclusive-cursor order', async () => {
-    const query = vi.fn(async () => ({
-      type: 'bindings' as const,
+    const { engine, discovery } = fixture();
+    const query = vi.spyOn(engine, 'query').mockResolvedValue({
       bindings: [
         { peerId: '"peer-011"' },
         { peerId: '"peer-012"' },
       ],
-    }));
-    const discovery = new DiscoveryClient({ query } as any);
+    });
 
     await expect(discovery.findAgentPeerIdsByAddress(
       '0xabc',
       { afterPeerId: 'peer-010', limit: 2 },
-    )).resolves.toEqual(['peer-011', 'peer-012']);
+    )).resolves.toEqual({ peerIds: ['peer-011', 'peer-012'], nextAfterPeerId: null });
 
     const [sparql, options] = query.mock.calls[0]!;
-    expect(sparql).toContain('SELECT DISTINCT ?peerId');
-    expect(sparql).toContain('FILTER(STR(?peerId) > "peer-010")');
+    expect(sparql).toContain('SELECT DISTINCT (STR(?storedPeerId) AS ?peerId)');
+    expect(sparql).toContain('FILTER(STR(?storedPeerId) > "peer-010")');
     expect(sparql).toContain('ORDER BY ASC(STR(?peerId))');
-    expect(sparql).toContain('LIMIT 2');
+    expect(sparql).toContain('LIMIT 3');
     expect(options).toMatchObject({ contextGraphId: 'agents' });
   });
 
@@ -42,11 +51,11 @@ describe('DiscoveryClient curator peer pagination', () => {
       const discovery = new DiscoveryClient(new DKGQueryEngine(store));
 
       await expect(discovery.findAgentPeerIdsByAddress(curator, { limit: 1 }))
-        .resolves.toEqual(['peer-001']);
+        .resolves.toEqual({ peerIds: ['peer-001'], nextAfterPeerId: 'peer-001' });
       await expect(discovery.findAgentPeerIdsByAddress(
         curator,
         { afterPeerId: 'peer-001', limit: 2 },
-      )).resolves.toEqual(['peer-002']);
+      )).resolves.toEqual({ peerIds: ['peer-002'], nextAfterPeerId: null });
     } finally {
       await store.close();
     }
@@ -68,10 +77,90 @@ describe('DiscoveryClient curator peer pagination', () => {
       await store.insert(legacyQuads);
       const discovery = new DiscoveryClient(new DKGQueryEngine(store));
 
-      await expect(discovery.findAgentPeerIdsByAddress(lowerAddress))
-        .resolves.toEqual(['peer-checksum']);
+      await expect(discovery.findAgentPeerIdsByAddress(lowerAddress, { limit: 1 }))
+        .resolves.toEqual({ peerIds: ['peer-checksum'], nextAfterPeerId: null });
     } finally {
       await store.close();
     }
   });
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, MAX_AGENT_PEER_PAGE_SIZE + 1])(
+    'rejects invalid limit %s before a store query', async limit => {
+      const { engine, discovery } = fixture();
+      const query = vi.spyOn(engine, 'query');
+      await expect(discovery.findAgentPeerIdsByAddress('curator', { limit })).rejects.toThrow(RangeError);
+      expect(query).not.toHaveBeenCalled();
+    },
+  );
+
+  it('bounds every page despite optional-profile multiplicity and RDF peer-ID aliases', async () => {
+    const { store, engine, discovery } = fixture();
+    const wallet = '0x00000000000000000000000000000000000000ab';
+    const expected = Array.from({ length: MAX_CONTEXT_GRAPH_PARTICIPANT_AGENTS + 17 }, (_, i) => `peer-${String(i).padStart(4, '0')}`);
+    for (const peerId of expected) {
+      const profile = buildAgentProfile({ peerId, name: peerId, agentAddress: wallet, skills: [] });
+      const identity = profile.quads.find(q => q.predicate.endsWith('#peerId'))!;
+      await store.insert([
+        ...profile.quads,
+        { ...identity, object: `"${peerId}"@en` },
+        { ...identity, object: `"${peerId}"^^<http://www.w3.org/2001/XMLSchema#string>` },
+        ...Array.from({ length: 40 }, (_, n) => ({
+          ...identity, predicate: 'https://dkg.origintrail.io/skill#framework', object: `"framework-${n}"`,
+        })),
+      ]);
+    }
+    const query = vi.spyOn(engine, 'query');
+    const observed: string[] = [];
+    let afterPeerId: string | undefined;
+    do {
+      const page = await discovery.findAgentPeerIdsByAddress(wallet, { limit: 7, afterPeerId });
+      expect(page.peerIds.length).toBeLessThanOrEqual(7);
+      observed.push(...page.peerIds);
+      afterPeerId = page.nextAfterPeerId ?? undefined;
+    } while (afterPeerId);
+    expect(observed).toEqual(expected);
+    expect(query).toHaveBeenCalledTimes(Math.ceil(expected.length / 7));
+    for (const call of query.mock.results) {
+      const result = await call.value;
+      expect(result.bindings.length).toBeLessThanOrEqual(8);
+    }
+  });
+
+  it('cancels before querying and rejects late query results after cancellation', async () => {
+    const { engine, discovery } = fixture();
+    const controller = new AbortController();
+    const query = vi.spyOn(engine, 'query');
+    controller.abort();
+    await expect(discovery.findAgentPeerIdsByAddress('curator', { limit: 1, signal: controller.signal }))
+      .rejects.toMatchObject({ name: 'AbortError' });
+    expect(query).not.toHaveBeenCalled();
+
+    const active = new AbortController();
+    let settle!: (value: { bindings: Array<Record<string, string>> }) => void;
+    query.mockImplementation(() => new Promise(resolve => { settle = resolve; }));
+    const pending = discovery.findAgentPeerIdsByAddress('curator', { limit: 1, signal: active.signal });
+    expect(query.mock.calls[0][1]?.signal).toBe(active.signal);
+    active.abort();
+    settle({ bindings: [{ peerId: 'peer-001' }] });
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('snapshots a caller-owned page request before awaiting the query', async () => {
+    const { engine, discovery } = fixture();
+    let settle!: (value: { bindings: Array<Record<string, string>> }) => void;
+    vi.spyOn(engine, 'query').mockImplementation(() => new Promise(resolve => { settle = resolve; }));
+    const request = { limit: 1 };
+    const pending = discovery.findAgentPeerIdsByAddress('curator', request);
+    request.limit = 100;
+    settle({ bindings: [{ peerId: 'peer-001' }, { peerId: 'peer-002' }] });
+    await expect(pending).resolves.toEqual({ peerIds: ['peer-001'], nextAfterPeerId: 'peer-001' });
+  });
+
+  it('rejects a query engine that returns more than the requested lookahead bound', async () => {
+    const { engine, discovery } = fixture();
+    vi.spyOn(engine, 'query').mockResolvedValue({ bindings: [
+      { peerId: 'peer-001' }, { peerId: 'peer-002' }, { peerId: 'peer-003' },
+    ] });
+    await expect(discovery.findAgentPeerIdsByAddress('curator', { limit: 1 })).rejects.toThrow('row limit');
+  });
+
 });

--- a/packages/agent/test/swm-curator-recovery-plan.test.ts
+++ b/packages/agent/test/swm-curator-recovery-plan.test.ts
@@ -346,18 +346,18 @@ describe('private SWM curator recovery planning', () => {
     const second = await agent.resolveCuratorPeerIdsForCg(contextGraphId, {
       maxPeerIds: 2,
       pagePeerIds: 1,
-      afterPeerId: first.nextPageAfterPeerId,
+      afterPeerId: first.rosterTraversal?.status === 'continue'
+        ? first.rosterTraversal.nextAfterPeerId
+        : undefined,
     });
 
     expect(first).toMatchObject({
       peerIds: ['peer-001'],
-      overflowed: true,
-      nextPageAfterPeerId: 'peer-001',
+      rosterTraversal: { status: 'continue', nextAfterPeerId: 'peer-001' },
     });
     expect(second).toMatchObject({
       peerIds: ['peer-002'],
-      overflowed: true,
-      nextPageAfterPeerId: 'peer-002',
+      rosterTraversal: { status: 'continue', nextAfterPeerId: 'peer-002' },
     });
     expect(calls).toEqual([
       { limit: 2, signal: undefined },

--- a/packages/agent/test/swm-curator-recovery-plan.test.ts
+++ b/packages/agent/test/swm-curator-recovery-plan.test.ts
@@ -346,18 +346,20 @@ describe('private SWM curator recovery planning', () => {
     const second = await agent.resolveCuratorPeerIdsForCg(contextGraphId, {
       maxPeerIds: 2,
       pagePeerIds: 1,
-      afterPeerId: first.rosterTraversal?.status === 'continue'
-        ? first.rosterTraversal.nextAfterPeerId
+      afterPeerId: first.rosterStatus === 'continue'
+        ? first.nextPageAfterPeerId
         : undefined,
     });
 
     expect(first).toMatchObject({
       peerIds: ['peer-001'],
-      rosterTraversal: { status: 'continue', nextAfterPeerId: 'peer-001' },
+      rosterStatus: 'continue',
+      nextPageAfterPeerId: 'peer-001',
     });
     expect(second).toMatchObject({
       peerIds: ['peer-002'],
-      rosterTraversal: { status: 'continue', nextAfterPeerId: 'peer-002' },
+      rosterStatus: 'continue',
+      nextPageAfterPeerId: 'peer-002',
     });
     expect(calls).toEqual([
       { limit: 2, signal: undefined },

--- a/packages/agent/test/swm-curator-recovery-plan.test.ts
+++ b/packages/agent/test/swm-curator-recovery-plan.test.ts
@@ -329,7 +329,7 @@ describe('private SWM curator recovery planning', () => {
     ];
     const calls: Array<{ afterPeerId?: string; limit?: number }> = [];
     const provider: AgentPeerDiscovery = {
-      findAgentPeerIdsByAddress: async (
+      findAgentPeerPageByAddress: async (
         _address: string,
         options,
       ) => {
@@ -338,7 +338,7 @@ describe('private SWM curator recovery planning', () => {
       },
     };
 
-    vi.spyOn(agent.discovery, 'findAgentPeerIdsByAddress').mockImplementation(provider.findAgentPeerIdsByAddress);
+    vi.spyOn(agent.discovery, 'findAgentPeerPageByAddress').mockImplementation(provider.findAgentPeerPageByAddress);
     const first = await agent.resolveCuratorPeerIdsForCg(contextGraphId, {
       maxPeerIds: 2,
       pagePeerIds: 1,

--- a/packages/agent/test/swm-curator-recovery-plan.test.ts
+++ b/packages/agent/test/swm-curator-recovery-plan.test.ts
@@ -1,8 +1,8 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ethers } from 'ethers';
 import { createOperationContext } from '@origintrail-official/dkg-core';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
-import { DKGAgent } from '../src/index.js';
+import { DKGAgent, type AgentPeerDiscovery, type AgentPeerPage } from '../src/index.js';
 
 describe('private SWM curator recovery planning', () => {
   const agents: DKGAgent[] = [];
@@ -323,29 +323,27 @@ describe('private SWM curator recovery planning', () => {
     const curator = ethers.Wallet.createRandom().address.toLowerCase();
     const contextGraphId = `${curator}/paged-curator-plan`;
     const agent = await createAgent('CuratorRecoveryPagination');
-    const pages = [
-      ['peer-001', 'peer-002', 'peer-003'],
-      ['peer-002', 'peer-003', 'peer-004'],
+    const pages: AgentPeerPage[] = [
+      { peerIds: ['peer-001', 'peer-002'], nextAfterPeerId: 'peer-002' },
+      { peerIds: ['peer-002'], nextAfterPeerId: 'peer-002' },
     ];
     const calls: Array<{ afterPeerId?: string; limit?: number }> = [];
-    const internals = agent as any;
-    internals.localAgents.clear();
-    internals.discovery = {
+    const provider: AgentPeerDiscovery = {
       findAgentPeerIdsByAddress: async (
         _address: string,
-        options: { afterPeerId?: string; limit?: number },
+        options,
       ) => {
         calls.push(options);
-        return pages[calls.length - 1] ?? [];
+        return pages[calls.length - 1] ?? { peerIds: [], nextAfterPeerId: null };
       },
-      findAgents: async () => [],
     };
 
-    const first = await internals.resolveCuratorPeerIdsForCg(contextGraphId, {
+    vi.spyOn(agent.discovery, 'findAgentPeerIdsByAddress').mockImplementation(provider.findAgentPeerIdsByAddress);
+    const first = await agent.resolveCuratorPeerIdsForCg(contextGraphId, {
       maxPeerIds: 2,
       pagePeerIds: 1,
     });
-    const second = await internals.resolveCuratorPeerIdsForCg(contextGraphId, {
+    const second = await agent.resolveCuratorPeerIdsForCg(contextGraphId, {
       maxPeerIds: 2,
       pagePeerIds: 1,
       afterPeerId: first.nextPageAfterPeerId,
@@ -362,8 +360,8 @@ describe('private SWM curator recovery planning', () => {
       nextPageAfterPeerId: 'peer-002',
     });
     expect(calls).toEqual([
-      { limit: 3, signal: undefined },
-      { afterPeerId: 'peer-001', limit: 2, signal: undefined },
+      { limit: 2, signal: undefined },
+      { afterPeerId: 'peer-001', limit: 1, signal: undefined },
     ]);
   });
 

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -20,6 +20,8 @@ export default defineConfig({
     include: [
       ...RFC64_UNIT_TESTS,
       "test/endorse.test.ts",
+      "test/bounded-curator-discovery.test.ts",
+      "test/discovery-peer-pagination.test.ts",
       "test/ack-candidate-pool.test.ts",
       "test/e2e-dht-dial.test.ts",
       "test/generic-sql-source.test.ts",


### PR DESCRIPTION
Bounded curator recovery could fall back to `findAgents()` when a provider lacked peer pagination, loading the entire rich-profile registry before applying its roster cap. Its metadata-refresh fallback could repeat the same unbounded query.

Both paths now require the typed `AgentPeerDiscovery` page contract. Missing, unsupported, or malformed providers produce a lookup failure; they cannot trigger rich-profile fallback. `DiscoveryClient.findAgentPeerPageByAddress()` requires a positive page size capped at 1,024, retains at most one lookahead row, and returns an explicit continuation. Peer IDs are normalized in the SPARQL DISTINCT projection before LIMIT, so optional-profile multiplicity and alternate RDF encodings cannot consume page slots or hide later peers. Cancellation is forwarded and rechecked after provider/query completion.

The recovery owner consumes explicit complete, continue, and cycle traversal states. Tail pages remain incomplete roster evidence even when registry churn makes them short; cycle clears the saved cursor before the next recovery pass. The existing SDK overflowed and nextPageAfterPeerId fields remain available as compatibility projections, including support for custom providers returning the prior shape. Exhausted cursors wrap through a fresh bounded first-page query. Legacy single-curator metadata resolution and explicit rich-profile calls keep their existing behavior. The published `findAgentPeerIdsByAddress(wallet, options?)` method remains as a deprecated, array-returning compatibility facade that walks bounded pages internally. Bounded recovery requires the new page method and never invokes this facade. The README documents both contracts.

Closes #2062.

Validation:
- 345 tests pass across 11 discovery, contract, planning, recovery-consumer, metadata-refresh, and telemetry suites.
- The real embedded-Oxigraph resource fixture walks 273 peers (above the 256-peer proof cap), 40 optional framework values per profile, and duplicate peer-ID RDF encodings. Seven-peer pages return at most eight query rows, with no duplicated or omitted peers.
- Restoring the prior canary lifecycle implementation makes the missing-pagination regression fail. The working file was restored byte-for-byte before final validation.
- Three regressions fail against the preceding implementation and pass after the fix: a provider-supplied array iterator, exhausted-cursor restart, and legacy-shaped partial rosters being incorrectly confirmed and put into recovery backoff. Both legacy and explicit traversal owners visit all five peers and return to a newly populated first peer without suppressing recovery.
- A successful bounded wallet-curator fallback returns the registry peer with registry provenance, requests limit 1, avoids rich discovery, and overrides a bootstrap hint without earning authority.
- Public runtime/type compatibility checks preserve omitted-limit, limited, and cursor-based array calls, including limits larger than one page.
- Agent build, public type fixtures, strict changed runtime-fixture types, lint, the 1,801-file test inventory, SPARQL checks, and merge compatibility pass. The two discovery suites are explicitly included in the agent unit lane.
- The page-contract and bounded roster traversal modules each have 100% scoped statement/branch/function/line coverage. This is not a whole-package coverage claim; no live chain or remote production deployment was exercised.
