### PR TITLE
feat(chain): attribute eth_getLogs RPC usage

### DIFF
--- a/packages/agent/test/rpc-usage-boundary.test.ts
+++ b/packages/agent/test/rpc-usage-boundary.test.ts
@@ -29,12 +29,22 @@ describe('DKGAgent.drainRpcUsage — the adapter→agent telemetry boundary', ()
   it('returns the real MockChainAdapter empty window (capability present, no transport)', () => {
     const chain = new MockChainAdapter();
     const out = drain.call({ chain } as never);
-    expect(out).toEqual({ byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 0 });
+    expect(out).toEqual({
+      byMethod: {},
+      ethCallByConsumer: {},
+      ethGetLogsByConsumerAndEndpointSlot: {},
+      lifetimeTotal: 0,
+    });
   });
 
   it('collapses a missing adapter capability to a concrete EMPTY window (consumers never see undefined)', () => {
     const out = drain.call({ chain: {} } as never);
-    expect(out).toEqual({ byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 0 });
+    expect(out).toEqual({
+      byMethod: {},
+      ethCallByConsumer: {},
+      ethGetLogsByConsumerAndEndpointSlot: {},
+      lifetimeTotal: 0,
+    });
   });
 
   it('is inherited by the composed DKGAgent class (the daemon consumes agent, not the base)', () => {

--- a/packages/agent/test/rpc-usage-boundary.test.ts
+++ b/packages/agent/test/rpc-usage-boundary.test.ts
@@ -32,7 +32,7 @@ describe('DKGAgent.drainRpcUsage — the adapter→agent telemetry boundary', ()
     expect(out).toEqual({
       byMethod: {},
       ethCallByConsumer: {},
-      ethGetLogsByConsumerAndEndpointSlot: {},
+      attributions: [],
       lifetimeTotal: 0,
     });
   });
@@ -42,7 +42,7 @@ describe('DKGAgent.drainRpcUsage — the adapter→agent telemetry boundary', ()
     expect(out).toEqual({
       byMethod: {},
       ethCallByConsumer: {},
-      ethGetLogsByConsumerAndEndpointSlot: {},
+      attributions: [],
       lifetimeTotal: 0,
     });
   });

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -946,6 +946,7 @@ export class EVMChainAdapterBase {
           connected,
           label,
           preferred,
+          rpcUsageConsumer,
         ) => this.queryEventLogsPage(
           baseContract,
           filter,
@@ -955,6 +956,7 @@ export class EVMChainAdapterBase {
           connected,
           label,
           preferred,
+          rpcUsageConsumer,
         ),
       }),
     });
@@ -3222,6 +3224,7 @@ export class EVMChainAdapterBase {
       connected,
       'getMaxKaNumberForAuthor KnowledgeAssetCreated',
       preferred,
+      'getMaxKaNumberForAuthor',
     );
   }
 
@@ -3234,6 +3237,7 @@ export class EVMChainAdapterBase {
     connected: Map<JsonRpcProvider, Contract>,
     label: string,
     preferred?: JsonRpcProvider,
+    rpcUsageConsumer = 'eventLogPageScan',
   ): Promise<{ logs: ReadonlyArray<ethers.EventLog | ethers.Log>; provider: JsonRpcProvider }> {
     return withSpan(
       'chain.eth_getLogs',
@@ -3269,7 +3273,7 @@ export class EVMChainAdapterBase {
             // bounded consumer scope explicitly so a large historical crawl
             // (notably the pre-10.0.4 KA high-water fallback) cannot collapse
             // into `consumer=unattributed` in raw eth_getLogs telemetry.
-            const logs = await withRpcUsageConsumer(label, () => withTimeout(
+            const logs = await withRpcUsageConsumer(rpcUsageConsumer, () => withTimeout(
               contract.queryFilter(filter as any, lo, hi),
               KA_HIGH_WATER_PAGE_TIMEOUT_MS,
               `${label} getLogs [${lo}, ${hi}]`,

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -1185,11 +1185,11 @@ export class EVMChainAdapterBase {
       ? undefined
       : ethers.Network.from(this.configuredStaticChainId);
     this.providers = this.rpcUrls.map(
-      (url) => createCountingJsonRpcProvider(url, perEndpointRetries, this.rpcUsage, {
+      (url, endpointSlot) => createCountingJsonRpcProvider(url, perEndpointRetries, this.rpcUsage, {
         cacheTimeout: -1,
         polling: true,
         batchMaxCount: 1,
-      }, staticNetwork),
+      }, staticNetwork, endpointSlot),
     );
     this.primaryProvider = this.providers[0];
     // No `FallbackProvider`: reads route through the `RpcFailoverClient` read

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -1190,11 +1190,16 @@ export class EVMChainAdapterBase {
       ? undefined
       : ethers.Network.from(this.configuredStaticChainId);
     this.providers = this.rpcUrls.map(
-      (url, endpointSlot) => createCountingJsonRpcProvider(url, perEndpointRetries, this.rpcUsage, {
-        cacheTimeout: -1,
-        polling: true,
-        batchMaxCount: 1,
-      }, staticNetwork, endpointSlot),
+      (url, endpointSlot) => createCountingJsonRpcProvider(url, this.rpcUsage, {
+        maxRetries: perEndpointRetries,
+        providerOptions: {
+          cacheTimeout: -1,
+          polling: true,
+          batchMaxCount: 1,
+        },
+        network: staticNetwork,
+        endpointSlot,
+      }),
     );
     this.primaryProvider = this.providers[0];
     // No `FallbackProvider`: reads route through the `RpcFailoverClient` read

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -34,7 +34,12 @@ import { rpcHost } from './rpc-failover-log.js';
 import { ChainRpcTransportError } from './chain-rpc-transport-error.js';
 import { RpcFailoverClient, type ReadOpts, type ReceiptLookupOptions } from './rpc-failover-client.js';
 import { waitForReceiptWithDeadline } from './receipt-wait.js';
-import { RpcUsageTracker, createCountingJsonRpcProvider, type RpcUsageWindow } from './rpc-usage.js';
+import {
+  RpcUsageTracker,
+  createCountingJsonRpcProvider,
+  withRpcUsageConsumer,
+  type RpcUsageWindow,
+} from './rpc-usage.js';
 import { computeApprovalAction, effectivePublishAllowance, V10_PUBLISH_ONCHAIN_MIN_ALLOWANCE } from './evm-adapter-allowance.js';
 import { formatProviderContext } from './evm-adapter-types.js';
 import { ReadThroughTtlCache } from './keyed-ttl-single-flight-cache.js';
@@ -3278,11 +3283,16 @@ export class EVMChainAdapterBase {
               contract = baseContract.connect(provider) as Contract;
               connected.set(provider, contract);
             }
-            const logs = await withTimeout(
+            // This scan bypasses RpcFailoverClient intentionally because it
+            // owns a page-aware provider order and timeout. Establish the same
+            // bounded consumer scope explicitly so a large historical crawl
+            // (notably the pre-10.0.4 KA high-water fallback) cannot collapse
+            // into `consumer=unattributed` in raw eth_getLogs telemetry.
+            const logs = await withRpcUsageConsumer(label, () => withTimeout(
               contract.queryFilter(filter as any, lo, hi),
               KA_HIGH_WATER_PAGE_TIMEOUT_MS,
               `${label} getLogs [${lo}, ${hi}]`,
-            );
+            ));
             metrics.chainRpcTotal.add(1, {
               rpc_method: 'eth_getLogs', outcome: 'ok', retryable: false, chain_id: this.chainId,
             });

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -381,6 +381,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           connected,
           'listContextGraphsFromChain NameClaimed',
           preferred,
+          'listContextGraphsFromChain',
         );
         preferred = page.provider;
         pageResults = [];

--- a/packages/chain/src/evm-context-graph-name-hash-fence.ts
+++ b/packages/chain/src/evm-context-graph-name-hash-fence.ts
@@ -90,6 +90,7 @@ export interface EvmContextGraphNameHashFenceDependencies {
     connected: Map<JsonRpcProvider, Contract>,
     label: string,
     preferred?: JsonRpcProvider,
+    rpcUsageConsumer?: string,
   ) => Promise<{
     readonly logs: ReadonlyArray<ethers.EventLog | ethers.Log>;
     readonly provider: JsonRpcProvider;
@@ -756,6 +757,7 @@ export class EvmContextGraphNameHashFence implements EvmContextGraphNameHashSour
               connected,
               'resolveContextGraphIdByNameHash ContextGraphCreated',
               preferred,
+              'resolveContextGraphIdByNameHash',
             );
             const ids: bigint[] = [];
             for (const log of page.logs) {

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -126,14 +126,16 @@ export {
 } from './publisher-plan.js';
 // RPC-usage accounting: ONLY the typed window contract is public API (consumed
 // by the ChainAdapter.drainRpcUsage capability, the agent boundary, and the
-// daemon's rpc_usage log emission). The parsing/label-bounding helpers stay
-// package-internal (imported via ./rpc-usage.js) so the transport accounting
-// implementation can change without a public-API break.
+// daemon's rpc_usage log emission). Endpoint-slot normalization is shared with
+// downstream formatters so producer and consumer use one bounded vocabulary.
 export {
   emptyRpcUsageWindow,
   mergeRpcUsageWindows,
   normalizeRpcUsageWindow,
+  normalizeRpcEndpointSlotLabel,
   rpcUsageWindowTotal,
+  type RpcEndpointSlotLabel,
+  type RpcUsageAttribution,
   type NormalizedRpcUsageWindow,
   type RpcUsageDrainable,
   type RpcUsageWindow,

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -132,6 +132,7 @@ export {
 export {
   emptyRpcUsageWindow,
   mergeRpcUsageWindows,
+  RPC_ENDPOINT_SLOT_LABELS,
   normalizeRpcUsageWindow,
   normalizeRpcEndpointSlotLabel,
   rpcUsageWindowTotal,

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -267,7 +267,12 @@ export class MockChainAdapter implements ChainAdapter {
 
   /** RPC-usage capability: the mock has no RPC transport → always-empty window. */
   drainRpcUsage(): RpcUsageWindow {
-    return { byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 0 };
+    return {
+      byMethod: {},
+      ethCallByConsumer: {},
+      ethGetLogsByConsumerAndEndpointSlot: {},
+      lifetimeTotal: 0,
+    };
   }
 
   async ensureProfile(_options?: { nodeName?: string; stakeAmount?: bigint; lockTier?: number }): Promise<bigint> {

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -37,7 +37,7 @@ import type {
   KnowledgeAssetUpdateContext,
   ContextGraphAuthoritySnapshot,
 } from './chain-adapter.js';
-import type { RpcUsageWindow } from './rpc-usage.js';
+import { emptyRpcUsageWindow, type RpcUsageWindow } from './rpc-usage.js';
 import {
   NoEligibleContextGraphError,
   NoEligibleKnowledgeCollectionError,
@@ -267,12 +267,7 @@ export class MockChainAdapter implements ChainAdapter {
 
   /** RPC-usage capability: the mock has no RPC transport → always-empty window. */
   drainRpcUsage(): RpcUsageWindow {
-    return {
-      byMethod: {},
-      ethCallByConsumer: {},
-      ethGetLogsByConsumerAndEndpointSlot: {},
-      lifetimeTotal: 0,
-    };
+    return emptyRpcUsageWindow();
   }
 
   async ensureProfile(_options?: { nodeName?: string; stakeAmount?: bigint; lockTier?: number }): Promise<bigint> {

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -94,8 +94,9 @@ export type ReadPolicy =
   | 'failOpenFundingRead';
 
 /** Per-read options: timeout/failover behavior plus an explicit low-cardinality
- *  telemetry consumer key for `eth_call` attribution. `label` remains a human
- *  failover/span label and is not implicitly part of the daemon log contract. */
+ *  telemetry consumer key for raw-read attribution (`eth_call` and
+ *  `eth_getLogs`). `label` remains a human failover/span label and is not
+ *  implicitly part of the daemon log contract. */
 export interface ReadOpts {
   policy?: ReadPolicy;
   isRetryable?: (err: unknown) => boolean;

--- a/packages/chain/src/rpc-usage.ts
+++ b/packages/chain/src/rpc-usage.ts
@@ -89,22 +89,65 @@ export function jsonRpcMethodsFromBody(body: Uint8Array | null | undefined): str
 }
 
 /** A fresh all-zero window — the identity element for merging and the value of "nothing to report". */
-export function emptyRpcUsageWindow(): NormalizedRpcUsageWindow {
+export type RpcEndpointSlotLabel =
+  | 'primary'
+  | 'fallback_1' | 'fallback_2' | 'fallback_3' | 'fallback_4' | 'fallback_5'
+  | 'fallback_6' | 'fallback_7' | 'fallback_8' | 'fallback_9' | 'fallback_10'
+  | 'fallback_11' | 'fallback_12' | 'fallback_13' | 'fallback_14' | 'fallback_15'
+  | 'other';
+
+/** Canonical method-aware diagnostic attribution carried by a usage window. */
+export type RpcUsageAttribution =
+  | { readonly method: 'eth_call'; readonly consumer: string; readonly count: number }
+  | {
+      readonly method: 'eth_getLogs';
+      readonly consumer: string;
+      readonly endpointSlot: RpcEndpointSlotLabel;
+      readonly count: number;
+    };
+
+type ConcreteRpcUsageWindow = NormalizedRpcUsageWindow & {
+  readonly attributions: readonly RpcUsageAttribution[];
+};
+
+export function emptyRpcUsageWindow(): ConcreteRpcUsageWindow {
   return {
     byMethod: {},
     ethCallByConsumer: {},
-    ethGetLogsByConsumerAndEndpointSlot: {},
+    attributions: [],
     lifetimeTotal: 0,
   };
 }
 
 /** Normalize a public drain-window input into the concrete telemetry model. */
-export function normalizeRpcUsageWindow(window: RpcUsageWindow): NormalizedRpcUsageWindow {
+export function normalizeRpcUsageWindow(window: RpcUsageWindow): ConcreteRpcUsageWindow {
+  const attributions = window.attributions
+    ? [...window.attributions]
+    : [
+        ...Object.entries(window.ethCallByConsumer ?? {}).map(
+          ([consumer, count]): RpcUsageAttribution => ({ method: 'eth_call', consumer, count }),
+        ),
+        ...Object.entries(window.ethGetLogsByConsumerAndEndpointSlot ?? {}).flatMap(
+          ([consumer, byEndpointSlot]) => Object.entries(byEndpointSlot).map(
+            ([endpointSlot, count]): RpcUsageAttribution => ({
+              method: 'eth_getLogs',
+              consumer,
+              endpointSlot: normalizeRpcEndpointSlotLabel(endpointSlot),
+              count,
+            }),
+          ),
+        ),
+      ];
+  const ethCallByConsumer: Record<string, number> = {};
+  for (const attribution of attributions) {
+    if (attribution.method !== 'eth_call') continue;
+    ethCallByConsumer[attribution.consumer] =
+      (ethCallByConsumer[attribution.consumer] ?? 0) + attribution.count;
+  }
   return {
     byMethod: window.byMethod,
-    ethCallByConsumer: window.ethCallByConsumer ?? {},
-    ethGetLogsByConsumerAndEndpointSlot:
-      window.ethGetLogsByConsumerAndEndpointSlot ?? {},
+    ethCallByConsumer,
+    attributions,
     lifetimeTotal: window.lifetimeTotal,
   };
 }
@@ -137,42 +180,33 @@ export function mergeRpcUsageWindows(
   const defined = windows.filter((w): w is RpcUsageWindow => w !== undefined);
   if (defined.length === 0) return emptyRpcUsageWindow();
   const byMethod: Record<string, number> = {};
-  const ethCallByConsumer: Record<string, number> = {};
-  const ethGetLogsByConsumerAndEndpointSlot:
-    Record<string, Record<string, number>> = {};
+  const attributions = new Map<string, RpcUsageAttribution>();
   let lifetimeTotal = 0;
   for (const input of defined) {
     const w = normalizeRpcUsageWindow(input);
     for (const [m, c] of Object.entries(w.byMethod)) byMethod[m] = (byMethod[m] ?? 0) + c;
-    for (const [consumer, c] of Object.entries(w.ethCallByConsumer)) {
-      ethCallByConsumer[consumer] = (ethCallByConsumer[consumer] ?? 0) + c;
-    }
-    for (const [consumer, byEndpointSlot] of Object.entries(
-      w.ethGetLogsByConsumerAndEndpointSlot,
-    )) {
-      const mergedByEndpointSlot = Object.prototype.hasOwnProperty.call(
-        ethGetLogsByConsumerAndEndpointSlot,
-        consumer,
-      )
-        ? ethGetLogsByConsumerAndEndpointSlot[consumer]
-        : (ethGetLogsByConsumerAndEndpointSlot[consumer] = {});
-      for (const [endpointSlot, c] of Object.entries(byEndpointSlot)) {
-        const current = Object.prototype.hasOwnProperty.call(
-          mergedByEndpointSlot,
-          endpointSlot,
-        )
-          ? mergedByEndpointSlot[endpointSlot]
-          : 0;
-        mergedByEndpointSlot[endpointSlot] =
-          current + c;
-      }
+    for (const attribution of w.attributions) {
+      const key = attribution.method === 'eth_call'
+        ? `${attribution.method}\0${attribution.consumer}`
+        : `${attribution.method}\0${attribution.consumer}\0${attribution.endpointSlot}`;
+      const current = attributions.get(key);
+      attributions.set(key, {
+        ...attribution,
+        count: (current?.count ?? 0) + attribution.count,
+      } as RpcUsageAttribution);
     }
     lifetimeTotal += w.lifetimeTotal;
+  }
+  const mergedAttributions = [...attributions.values()];
+  const ethCallByConsumer: Record<string, number> = {};
+  for (const attribution of mergedAttributions) {
+    if (attribution.method !== 'eth_call') continue;
+    ethCallByConsumer[attribution.consumer] = attribution.count;
   }
   return {
     byMethod,
     ethCallByConsumer,
-    ethGetLogsByConsumerAndEndpointSlot,
+    attributions: mergedAttributions,
     lifetimeTotal,
   };
 }
@@ -199,6 +233,11 @@ export interface RpcUsageWindow {
    */
   ethCallByConsumer?: Record<string, number>;
   /**
+   * Canonical diagnostic attribution. When absent, normalization accepts the
+   * legacy method-specific maps below for source compatibility.
+   */
+  attributions?: readonly RpcUsageAttribution[];
+  /**
    * Raw `eth_getLogs` attribution by bounded code-owned consumer and configured
    * endpoint slot. This is diagnostic detail only: `byMethod.eth_getLogs`
    * remains the billing-exact aggregate. Endpoint slots are deliberately
@@ -216,7 +255,6 @@ export interface RpcUsageWindow {
 /** Concrete package-owned telemetry window after legacy inputs are normalized. */
 export interface NormalizedRpcUsageWindow extends RpcUsageWindow {
   ethCallByConsumer: Record<string, number>;
-  ethGetLogsByConsumerAndEndpointSlot: Record<string, Record<string, number>>;
 }
 
 /**
@@ -265,9 +303,17 @@ function activeRpcUsageConsumer(): string | undefined {
  * configured endpoints retain individual attribution; larger or missing slots
  * collapse to `other` rather than expanding telemetry cardinality.
  */
+export function normalizeRpcEndpointSlotLabel(value: unknown): RpcEndpointSlotLabel {
+  if (value === 'primary' || value === 'other') return value;
+  if (typeof value === 'string' && /^fallback_(?:[1-9]|1[0-5])$/.test(value)) {
+    return value as RpcEndpointSlotLabel;
+  }
+  return 'other';
+}
+
 export function boundedRpcEndpointSlotLabel(
   endpointSlot: number | undefined,
-): string {
+): RpcEndpointSlotLabel {
   if (
     typeof endpointSlot !== 'number'
     || !Number.isSafeInteger(endpointSlot)
@@ -275,7 +321,7 @@ export function boundedRpcEndpointSlotLabel(
   ) return 'other';
   if (endpointSlot === 0) return 'primary';
   if (endpointSlot < RpcUsageTracker.MAX_TRACKED_ENDPOINT_SLOTS) {
-    return `fallback_${endpointSlot}`;
+    return normalizeRpcEndpointSlotLabel(`fallback_${endpointSlot}`);
   }
   return 'other';
 }
@@ -290,7 +336,7 @@ export class RpcUsageTracker {
   private ethCallConsumers = new Map<string, number>();
   private ethGetLogsAttributions = new Map<
     string,
-    { consumer: string; endpointSlot: string; count: number }
+    { consumer: string; endpointSlot: RpcEndpointSlotLabel; count: number }
   >();
   private lifetime = 0;
 
@@ -373,29 +419,31 @@ export class RpcUsageTracker {
    * cumulative totals) are what the daemon logs, so `sum_over_time` in Grafana
    * yields exact request counts over any range.
    */
-  drainWindow(): NormalizedRpcUsageWindow {
+  drainWindow(): ConcreteRpcUsageWindow {
     const byMethod: Record<string, number> = {};
     for (const [method, count] of this.window) byMethod[method] = count;
     this.window.clear();
     const ethCallByConsumer: Record<string, number> = {};
     for (const [consumer, count] of this.ethCallConsumers) ethCallByConsumer[consumer] = count;
     this.ethCallConsumers.clear();
-    const ethGetLogsByConsumerAndEndpointSlot:
-      Record<string, Record<string, number>> = {};
-    for (const { consumer, endpointSlot, count } of this.ethGetLogsAttributions.values()) {
-      const byEndpointSlot = Object.prototype.hasOwnProperty.call(
-        ethGetLogsByConsumerAndEndpointSlot,
-        consumer,
-      )
-        ? ethGetLogsByConsumerAndEndpointSlot[consumer]
-        : (ethGetLogsByConsumerAndEndpointSlot[consumer] = {});
-      byEndpointSlot[endpointSlot] = count;
-    }
+    const attributions: RpcUsageAttribution[] = [
+      ...Object.entries(ethCallByConsumer).map(
+        ([consumer, count]): RpcUsageAttribution => ({ method: 'eth_call', consumer, count }),
+      ),
+      ...[...this.ethGetLogsAttributions.values()].map(
+        ({ consumer, endpointSlot, count }): RpcUsageAttribution => ({
+          method: 'eth_getLogs',
+          consumer,
+          endpointSlot: normalizeRpcEndpointSlotLabel(endpointSlot),
+          count,
+        }),
+      ),
+    ];
     this.ethGetLogsAttributions.clear();
     return {
       byMethod,
       ethCallByConsumer,
-      ethGetLogsByConsumerAndEndpointSlot,
+      attributions,
       lifetimeTotal: this.lifetime,
     };
   }
@@ -433,6 +481,13 @@ export class CountingJsonRpcProvider extends JsonRpcProvider {
   }
 }
 
+export interface CountingJsonRpcProviderConfig {
+  readonly maxRetries?: number;
+  readonly providerOptions: JsonRpcApiProviderOptions;
+  readonly network?: Networkish;
+  readonly endpointSlot?: number;
+}
+
 /**
  * The ONE transport factory for a usage-counted provider: wires BOTH accounting
  * hooks (the `_send` first-attempt count and the FetchRequest retry-attempt
@@ -443,11 +498,8 @@ export class CountingJsonRpcProvider extends JsonRpcProvider {
  */
 export function createCountingJsonRpcProvider(
   url: string,
-  maxRetries: number | undefined,
   tracker: RpcUsageTracker,
-  options: JsonRpcApiProviderOptions,
-  network?: Networkish,
-  endpointSlot?: number,
+  config: CountingJsonRpcProviderConfig,
 ): CountingJsonRpcProvider {
   // boundedRetryFetchRequest stays PURE retry policy; the accounting
   // composition lives HERE, with the rest of the accounting. Ethers' throttle
@@ -455,6 +507,7 @@ export function createCountingJsonRpcProvider(
   // HTTP attempts under 429/5xx) and every attempt bills at the provider, so
   // the retryFunc is decorated to record each RE-attempt's methods; the first
   // attempt is counted at _send by CountingJsonRpcProvider.
+  const { maxRetries, providerOptions: options, network, endpointSlot } = config;
   const fetchRequest = boundedRetryFetchRequest(url, maxRetries);
   const pureRetry = fetchRequest.retryFunc!;
   fetchRequest.retryFunc = async (attemptReq, response, attempt) => {

--- a/packages/chain/src/rpc-usage.ts
+++ b/packages/chain/src/rpc-usage.ts
@@ -90,7 +90,12 @@ export function jsonRpcMethodsFromBody(body: Uint8Array | null | undefined): str
 
 /** A fresh all-zero window — the identity element for merging and the value of "nothing to report". */
 export function emptyRpcUsageWindow(): NormalizedRpcUsageWindow {
-  return { byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 0 };
+  return {
+    byMethod: {},
+    ethCallByConsumer: {},
+    ethGetLogsByConsumerAndEndpointSlot: {},
+    lifetimeTotal: 0,
+  };
 }
 
 /** Normalize a public drain-window input into the concrete telemetry model. */
@@ -98,6 +103,8 @@ export function normalizeRpcUsageWindow(window: RpcUsageWindow): NormalizedRpcUs
   return {
     byMethod: window.byMethod,
     ethCallByConsumer: window.ethCallByConsumer ?? {},
+    ethGetLogsByConsumerAndEndpointSlot:
+      window.ethGetLogsByConsumerAndEndpointSlot ?? {},
     lifetimeTotal: window.lifetimeTotal,
   };
 }
@@ -131,6 +138,8 @@ export function mergeRpcUsageWindows(
   if (defined.length === 0) return emptyRpcUsageWindow();
   const byMethod: Record<string, number> = {};
   const ethCallByConsumer: Record<string, number> = {};
+  const ethGetLogsByConsumerAndEndpointSlot:
+    Record<string, Record<string, number>> = {};
   let lifetimeTotal = 0;
   for (const input of defined) {
     const w = normalizeRpcUsageWindow(input);
@@ -138,9 +147,34 @@ export function mergeRpcUsageWindows(
     for (const [consumer, c] of Object.entries(w.ethCallByConsumer)) {
       ethCallByConsumer[consumer] = (ethCallByConsumer[consumer] ?? 0) + c;
     }
+    for (const [consumer, byEndpointSlot] of Object.entries(
+      w.ethGetLogsByConsumerAndEndpointSlot,
+    )) {
+      const mergedByEndpointSlot = Object.prototype.hasOwnProperty.call(
+        ethGetLogsByConsumerAndEndpointSlot,
+        consumer,
+      )
+        ? ethGetLogsByConsumerAndEndpointSlot[consumer]
+        : (ethGetLogsByConsumerAndEndpointSlot[consumer] = {});
+      for (const [endpointSlot, c] of Object.entries(byEndpointSlot)) {
+        const current = Object.prototype.hasOwnProperty.call(
+          mergedByEndpointSlot,
+          endpointSlot,
+        )
+          ? mergedByEndpointSlot[endpointSlot]
+          : 0;
+        mergedByEndpointSlot[endpointSlot] =
+          current + c;
+      }
+    }
     lifetimeTotal += w.lifetimeTotal;
   }
-  return { byMethod, ethCallByConsumer, lifetimeTotal };
+  return {
+    byMethod,
+    ethCallByConsumer,
+    ethGetLogsByConsumerAndEndpointSlot,
+    lifetimeTotal,
+  };
 }
 
 export interface RpcUsageWindow {
@@ -164,6 +198,17 @@ export interface RpcUsageWindow {
    * concrete {@link NormalizedRpcUsageWindow} shape.
    */
   ethCallByConsumer?: Record<string, number>;
+  /**
+   * Raw `eth_getLogs` attribution by bounded code-owned consumer and configured
+   * endpoint slot. This is diagnostic detail only: `byMethod.eth_getLogs`
+   * remains the billing-exact aggregate. Endpoint slots are deliberately
+   * opaque (`primary`, `fallback_1` ... `fallback_15`, `other`) so provider
+   * URLs, credentials, and hostnames can never enter this telemetry surface.
+   * Unscoped calls use the fixed `unattributed` consumer, which makes the
+   * detail sum reconcile with the aggregate for package-owned producers.
+   * Optional for source compatibility with pre-attribution drain sources.
+   */
+  ethGetLogsByConsumerAndEndpointSlot?: Record<string, Record<string, number>>;
   /** Raw requests since process start (monotonic; NOT reset by drain). */
   lifetimeTotal: number;
 }
@@ -171,6 +216,7 @@ export interface RpcUsageWindow {
 /** Concrete package-owned telemetry window after legacy inputs are normalized. */
 export interface NormalizedRpcUsageWindow extends RpcUsageWindow {
   ethCallByConsumer: Record<string, number>;
+  ethGetLogsByConsumerAndEndpointSlot: Record<string, Record<string, number>>;
 }
 
 /**
@@ -215,6 +261,26 @@ function activeRpcUsageConsumer(): string | undefined {
 }
 
 /**
+ * Bound endpoint identity to a fixed, non-secret configured slot. The first 16
+ * configured endpoints retain individual attribution; larger or missing slots
+ * collapse to `other` rather than expanding telemetry cardinality.
+ */
+export function boundedRpcEndpointSlotLabel(
+  endpointSlot: number | undefined,
+): string {
+  if (
+    typeof endpointSlot !== 'number'
+    || !Number.isSafeInteger(endpointSlot)
+    || endpointSlot < 0
+  ) return 'other';
+  if (endpointSlot === 0) return 'primary';
+  if (endpointSlot < RpcUsageTracker.MAX_TRACKED_ENDPOINT_SLOTS) {
+    return `fallback_${endpointSlot}`;
+  }
+  return 'other';
+}
+
+/**
  * In-process accumulator for raw JSON-RPC request counts. `record()` is on the
  * hot path of every RPC — it does one map increment and one counter add, never
  * throws, and never touches the network.
@@ -222,6 +288,10 @@ function activeRpcUsageConsumer(): string | undefined {
 export class RpcUsageTracker {
   private window = new Map<string, number>();
   private ethCallConsumers = new Map<string, number>();
+  private ethGetLogsAttributions = new Map<
+    string,
+    { consumer: string; endpointSlot: string; count: number }
+  >();
   private lifetime = 0;
 
   constructor(
@@ -244,8 +314,10 @@ export class RpcUsageTracker {
    */
   static readonly MAX_WINDOW_METHODS = 64;
   static readonly MAX_WINDOW_CONSUMERS = 128;
+  static readonly MAX_TRACKED_ENDPOINT_SLOTS = 16;
+  static readonly MAX_WINDOW_GET_LOGS_ATTRIBUTIONS = 256;
 
-  record(method: string): void {
+  record(method: string, endpointSlot?: number): void {
     // Authoritative window/lifetime state first, OUTSIDE any try — pure map
     // arithmetic that cannot realistically throw, and it must never be
     // skipped because an OPTIONAL sink misbehaved.
@@ -260,6 +332,26 @@ export class RpcUsageTracker {
           ? normalizedConsumer
           : 'other';
         this.ethCallConsumers.set(consumerKey, (this.ethCallConsumers.get(consumerKey) ?? 0) + 1);
+      }
+    }
+    if (raw === 'eth_getLogs') {
+      const consumer = activeRpcUsageConsumer() ?? 'unattributed';
+      const slot = boundedRpcEndpointSlotLabel(endpointSlot);
+      const rawKey = `${consumer}\0${slot}`;
+      const overflowKey = 'other\0other';
+      const overflow = !this.ethGetLogsAttributions.has(rawKey)
+        && this.ethGetLogsAttributions.size
+          >= RpcUsageTracker.MAX_WINDOW_GET_LOGS_ATTRIBUTIONS;
+      const key = overflow ? overflowKey : rawKey;
+      const existing = this.ethGetLogsAttributions.get(key);
+      if (existing) {
+        existing.count += 1;
+      } else {
+        this.ethGetLogsAttributions.set(key, {
+          consumer: overflow ? 'other' : consumer,
+          endpointSlot: overflow ? 'other' : slot,
+          count: 1,
+        });
       }
     }
     this.lifetime += 1;
@@ -288,7 +380,24 @@ export class RpcUsageTracker {
     const ethCallByConsumer: Record<string, number> = {};
     for (const [consumer, count] of this.ethCallConsumers) ethCallByConsumer[consumer] = count;
     this.ethCallConsumers.clear();
-    return { byMethod, ethCallByConsumer, lifetimeTotal: this.lifetime };
+    const ethGetLogsByConsumerAndEndpointSlot:
+      Record<string, Record<string, number>> = {};
+    for (const { consumer, endpointSlot, count } of this.ethGetLogsAttributions.values()) {
+      const byEndpointSlot = Object.prototype.hasOwnProperty.call(
+        ethGetLogsByConsumerAndEndpointSlot,
+        consumer,
+      )
+        ? ethGetLogsByConsumerAndEndpointSlot[consumer]
+        : (ethGetLogsByConsumerAndEndpointSlot[consumer] = {});
+      byEndpointSlot[endpointSlot] = count;
+    }
+    this.ethGetLogsAttributions.clear();
+    return {
+      byMethod,
+      ethCallByConsumer,
+      ethGetLogsByConsumerAndEndpointSlot,
+      lifetimeTotal: this.lifetime,
+    };
   }
 }
 
@@ -338,6 +447,7 @@ export function createCountingJsonRpcProvider(
   tracker: RpcUsageTracker,
   options: JsonRpcApiProviderOptions,
   network?: Networkish,
+  endpointSlot?: number,
 ): CountingJsonRpcProvider {
   // boundedRetryFetchRequest stays PURE retry policy; the accounting
   // composition lives HERE, with the rest of the accounting. Ethers' throttle
@@ -351,7 +461,9 @@ export function createCountingJsonRpcProvider(
     const retry = await pureRetry(attemptReq, response, attempt);
     if (retry) {
       try {
-        for (const method of jsonRpcMethodsFromBody(attemptReq?.body)) tracker.record(method);
+        for (const method of jsonRpcMethodsFromBody(attemptReq?.body)) {
+          tracker.record(method, endpointSlot);
+        }
       } catch { /* accounting must never break the retry path */ }
     }
     return retry;
@@ -370,6 +482,6 @@ export function createCountingJsonRpcProvider(
     fetchRequest,
     network,
     providerOptions,
-    (method) => tracker.record(method),
+    (method) => tracker.record(method, endpointSlot),
   );
 }

--- a/packages/chain/src/rpc-usage.ts
+++ b/packages/chain/src/rpc-usage.ts
@@ -88,13 +88,29 @@ export function jsonRpcMethodsFromBody(body: Uint8Array | null | undefined): str
   }
 }
 
-/** A fresh all-zero window — the identity element for merging and the value of "nothing to report". */
-export type RpcEndpointSlotLabel =
-  | 'primary'
-  | 'fallback_1' | 'fallback_2' | 'fallback_3' | 'fallback_4' | 'fallback_5'
-  | 'fallback_6' | 'fallback_7' | 'fallback_8' | 'fallback_9' | 'fallback_10'
-  | 'fallback_11' | 'fallback_12' | 'fallback_13' | 'fallback_14' | 'fallback_15'
-  | 'other';
+/** The complete bounded vocabulary for individually attributed endpoint slots. */
+export const RPC_ENDPOINT_SLOT_LABELS = Object.freeze([
+  'primary',
+  'fallback_1',
+  'fallback_2',
+  'fallback_3',
+  'fallback_4',
+  'fallback_5',
+  'fallback_6',
+  'fallback_7',
+  'fallback_8',
+  'fallback_9',
+  'fallback_10',
+  'fallback_11',
+  'fallback_12',
+  'fallback_13',
+  'fallback_14',
+  'fallback_15',
+] as const);
+
+type TrackedRpcEndpointSlotLabel = typeof RPC_ENDPOINT_SLOT_LABELS[number];
+export type RpcEndpointSlotLabel = TrackedRpcEndpointSlotLabel | 'other';
+const RPC_ENDPOINT_SLOT_LABEL_SET: ReadonlySet<string> = new Set(RPC_ENDPOINT_SLOT_LABELS);
 
 /** Canonical method-aware diagnostic attribution carried by a usage window. */
 export type RpcUsageAttribution =
@@ -110,6 +126,35 @@ type ConcreteRpcUsageWindow = NormalizedRpcUsageWindow & {
   readonly attributions: readonly RpcUsageAttribution[];
 };
 
+function normalizeRpcUsageAttribution(value: unknown): RpcUsageAttribution | undefined {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const candidate = value as {
+    method?: unknown;
+    consumer?: unknown;
+    endpointSlot?: unknown;
+    count?: unknown;
+  };
+  if (typeof candidate.consumer !== 'string' || typeof candidate.count !== 'number') {
+    return undefined;
+  }
+  if (candidate.method === 'eth_call') {
+    return {
+      method: 'eth_call',
+      consumer: candidate.consumer,
+      count: candidate.count,
+    };
+  }
+  if (candidate.method === 'eth_getLogs') {
+    return {
+      method: 'eth_getLogs',
+      consumer: candidate.consumer,
+      endpointSlot: normalizeRpcEndpointSlotLabel(candidate.endpointSlot),
+      count: candidate.count,
+    };
+  }
+  return undefined;
+}
+
 export function emptyRpcUsageWindow(): ConcreteRpcUsageWindow {
   return {
     byMethod: {},
@@ -122,7 +167,10 @@ export function emptyRpcUsageWindow(): ConcreteRpcUsageWindow {
 /** Normalize a public drain-window input into the concrete telemetry model. */
 export function normalizeRpcUsageWindow(window: RpcUsageWindow): ConcreteRpcUsageWindow {
   const attributions = window.attributions
-    ? [...window.attributions]
+    ? window.attributions.flatMap((value) => {
+        const normalized = normalizeRpcUsageAttribution(value);
+        return normalized === undefined ? [] : [normalized];
+      })
     : [
         ...Object.entries(window.ethCallByConsumer ?? {}).map(
           ([consumer, count]): RpcUsageAttribution => ({ method: 'eth_call', consumer, count }),
@@ -304,9 +352,9 @@ function activeRpcUsageConsumer(): string | undefined {
  * collapse to `other` rather than expanding telemetry cardinality.
  */
 export function normalizeRpcEndpointSlotLabel(value: unknown): RpcEndpointSlotLabel {
-  if (value === 'primary' || value === 'other') return value;
-  if (typeof value === 'string' && /^fallback_(?:[1-9]|1[0-5])$/.test(value)) {
-    return value as RpcEndpointSlotLabel;
+  if (value === 'other') return value;
+  if (typeof value === 'string' && RPC_ENDPOINT_SLOT_LABEL_SET.has(value)) {
+    return value as TrackedRpcEndpointSlotLabel;
   }
   return 'other';
 }
@@ -319,11 +367,7 @@ export function boundedRpcEndpointSlotLabel(
     || !Number.isSafeInteger(endpointSlot)
     || endpointSlot < 0
   ) return 'other';
-  if (endpointSlot === 0) return 'primary';
-  if (endpointSlot < RpcUsageTracker.MAX_TRACKED_ENDPOINT_SLOTS) {
-    return normalizeRpcEndpointSlotLabel(`fallback_${endpointSlot}`);
-  }
-  return 'other';
+  return RPC_ENDPOINT_SLOT_LABELS[endpointSlot] ?? 'other';
 }
 
 /**
@@ -360,7 +404,7 @@ export class RpcUsageTracker {
    */
   static readonly MAX_WINDOW_METHODS = 64;
   static readonly MAX_WINDOW_CONSUMERS = 128;
-  static readonly MAX_TRACKED_ENDPOINT_SLOTS = 16;
+  static readonly MAX_TRACKED_ENDPOINT_SLOTS = RPC_ENDPOINT_SLOT_LABELS.length;
   static readonly MAX_WINDOW_GET_LOGS_ATTRIBUTIONS = 256;
 
   record(method: string, endpointSlot?: number): void {

--- a/packages/chain/test/chain-rpc-telemetry.unit.test.ts
+++ b/packages/chain/test/chain-rpc-telemetry.unit.test.ts
@@ -152,6 +152,34 @@ describe('chain RPC telemetry — real readContractWith emits bounded labels', (
     a.destroy?.();
   });
 
+  it('attributes direct page-scan eth_getLogs requests to the bounded scan label', async () => {
+    const a: any = new EVMChainAdapter(minimalConfig());
+    const contract = logScanContract(async () => {
+      // Emulate CountingJsonRpcProvider's raw transport hook at the direct
+      // queryFilter seam. The page scan deliberately does not use
+      // RpcFailoverClient, so this pins its explicit consumer scope.
+      a.rpcUsage.record('eth_getLogs', 0);
+      return [];
+    });
+
+    await a.queryEventLogsPage(
+      contract,
+      {},
+      0,
+      100,
+      scanProviders,
+      new Map(),
+      'getMaxKaNumberForAuthor KnowledgeAssetCreated',
+    );
+
+    const usage = a.drainRpcUsage();
+    expect(usage.byMethod.eth_getLogs).toBe(1);
+    expect(usage.ethGetLogsByConsumerAndEndpointSlot).toEqual({
+      getMaxKaNumberForAuthor_KnowledgeAssetCreated: { primary: 1 },
+    });
+    a.destroy?.();
+  });
+
   it('eth_getLogs FAILURE (all backends error): records a non-ok outcome', async () => {
     installMeter();
     const a: any = new EVMChainAdapter(minimalConfig());

--- a/packages/chain/test/chain-rpc-telemetry.unit.test.ts
+++ b/packages/chain/test/chain-rpc-telemetry.unit.test.ts
@@ -174,9 +174,12 @@ describe('chain RPC telemetry — real readContractWith emits bounded labels', (
 
     const usage = a.drainRpcUsage();
     expect(usage.byMethod.eth_getLogs).toBe(1);
-    expect(usage.ethGetLogsByConsumerAndEndpointSlot).toEqual({
-      getMaxKaNumberForAuthor_KnowledgeAssetCreated: { primary: 1 },
-    });
+    expect(usage.attributions).toEqual([{
+      method: 'eth_getLogs',
+      consumer: 'getMaxKaNumberForAuthor_KnowledgeAssetCreated',
+      endpointSlot: 'primary',
+      count: 1,
+    }]);
     a.destroy?.();
   });
 

--- a/packages/chain/test/chain-rpc-telemetry.unit.test.ts
+++ b/packages/chain/test/chain-rpc-telemetry.unit.test.ts
@@ -152,7 +152,7 @@ describe('chain RPC telemetry — real readContractWith emits bounded labels', (
     a.destroy?.();
   });
 
-  it('attributes direct page-scan eth_getLogs requests to the bounded scan label', async () => {
+  it('attributes direct page-scan eth_getLogs requests to a stable operation key', async () => {
     const a: any = new EVMChainAdapter(minimalConfig());
     const contract = logScanContract(async () => {
       // Emulate CountingJsonRpcProvider's raw transport hook at the direct
@@ -170,15 +170,28 @@ describe('chain RPC telemetry — real readContractWith emits bounded labels', (
       scanProviders,
       new Map(),
       'getMaxKaNumberForAuthor KnowledgeAssetCreated',
+      undefined,
+      'getMaxKaNumberForAuthor',
+    );
+    await a.queryEventLogsPage(
+      contract,
+      {},
+      101,
+      200,
+      scanProviders,
+      new Map(),
+      'wording can change without changing telemetry identity',
+      undefined,
+      'getMaxKaNumberForAuthor',
     );
 
     const usage = a.drainRpcUsage();
-    expect(usage.byMethod.eth_getLogs).toBe(1);
+    expect(usage.byMethod.eth_getLogs).toBe(2);
     expect(usage.attributions).toEqual([{
       method: 'eth_getLogs',
-      consumer: 'getMaxKaNumberForAuthor_KnowledgeAssetCreated',
+      consumer: 'getMaxKaNumberForAuthor',
       endpointSlot: 'primary',
-      count: 1,
+      count: 2,
     }]);
     a.destroy?.();
   });

--- a/packages/chain/test/rpc-usage-public-contract.typecheck.ts
+++ b/packages/chain/test/rpc-usage-public-contract.typecheck.ts
@@ -1,0 +1,12 @@
+import type { NormalizedRpcUsageWindow } from '../src/index.js';
+
+// A downstream consumer constructing the pre-getLogs normalized shape remains
+// source-compatible. New attribution is optional on the released window type
+// and becomes concrete only after normalizeRpcUsageWindow().
+const legacyNormalizedWindow: NormalizedRpcUsageWindow = {
+  byMethod: {},
+  ethCallByConsumer: {},
+  lifetimeTotal: 0,
+};
+
+void legacyNormalizedWindow;

--- a/packages/chain/test/rpc-usage.unit.test.ts
+++ b/packages/chain/test/rpc-usage.unit.test.ts
@@ -23,6 +23,7 @@ import {
   boundedRpcEndpointSlotLabel,
   boundedRpcMethodLabel,
   mergeRpcUsageWindows,
+  normalizeRpcEndpointSlotLabel,
   normalizeRpcUsageWindow,
   normalizeRpcUsageConsumer,
   rpcUsageWindowTotal,
@@ -122,9 +123,8 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     servers.push(rpc);
     const provider = createCountingJsonRpcProvider(
       rpc.url,
-      0,
       new RpcUsageTracker(() => 'evm:31337'),
-      { batchMaxCount: 1 },
+      { maxRetries: 0, providerOptions: { batchMaxCount: 1 } },
     );
     const controller = new AbortController();
     const timeoutError = createRpcTimeoutError('authentication attempt timed out');
@@ -403,7 +403,10 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     expect(merged).toEqual({
       byMethod: { eth_call: 8, eth_estimateGas: 2, eth_sendRawTransaction: 4 },
       ethCallByConsumer: { 'pcaNFT.getAccountInfo': 3, 'token.balanceOf': 2 },
-      ethGetLogsByConsumerAndEndpointSlot: {},
+      attributions: [
+        { method: 'eth_call', consumer: 'pcaNFT.getAccountInfo', count: 3 },
+        { method: 'eth_call', consumer: 'token.balanceOf', count: 2 },
+      ],
       lifetimeTotal: 150,
     });
   });
@@ -419,20 +422,25 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     const empty = {
       byMethod: {},
       ethCallByConsumer: {},
-      ethGetLogsByConsumerAndEndpointSlot: {},
+      attributions: [],
       lifetimeTotal: 0,
     };
-    expect(mergeRpcUsageWindows(undefined, w, undefined)).toEqual(w);
+    expect(mergeRpcUsageWindows(undefined, w, undefined)).toEqual({
+      byMethod: { eth_call: 1 },
+      ethCallByConsumer: {},
+      attributions: [],
+      lifetimeTotal: 1,
+    });
     expect(mergeRpcUsageWindows(legacy)).toEqual({
       byMethod: { eth_call: 2 },
       ethCallByConsumer: {},
-      ethGetLogsByConsumerAndEndpointSlot: {},
+      attributions: [],
       lifetimeTotal: 2,
     });
     expect(normalizeRpcUsageWindow(legacy)).toEqual({
       byMethod: { eth_call: 2 },
       ethCallByConsumer: {},
-      ethGetLogsByConsumerAndEndpointSlot: {},
+      attributions: [],
       lifetimeTotal: 2,
     });
     expect(mergeRpcUsageWindows(undefined, undefined)).toEqual(empty);
@@ -450,7 +458,7 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     expect(mergeRpcUsageWindows(drainable.drainRpcUsage(), adapter.drainRpcUsage?.())).toEqual({
       byMethod: { eth_call: 1, eth_getLogs: 2 },
       ethCallByConsumer: {},
-      ethGetLogsByConsumerAndEndpointSlot: {},
+      attributions: [],
       lifetimeTotal: 3,
     });
   });
@@ -556,6 +564,10 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     expect(boundedRpcEndpointSlotLabel(-1)).toBe('other');
     expect(boundedRpcEndpointSlotLabel(undefined)).toBe('other');
     expect(boundedRpcEndpointSlotLabel(Number.NaN)).toBe('other');
+    expect(normalizeRpcEndpointSlotLabel('primary')).toBe('primary');
+    expect(normalizeRpcEndpointSlotLabel('fallback_15')).toBe('fallback_15');
+    expect(normalizeRpcEndpointSlotLabel('fallback_16')).toBe('other');
+    expect(normalizeRpcEndpointSlotLabel('https://secret.example/rpc')).toBe('other');
   });
 
   it('attributes every eth_getLogs request, including unscoped calls, without changing the aggregate', () => {
@@ -568,14 +580,14 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
 
     const w = t.drainWindow();
     expect(w.byMethod.eth_getLogs).toBe(3);
-    expect(w.ethGetLogsByConsumerAndEndpointSlot).toEqual({
-      'cg.authority.history': { primary: 1, fallback_1: 1 },
-      unattributed: { primary: 1 },
-    });
-    expect(Object.values(w.ethGetLogsByConsumerAndEndpointSlot)
-      .flatMap((bySlot) => Object.values(bySlot))
-      .reduce((sum, count) => sum + count, 0)).toBe(w.byMethod.eth_getLogs);
-    expect(t.drainWindow().ethGetLogsByConsumerAndEndpointSlot).toEqual({});
+    expect(w.attributions).toEqual([
+      { method: 'eth_getLogs', consumer: 'cg.authority.history', endpointSlot: 'primary', count: 1 },
+      { method: 'eth_getLogs', consumer: 'cg.authority.history', endpointSlot: 'fallback_1', count: 1 },
+      { method: 'eth_getLogs', consumer: 'unattributed', endpointSlot: 'primary', count: 1 },
+    ]);
+    expect(w.attributions.reduce((sum, attribution) => sum + attribution.count, 0))
+      .toBe(w.byMethod.eth_getLogs);
+    expect(t.drainWindow().attributions).toEqual([]);
   });
 
   it('caps distinct eth_getLogs consumer/slot pairs and reconciles overflow to other/other', () => {
@@ -587,12 +599,15 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     withRpcUsageConsumer('consumer.0', () => t.record('eth_getLogs', 0));
 
     const w = t.drainWindow();
-    const pairs = Object.values(w.ethGetLogsByConsumerAndEndpointSlot)
-      .flatMap((bySlot) => Object.values(bySlot));
-    expect(pairs).toHaveLength(max + 1);
-    expect(w.ethGetLogsByConsumerAndEndpointSlot['consumer.0'].primary).toBe(2);
-    expect(w.ethGetLogsByConsumerAndEndpointSlot.other.other).toBe(4);
-    expect(pairs.reduce((sum, count) => sum + count, 0)).toBe(max + 5);
+    expect(w.attributions).toHaveLength(max + 1);
+    expect(w.attributions).toContainEqual({
+      method: 'eth_getLogs', consumer: 'consumer.0', endpointSlot: 'primary', count: 2,
+    });
+    expect(w.attributions).toContainEqual({
+      method: 'eth_getLogs', consumer: 'other', endpointSlot: 'other', count: 4,
+    });
+    expect(w.attributions.reduce((sum, attribution) => sum + attribution.count, 0))
+      .toBe(max + 5);
     expect(w.byMethod.eth_getLogs).toBe(max + 5);
   });
 
@@ -616,10 +631,11 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     )).toEqual({
       byMethod: { eth_getLogs: 7 },
       ethCallByConsumer: {},
-      ethGetLogsByConsumerAndEndpointSlot: {
-        'cg.authority.history': { primary: 3, fallback_1: 1 },
-        'cg.subscription.events': { fallback_1: 3 },
-      },
+      attributions: [
+        { method: 'eth_getLogs', consumer: 'cg.authority.history', endpointSlot: 'primary', count: 3 },
+        { method: 'eth_getLogs', consumer: 'cg.authority.history', endpointSlot: 'fallback_1', count: 1 },
+        { method: 'eth_getLogs', consumer: 'cg.subscription.events', endpointSlot: 'fallback_1', count: 3 },
+      ],
       lifetimeTotal: 7,
     });
   });
@@ -648,13 +664,13 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     expect(primaryHits).toBe(1);
     expect(backupHits).toBe(1);
     expect(usage.byMethod.eth_getLogs).toBe(primaryHits + backupHits);
-    expect(usage.ethGetLogsByConsumerAndEndpointSlot['unit.getLogs.failover']).toEqual({
-      primary: primaryHits,
-      fallback_1: backupHits,
-    });
-    expect(JSON.stringify(usage.ethGetLogsByConsumerAndEndpointSlot))
+    expect(usage.attributions).toEqual([
+      { method: 'eth_getLogs', consumer: 'unit.getLogs.failover', endpointSlot: 'primary', count: primaryHits },
+      { method: 'eth_getLogs', consumer: 'unit.getLogs.failover', endpointSlot: 'fallback_1', count: backupHits },
+    ]);
+    expect(JSON.stringify(usage.attributions))
       .not.toContain(primary.url);
-    expect(JSON.stringify(usage.ethGetLogsByConsumerAndEndpointSlot))
+    expect(JSON.stringify(usage.attributions))
       .not.toContain(backup.url);
   }, 30_000);
 
@@ -664,11 +680,8 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     const tracker = new RpcUsageTracker(() => 'evm:31337');
     const provider = createCountingJsonRpcProvider(
       rpc.url,
-      1,
       tracker,
-      { batchMaxCount: 1 },
-      undefined,
-      3,
+      { maxRetries: 1, providerOptions: { batchMaxCount: 1 }, endpointSlot: 3 },
     );
 
     try {
@@ -681,8 +694,9 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
       const hits = rpc.hits('eth_getLogs');
       expect(hits).toBe(2);
       expect(usage.byMethod.eth_getLogs).toBe(hits);
-      expect(usage.ethGetLogsByConsumerAndEndpointSlot['unit.getLogs.retry'])
-        .toEqual({ fallback_3: hits });
+      expect(usage.attributions).toEqual([
+        { method: 'eth_getLogs', consumer: 'unit.getLogs.retry', endpointSlot: 'fallback_3', count: hits },
+      ]);
     } finally {
       provider.destroy();
     }

--- a/packages/chain/test/rpc-usage.unit.test.ts
+++ b/packages/chain/test/rpc-usage.unit.test.ts
@@ -26,6 +26,7 @@ import {
   normalizeRpcEndpointSlotLabel,
   normalizeRpcUsageWindow,
   normalizeRpcUsageConsumer,
+  RPC_ENDPOINT_SLOT_LABELS,
   rpcUsageWindowTotal,
   RpcUsageTracker,
   createCountingJsonRpcProvider,
@@ -557,15 +558,14 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
   });
 
   it('bounds configured endpoint slots without exposing endpoint identity', () => {
-    expect(boundedRpcEndpointSlotLabel(0)).toBe('primary');
-    expect(boundedRpcEndpointSlotLabel(1)).toBe('fallback_1');
-    expect(boundedRpcEndpointSlotLabel(15)).toBe('fallback_15');
-    expect(boundedRpcEndpointSlotLabel(16)).toBe('other');
+    for (const [slot, label] of RPC_ENDPOINT_SLOT_LABELS.entries()) {
+      expect(boundedRpcEndpointSlotLabel(slot)).toBe(label);
+      expect(normalizeRpcEndpointSlotLabel(label)).toBe(label);
+    }
+    expect(boundedRpcEndpointSlotLabel(RPC_ENDPOINT_SLOT_LABELS.length)).toBe('other');
     expect(boundedRpcEndpointSlotLabel(-1)).toBe('other');
     expect(boundedRpcEndpointSlotLabel(undefined)).toBe('other');
     expect(boundedRpcEndpointSlotLabel(Number.NaN)).toBe('other');
-    expect(normalizeRpcEndpointSlotLabel('primary')).toBe('primary');
-    expect(normalizeRpcEndpointSlotLabel('fallback_15')).toBe('fallback_15');
     expect(normalizeRpcEndpointSlotLabel('fallback_16')).toBe('other');
     expect(normalizeRpcEndpointSlotLabel('https://secret.example/rpc')).toBe('other');
   });

--- a/packages/chain/test/rpc-usage.unit.test.ts
+++ b/packages/chain/test/rpc-usage.unit.test.ts
@@ -20,6 +20,7 @@ import {
 import { rebuildMetrics } from '@origintrail-official/dkg-core';
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
 import {
+  boundedRpcEndpointSlotLabel,
   boundedRpcMethodLabel,
   mergeRpcUsageWindows,
   normalizeRpcUsageWindow,
@@ -402,23 +403,36 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     expect(merged).toEqual({
       byMethod: { eth_call: 8, eth_estimateGas: 2, eth_sendRawTransaction: 4 },
       ethCallByConsumer: { 'pcaNFT.getAccountInfo': 3, 'token.balanceOf': 2 },
+      ethGetLogsByConsumerAndEndpointSlot: {},
       lifetimeTotal: 150,
     });
   });
 
   it('mergeRpcUsageWindows skips undefined inputs; nothing to merge yields a concrete EMPTY window', () => {
-    const w = { byMethod: { eth_call: 1 }, ethCallByConsumer: {}, lifetimeTotal: 1 };
+    const w = {
+      byMethod: { eth_call: 1 },
+      ethCallByConsumer: {},
+      ethGetLogsByConsumerAndEndpointSlot: {},
+      lifetimeTotal: 1,
+    };
     const legacy = { byMethod: { eth_call: 2 }, lifetimeTotal: 2 };
-    const empty = { byMethod: {}, ethCallByConsumer: {}, lifetimeTotal: 0 };
+    const empty = {
+      byMethod: {},
+      ethCallByConsumer: {},
+      ethGetLogsByConsumerAndEndpointSlot: {},
+      lifetimeTotal: 0,
+    };
     expect(mergeRpcUsageWindows(undefined, w, undefined)).toEqual(w);
     expect(mergeRpcUsageWindows(legacy)).toEqual({
       byMethod: { eth_call: 2 },
       ethCallByConsumer: {},
+      ethGetLogsByConsumerAndEndpointSlot: {},
       lifetimeTotal: 2,
     });
     expect(normalizeRpcUsageWindow(legacy)).toEqual({
       byMethod: { eth_call: 2 },
       ethCallByConsumer: {},
+      ethGetLogsByConsumerAndEndpointSlot: {},
       lifetimeTotal: 2,
     });
     expect(mergeRpcUsageWindows(undefined, undefined)).toEqual(empty);
@@ -436,6 +450,7 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     expect(mergeRpcUsageWindows(drainable.drainRpcUsage(), adapter.drainRpcUsage?.())).toEqual({
       byMethod: { eth_call: 1, eth_getLogs: 2 },
       ethCallByConsumer: {},
+      ethGetLogsByConsumerAndEndpointSlot: {},
       lifetimeTotal: 3,
     });
   });
@@ -532,6 +547,146 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
     expect(w.ethCallByConsumer.other).toBe(4);
     expect(w.byMethod.eth_call).toBe(max + 5);
   });
+
+  it('bounds configured endpoint slots without exposing endpoint identity', () => {
+    expect(boundedRpcEndpointSlotLabel(0)).toBe('primary');
+    expect(boundedRpcEndpointSlotLabel(1)).toBe('fallback_1');
+    expect(boundedRpcEndpointSlotLabel(15)).toBe('fallback_15');
+    expect(boundedRpcEndpointSlotLabel(16)).toBe('other');
+    expect(boundedRpcEndpointSlotLabel(-1)).toBe('other');
+    expect(boundedRpcEndpointSlotLabel(undefined)).toBe('other');
+    expect(boundedRpcEndpointSlotLabel(Number.NaN)).toBe('other');
+  });
+
+  it('attributes every eth_getLogs request, including unscoped calls, without changing the aggregate', () => {
+    const t = new RpcUsageTracker(() => 'evm:31337');
+    withRpcUsageConsumer('cg.authority.history', () => {
+      t.record('eth_getLogs', 0);
+      t.record('eth_getLogs', 1);
+    });
+    t.record('eth_getLogs', 0);
+
+    const w = t.drainWindow();
+    expect(w.byMethod.eth_getLogs).toBe(3);
+    expect(w.ethGetLogsByConsumerAndEndpointSlot).toEqual({
+      'cg.authority.history': { primary: 1, fallback_1: 1 },
+      unattributed: { primary: 1 },
+    });
+    expect(Object.values(w.ethGetLogsByConsumerAndEndpointSlot)
+      .flatMap((bySlot) => Object.values(bySlot))
+      .reduce((sum, count) => sum + count, 0)).toBe(w.byMethod.eth_getLogs);
+    expect(t.drainWindow().ethGetLogsByConsumerAndEndpointSlot).toEqual({});
+  });
+
+  it('caps distinct eth_getLogs consumer/slot pairs and reconciles overflow to other/other', () => {
+    const t = new RpcUsageTracker(() => 'evm:31337');
+    const max = RpcUsageTracker.MAX_WINDOW_GET_LOGS_ATTRIBUTIONS;
+    for (let i = 0; i < max + 4; i += 1) {
+      withRpcUsageConsumer(`consumer.${i}`, () => t.record('eth_getLogs', i % 2));
+    }
+    withRpcUsageConsumer('consumer.0', () => t.record('eth_getLogs', 0));
+
+    const w = t.drainWindow();
+    const pairs = Object.values(w.ethGetLogsByConsumerAndEndpointSlot)
+      .flatMap((bySlot) => Object.values(bySlot));
+    expect(pairs).toHaveLength(max + 1);
+    expect(w.ethGetLogsByConsumerAndEndpointSlot['consumer.0'].primary).toBe(2);
+    expect(w.ethGetLogsByConsumerAndEndpointSlot.other.other).toBe(4);
+    expect(pairs.reduce((sum, count) => sum + count, 0)).toBe(max + 5);
+    expect(w.byMethod.eth_getLogs).toBe(max + 5);
+  });
+
+  it('merges eth_getLogs attribution by consumer and endpoint slot', () => {
+    expect(mergeRpcUsageWindows(
+      {
+        byMethod: { eth_getLogs: 3 },
+        ethGetLogsByConsumerAndEndpointSlot: {
+          'cg.authority.history': { primary: 2, fallback_1: 1 },
+        },
+        lifetimeTotal: 3,
+      },
+      {
+        byMethod: { eth_getLogs: 4 },
+        ethGetLogsByConsumerAndEndpointSlot: {
+          'cg.authority.history': { primary: 1 },
+          'cg.subscription.events': { fallback_1: 3 },
+        },
+        lifetimeTotal: 4,
+      },
+    )).toEqual({
+      byMethod: { eth_getLogs: 7 },
+      ethCallByConsumer: {},
+      ethGetLogsByConsumerAndEndpointSlot: {
+        'cg.authority.history': { primary: 3, fallback_1: 1 },
+        'cg.subscription.events': { fallback_1: 3 },
+      },
+      lifetimeTotal: 7,
+    });
+  });
+
+  it('attributes failover eth_getLogs attempts to fixed configured endpoint slots', async () => {
+    installMeter();
+    const primary = await startLoopbackRpc({ throttle: ['eth_getLogs'] });
+    const backup = await startLoopbackRpc();
+    servers.push(primary, backup);
+    const a: any = new EVMChainAdapter(minimalConfig({
+      rpcUrl: primary.url,
+      rpcUrls: [backup.url],
+      chainId: 'evm:31337',
+    }));
+    adapters.push(a);
+
+    await expect(a.readProvider(
+      'unit.getLogs.failover',
+      (provider: any) => provider.send('eth_getLogs', [{ fromBlock: '0x0', toBlock: '0x1' }]),
+      { policy: 'wideLogScan' },
+    )).resolves.toBeDefined();
+
+    const usage = a.drainRpcUsage();
+    const primaryHits = primary.hits('eth_getLogs');
+    const backupHits = backup.hits('eth_getLogs');
+    expect(primaryHits).toBe(1);
+    expect(backupHits).toBe(1);
+    expect(usage.byMethod.eth_getLogs).toBe(primaryHits + backupHits);
+    expect(usage.ethGetLogsByConsumerAndEndpointSlot['unit.getLogs.failover']).toEqual({
+      primary: primaryHits,
+      fallback_1: backupHits,
+    });
+    expect(JSON.stringify(usage.ethGetLogsByConsumerAndEndpointSlot))
+      .not.toContain(primary.url);
+    expect(JSON.stringify(usage.ethGetLogsByConsumerAndEndpointSlot))
+      .not.toContain(backup.url);
+  }, 30_000);
+
+  it('attributes ethers-internal eth_getLogs retries to the same endpoint slot', async () => {
+    const rpc = await startLoopbackRpc({ throttle: ['eth_getLogs'] });
+    servers.push(rpc);
+    const tracker = new RpcUsageTracker(() => 'evm:31337');
+    const provider = createCountingJsonRpcProvider(
+      rpc.url,
+      1,
+      tracker,
+      { batchMaxCount: 1 },
+      undefined,
+      3,
+    );
+
+    try {
+      await expect(withRpcUsageConsumer(
+        'unit.getLogs.retry',
+        () => provider.send('eth_getLogs', [{ fromBlock: '0x0', toBlock: '0x1' }]),
+      )).rejects.toBeTruthy();
+
+      const usage = tracker.drainWindow();
+      const hits = rpc.hits('eth_getLogs');
+      expect(hits).toBe(2);
+      expect(usage.byMethod.eth_getLogs).toBe(hits);
+      expect(usage.ethGetLogsByConsumerAndEndpointSlot['unit.getLogs.retry'])
+        .toEqual({ fallback_3: hits });
+    } finally {
+      provider.destroy();
+    }
+  }, 30_000);
 
   it('attributes failover eth_call attempts to the readProvider label', async () => {
     installMeter();

--- a/packages/chain/test/rpc-usage.unit.test.ts
+++ b/packages/chain/test/rpc-usage.unit.test.ts
@@ -19,6 +19,7 @@ import {
 } from '@opentelemetry/sdk-metrics';
 import { rebuildMetrics } from '@origintrail-official/dkg-core';
 import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
+import { MockChainAdapter } from '../src/mock-adapter.js';
 import {
   boundedRpcEndpointSlotLabel,
   boundedRpcMethodLabel,
@@ -461,6 +462,63 @@ describe('RPC usage accounting — raw request counts EQUAL the server-received 
       ethCallByConsumer: {},
       attributions: [],
       lifetimeTotal: 3,
+    });
+  });
+
+  it('normalizes canonical attribution arrays and drops malformed external entries', () => {
+    const normalized = normalizeRpcUsageWindow({
+      byMethod: { eth_call: 2, eth_getLogs: 2 },
+      attributions: [
+        { method: 'eth_call', consumer: 'token.balanceOf', count: 2 },
+        {
+          method: 'eth_getLogs',
+          consumer: 'cg.authority.history',
+          endpointSlot: 'fallback_1',
+          count: 1,
+        },
+        {
+          method: 'eth_getLogs',
+          consumer: 'cg.authority.history',
+          endpointSlot: 'https://secret.example/rpc',
+          count: 1,
+        },
+        null,
+        [],
+        { method: 'eth_call', consumer: 7, count: 1 },
+        { method: 'eth_call', consumer: 'invalid-count', count: '1' },
+        { method: 'net_version', consumer: 'unsupported', count: 1 },
+      ],
+      lifetimeTotal: 4,
+    } as unknown as Parameters<typeof normalizeRpcUsageWindow>[0]);
+
+    expect(normalized).toEqual({
+      byMethod: { eth_call: 2, eth_getLogs: 2 },
+      ethCallByConsumer: { 'token.balanceOf': 2 },
+      attributions: [
+        { method: 'eth_call', consumer: 'token.balanceOf', count: 2 },
+        {
+          method: 'eth_getLogs',
+          consumer: 'cg.authority.history',
+          endpointSlot: 'fallback_1',
+          count: 1,
+        },
+        {
+          method: 'eth_getLogs',
+          consumer: 'cg.authority.history',
+          endpointSlot: 'other',
+          count: 1,
+        },
+      ],
+      lifetimeTotal: 4,
+    });
+  });
+
+  it('returns a concrete empty RPC usage window from the mock adapter', () => {
+    expect(new MockChainAdapter().drainRpcUsage()).toEqual({
+      byMethod: {},
+      ethCallByConsumer: {},
+      attributions: [],
+      lifetimeTotal: 0,
     });
   });
 

--- a/packages/cli/src/daemon/rpc-usage-log.ts
+++ b/packages/cli/src/daemon/rpc-usage-log.ts
@@ -10,6 +10,9 @@
  *
  * Companion diagnostic line shape for `eth_call` attribution:
  *   rpc_usage_by_consumer method=eth_call consumer=pcaNFT.getAccountInfo count=7 window_s=60 chain=base:8453
+ *
+ * `eth_getLogs` additionally identifies the non-secret configured endpoint slot:
+ *   rpc_usage_by_consumer method=eth_getLogs consumer=getContextGraphAuthoritySnapshot endpoint_slot=fallback_1 count=7 window_s=60 chain=base:8453
  */
 
 import {
@@ -22,6 +25,15 @@ import {
 /** logfmt-token safety: methods/chain ids are self-generated, but never emit a token that could break parsing. */
 function safeToken(value: string, fallback: string): string {
   return /^[A-Za-z0-9_.:-]{1,64}$/.test(value) ? value : fallback;
+}
+
+/** Accept only tracker-owned slot labels. Never pass a URL/hostname through. */
+function safeEndpointSlot(value: string): string {
+  return value === 'primary'
+    || value === 'other'
+    || /^fallback_(?:[1-9]|1[0-5])$/.test(value)
+    ? value
+    : 'other';
 }
 
 /**
@@ -48,6 +60,36 @@ export function formatRpcUsageLines(
     lines.push(
       `rpc_usage_by_consumer method=eth_call consumer=${safeToken(consumer, 'other')} ` +
       `count=${Math.floor(count)} window_s=${windowSeconds}${chain}`,
+    );
+  }
+  const getLogsLines = new Map<string, {
+    consumer: string;
+    endpointSlot: string;
+    count: number;
+  }>();
+  for (const [consumer, byEndpointSlot] of Object.entries(
+    normalized.ethGetLogsByConsumerAndEndpointSlot,
+  )) {
+    for (const [endpointSlot, count] of Object.entries(byEndpointSlot)) {
+      if (!Number.isFinite(count) || count <= 0) continue;
+      const safeConsumer = safeToken(consumer, 'other');
+      const safeSlot = safeEndpointSlot(endpointSlot);
+      const key = `${safeConsumer}\0${safeSlot}`;
+      const existing = getLogsLines.get(key);
+      if (existing) existing.count += Math.floor(count);
+      else {
+        getLogsLines.set(key, {
+          consumer: safeConsumer,
+          endpointSlot: safeSlot,
+          count: Math.floor(count),
+        });
+      }
+    }
+  }
+  for (const { consumer, endpointSlot, count } of getLogsLines.values()) {
+    lines.push(
+      `rpc_usage_by_consumer method=eth_getLogs consumer=${consumer} ` +
+      `endpoint_slot=${endpointSlot} count=${count} window_s=${windowSeconds}${chain}`,
     );
   }
   return lines;

--- a/packages/cli/src/daemon/rpc-usage-log.ts
+++ b/packages/cli/src/daemon/rpc-usage-log.ts
@@ -16,6 +16,7 @@
  */
 
 import {
+  normalizeRpcEndpointSlotLabel,
   normalizeRpcUsageWindow,
   rpcUsageWindowTotal,
   type RpcUsageDrainable,
@@ -25,15 +26,6 @@ import {
 /** logfmt-token safety: methods/chain ids are self-generated, but never emit a token that could break parsing. */
 function safeToken(value: string, fallback: string): string {
   return /^[A-Za-z0-9_.:-]{1,64}$/.test(value) ? value : fallback;
-}
-
-/** Accept only tracker-owned slot labels. Never pass a URL/hostname through. */
-function safeEndpointSlot(value: string): string {
-  return value === 'primary'
-    || value === 'other'
-    || /^fallback_(?:[1-9]|1[0-5])$/.test(value)
-    ? value
-    : 'other';
 }
 
 /**
@@ -55,41 +47,35 @@ export function formatRpcUsageLines(
     if (!Number.isFinite(count) || count <= 0) continue;
     lines.push(`rpc_usage method=${safeToken(method, 'other')} count=${Math.floor(count)} window_s=${windowSeconds}${chain}`);
   }
-  for (const [consumer, count] of Object.entries(normalized.ethCallByConsumer)) {
-    if (!Number.isFinite(count) || count <= 0) continue;
-    lines.push(
-      `rpc_usage_by_consumer method=eth_call consumer=${safeToken(consumer, 'other')} ` +
-      `count=${Math.floor(count)} window_s=${windowSeconds}${chain}`,
-    );
-  }
-  const getLogsLines = new Map<string, {
+  const attributionLines = new Map<string, {
+    method: 'eth_call' | 'eth_getLogs';
     consumer: string;
-    endpointSlot: string;
+    endpointSlot?: string;
     count: number;
   }>();
-  for (const [consumer, byEndpointSlot] of Object.entries(
-    normalized.ethGetLogsByConsumerAndEndpointSlot,
-  )) {
-    for (const [endpointSlot, count] of Object.entries(byEndpointSlot)) {
-      if (!Number.isFinite(count) || count <= 0) continue;
-      const safeConsumer = safeToken(consumer, 'other');
-      const safeSlot = safeEndpointSlot(endpointSlot);
-      const key = `${safeConsumer}\0${safeSlot}`;
-      const existing = getLogsLines.get(key);
-      if (existing) existing.count += Math.floor(count);
-      else {
-        getLogsLines.set(key, {
-          consumer: safeConsumer,
-          endpointSlot: safeSlot,
-          count: Math.floor(count),
-        });
-      }
+  for (const attribution of normalized.attributions) {
+    if (!Number.isFinite(attribution.count) || attribution.count <= 0) continue;
+    const consumer = safeToken(attribution.consumer, 'other');
+    const endpointSlot = attribution.method === 'eth_getLogs'
+      ? normalizeRpcEndpointSlotLabel(attribution.endpointSlot)
+      : undefined;
+    const key = `${attribution.method}\0${consumer}\0${endpointSlot ?? ''}`;
+    const existing = attributionLines.get(key);
+    if (existing) existing.count += Math.floor(attribution.count);
+    else {
+      attributionLines.set(key, {
+        method: attribution.method,
+        consumer,
+        ...(endpointSlot ? { endpointSlot } : {}),
+        count: Math.floor(attribution.count),
+      });
     }
   }
-  for (const { consumer, endpointSlot, count } of getLogsLines.values()) {
+  for (const { method, consumer, endpointSlot, count } of attributionLines.values()) {
     lines.push(
-      `rpc_usage_by_consumer method=eth_getLogs consumer=${consumer} ` +
-      `endpoint_slot=${endpointSlot} count=${count} window_s=${windowSeconds}${chain}`,
+      `rpc_usage_by_consumer method=${method} consumer=${consumer} ` +
+      `${endpointSlot ? `endpoint_slot=${endpointSlot} ` : ''}` +
+      `count=${count} window_s=${windowSeconds}${chain}`,
     );
   }
   return lines;

--- a/packages/cli/test/rpc-usage-log.test.ts
+++ b/packages/cli/test/rpc-usage-log.test.ts
@@ -52,11 +52,12 @@ describe('formatRpcUsageLines — the Grafana-facing rpc_usage contract', () => 
     const lines = formatRpcUsageLines(
       {
         byMethod: { eth_call: 42, eth_getLogs: 7 },
-        ethCallByConsumer: {
-          'pcaNFT.getAccountInfo': 30,
-          'Hub.getContractAddress_Token': 12,
-          unsafe_consumer: 0,
-        },
+        ethCallByConsumer: {},
+        attributions: [
+          { method: 'eth_call', consumer: 'pcaNFT.getAccountInfo', count: 30 },
+          { method: 'eth_call', consumer: 'Hub.getContractAddress_Token', count: 12 },
+          { method: 'eth_call', consumer: 'unsafe_consumer', count: 0 },
+        ],
         lifetimeTotal: 49,
       },
       60,
@@ -94,10 +95,11 @@ describe('formatRpcUsageLines — the Grafana-facing rpc_usage contract', () => 
     const lines = formatRpcUsageLines(
       {
         byMethod: { eth_getLogs: 7 },
-        ethGetLogsByConsumerAndEndpointSlot: {
-          getContextGraphAuthoritySnapshot: { primary: 2, fallback_1: 3 },
-          unattributed: { fallback_2: 2 },
-        },
+        attributions: [
+          { method: 'eth_getLogs', consumer: 'getContextGraphAuthoritySnapshot', endpointSlot: 'primary', count: 2 },
+          { method: 'eth_getLogs', consumer: 'getContextGraphAuthoritySnapshot', endpointSlot: 'fallback_1', count: 3 },
+          { method: 'eth_getLogs', consumer: 'unattributed', endpointSlot: 'fallback_2', count: 2 },
+        ],
         lifetimeTotal: 7,
       },
       60,

--- a/packages/cli/test/rpc-usage-log.test.ts
+++ b/packages/cli/test/rpc-usage-log.test.ts
@@ -91,6 +91,24 @@ describe('formatRpcUsageLines — the Grafana-facing rpc_usage contract', () => 
     ]);
   });
 
+  it('drops unsupported attribution methods before log formatting', () => {
+    const lines = formatRpcUsageLines(
+      {
+        byMethod: { eth_call: 1 },
+        attributions: [{
+          method: 'eth_call\nlevel=error',
+          consumer: 'malicious',
+          count: 1,
+        } as never],
+        lifetimeTotal: 1,
+      },
+      60,
+    );
+
+    expect(lines).toEqual(['rpc_usage method=eth_call count=1 window_s=60']);
+    expect(lines.join('\n')).not.toContain('level=error');
+  });
+
   it('emits bounded eth_getLogs consumer and endpoint-slot attribution', () => {
     const lines = formatRpcUsageLines(
       {

--- a/packages/cli/test/rpc-usage-log.test.ts
+++ b/packages/cli/test/rpc-usage-log.test.ts
@@ -89,6 +89,62 @@ describe('formatRpcUsageLines — the Grafana-facing rpc_usage contract', () => 
       'rpc_usage_by_consumer method=eth_call consumer=other count=2 window_s=60',
     ]);
   });
+
+  it('emits bounded eth_getLogs consumer and endpoint-slot attribution', () => {
+    const lines = formatRpcUsageLines(
+      {
+        byMethod: { eth_getLogs: 7 },
+        ethGetLogsByConsumerAndEndpointSlot: {
+          getContextGraphAuthoritySnapshot: { primary: 2, fallback_1: 3 },
+          unattributed: { fallback_2: 2 },
+        },
+        lifetimeTotal: 7,
+      },
+      60,
+      'base:84532',
+    );
+
+    expect(lines).toContain(
+      'rpc_usage method=eth_getLogs count=7 window_s=60 chain=base:84532',
+    );
+    expect(lines).toContain(
+      'rpc_usage_by_consumer method=eth_getLogs consumer=getContextGraphAuthoritySnapshot endpoint_slot=primary count=2 window_s=60 chain=base:84532',
+    );
+    expect(lines).toContain(
+      'rpc_usage_by_consumer method=eth_getLogs consumer=getContextGraphAuthoritySnapshot endpoint_slot=fallback_1 count=3 window_s=60 chain=base:84532',
+    );
+    expect(lines).toContain(
+      'rpc_usage_by_consumer method=eth_getLogs consumer=unattributed endpoint_slot=fallback_2 count=2 window_s=60 chain=base:84532',
+    );
+    expect(lines).toHaveLength(4);
+    for (const line of lines) {
+      expect(line).toMatch(/^rpc_usage(_by_consumer)?( [a-z_]+=[A-Za-z0-9_.:-]+)+$/);
+    }
+  });
+
+  it('never emits endpoint URLs and aggregates invalid external slots under other', () => {
+    const endpointUrl = 'https://secret-token.example/rpc';
+    const lines = formatRpcUsageLines(
+      {
+        byMethod: { eth_getLogs: 3 },
+        ethGetLogsByConsumerAndEndpointSlot: {
+          authority: {
+            [endpointUrl]: 2,
+            'attacker.example': 1,
+          },
+        },
+        lifetimeTotal: 3,
+      },
+      60,
+    );
+
+    expect(lines).toEqual([
+      'rpc_usage method=eth_getLogs count=3 window_s=60',
+      'rpc_usage_by_consumer method=eth_getLogs consumer=authority endpoint_slot=other count=3 window_s=60',
+    ]);
+    expect(lines.join('\n')).not.toContain(endpointUrl);
+    expect(lines.join('\n')).not.toContain('attacker.example');
+  });
 });
 
 describe('composite daemon source — agent + publisher-runtime windows merged at drain time', () => {


### PR DESCRIPTION
## Summary

This PR makes raw `eth_getLogs` usage attributable to the DKG operation that caused it and to the configured RPC endpoint slot that served or retried it.

The existing `rpc_usage` accounting remains the transport-level source of truth: it counts raw JSON-RPC requests, including failed attempts, failover attempts, and ethers-internal retries. This change adds a diagnostic breakdown without changing those aggregate totals.

The immediate operational goal is to answer questions such as:

- how much `eth_getLogs` traffic comes from RFC-64 authority-history resolution;
- which fallback slot receives the work after a primary failure;
- whether a reduction is real work elimination or simply traffic moving between endpoints; and
- whether retries and failover are amplifying one logical scan into many transport requests.

## Why

At fleet scale, aggregate `eth_getLogs` metrics identify total load but not the originating subsystem or endpoint. That makes it difficult to distinguish RFC-64 authority scans from other historical scanners and to quantify the effect of each optimization.

Logical operation counters are not enough for this purpose. One logical read can generate multiple provider requests because of page iteration, fallback, and transport retries. The diagnostic attribution therefore has to live on the same raw transport path as aggregate accounting.

## Request and attribution sequence

```mermaid
sequenceDiagram
    autonumber
    participant C as DKG consumer
    participant F as RpcFailoverClient
    participant P as Primary endpoint
    participant B as Fallback endpoint
    participant T as RpcUsageTracker
    participant D as Daemon usage logger

    C->>F: read under consumer=getContextGraphAuthoritySnapshot
    F->>P: eth_getLogs
    F->>T: record eth_getLogs + consumer + primary
    P-->>F: 429 / timeout
    F->>B: eth_getLogs
    F->>T: record eth_getLogs + consumer + fallback_1
    B-->>F: result
    F-->>C: decoded logs
    D->>T: drain usage window
    T-->>D: aggregate totals + bounded attribution
    D-->>D: emit rpc_usage and rpc_usage_by_consumer
```

If ethers retries the same HTTP request inside one endpoint, every retry is counted and retains the same consumer and endpoint slot.

## What changes

### Method-aware attribution

- Extends the normalized usage window with a canonical attribution union.
- Preserves the existing `eth_call` consumer breakdown.
- Adds `eth_getLogs` attribution by stable consumer label and endpoint slot.
- Merges multiple adapter/runtime windows without double-counting aggregate requests.
- Accepts legacy aggregate-only and method-specific window shapes at public boundaries.

### Transport-bound counting

- Carries the current consumer through asynchronous provider work using `AsyncLocalStorage`.
- Records both the initial request and ethers-internal retry attempts.
- Attributes explicit failover attempts to their configured slots.
- Wraps direct historical page scans that intentionally bypass `RpcFailoverClient`, preventing those calls from collapsing into `consumer=unattributed`.
- Keeps `byMethod.eth_getLogs` as the authoritative raw total; attribution is diagnostic detail whose sum can be reconciled with that total.

### Bounded, credential-safe labels

Endpoint identity is deliberately represented only as:

| Configured position | Emitted value |
|---|---|
| First URL | `primary` |
| Next 15 URLs | `fallback_1` … `fallback_15` |
| Missing, invalid, or overflow | `other` |

No RPC URL, hostname, query string, API key, contract address, CG identifier, or peer-controlled value is used as an endpoint label. Consumer names are code-owned, normalized, capped to 64 characters, and bounded in cardinality. Overflow is folded into `other` rather than creating unbounded metric or log series.

### Operator-visible output

Aggregate lines remain unchanged:

```text
rpc_usage method=eth_getLogs count=125 window_s=60 chain=base:8453
```

The companion diagnostic lines add the cause and non-secret endpoint slot:

```text
rpc_usage_by_consumer method=eth_getLogs consumer=getContextGraphAuthoritySnapshot endpoint_slot=primary count=100 window_s=60 chain=base:8453
rpc_usage_by_consumer method=eth_getLogs consumer=getContextGraphAuthoritySnapshot endpoint_slot=fallback_1 count=25 window_s=60 chain=base:8453
```

## User and operator impact

- No RPC requests are added intentionally by the feature; it observes requests already leaving the process.
- No chain-read, publishing, RFC-64 authorization, SWM, or VM behavior changes.
- Existing aggregate dashboards and consumers remain compatible.
- Operators can identify the code path and endpoint slot responsible for `eth_getLogs` load and verify later optimizations against raw request attempts.

## Non-goals

This PR does **not**:

- reduce RPC traffic by itself;
- rate-limit or prioritize requests;
- prevent retry storms;
- make authority-history warm-up resumable; or
- expose provider URLs or model provider-specific accounting policies.

Those controls belong to the backpressure and durable authority-history work. This PR supplies the evidence needed to tune and verify them.

## Compatibility and failure behavior

- Telemetry remains best-effort and must never break a chain operation.
- Unsupported external attribution methods are discarded at normalization.
- Invalid external endpoint slots collapse to `other`.
- Missing attribution remains visible as `unattributed` rather than disappearing from the accounting total.
- Public drain sources that only provide the previous aggregate shape continue to normalize successfully.

## Files changed

| Area | Purpose |
|---|---|
| `packages/chain/src/rpc-usage.ts` | Canonical attribution model, bounded endpoint slots, async consumer scope, raw-attempt accounting, window normalization and merge behavior |
| `packages/chain/src/rpc-failover-client.ts` | Propagate stable diagnostic consumers through failover reads |
| `packages/chain/src/evm-adapter-base.ts` | Assign endpoint positions and explicitly scope direct historical scans |
| `packages/chain/src/evm-adapter-context-graph.ts` | Attribute RFC-64 authority-history reads |
| `packages/cli/src/daemon/rpc-usage-log.ts` | Emit bounded `rpc_usage_by_consumer` lines for `eth_call` and `eth_getLogs` |
| Chain, agent, and CLI tests | Verify raw counts, retries, failover, cardinality, compatibility, and daemon output |

## Validation

Automated coverage includes:

- server-observed request counts matching tracker totals;
- initial requests, same-endpoint retries, and cross-endpoint failover attempts;
- stable consumer attribution independent of human-readable failover labels;
- direct historical page-scan attribution;
- async consumer-scope isolation;
- endpoint-slot and consumer cardinality overflow;
- legacy usage-window compatibility and multi-source merging;
- logfmt sanitization and explicit proof that endpoint URLs are never emitted; and
- adapter → agent → daemon emission through the real public boundary.

Required before merge:

- [x] EVM integration gate on the retargeted `testnet-canary` PR
- [ ] Full CI gate on the retargeted `testnet-canary` PR
- [ ] Testnet observation showing that attribution detail reconciles with aggregate `eth_getLogs` counts over the same windows

## Review focus

Please pay particular attention to:

1. whether every raw retry/failover attempt retains its originating consumer;
2. whether the attribution sum can diverge from the raw transport aggregate;
3. the fixed endpoint-slot/cardinality boundaries and credential non-disclosure; and
4. source compatibility for older or external `RpcUsageDrainable` implementations.

## Related work

- #2540 — in-process incremental authority-history scans
- #2548 — durable authority-history checkpoints and bounded cold scans
- #2550 — shared RFC-64 authority-read circuit breaker
