### PR TITLE
fix(ui): ignore incompatible local LLM endpoints

### DIFF
--- a/docs/use-dkg/local-llm.md
+++ b/docs/use-dkg/local-llm.md
@@ -583,9 +583,11 @@ Local LLM** in the Agents panel. There is no separate provider selector in the
 browser: Node UI uses `DKG_LLM_URL`, `DKG_LLM_MODEL`, and `DKG_LLM_BACKEND`
 from the daemon environment. `DKG_LLM_BACKEND` accepts `ollama`, `llama.cpp`,
 or the backward-compatible default `auto`. Node UI hides the integration when
-none of those environment overrides is set and no server is reachable at the
-default local endpoint. An explicitly configured server remains visible while
-offline so the panel can report its error. The integration remains read-only:
+none of those environment overrides is set and the default local endpoint does
+not match a supported llama.cpp or Ollama health contract. A different HTTP
+service listening on the same port is not treated as a Local LLM. An explicitly
+configured server remains visible while unavailable so the panel can report its
+error. The integration remains read-only:
 the daemon always creates this
 UI runtime with writes disabled. The HTTP surface is also node-admin-only.
 Agent-scoped bearer tokens receive `403` and cannot start, continue, or clear

--- a/packages/cli/src/daemon/local-llm-service.ts
+++ b/packages/cli/src/daemon/local-llm-service.ts
@@ -55,6 +55,8 @@ export interface DaemonLocalLlmHealth {
   ok: boolean;
   /** True when the operator supplied at least one local-LLM environment override. */
   configured: boolean;
+  /** True when the endpoint matches a supported local-LLM health contract. */
+  detected: boolean;
   ready: boolean;
   reachable: boolean;
   offline: boolean;
@@ -185,6 +187,7 @@ export function createDaemonLocalLlmService(
       return Promise.resolve(Object.freeze({
         status: 'offline',
         reachable: false,
+        detected: false,
         error: `Local LLM endpoint configuration is invalid: ${settings.probeConfigurationError}`,
       }));
     }
@@ -221,6 +224,7 @@ export function createDaemonLocalLlmService(
       return {
         ok: ready,
         configured: settings.configured,
+        detected: availability.detected,
         ready,
         reachable,
         offline: !reachable,

--- a/packages/cli/src/daemon/local-llm-service.ts
+++ b/packages/cli/src/daemon/local-llm-service.ts
@@ -186,8 +186,6 @@ export function createDaemonLocalLlmService(
     if (settings.probeConfigurationError) {
       return Promise.resolve(Object.freeze({
         status: 'offline',
-        reachable: false,
-        detected: false,
         error: `Local LLM endpoint configuration is invalid: ${settings.probeConfigurationError}`,
       }));
     }
@@ -203,7 +201,7 @@ export function createDaemonLocalLlmService(
   const unavailableError = (
     availability: Exclude<LocalModelEndpointAvailability, { status: 'ready' }>,
   ): DaemonLocalLlmError => new DaemonLocalLlmError(
-    availability.status === 'not-ready' ? 'LOCAL_LLM_NOT_READY' : 'LOCAL_LLM_OFFLINE',
+    availability.status === 'offline' ? 'LOCAL_LLM_OFFLINE' : 'LOCAL_LLM_NOT_READY',
     503,
     availability.error,
   );
@@ -220,11 +218,12 @@ export function createDaemonLocalLlmService(
     async health() {
       const availability = await probe();
       const reachable = availability.status !== 'offline';
+      const detected = availability.status === 'ready' || availability.status === 'not-ready';
       const ready = availability.status === 'ready' && !initFailure && !closed;
       return {
         ok: ready,
         configured: settings.configured,
-        detected: availability.detected,
+        detected,
         ready,
         reachable,
         offline: !reachable,

--- a/packages/cli/test/daemon-local-llm-service.test.ts
+++ b/packages/cli/test/daemon-local-llm-service.test.ts
@@ -306,10 +306,12 @@ describe('daemon local LLM service', () => {
 
     expect(await service.health()).toEqual(expect.objectContaining({
       ok: false,
+      configured: false,
+      detected: false,
       ready: false,
       reachable: true,
       offline: false,
-      error: expect.stringContaining('reachable but not ready'),
+      error: expect.stringContaining('No compatible local LLM server was detected'),
     }));
     await expect(service.chat({ message: 'hello' })).rejects.toMatchObject({
       code: 'LOCAL_LLM_NOT_READY', status: 503,
@@ -322,7 +324,8 @@ describe('daemon local LLM service', () => {
       dkgHome: '/tmp/dkg', fetch: onlineFetch(), createSession,
     });
     expect(await online.health()).toEqual(expect.objectContaining({
-      ok: true, ready: true, reachable: true, offline: false, initialized: false, readOnly: true,
+      ok: true, detected: true, ready: true, reachable: true, offline: false,
+      initialized: false, readOnly: true,
     }));
     expect(createSession).not.toHaveBeenCalled();
 
@@ -332,7 +335,7 @@ describe('daemon local LLM service', () => {
       createSession,
     });
     expect(await offline.health()).toEqual(expect.objectContaining({
-      ok: false, configured: false, reachable: false, offline: true,
+      ok: false, configured: false, detected: false, reachable: false, offline: true,
     }));
     await expect(offline.chat({ message: 'hello' })).rejects.toMatchObject({
       code: 'LOCAL_LLM_OFFLINE', status: 503,

--- a/packages/cli/test/daemon-local-llm-service.test.ts
+++ b/packages/cli/test/daemon-local-llm-service.test.ts
@@ -267,7 +267,9 @@ describe('daemon local LLM service', () => {
       if (url.endsWith('/health')) {
         return healthy
           ? Response.json({ status: 'ok' })
-          : new Response('loading model', { status: 503 });
+          : Response.json({
+            error: { code: 503, message: 'Loading model', type: 'unavailable_error' },
+          }, { status: 503 });
       }
       return new Response('not found', { status: 404 });
     });
@@ -280,7 +282,7 @@ describe('daemon local LLM service', () => {
     });
 
     expect(await service.health()).toEqual(expect.objectContaining({
-      ok: false, ready: false, reachable: true, offline: false,
+      ok: false, detected: true, ready: false, reachable: true, offline: false,
     }));
     await expect(service.chat({ message: 'hello' })).rejects.toMatchObject({
       code: 'LOCAL_LLM_NOT_READY', status: 503,

--- a/packages/local-llm/src/model-endpoint.ts
+++ b/packages/local-llm/src/model-endpoint.ts
@@ -166,11 +166,6 @@ function inspectLlamaCppHealth(
   if (httpStatus >= 200 && httpStatus < 300 && record.status === 'ok') {
     return { status: 'ready' };
   }
-  // llama.cpp has used this compact shape for an initialized server whose
-  // model is not ready yet.
-  if (httpStatus >= 200 && httpStatus < 300 && record.status === 'loading') {
-    return { status: 'not-ready', reason: 'llama.cpp model is still loading' };
-  }
   const error = record.error;
   if (httpStatus === 503 && typeof error === 'object' && error !== null && !Array.isArray(error)) {
     const detail = error as Record<string, unknown>;

--- a/packages/local-llm/src/model-endpoint.ts
+++ b/packages/local-llm/src/model-endpoint.ts
@@ -4,21 +4,17 @@ export type LocalModelEndpointProbeStrategy =
   | Readonly<{ kind: 'llama.cpp' }>;
 
 export type LocalModelEndpointAvailability =
-  | Readonly<{
-    status: 'ready';
-    reachable: true;
-    detected: true;
-  }>
+  | Readonly<{ status: 'ready' }>
   | Readonly<{
     status: 'not-ready';
-    reachable: true;
-    detected: boolean;
+    error: string;
+  }>
+  | Readonly<{
+    status: 'incompatible';
     error: string;
   }>
   | Readonly<{
     status: 'offline';
-    reachable: false;
-    detected: false;
     error: string;
   }>;
 
@@ -137,25 +133,60 @@ function inspectModelList(
 }
 
 function offline(error: string): LocalModelEndpointAvailability {
-  return Object.freeze({ status: 'offline', reachable: false, detected: false, error });
+  return Object.freeze({ status: 'offline', error });
 }
 
 function notReady(attempts: readonly string[]): LocalModelEndpointAvailability {
   return Object.freeze({
     status: 'not-ready',
-    reachable: true,
-    detected: true,
     error: `Local LLM server is reachable but not ready: ${attempts.join('; ')}`,
   });
 }
 
 function incompatible(attempts: readonly string[]): LocalModelEndpointAvailability {
   return Object.freeze({
-    status: 'not-ready',
-    reachable: true,
-    detected: false,
+    status: 'incompatible',
     error: `No compatible local LLM server was detected: ${attempts.join('; ')}`,
   });
+}
+
+type LlamaCppHealthInspection =
+  | Readonly<{ status: 'ready' }>
+  | Readonly<{ status: 'not-ready'; reason: string }>
+  | Readonly<{ status: 'incompatible'; reason: string }>;
+
+function inspectLlamaCppHealth(
+  value: unknown,
+  httpStatus: number,
+): LlamaCppHealthInspection {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return { status: 'incompatible', reason: 'llama.cpp health fallback returned an invalid body' };
+  }
+  const record = value as Record<string, unknown>;
+  if (httpStatus >= 200 && httpStatus < 300 && record.status === 'ok') {
+    return { status: 'ready' };
+  }
+  // llama.cpp has used this compact shape for an initialized server whose
+  // model is not ready yet.
+  if (httpStatus >= 200 && httpStatus < 300 && record.status === 'loading') {
+    return { status: 'not-ready', reason: 'llama.cpp model is still loading' };
+  }
+  const error = record.error;
+  if (httpStatus === 503 && typeof error === 'object' && error !== null && !Array.isArray(error)) {
+    const detail = error as Record<string, unknown>;
+    if (
+      detail.code === 503
+      && detail.type === 'unavailable_error'
+      && typeof detail.message === 'string'
+      && detail.message.trim().toLowerCase().startsWith('loading model')
+    ) {
+      return { status: 'not-ready', reason: detail.message.trim() };
+    }
+  }
+  return {
+    status: 'incompatible',
+    reason: `llama.cpp health fallback returned an unrecognized HTTP ${httpStatus} response`,
+  };
 }
 
 /**
@@ -198,15 +229,15 @@ export async function probeLocalModelEndpoint(
     if (response.ok) {
       try {
         const inspection = inspectModelList(await response.json(), configuredModel, strategy);
-        detected = inspection.status !== 'incompatible';
         if (inspection.status === 'ready') {
-          return Object.freeze({ status: 'ready', reachable: true, detected: true });
+          return Object.freeze({ status: 'ready' });
         }
         attempts.push(inspection.reason);
         if (inspection.status === 'incompatible') return incompatible(attempts);
         if (inspection.status === 'not-ready') {
           return notReady(attempts);
         }
+        detected = true;
       } catch (error) {
         attempts.push(`OpenAI-compatible models probe returned invalid JSON: ${errorMessage(error)}`);
         return incompatible(attempts);
@@ -230,31 +261,13 @@ export async function probeLocalModelEndpoint(
       signal: AbortSignal.timeout(timeoutMs),
     });
     reachable = true;
-    if (response.ok) {
-      try {
-        const payload = await response.json() as { status?: unknown };
-        if (
-          typeof payload === 'object'
-          && payload !== null
-          && !Array.isArray(payload)
-          && payload.status === 'ok'
-        ) {
-          return Object.freeze({ status: 'ready', reachable: true, detected: true });
-        }
-        if (
-          typeof payload === 'object'
-          && payload !== null
-          && !Array.isArray(payload)
-          && typeof payload.status === 'string'
-        ) {
-          detected = true;
-        }
-        attempts.push('llama.cpp health fallback did not return {"status":"ok"}');
-      } catch (error) {
-        attempts.push(`llama.cpp health fallback returned invalid JSON: ${errorMessage(error)}`);
-      }
-    } else {
-      attempts.push(`llama.cpp health fallback returned HTTP ${response.status}`);
+    try {
+      const inspection = inspectLlamaCppHealth(await response.json(), response.status);
+      if (inspection.status === 'ready') return Object.freeze({ status: 'ready' });
+      attempts.push(inspection.reason);
+      if (inspection.status === 'not-ready') return notReady(attempts);
+    } catch (error) {
+      attempts.push(`llama.cpp health fallback returned invalid JSON: ${errorMessage(error)}`);
     }
   } catch (error) {
     attempts.push(`llama.cpp health fallback failed: ${errorMessage(error)}`);

--- a/packages/local-llm/src/model-endpoint.ts
+++ b/packages/local-llm/src/model-endpoint.ts
@@ -7,15 +7,18 @@ export type LocalModelEndpointAvailability =
   | Readonly<{
     status: 'ready';
     reachable: true;
+    detected: true;
   }>
   | Readonly<{
     status: 'not-ready';
     reachable: true;
+    detected: boolean;
     error: string;
   }>
   | Readonly<{
     status: 'offline';
     reachable: false;
+    detected: false;
     error: string;
   }>;
 
@@ -40,7 +43,8 @@ interface ModelListEntry {
 type ModelListInspection =
   | Readonly<{ status: 'ready' }>
   | Readonly<{ status: 'fallback'; reason: string }>
-  | Readonly<{ status: 'not-ready'; reason: string }>;
+  | Readonly<{ status: 'not-ready'; reason: string }>
+  | Readonly<{ status: 'incompatible'; reason: string }>;
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -102,7 +106,7 @@ function inspectModelList(
   const entries = parseModelList(value);
   if (!entries) {
     return {
-      status: 'not-ready',
+      status: 'incompatible',
       reason: 'OpenAI-compatible models probe returned no valid model list',
     };
   }
@@ -133,14 +137,24 @@ function inspectModelList(
 }
 
 function offline(error: string): LocalModelEndpointAvailability {
-  return Object.freeze({ status: 'offline', reachable: false, error });
+  return Object.freeze({ status: 'offline', reachable: false, detected: false, error });
 }
 
 function notReady(attempts: readonly string[]): LocalModelEndpointAvailability {
   return Object.freeze({
     status: 'not-ready',
     reachable: true,
+    detected: true,
     error: `Local LLM server is reachable but not ready: ${attempts.join('; ')}`,
+  });
+}
+
+function incompatible(attempts: readonly string[]): LocalModelEndpointAvailability {
+  return Object.freeze({
+    status: 'not-ready',
+    reachable: true,
+    detected: false,
+    error: `No compatible local LLM server was detected: ${attempts.join('; ')}`,
   });
 }
 
@@ -171,6 +185,7 @@ export async function probeLocalModelEndpoint(
 
   const attempts: string[] = [];
   let reachable = false;
+  let detected = false;
   let useHealthFallback = strategy.kind !== 'ollama';
 
   try {
@@ -183,14 +198,18 @@ export async function probeLocalModelEndpoint(
     if (response.ok) {
       try {
         const inspection = inspectModelList(await response.json(), configuredModel, strategy);
+        detected = inspection.status !== 'incompatible';
         if (inspection.status === 'ready') {
-          return Object.freeze({ status: 'ready', reachable: true });
+          return Object.freeze({ status: 'ready', reachable: true, detected: true });
         }
         attempts.push(inspection.reason);
-        if (inspection.status === 'not-ready') return notReady(attempts);
+        if (inspection.status === 'incompatible') return incompatible(attempts);
+        if (inspection.status === 'not-ready') {
+          return notReady(attempts);
+        }
       } catch (error) {
         attempts.push(`OpenAI-compatible models probe returned invalid JSON: ${errorMessage(error)}`);
-        return notReady(attempts);
+        return incompatible(attempts);
       }
     } else {
       attempts.push(`OpenAI-compatible models probe returned HTTP ${response.status}`);
@@ -201,7 +220,7 @@ export async function probeLocalModelEndpoint(
   }
 
   if (!useHealthFallback) {
-    return reachable ? notReady(attempts) : offline(`Local LLM server is offline: ${attempts.join('; ')}`);
+    return reachable ? incompatible(attempts) : offline(`Local LLM server is offline: ${attempts.join('; ')}`);
   }
 
   try {
@@ -220,7 +239,15 @@ export async function probeLocalModelEndpoint(
           && !Array.isArray(payload)
           && payload.status === 'ok'
         ) {
-          return Object.freeze({ status: 'ready', reachable: true });
+          return Object.freeze({ status: 'ready', reachable: true, detected: true });
+        }
+        if (
+          typeof payload === 'object'
+          && payload !== null
+          && !Array.isArray(payload)
+          && typeof payload.status === 'string'
+        ) {
+          detected = true;
         }
         attempts.push('llama.cpp health fallback did not return {"status":"ok"}');
       } catch (error) {
@@ -234,6 +261,6 @@ export async function probeLocalModelEndpoint(
   }
 
   return reachable
-    ? notReady(attempts)
+    ? (detected ? notReady(attempts) : incompatible(attempts))
     : offline(`Local LLM server is offline: ${attempts.join('; ')}`);
 }

--- a/packages/local-llm/test/model-endpoint.test.ts
+++ b/packages/local-llm/test/model-endpoint.test.ts
@@ -19,13 +19,13 @@ describe('local model endpoint probing', () => {
       chatCompletionsUrl: 'http://127.0.0.1:8080/v1/chat/completions?ignored=yes',
       strategy: { kind: 'llama.cpp' },
       fetch: fetcher as typeof fetch,
-    })).resolves.toEqual({ status: 'ready', reachable: true });
+    })).resolves.toEqual({ status: 'ready', reachable: true, detected: true });
     await expect(probeLocalModelEndpoint({
       ...DEFAULT_OPTIONS,
       chatCompletionsUrl: 'http://localhost:9000/proxy/v1/chat/completions#ignored',
       strategy: { kind: 'llama.cpp' },
       fetch: fetcher as typeof fetch,
-    })).resolves.toEqual({ status: 'ready', reachable: true });
+    })).resolves.toEqual({ status: 'ready', reachable: true, detected: true });
 
     expect(fetcher.mock.calls.map(([input]) => new URL(String(input)).pathname)).toEqual([
       '/v1/models',
@@ -47,7 +47,7 @@ describe('local model endpoint probing', () => {
       model: 'qwen3',
       strategy: { kind: 'ollama' },
       fetch: fetcher as typeof fetch,
-    })).resolves.toEqual({ status: 'ready', reachable: true });
+    })).resolves.toEqual({ status: 'ready', reachable: true, detected: true });
     expect(fetcher).toHaveBeenCalledOnce();
   });
 
@@ -60,7 +60,7 @@ describe('local model endpoint probing', () => {
     await expect(probeLocalModelEndpoint({
       ...DEFAULT_OPTIONS,
       fetch: fetcher as typeof fetch,
-    })).resolves.toEqual({ status: 'ready', reachable: true });
+    })).resolves.toEqual({ status: 'ready', reachable: true, detected: true });
     expect(fetcher).toHaveBeenCalledOnce();
   });
 
@@ -73,7 +73,7 @@ describe('local model endpoint probing', () => {
     await expect(probeLocalModelEndpoint({
       ...DEFAULT_OPTIONS,
       fetch: fetcher as typeof fetch,
-    })).resolves.toEqual({ status: 'ready', reachable: true });
+    })).resolves.toEqual({ status: 'ready', reachable: true, detected: true });
     expect(fetcher).toHaveBeenCalledOnce();
   });
 
@@ -87,7 +87,7 @@ describe('local model endpoint probing', () => {
     await expect(probeLocalModelEndpoint({
       ...DEFAULT_OPTIONS,
       fetch: fetcher as typeof fetch,
-    })).resolves.toEqual({ status: 'ready', reachable: true });
+    })).resolves.toEqual({ status: 'ready', reachable: true, detected: true });
     expect(fetcher.mock.calls.map(([input]) => new URL(String(input)).pathname))
       .toEqual(['/v1/models', '/health']);
   });
@@ -107,6 +107,7 @@ describe('local model endpoint probing', () => {
     })).resolves.toEqual({
       status: 'not-ready',
       reachable: true,
+      detected: true,
       error: expect.stringContaining("Configured model 'qwen3:8b' is not listed"),
     });
     expect(fetcher).toHaveBeenCalledOnce();
@@ -125,7 +126,7 @@ describe('local model endpoint probing', () => {
       ...DEFAULT_OPTIONS,
       strategy: { kind: 'llama.cpp' },
       fetch: fetcher as typeof fetch,
-    })).resolves.toEqual({ status: 'ready', reachable: true });
+    })).resolves.toEqual({ status: 'ready', reachable: true, detected: true });
     expect(fetcher).toHaveBeenCalledOnce();
   });
 
@@ -148,6 +149,7 @@ describe('local model endpoint probing', () => {
     })).resolves.toEqual({
       status: 'not-ready',
       reachable: true,
+      detected: true,
       error: expect.stringContaining('does not report the configured model as loaded'),
     });
     expect(fetcher.mock.calls.map(([input]) => new URL(String(input)).pathname))
@@ -170,7 +172,7 @@ describe('local model endpoint probing', () => {
       ...DEFAULT_OPTIONS,
       strategy: { kind: 'llama.cpp' },
       fetch: fetcher as typeof fetch,
-    })).resolves.toEqual({ status: 'ready', reachable: true });
+    })).resolves.toEqual({ status: 'ready', reachable: true, detected: true });
     expect(fetcher.mock.calls.map(([input]) => new URL(String(input)).pathname))
       .toEqual(['/v1/models', '/health']);
   });
@@ -186,20 +188,14 @@ describe('local model endpoint probing', () => {
       ...DEFAULT_OPTIONS,
       strategy: { kind: 'llama.cpp' },
       fetch: fetcher as typeof fetch,
-    })).resolves.toEqual({ status: 'ready', reachable: true });
+    })).resolves.toEqual({ status: 'ready', reachable: true, detected: true });
   });
 
-  it.each([
-    ['a non-ok payload', () => Response.json({ status: 'loading' })],
-    ['malformed JSON', () => new Response('<html>ok</html>', {
-      status: 200,
-      headers: { 'content-type': 'text/html' },
-    })],
-  ])('rejects %s from the llama.cpp health fallback', async (_label, healthResponse) => {
+  it('keeps a recognized but non-ready llama.cpp health response detected', async () => {
     const fetcher = vi.fn(async (input: string | URL | Request) => {
       const url = String(input);
       if (url.endsWith('/v1/models')) return new Response('not found', { status: 404 });
-      return healthResponse();
+      return Response.json({ status: 'loading' });
     });
 
     await expect(probeLocalModelEndpoint({
@@ -209,8 +205,47 @@ describe('local model endpoint probing', () => {
     })).resolves.toEqual({
       status: 'not-ready',
       reachable: true,
+      detected: true,
       error: expect.stringContaining('health fallback'),
     });
+  });
+
+  it('classifies an invalid health response as an incompatible HTTP service', async () => {
+    const fetcher = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/v1/models')) return new Response('not found', { status: 404 });
+      return new Response('<html>ok</html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      });
+    });
+
+    await expect(probeLocalModelEndpoint({
+      ...DEFAULT_OPTIONS,
+      strategy: { kind: 'llama.cpp' },
+      fetch: fetcher as typeof fetch,
+    })).resolves.toEqual({
+      status: 'not-ready',
+      reachable: true,
+      detected: false,
+      error: expect.stringContaining('No compatible local LLM server was detected'),
+    });
+  });
+
+  it('does not detect an unrelated HTTP service that returns 404 for both probes', async () => {
+    const fetcher = vi.fn(async () => new Response('not found', { status: 404 }));
+
+    await expect(probeLocalModelEndpoint({
+      ...DEFAULT_OPTIONS,
+      fetch: fetcher as typeof fetch,
+    })).resolves.toEqual({
+      status: 'not-ready',
+      reachable: true,
+      detected: false,
+      error: expect.stringContaining('No compatible local LLM server was detected'),
+    });
+    expect(fetcher.mock.calls.map(([input]) => new URL(String(input)).pathname))
+      .toEqual(['/v1/models', '/health']);
   });
 
   it('returns structured offline availability for a malformed endpoint URL', async () => {
@@ -222,6 +257,7 @@ describe('local model endpoint probing', () => {
     })).resolves.toEqual({
       status: 'offline',
       reachable: false,
+      detected: false,
       error: expect.stringContaining('endpoint configuration is invalid'),
     });
     expect(fetcher).not.toHaveBeenCalled();
@@ -238,6 +274,7 @@ describe('local model endpoint probing', () => {
     })).resolves.toEqual({
       status: 'offline',
       reachable: false,
+      detected: false,
       error: expect.stringContaining('Local LLM server is offline'),
     });
   });

--- a/packages/local-llm/test/model-endpoint.test.ts
+++ b/packages/local-llm/test/model-endpoint.test.ts
@@ -19,13 +19,13 @@ describe('local model endpoint probing', () => {
       chatCompletionsUrl: 'http://127.0.0.1:8080/v1/chat/completions?ignored=yes',
       strategy: { kind: 'llama.cpp' },
       fetch: fetcher as typeof fetch,
-    })).resolves.toEqual({ status: 'ready', reachable: true, detected: true });
+    })).resolves.toEqual({ status: 'ready' });
     await expect(probeLocalModelEndpoint({
       ...DEFAULT_OPTIONS,
       chatCompletionsUrl: 'http://localhost:9000/proxy/v1/chat/completions#ignored',
       strategy: { kind: 'llama.cpp' },
       fetch: fetcher as typeof fetch,
-    })).resolves.toEqual({ status: 'ready', reachable: true, detected: true });
+    })).resolves.toEqual({ status: 'ready' });
 
     expect(fetcher.mock.calls.map(([input]) => new URL(String(input)).pathname)).toEqual([
       '/v1/models',
@@ -47,7 +47,7 @@ describe('local model endpoint probing', () => {
       model: 'qwen3',
       strategy: { kind: 'ollama' },
       fetch: fetcher as typeof fetch,
-    })).resolves.toEqual({ status: 'ready', reachable: true, detected: true });
+    })).resolves.toEqual({ status: 'ready' });
     expect(fetcher).toHaveBeenCalledOnce();
   });
 
@@ -60,7 +60,7 @@ describe('local model endpoint probing', () => {
     await expect(probeLocalModelEndpoint({
       ...DEFAULT_OPTIONS,
       fetch: fetcher as typeof fetch,
-    })).resolves.toEqual({ status: 'ready', reachable: true, detected: true });
+    })).resolves.toEqual({ status: 'ready' });
     expect(fetcher).toHaveBeenCalledOnce();
   });
 
@@ -73,7 +73,7 @@ describe('local model endpoint probing', () => {
     await expect(probeLocalModelEndpoint({
       ...DEFAULT_OPTIONS,
       fetch: fetcher as typeof fetch,
-    })).resolves.toEqual({ status: 'ready', reachable: true, detected: true });
+    })).resolves.toEqual({ status: 'ready' });
     expect(fetcher).toHaveBeenCalledOnce();
   });
 
@@ -87,7 +87,7 @@ describe('local model endpoint probing', () => {
     await expect(probeLocalModelEndpoint({
       ...DEFAULT_OPTIONS,
       fetch: fetcher as typeof fetch,
-    })).resolves.toEqual({ status: 'ready', reachable: true, detected: true });
+    })).resolves.toEqual({ status: 'ready' });
     expect(fetcher.mock.calls.map(([input]) => new URL(String(input)).pathname))
       .toEqual(['/v1/models', '/health']);
   });
@@ -106,8 +106,6 @@ describe('local model endpoint probing', () => {
       fetch: fetcher as typeof fetch,
     })).resolves.toEqual({
       status: 'not-ready',
-      reachable: true,
-      detected: true,
       error: expect.stringContaining("Configured model 'qwen3:8b' is not listed"),
     });
     expect(fetcher).toHaveBeenCalledOnce();
@@ -126,7 +124,7 @@ describe('local model endpoint probing', () => {
       ...DEFAULT_OPTIONS,
       strategy: { kind: 'llama.cpp' },
       fetch: fetcher as typeof fetch,
-    })).resolves.toEqual({ status: 'ready', reachable: true, detected: true });
+    })).resolves.toEqual({ status: 'ready' });
     expect(fetcher).toHaveBeenCalledOnce();
   });
 
@@ -148,8 +146,6 @@ describe('local model endpoint probing', () => {
       fetch: fetcher as typeof fetch,
     })).resolves.toEqual({
       status: 'not-ready',
-      reachable: true,
-      detected: true,
       error: expect.stringContaining('does not report the configured model as loaded'),
     });
     expect(fetcher.mock.calls.map(([input]) => new URL(String(input)).pathname))
@@ -172,7 +168,7 @@ describe('local model endpoint probing', () => {
       ...DEFAULT_OPTIONS,
       strategy: { kind: 'llama.cpp' },
       fetch: fetcher as typeof fetch,
-    })).resolves.toEqual({ status: 'ready', reachable: true, detected: true });
+    })).resolves.toEqual({ status: 'ready' });
     expect(fetcher.mock.calls.map(([input]) => new URL(String(input)).pathname))
       .toEqual(['/v1/models', '/health']);
   });
@@ -188,7 +184,7 @@ describe('local model endpoint probing', () => {
       ...DEFAULT_OPTIONS,
       strategy: { kind: 'llama.cpp' },
       fetch: fetcher as typeof fetch,
-    })).resolves.toEqual({ status: 'ready', reachable: true, detected: true });
+    })).resolves.toEqual({ status: 'ready' });
   });
 
   it('keeps a recognized but non-ready llama.cpp health response detected', async () => {
@@ -204,9 +200,43 @@ describe('local model endpoint probing', () => {
       fetch: fetcher as typeof fetch,
     })).resolves.toEqual({
       status: 'not-ready',
-      reachable: true,
-      detected: true,
-      error: expect.stringContaining('health fallback'),
+      error: expect.stringContaining('model is still loading'),
+    });
+  });
+
+  it('recognizes llama.cpp documented 503 response while a model is loading', async () => {
+    const fetcher = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/v1/models')) return new Response('not found', { status: 404 });
+      return Response.json({
+        error: { code: 503, message: 'Loading model', type: 'unavailable_error' },
+      }, { status: 503 });
+    });
+
+    await expect(probeLocalModelEndpoint({
+      ...DEFAULT_OPTIONS,
+      strategy: { kind: 'llama.cpp' },
+      fetch: fetcher as typeof fetch,
+    })).resolves.toEqual({
+      status: 'not-ready',
+      error: expect.stringContaining('Loading model'),
+    });
+  });
+
+  it('does not treat an arbitrary string health status as llama.cpp detection', async () => {
+    const fetcher = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/v1/models')) return new Response('not found', { status: 404 });
+      return Response.json({ status: 'healthy' });
+    });
+
+    await expect(probeLocalModelEndpoint({
+      ...DEFAULT_OPTIONS,
+      strategy: { kind: 'llama.cpp' },
+      fetch: fetcher as typeof fetch,
+    })).resolves.toEqual({
+      status: 'incompatible',
+      error: expect.stringContaining('No compatible local LLM server was detected'),
     });
   });
 
@@ -225,9 +255,7 @@ describe('local model endpoint probing', () => {
       strategy: { kind: 'llama.cpp' },
       fetch: fetcher as typeof fetch,
     })).resolves.toEqual({
-      status: 'not-ready',
-      reachable: true,
-      detected: false,
+      status: 'incompatible',
       error: expect.stringContaining('No compatible local LLM server was detected'),
     });
   });
@@ -239,9 +267,7 @@ describe('local model endpoint probing', () => {
       ...DEFAULT_OPTIONS,
       fetch: fetcher as typeof fetch,
     })).resolves.toEqual({
-      status: 'not-ready',
-      reachable: true,
-      detected: false,
+      status: 'incompatible',
       error: expect.stringContaining('No compatible local LLM server was detected'),
     });
     expect(fetcher.mock.calls.map(([input]) => new URL(String(input)).pathname))
@@ -256,8 +282,6 @@ describe('local model endpoint probing', () => {
       fetch: fetcher as typeof fetch,
     })).resolves.toEqual({
       status: 'offline',
-      reachable: false,
-      detected: false,
       error: expect.stringContaining('endpoint configuration is invalid'),
     });
     expect(fetcher).not.toHaveBeenCalled();
@@ -273,8 +297,6 @@ describe('local model endpoint probing', () => {
       fetch: fetcher as typeof fetch,
     })).resolves.toEqual({
       status: 'offline',
-      reachable: false,
-      detected: false,
       error: expect.stringContaining('Local LLM server is offline'),
     });
   });

--- a/packages/local-llm/test/model-endpoint.test.ts
+++ b/packages/local-llm/test/model-endpoint.test.ts
@@ -187,7 +187,7 @@ describe('local model endpoint probing', () => {
     })).resolves.toEqual({ status: 'ready' });
   });
 
-  it('keeps a recognized but non-ready llama.cpp health response detected', async () => {
+  it('does not treat a generic string health status as llama.cpp detection', async () => {
     const fetcher = vi.fn(async (input: string | URL | Request) => {
       const url = String(input);
       if (url.endsWith('/v1/models')) return new Response('not found', { status: 404 });
@@ -199,8 +199,8 @@ describe('local model endpoint probing', () => {
       strategy: { kind: 'llama.cpp' },
       fetch: fetcher as typeof fetch,
     })).resolves.toEqual({
-      status: 'not-ready',
-      error: expect.stringContaining('model is still loading'),
+      status: 'incompatible',
+      error: expect.stringContaining('No compatible local LLM server was detected'),
     });
   });
 

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1962,6 +1962,7 @@ export type LocalAgentChannelTarget = 'bridge' | 'gateway';
 export interface LocalAgentHealthResponse {
   ok: boolean;
   configured?: boolean;
+  detected?: boolean;
   ready?: boolean;
   reachable?: boolean;
   offline?: boolean;
@@ -2818,9 +2819,12 @@ async function mapLocalAgentIntegrationRecord(
     : null;
   // The daemon-owned integration exists in the registry on every node. Keep it
   // out of the UI when the operator supplied no local-LLM configuration and
-  // the conventional local endpoint was not auto-detected. An explicit but
-  // temporarily offline configuration remains visible so its error is useful.
-  if (id === 'local-llm' && health?.configured === false && health.reachable !== true) {
+  // the conventional local endpoint was not recognized as a supported backend.
+  // An explicit but temporarily unavailable configuration remains visible so
+  // its error is useful. `ready` is the safe fallback for v10.0.16 daemons,
+  // which did not expose `detected` and treated any HTTP response as reachable.
+  const localLlmDetected = health?.detected ?? health?.ready === true;
+  if (id === 'local-llm' && health?.configured === false && !localLlmDetected) {
     return null;
   }
   const degraded = isDegradedLocalAgentHealth(runtimeStatus, health);
@@ -2926,7 +2930,7 @@ async function mapLocalAgentIntegrationRecord(
     chatAttachments,
     connectSupported,
     configured,
-    detected: configured || chatReady,
+    detected: configured || health?.detected === true || chatReady,
     persistentChat,
     chatReady,
     bridgeOnline,

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -2306,8 +2306,23 @@ interface LocalLlmChatWireResponse {
   readOnly: true;
 }
 
-export const fetchLocalLlmHealth = () =>
-  get<LocalAgentHealthResponse>('/api/local-llm/health');
+interface LocalLlmHealthWireResponse extends Omit<LocalAgentHealthResponse, 'detected'> {
+  detected?: boolean;
+}
+
+function normalizeLocalLlmHealth(
+  health: LocalLlmHealthWireResponse,
+): LocalAgentHealthResponse & { detected: boolean } {
+  return {
+    ...health,
+    // v10.0.16 daemons did not expose detection separately. Their ready bit is
+    // the only positive evidence that the conventional endpoint was compatible.
+    detected: typeof health.detected === 'boolean' ? health.detected : health.ready === true,
+  };
+}
+
+export const fetchLocalLlmHealth = async () =>
+  normalizeLocalLlmHealth(await get<LocalLlmHealthWireResponse>('/api/local-llm/health'));
 
 export async function sendLocalLlmChat(
   text: string,
@@ -2518,6 +2533,9 @@ interface LocalAgentSurface {
     profile?: string;
   }) => Record<string, unknown>;
   fetchHealth?: () => Promise<LocalAgentHealthResponse>;
+  isVisible?: (args: {
+    health: LocalAgentHealthResponse | null;
+  }) => boolean;
   streamChat?: typeof streamOpenClawLocalChat;
 }
 
@@ -2528,6 +2546,13 @@ const LOCAL_AGENT_SURFACES: Record<string, LocalAgentSurface> = {
     defaultSessionId: () => 'local-llm:dkg-ui',
     resolveChatContext: () => ({}),
     fetchHealth: fetchLocalLlmHealth,
+    // Keep an explicitly configured endpoint visible even while unavailable.
+    // For convention-based discovery, show only a backend the daemon recognized.
+    isVisible: ({ health }) => (
+      health === null
+      || health.configured !== false
+      || health.detected === true
+    ),
     streamChat: streamLocalLlmChat,
   },
   openclaw: {
@@ -2817,14 +2842,7 @@ async function mapLocalAgentIntegrationRecord(
   const health = configured && hasChatBridge && surface?.fetchHealth
     ? normalizeLocalAgentHealth(await surface.fetchHealth().catch(() => null))
     : null;
-  // The daemon-owned integration exists in the registry on every node. Keep it
-  // out of the UI when the operator supplied no local-LLM configuration and
-  // the conventional local endpoint was not recognized as a supported backend.
-  // An explicit but temporarily unavailable configuration remains visible so
-  // its error is useful. `ready` is the safe fallback for v10.0.16 daemons,
-  // which did not expose `detected` and treated any HTTP response as reachable.
-  const localLlmDetected = health?.detected ?? health?.ready === true;
-  if (id === 'local-llm' && health?.configured === false && !localLlmDetected) {
+  if (surface?.isVisible?.({ health }) === false) {
     return null;
   }
   const degraded = isDegradedLocalAgentHealth(runtimeStatus, health);

--- a/packages/node-ui/test/local-llm-ui.test.ts
+++ b/packages/node-ui/test/local-llm-ui.test.ts
@@ -79,11 +79,59 @@ describe('DKG Local LLM Node UI surface', () => {
         return json({
           ok: false,
           configured: false,
+          detected: false,
           ready: false,
           reachable: false,
           offline: true,
           readOnly: true,
           error: 'Local LLM server is offline: fetch failed',
+        });
+      }
+      return json({ error: `Unexpected request: ${url}` }, 500);
+    }) as typeof globalThis.fetch;
+
+    await expect(fetchLocalAgentIntegrations()).resolves.toEqual({ integrations: [] });
+  });
+
+  it('hides an unrelated HTTP service on the default Local LLM port', async () => {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/api/local-agent-integrations')) {
+        return json({ integrations: [localLlmRecord()] });
+      }
+      if (url.endsWith('/api/local-llm/health')) {
+        return json({
+          ok: false,
+          configured: false,
+          detected: false,
+          ready: false,
+          reachable: true,
+          offline: false,
+          readOnly: true,
+          error: 'No compatible local LLM server was detected',
+        });
+      }
+      return json({ error: `Unexpected request: ${url}` }, 500);
+    }) as typeof globalThis.fetch;
+
+    await expect(fetchLocalAgentIntegrations()).resolves.toEqual({ integrations: [] });
+  });
+
+  it('hides the same false positive from a v10.0.16 daemon without detected health', async () => {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/api/local-agent-integrations')) {
+        return json({ integrations: [localLlmRecord()] });
+      }
+      if (url.endsWith('/api/local-llm/health')) {
+        return json({
+          ok: false,
+          configured: false,
+          ready: false,
+          reachable: true,
+          offline: false,
+          readOnly: true,
+          error: 'Local LLM server is reachable but not ready',
         });
       }
       return json({ error: `Unexpected request: ${url}` }, 500);
@@ -102,6 +150,7 @@ describe('DKG Local LLM Node UI surface', () => {
         return json({
           ok: true,
           configured: false,
+          detected: true,
           ready: true,
           reachable: true,
           offline: false,
@@ -117,6 +166,37 @@ describe('DKG Local LLM Node UI surface', () => {
       id: 'local-llm',
       chatReady: true,
       status: 'chat_ready',
+    });
+  });
+
+  it('shows an auto-detected Local LLM while its model is still loading', async () => {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/api/local-agent-integrations')) {
+        return json({ integrations: [localLlmRecord()] });
+      }
+      if (url.endsWith('/api/local-llm/health')) {
+        return json({
+          ok: false,
+          configured: false,
+          detected: true,
+          ready: false,
+          reachable: true,
+          offline: false,
+          readOnly: true,
+          error: 'llama.cpp model is still loading',
+        });
+      }
+      return json({ error: `Unexpected request: ${url}` }, 500);
+    }) as typeof globalThis.fetch;
+
+    const { integrations } = await fetchLocalAgentIntegrations();
+    expect(integrations).toHaveLength(1);
+    expect(integrations[0]).toMatchObject({
+      id: 'local-llm',
+      detected: true,
+      chatReady: false,
+      error: 'llama.cpp model is still loading',
     });
   });
 


### PR DESCRIPTION
## Summary

- distinguish HTTP reachability from detecting a supported llama.cpp or Ollama endpoint
- hide the daemon-owned Local LLM UI entry when the default port belongs to an unrelated service
- keep explicitly configured endpoints and detected-but-loading local models visible
- retain a frontend fallback for v10.0.16 daemons that do not expose the new detection signal

## Validation

- `pnpm run build`
- `pnpm run lint`
- `pnpm exec vitest run test/model-endpoint.test.ts` (15 tests)
- `pnpm exec vitest run --config vitest.unit.config.ts test/daemon-local-llm-service.test.ts` (22 tests)
- `pnpm exec vitest run test/local-llm-ui.test.ts` (9 tests)