### PR TITLE
fix(chain): persist authority history checkpoints

### DIFF
--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -56,7 +56,7 @@ import type {
 import type {
   ApprovalPolicy,
   ChainAdapter,
-  TrustedContextGraphAuthorityHistoryStore,
+  ContextGraphAuthorityHistoryStore,
   ContextGraphRegistryScanCursorStore,
 } from '@origintrail-official/dkg-chain';
 import type { QueryAccessConfig } from '@origintrail-official/dkg-query';
@@ -1894,8 +1894,8 @@ export interface DKGAgentConfig {
   chainEventCursorStore?: ChainEventCursorPersistence;
   /** Durable ContextGraphNameRegistry discovery cursor store. Defaults to in-memory adapter state. */
   contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStore;
-  /** Durable finalized Context Graph authority-history checkpoints. */
-  contextGraphAuthorityHistoryStore?: TrustedContextGraphAuthorityHistoryStore;
+  /** Process-owned local durable finalized Context Graph authority-history checkpoints. */
+  localContextGraphAuthorityHistoryStore?: ContextGraphAuthorityHistoryStore;
   /**
    * Intentional cap on how many persisted context-graph subscriptions are
    * *activated* (gossip-subscribed + sync-tracked) when rehydrating at startup.

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -56,7 +56,7 @@ import type {
 import type {
   ApprovalPolicy,
   ChainAdapter,
-  ContextGraphAuthorityHistoryStore,
+  TrustedContextGraphAuthorityHistoryStore,
   ContextGraphRegistryScanCursorStore,
 } from '@origintrail-official/dkg-chain';
 import type { QueryAccessConfig } from '@origintrail-official/dkg-query';
@@ -1895,7 +1895,7 @@ export interface DKGAgentConfig {
   /** Durable ContextGraphNameRegistry discovery cursor store. Defaults to in-memory adapter state. */
   contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStore;
   /** Durable finalized Context Graph authority-history checkpoints. */
-  contextGraphAuthorityHistoryStore?: ContextGraphAuthorityHistoryStore;
+  contextGraphAuthorityHistoryStore?: TrustedContextGraphAuthorityHistoryStore;
   /**
    * Intentional cap on how many persisted context-graph subscriptions are
    * *activated* (gossip-subscribed + sync-tracked) when rehydrating at startup.

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -53,7 +53,12 @@ import type {
   WorkspacePublicSnapshotStore,
   CursorPersistence as ChainEventCursorPersistence,
 } from '@origintrail-official/dkg-publisher';
-import type { ApprovalPolicy, ChainAdapter, ContextGraphRegistryScanCursorStore } from '@origintrail-official/dkg-chain';
+import type {
+  ApprovalPolicy,
+  ChainAdapter,
+  ContextGraphAuthorityHistoryStore,
+  ContextGraphRegistryScanCursorStore,
+} from '@origintrail-official/dkg-chain';
 import type { QueryAccessConfig } from '@origintrail-official/dkg-query';
 import type { SkillHandler } from './messaging.js';
 import type { CclFactResolutionMode } from './ccl-fact-resolution.js';
@@ -1889,6 +1894,8 @@ export interface DKGAgentConfig {
   chainEventCursorStore?: ChainEventCursorPersistence;
   /** Durable ContextGraphNameRegistry discovery cursor store. Defaults to in-memory adapter state. */
   contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStore;
+  /** Durable finalized Context Graph authority-history checkpoints. */
+  contextGraphAuthorityHistoryStore?: ContextGraphAuthorityHistoryStore;
   /**
    * Intentional cap on how many persisted context-graph subscriptions are
    * *activated* (gossip-subscribed + sync-tracked) when rehydrating at startup.

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -755,6 +755,7 @@ function constructConfiguredChainAdapter(
       minPublisherNativeWei: config.chainConfig.minPublisherNativeWei,
       minPublisherTracWei: config.chainConfig.minPublisherTracWei,
       contextGraphRegistryScanCursorStore: config.contextGraphRegistryScanCursorStore,
+      contextGraphAuthorityHistoryStore: config.contextGraphAuthorityHistoryStore,
     };
     const chain = config.chainConfig.adminPrivateKey
       ? new EVMChainAdapter({ ...evmConfigBase, adminPrivateKey: config.chainConfig.adminPrivateKey })

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -755,7 +755,7 @@ function constructConfiguredChainAdapter(
       minPublisherNativeWei: config.chainConfig.minPublisherNativeWei,
       minPublisherTracWei: config.chainConfig.minPublisherTracWei,
       contextGraphRegistryScanCursorStore: config.contextGraphRegistryScanCursorStore,
-      contextGraphAuthorityHistoryStore: config.contextGraphAuthorityHistoryStore,
+      localContextGraphAuthorityHistoryStore: config.localContextGraphAuthorityHistoryStore,
     };
     const chain = config.chainConfig.adminPrivateKey
       ? new EVMChainAdapter({ ...evmConfigBase, adminPrivateKey: config.chainConfig.adminPrivateKey })

--- a/packages/agent/src/rfc64/catalog-authority-config-v1.ts
+++ b/packages/agent/src/rfc64/catalog-authority-config-v1.ts
@@ -37,7 +37,11 @@ const RFC64_CATALOG_AUTHORITY_REFRESH_INTERVAL_MS_V1 = 5 * 60_000;
 export const RFC64_CATALOG_AUTHORITY_REFRESH_POLICY_V1 = Object.freeze({
   intervalMs: RFC64_CATALOG_AUTHORITY_REFRESH_INTERVAL_MS_V1,
   freshnessIntervalCount: 4,
-  maxConcurrentReads: 4,
+  // A brand-new node has no durable authority checkpoints yet. Keep the first
+  // historical walks serial so one restart cannot fan four graphs × six event
+  // filters into the RPC simultaneously. Warm suffix reads stay cheap because
+  // the finalized checkpoints below are reused across process restarts.
+  maxConcurrentReads: 1,
 });
 
 /**

--- a/packages/agent/src/rfc64/catalog-authority-config-v1.ts
+++ b/packages/agent/src/rfc64/catalog-authority-config-v1.ts
@@ -37,11 +37,7 @@ const RFC64_CATALOG_AUTHORITY_REFRESH_INTERVAL_MS_V1 = 5 * 60_000;
 export const RFC64_CATALOG_AUTHORITY_REFRESH_POLICY_V1 = Object.freeze({
   intervalMs: RFC64_CATALOG_AUTHORITY_REFRESH_INTERVAL_MS_V1,
   freshnessIntervalCount: 4,
-  // A brand-new node has no durable authority checkpoints yet. Keep graph
-  // histories serial (the chain cache also serializes their cold event streams)
-  // so one restart cannot fan four graphs × six filters into the RPC. Warm
-  // suffix reads stay cheap because finalized checkpoints survive restarts.
-  maxConcurrentReads: 1,
+  maxConcurrentReads: 4,
 });
 
 /**

--- a/packages/agent/src/rfc64/catalog-authority-config-v1.ts
+++ b/packages/agent/src/rfc64/catalog-authority-config-v1.ts
@@ -37,10 +37,10 @@ const RFC64_CATALOG_AUTHORITY_REFRESH_INTERVAL_MS_V1 = 5 * 60_000;
 export const RFC64_CATALOG_AUTHORITY_REFRESH_POLICY_V1 = Object.freeze({
   intervalMs: RFC64_CATALOG_AUTHORITY_REFRESH_INTERVAL_MS_V1,
   freshnessIntervalCount: 4,
-  // A brand-new node has no durable authority checkpoints yet. Keep the first
-  // historical walks serial so one restart cannot fan four graphs × six event
-  // filters into the RPC simultaneously. Warm suffix reads stay cheap because
-  // the finalized checkpoints below are reused across process restarts.
+  // A brand-new node has no durable authority checkpoints yet. Keep graph
+  // histories serial (the chain cache also serializes their cold event streams)
+  // so one restart cannot fan four graphs × six filters into the RPC. Warm
+  // suffix reads stay cheap because finalized checkpoints survive restarts.
   maxConcurrentReads: 1,
 });
 

--- a/packages/agent/test/chain-cursor-wiring.test.ts
+++ b/packages/agent/test/chain-cursor-wiring.test.ts
@@ -18,6 +18,11 @@ describe('DKGAgent chain cursor wiring', () => {
       load: vi.fn(async () => undefined),
       save: vi.fn(async () => {}),
     };
+    const authorityHistoryStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+      delete: vi.fn(async () => {}),
+    };
 
     agent = await DKGAgent.create({
       name: 'RegistryCursorWiring',
@@ -32,9 +37,11 @@ describe('DKGAgent chain cursor wiring', () => {
         minPublisherTracWei: 456n,
       },
       contextGraphRegistryScanCursorStore: registryCursorStore,
+      contextGraphAuthorityHistoryStore: authorityHistoryStore,
     });
 
     expect((agent as any).chain.contextGraphRegistryScanCursor?.input?.store).toBe(registryCursorStore);
+    expect((agent as any).chain.contextGraphAuthorityHistory?.store).toBe(authorityHistoryStore);
     expect((agent as any).chain.minPublisherNativeWei).toBe(123n);
     expect((agent as any).chain.minPublisherTracWei).toBe(456n);
     expect((agent as any).chain.receiptTimeoutMs).toBe(1_200_000);

--- a/packages/agent/test/chain-cursor-wiring.test.ts
+++ b/packages/agent/test/chain-cursor-wiring.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import {
+  MockChainAdapter,
+  trustContextGraphAuthorityHistoryStore,
+} from '@origintrail-official/dkg-chain';
 import { DKGAgent } from '../src/index.js';
 
 const OPERATIONAL_KEY =
@@ -37,7 +40,9 @@ describe('DKGAgent chain cursor wiring', () => {
         minPublisherTracWei: 456n,
       },
       contextGraphRegistryScanCursorStore: registryCursorStore,
-      contextGraphAuthorityHistoryStore: authorityHistoryStore,
+      contextGraphAuthorityHistoryStore: trustContextGraphAuthorityHistoryStore(
+        authorityHistoryStore,
+      ),
     });
 
     expect((agent as any).chain.contextGraphRegistryScanCursor?.input?.store).toBe(registryCursorStore);

--- a/packages/agent/test/chain-cursor-wiring.test.ts
+++ b/packages/agent/test/chain-cursor-wiring.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   MockChainAdapter,
-  trustContextGraphAuthorityHistoryStore,
 } from '@origintrail-official/dkg-chain';
 import { DKGAgent } from '../src/index.js';
 
@@ -40,13 +39,11 @@ describe('DKGAgent chain cursor wiring', () => {
         minPublisherTracWei: 456n,
       },
       contextGraphRegistryScanCursorStore: registryCursorStore,
-      contextGraphAuthorityHistoryStore: trustContextGraphAuthorityHistoryStore(
-        authorityHistoryStore,
-      ),
+      localContextGraphAuthorityHistoryStore: authorityHistoryStore,
     });
 
     expect((agent as any).chain.contextGraphRegistryScanCursor?.input?.store).toBe(registryCursorStore);
-    expect((agent as any).chain.contextGraphAuthorityHistory?.store).toBe(authorityHistoryStore);
+    expect((agent as any).chain.contextGraphAuthorityHistory?.localStore).toBe(authorityHistoryStore);
     expect((agent as any).chain.minPublisherNativeWei).toBe(123n);
     expect((agent as any).chain.minPublisherTracWei).toBe(456n);
     expect((agent as any).chain.receiptTimeoutMs).toBe(1_200_000);

--- a/packages/agent/test/rfc64-catalog-authority-refresh-loop-v1.test.ts
+++ b/packages/agent/test/rfc64-catalog-authority-refresh-loop-v1.test.ts
@@ -233,9 +233,9 @@ describe('RFC-64 catalog authority refresh loop', () => {
     await closing;
   });
 
-  it('serializes production authority reads by default to bound cold-start RPC load', async () => {
+  it('uses the production four-read concurrency cap by default', async () => {
     const limit = RFC64_CATALOG_AUTHORITY_REFRESH_POLICY_V1.maxConcurrentReads;
-    expect(limit).toBe(1);
+    expect(limit).toBe(4);
     const contextGraphIds = Array.from(
       { length: limit + 1 },
       (_, index) => `cg-${index + 1}`,

--- a/packages/agent/test/rfc64-catalog-authority-refresh-loop-v1.test.ts
+++ b/packages/agent/test/rfc64-catalog-authority-refresh-loop-v1.test.ts
@@ -233,9 +233,9 @@ describe('RFC-64 catalog authority refresh loop', () => {
     await closing;
   });
 
-  it('uses the production four-read concurrency cap by default', async () => {
+  it('serializes production authority reads by default to bound cold-start RPC load', async () => {
     const limit = RFC64_CATALOG_AUTHORITY_REFRESH_POLICY_V1.maxConcurrentReads;
-    expect(limit).toBe(4);
+    expect(limit).toBe(1);
     const contextGraphIds = Array.from(
       { length: limit + 1 },
       (_, index) => `cg-${index + 1}`,
@@ -265,10 +265,10 @@ describe('RFC-64 catalog authority refresh loop', () => {
     await Promise.all(started.slice(0, limit));
     expect(attempts).toEqual(contextGraphIds.slice(0, limit));
 
-    let fifthStarted = false;
-    void started[limit]!.then(() => { fifthStarted = true; });
+    let nextStarted = false;
+    void started[limit]!.then(() => { nextStarted = true; });
     await Promise.resolve();
-    expect(fifthStarted).toBe(false);
+    expect(nextStarted).toBe(false);
 
     releases[0]!();
     await started[limit];

--- a/packages/chain/src/context-graph-authority-history.ts
+++ b/packages/chain/src/context-graph-authority-history.ts
@@ -353,7 +353,16 @@ async function loadContextGraphAuthorityHistory(
     for (let lo = fromBlock; lo <= input.finalized.number; lo += input.pageSize) {
       input.signal?.throwIfAborted();
       const hi = Math.min(lo + input.pageSize - 1, input.finalized.number);
-      events.push(...await input.readEvents({ name, contextGraphId: input.contextGraphId }, lo, hi));
+      events.push(...await readAuthorityHistoryRange(
+        (rangeFrom, rangeTo) => input.readEvents(
+          { name, contextGraphId: input.contextGraphId },
+          rangeFrom,
+          rangeTo,
+        ),
+        lo,
+        hi,
+        input.signal,
+      ));
     }
     return events;
   };
@@ -362,7 +371,16 @@ async function loadContextGraphAuthorityHistory(
     for (let lo = fromBlock; lo <= input.finalized.number; lo += input.pageSize) {
       input.signal?.throwIfAborted();
       const hi = Math.min(lo + input.pageSize - 1, input.finalized.number);
-      events.push(...await input.readCreationEvents(input.contextGraphId, lo, hi));
+      events.push(...await readAuthorityHistoryRange(
+        (rangeFrom, rangeTo) => input.readCreationEvents(
+          input.contextGraphId,
+          rangeFrom,
+          rangeTo,
+        ),
+        lo,
+        hi,
+        input.signal,
+      ));
     }
     return events;
   };
@@ -433,4 +451,42 @@ async function loadContextGraphAuthorityHistory(
     sourceBlockNumber,
     sourceBlockHash: sourceBlockHash.toLowerCase(),
   });
+}
+
+/**
+ * Retry only provider-declared block-range limits, splitting sequentially so a
+ * 50-block fallback RPC can finish a scan configured for 200/2,000-block
+ * providers without multiplying the cold-start request burst.
+ */
+async function readAuthorityHistoryRange<T>(
+  read: (fromBlock: number, toBlock: number) => Promise<readonly T[]>,
+  fromBlock: number,
+  toBlock: number,
+  signal?: AbortSignal,
+): Promise<T[]> {
+  signal?.throwIfAborted();
+  try {
+    return [...await read(fromBlock, toBlock)];
+  } catch (err) {
+    if (fromBlock >= toBlock || !isRpcBlockRangeLimitError(err)) throw err;
+    const midpoint = fromBlock + Math.floor((toBlock - fromBlock) / 2);
+    const left = await readAuthorityHistoryRange(read, fromBlock, midpoint, signal);
+    const right = await readAuthorityHistoryRange(read, midpoint + 1, toBlock, signal);
+    return [...left, ...right];
+  }
+}
+
+function isRpcBlockRangeLimitError(err: unknown): boolean {
+  const candidate = err as {
+    message?: unknown;
+    error?: { message?: unknown };
+    info?: { error?: { message?: unknown } };
+  };
+  const message = [
+    candidate?.message,
+    candidate?.error?.message,
+    candidate?.info?.error?.message,
+  ].filter((value): value is string => typeof value === 'string').join(' ');
+  return /(?:block range too large|exceeds? (?:the )?(?:max(?:imum)? )?block range|maximum allowed is \d+ blocks|limited to (?:a )?\d+ blocks?)/i
+    .test(message);
 }

--- a/packages/chain/src/context-graph-authority-history.ts
+++ b/packages/chain/src/context-graph-authority-history.ts
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { BoundedLruCache } from '@origintrail-official/dkg-core';
+import { ethers } from 'ethers';
+import { KeyedSerializer } from './keyed-mutex.js';
 
 export const CONTEXT_GRAPH_AUTHORITY_HISTORY_MAX_ENTRIES = 1_024;
 
@@ -27,18 +29,43 @@ export interface ContextGraphAuthorityHistoryState {
   readonly sourceBlockHash: string;
 }
 
-/**
- * Optional durable backing for finalized authority-history watermarks.
- *
- * Keys are already scoped by chain deployment, ContextGraphs contract, and
- * context-graph id by the adapter. Implementations must treat values as
- * replaceable checkpoints: the cache revalidates the recorded finalized block
- * hash before using one and falls back to a cold scan on any mismatch.
- */
+export const CONTEXT_GRAPH_AUTHORITY_HISTORY_CHECKPOINT_VERSION = 1 as const;
+
+export interface ContextGraphAuthorityHistoryCheckpointV1 {
+  readonly version: typeof CONTEXT_GRAPH_AUTHORITY_HISTORY_CHECKPOINT_VERSION;
+  readonly state: ContextGraphAuthorityHistoryState;
+  /** Detects torn, stale-schema, and accidentally edited local payloads. */
+  readonly integrity: string;
+}
+
+/** Opaque persistence backend; decoding and version ownership stay in chain. */
 export interface ContextGraphAuthorityHistoryStore {
-  load(cacheKey: string): Promise<ContextGraphAuthorityHistoryState | undefined>;
-  save(cacheKey: string, state: ContextGraphAuthorityHistoryState): Promise<void>;
+  load(cacheKey: string): Promise<unknown>;
+  save(cacheKey: string, checkpoint: ContextGraphAuthorityHistoryCheckpointV1): Promise<void>;
   delete(cacheKey: string): Promise<void>;
+}
+
+declare const TRUSTED_AUTHORITY_HISTORY_STORE: unique symbol;
+
+/**
+ * Authority generations are historical aggregates and cannot be authenticated
+ * from a block hash alone. A checkpoint backend therefore belongs to the
+ * node's trusted local integrity domain; untrusted remote/shared stores must
+ * not be promoted through this interface.
+ */
+export interface TrustedContextGraphAuthorityHistoryStore
+  extends ContextGraphAuthorityHistoryStore {
+  readonly [TRUSTED_AUTHORITY_HISTORY_STORE]: true;
+}
+
+const trustedAuthorityHistoryStores = new WeakSet<object>();
+
+/** Explicitly admit a process-owned backend into the authority trust boundary. */
+export function trustContextGraphAuthorityHistoryStore<T extends ContextGraphAuthorityHistoryStore>(
+  store: T,
+): T & TrustedContextGraphAuthorityHistoryStore {
+  trustedAuthorityHistoryStores.add(store);
+  return store as T & TrustedContextGraphAuthorityHistoryStore;
 }
 
 export type ContextGraphAuthorityHistoryEventName =
@@ -81,6 +108,83 @@ export interface ContextGraphAuthorityHistoryResolution {
   publish(): Promise<void>;
 }
 
+interface ColdScanWaiter {
+  readonly cacheKey: string;
+  readonly signal?: AbortSignal;
+  readonly resolve: () => void;
+}
+
+/**
+ * One cold Context Graph history at a time, while allowing concurrent provider
+ * attempts for that same graph so failover can leave a stalled endpoint behind.
+ */
+class ContextGraphAuthorityColdScanAdmission {
+  #activeCacheKey: string | undefined;
+  #activeCount = 0;
+  readonly #waiters: ColdScanWaiter[] = [];
+
+  async run<T>(
+    cacheKey: string,
+    signal: AbortSignal | undefined,
+    read: () => Promise<T>,
+  ): Promise<T> {
+    await this.#acquire(cacheKey, signal);
+    try {
+      signal?.throwIfAborted();
+      return await read();
+    } finally {
+      this.#release();
+    }
+  }
+
+  async #acquire(cacheKey: string, signal?: AbortSignal): Promise<void> {
+    signal?.throwIfAborted();
+    if (this.#activeCacheKey === undefined || this.#activeCacheKey === cacheKey) {
+      this.#activeCacheKey = cacheKey;
+      this.#activeCount += 1;
+      return;
+    }
+    await new Promise<void>((resolve, reject) => {
+      const waiter: ColdScanWaiter = {
+        cacheKey,
+        signal,
+        resolve: () => {
+          if (signal) signal.removeEventListener('abort', abort);
+          resolve();
+        },
+      };
+      const abort = () => {
+        const index = this.#waiters.indexOf(waiter);
+        if (index >= 0) this.#waiters.splice(index, 1);
+        reject(signal?.reason ?? new DOMException('Aborted', 'AbortError'));
+      };
+      if (signal) signal.addEventListener('abort', abort, { once: true });
+      this.#waiters.push(waiter);
+    });
+  }
+
+  #release(): void {
+    this.#activeCount -= 1;
+    if (this.#activeCount > 0) return;
+    this.#activeCacheKey = undefined;
+    while (this.#waiters.length > 0) {
+      const first = this.#waiters.shift()!;
+      if (first.signal?.aborted) continue;
+      this.#activeCacheKey = first.cacheKey;
+      const admitted = [first];
+      for (let index = this.#waiters.length - 1; index >= 0; index -= 1) {
+        const waiter = this.#waiters[index]!;
+        if (waiter.cacheKey !== first.cacheKey || waiter.signal?.aborted) continue;
+        admitted.push(waiter);
+        this.#waiters.splice(index, 1);
+      }
+      this.#activeCount = admitted.length;
+      for (const waiter of admitted) waiter.resolve();
+      return;
+    }
+  }
+}
+
 /**
  * Atomic owner of finalized history loading, publication, and invalidation.
  * Same-head readers share a scan, an older completion cannot replace a newer
@@ -89,17 +193,23 @@ export interface ContextGraphAuthorityHistoryResolution {
 export class ContextGraphAuthorityHistoryCache {
   readonly #entries: BoundedLruCache<string, ContextGraphAuthorityHistoryState>;
   readonly #inflight = new Map<string, Promise<ContextGraphAuthorityHistoryState>>();
-  readonly #persistence = new Map<string, Promise<void>>();
+  readonly #persistence = new KeyedSerializer();
+  readonly #coldScans = new ContextGraphAuthorityColdScanAdmission();
   readonly #identityIds = new WeakMap<object, number>();
   #nextIdentityId = 1;
   #epoch = 0;
 
   constructor(
     readonly maxEntries: number = CONTEXT_GRAPH_AUTHORITY_HISTORY_MAX_ENTRIES,
-    readonly store?: ContextGraphAuthorityHistoryStore,
+    readonly store?: TrustedContextGraphAuthorityHistoryStore,
   ) {
     if (!Number.isSafeInteger(maxEntries) || maxEntries < 1) {
       throw new Error('Context Graph authority history cache must retain at least one entry');
+    }
+    if (store !== undefined && !trustedAuthorityHistoryStores.has(store)) {
+      throw new Error(
+        'Context Graph authority history store must be explicitly admitted as trusted local storage',
+      );
     }
     this.#entries = new BoundedLruCache(maxEntries);
   }
@@ -186,12 +296,19 @@ export class ContextGraphAuthorityHistoryCache {
       previous = await this.#loadCheckpoint(input.cacheKey);
       if (previous !== undefined) this.#entries.set(input.cacheKey, previous);
     }
+    // A lagging endpoint cannot authenticate a watermark from its future. Keep
+    // that higher checkpoint in memory and durable storage, cold-scan only for
+    // this request, and let publish monotonicity prevent the older result from
+    // replacing it. A later caught-up endpoint can validate and resume from it.
+    if (previous !== undefined && previous.throughBlockNumber > input.finalized.number) {
+      return this.#coldScans.run(input.cacheKey, input.signal, () => (
+        loadContextGraphAuthorityHistory({ ...input, previous: undefined })
+      ));
+    }
     if (previous !== undefined) {
       const anchorHash = previous.throughBlockNumber === input.finalized.number
         ? input.finalized.hash
-        : previous.throughBlockNumber < input.finalized.number
-          ? await input.readBlockHash(previous.throughBlockNumber)
-          : null;
+        : await input.readBlockHash(previous.throughBlockNumber);
       if (anchorHash?.toLowerCase() !== previous.throughBlockHash) {
         // Do not let a slow stale-anchor check delete a newer state published
         // while its RPC request was in flight.
@@ -201,14 +318,18 @@ export class ContextGraphAuthorityHistoryCache {
         // A null historical lookup can be a transient/non-archive provider
         // limitation. Fail closed for this attempt without destroying a
         // checkpoint that a failover provider may still validate. A concrete
-        // hash mismatch (or a watermark from the future) is genuinely stale.
-        if (anchorHash !== null || previous.throughBlockNumber > input.finalized.number) {
+        // hash mismatch is a genuinely stale anchor.
+        if (anchorHash !== null) {
           await this.#deleteCheckpoint(input.cacheKey);
         }
         previous = undefined;
       }
     }
-    return loadContextGraphAuthorityHistory({ ...input, previous });
+    return previous === undefined
+      ? this.#coldScans.run(input.cacheKey, input.signal, () => (
+          loadContextGraphAuthorityHistory({ ...input, previous: undefined })
+        ))
+      : loadContextGraphAuthorityHistory({ ...input, previous });
   }
 
   async #loadCheckpoint(
@@ -216,7 +337,7 @@ export class ContextGraphAuthorityHistoryCache {
   ): Promise<ContextGraphAuthorityHistoryState | undefined> {
     if (this.store === undefined) return undefined;
     try {
-      return normalizeContextGraphAuthorityHistoryState(await this.store.load(cacheKey));
+      return decodeContextGraphAuthorityHistoryCheckpoint(await this.store.load(cacheKey));
     } catch (err) {
       console.warn(
         `[chain] Context Graph authority history checkpoint load failed: ${formatError(err)}`,
@@ -230,38 +351,38 @@ export class ContextGraphAuthorityHistoryCache {
     state: ContextGraphAuthorityHistoryState,
   ): Promise<void> {
     if (this.store === undefined) return;
-    const previousSave = this.#persistence.get(cacheKey) ?? Promise.resolve();
-    const pending = previousSave.catch(() => {}).then(async () => {
+    await this.#persistence.run(cacheKey, async () => {
       // A newer publication can arrive while an older store write is queued.
       // Persist only the current watermark so async stores cannot regress it.
       if (this.#entries.get(cacheKey) !== state) return;
       try {
-        await this.store!.save(cacheKey, state);
+        await this.store!.save(cacheKey, encodeContextGraphAuthorityHistoryCheckpoint(state));
       } catch (err) {
-        // Persistence is an RPC-load optimization, never an authority boundary.
-        // The verified in-memory state remains usable for this process lifetime.
+        // Persistence is optional for availability. Once explicitly admitted,
+        // its valid checkpoints are authority-bearing; a write failure still
+        // leaves this process's chain-derived in-memory state usable.
         console.warn(
           `[chain] Context Graph authority history checkpoint save failed: ${formatError(err)}`,
         );
       }
     });
-    this.#persistence.set(cacheKey, pending);
-    try {
-      await pending;
-    } finally {
-      if (this.#persistence.get(cacheKey) === pending) this.#persistence.delete(cacheKey);
-    }
   }
 
   async #deleteCheckpoint(cacheKey: string): Promise<void> {
     if (this.store === undefined) return;
-    try {
-      await this.store.delete(cacheKey);
-    } catch (err) {
-      console.warn(
-        `[chain] Context Graph authority history checkpoint delete failed: ${formatError(err)}`,
-      );
-    }
+    await this.#persistence.run(cacheKey, async () => {
+      // A concurrent publication may have installed a newer desired state
+      // before this queued delete begins. In that case the deletion belongs to
+      // an obsolete generation and must not touch durable storage.
+      if (this.#entries.get(cacheKey) !== undefined) return;
+      try {
+        await this.store!.delete(cacheKey);
+      } catch (err) {
+        console.warn(
+          `[chain] Context Graph authority history checkpoint delete failed: ${formatError(err)}`,
+        );
+      }
+    });
   }
 }
 
@@ -316,6 +437,55 @@ export function normalizeContextGraphAuthorityHistoryState(
   });
 }
 
+function contextGraphAuthorityHistoryStateIntegrity(
+  state: ContextGraphAuthorityHistoryState,
+): string {
+  const canonical = JSON.stringify([
+    'dkg-context-graph-authority-history-checkpoint-v1',
+    state.throughBlockNumber,
+    state.throughBlockHash,
+    state.nameHash,
+    state.ownershipEra,
+    state.policyVersion,
+    state.rosterVersion,
+    state.sourceBlockNumber,
+    state.sourceBlockHash,
+  ]);
+  return ethers.keccak256(ethers.toUtf8Bytes(canonical)).toLowerCase();
+}
+
+/** The chain-owned encoder used before an opaque backend write. */
+export function encodeContextGraphAuthorityHistoryCheckpoint(
+  value: ContextGraphAuthorityHistoryState,
+): ContextGraphAuthorityHistoryCheckpointV1 {
+  const state = normalizeContextGraphAuthorityHistoryState(value);
+  if (state === undefined) {
+    throw new Error('Cannot persist an invalid Context Graph authority history state');
+  }
+  return Object.freeze({
+    version: CONTEXT_GRAPH_AUTHORITY_HISTORY_CHECKPOINT_VERSION,
+    state,
+    integrity: contextGraphAuthorityHistoryStateIntegrity(state),
+  });
+}
+
+/** Reject raw, old-version, malformed, or integrity-mismatched backend data. */
+export function decodeContextGraphAuthorityHistoryCheckpoint(
+  value: unknown,
+): ContextGraphAuthorityHistoryState | undefined {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const candidate = value as Partial<Record<keyof ContextGraphAuthorityHistoryCheckpointV1, unknown>>;
+  if (candidate.version !== CONTEXT_GRAPH_AUTHORITY_HISTORY_CHECKPOINT_VERSION) return undefined;
+  const state = normalizeContextGraphAuthorityHistoryState(candidate.state);
+  const integrity = normalizeHash(candidate.integrity);
+  if (
+    state === undefined
+    || integrity === undefined
+    || integrity !== contextGraphAuthorityHistoryStateIntegrity(state)
+  ) return undefined;
+  return state;
+}
+
 export interface ResolveContextGraphAuthorityHistoryInput
   extends ContextGraphAuthorityHistoryLoadInput {
   readonly cache: ContextGraphAuthorityHistoryCache;
@@ -353,15 +523,10 @@ async function loadContextGraphAuthorityHistory(
     for (let lo = fromBlock; lo <= input.finalized.number; lo += input.pageSize) {
       input.signal?.throwIfAborted();
       const hi = Math.min(lo + input.pageSize - 1, input.finalized.number);
-      events.push(...await readAuthorityHistoryRange(
-        (rangeFrom, rangeTo) => input.readEvents(
-          { name, contextGraphId: input.contextGraphId },
-          rangeFrom,
-          rangeTo,
-        ),
+      events.push(...await input.readEvents(
+        { name, contextGraphId: input.contextGraphId },
         lo,
         hi,
-        input.signal,
       ));
     }
     return events;
@@ -371,16 +536,7 @@ async function loadContextGraphAuthorityHistory(
     for (let lo = fromBlock; lo <= input.finalized.number; lo += input.pageSize) {
       input.signal?.throwIfAborted();
       const hi = Math.min(lo + input.pageSize - 1, input.finalized.number);
-      events.push(...await readAuthorityHistoryRange(
-        (rangeFrom, rangeTo) => input.readCreationEvents(
-          input.contextGraphId,
-          rangeFrom,
-          rangeTo,
-        ),
-        lo,
-        hi,
-        input.signal,
-      ));
+      events.push(...await input.readCreationEvents(input.contextGraphId, lo, hi));
     }
     return events;
   };
@@ -464,42 +620,4 @@ async function loadContextGraphAuthorityHistory(
     sourceBlockNumber,
     sourceBlockHash: sourceBlockHash.toLowerCase(),
   });
-}
-
-/**
- * Retry only provider-declared block-range limits, splitting sequentially so a
- * 50-block fallback RPC can finish a scan configured for 200/2,000-block
- * providers without multiplying the cold-start request burst.
- */
-async function readAuthorityHistoryRange<T>(
-  read: (fromBlock: number, toBlock: number) => Promise<readonly T[]>,
-  fromBlock: number,
-  toBlock: number,
-  signal?: AbortSignal,
-): Promise<T[]> {
-  signal?.throwIfAborted();
-  try {
-    return [...await read(fromBlock, toBlock)];
-  } catch (err) {
-    if (fromBlock >= toBlock || !isRpcBlockRangeLimitError(err)) throw err;
-    const midpoint = fromBlock + Math.floor((toBlock - fromBlock) / 2);
-    const left = await readAuthorityHistoryRange(read, fromBlock, midpoint, signal);
-    const right = await readAuthorityHistoryRange(read, midpoint + 1, toBlock, signal);
-    return [...left, ...right];
-  }
-}
-
-function isRpcBlockRangeLimitError(err: unknown): boolean {
-  const candidate = err as {
-    message?: unknown;
-    error?: { message?: unknown };
-    info?: { error?: { message?: unknown } };
-  };
-  const message = [
-    candidate?.message,
-    candidate?.error?.message,
-    candidate?.info?.error?.message,
-  ].filter((value): value is string => typeof value === 'string').join(' ');
-  return /(?:block range too large|exceeds? (?:the )?(?:max(?:imum)? )?block range|maximum allowed is \d+ blocks|limited to (?:a )?\d+ blocks?)/i
-    .test(message);
 }

--- a/packages/chain/src/context-graph-authority-history.ts
+++ b/packages/chain/src/context-graph-authority-history.ts
@@ -384,15 +384,28 @@ async function loadContextGraphAuthorityHistory(
     }
     return events;
   };
+  // A cold history may span thousands of pages. Serialize its event streams so
+  // a node with no checkpoint cannot saturate every fallback endpoint with six
+  // independent walks. Once a verified checkpoint exists, retain parallel
+  // one-page suffix reads for the steady-state path.
   const [created, transfers, publishPolicy, publishAuthority, participantAdds,
-    participantRemoves] = await Promise.all([
-    previous === undefined ? readCreation() : Promise.resolve([]),
-    read('Transfer'),
-    read('PublishPolicyUpdated'),
-    read('PublishAuthorityUpdated'),
-    read('AgentParticipantAdded'),
-    read('AgentParticipantRemoved'),
-  ]);
+    participantRemoves] = previous === undefined
+    ? [
+        await readCreation(),
+        await read('Transfer'),
+        await read('PublishPolicyUpdated'),
+        await read('PublishAuthorityUpdated'),
+        await read('AgentParticipantAdded'),
+        await read('AgentParticipantRemoved'),
+      ]
+    : await Promise.all([
+        Promise.resolve([] as ContextGraphAuthorityHistoryCreationEvent[]),
+        read('Transfer'),
+        read('PublishPolicyUpdated'),
+        read('PublishAuthorityUpdated'),
+        read('AgentParticipantAdded'),
+        read('AgentParticipantRemoved'),
+      ]);
   const baseline: Readonly<{
     nameHash: string;
     ownershipEra: number;

--- a/packages/chain/src/context-graph-authority-history.ts
+++ b/packages/chain/src/context-graph-authority-history.ts
@@ -27,6 +27,20 @@ export interface ContextGraphAuthorityHistoryState {
   readonly sourceBlockHash: string;
 }
 
+/**
+ * Optional durable backing for finalized authority-history watermarks.
+ *
+ * Keys are already scoped by chain deployment, ContextGraphs contract, and
+ * context-graph id by the adapter. Implementations must treat values as
+ * replaceable checkpoints: the cache revalidates the recorded finalized block
+ * hash before using one and falls back to a cold scan on any mismatch.
+ */
+export interface ContextGraphAuthorityHistoryStore {
+  load(cacheKey: string): Promise<ContextGraphAuthorityHistoryState | undefined>;
+  save(cacheKey: string, state: ContextGraphAuthorityHistoryState): Promise<void>;
+  delete(cacheKey: string): Promise<void>;
+}
+
 export type ContextGraphAuthorityHistoryEventName =
   | 'Transfer'
   | 'PublishPolicyUpdated'
@@ -75,12 +89,14 @@ export interface ContextGraphAuthorityHistoryResolution {
 export class ContextGraphAuthorityHistoryCache {
   readonly #entries: BoundedLruCache<string, ContextGraphAuthorityHistoryState>;
   readonly #inflight = new Map<string, Promise<ContextGraphAuthorityHistoryState>>();
+  readonly #persistence = new Map<string, Promise<void>>();
   readonly #identityIds = new WeakMap<object, number>();
   #nextIdentityId = 1;
   #epoch = 0;
 
   constructor(
     readonly maxEntries: number = CONTEXT_GRAPH_AUTHORITY_HISTORY_MAX_ENTRIES,
+    readonly store?: ContextGraphAuthorityHistoryStore,
   ) {
     if (!Number.isSafeInteger(maxEntries) || maxEntries < 1) {
       throw new Error('Context Graph authority history cache must retain at least one entry');
@@ -138,6 +154,7 @@ export class ContextGraphAuthorityHistoryCache {
           && current.throughBlockHash === state.throughBlockHash
         ) return;
         this.#entries.set(input.cacheKey, state);
+        await this.#saveCheckpoint(input.cacheKey, state);
       },
     });
   }
@@ -165,6 +182,10 @@ export class ContextGraphAuthorityHistoryCache {
     input: ContextGraphAuthorityHistoryLoadInput,
   ): Promise<ContextGraphAuthorityHistoryState> {
     let previous = this.#entries.get(input.cacheKey);
+    if (previous === undefined) {
+      previous = await this.#loadCheckpoint(input.cacheKey);
+      if (previous !== undefined) this.#entries.set(input.cacheKey, previous);
+    }
     if (previous !== undefined) {
       const anchorHash = previous.throughBlockNumber === input.finalized.number
         ? input.finalized.hash
@@ -177,11 +198,122 @@ export class ContextGraphAuthorityHistoryCache {
         if (this.#entries.get(input.cacheKey) === previous) {
           this.#entries.delete(input.cacheKey);
         }
+        // A null historical lookup can be a transient/non-archive provider
+        // limitation. Fail closed for this attempt without destroying a
+        // checkpoint that a failover provider may still validate. A concrete
+        // hash mismatch (or a watermark from the future) is genuinely stale.
+        if (anchorHash !== null || previous.throughBlockNumber > input.finalized.number) {
+          await this.#deleteCheckpoint(input.cacheKey);
+        }
         previous = undefined;
       }
     }
     return loadContextGraphAuthorityHistory({ ...input, previous });
   }
+
+  async #loadCheckpoint(
+    cacheKey: string,
+  ): Promise<ContextGraphAuthorityHistoryState | undefined> {
+    if (this.store === undefined) return undefined;
+    try {
+      return normalizeContextGraphAuthorityHistoryState(await this.store.load(cacheKey));
+    } catch (err) {
+      console.warn(
+        `[chain] Context Graph authority history checkpoint load failed: ${formatError(err)}`,
+      );
+      return undefined;
+    }
+  }
+
+  async #saveCheckpoint(
+    cacheKey: string,
+    state: ContextGraphAuthorityHistoryState,
+  ): Promise<void> {
+    if (this.store === undefined) return;
+    const previousSave = this.#persistence.get(cacheKey) ?? Promise.resolve();
+    const pending = previousSave.catch(() => {}).then(async () => {
+      // A newer publication can arrive while an older store write is queued.
+      // Persist only the current watermark so async stores cannot regress it.
+      if (this.#entries.get(cacheKey) !== state) return;
+      try {
+        await this.store!.save(cacheKey, state);
+      } catch (err) {
+        // Persistence is an RPC-load optimization, never an authority boundary.
+        // The verified in-memory state remains usable for this process lifetime.
+        console.warn(
+          `[chain] Context Graph authority history checkpoint save failed: ${formatError(err)}`,
+        );
+      }
+    });
+    this.#persistence.set(cacheKey, pending);
+    try {
+      await pending;
+    } finally {
+      if (this.#persistence.get(cacheKey) === pending) this.#persistence.delete(cacheKey);
+    }
+  }
+
+  async #deleteCheckpoint(cacheKey: string): Promise<void> {
+    if (this.store === undefined) return;
+    try {
+      await this.store.delete(cacheKey);
+    } catch (err) {
+      console.warn(
+        `[chain] Context Graph authority history checkpoint delete failed: ${formatError(err)}`,
+      );
+    }
+  }
+}
+
+function formatError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function normalizeHash(value: unknown): string | undefined {
+  return typeof value === 'string' && /^0x[0-9a-f]{64}$/i.test(value)
+    ? value.toLowerCase()
+    : undefined;
+}
+
+function normalizeNonNegativeSafeInteger(value: unknown): number | undefined {
+  return Number.isSafeInteger(value) && Number(value) >= 0 ? Number(value) : undefined;
+}
+
+/** Reject malformed/corrupt durable input before it can influence scan bounds. */
+export function normalizeContextGraphAuthorityHistoryState(
+  value: unknown,
+): ContextGraphAuthorityHistoryState | undefined {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const candidate = value as Partial<Record<keyof ContextGraphAuthorityHistoryState, unknown>>;
+  const throughBlockNumber = normalizeNonNegativeSafeInteger(candidate.throughBlockNumber);
+  const throughBlockHash = normalizeHash(candidate.throughBlockHash);
+  const nameHash = normalizeHash(candidate.nameHash);
+  const ownershipEra = normalizeNonNegativeSafeInteger(candidate.ownershipEra);
+  const policyVersion = normalizeNonNegativeSafeInteger(candidate.policyVersion);
+  const rosterVersion = normalizeNonNegativeSafeInteger(candidate.rosterVersion);
+  const sourceBlockNumber = normalizeNonNegativeSafeInteger(candidate.sourceBlockNumber);
+  const sourceBlockHash = normalizeHash(candidate.sourceBlockHash);
+  if (
+    throughBlockNumber === undefined
+    || throughBlockHash === undefined
+    || nameHash === undefined
+    || ownershipEra === undefined
+    || policyVersion === undefined
+    || rosterVersion === undefined
+    || sourceBlockNumber === undefined
+    || sourceBlockHash === undefined
+    || sourceBlockNumber > throughBlockNumber
+  ) return undefined;
+  return Object.freeze({
+    throughBlockNumber,
+    throughBlockHash,
+    nameHash,
+    ownershipEra,
+    policyVersion,
+    rosterVersion,
+    sourceBlockNumber,
+    sourceBlockHash,
+  });
 }
 
 export interface ResolveContextGraphAuthorityHistoryInput

--- a/packages/chain/src/context-graph-authority-history.ts
+++ b/packages/chain/src/context-graph-authority-history.ts
@@ -45,29 +45,6 @@ export interface ContextGraphAuthorityHistoryStore {
   delete(cacheKey: string): Promise<void>;
 }
 
-declare const TRUSTED_AUTHORITY_HISTORY_STORE: unique symbol;
-
-/**
- * Authority generations are historical aggregates and cannot be authenticated
- * from a block hash alone. A checkpoint backend therefore belongs to the
- * node's trusted local integrity domain; untrusted remote/shared stores must
- * not be promoted through this interface.
- */
-export interface TrustedContextGraphAuthorityHistoryStore
-  extends ContextGraphAuthorityHistoryStore {
-  readonly [TRUSTED_AUTHORITY_HISTORY_STORE]: true;
-}
-
-const trustedAuthorityHistoryStores = new WeakSet<object>();
-
-/** Explicitly admit a process-owned backend into the authority trust boundary. */
-export function trustContextGraphAuthorityHistoryStore<T extends ContextGraphAuthorityHistoryStore>(
-  store: T,
-): T & TrustedContextGraphAuthorityHistoryStore {
-  trustedAuthorityHistoryStores.add(store);
-  return store as T & TrustedContextGraphAuthorityHistoryStore;
-}
-
 export type ContextGraphAuthorityHistoryEventName =
   | 'Transfer'
   | 'PublishPolicyUpdated'
@@ -108,10 +85,48 @@ export interface ContextGraphAuthorityHistoryResolution {
   publish(): Promise<void>;
 }
 
+export type ContextGraphAuthorityCheckpointAdmission =
+  | { readonly kind: 'warm'; readonly state: ContextGraphAuthorityHistoryState }
+  | {
+      readonly kind: 'cold';
+      readonly reason: 'missing' | 'ahead' | 'unverifiable' | 'stale';
+      readonly invalidateMemory: boolean;
+      readonly invalidateDurable: boolean;
+    };
+
+/** Pure checkpoint policy: classify once, then apply its explicit actions. */
+export function classifyContextGraphAuthorityCheckpoint(
+  checkpoint: ContextGraphAuthorityHistoryState | undefined,
+  finalized: Readonly<{ number: number; hash: string }>,
+  anchorHash: string | null,
+): ContextGraphAuthorityCheckpointAdmission {
+  if (checkpoint === undefined) {
+    return Object.freeze({
+      kind: 'cold', reason: 'missing', invalidateMemory: false, invalidateDurable: false,
+    });
+  }
+  if (checkpoint.throughBlockNumber > finalized.number) {
+    return Object.freeze({
+      kind: 'cold', reason: 'ahead', invalidateMemory: false, invalidateDurable: false,
+    });
+  }
+  if (anchorHash?.toLowerCase() === checkpoint.throughBlockHash) {
+    return Object.freeze({ kind: 'warm', state: checkpoint });
+  }
+  if (anchorHash === null) {
+    return Object.freeze({
+      kind: 'cold', reason: 'unverifiable', invalidateMemory: true, invalidateDurable: false,
+    });
+  }
+  return Object.freeze({
+    kind: 'cold', reason: 'stale', invalidateMemory: true, invalidateDurable: true,
+  });
+}
+
 interface ColdScanWaiter {
   readonly cacheKey: string;
   readonly signal?: AbortSignal;
-  readonly resolve: () => void;
+  readonly resolve: (generation: number) => void;
 }
 
 /**
@@ -121,6 +136,7 @@ interface ColdScanWaiter {
 class ContextGraphAuthorityColdScanAdmission {
   #activeCacheKey: string | undefined;
   #activeCount = 0;
+  #activeGeneration = 0;
   readonly #waiters: ColdScanWaiter[] = [];
 
   async run<T>(
@@ -128,29 +144,37 @@ class ContextGraphAuthorityColdScanAdmission {
     signal: AbortSignal | undefined,
     read: () => Promise<T>,
   ): Promise<T> {
-    await this.#acquire(cacheKey, signal);
+    const generation = await this.#acquire(cacheKey, signal);
+    let completed = false;
     try {
       signal?.throwIfAborted();
-      return await read();
+      const result = await read();
+      // A successful provider completes the logical cold scan. Supersede every
+      // other same-graph attempt so a timed-out transport promise that ignores
+      // cancellation cannot retain the global admission slot forever.
+      this.#complete(cacheKey, generation);
+      completed = true;
+      return result;
     } finally {
-      this.#release();
+      if (!completed) this.#release(cacheKey, generation);
     }
   }
 
-  async #acquire(cacheKey: string, signal?: AbortSignal): Promise<void> {
+  async #acquire(cacheKey: string, signal?: AbortSignal): Promise<number> {
     signal?.throwIfAborted();
     if (this.#activeCacheKey === undefined || this.#activeCacheKey === cacheKey) {
+      if (this.#activeCacheKey === undefined) this.#activeGeneration += 1;
       this.#activeCacheKey = cacheKey;
       this.#activeCount += 1;
-      return;
+      return this.#activeGeneration;
     }
-    await new Promise<void>((resolve, reject) => {
+    return new Promise<number>((resolve, reject) => {
       const waiter: ColdScanWaiter = {
         cacheKey,
         signal,
-        resolve: () => {
+        resolve: (generation) => {
           if (signal) signal.removeEventListener('abort', abort);
-          resolve();
+          resolve(generation);
         },
       };
       const abort = () => {
@@ -163,14 +187,27 @@ class ContextGraphAuthorityColdScanAdmission {
     });
   }
 
-  #release(): void {
+  #release(cacheKey: string, generation: number): void {
+    if (this.#activeCacheKey !== cacheKey || this.#activeGeneration !== generation) return;
     this.#activeCount -= 1;
     if (this.#activeCount > 0) return;
     this.#activeCacheKey = undefined;
+    this.#drain();
+  }
+
+  #complete(cacheKey: string, generation: number): void {
+    if (this.#activeCacheKey !== cacheKey || this.#activeGeneration !== generation) return;
+    this.#activeCount = 0;
+    this.#activeCacheKey = undefined;
+    this.#drain();
+  }
+
+  #drain(): void {
     while (this.#waiters.length > 0) {
       const first = this.#waiters.shift()!;
       if (first.signal?.aborted) continue;
       this.#activeCacheKey = first.cacheKey;
+      this.#activeGeneration += 1;
       const admitted = [first];
       for (let index = this.#waiters.length - 1; index >= 0; index -= 1) {
         const waiter = this.#waiters[index]!;
@@ -179,7 +216,7 @@ class ContextGraphAuthorityColdScanAdmission {
         this.#waiters.splice(index, 1);
       }
       this.#activeCount = admitted.length;
-      for (const waiter of admitted) waiter.resolve();
+      for (const waiter of admitted) waiter.resolve(this.#activeGeneration);
       return;
     }
   }
@@ -201,15 +238,11 @@ export class ContextGraphAuthorityHistoryCache {
 
   constructor(
     readonly maxEntries: number = CONTEXT_GRAPH_AUTHORITY_HISTORY_MAX_ENTRIES,
-    readonly store?: TrustedContextGraphAuthorityHistoryStore,
+    /** Explicitly named local composition input; never populate from remote/shared data. */
+    readonly localStore?: ContextGraphAuthorityHistoryStore,
   ) {
     if (!Number.isSafeInteger(maxEntries) || maxEntries < 1) {
       throw new Error('Context Graph authority history cache must retain at least one entry');
-    }
-    if (store !== undefined && !trustedAuthorityHistoryStores.has(store)) {
-      throw new Error(
-        'Context Graph authority history store must be explicitly admitted as trusted local storage',
-      );
     }
     this.#entries = new BoundedLruCache(maxEntries);
   }
@@ -291,53 +324,44 @@ export class ContextGraphAuthorityHistoryCache {
   async #load(
     input: ContextGraphAuthorityHistoryLoadInput,
   ): Promise<ContextGraphAuthorityHistoryState> {
-    let previous = this.#entries.get(input.cacheKey);
-    if (previous === undefined) {
-      previous = await this.#loadCheckpoint(input.cacheKey);
-      if (previous !== undefined) this.#entries.set(input.cacheKey, previous);
+    let checkpoint = this.#entries.get(input.cacheKey);
+    if (checkpoint === undefined) {
+      checkpoint = await this.#loadCheckpoint(input.cacheKey);
+      if (checkpoint !== undefined) this.#entries.set(input.cacheKey, checkpoint);
     }
-    // A lagging endpoint cannot authenticate a watermark from its future. Keep
-    // that higher checkpoint in memory and durable storage, cold-scan only for
-    // this request, and let publish monotonicity prevent the older result from
-    // replacing it. A later caught-up endpoint can validate and resume from it.
-    if (previous !== undefined && previous.throughBlockNumber > input.finalized.number) {
-      return this.#coldScans.run(input.cacheKey, input.signal, () => (
-        loadContextGraphAuthorityHistory({ ...input, previous: undefined })
-      ));
-    }
-    if (previous !== undefined) {
-      const anchorHash = previous.throughBlockNumber === input.finalized.number
+    const anchorHash = checkpoint === undefined
+      || checkpoint.throughBlockNumber > input.finalized.number
+      ? null
+      : checkpoint.throughBlockNumber === input.finalized.number
         ? input.finalized.hash
-        : await input.readBlockHash(previous.throughBlockNumber);
-      if (anchorHash?.toLowerCase() !== previous.throughBlockHash) {
-        // Do not let a slow stale-anchor check delete a newer state published
-        // while its RPC request was in flight.
-        if (this.#entries.get(input.cacheKey) === previous) {
-          this.#entries.delete(input.cacheKey);
-        }
-        // A null historical lookup can be a transient/non-archive provider
-        // limitation. Fail closed for this attempt without destroying a
-        // checkpoint that a failover provider may still validate. A concrete
-        // hash mismatch is a genuinely stale anchor.
-        if (anchorHash !== null) {
-          await this.#deleteCheckpoint(input.cacheKey);
-        }
-        previous = undefined;
+        : await input.readBlockHash(checkpoint.throughBlockNumber);
+    const admission = classifyContextGraphAuthorityCheckpoint(
+      checkpoint,
+      input.finalized,
+      anchorHash,
+    );
+    if (admission.kind === 'warm') {
+      return loadContextGraphAuthorityHistory({ ...input, previous: admission.state });
+    }
+    if (checkpoint !== undefined && admission.invalidateMemory) {
+      // Do not let a slow stale-anchor check delete a newer state published
+      // while its RPC request was in flight.
+      if (this.#entries.get(input.cacheKey) === checkpoint) {
+        this.#entries.delete(input.cacheKey);
       }
     }
-    return previous === undefined
-      ? this.#coldScans.run(input.cacheKey, input.signal, () => (
-          loadContextGraphAuthorityHistory({ ...input, previous: undefined })
-        ))
-      : loadContextGraphAuthorityHistory({ ...input, previous });
+    if (admission.invalidateDurable) await this.#deleteCheckpoint(input.cacheKey);
+    return this.#coldScans.run(input.cacheKey, input.signal, () => (
+      loadContextGraphAuthorityHistory({ ...input, previous: undefined })
+    ));
   }
 
   async #loadCheckpoint(
     cacheKey: string,
   ): Promise<ContextGraphAuthorityHistoryState | undefined> {
-    if (this.store === undefined) return undefined;
+    if (this.localStore === undefined) return undefined;
     try {
-      return decodeContextGraphAuthorityHistoryCheckpoint(await this.store.load(cacheKey));
+      return decodeContextGraphAuthorityHistoryCheckpoint(await this.localStore.load(cacheKey));
     } catch (err) {
       console.warn(
         `[chain] Context Graph authority history checkpoint load failed: ${formatError(err)}`,
@@ -350,13 +374,13 @@ export class ContextGraphAuthorityHistoryCache {
     cacheKey: string,
     state: ContextGraphAuthorityHistoryState,
   ): Promise<void> {
-    if (this.store === undefined) return;
+    if (this.localStore === undefined) return;
     await this.#persistence.run(cacheKey, async () => {
       // A newer publication can arrive while an older store write is queued.
       // Persist only the current watermark so async stores cannot regress it.
       if (this.#entries.get(cacheKey) !== state) return;
       try {
-        await this.store!.save(cacheKey, encodeContextGraphAuthorityHistoryCheckpoint(state));
+        await this.localStore!.save(cacheKey, encodeContextGraphAuthorityHistoryCheckpoint(state));
       } catch (err) {
         // Persistence is optional for availability. Once explicitly admitted,
         // its valid checkpoints are authority-bearing; a write failure still
@@ -369,14 +393,14 @@ export class ContextGraphAuthorityHistoryCache {
   }
 
   async #deleteCheckpoint(cacheKey: string): Promise<void> {
-    if (this.store === undefined) return;
+    if (this.localStore === undefined) return;
     await this.#persistence.run(cacheKey, async () => {
       // A concurrent publication may have installed a newer desired state
       // before this queued delete begins. In that case the deletion belongs to
       // an obsolete generation and must not touch durable storage.
       if (this.#entries.get(cacheKey) !== undefined) return;
       try {
-        await this.store!.delete(cacheKey);
+        await this.localStore!.delete(cacheKey);
       } catch (err) {
         console.warn(
           `[chain] Context Graph authority history checkpoint delete failed: ${formatError(err)}`,

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -28,7 +28,7 @@ import { HubResolutionCache } from './hub-resolution-cache.js';
 import { SignerTxSerializer, type SignerTxLaneState } from './signer-tx-serializer.js';
 import { floorPublishTokenAmount, withSpan, getMetrics } from '@origintrail-official/dkg-core';
 import { loadAbi } from './evm-adapter-abi.js';
-import { errorCode, errorMessage, errorStatus, isTooLowAllowanceError, enrichEvmError, getPcaLogicInterface, HUB_STALE_ERROR_MARKERS, isInsufficientFundsError, InsufficientPublisherFundsError, formatNoFundedPublisherWalletMessage, type PublisherWalletBalance } from './evm-adapter-errors.js';
+import { collectEvmErrorText, errorCode, errorMessage, errorStatus, isTooLowAllowanceError, enrichEvmError, getPcaLogicInterface, HUB_STALE_ERROR_MARKERS, isInsufficientFundsError, InsufficientPublisherFundsError, formatNoFundedPublisherWalletMessage, type PublisherWalletBalance } from './evm-adapter-errors.js';
 import { resolveRpcUrls, boundedRetryFetchRequest, withTimeout, isRetryableRpcError, assertSuccessfulReceipt, sleep } from './evm-adapter-rpc.js';
 import { rpcHost } from './rpc-failover-log.js';
 import { ChainRpcTransportError } from './chain-rpc-transport-error.js';
@@ -454,30 +454,6 @@ function kaHighWaterViewSelectorInCode(storage: Contract, code: string): boolean
  * the common provider phrasings (geth/erigon/nethermind/managed endpoints).
  */
 /**
- * Flatten an error into a single lowercased string across the nested fields
- * ethers v6 / managed RPCs actually populate — `message`, `shortMessage`,
- * `reason`, `body`, and recursively `error` / `info` / `cause` / `data`. The
- * plain `errorMessage` reads only `.message`, so a managed-RPC denial whose text
- * lives in `err.info.error.message` / `err.body` would otherwise be invisible.
- */
-function allErrorText(err: unknown): string {
-  const parts: string[] = [];
-  const seen = new Set<unknown>();
-  const visit = (e: any, depth: number): void => {
-    if (e == null || depth > 5 || seen.has(e)) return;
-    if (typeof e === 'string') { parts.push(e); return; }
-    if (typeof e !== 'object') return;
-    seen.add(e);
-    for (const k of ['message', 'shortMessage', 'reason', 'body']) {
-      if (typeof e[k] === 'string') parts.push(e[k]);
-    }
-    for (const k of ['error', 'info', 'cause', 'data']) visit(e[k], depth + 1);
-  };
-  visit(err, 0);
-  return parts.join(' ').toLowerCase();
-}
-
-/**
  * True when `err` is a TRANSIENT rate-limit / throttle from the RPC provider —
  * keyed on the provider HTTP status (`429`; `errorStatus` recurses nested
  * `cause`/`info`/`error` fields) plus a rate-limit / quota / compute-unit
@@ -496,7 +472,7 @@ function allErrorText(err: unknown): string {
  */
 function isTransientThrottle(err: unknown): boolean {
   if (errorStatus(err) === 429) return true;
-  const msg = allErrorText(err);
+  const msg = collectEvmErrorText(err);
   return /\b(too many requests|rate[ -]?limit|throttl|compute units?|capacity|quota|credits?|(daily|monthly|request|compute)[^.]{0,12}\blimit|limit reached|over (the )?limit)\b/.test(msg);
 }
 
@@ -510,7 +486,7 @@ function isTransientThrottle(err: unknown): boolean {
 function isHistoricalStateUnavailable(err: unknown): boolean {
   if (isTransientThrottle(err)) return false;
 
-  const msg = allErrorText(err);
+  const msg = collectEvmErrorText(err);
 
   // Genuine "node lacks historical state" shapes → degrade to the genesis log scan.
   // NOTE: a bare `header not found` is intentionally NOT here — nodes also return

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -1299,7 +1299,7 @@ export class EVMChainAdapterBase {
     });
     this.contextGraphAuthorityHistory = new ContextGraphAuthorityHistoryCache(
       undefined,
-      config.contextGraphAuthorityHistoryStore,
+      config.localContextGraphAuthorityHistoryStore,
     );
     this.approvalPolicy = config.approvalPolicy ?? DEFAULT_APPROVAL_POLICY;
     this.minPublisherNativeWei = config.minPublisherNativeWei ?? 0n;

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -983,7 +983,7 @@ export class EVMChainAdapterBase {
   protected readonly contextGraphRegistryScanCursor: ContextGraphRegistryScanCursor;
 
   /** Finalized authority scan watermarks owned by this adapter lifecycle. */
-  protected readonly contextGraphAuthorityHistory = new ContextGraphAuthorityHistoryCache();
+  protected readonly contextGraphAuthorityHistory: ContextGraphAuthorityHistoryCache;
 
   /**
    * eth_getLogs block-window for the pre-10.0.4 getMaxKaNumberForAuthor fallback
@@ -1321,6 +1321,10 @@ export class EVMChainAdapterBase {
       deploymentId: this.deploymentId,
       store: config.contextGraphRegistryScanCursorStore,
     });
+    this.contextGraphAuthorityHistory = new ContextGraphAuthorityHistoryCache(
+      undefined,
+      config.contextGraphAuthorityHistoryStore,
+    );
     this.approvalPolicy = config.approvalPolicy ?? DEFAULT_APPROVAL_POLICY;
     this.minPublisherNativeWei = config.minPublisherNativeWei ?? 0n;
     this.minPublisherTracWei = config.minPublisherTracWei ?? 0n;

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -26,6 +26,7 @@ import {
   type ContextGraphAuthorityHistoryEvent,
   type ContextGraphAuthorityHistoryEventQuery,
 } from './context-graph-authority-history.js';
+import { readAdaptiveEvmLogRange } from './evm-log-range.js';
 
 type ContextGraphRegistryScanPlan =
   | {
@@ -950,8 +951,15 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
               : filters[name]!(targetContextGraphId);
             authorityFilters.set(name, filter);
           }
-          return (await contract.queryFilter(filter, fromBlock, toBlock))
-            .map((rawEvent) => rawEvent as ethers.EventLog);
+          return readAdaptiveEvmLogRange({
+            read: async (rangeFrom, rangeTo) => (
+              (await contract.queryFilter(filter!, rangeFrom, rangeTo))
+                .map((rawEvent) => rawEvent as ethers.EventLog)
+            ),
+            fromBlock,
+            toBlock,
+            signal: options.signal,
+          });
         };
         const [current, historyResolution] = await Promise.all([
           (contract as any).getContextGraph.staticCall(

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -931,7 +931,11 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         >;
         const contractAddress = (await contract.getAddress()).toLowerCase();
         const cache = this.contextGraphAuthorityHistory;
-        const cacheKey = `${contractAddress}:${contextGraphId.toString(10)}`;
+        const cacheKey = [
+          this.deploymentId,
+          contractAddress,
+          contextGraphId.toString(10),
+        ].join(':');
         const authorityFilters = new Map<string, ethers.DeferredTopicFilter>();
         const readAuthorityEvents = async (
           name: 'ContextGraphCreated' | ContextGraphAuthorityHistoryEventQuery['name'],

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -1051,7 +1051,13 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         await historyResolution.publish();
         return snapshot;
       },
-      { signal: options.signal },
+      {
+        signal: options.signal,
+        // A cold authority resolution performs a bounded historical log scan;
+        // the default 4s point-read cap aborts healthy fallback providers before
+        // they can finish. Warm checkpoint suffixes remain fast under this cap.
+        policy: 'wideLogScan',
+      },
     );
   }
 

--- a/packages/chain/src/evm-adapter-errors.ts
+++ b/packages/chain/src/evm-adapter-errors.ts
@@ -23,6 +23,34 @@ export function errorMessage(err: unknown): string {
 }
 
 /**
+ * Flatten the nested text fields used by ethers and managed JSON-RPC
+ * providers. Transport classifiers share this boundary so domain reducers do
+ * not grow their own incomplete error-envelope parsers.
+ */
+export function collectEvmErrorText(err: unknown): string {
+  const parts: string[] = [];
+  const seen = new Set<unknown>();
+  const visit = (value: unknown, depth: number): void => {
+    if (value == null || depth > 5 || seen.has(value)) return;
+    if (typeof value === 'string') {
+      parts.push(value);
+      return;
+    }
+    if (typeof value !== 'object') return;
+    seen.add(value);
+    const record = value as Record<string, unknown>;
+    for (const key of ['message', 'shortMessage', 'reason', 'body']) {
+      if (typeof record[key] === 'string') parts.push(record[key]);
+    }
+    for (const key of ['error', 'info', 'cause', 'data']) {
+      visit(record[key], depth + 1);
+    }
+  };
+  visit(err, 0);
+  return parts.join(' ').toLowerCase();
+}
+
+/**
  * Read the top-level error class name exposed by Error / DOMException shapes.
  * Unlike status and code extraction, this deliberately does not traverse
  * wrappers: a name describes the caught surface error, while nested transport

--- a/packages/chain/src/evm-adapter-types.ts
+++ b/packages/chain/src/evm-adapter-types.ts
@@ -7,7 +7,7 @@
  */
 import { Contract } from 'ethers';
 import type { ApprovalPolicy, ContextGraphRegistryScanCursorStore } from './chain-adapter.js';
-import type { TrustedContextGraphAuthorityHistoryStore } from './context-graph-authority-history.js';
+import type { ContextGraphAuthorityHistoryStore } from './context-graph-authority-history.js';
 
 export interface EVMAdapterBaseConfig {
   rpcUrl: string;
@@ -100,12 +100,11 @@ export interface EVMAdapterBaseConfig {
    */
   contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStore;
   /**
-   * Optional durable finalized authority-history checkpoints from an explicitly
-   * trusted, process-owned backend. The finalized watermark is block-hash
-   * revalidated before use; the historical aggregate remains authority-bearing
-   * within that local integrity boundary.
+   * Optional durable finalized authority-history checkpoints. This explicitly
+   * named composition input must point to process-owned local storage; the
+   * structural interface itself does not pretend to enforce locality.
    */
-  contextGraphAuthorityHistoryStore?: TrustedContextGraphAuthorityHistoryStore;
+  localContextGraphAuthorityHistoryStore?: ContextGraphAuthorityHistoryStore;
   /**
    * Funding-aware publish wallet selection: minimum NATIVE gas balance (wei) an
    * operational wallet must hold to be PREFERRED when selecting the publish

--- a/packages/chain/src/evm-adapter-types.ts
+++ b/packages/chain/src/evm-adapter-types.ts
@@ -7,6 +7,7 @@
  */
 import { Contract } from 'ethers';
 import type { ApprovalPolicy, ContextGraphRegistryScanCursorStore } from './chain-adapter.js';
+import type { ContextGraphAuthorityHistoryStore } from './context-graph-authority-history.js';
 
 export interface EVMAdapterBaseConfig {
   rpcUrl: string;
@@ -98,6 +99,11 @@ export interface EVMAdapterBaseConfig {
    * repeating a historical `eth_getLogs` walk.
    */
   contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStore;
+  /**
+   * Optional durable finalized authority-history checkpoints. Checkpoints are
+   * block-hash revalidated before use and only reduce restart-time log scans.
+   */
+  contextGraphAuthorityHistoryStore?: ContextGraphAuthorityHistoryStore;
   /**
    * Funding-aware publish wallet selection: minimum NATIVE gas balance (wei) an
    * operational wallet must hold to be PREFERRED when selecting the publish

--- a/packages/chain/src/evm-adapter-types.ts
+++ b/packages/chain/src/evm-adapter-types.ts
@@ -7,7 +7,7 @@
  */
 import { Contract } from 'ethers';
 import type { ApprovalPolicy, ContextGraphRegistryScanCursorStore } from './chain-adapter.js';
-import type { ContextGraphAuthorityHistoryStore } from './context-graph-authority-history.js';
+import type { TrustedContextGraphAuthorityHistoryStore } from './context-graph-authority-history.js';
 
 export interface EVMAdapterBaseConfig {
   rpcUrl: string;
@@ -100,10 +100,12 @@ export interface EVMAdapterBaseConfig {
    */
   contextGraphRegistryScanCursorStore?: ContextGraphRegistryScanCursorStore;
   /**
-   * Optional durable finalized authority-history checkpoints. Checkpoints are
-   * block-hash revalidated before use and only reduce restart-time log scans.
+   * Optional durable finalized authority-history checkpoints from an explicitly
+   * trusted, process-owned backend. The finalized watermark is block-hash
+   * revalidated before use; the historical aggregate remains authority-bearing
+   * within that local integrity boundary.
    */
-  contextGraphAuthorityHistoryStore?: ContextGraphAuthorityHistoryStore;
+  contextGraphAuthorityHistoryStore?: TrustedContextGraphAuthorityHistoryStore;
   /**
    * Funding-aware publish wallet selection: minimum NATIVE gas balance (wei) an
    * operational wallet must hold to be PREFERRED when selecting the publish

--- a/packages/chain/src/evm-log-range.ts
+++ b/packages/chain/src/evm-log-range.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { collectEvmErrorText } from './evm-adapter-errors.js';
+
+/** Provider-declared eth_getLogs range caps that are safe to retry by splitting. */
+export function isEvmLogRangeLimitError(err: unknown): boolean {
+  return /(?:block range too large|exceeds? (?:the )?(?:max(?:imum)? )?block range|maximum allowed is \d+ blocks|limited to (?:a )?\d+ blocks?)/i
+    .test(collectEvmErrorText(err));
+}
+
+/**
+ * Read one inclusive eth_getLogs range, recursively splitting only explicit
+ * provider range-limit failures. Halves are read sequentially to avoid turning
+ * a compatibility retry into a request burst, and their results retain chain
+ * order.
+ */
+export async function readAdaptiveEvmLogRange<T>(params: Readonly<{
+  read: (fromBlock: number, toBlock: number) => Promise<readonly T[]>;
+  fromBlock: number;
+  toBlock: number;
+  signal?: AbortSignal;
+}>): Promise<T[]> {
+  params.signal?.throwIfAborted();
+  try {
+    return [...await params.read(params.fromBlock, params.toBlock)];
+  } catch (err) {
+    if (params.fromBlock >= params.toBlock || !isEvmLogRangeLimitError(err)) throw err;
+    const midpoint = params.fromBlock
+      + Math.floor((params.toBlock - params.fromBlock) / 2);
+    const left = await readAdaptiveEvmLogRange({
+      ...params,
+      toBlock: midpoint,
+    });
+    const right = await readAdaptiveEvmLogRange({
+      ...params,
+      fromBlock: midpoint + 1,
+    });
+    return [...left, ...right];
+  }
+}

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -1,7 +1,10 @@
 export * from './chain-adapter.js';
 export {
+  trustContextGraphAuthorityHistoryStore,
+  type ContextGraphAuthorityHistoryCheckpointV1,
   type ContextGraphAuthorityHistoryState,
   type ContextGraphAuthorityHistoryStore,
+  type TrustedContextGraphAuthorityHistoryStore,
 } from './context-graph-authority-history.js';
 export {
   bindContextGraphAuthorityReader,

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -1,10 +1,8 @@
 export * from './chain-adapter.js';
 export {
-  trustContextGraphAuthorityHistoryStore,
   type ContextGraphAuthorityHistoryCheckpointV1,
   type ContextGraphAuthorityHistoryState,
   type ContextGraphAuthorityHistoryStore,
-  type TrustedContextGraphAuthorityHistoryStore,
 } from './context-graph-authority-history.js';
 export {
   bindContextGraphAuthorityReader,

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -1,5 +1,9 @@
 export * from './chain-adapter.js';
 export {
+  type ContextGraphAuthorityHistoryState,
+  type ContextGraphAuthorityHistoryStore,
+} from './context-graph-authority-history.js';
+export {
   bindContextGraphAuthorityReader,
   type ContextGraphAuthorityReader,
   type ContextGraphAuthorityReaderCapability,

--- a/packages/chain/test/context-graph-authority-history.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-history.unit.test.ts
@@ -6,6 +6,8 @@ import {
   ContextGraphAuthorityHistoryCache,
   resolveContextGraphAuthorityHistory,
   type ContextGraphAuthorityHistoryCreationEvent,
+  type ContextGraphAuthorityHistoryState,
+  type ContextGraphAuthorityHistoryStore,
   type ResolveContextGraphAuthorityHistoryInput,
 } from '../src/context-graph-authority-history.js';
 
@@ -13,6 +15,24 @@ const FINALIZED_HASH = `0x${'55'.repeat(32)}`;
 const NEXT_FINALIZED_HASH = `0x${'56'.repeat(32)}`;
 const NAME_HASH = `0x${'88'.repeat(32)}`;
 const DIRECT_READ_SCOPE = {};
+
+class MemoryHistoryStore implements ContextGraphAuthorityHistoryStore {
+  readonly states = new Map<string, ContextGraphAuthorityHistoryState>();
+  readonly deleted: string[] = [];
+
+  async load(cacheKey: string): Promise<ContextGraphAuthorityHistoryState | undefined> {
+    return this.states.get(cacheKey);
+  }
+
+  async save(cacheKey: string, state: ContextGraphAuthorityHistoryState): Promise<void> {
+    this.states.set(cacheKey, state);
+  }
+
+  async delete(cacheKey: string): Promise<void> {
+    this.deleted.push(cacheKey);
+    this.states.delete(cacheKey);
+  }
+}
 
 function directHistoryInput(params: Readonly<{
   cache: ContextGraphAuthorityHistoryCache;
@@ -229,6 +249,106 @@ describe('ContextGraphAuthorityHistoryCache', () => {
     expect(coldReads.get('a')?.count).toBe(1);
     expect(coldReads.get('b')?.count).toBe(2);
     expect(coldReads.get('c')?.count).toBe(1);
+  });
+
+  it('hydrates a verified durable checkpoint and scans only its suffix', async () => {
+    const store = new MemoryHistoryStore();
+    const firstColdReads = { count: 0 };
+    const initial = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache: new ContextGraphAuthorityHistoryCache(1_024, store),
+      cacheKey: 'durable',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+      coldReads: firstColdReads,
+    }));
+    expect(store.states.size).toBe(0);
+    await initial.publish();
+    expect(firstColdReads.count).toBe(1);
+
+    const restartedColdReads = { count: 0 };
+    const ranges: Array<readonly [number, number]> = [];
+    const restarted = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache: new ContextGraphAuthorityHistoryCache(1_024, store),
+      cacheKey: 'durable',
+      blockNumber: 35,
+      blockHash: NEXT_FINALIZED_HASH,
+      blockHashes: { 30: FINALIZED_HASH },
+      coldReads: restartedColdReads,
+      ordinaryRanges: ranges,
+    }));
+    expect(restartedColdReads.count).toBe(0);
+    expect(ranges).toEqual(Array(5).fill([31, 35]));
+    await restarted.publish();
+    expect(store.states.get('durable')?.throughBlockNumber).toBe(35);
+  });
+
+  it('deletes a durable checkpoint whose finalized anchor changed', async () => {
+    const store = new MemoryHistoryStore();
+    const initial = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache: new ContextGraphAuthorityHistoryCache(1_024, store),
+      cacheKey: 'reorged',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+    }));
+    await initial.publish();
+
+    const coldReads = { count: 0 };
+    const replacement = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache: new ContextGraphAuthorityHistoryCache(1_024, store),
+      cacheKey: 'reorged',
+      blockNumber: 35,
+      blockHash: NEXT_FINALIZED_HASH,
+      blockHashes: { 30: `0x${'99'.repeat(32)}` },
+      coldReads,
+    }));
+    expect(coldReads.count).toBe(1);
+    expect(store.deleted).toEqual(['reorged']);
+    await replacement.publish();
+  });
+
+  it('retains a checkpoint when one provider cannot read its historical anchor', async () => {
+    const store = new MemoryHistoryStore();
+    const initial = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache: new ContextGraphAuthorityHistoryCache(1_024, store),
+      cacheKey: 'non-archive-provider',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+    }));
+    await initial.publish();
+
+    await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache: new ContextGraphAuthorityHistoryCache(1_024, store),
+      cacheKey: 'non-archive-provider',
+      blockNumber: 35,
+      blockHash: NEXT_FINALIZED_HASH,
+    }));
+    expect(store.deleted).toEqual([]);
+    expect(store.states.get('non-archive-provider')?.throughBlockNumber).toBe(30);
+  });
+
+  it('ignores malformed durable input before choosing a scan bound', async () => {
+    const store = new MemoryHistoryStore();
+    store.states.set('malformed', {
+      throughBlockNumber: 30,
+      throughBlockHash: 'not-a-hash',
+      nameHash: NAME_HASH,
+      ownershipEra: 0,
+      policyVersion: 0,
+      rosterVersion: 0,
+      sourceBlockNumber: 1,
+      sourceBlockHash: `0x${'01'.repeat(32)}`,
+    });
+    const coldReads = { count: 0 };
+    const resolution = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache: new ContextGraphAuthorityHistoryCache(1_024, store),
+      cacheKey: 'malformed',
+      blockNumber: 35,
+      blockHash: NEXT_FINALIZED_HASH,
+      coldReads,
+    }));
+    expect(coldReads.count).toBe(1);
+    await resolution.publish();
+    expect(store.states.get('malformed')?.throughBlockHash).toBe(NEXT_FINALIZED_HASH);
   });
 
   it('rejects a malformed creation event without a name hash at runtime', async () => {

--- a/packages/chain/test/context-graph-authority-history.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-history.unit.test.ts
@@ -4,11 +4,11 @@ import { describe, expect, it } from 'vitest';
 
 import {
   ContextGraphAuthorityHistoryCache,
+  classifyContextGraphAuthorityCheckpoint,
   decodeContextGraphAuthorityHistoryCheckpoint,
   encodeContextGraphAuthorityHistoryCheckpoint,
   normalizeContextGraphAuthorityHistoryState,
   resolveContextGraphAuthorityHistory,
-  trustContextGraphAuthorityHistoryStore,
   type ContextGraphAuthorityHistoryCreationEvent,
   type ContextGraphAuthorityHistoryEvent,
   type ContextGraphAuthorityHistoryEventName,
@@ -22,6 +22,40 @@ const FINALIZED_HASH = `0x${'55'.repeat(32)}`;
 const NEXT_FINALIZED_HASH = `0x${'56'.repeat(32)}`;
 const NAME_HASH = `0x${'88'.repeat(32)}`;
 const DIRECT_READ_SCOPE = {};
+
+describe('Context Graph authority checkpoint admission policy', () => {
+  const checkpoint: ContextGraphAuthorityHistoryState = {
+    throughBlockNumber: 30,
+    throughBlockHash: FINALIZED_HASH,
+    nameHash: NAME_HASH,
+    ownershipEra: 1,
+    policyVersion: 2,
+    rosterVersion: 3,
+    sourceBlockNumber: 30,
+    sourceBlockHash: FINALIZED_HASH,
+  };
+
+  it('makes warm, future, unverifiable, and stale actions explicit', () => {
+    expect(classifyContextGraphAuthorityCheckpoint(
+      checkpoint, { number: 30, hash: FINALIZED_HASH }, FINALIZED_HASH,
+    )).toEqual({ kind: 'warm', state: checkpoint });
+    expect(classifyContextGraphAuthorityCheckpoint(
+      checkpoint, { number: 20, hash: NEXT_FINALIZED_HASH }, null,
+    )).toEqual({
+      kind: 'cold', reason: 'ahead', invalidateMemory: false, invalidateDurable: false,
+    });
+    expect(classifyContextGraphAuthorityCheckpoint(
+      checkpoint, { number: 35, hash: NEXT_FINALIZED_HASH }, null,
+    )).toEqual({
+      kind: 'cold', reason: 'unverifiable', invalidateMemory: true, invalidateDurable: false,
+    });
+    expect(classifyContextGraphAuthorityCheckpoint(
+      checkpoint, { number: 35, hash: NEXT_FINALIZED_HASH }, NEXT_FINALIZED_HASH,
+    )).toEqual({
+      kind: 'cold', reason: 'stale', invalidateMemory: true, invalidateDurable: true,
+    });
+  });
+});
 
 class MemoryHistoryStore implements ContextGraphAuthorityHistoryStore {
   readonly checkpoints = new Map<string, unknown>();
@@ -75,7 +109,7 @@ class DelayedHistoryStore extends MemoryHistoryStore {
 function cacheWithStore(store: ContextGraphAuthorityHistoryStore) {
   return new ContextGraphAuthorityHistoryCache(
     1_024,
-    trustContextGraphAuthorityHistoryStore(store),
+    store,
   );
 }
 
@@ -193,7 +227,7 @@ describe('ContextGraphAuthorityHistoryCache', () => {
     await Promise.all([firstResolution.publish(), secondResolution.publish()]);
   });
 
-  it('does not let a stalled provider attempt capture same-head failover', async () => {
+  it('a successful fallback retires a stalled same-graph lease for other cold graphs', async () => {
     const cache = new ContextGraphAuthorityHistoryCache();
     const stalledScope = {};
     const healthyScope = {};
@@ -209,6 +243,13 @@ describe('ContextGraphAuthorityHistoryCache', () => {
     }));
     await entered.promise;
 
+    const otherGraph = resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'provider-failover-other-graph',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+    }));
+
     const healthy = await resolveContextGraphAuthorityHistory(directHistoryInput({
       cache,
       cacheKey: 'provider-failover',
@@ -219,8 +260,14 @@ describe('ContextGraphAuthorityHistoryCache', () => {
     expect(healthy.state.nameHash).toBe(NAME_HASH);
     await healthy.publish();
 
+    const otherBeforeStalledRetires = await Promise.race([
+      otherGraph.then(() => 'started'),
+      new Promise<'blocked'>((resolve) => setTimeout(() => resolve('blocked'), 25)),
+    ]);
     release.resolve();
     await expect(stalled).resolves.toMatchObject({ state: healthy.state });
+    await expect(otherGraph).resolves.toMatchObject({ state: { nameHash: NAME_HASH } });
+    expect(otherBeforeStalledRetires).toBe('started');
   });
 
   it('does not let one reader abort an independent same-head reader', async () => {
@@ -342,11 +389,9 @@ describe('ContextGraphAuthorityHistoryCache', () => {
     expect(coldReads.get('c')?.count).toBe(1);
   });
 
-  it('requires an explicit trusted-local admission for authority aggregates', () => {
-    const untrusted = new MemoryHistoryStore();
-    expect(() => new ContextGraphAuthorityHistoryCache(1_024, untrusted as never))
-      .toThrow(/explicitly admitted as trusted local storage/);
-    expect(() => cacheWithStore(untrusted)).not.toThrow();
+  it('takes the process-local checkpoint store directly at its composition boundary', () => {
+    const localStore = new MemoryHistoryStore();
+    expect(cacheWithStore(localStore).localStore).toBe(localStore);
   });
 
   it('serializes cold histories across graphs without blocking same-graph failover', async () => {

--- a/packages/chain/test/context-graph-authority-history.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-history.unit.test.ts
@@ -4,12 +4,19 @@ import { describe, expect, it } from 'vitest';
 
 import {
   ContextGraphAuthorityHistoryCache,
+  decodeContextGraphAuthorityHistoryCheckpoint,
+  encodeContextGraphAuthorityHistoryCheckpoint,
+  normalizeContextGraphAuthorityHistoryState,
   resolveContextGraphAuthorityHistory,
+  trustContextGraphAuthorityHistoryStore,
   type ContextGraphAuthorityHistoryCreationEvent,
+  type ContextGraphAuthorityHistoryEvent,
+  type ContextGraphAuthorityHistoryEventName,
   type ContextGraphAuthorityHistoryState,
   type ContextGraphAuthorityHistoryStore,
   type ResolveContextGraphAuthorityHistoryInput,
 } from '../src/context-graph-authority-history.js';
+import { readAdaptiveEvmLogRange } from '../src/evm-log-range.js';
 
 const FINALIZED_HASH = `0x${'55'.repeat(32)}`;
 const NEXT_FINALIZED_HASH = `0x${'56'.repeat(32)}`;
@@ -17,21 +24,59 @@ const NAME_HASH = `0x${'88'.repeat(32)}`;
 const DIRECT_READ_SCOPE = {};
 
 class MemoryHistoryStore implements ContextGraphAuthorityHistoryStore {
-  readonly states = new Map<string, ContextGraphAuthorityHistoryState>();
+  readonly checkpoints = new Map<string, unknown>();
   readonly deleted: string[] = [];
 
-  async load(cacheKey: string): Promise<ContextGraphAuthorityHistoryState | undefined> {
-    return this.states.get(cacheKey);
+  async load(cacheKey: string): Promise<unknown> {
+    return this.checkpoints.get(cacheKey);
   }
 
-  async save(cacheKey: string, state: ContextGraphAuthorityHistoryState): Promise<void> {
-    this.states.set(cacheKey, state);
+  async save(cacheKey: string, checkpoint: unknown): Promise<void> {
+    this.checkpoints.set(cacheKey, checkpoint);
   }
 
   async delete(cacheKey: string): Promise<void> {
     this.deleted.push(cacheKey);
-    this.states.delete(cacheKey);
+    this.checkpoints.delete(cacheKey);
   }
+
+  state(cacheKey: string): ContextGraphAuthorityHistoryState | undefined {
+    return decodeContextGraphAuthorityHistoryCheckpoint(this.checkpoints.get(cacheKey));
+  }
+}
+
+class DelayedHistoryStore extends MemoryHistoryStore {
+  readonly saveEntered = Promise.withResolvers<void>();
+  readonly releaseSave = Promise.withResolvers<void>();
+  readonly deleteEntered = Promise.withResolvers<void>();
+  readonly releaseDelete = Promise.withResolvers<void>();
+  delayNextSave = false;
+  delayNextDelete = false;
+
+  override async save(cacheKey: string, checkpoint: unknown): Promise<void> {
+    if (this.delayNextSave) {
+      this.delayNextSave = false;
+      this.saveEntered.resolve();
+      await this.releaseSave.promise;
+    }
+    await super.save(cacheKey, checkpoint);
+  }
+
+  override async delete(cacheKey: string): Promise<void> {
+    if (this.delayNextDelete) {
+      this.delayNextDelete = false;
+      this.deleteEntered.resolve();
+      await this.releaseDelete.promise;
+    }
+    await super.delete(cacheKey);
+  }
+}
+
+function cacheWithStore(store: ContextGraphAuthorityHistoryStore) {
+  return new ContextGraphAuthorityHistoryCache(
+    1_024,
+    trustContextGraphAuthorityHistoryStore(store),
+  );
 }
 
 function directHistoryInput(params: Readonly<{
@@ -42,6 +87,7 @@ function directHistoryInput(params: Readonly<{
   coldReads?: { count: number };
   ordinaryRanges?: Array<readonly [number, number]>;
   blockHashes?: Readonly<Record<number, string>>;
+  readBlockHash?: (blockNumber: number) => Promise<string | null>;
   creationGate?: Readonly<{ entered(): void; wait: Promise<void> }>;
   readScope?: object;
   signal?: AbortSignal;
@@ -49,6 +95,8 @@ function directHistoryInput(params: Readonly<{
   rangeLimit?: number;
   rangeAttempts?: { count: number };
   readConcurrency?: { active: number; peak: number };
+  events?: Partial<Record<ContextGraphAuthorityHistoryEventName,
+    readonly ContextGraphAuthorityHistoryEvent[]>>;
 }>): ResolveContextGraphAuthorityHistoryInput {
   const enforceRangeLimit = (fromBlock: number, toBlock: number) => {
     if (params.rangeAttempts) params.rangeAttempts.count += 1;
@@ -72,6 +120,11 @@ function directHistoryInput(params: Readonly<{
       params.readConcurrency.active -= 1;
     }
   };
+  const adaptiveRead = <T>(
+    read: (fromBlock: number, toBlock: number) => Promise<readonly T[]>,
+    fromBlock: number,
+    toBlock: number,
+  ) => readAdaptiveEvmLogRange({ read, fromBlock, toBlock, signal: params.signal });
   return {
     cache: params.cache,
     cacheKey: params.cacheKey,
@@ -84,13 +137,13 @@ function directHistoryInput(params: Readonly<{
       if (params.coldReads) params.coldReads.count += 1;
       return 1;
     },
-    readBlockHash: async (blockNumber) => params.blockHashes?.[blockNumber]
-      ?? (blockNumber === params.blockNumber ? params.blockHash : null),
-    readCreationEvents: async (_contextGraphId, fromBlock, toBlock) => {
-      return trackRead(() => {
-        enforceRangeLimit(fromBlock, toBlock);
+    readBlockHash: params.readBlockHash ?? (async (blockNumber) => params.blockHashes?.[blockNumber]
+      ?? (blockNumber === params.blockNumber ? params.blockHash : null)),
+    readCreationEvents: async (_contextGraphId, fromBlock, toBlock) => (
+      adaptiveRead(async (rangeFrom, rangeTo) => trackRead(() => {
+        enforceRangeLimit(rangeFrom, rangeTo);
         params.creationGate?.entered();
-        if (fromBlock > 1 || toBlock < 1) return [];
+        if (rangeFrom > 1 || rangeTo < 1) return [];
         return [{
           blockNumber: 1,
           blockHash: `0x${'01'.repeat(32)}`,
@@ -100,15 +153,19 @@ function directHistoryInput(params: Readonly<{
       }).then(async (events) => {
         if (params.creationGate) await params.creationGate.wait;
         return events;
-      });
-    },
-    readEvents: async (_query, fromBlock, toBlock) => {
-      return trackRead(() => {
-        enforceRangeLimit(fromBlock, toBlock);
-        params.ordinaryRanges?.push([fromBlock, toBlock]);
-        return [];
-      });
-    },
+      }), fromBlock, toBlock)
+    ),
+    readEvents: async (query, fromBlock, toBlock) => adaptiveRead(
+      async (rangeFrom, rangeTo) => trackRead(() => {
+        enforceRangeLimit(rangeFrom, rangeTo);
+        params.ordinaryRanges?.push([rangeFrom, rangeTo]);
+        return (params.events?.[query.name] ?? []).filter((event) => (
+          event.blockNumber >= rangeFrom && event.blockNumber <= rangeTo
+        ));
+      }),
+      fromBlock,
+      toBlock,
+    ),
   };
 }
 
@@ -285,24 +342,59 @@ describe('ContextGraphAuthorityHistoryCache', () => {
     expect(coldReads.get('c')?.count).toBe(1);
   });
 
+  it('requires an explicit trusted-local admission for authority aggregates', () => {
+    const untrusted = new MemoryHistoryStore();
+    expect(() => new ContextGraphAuthorityHistoryCache(1_024, untrusted as never))
+      .toThrow(/explicitly admitted as trusted local storage/);
+    expect(() => cacheWithStore(untrusted)).not.toThrow();
+  });
+
+  it('serializes cold histories across graphs without blocking same-graph failover', async () => {
+    const cache = new ContextGraphAuthorityHistoryCache();
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const secondColdReads = { count: 0 };
+    const first = resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'cold-graph-a',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+      creationGate: { entered: entered.resolve, wait: release.promise },
+    }));
+    await entered.promise;
+    const second = resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'cold-graph-b',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+      coldReads: secondColdReads,
+    }));
+    await Promise.resolve();
+    expect(secondColdReads.count).toBe(0);
+    release.resolve();
+    const [firstResolution, secondResolution] = await Promise.all([first, second]);
+    expect(secondColdReads.count).toBe(1);
+    await Promise.all([firstResolution.publish(), secondResolution.publish()]);
+  });
+
   it('hydrates a verified durable checkpoint and scans only its suffix', async () => {
     const store = new MemoryHistoryStore();
     const firstColdReads = { count: 0 };
     const initial = await resolveContextGraphAuthorityHistory(directHistoryInput({
-      cache: new ContextGraphAuthorityHistoryCache(1_024, store),
+      cache: cacheWithStore(store),
       cacheKey: 'durable',
       blockNumber: 30,
       blockHash: FINALIZED_HASH,
       coldReads: firstColdReads,
     }));
-    expect(store.states.size).toBe(0);
+    expect(store.checkpoints.size).toBe(0);
     await initial.publish();
     expect(firstColdReads.count).toBe(1);
 
     const restartedColdReads = { count: 0 };
     const ranges: Array<readonly [number, number]> = [];
     const restarted = await resolveContextGraphAuthorityHistory(directHistoryInput({
-      cache: new ContextGraphAuthorityHistoryCache(1_024, store),
+      cache: cacheWithStore(store),
       cacheKey: 'durable',
       blockNumber: 35,
       blockHash: NEXT_FINALIZED_HASH,
@@ -313,13 +405,113 @@ describe('ContextGraphAuthorityHistoryCache', () => {
     expect(restartedColdReads.count).toBe(0);
     expect(ranges).toEqual(Array(5).fill([31, 35]));
     await restarted.publish();
-    expect(store.states.get('durable')?.throughBlockNumber).toBe(35);
+    expect(store.state('durable')?.throughBlockNumber).toBe(35);
+  });
+
+  it('preserves a future durable watermark across a lagging provider read', async () => {
+    const store = new MemoryHistoryStore();
+    const checkpointHash = `0x${'60'.repeat(32)}`;
+    const initial = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache: cacheWithStore(store),
+      cacheKey: 'lagging-provider',
+      blockNumber: 100,
+      blockHash: checkpointHash,
+    }));
+    await initial.publish();
+
+    const restartedCache = cacheWithStore(store);
+    const laggingColdReads = { count: 0 };
+    const lagging = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache: restartedCache,
+      cacheKey: 'lagging-provider',
+      blockNumber: 90,
+      blockHash: `0x${'59'.repeat(32)}`,
+      coldReads: laggingColdReads,
+    }));
+    await lagging.publish();
+    expect(laggingColdReads.count).toBe(1);
+    expect(store.state('lagging-provider')?.throughBlockNumber).toBe(100);
+    expect(store.deleted).toEqual([]);
+
+    const suffixRanges: Array<readonly [number, number]> = [];
+    const caughtUp = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache: restartedCache,
+      cacheKey: 'lagging-provider',
+      blockNumber: 110,
+      blockHash: `0x${'61'.repeat(32)}`,
+      blockHashes: { 100: checkpointHash },
+      ordinaryRanges: suffixRanges,
+    }));
+    expect(suffixRanges).toEqual(Array(5).fill([101, 110]));
+    await caughtUp.publish();
+    expect(store.state('lagging-provider')?.throughBlockNumber).toBe(110);
+  });
+
+  it('orders overlapping checkpoint publications so a late old save cannot regress storage', async () => {
+    const store = new DelayedHistoryStore();
+    store.delayNextSave = true;
+    const cache = cacheWithStore(store);
+    const older = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'overlapping-saves',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+    }));
+    const olderPublish = older.publish();
+    await store.saveEntered.promise;
+
+    const newer = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'overlapping-saves',
+      blockNumber: 35,
+      blockHash: NEXT_FINALIZED_HASH,
+      blockHashes: { 30: FINALIZED_HASH },
+    }));
+    const newerPublish = newer.publish();
+    store.releaseSave.resolve();
+    await Promise.all([olderPublish, newerPublish]);
+    expect(store.state('overlapping-saves')?.throughBlockNumber).toBe(35);
+  });
+
+  it('orders stale-anchor deletion before a concurrent newer checkpoint save', async () => {
+    const store = new DelayedHistoryStore();
+    const seeded = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache: cacheWithStore(store),
+      cacheKey: 'delete-save-race',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+    }));
+    await seeded.publish();
+    store.delayNextDelete = true;
+
+    const cache = cacheWithStore(store);
+    const stale = resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'delete-save-race',
+      blockNumber: 35,
+      blockHash: NEXT_FINALIZED_HASH,
+      blockHashes: { 30: `0x${'99'.repeat(32)}` },
+    }));
+    await store.deleteEntered.promise;
+
+    const newer = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'delete-save-race',
+      blockNumber: 40,
+      blockHash: `0x${'57'.repeat(32)}`,
+      blockHashes: { 30: FINALIZED_HASH },
+      readScope: {},
+    }));
+    const newerPublish = newer.publish();
+    store.releaseDelete.resolve();
+    await Promise.all([stale, newerPublish]);
+    expect(store.state('delete-save-race')?.throughBlockNumber).toBe(40);
   });
 
   it('deletes a durable checkpoint whose finalized anchor changed', async () => {
     const store = new MemoryHistoryStore();
     const initial = await resolveContextGraphAuthorityHistory(directHistoryInput({
-      cache: new ContextGraphAuthorityHistoryCache(1_024, store),
+      cache: cacheWithStore(store),
       cacheKey: 'reorged',
       blockNumber: 30,
       blockHash: FINALIZED_HASH,
@@ -328,7 +520,7 @@ describe('ContextGraphAuthorityHistoryCache', () => {
 
     const coldReads = { count: 0 };
     const replacement = await resolveContextGraphAuthorityHistory(directHistoryInput({
-      cache: new ContextGraphAuthorityHistoryCache(1_024, store),
+      cache: cacheWithStore(store),
       cacheKey: 'reorged',
       blockNumber: 35,
       blockHash: NEXT_FINALIZED_HASH,
@@ -343,7 +535,7 @@ describe('ContextGraphAuthorityHistoryCache', () => {
   it('retains a checkpoint when one provider cannot read its historical anchor', async () => {
     const store = new MemoryHistoryStore();
     const initial = await resolveContextGraphAuthorityHistory(directHistoryInput({
-      cache: new ContextGraphAuthorityHistoryCache(1_024, store),
+      cache: cacheWithStore(store),
       cacheKey: 'non-archive-provider',
       blockNumber: 30,
       blockHash: FINALIZED_HASH,
@@ -351,30 +543,34 @@ describe('ContextGraphAuthorityHistoryCache', () => {
     await initial.publish();
 
     await resolveContextGraphAuthorityHistory(directHistoryInput({
-      cache: new ContextGraphAuthorityHistoryCache(1_024, store),
+      cache: cacheWithStore(store),
       cacheKey: 'non-archive-provider',
       blockNumber: 35,
       blockHash: NEXT_FINALIZED_HASH,
     }));
     expect(store.deleted).toEqual([]);
-    expect(store.states.get('non-archive-provider')?.throughBlockNumber).toBe(30);
+    expect(store.state('non-archive-provider')?.throughBlockNumber).toBe(30);
   });
 
   it('ignores malformed durable input before choosing a scan bound', async () => {
     const store = new MemoryHistoryStore();
-    store.states.set('malformed', {
-      throughBlockNumber: 30,
-      throughBlockHash: 'not-a-hash',
-      nameHash: NAME_HASH,
-      ownershipEra: 0,
-      policyVersion: 0,
-      rosterVersion: 0,
-      sourceBlockNumber: 1,
-      sourceBlockHash: `0x${'01'.repeat(32)}`,
+    store.checkpoints.set('malformed', {
+      version: 1,
+      integrity: FINALIZED_HASH,
+      state: {
+        throughBlockNumber: 30,
+        throughBlockHash: 'not-a-hash',
+        nameHash: NAME_HASH,
+        ownershipEra: 0,
+        policyVersion: 0,
+        rosterVersion: 0,
+        sourceBlockNumber: 1,
+        sourceBlockHash: `0x${'01'.repeat(32)}`,
+      },
     });
     const coldReads = { count: 0 };
     const resolution = await resolveContextGraphAuthorityHistory(directHistoryInput({
-      cache: new ContextGraphAuthorityHistoryCache(1_024, store),
+      cache: cacheWithStore(store),
       cacheKey: 'malformed',
       blockNumber: 35,
       blockHash: NEXT_FINALIZED_HASH,
@@ -382,11 +578,88 @@ describe('ContextGraphAuthorityHistoryCache', () => {
     }));
     expect(coldReads.count).toBe(1);
     await resolution.publish();
-    expect(store.states.get('malformed')?.throughBlockHash).toBe(NEXT_FINALIZED_HASH);
+    expect(store.state('malformed')?.throughBlockHash).toBe(NEXT_FINALIZED_HASH);
+  });
+
+  it('rejects a canonical-anchor checkpoint whose aggregate was altered', async () => {
+    const store = new MemoryHistoryStore();
+    const validState: ContextGraphAuthorityHistoryState = {
+      throughBlockNumber: 30,
+      throughBlockHash: FINALIZED_HASH,
+      nameHash: NAME_HASH,
+      ownershipEra: 2,
+      policyVersion: 4,
+      rosterVersion: 7,
+      sourceBlockNumber: 20,
+      sourceBlockHash: `0x${'20'.repeat(32)}`,
+    };
+    const checkpoint = encodeContextGraphAuthorityHistoryCheckpoint(validState);
+    store.checkpoints.set('altered-aggregate', {
+      ...checkpoint,
+      state: { ...checkpoint.state, ownershipEra: 99 },
+    });
+    const coldReads = { count: 0 };
+    const resolution = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache: cacheWithStore(store),
+      cacheKey: 'altered-aggregate',
+      blockNumber: 35,
+      blockHash: NEXT_FINALIZED_HASH,
+      blockHashes: { 30: FINALIZED_HASH },
+      coldReads,
+    }));
+    expect(coldReads.count).toBe(1);
+    expect(resolution.state.ownershipEra).toBe(0);
+    await resolution.publish();
+  });
+
+  it.each([
+    ['negative watermark', { throughBlockNumber: -1 }],
+    ['malformed anchor hash', { throughBlockHash: '0x1234' }],
+    ['malformed name hash', { nameHash: 'not-a-hash' }],
+    ['negative ownership generation', { ownershipEra: -1 }],
+    ['fractional policy generation', { policyVersion: 1.5 }],
+    ['unsafe roster generation', { rosterVersion: Number.MAX_SAFE_INTEGER + 1 }],
+    ['negative source block', { sourceBlockNumber: -1 }],
+    ['source after watermark', { sourceBlockNumber: 31 }],
+    ['malformed source hash', { sourceBlockHash: '0x00' }],
+  ])('rejects malformed state: %s', (_label, patch) => {
+    const valid: ContextGraphAuthorityHistoryState = {
+      throughBlockNumber: 30,
+      throughBlockHash: FINALIZED_HASH,
+      nameHash: NAME_HASH,
+      ownershipEra: 2,
+      policyVersion: 4,
+      rosterVersion: 7,
+      sourceBlockNumber: 20,
+      sourceBlockHash: `0x${'20'.repeat(32)}`,
+    };
+    expect(normalizeContextGraphAuthorityHistoryState({ ...valid, ...patch })).toBeUndefined();
+  });
+
+  it('rejects old-version and integrity-less checkpoint envelopes', () => {
+    const state: ContextGraphAuthorityHistoryState = {
+      throughBlockNumber: 30,
+      throughBlockHash: FINALIZED_HASH,
+      nameHash: NAME_HASH,
+      ownershipEra: 0,
+      policyVersion: 0,
+      rosterVersion: 0,
+      sourceBlockNumber: 1,
+      sourceBlockHash: `0x${'01'.repeat(32)}`,
+    };
+    expect(decodeContextGraphAuthorityHistoryCheckpoint({ version: 0, state }))
+      .toBeUndefined();
+    expect(decodeContextGraphAuthorityHistoryCheckpoint({ version: 1, state }))
+      .toBeUndefined();
   });
 
   it('sequentially splits pages rejected by a fallback RPC range cap', async () => {
     const rangeAttempts = { count: 0 };
+    const transfer = (blockNumber: number, index: number): ContextGraphAuthorityHistoryEvent => ({
+      blockNumber,
+      blockHash: `0x${blockNumber.toString(16).padStart(64, '0')}`,
+      index,
+    });
     const resolution = await resolveContextGraphAuthorityHistory(directHistoryInput({
       cache: new ContextGraphAuthorityHistoryCache(),
       cacheKey: 'adaptive-range',
@@ -394,8 +667,18 @@ describe('ContextGraphAuthorityHistoryCache', () => {
       blockHash: FINALIZED_HASH,
       rangeLimit: 50,
       rangeAttempts,
+      // Both configured pages carry an event in each split half. The reducer
+      // assertion proves the transport helper concatenates right-hand results,
+      // rather than merely proving that it retried a particular number of times.
+      events: { Transfer: [transfer(25, 0), transfer(75, 1), transfer(125, 2), transfer(175, 3)] },
     }));
-    expect(resolution.state.throughBlockNumber).toBe(200);
+    expect(resolution.state).toMatchObject({
+      throughBlockNumber: 200,
+      ownershipEra: 4,
+      policyVersion: 4,
+      rosterVersion: 4,
+      sourceBlockNumber: 175,
+    });
     // Two configured 100-block pages × six event streams: each rejected page
     // is retried as two accepted 50-block reads.
     expect(rangeAttempts.count).toBe(36);
@@ -436,5 +719,30 @@ describe('ContextGraphAuthorityHistoryCache', () => {
       blockHash: FINALIZED_HASH,
       omitCreationNameHash: true,
     }))).rejects.toThrow('creation event has no name hash');
+  });
+});
+
+describe('adaptive EVM log-range transport', () => {
+  it('recognizes nested managed-provider errors and preserves both split halves', async () => {
+    const calls: Array<readonly [number, number]> = [];
+    const result = await readAdaptiveEvmLogRange({
+      fromBlock: 1,
+      toBlock: 100,
+      read: async (fromBlock, toBlock) => {
+        calls.push([fromBlock, toBlock]);
+        if (toBlock - fromBlock + 1 > 50) {
+          throw {
+            cause: {
+              info: {
+                error: { message: 'eth_getLogs is limited to 50 blocks' },
+              },
+            },
+          };
+        }
+        return [`${fromBlock}-${toBlock}`];
+      },
+    });
+    expect(calls).toEqual([[1, 100], [1, 50], [51, 100]]);
+    expect(result).toEqual(['1-50', '51-100']);
   });
 });

--- a/packages/chain/test/context-graph-authority-history.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-history.unit.test.ts
@@ -46,7 +46,17 @@ function directHistoryInput(params: Readonly<{
   readScope?: object;
   signal?: AbortSignal;
   omitCreationNameHash?: boolean;
+  rangeLimit?: number;
+  rangeAttempts?: { count: number };
 }>): ResolveContextGraphAuthorityHistoryInput {
+  const enforceRangeLimit = (fromBlock: number, toBlock: number) => {
+    if (params.rangeAttempts) params.rangeAttempts.count += 1;
+    if (params.rangeLimit !== undefined && toBlock - fromBlock + 1 > params.rangeLimit) {
+      throw new Error(
+        `Block range too large: maximum allowed is ${params.rangeLimit} blocks`,
+      );
+    }
+  };
   return {
     cache: params.cache,
     cacheKey: params.cacheKey,
@@ -61,9 +71,11 @@ function directHistoryInput(params: Readonly<{
     },
     readBlockHash: async (blockNumber) => params.blockHashes?.[blockNumber]
       ?? (blockNumber === params.blockNumber ? params.blockHash : null),
-    readCreationEvents: async () => {
+    readCreationEvents: async (_contextGraphId, fromBlock, toBlock) => {
+      enforceRangeLimit(fromBlock, toBlock);
       params.creationGate?.entered();
       if (params.creationGate) await params.creationGate.wait;
+      if (fromBlock > 1 || toBlock < 1) return [];
       return [{
         blockNumber: 1,
         blockHash: `0x${'01'.repeat(32)}`,
@@ -72,6 +84,7 @@ function directHistoryInput(params: Readonly<{
       }] as unknown as readonly ContextGraphAuthorityHistoryCreationEvent[];
     },
     readEvents: async (_query, fromBlock, toBlock) => {
+      enforceRangeLimit(fromBlock, toBlock);
       params.ordinaryRanges?.push([fromBlock, toBlock]);
       return [];
     },
@@ -349,6 +362,23 @@ describe('ContextGraphAuthorityHistoryCache', () => {
     expect(coldReads.count).toBe(1);
     await resolution.publish();
     expect(store.states.get('malformed')?.throughBlockHash).toBe(NEXT_FINALIZED_HASH);
+  });
+
+  it('sequentially splits pages rejected by a fallback RPC range cap', async () => {
+    const rangeAttempts = { count: 0 };
+    const resolution = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache: new ContextGraphAuthorityHistoryCache(),
+      cacheKey: 'adaptive-range',
+      blockNumber: 200,
+      blockHash: FINALIZED_HASH,
+      rangeLimit: 50,
+      rangeAttempts,
+    }));
+    expect(resolution.state.throughBlockNumber).toBe(200);
+    // Two configured 100-block pages × six event streams: each rejected page
+    // is retried as two accepted 50-block reads.
+    expect(rangeAttempts.count).toBe(36);
+    await resolution.publish();
   });
 
   it('rejects a malformed creation event without a name hash at runtime', async () => {

--- a/packages/chain/test/context-graph-authority-history.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-history.unit.test.ts
@@ -48,6 +48,7 @@ function directHistoryInput(params: Readonly<{
   omitCreationNameHash?: boolean;
   rangeLimit?: number;
   rangeAttempts?: { count: number };
+  readConcurrency?: { active: number; peak: number };
 }>): ResolveContextGraphAuthorityHistoryInput {
   const enforceRangeLimit = (fromBlock: number, toBlock: number) => {
     if (params.rangeAttempts) params.rangeAttempts.count += 1;
@@ -55,6 +56,20 @@ function directHistoryInput(params: Readonly<{
       throw new Error(
         `Block range too large: maximum allowed is ${params.rangeLimit} blocks`,
       );
+    }
+  };
+  const trackRead = async <T>(read: () => T): Promise<T> => {
+    if (params.readConcurrency === undefined) return read();
+    params.readConcurrency.active += 1;
+    params.readConcurrency.peak = Math.max(
+      params.readConcurrency.peak,
+      params.readConcurrency.active,
+    );
+    await Promise.resolve();
+    try {
+      return read();
+    } finally {
+      params.readConcurrency.active -= 1;
     }
   };
   return {
@@ -72,21 +87,27 @@ function directHistoryInput(params: Readonly<{
     readBlockHash: async (blockNumber) => params.blockHashes?.[blockNumber]
       ?? (blockNumber === params.blockNumber ? params.blockHash : null),
     readCreationEvents: async (_contextGraphId, fromBlock, toBlock) => {
-      enforceRangeLimit(fromBlock, toBlock);
-      params.creationGate?.entered();
-      if (params.creationGate) await params.creationGate.wait;
-      if (fromBlock > 1 || toBlock < 1) return [];
-      return [{
-        blockNumber: 1,
-        blockHash: `0x${'01'.repeat(32)}`,
-        index: 0,
-        ...(params.omitCreationNameHash ? {} : { nameHash: NAME_HASH }),
-      }] as unknown as readonly ContextGraphAuthorityHistoryCreationEvent[];
+      return trackRead(() => {
+        enforceRangeLimit(fromBlock, toBlock);
+        params.creationGate?.entered();
+        if (fromBlock > 1 || toBlock < 1) return [];
+        return [{
+          blockNumber: 1,
+          blockHash: `0x${'01'.repeat(32)}`,
+          index: 0,
+          ...(params.omitCreationNameHash ? {} : { nameHash: NAME_HASH }),
+        }] as unknown as readonly ContextGraphAuthorityHistoryCreationEvent[];
+      }).then(async (events) => {
+        if (params.creationGate) await params.creationGate.wait;
+        return events;
+      });
     },
     readEvents: async (_query, fromBlock, toBlock) => {
-      enforceRangeLimit(fromBlock, toBlock);
-      params.ordinaryRanges?.push([fromBlock, toBlock]);
-      return [];
+      return trackRead(() => {
+        enforceRangeLimit(fromBlock, toBlock);
+        params.ordinaryRanges?.push([fromBlock, toBlock]);
+        return [];
+      });
     },
   };
 }
@@ -379,6 +400,32 @@ describe('ContextGraphAuthorityHistoryCache', () => {
     // is retried as two accepted 50-block reads.
     expect(rangeAttempts.count).toBe(36);
     await resolution.publish();
+  });
+
+  it('serializes cold event streams but keeps warm suffix streams parallel', async () => {
+    const cache = new ContextGraphAuthorityHistoryCache();
+    const coldConcurrency = { active: 0, peak: 0 };
+    const cold = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'cold-concurrency',
+      blockNumber: 30,
+      blockHash: FINALIZED_HASH,
+      readConcurrency: coldConcurrency,
+    }));
+    expect(coldConcurrency.peak).toBe(1);
+    await cold.publish();
+
+    const warmConcurrency = { active: 0, peak: 0 };
+    const warm = await resolveContextGraphAuthorityHistory(directHistoryInput({
+      cache,
+      cacheKey: 'cold-concurrency',
+      blockNumber: 35,
+      blockHash: NEXT_FINALIZED_HASH,
+      blockHashes: { 30: FINALIZED_HASH },
+      readConcurrency: warmConcurrency,
+    }));
+    expect(warmConcurrency.peak).toBe(5);
+    await warm.publish();
   });
 
   it('rejects a malformed creation event without a name hash at runtime', async () => {

--- a/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
@@ -34,6 +34,7 @@ interface AuthorityEvidence {
   readonly ranges: Array<readonly [number, number]>;
   readonly staticCalls: Array<readonly [bigint, { blockTag: number }]>;
   readonly deploymentReads: Array<readonly [string, string, string]>;
+  readonly readOptions: Array<Readonly<{ policy?: string }>>;
 }
 
 interface EvmAuthorityHarness {
@@ -63,6 +64,7 @@ function makeEvmAuthorityAdapter(options: { reorg?: boolean } = {}): EvmAuthorit
     ranges: [] as Array<readonly [number, number]>,
     staticCalls: [] as Array<readonly [bigint, { blockTag: number }]>,
     deploymentReads: [] as Array<readonly [string, string, string]>,
+    readOptions: [],
   };
 
   let finalizedNumber = 30;
@@ -150,7 +152,11 @@ function makeEvmAuthorityAdapter(options: { reorg?: boolean } = {}): EvmAuthorit
   adapter.readTipProvider = async (
     _label: string,
     read: (selectedProvider: typeof provider) => Promise<unknown>,
-  ) => read(provider);
+    readOptions: Readonly<{ policy?: string }>,
+  ) => {
+    evidence.readOptions.push(readOptions);
+    return read(provider);
+  };
   adapter.resolveContractDeployBlock = async (
     address: string,
     operation: string,
@@ -227,6 +233,7 @@ describe('RFC-64 Context Graph authority snapshots', () => {
       'getContextGraphAuthoritySnapshot',
       'ContextGraphStorage',
     ]]);
+    expect(evidence.readOptions[0]).toMatchObject({ policy: 'wideLogScan' });
     expect(evidence.filters).toEqual([
       ['ContextGraphCreated', 9n],
       ['Transfer', null, null, 9n],
@@ -360,11 +367,9 @@ describe('RFC-64 Context Graph authority snapshots', () => {
       policyVersion: '4',
     });
     expect(evidence.deploymentReads).toHaveLength(2);
-    expect(evidence.ranges.slice(18)).toEqual([
-      ...Array(6).fill([7, 16]),
-      ...Array(6).fill([17, 26]),
-      ...Array(6).fill([27, 35]),
-    ]);
+    expect(evidence.ranges.slice(18)).toEqual(
+      Array.from({ length: 6 }, () => [[7, 16], [17, 26], [27, 35]]).flat(),
+    );
   });
 
   it('clears cached generations when ContextGraphStorage rotates', async () => {

--- a/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
@@ -48,7 +48,9 @@ interface EvmAuthorityHarness {
   rotateContextGraphStorage(): void;
 }
 
-function makeEvmAuthorityAdapter(options: { reorg?: boolean } = {}): EvmAuthorityHarness {
+function makeEvmAuthorityAdapter(
+  options: { reorg?: boolean; providerRangeLimit?: number } = {},
+): EvmAuthorityHarness {
   const adapter: any = new EVMChainAdapter({
     rpcUrl: 'http://127.0.0.1:1',
     hubAddress: GOVERNANCE,
@@ -108,7 +110,20 @@ function makeEvmAuthorityAdapter(options: { reorg?: boolean } = {}): EvmAuthorit
     ])),
     queryFilter: async (filter: { name: string }, fromBlock: number, toBlock: number) => {
       evidence.ranges.push([fromBlock, toBlock]);
-      if (toBlock - fromBlock + 1 > 10) throw new Error('oversized log range');
+      if (
+        options.providerRangeLimit !== undefined
+        && toBlock - fromBlock + 1 > options.providerRangeLimit
+      ) {
+        throw {
+          cause: {
+            info: {
+              error: {
+                message: `eth_getLogs is limited to ${options.providerRangeLimit} blocks`,
+              },
+            },
+          },
+        };
+      }
       return (logs[filter.name] ?? []).filter(
         (entry) => entry.blockNumber >= fromBlock && entry.blockNumber <= toBlock,
       );
@@ -273,6 +288,31 @@ describe('RFC-64 Context Graph authority snapshots', () => {
     // immutable and is never scanned again.
     expect(evidence.ranges.slice(18)).toEqual(Array(5).fill([31, 35]));
     expect(evidence.deploymentReads).toHaveLength(1);
+  });
+
+  it('splits provider-capped ranges through the real adapter queryFilter boundary', async () => {
+    const { adapter, evidence } = makeEvmAuthorityAdapter({ providerRangeLimit: 10 });
+    (adapter as any).cgRegistryScanPageSize = 30;
+
+    const snapshot = await adapter.getContextGraphAuthoritySnapshot(9n);
+
+    expect(snapshot).toMatchObject({
+      contextGraphId: '9',
+      owner: OWNER,
+      publishPolicy: 0,
+      ownershipEra: '1',
+      policyVersion: '3',
+      rosterVersion: '3',
+    });
+    expect(evidence.ranges).toEqual(expect.arrayContaining([
+      [7, 30],
+      [7, 18],
+      [7, 12],
+      [13, 18],
+      [19, 30],
+      [19, 24],
+      [25, 30],
+    ]));
   });
 
   it('rejects a finalized anchor that changes while the generation is read', async () => {

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -66,6 +66,7 @@ import {
   buildEvmDeploymentId,
   MockChainAdapter,
   mergeRpcUsageWindows,
+  trustContextGraphAuthorityHistoryStore,
 } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets, KaNumberAllocator, resolveSyncAgentsMeta } from '@origintrail-official/dkg-agent';
 import { isExternalBackend } from '@origintrail-official/dkg-storage';
@@ -1791,7 +1792,13 @@ async function runDaemonInnerWithStartupOwnership(
   const changelogEraGuard = config.store?.changelog ? new SqliteChangelogEraGuard(dashDb) : undefined;
   const chainEventCursorStore = new SqliteChainEventCursorStore(dashDb, { scope: chainCursorScope });
   const contextGraphRegistryScanCursorStore = new SqliteContextGraphRegistryScanCursorStore(dashDb);
-  const contextGraphAuthorityHistoryStore = new SqliteContextGraphAuthorityHistoryStore(dashDb);
+  // DashboardDB is process-owned local state under the same integrity boundary
+  // as the node identity/configuration. Authority generations cannot be proven
+  // from a watermark hash alone, so this composition-root admission is
+  // deliberately explicit rather than inferred from a structural store type.
+  const contextGraphAuthorityHistoryStore = trustContextGraphAuthorityHistoryStore(
+    new SqliteContextGraphAuthorityHistoryStore(dashDb),
+  );
 
   // OT-RFC-43 Option-1 deterministic KA identity (B2 allocator core).
   // Durable per-author KA-number sequence backing the off-chain

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -66,7 +66,6 @@ import {
   buildEvmDeploymentId,
   MockChainAdapter,
   mergeRpcUsageWindows,
-  trustContextGraphAuthorityHistoryStore,
 } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets, KaNumberAllocator, resolveSyncAgentsMeta } from '@origintrail-official/dkg-agent';
 import { isExternalBackend } from '@origintrail-official/dkg-storage';
@@ -1796,9 +1795,8 @@ async function runDaemonInnerWithStartupOwnership(
   // as the node identity/configuration. Authority generations cannot be proven
   // from a watermark hash alone, so this composition-root admission is
   // deliberately explicit rather than inferred from a structural store type.
-  const contextGraphAuthorityHistoryStore = trustContextGraphAuthorityHistoryStore(
-    new SqliteContextGraphAuthorityHistoryStore(dashDb),
-  );
+  const localContextGraphAuthorityHistoryStore =
+    new SqliteContextGraphAuthorityHistoryStore(dashDb);
 
   // OT-RFC-43 Option-1 deterministic KA identity (B2 allocator core).
   // Durable per-author KA-number sequence backing the off-chain
@@ -1928,7 +1926,7 @@ async function runDaemonInnerWithStartupOwnership(
     changelogCursorStore,
     chainEventCursorStore,
     contextGraphRegistryScanCursorStore,
-    contextGraphAuthorityHistoryStore,
+    localContextGraphAuthorityHistoryStore,
     contextGraphSubscriptionStore: {
       loadAll: async () => dashDb.listContextGraphSubscriptions().map((row) => ({
         id: row.context_graph_id,

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -97,6 +97,7 @@ import {
   SqliteChangelogCursorStore,
   SqliteChangelogEraGuard,
   SqliteChainEventCursorStore,
+  SqliteContextGraphAuthorityHistoryStore,
   SqliteContextGraphRegistryScanCursorStore,
   SqliteKaNumberStore,
   type MetricsSource,
@@ -1790,6 +1791,7 @@ async function runDaemonInnerWithStartupOwnership(
   const changelogEraGuard = config.store?.changelog ? new SqliteChangelogEraGuard(dashDb) : undefined;
   const chainEventCursorStore = new SqliteChainEventCursorStore(dashDb, { scope: chainCursorScope });
   const contextGraphRegistryScanCursorStore = new SqliteContextGraphRegistryScanCursorStore(dashDb);
+  const contextGraphAuthorityHistoryStore = new SqliteContextGraphAuthorityHistoryStore(dashDb);
 
   // OT-RFC-43 Option-1 deterministic KA identity (B2 allocator core).
   // Durable per-author KA-number sequence backing the off-chain
@@ -1919,6 +1921,7 @@ async function runDaemonInnerWithStartupOwnership(
     changelogCursorStore,
     chainEventCursorStore,
     contextGraphRegistryScanCursorStore,
+    contextGraphAuthorityHistoryStore,
     contextGraphSubscriptionStore: {
       loadAll: async () => dashDb.listContextGraphSubscriptions().map((row) => ({
         id: row.context_graph_id,

--- a/packages/cli/test/daemon-startup-validation.test.ts
+++ b/packages/cli/test/daemon-startup-validation.test.ts
@@ -247,7 +247,26 @@ describe('daemon startup network validation', () => {
         load: expect.any(Function),
         save: expect.any(Function),
       },
+      contextGraphAuthorityHistoryStore: {
+        load: expect.any(Function),
+        save: expect.any(Function),
+        delete: expect.any(Function),
+      },
     });
+    const authorityCheckpoint = {
+      version: 1,
+      state: { throughBlockNumber: 30 },
+      integrity: `0x${'11'.repeat(32)}`,
+    };
+    await createArg.contextGraphAuthorityHistoryStore.save(
+      'daemon-startup-wiring',
+      authorityCheckpoint,
+    );
+    await expect(createArg.contextGraphAuthorityHistoryStore.load('daemon-startup-wiring'))
+      .resolves.toEqual(authorityCheckpoint);
+    await createArg.contextGraphAuthorityHistoryStore.delete('daemon-startup-wiring');
+    await expect(createArg.contextGraphAuthorityHistoryStore.load('daemon-startup-wiring'))
+      .resolves.toBeUndefined();
     expect((createArg.chainEventCursorStore as any).scope).toBe(buildEvmDeploymentId({
       chainId: 'gnosis:100',
       hubAddress: '0x1234567890123456789012345678901234567890',

--- a/packages/cli/test/daemon-startup-validation.test.ts
+++ b/packages/cli/test/daemon-startup-validation.test.ts
@@ -247,7 +247,7 @@ describe('daemon startup network validation', () => {
         load: expect.any(Function),
         save: expect.any(Function),
       },
-      contextGraphAuthorityHistoryStore: {
+      localContextGraphAuthorityHistoryStore: {
         load: expect.any(Function),
         save: expect.any(Function),
         delete: expect.any(Function),
@@ -258,14 +258,14 @@ describe('daemon startup network validation', () => {
       state: { throughBlockNumber: 30 },
       integrity: `0x${'11'.repeat(32)}`,
     };
-    await createArg.contextGraphAuthorityHistoryStore.save(
+    await createArg.localContextGraphAuthorityHistoryStore.save(
       'daemon-startup-wiring',
       authorityCheckpoint,
     );
-    await expect(createArg.contextGraphAuthorityHistoryStore.load('daemon-startup-wiring'))
+    await expect(createArg.localContextGraphAuthorityHistoryStore.load('daemon-startup-wiring'))
       .resolves.toEqual(authorityCheckpoint);
-    await createArg.contextGraphAuthorityHistoryStore.delete('daemon-startup-wiring');
-    await expect(createArg.contextGraphAuthorityHistoryStore.load('daemon-startup-wiring'))
+    await createArg.localContextGraphAuthorityHistoryStore.delete('daemon-startup-wiring');
+    await expect(createArg.localContextGraphAuthorityHistoryStore.load('daemon-startup-wiring'))
       .resolves.toBeUndefined();
     expect((createArg.chainEventCursorStore as any).scope).toBe(buildEvmDeploymentId({
       chainId: 'gnosis:100',

--- a/packages/node-ui/src/chain-cursor-stores.ts
+++ b/packages/node-ui/src/chain-cursor-stores.ts
@@ -1,6 +1,17 @@
 import Database from 'better-sqlite3';
 import type { DashboardDB } from './db.js';
 
+interface ContextGraphAuthorityHistoryStateRecord {
+  readonly throughBlockNumber: number;
+  readonly throughBlockHash: string;
+  readonly nameHash: string;
+  readonly ownershipEra: number;
+  readonly policyVersion: number;
+  readonly rosterVersion: number;
+  readonly sourceBlockNumber: number;
+  readonly sourceBlockHash: string;
+}
+
 function parsePositiveSafeInteger(value: number | string | undefined): number | undefined {
   if (value == null) return undefined;
   const parsed = Number(value);
@@ -121,5 +132,59 @@ export class SqliteContextGraphRegistryScanCursorStore {
       key.deploymentId,
       key.registryAddress.toLowerCase(),
     ].join(':');
+  }
+}
+
+/**
+ * Versioned, SQLite-backed authority-history checkpoints.
+ *
+ * SQLite makes each replacement atomic. The chain package treats the payload
+ * as untrusted, validates every field, and verifies the finalized anchor hash
+ * before using it as a suffix-scan watermark.
+ */
+export class SqliteContextGraphAuthorityHistoryStore {
+  static readonly VERSION = 1;
+  static readonly KEY_PREFIX = 'contextGraphAuthorityHistory.checkpoint:v1:';
+
+  private readonly db: Database.Database;
+
+  constructor(dashboard: DashboardDB) {
+    this.db = dashboard.db;
+  }
+
+  async load(cacheKey: string): Promise<ContextGraphAuthorityHistoryStateRecord | undefined> {
+    const row = this.db.prepare(
+      `SELECT value FROM settings WHERE key = ?`,
+    ).get(this.key(cacheKey)) as { value: string } | undefined;
+    if (row === undefined) return undefined;
+    try {
+      const payload = JSON.parse(row.value) as {
+        version?: unknown;
+        state?: ContextGraphAuthorityHistoryStateRecord;
+      };
+      return payload?.version === SqliteContextGraphAuthorityHistoryStore.VERSION
+        ? payload.state
+        : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async save(cacheKey: string, state: ContextGraphAuthorityHistoryStateRecord): Promise<void> {
+    const value = JSON.stringify({
+      version: SqliteContextGraphAuthorityHistoryStore.VERSION,
+      state,
+    });
+    this.db.prepare(
+      `INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`,
+    ).run(this.key(cacheKey), value);
+  }
+
+  async delete(cacheKey: string): Promise<void> {
+    this.db.prepare(`DELETE FROM settings WHERE key = ?`).run(this.key(cacheKey));
+  }
+
+  private key(cacheKey: string): string {
+    return `${SqliteContextGraphAuthorityHistoryStore.KEY_PREFIX}${cacheKey}`;
   }
 }

--- a/packages/node-ui/src/chain-cursor-stores.ts
+++ b/packages/node-ui/src/chain-cursor-stores.ts
@@ -1,17 +1,6 @@
 import Database from 'better-sqlite3';
 import type { DashboardDB } from './db.js';
 
-interface ContextGraphAuthorityHistoryStateRecord {
-  readonly throughBlockNumber: number;
-  readonly throughBlockHash: string;
-  readonly nameHash: string;
-  readonly ownershipEra: number;
-  readonly policyVersion: number;
-  readonly rosterVersion: number;
-  readonly sourceBlockNumber: number;
-  readonly sourceBlockHash: string;
-}
-
 function parsePositiveSafeInteger(value: number | string | undefined): number | undefined {
   if (value == null) return undefined;
   const parsed = Number(value);
@@ -136,14 +125,13 @@ export class SqliteContextGraphRegistryScanCursorStore {
 }
 
 /**
- * Versioned, SQLite-backed authority-history checkpoints.
+ * Opaque, SQLite-backed authority-history checkpoints.
  *
- * SQLite makes each replacement atomic. The chain package treats the payload
- * as untrusted, validates every field, and verifies the finalized anchor hash
- * before using it as a suffix-scan watermark.
+ * SQLite makes each replacement atomic. The chain package exclusively owns
+ * the versioned codec, integrity check, and authority-state model; this adapter
+ * intentionally only persists and returns JSON values.
  */
 export class SqliteContextGraphAuthorityHistoryStore {
-  static readonly VERSION = 1;
   static readonly KEY_PREFIX = 'contextGraphAuthorityHistory.checkpoint:v1:';
 
   private readonly db: Database.Database;
@@ -152,29 +140,20 @@ export class SqliteContextGraphAuthorityHistoryStore {
     this.db = dashboard.db;
   }
 
-  async load(cacheKey: string): Promise<ContextGraphAuthorityHistoryStateRecord | undefined> {
+  async load(cacheKey: string): Promise<unknown> {
     const row = this.db.prepare(
       `SELECT value FROM settings WHERE key = ?`,
     ).get(this.key(cacheKey)) as { value: string } | undefined;
     if (row === undefined) return undefined;
     try {
-      const payload = JSON.parse(row.value) as {
-        version?: unknown;
-        state?: ContextGraphAuthorityHistoryStateRecord;
-      };
-      return payload?.version === SqliteContextGraphAuthorityHistoryStore.VERSION
-        ? payload.state
-        : undefined;
+      return JSON.parse(row.value) as unknown;
     } catch {
       return undefined;
     }
   }
 
-  async save(cacheKey: string, state: ContextGraphAuthorityHistoryStateRecord): Promise<void> {
-    const value = JSON.stringify({
-      version: SqliteContextGraphAuthorityHistoryStore.VERSION,
-      state,
-    });
+  async save(cacheKey: string, checkpoint: unknown): Promise<void> {
+    const value = JSON.stringify(checkpoint);
     this.db.prepare(
       `INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`,
     ).run(this.key(cacheKey), value);

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -26,6 +26,7 @@ import {
 } from './routine-log-retention.js';
 export {
   SqliteChainEventCursorStore,
+  SqliteContextGraphAuthorityHistoryStore,
   SqliteContextGraphRegistryScanCursorStore,
 } from './chain-cursor-stores.js';
 

--- a/packages/node-ui/src/index.ts
+++ b/packages/node-ui/src/index.ts
@@ -17,6 +17,7 @@ export {
 } from './db.js';
 export {
   SqliteChainEventCursorStore,
+  SqliteContextGraphAuthorityHistoryStore,
   SqliteContextGraphRegistryScanCursorStore,
 } from './chain-cursor-stores.js';
 export type {

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import Database from 'better-sqlite3';
-import { DashboardDB, SqliteChainEventCursorStore, SqliteContextGraphRegistryScanCursorStore, SqliteKaNumberStore, SqliteSyncCheckpointStore, SqliteChangelogCursorStore, SqliteChangelogEraGuard, buildActivityDigestKey, ACTIVITY_DIGEST_WINDOW_MS, ASSERTION_ACTIVITY_TYPE, SCHEMA_VERSION } from '../src/db.js';
+import { DashboardDB, SqliteChainEventCursorStore, SqliteContextGraphAuthorityHistoryStore, SqliteContextGraphRegistryScanCursorStore, SqliteKaNumberStore, SqliteSyncCheckpointStore, SqliteChangelogCursorStore, SqliteChangelogEraGuard, buildActivityDigestKey, ACTIVITY_DIGEST_WINDOW_MS, ASSERTION_ACTIVITY_TYPE, SCHEMA_VERSION } from '../src/db.js';
 
 let db: DashboardDB;
 let dir: string;
@@ -2328,6 +2328,35 @@ describe('DashboardDB — chain RPC cursor stores', () => {
     const reopened = new SqliteContextGraphRegistryScanCursorStore(db);
     expect(await reopened.load(key)).toBe(5000);
     expect(await reopened.load({ ...key, registryAddress: '0x6666666666666666666666666666666666666666' })).toBe(6000);
+  });
+
+  it('atomically persists versioned Context Graph authority checkpoints', async () => {
+    const store = new SqliteContextGraphAuthorityHistoryStore(db);
+    const key = 'evm:84532:hub=0xabc:0x3333333333333333333333333333333333333333:9';
+    const state = {
+      throughBlockNumber: 5000,
+      throughBlockHash: `0x${'55'.repeat(32)}`,
+      nameHash: `0x${'88'.repeat(32)}`,
+      ownershipEra: 2,
+      policyVersion: 4,
+      rosterVersion: 7,
+      sourceBlockNumber: 4990,
+      sourceBlockHash: `0x${'44'.repeat(32)}`,
+    };
+
+    await store.save(key, state);
+    expect(await store.load(key)).toEqual(state);
+    const persisted = db.db.prepare(
+      `SELECT value FROM settings WHERE key = ?`,
+    ).get(`${SqliteContextGraphAuthorityHistoryStore.KEY_PREFIX}${key}`) as { value: string };
+    expect(JSON.parse(persisted.value)).toEqual({ version: 1, state });
+
+    db.close();
+    db = new DashboardDB({ dataDir: dir });
+    const reopened = new SqliteContextGraphAuthorityHistoryStore(db);
+    expect(await reopened.load(key)).toEqual(state);
+    await reopened.delete(key);
+    expect(await reopened.load(key)).toBeUndefined();
   });
 });
 

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -2333,28 +2333,32 @@ describe('DashboardDB — chain RPC cursor stores', () => {
   it('atomically persists versioned Context Graph authority checkpoints', async () => {
     const store = new SqliteContextGraphAuthorityHistoryStore(db);
     const key = 'evm:84532:hub=0xabc:0x3333333333333333333333333333333333333333:9';
-    const state = {
-      throughBlockNumber: 5000,
-      throughBlockHash: `0x${'55'.repeat(32)}`,
-      nameHash: `0x${'88'.repeat(32)}`,
-      ownershipEra: 2,
-      policyVersion: 4,
-      rosterVersion: 7,
-      sourceBlockNumber: 4990,
-      sourceBlockHash: `0x${'44'.repeat(32)}`,
+    const checkpoint = {
+      version: 1,
+      state: {
+        throughBlockNumber: 5000,
+        throughBlockHash: `0x${'55'.repeat(32)}`,
+        nameHash: `0x${'88'.repeat(32)}`,
+        ownershipEra: 2,
+        policyVersion: 4,
+        rosterVersion: 7,
+        sourceBlockNumber: 4990,
+        sourceBlockHash: `0x${'44'.repeat(32)}`,
+      },
+      integrity: `0x${'99'.repeat(32)}`,
     };
 
-    await store.save(key, state);
-    expect(await store.load(key)).toEqual(state);
+    await store.save(key, checkpoint);
+    expect(await store.load(key)).toEqual(checkpoint);
     const persisted = db.db.prepare(
       `SELECT value FROM settings WHERE key = ?`,
     ).get(`${SqliteContextGraphAuthorityHistoryStore.KEY_PREFIX}${key}`) as { value: string };
-    expect(JSON.parse(persisted.value)).toEqual({ version: 1, state });
+    expect(JSON.parse(persisted.value)).toEqual(checkpoint);
 
     db.close();
     db = new DashboardDB({ dataDir: dir });
     const reopened = new SqliteContextGraphAuthorityHistoryStore(db);
-    expect(await reopened.load(key)).toEqual(state);
+    expect(await reopened.load(key)).toEqual(checkpoint);
     await reopened.delete(key);
     expect(await reopened.load(key)).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

Follow-up to #2540 that makes finalized Context Graph authority-history watermarks survive daemon restarts.

- persist versioned checkpoints atomically in the existing node SQLite database
- scope keys by chain deployment, ContextGraphs contract, and context graph id
- validate stored fields and revalidate the finalized anchor hash before suffix scanning
- fail closed to a cold scan on corrupt/stale state without discarding checkpoints for a transient non-archive provider miss
- serialize cold-start graph and event-stream refreshes to bound RPC fan-out
- adaptively split historical log ranges when an RPC declares a smaller maximum range
- classify authority-history reads as wide log scans so they use the existing multi-endpoint 30-second policy

## Why

#2540 removes repeat historical scans during one process lifetime, but a daemon restart starts cold. On the testnet beacons that immediately fans multiple graphs and event filters into the shared RPC, and rate limiting can keep the cache from ever publishing. This change preserves the verified watermark across restarts and limits the unavoidable first warm-up.

## Validation

- authority-history unit tests: 13 passed
- authority-snapshot unit tests: 9 passed
- combined focused authority suite: 22 passed
- SQLite lifecycle tests: 120 passed
- agent chain cursor/store wiring: 2 passed
- chain, node-ui, agent, and CLI builds/type-boundary tests passed
- oxlint on changed files: no errors
- required GitHub CI gate and EVM integration gate passed

## Testnet-canary hotfix verification

Commit `e2c9dd344e49e3c24ad4060efc4df221b775dbb5` is running on all four testnet beacons. Each node has its DKG worker, P2P listener, and HTTP API healthy.

The live SQLite stores still contain zero authority-history checkpoints because every configured Base Sepolia RPC backend is currently returning rate limits/timeouts before a full trusted scan can finish. The checkpoint path is covered by unit tests, but live restart reuse cannot be verified until one complete scan succeeds and seeds the first record.
