### PR TITLE
fix(agent): back off shared authority RPC scans

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -47,6 +47,7 @@
     "./dist/rfc64/catalog-access-policy-v1.js": null,
     "./dist/rfc64/catalog-authority-config-v1.js": null,
     "./dist/rfc64/catalog-authority-refresh-loop-v1.js": null,
+    "./dist/rfc64/authority-rpc-circuit-breaker-v1.js": null,
     "./dist/rfc64/public-catalog-workload-owner-v1.js": null,
     "./dist/rfc64/catalog-rollout-authority-v1.js": null,
     "./dist/rfc64/catalog-responsibility-registry-v1.js": null,

--- a/packages/agent/scripts/test-package-root.mjs
+++ b/packages/agent/scripts/test-package-root.mjs
@@ -250,6 +250,7 @@ const blockedRfc64Modules = [
   'catalog-access-policy-v1.js',
   'catalog-authority-config-v1.js',
   'catalog-authority-refresh-loop-v1.js',
+  'authority-rpc-circuit-breaker-v1.js',
   'public-catalog-workload-owner-v1.js',
   'catalog-responsibility-registry-v1.js',
   'release-native-catalog-authority-v1.js',

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -28,8 +28,6 @@ import type { Rfc64CatalogSynchronizationEvidenceV1 } from
 import { Rfc64PublicCatalogReconciliationFailureRegistryV1 } from './rfc64/public-catalog-reconciliation-failure-v1.js';
 import { Rfc64CatalogMutationCoordinatorV1 } from './rfc64/catalog-mutation-runtime-v1.js';
 import type { Rfc64CatalogRuntimeV1 } from './rfc64/catalog-runtime-v1.js';
-import { Rfc64AuthorityRpcCircuitBreakerV1 } from
-  './rfc64/authority-rpc-circuit-breaker-v1.js';
 import { resolveVmReconcileStartupMaxDelayMs } from './startup-jitter.js';
 import { ContextGraphMembershipPersistScheduler } from './context-graph-membership-persist-scheduler.js';
 import { ContextGraphBindingState } from './context-graph-binding-state.js';
@@ -1217,9 +1215,10 @@ export class DKGAgentBase {
   protected readonly finalizationRuntime = new FinalizationRuntime();
   /** Single owner for RFC-64 public transport, authority refresh, and persistence. */
   protected rfc64PublicCatalogOwnerV1!: Rfc64PublicCatalogWorkloadOwnerV1;
-  /** Shared provider-pool backpressure for registered RFC-64 authority refreshes. */
-  protected readonly rfc64AuthorityRpcCircuitBreakerV1 =
-    new Rfc64AuthorityRpcCircuitBreakerV1();
+  /** Authority-read scheduling is owned by the public-catalog workload owner. */
+  protected get rfc64AuthorityReadCoordinatorV1() {
+    return this.rfc64PublicCatalogOwnerV1.authorityReads;
+  }
   /** Compatibility view for catalog methods that operate on the active service. */
   protected get rfc64PublicCatalogServiceV1(): Rfc64PublicCatalogServiceV1 | undefined {
     return this.rfc64PublicCatalogOwnerV1?.service;

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -28,6 +28,8 @@ import type { Rfc64CatalogSynchronizationEvidenceV1 } from
 import { Rfc64PublicCatalogReconciliationFailureRegistryV1 } from './rfc64/public-catalog-reconciliation-failure-v1.js';
 import { Rfc64CatalogMutationCoordinatorV1 } from './rfc64/catalog-mutation-runtime-v1.js';
 import type { Rfc64CatalogRuntimeV1 } from './rfc64/catalog-runtime-v1.js';
+import { Rfc64AuthorityRpcCircuitBreakerV1 } from
+  './rfc64/authority-rpc-circuit-breaker-v1.js';
 import { resolveVmReconcileStartupMaxDelayMs } from './startup-jitter.js';
 import { ContextGraphMembershipPersistScheduler } from './context-graph-membership-persist-scheduler.js';
 import { ContextGraphBindingState } from './context-graph-binding-state.js';
@@ -1215,6 +1217,9 @@ export class DKGAgentBase {
   protected readonly finalizationRuntime = new FinalizationRuntime();
   /** Single owner for RFC-64 public transport, authority refresh, and persistence. */
   protected rfc64PublicCatalogOwnerV1!: Rfc64PublicCatalogWorkloadOwnerV1;
+  /** Shared provider-pool backpressure for registered RFC-64 authority refreshes. */
+  protected readonly rfc64AuthorityRpcCircuitBreakerV1 =
+    new Rfc64AuthorityRpcCircuitBreakerV1();
   /** Compatibility view for catalog methods that operate on the active service. */
   protected get rfc64PublicCatalogServiceV1(): Rfc64PublicCatalogServiceV1 | undefined {
     return this.rfc64PublicCatalogOwnerV1?.service;

--- a/packages/agent/src/dkg-agent-rfc64-catalog.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog.ts
@@ -1917,7 +1917,13 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
         );
         const expectedOnChainId = BigInt(onChainId);
         const snapshot = parseRfc64AuthoritySnapshotV1(
-          await reader.getContextGraphAuthoritySnapshot(expectedOnChainId),
+          await this.rfc64AuthorityRpcCircuitBreakerV1.run(
+            signal,
+            () => reader.getContextGraphAuthoritySnapshot(
+              expectedOnChainId,
+              { signal },
+            ),
+          ),
           expectedOnChainId,
         );
         if (signal?.aborted) throw signal.reason;

--- a/packages/agent/src/dkg-agent-rfc64-catalog.ts
+++ b/packages/agent/src/dkg-agent-rfc64-catalog.ts
@@ -1909,23 +1909,29 @@ export class Rfc64CatalogMethods extends DKGAgentBase {
       if (networkId === undefined || networkId === 'none') {
         throw new Error('RFC-64 release-native authority requires a trusted chain network');
       }
-      const onChainId = await this.getContextGraphOnChainId(contextGraphId);
-      let authority: Rfc64ReleaseNativeAuthoritySnapshotV1;
-      if (onChainId !== null) {
-        const reader = requireRfc64ContextGraphAuthorityReaderV1(
-          this.contextGraphAuthorityReaderCapability,
-        );
-        const expectedOnChainId = BigInt(onChainId);
-        const snapshot = parseRfc64AuthoritySnapshotV1(
-          await this.rfc64AuthorityRpcCircuitBreakerV1.run(
-            signal,
-            () => reader.getContextGraphAuthoritySnapshot(
+      const registeredAuthorityRead = await this.rfc64AuthorityReadCoordinatorV1.run(
+        signal,
+        async (readSignal) => {
+          const onChainId = await this.getContextGraphOnChainId(contextGraphId);
+          if (readSignal?.aborted) throw readSignal.reason;
+          if (onChainId === null) return null;
+          const reader = requireRfc64ContextGraphAuthorityReaderV1(
+            this.contextGraphAuthorityReaderCapability,
+          );
+          const expectedOnChainId = BigInt(onChainId);
+          const snapshot = parseRfc64AuthoritySnapshotV1(
+            await reader.getContextGraphAuthoritySnapshot(
               expectedOnChainId,
-              { signal },
+              { signal: readSignal },
             ),
-          ),
-          expectedOnChainId,
-        );
+            expectedOnChainId,
+          );
+          return { expectedOnChainId, snapshot } as const;
+        },
+      );
+      let authority: Rfc64ReleaseNativeAuthoritySnapshotV1;
+      if (registeredAuthorityRead !== null) {
+        const { snapshot } = registeredAuthorityRead;
         if (signal?.aborted) throw signal.reason;
         const explicitNameHash = this.subscribedContextGraphs.get(contextGraphId)?.onChainHash;
         const expectedNameHash = explicitNameHash === undefined

--- a/packages/agent/src/rfc64/authority-rpc-circuit-breaker-v1.ts
+++ b/packages/agent/src/rfc64/authority-rpc-circuit-breaker-v1.ts
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  isChainRpcTransportError,
+  type ChainRpcTransportErrorLike,
+} from '@origintrail-official/dkg-chain';
+
+import { RFC64_CATALOG_AUTHORITY_REFRESH_POLICY_V1 } from
+  './catalog-authority-config-v1.js';
+
+export const RFC64_AUTHORITY_RPC_CIRCUIT_OPEN_CODE_V1 =
+  'RFC64_AUTHORITY_RPC_CIRCUIT_OPEN' as const;
+
+export interface Rfc64AuthorityRpcCircuitBreakerOptionsV1 {
+  readonly baseBackoffMs?: number;
+  readonly maxBackoffMs?: number;
+  readonly jitterRatio?: number;
+  readonly now?: () => number;
+  readonly random?: () => number;
+}
+
+export interface Rfc64AuthorityRpcCircuitSnapshotV1 {
+  readonly state: 'closed' | 'open' | 'half-open';
+  readonly consecutiveExhaustions: number;
+  readonly retryAtMs: number | null;
+}
+
+/**
+ * A caller-visible deferral, distinct from a failed RPC attempt. Callers may
+ * keep their last accepted authority while the shared provider pool cools down.
+ */
+export class Rfc64AuthorityRpcCircuitOpenErrorV1 extends Error {
+  readonly code = RFC64_AUTHORITY_RPC_CIRCUIT_OPEN_CODE_V1;
+
+  constructor(
+    readonly retryAtMs: number,
+    readonly retryAfterMs: number,
+  ) {
+    super(`RFC-64 authority RPC circuit is open for another ${retryAfterMs}ms`);
+    this.name = 'Rfc64AuthorityRpcCircuitOpenErrorV1';
+  }
+}
+
+export function isRfc64AuthorityRpcCircuitOpenErrorV1(
+  error: unknown,
+): error is Rfc64AuthorityRpcCircuitOpenErrorV1 {
+  return error instanceof Rfc64AuthorityRpcCircuitOpenErrorV1
+    || (
+      error !== null
+      && typeof error === 'object'
+      && (error as { code?: unknown }).code === RFC64_AUTHORITY_RPC_CIRCUIT_OPEN_CODE_V1
+    );
+}
+
+function positiveSafeInteger(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new TypeError(`${label} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function unitInterval(value: number, label: string): number {
+  if (!Number.isFinite(value) || value < 0 || value > 1) {
+    throw new TypeError(`${label} must be between 0 and 1`);
+  }
+  return value;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (!signal?.aborted) return;
+  throw signal.reason ?? new DOMException('The operation was aborted', 'AbortError');
+}
+
+/**
+ * Node-local governor shared by every registered RFC-64 authority read.
+ *
+ * Work is serialized even while the circuit is closed. This covers authority
+ * bootstrap calls that do not pass through the periodic loop's permit pool and
+ * guarantees that, after one full-pool exhaustion, queued graphs observe the
+ * open circuit instead of stampeding the same endpoints. At the retry deadline
+ * the serializer admits exactly one half-open probe; its success closes the
+ * circuit and its exhaustion reopens it with the next backoff step.
+ *
+ * Only a typed `RPC_ENDPOINTS_EXHAUSTED` result trips the circuit. Contract
+ * reverts and graph-specific validation failures retain their normal behavior.
+ */
+export class Rfc64AuthorityRpcCircuitBreakerV1 {
+  readonly #baseBackoffMs: number;
+  readonly #maxBackoffMs: number;
+  readonly #jitterRatio: number;
+  readonly #now: () => number;
+  readonly #random: () => number;
+  #consecutiveExhaustions = 0;
+  #retryAtMs = 0;
+  #running = false;
+  #tail: Promise<void> = Promise.resolve();
+
+  constructor(options: Rfc64AuthorityRpcCircuitBreakerOptionsV1 = {}) {
+    this.#baseBackoffMs = positiveSafeInteger(
+      options.baseBackoffMs
+        ?? RFC64_CATALOG_AUTHORITY_REFRESH_POLICY_V1.rpcCircuitBaseBackoffMs,
+      'RFC-64 authority RPC circuit baseBackoffMs',
+    );
+    this.#maxBackoffMs = positiveSafeInteger(
+      options.maxBackoffMs
+        ?? RFC64_CATALOG_AUTHORITY_REFRESH_POLICY_V1.rpcCircuitMaxBackoffMs,
+      'RFC-64 authority RPC circuit maxBackoffMs',
+    );
+    if (this.#maxBackoffMs < this.#baseBackoffMs) {
+      throw new TypeError(
+        'RFC-64 authority RPC circuit maxBackoffMs must be at least baseBackoffMs',
+      );
+    }
+    this.#jitterRatio = unitInterval(
+      options.jitterRatio
+        ?? RFC64_CATALOG_AUTHORITY_REFRESH_POLICY_V1.rpcCircuitJitterRatio,
+      'RFC-64 authority RPC circuit jitterRatio',
+    );
+    this.#now = options.now ?? Date.now;
+    this.#random = options.random ?? Math.random;
+  }
+
+  async run<T>(
+    signal: AbortSignal | undefined,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const previous = this.#tail;
+    let release!: () => void;
+    this.#tail = new Promise<void>((resolve) => { release = resolve; });
+    await previous;
+
+    try {
+      throwIfAborted(signal);
+      const now = this.#now();
+      if (now < this.#retryAtMs) {
+        throw new Rfc64AuthorityRpcCircuitOpenErrorV1(
+          this.#retryAtMs,
+          this.#retryAtMs - now,
+        );
+      }
+
+      this.#running = true;
+      try {
+        const result = await operation();
+        this.#consecutiveExhaustions = 0;
+        this.#retryAtMs = 0;
+        return result;
+      } catch (error) {
+        if (this.#isProviderPoolExhaustion(error)) this.#open(error);
+        throw error;
+      } finally {
+        this.#running = false;
+      }
+    } finally {
+      release();
+    }
+  }
+
+  snapshot(): Rfc64AuthorityRpcCircuitSnapshotV1 {
+    const now = this.#now();
+    return Object.freeze({
+      state: this.#running && this.#consecutiveExhaustions > 0
+        ? 'half-open'
+        : now < this.#retryAtMs
+          ? 'open'
+          : 'closed',
+      consecutiveExhaustions: this.#consecutiveExhaustions,
+      retryAtMs: this.#retryAtMs > now ? this.#retryAtMs : null,
+    });
+  }
+
+  #isProviderPoolExhaustion(
+    error: unknown,
+  ): error is ChainRpcTransportErrorLike & { code: 'RPC_ENDPOINTS_EXHAUSTED' } {
+    return isChainRpcTransportError(error) && error.code === 'RPC_ENDPOINTS_EXHAUSTED';
+  }
+
+  #open(error: ChainRpcTransportErrorLike): void {
+    this.#consecutiveExhaustions += 1;
+    const exponent = Math.min(this.#consecutiveExhaustions - 1, 30);
+    const exponential = Math.min(
+      this.#maxBackoffMs,
+      this.#baseBackoffMs * (2 ** exponent),
+    );
+    const sample = this.#random();
+    // Backpressure must never replace the original RPC failure because an
+    // injected/random source misbehaved. Production Math.random is bounded;
+    // defensively fall back to the midpoint for any foreign value.
+    const random = Number.isFinite(sample) && sample >= 0 && sample <= 1
+      ? sample
+      : 0.5;
+    const jitterMultiplier = 1 + ((random * 2) - 1) * this.#jitterRatio;
+    const jittered = Math.round(exponential * jitterMultiplier);
+    const providerDelay = typeof error.retryAfterMs === 'number'
+      && Number.isFinite(error.retryAfterMs)
+      && error.retryAfterMs >= 0
+      ? Math.round(error.retryAfterMs)
+      : 0;
+    const delay = Math.min(
+      this.#maxBackoffMs,
+      Math.max(1, jittered, providerDelay),
+    );
+    this.#retryAtMs = this.#now() + delay;
+  }
+}

--- a/packages/agent/src/rfc64/authority-rpc-circuit-breaker-v1.ts
+++ b/packages/agent/src/rfc64/authority-rpc-circuit-breaker-v1.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-  isChainRpcTransportError,
-  type ChainRpcTransportErrorLike,
+  isRpcEndpointsExhaustedError,
+  type RpcEndpointsExhaustedErrorLike,
 } from '@origintrail-official/dkg-chain';
 
 import { RFC64_CATALOG_AUTHORITY_REFRESH_POLICY_V1 } from
@@ -11,7 +11,7 @@ import { RFC64_CATALOG_AUTHORITY_REFRESH_POLICY_V1 } from
 export const RFC64_AUTHORITY_RPC_CIRCUIT_OPEN_CODE_V1 =
   'RFC64_AUTHORITY_RPC_CIRCUIT_OPEN' as const;
 
-export interface Rfc64AuthorityRpcCircuitBreakerOptionsV1 {
+export interface Rfc64AuthorityReadCoordinatorOptionsV1 {
   readonly baseBackoffMs?: number;
   readonly maxBackoffMs?: number;
   readonly jitterRatio?: number;
@@ -19,7 +19,7 @@ export interface Rfc64AuthorityRpcCircuitBreakerOptionsV1 {
   readonly random?: () => number;
 }
 
-export interface Rfc64AuthorityRpcCircuitSnapshotV1 {
+export interface Rfc64AuthorityReadCoordinatorSnapshotV1 {
   readonly state: 'closed' | 'open' | 'half-open';
   readonly consecutiveExhaustions: number;
   readonly retryAtMs: number | null;
@@ -84,7 +84,7 @@ function throwIfAborted(signal: AbortSignal | undefined): void {
  * Only a typed `RPC_ENDPOINTS_EXHAUSTED` result trips the circuit. Contract
  * reverts and graph-specific validation failures retain their normal behavior.
  */
-export class Rfc64AuthorityRpcCircuitBreakerV1 {
+export class Rfc64AuthorityReadCoordinatorV1 {
   readonly #baseBackoffMs: number;
   readonly #maxBackoffMs: number;
   readonly #jitterRatio: number;
@@ -94,8 +94,9 @@ export class Rfc64AuthorityRpcCircuitBreakerV1 {
   #retryAtMs = 0;
   #running = false;
   #tail: Promise<void> = Promise.resolve();
+  #lifecycleAbort = new AbortController();
 
-  constructor(options: Rfc64AuthorityRpcCircuitBreakerOptionsV1 = {}) {
+  constructor(options: Rfc64AuthorityReadCoordinatorOptionsV1 = {}) {
     this.#baseBackoffMs = positiveSafeInteger(
       options.baseBackoffMs
         ?? RFC64_CATALOG_AUTHORITY_REFRESH_POLICY_V1.rpcCircuitBaseBackoffMs,
@@ -122,41 +123,79 @@ export class Rfc64AuthorityRpcCircuitBreakerV1 {
 
   async run<T>(
     signal: AbortSignal | undefined,
-    operation: () => Promise<T>,
+    operation: (signal: AbortSignal | undefined) => Promise<T>,
   ): Promise<T> {
+    const runSignal = signal === undefined
+      ? this.#lifecycleAbort.signal
+      : AbortSignal.any([signal, this.#lifecycleAbort.signal]);
     const previous = this.#tail;
     let release!: () => void;
     this.#tail = new Promise<void>((resolve) => { release = resolve; });
-    await previous;
-
-    try {
-      throwIfAborted(signal);
-      const now = this.#now();
-      if (now < this.#retryAtMs) {
-        throw new Rfc64AuthorityRpcCircuitOpenErrorV1(
-          this.#retryAtMs,
-          this.#retryAtMs - now,
-        );
-      }
-
-      this.#running = true;
+    const queued = previous.then(async () => {
       try {
-        const result = await operation();
-        this.#consecutiveExhaustions = 0;
-        this.#retryAtMs = 0;
-        return result;
-      } catch (error) {
-        if (this.#isProviderPoolExhaustion(error)) this.#open(error);
-        throw error;
+        throwIfAborted(runSignal);
+        const now = this.#now();
+        if (now < this.#retryAtMs) {
+          throw new Rfc64AuthorityRpcCircuitOpenErrorV1(
+            this.#retryAtMs,
+            this.#retryAtMs - now,
+          );
+        }
+
+        this.#running = true;
+        try {
+          const result = await operation(runSignal);
+          this.#consecutiveExhaustions = 0;
+          this.#retryAtMs = 0;
+          return result;
+        } catch (error) {
+          if (isRpcEndpointsExhaustedError(error)) this.#open(error);
+          throw error;
+        } finally {
+          this.#running = false;
+        }
       } finally {
-        this.#running = false;
+        release();
       }
+    });
+
+    let removeAbortListener: () => void = () => undefined;
+    const aborted = new Promise<never>((_resolve, reject) => {
+      const onAbort = () => reject(
+        runSignal.reason ?? new DOMException('The operation was aborted', 'AbortError'),
+      );
+      runSignal.addEventListener('abort', onAbort, { once: true });
+      removeAbortListener = () => runSignal.removeEventListener('abort', onAbort);
+      if (runSignal.aborted) onAbort();
+    });
+    try {
+      return await Promise.race([queued, aborted]);
     } finally {
-      release();
+      removeAbortListener();
+      // An aborted waiter settles for its caller immediately, but its queue
+      // token stays in FIFO order until the predecessor retires. Consume that
+      // later cancellation so it cannot become an unhandled rejection.
+      void queued.catch(() => undefined);
     }
   }
 
-  snapshot(): Rfc64AuthorityRpcCircuitSnapshotV1 {
+  whenIdle(): Promise<void> {
+    return this.#tail;
+  }
+
+  close(): Promise<void> {
+    if (!this.#lifecycleAbort.signal.aborted) {
+      this.#lifecycleAbort.abort(new Error('RFC-64 authority read coordinator is closing'));
+    }
+    return this.#tail;
+  }
+
+  reopen(): void {
+    if (!this.#lifecycleAbort.signal.aborted) return;
+    this.#lifecycleAbort = new AbortController();
+  }
+
+  snapshot(): Rfc64AuthorityReadCoordinatorSnapshotV1 {
     const now = this.#now();
     return Object.freeze({
       state: this.#running && this.#consecutiveExhaustions > 0
@@ -169,13 +208,7 @@ export class Rfc64AuthorityRpcCircuitBreakerV1 {
     });
   }
 
-  #isProviderPoolExhaustion(
-    error: unknown,
-  ): error is ChainRpcTransportErrorLike & { code: 'RPC_ENDPOINTS_EXHAUSTED' } {
-    return isChainRpcTransportError(error) && error.code === 'RPC_ENDPOINTS_EXHAUSTED';
-  }
-
-  #open(error: ChainRpcTransportErrorLike): void {
+  #open(error: RpcEndpointsExhaustedErrorLike): void {
     this.#consecutiveExhaustions += 1;
     const exponent = Math.min(this.#consecutiveExhaustions - 1, 30);
     const exponential = Math.min(

--- a/packages/agent/src/rfc64/catalog-authority-config-v1.ts
+++ b/packages/agent/src/rfc64/catalog-authority-config-v1.ts
@@ -37,7 +37,6 @@ const RFC64_CATALOG_AUTHORITY_REFRESH_INTERVAL_MS_V1 = 5 * 60_000;
 export const RFC64_CATALOG_AUTHORITY_REFRESH_POLICY_V1 = Object.freeze({
   intervalMs: RFC64_CATALOG_AUTHORITY_REFRESH_INTERVAL_MS_V1,
   freshnessIntervalCount: 4,
-  maxConcurrentReads: 4,
   // A provider-pool exhaustion is shared infrastructure state, not a reason
   // for every registered graph to immediately repeat the same cold scan.
   rpcCircuitBaseBackoffMs: 60_000,

--- a/packages/agent/src/rfc64/catalog-authority-config-v1.ts
+++ b/packages/agent/src/rfc64/catalog-authority-config-v1.ts
@@ -38,6 +38,11 @@ export const RFC64_CATALOG_AUTHORITY_REFRESH_POLICY_V1 = Object.freeze({
   intervalMs: RFC64_CATALOG_AUTHORITY_REFRESH_INTERVAL_MS_V1,
   freshnessIntervalCount: 4,
   maxConcurrentReads: 4,
+  // A provider-pool exhaustion is shared infrastructure state, not a reason
+  // for every registered graph to immediately repeat the same cold scan.
+  rpcCircuitBaseBackoffMs: 60_000,
+  rpcCircuitMaxBackoffMs: 30 * 60_000,
+  rpcCircuitJitterRatio: 0.2,
 });
 
 /**

--- a/packages/agent/src/rfc64/catalog-authority-refresh-loop-v1.ts
+++ b/packages/agent/src/rfc64/catalog-authority-refresh-loop-v1.ts
@@ -35,76 +35,11 @@ export interface Rfc64CatalogAuthorityRefreshLoopOptionsV1 {
   ) => Promise<unknown>;
   readonly onRefreshFailure: (contextGraphId: string, error: unknown) => void;
   readonly scheduler?: Rfc64CatalogAuthorityRefreshSchedulerV1;
-  readonly maxConcurrentReads?: number;
-}
-
-type RefreshPermitReleaseV1 = () => void;
-
-/** Cancellation-aware global bound shared by the independent per-CG lanes. */
-class Rfc64AuthorityRefreshPermitPoolV1 {
-  readonly #limit: number;
-  #active = 0;
-  readonly #waiters: Array<Readonly<{
-    signal: AbortSignal;
-    resolve: (release: RefreshPermitReleaseV1 | null) => void;
-    onAbort: () => void;
-  }>> = [];
-
-  constructor(limit: number) {
-    this.#limit = limit;
-  }
-
-  acquire(
-    signal: AbortSignal,
-  ): RefreshPermitReleaseV1 | null | Promise<RefreshPermitReleaseV1 | null> {
-    if (signal.aborted) return null;
-    if (this.#active < this.#limit) {
-      this.#active += 1;
-      return this.#createRelease();
-    }
-    return new Promise((resolve) => {
-      const waiter = {
-        signal,
-        resolve,
-        onAbort: () => {
-          const index = this.#waiters.indexOf(waiter);
-          if (index >= 0) this.#waiters.splice(index, 1);
-          resolve(null);
-        },
-      };
-      this.#waiters.push(waiter);
-      signal.addEventListener('abort', waiter.onAbort, { once: true });
-    });
-  }
-
-  #createRelease(): RefreshPermitReleaseV1 {
-    let released = false;
-    return () => {
-      if (released) return;
-      released = true;
-      this.#active -= 1;
-      this.#drain();
-    };
-  }
-
-  #drain(): void {
-    while (this.#active < this.#limit && this.#waiters.length > 0) {
-      const waiter = this.#waiters.shift()!;
-      waiter.signal.removeEventListener('abort', waiter.onAbort);
-      if (waiter.signal.aborted) {
-        waiter.resolve(null);
-        continue;
-      }
-      this.#active += 1;
-      waiter.resolve(this.#createRelease());
-    }
-  }
 }
 
 /** Bounded independent authority lanes with explicit scheduling and shutdown ownership. */
 export class Rfc64CatalogAuthorityRefreshLoopV1 implements Rfc64CatalogWorkloadOwnerV1 {
   readonly #scheduler: Rfc64CatalogAuthorityRefreshSchedulerV1;
-  readonly #permits: Rfc64AuthorityRefreshPermitPoolV1;
   readonly #lanes = new Map<string, Rfc64CoalescingSupervisorV1>();
   readonly #retirements = new Set<Promise<void>>();
   #timer: ReturnType<typeof setInterval> | null = null;
@@ -113,31 +48,18 @@ export class Rfc64CatalogAuthorityRefreshLoopV1 implements Rfc64CatalogWorkloadO
 
   constructor(private readonly options: Rfc64CatalogAuthorityRefreshLoopOptionsV1) {
     this.#scheduler = options.scheduler ?? rfc64CatalogAuthorityRefreshSchedulerV1;
-    const maxConcurrentReads = options.maxConcurrentReads
-      ?? RFC64_CATALOG_AUTHORITY_REFRESH_POLICY_V1.maxConcurrentReads;
-    if (!Number.isSafeInteger(maxConcurrentReads) || maxConcurrentReads < 1) {
-      throw new TypeError('RFC-64 authority refresh concurrency must be a positive integer');
-    }
-    this.#permits = new Rfc64AuthorityRefreshPermitPoolV1(maxConcurrentReads);
   }
 
   #createLane(contextGraphId: string): Rfc64CoalescingSupervisorV1 {
     return new Rfc64CoalescingSupervisorV1({
       requestWhileRunning: 'drop',
       runPass: async (signal) => {
-        const admission = this.#permits.acquire(signal);
-        const release = typeof admission === 'function' || admission === null
-          ? admission
-          : await admission;
-        if (release === null) return;
         try {
           await this.options.refreshContextGraph(contextGraphId, signal);
           if (signal.aborted) return;
         } catch (error) {
           if (signal.aborted) return;
           this.options.onRefreshFailure(contextGraphId, error);
-        } finally {
-          release();
         }
       },
       // Per-context-graph failures are reported by the lane body.

--- a/packages/agent/src/rfc64/public-catalog-workload-owner-v1.ts
+++ b/packages/agent/src/rfc64/public-catalog-workload-owner-v1.ts
@@ -7,6 +7,8 @@ import type {
   Rfc64CatalogWorkloadOwnerV1,
   Rfc64PublicCatalogRuntimeOwnerV1,
 } from './catalog-runtime-v1.js';
+import { Rfc64AuthorityReadCoordinatorV1 } from
+  './authority-rpc-circuit-breaker-v1.js';
 
 /** Narrow transport lifecycle required by the workload owner. */
 export interface Rfc64PublicCatalogLifecyclePortV1 {
@@ -23,6 +25,7 @@ export interface Rfc64PublicCatalogWorkloadOwnerOptionsV1<
     ctx: OperationContext,
   ) => Service | null;
   readonly authorityRefresh: Rfc64CatalogWorkloadOwnerV1;
+  readonly authorityReads?: Rfc64AuthorityReadCoordinatorV1;
   readonly onServiceStarted: (ctx: OperationContext) => void;
 }
 
@@ -32,6 +35,7 @@ export class Rfc64PublicCatalogWorkloadOwnerV1<
 >
 implements Rfc64PublicCatalogRuntimeOwnerV1 {
   readonly #options: Rfc64PublicCatalogWorkloadOwnerOptionsV1<Service>;
+  readonly #authorityReads: Rfc64AuthorityReadCoordinatorV1;
   #service: Service | null = null;
   #authorityStartAttempted = false;
   #started = false;
@@ -39,10 +43,15 @@ implements Rfc64PublicCatalogRuntimeOwnerV1 {
 
   constructor(options: Rfc64PublicCatalogWorkloadOwnerOptionsV1<Service>) {
     this.#options = options;
+    this.#authorityReads = options.authorityReads ?? new Rfc64AuthorityReadCoordinatorV1();
   }
 
   get service(): Service | undefined {
     return this.#service ?? undefined;
+  }
+
+  get authorityReads(): Rfc64AuthorityReadCoordinatorV1 {
+    return this.#authorityReads;
   }
 
   start(ctx: OperationContext): void {
@@ -54,6 +63,7 @@ implements Rfc64PublicCatalogRuntimeOwnerV1 {
     let serviceStartAttempted = false;
     let authorityStartAttempted = false;
     try {
+      this.#authorityReads.reopen();
       service = this.#options.createService(ctx);
       if (service === null) {
         this.#started = true;
@@ -83,6 +93,7 @@ implements Rfc64PublicCatalogRuntimeOwnerV1 {
     await Promise.all([
       this.#service?.whenReceiverIdle(),
       this.#options.authorityRefresh.whenIdle(),
+      this.#authorityReads.whenIdle(),
     ]);
   }
 
@@ -124,6 +135,7 @@ implements Rfc64PublicCatalogRuntimeOwnerV1 {
           ? this.#options.authorityRefresh.close()
           : undefined
       )),
+      Promise.resolve().then(() => this.#authorityReads.close()),
     ]);
     for (const result of retirements) {
       if (result.status === 'rejected') failures.push(result.reason);

--- a/packages/agent/test/rfc64-authority-rpc-circuit-breaker-v1.test.ts
+++ b/packages/agent/test/rfc64-authority-rpc-circuit-breaker-v1.test.ts
@@ -176,7 +176,7 @@ describe('RFC-64 authority RPC circuit breaker', () => {
     });
   });
 
-  it('does not trip for deterministic failures and respects an aborted waiter', async () => {
+  it('does not trip for deterministic failures', async () => {
     let calls = 0;
     const breaker = new Rfc64AuthorityReadCoordinatorV1({
       baseBackoffMs: 100,
@@ -190,12 +190,6 @@ describe('RFC-64 authority RPC circuit breaker', () => {
     })).rejects.toMatchObject({ code: 'CALL_EXCEPTION' });
     expect(breaker.snapshot().state).toBe('closed');
 
-    const controller = new AbortController();
-    controller.abort(new Error('agent stopping'));
-    await expect(breaker.run(controller.signal, async () => {
-      calls += 1;
-      return 'must-not-run';
-    })).rejects.toThrow('agent stopping');
     expect(calls).toBe(1);
   });
 
@@ -217,11 +211,16 @@ describe('RFC-64 authority RPC circuit breaker', () => {
     await started;
 
     const controller = new AbortController();
-    const second = breaker.run(controller.signal, async () => 'must-not-run');
+    let cancelledCalls = 0;
+    const second = breaker.run(controller.signal, async () => {
+      cancelledCalls += 1;
+      return 'must-not-run';
+    });
     const third = breaker.run(undefined, async () => 'third');
     controller.abort(new Error('queued read cancelled'));
 
     await expect(second).rejects.toThrow('queued read cancelled');
+    expect(cancelledCalls).toBe(0);
     await expect(Promise.race([
       third.then(() => 'overtook'),
       new Promise<string>((resolve) => setTimeout(() => resolve('still-queued'), 10)),
@@ -229,6 +228,7 @@ describe('RFC-64 authority RPC circuit breaker', () => {
     releaseFirst();
     await expect(first).resolves.toBe('first');
     await expect(third).resolves.toBe('third');
+    expect(cancelledCalls).toBe(0);
   });
 
   it('rejects unsafe timing configuration', () => {

--- a/packages/agent/test/rfc64-authority-rpc-circuit-breaker-v1.test.ts
+++ b/packages/agent/test/rfc64-authority-rpc-circuit-breaker-v1.test.ts
@@ -1,16 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { ChainRpcTransportError } from '@origintrail-official/dkg-chain';
+import {
+  ChainRpcTransportError,
+  RpcEndpointsExhaustedError,
+} from '@origintrail-official/dkg-chain';
 import { describe, expect, it } from 'vitest';
 
 import {
-  Rfc64AuthorityRpcCircuitBreakerV1,
+  Rfc64AuthorityReadCoordinatorV1,
   isRfc64AuthorityRpcCircuitOpenErrorV1,
 } from '../src/rfc64/authority-rpc-circuit-breaker-v1.js';
 
 function exhausted(retryAfterMs?: number): ChainRpcTransportError {
-  return new ChainRpcTransportError(
-    'RPC_ENDPOINTS_EXHAUSTED',
+  return new RpcEndpointsExhaustedError(
     'authority read failed on every provider',
     {
       exhaustionKind: 'all-throttled',
@@ -27,7 +29,7 @@ describe('RFC-64 authority RPC circuit breaker', () => {
   it('shares one open circuit across queued graph refreshes', async () => {
     let now = 1_000;
     let calls = 0;
-    const breaker = new Rfc64AuthorityRpcCircuitBreakerV1({
+    const breaker = new Rfc64AuthorityReadCoordinatorV1({
       baseBackoffMs: 100,
       maxBackoffMs: 800,
       jitterRatio: 0,
@@ -60,7 +62,7 @@ describe('RFC-64 authority RPC circuit breaker', () => {
   it('admits exactly one half-open probe and reopens when it exhausts', async () => {
     let now = 0;
     let calls = 0;
-    const breaker = new Rfc64AuthorityRpcCircuitBreakerV1({
+    const breaker = new Rfc64AuthorityReadCoordinatorV1({
       baseBackoffMs: 100,
       maxBackoffMs: 800,
       jitterRatio: 0,
@@ -104,7 +106,7 @@ describe('RFC-64 authority RPC circuit breaker', () => {
   it('closes after a successful half-open probe and releases queued work', async () => {
     let now = 0;
     let calls = 0;
-    const breaker = new Rfc64AuthorityRpcCircuitBreakerV1({
+    const breaker = new Rfc64AuthorityReadCoordinatorV1({
       baseBackoffMs: 100,
       maxBackoffMs: 800,
       jitterRatio: 0,
@@ -135,9 +137,24 @@ describe('RFC-64 authority RPC circuit breaker', () => {
     });
   });
 
-  it('honors Retry-After, exponential backoff, jitter, and the absolute cap', async () => {
+  it('applies deterministic fleet jitter when no provider hint overrides it', async () => {
     let now = 0;
-    const breaker = new Rfc64AuthorityRpcCircuitBreakerV1({
+    const breaker = new Rfc64AuthorityReadCoordinatorV1({
+      baseBackoffMs: 100,
+      maxBackoffMs: 800,
+      jitterRatio: 0.2,
+      now: () => now,
+      random: () => 1,
+    });
+
+    await expect(breaker.run(undefined, async () => { throw exhausted(); }))
+      .rejects.toBeInstanceOf(ChainRpcTransportError);
+    expect(breaker.snapshot().retryAtMs).toBe(120);
+  });
+
+  it('honors Retry-After, exponential backoff, and the absolute cap', async () => {
+    let now = 0;
+    const breaker = new Rfc64AuthorityReadCoordinatorV1({
       baseBackoffMs: 100,
       maxBackoffMs: 800,
       jitterRatio: 0.2,
@@ -161,7 +178,7 @@ describe('RFC-64 authority RPC circuit breaker', () => {
 
   it('does not trip for deterministic failures and respects an aborted waiter', async () => {
     let calls = 0;
-    const breaker = new Rfc64AuthorityRpcCircuitBreakerV1({
+    const breaker = new Rfc64AuthorityReadCoordinatorV1({
       baseBackoffMs: 100,
       maxBackoffMs: 800,
       jitterRatio: 0,
@@ -182,12 +199,44 @@ describe('RFC-64 authority RPC circuit breaker', () => {
     expect(calls).toBe(1);
   });
 
+  it('settles a queued abort promptly without allowing later work to overtake', async () => {
+    const breaker = new Rfc64AuthorityReadCoordinatorV1({
+      baseBackoffMs: 100,
+      maxBackoffMs: 800,
+      jitterRatio: 0,
+    });
+    let releaseFirst!: () => void;
+    let markStarted!: () => void;
+    const gate = new Promise<void>((resolve) => { releaseFirst = resolve; });
+    const started = new Promise<void>((resolve) => { markStarted = resolve; });
+    const first = breaker.run(undefined, async () => {
+      markStarted();
+      await gate;
+      return 'first';
+    });
+    await started;
+
+    const controller = new AbortController();
+    const second = breaker.run(controller.signal, async () => 'must-not-run');
+    const third = breaker.run(undefined, async () => 'third');
+    controller.abort(new Error('queued read cancelled'));
+
+    await expect(second).rejects.toThrow('queued read cancelled');
+    await expect(Promise.race([
+      third.then(() => 'overtook'),
+      new Promise<string>((resolve) => setTimeout(() => resolve('still-queued'), 10)),
+    ])).resolves.toBe('still-queued');
+    releaseFirst();
+    await expect(first).resolves.toBe('first');
+    await expect(third).resolves.toBe('third');
+  });
+
   it('rejects unsafe timing configuration', () => {
-    expect(() => new Rfc64AuthorityRpcCircuitBreakerV1({
+    expect(() => new Rfc64AuthorityReadCoordinatorV1({
       baseBackoffMs: 1_000,
       maxBackoffMs: 999,
     })).toThrow(/at least baseBackoffMs/u);
-    expect(() => new Rfc64AuthorityRpcCircuitBreakerV1({
+    expect(() => new Rfc64AuthorityReadCoordinatorV1({
       jitterRatio: 1.1,
     })).toThrow(/between 0 and 1/u);
   });

--- a/packages/agent/test/rfc64-authority-rpc-circuit-breaker-v1.test.ts
+++ b/packages/agent/test/rfc64-authority-rpc-circuit-breaker-v1.test.ts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { ChainRpcTransportError } from '@origintrail-official/dkg-chain';
+import { describe, expect, it } from 'vitest';
+
+import {
+  Rfc64AuthorityRpcCircuitBreakerV1,
+  isRfc64AuthorityRpcCircuitOpenErrorV1,
+} from '../src/rfc64/authority-rpc-circuit-breaker-v1.js';
+
+function exhausted(retryAfterMs?: number): ChainRpcTransportError {
+  return new ChainRpcTransportError(
+    'RPC_ENDPOINTS_EXHAUSTED',
+    'authority read failed on every provider',
+    {
+      exhaustionKind: 'all-throttled',
+      ...(retryAfterMs === undefined ? {} : { retryAfterMs }),
+    },
+  );
+}
+
+function deterministicFailure(): Error {
+  return Object.assign(new Error('execution reverted'), { code: 'CALL_EXCEPTION' });
+}
+
+describe('RFC-64 authority RPC circuit breaker', () => {
+  it('shares one open circuit across queued graph refreshes', async () => {
+    let now = 1_000;
+    let calls = 0;
+    const breaker = new Rfc64AuthorityRpcCircuitBreakerV1({
+      baseBackoffMs: 100,
+      maxBackoffMs: 800,
+      jitterRatio: 0,
+      now: () => now,
+    });
+
+    const first = breaker.run(undefined, async () => {
+      calls += 1;
+      throw exhausted();
+    });
+    const queued = breaker.run(undefined, async () => {
+      calls += 1;
+      return 'must-not-run';
+    });
+
+    await expect(first).rejects.toMatchObject({ code: 'RPC_ENDPOINTS_EXHAUSTED' });
+    await expect(queued).rejects.toSatisfy(isRfc64AuthorityRpcCircuitOpenErrorV1);
+    expect(calls).toBe(1);
+    expect(breaker.snapshot()).toEqual({
+      state: 'open',
+      consecutiveExhaustions: 1,
+      retryAtMs: 1_100,
+    });
+
+    now = 1_099;
+    await expect(breaker.run(undefined, async () => 'too-early'))
+      .rejects.toSatisfy(isRfc64AuthorityRpcCircuitOpenErrorV1);
+  });
+
+  it('admits exactly one half-open probe and reopens when it exhausts', async () => {
+    let now = 0;
+    let calls = 0;
+    const breaker = new Rfc64AuthorityRpcCircuitBreakerV1({
+      baseBackoffMs: 100,
+      maxBackoffMs: 800,
+      jitterRatio: 0,
+      now: () => now,
+    });
+    await expect(breaker.run(undefined, async () => {
+      calls += 1;
+      throw exhausted();
+    })).rejects.toBeInstanceOf(ChainRpcTransportError);
+
+    now = 100;
+    let releaseProbe!: () => void;
+    let markProbeStarted!: () => void;
+    const probeGate = new Promise<void>((resolve) => { releaseProbe = resolve; });
+    const probeStarted = new Promise<void>((resolve) => { markProbeStarted = resolve; });
+    const probe = breaker.run(undefined, async () => {
+      calls += 1;
+      markProbeStarted();
+      await probeGate;
+      throw exhausted();
+    });
+    const queued = breaker.run(undefined, async () => {
+      calls += 1;
+      return 'must-not-run';
+    });
+    await probeStarted;
+    expect(breaker.snapshot().state).toBe('half-open');
+    expect(calls).toBe(2);
+    releaseProbe();
+
+    await expect(probe).rejects.toBeInstanceOf(ChainRpcTransportError);
+    await expect(queued).rejects.toSatisfy(isRfc64AuthorityRpcCircuitOpenErrorV1);
+    expect(calls).toBe(2);
+    expect(breaker.snapshot()).toEqual({
+      state: 'open',
+      consecutiveExhaustions: 2,
+      retryAtMs: 300,
+    });
+  });
+
+  it('closes after a successful half-open probe and releases queued work', async () => {
+    let now = 0;
+    let calls = 0;
+    const breaker = new Rfc64AuthorityRpcCircuitBreakerV1({
+      baseBackoffMs: 100,
+      maxBackoffMs: 800,
+      jitterRatio: 0,
+      now: () => now,
+    });
+    await expect(breaker.run(undefined, async () => {
+      calls += 1;
+      throw exhausted();
+    })).rejects.toBeInstanceOf(ChainRpcTransportError);
+    now = 100;
+
+    const recovered = breaker.run(undefined, async () => {
+      calls += 1;
+      return 'recovered';
+    });
+    const next = breaker.run(undefined, async () => {
+      calls += 1;
+      return 'next-graph';
+    });
+
+    await expect(recovered).resolves.toBe('recovered');
+    await expect(next).resolves.toBe('next-graph');
+    expect(calls).toBe(3);
+    expect(breaker.snapshot()).toEqual({
+      state: 'closed',
+      consecutiveExhaustions: 0,
+      retryAtMs: null,
+    });
+  });
+
+  it('honors Retry-After, exponential backoff, jitter, and the absolute cap', async () => {
+    let now = 0;
+    const breaker = new Rfc64AuthorityRpcCircuitBreakerV1({
+      baseBackoffMs: 100,
+      maxBackoffMs: 800,
+      jitterRatio: 0.2,
+      now: () => now,
+      random: () => 1,
+    });
+
+    await expect(breaker.run(undefined, async () => { throw exhausted(500); }))
+      .rejects.toBeInstanceOf(ChainRpcTransportError);
+    expect(breaker.snapshot().retryAtMs).toBe(500);
+
+    now = 500;
+    await expect(breaker.run(undefined, async () => { throw exhausted(5_000); }))
+      .rejects.toBeInstanceOf(ChainRpcTransportError);
+    expect(breaker.snapshot()).toEqual({
+      state: 'open',
+      consecutiveExhaustions: 2,
+      retryAtMs: 1_300,
+    });
+  });
+
+  it('does not trip for deterministic failures and respects an aborted waiter', async () => {
+    let calls = 0;
+    const breaker = new Rfc64AuthorityRpcCircuitBreakerV1({
+      baseBackoffMs: 100,
+      maxBackoffMs: 800,
+      jitterRatio: 0,
+    });
+
+    await expect(breaker.run(undefined, async () => {
+      calls += 1;
+      throw deterministicFailure();
+    })).rejects.toMatchObject({ code: 'CALL_EXCEPTION' });
+    expect(breaker.snapshot().state).toBe('closed');
+
+    const controller = new AbortController();
+    controller.abort(new Error('agent stopping'));
+    await expect(breaker.run(controller.signal, async () => {
+      calls += 1;
+      return 'must-not-run';
+    })).rejects.toThrow('agent stopping');
+    expect(calls).toBe(1);
+  });
+
+  it('rejects unsafe timing configuration', () => {
+    expect(() => new Rfc64AuthorityRpcCircuitBreakerV1({
+      baseBackoffMs: 1_000,
+      maxBackoffMs: 999,
+    })).toThrow(/at least baseBackoffMs/u);
+    expect(() => new Rfc64AuthorityRpcCircuitBreakerV1({
+      jitterRatio: 1.1,
+    })).toThrow(/between 0 and 1/u);
+  });
+});

--- a/packages/agent/test/rfc64-catalog-authority-refresh-loop-v1.test.ts
+++ b/packages/agent/test/rfc64-catalog-authority-refresh-loop-v1.test.ts
@@ -167,7 +167,6 @@ describe('RFC-64 catalog authority refresh loop', () => {
       },
       onRefreshFailure: () => undefined,
       scheduler,
-      maxConcurrentReads: 2,
     });
 
     loop.start();
@@ -190,7 +189,7 @@ describe('RFC-64 catalog authority refresh loop', () => {
     await closing;
   });
 
-  it('bounds independent lanes without letting one stalled graph own the queue', async () => {
+  it('delegates global admission while keeping per-graph lanes independent', async () => {
     let releaseA!: () => void;
     let releaseB!: () => void;
     let markAStarted!: () => void;
@@ -218,64 +217,16 @@ describe('RFC-64 catalog authority refresh loop', () => {
         }
       },
       onRefreshFailure: () => undefined,
-      maxConcurrentReads: 2,
     });
 
     loop.start();
-    await Promise.all([startedA, startedB]);
-    expect(attempts).toEqual(['cg-a', 'cg-b']);
-    releaseB();
-    await startedC;
+    await Promise.all([startedA, startedB, startedC]);
     expect(attempts).toEqual(['cg-a', 'cg-b', 'cg-c']);
 
     const closing = loop.close();
+    releaseB();
     releaseA();
     await closing;
-  });
-
-  it('uses the production four-read concurrency cap by default', async () => {
-    const limit = RFC64_CATALOG_AUTHORITY_REFRESH_POLICY_V1.maxConcurrentReads;
-    expect(limit).toBe(4);
-    const contextGraphIds = Array.from(
-      { length: limit + 1 },
-      (_, index) => `cg-${index + 1}`,
-    );
-    const releases: Array<() => void> = [];
-    const gates = contextGraphIds.map(() => new Promise<void>((resolve) => {
-      releases.push(resolve);
-    }));
-    const markStarted: Array<() => void> = [];
-    const started = contextGraphIds.map(() => new Promise<void>((resolve) => {
-      markStarted.push(resolve);
-    }));
-    const attempts: string[] = [];
-    const loop = new Rfc64CatalogAuthorityRefreshLoopV1({
-      readActiveContextGraphIds: () => contextGraphIds,
-      onActiveContextGraphIdsReadFailure: () => undefined,
-      refreshContextGraph: async (contextGraphId) => {
-        const index = contextGraphIds.indexOf(contextGraphId);
-        attempts.push(contextGraphId);
-        markStarted[index]!();
-        await gates[index];
-      },
-      onRefreshFailure: () => undefined,
-    });
-
-    loop.start();
-    await Promise.all(started.slice(0, limit));
-    expect(attempts).toEqual(contextGraphIds.slice(0, limit));
-
-    let nextStarted = false;
-    void started[limit]!.then(() => { nextStarted = true; });
-    await Promise.resolve();
-    expect(nextStarted).toBe(false);
-
-    releases[0]!();
-    await started[limit];
-    expect(attempts).toEqual(contextGraphIds);
-
-    for (const release of releases.slice(1)) release();
-    await loop.close();
   });
 
   it('aborts and physically drains an in-flight pass before close settles', async () => {
@@ -298,15 +249,14 @@ describe('RFC-64 catalog authority refresh loop', () => {
         signal.addEventListener('abort', markAborted, { once: true });
         markStarted();
         // Deliberately ignore cancellation and resolve successfully only when
-        // the physical operation retires. The loop, not this stub, must fence
-        // the next context graph after shutdown begins.
+        // the physical operation retires. Each per-graph lane must still be
+        // physically drained before loop shutdown settles.
         await retirement;
       },
       onRefreshFailure: (contextGraphId, error) => {
         reported.push(Object.freeze({ contextGraphId, error }));
       },
       scheduler,
-      maxConcurrentReads: 1,
     });
 
     loop.start();
@@ -324,7 +274,7 @@ describe('RFC-64 catalog authority refresh loop', () => {
     releaseRetirement();
     await close;
 
-    expect(attempts).toEqual(['cg-a']);
+    expect(attempts).toEqual(['cg-a', 'cg-b']);
     expect(reported).toEqual([]);
     expect(cleared).toEqual([scheduled[0]!.handle]);
   });
@@ -353,7 +303,6 @@ describe('RFC-64 catalog authority refresh loop', () => {
       },
       onRefreshFailure: () => undefined,
       scheduler,
-      maxConcurrentReads: 1,
     });
 
     loop.start();

--- a/packages/agent/test/rfc64-rollout-authority.integration.test.ts
+++ b/packages/agent/test/rfc64-rollout-authority.integration.test.ts
@@ -23,8 +23,8 @@ import {
 import { OxigraphStore, type Quad, type TripleStore } from '@origintrail-official/dkg-storage';
 import { computeFlatKCRootV10 } from '@origintrail-official/dkg-publisher';
 import {
-  ChainRpcTransportError,
   NoChainAdapter,
+  RpcEndpointsExhaustedError,
   type ChainAdapter,
   type ContextGraphAuthoritySnapshot,
 } from '@origintrail-official/dkg-chain';
@@ -961,8 +961,7 @@ describe('RFC-64 rollout authority integration', () => {
 
   it('shares provider-pool exhaustion across registered authority reconciliations', async () => {
     const readAuthority = vi.fn(async () => {
-      throw new ChainRpcTransportError(
-        'RPC_ENDPOINTS_EXHAUSTED',
+      throw new RpcEndpointsExhaustedError(
         'authority read failed on every provider',
         { exhaustionKind: 'mixed', retryAfterMs: 30_000 },
       );
@@ -984,7 +983,35 @@ describe('RFC-64 rollout authority integration', () => {
     )).rejects.toSatisfy(isRfc64AuthorityRpcCircuitOpenErrorV1);
 
     expect(readAuthority).toHaveBeenCalledOnce();
-    expect(readAuthority).toHaveBeenCalledWith(9n, { signal: undefined });
+    expect(readAuthority).toHaveBeenCalledWith(9n, {
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it('opens the shared circuit when cold numeric binding discovery exhausts providers', async () => {
+    const readAuthority = vi.fn();
+    const edge = await startAgent({
+      name: 'registered-authority-id-discovery-circuit',
+      config: {
+        chainAdapter: Object.assign(new NoChainAdapter(), {
+          getContextGraphAuthoritySnapshot: readAuthority,
+        }),
+      },
+    });
+    const resolveOnChainId = vi.spyOn(edge, 'getContextGraphOnChainId')
+      .mockRejectedValue(new RpcEndpointsExhaustedError(
+        'numeric context graph lookup exhausted every provider',
+        { exhaustionKind: 'mixed', retryAfterMs: 30_000 },
+      ));
+
+    await expect(edge.reconcileRfc64CatalogAccessAuthorityV1(CONTEXT_GRAPH_ID))
+      .rejects.toMatchObject({ code: 'RPC_ENDPOINTS_EXHAUSTED' });
+    await expect(edge.reconcileRfc64CatalogAccessAuthorityV1(
+      `${AUTHOR}/second-cold-binding` as ContextGraphIdV1,
+    )).rejects.toSatisfy(isRfc64AuthorityRpcCircuitOpenErrorV1);
+
+    expect(resolveOnChainId).toHaveBeenCalledOnce();
+    expect(readAuthority).not.toHaveBeenCalled();
   });
 
   it('rejects a curator binding returned for a different registered Context Graph ID', async () => {

--- a/packages/agent/test/rfc64-rollout-authority.integration.test.ts
+++ b/packages/agent/test/rfc64-rollout-authority.integration.test.ts
@@ -23,6 +23,7 @@ import {
 import { OxigraphStore, type Quad, type TripleStore } from '@origintrail-official/dkg-storage';
 import { computeFlatKCRootV10 } from '@origintrail-official/dkg-publisher';
 import {
+  ChainRpcTransportError,
   NoChainAdapter,
   type ChainAdapter,
   type ContextGraphAuthoritySnapshot,
@@ -35,6 +36,8 @@ import { Rfc64PublicCatalogSuccessorProducerV1 } from
   '../src/rfc64/public-catalog-successor-producer-v1.js';
 import { RFC64_CATALOG_AUTHORITY_REFRESH_POLICY_V1 } from
   '../src/rfc64/catalog-authority-config-v1.js';
+import { isRfc64AuthorityRpcCircuitOpenErrorV1 } from
+  '../src/rfc64/authority-rpc-circuit-breaker-v1.js';
 import type { Rfc64CatalogRuntimeV1 } from '../src/rfc64/catalog-runtime-v1.js';
 import { deriveRfc64PublicSwmGraphV1 } from
   '../src/rfc64/catalog-semantic-authority-transition-v1.js';
@@ -954,6 +957,34 @@ describe('RFC-64 rollout authority integration', () => {
         name: 'Rfc64CatalogAuthorityResolutionErrorV1',
         code: 'registered-authority-adapter-unsupported',
       });
+  });
+
+  it('shares provider-pool exhaustion across registered authority reconciliations', async () => {
+    const readAuthority = vi.fn(async () => {
+      throw new ChainRpcTransportError(
+        'RPC_ENDPOINTS_EXHAUSTED',
+        'authority read failed on every provider',
+        { exhaustionKind: 'mixed', retryAfterMs: 30_000 },
+      );
+    });
+    const edge = await startAgent({
+      name: 'registered-authority-shared-rpc-circuit',
+      config: {
+        chainAdapter: Object.assign(new NoChainAdapter(), {
+          getContextGraphAuthoritySnapshot: readAuthority,
+        }),
+      },
+    });
+    vi.spyOn(edge, 'getContextGraphOnChainId').mockResolvedValue('9');
+
+    await expect(edge.reconcileRfc64CatalogAccessAuthorityV1(CONTEXT_GRAPH_ID))
+      .rejects.toMatchObject({ code: 'RPC_ENDPOINTS_EXHAUSTED' });
+    await expect(edge.reconcileRfc64CatalogAccessAuthorityV1(
+      `${AUTHOR}/second-registered-authority` as ContextGraphIdV1,
+    )).rejects.toSatisfy(isRfc64AuthorityRpcCircuitOpenErrorV1);
+
+    expect(readAuthority).toHaveBeenCalledOnce();
+    expect(readAuthority).toHaveBeenCalledWith(9n, { signal: undefined });
   });
 
   it('rejects a curator binding returned for a different registered Context Graph ID', async () => {

--- a/packages/agent/test/rfc64-rollout-authority.integration.test.ts
+++ b/packages/agent/test/rfc64-rollout-authority.integration.test.ts
@@ -988,6 +988,39 @@ describe('RFC-64 rollout authority integration', () => {
     });
   });
 
+  it('propagates caller cancellation into the registered authority snapshot read', async () => {
+    let readSignal: AbortSignal | undefined;
+    const readAuthority = vi.fn(async (
+      _contextGraphId: bigint,
+      options?: { signal?: AbortSignal },
+    ) => {
+      readSignal = options?.signal;
+      return Object.freeze({
+        ...finalizedAuthoritySnapshot(CONTEXT_GRAPH_ID, [], '0'),
+        accessPolicy: 0,
+      });
+    });
+    const edge = await startAgent({
+      name: 'registered-authority-signal-propagation',
+      config: {
+        chainAdapter: Object.assign(new NoChainAdapter(), {
+          getContextGraphAuthoritySnapshot: readAuthority,
+        }),
+      },
+    });
+    vi.spyOn(edge, 'getContextGraphOnChainId').mockResolvedValue('9');
+    const controller = new AbortController();
+
+    await expect(edge.reconcileRfc64CatalogAccessAuthorityV1(
+      CONTEXT_GRAPH_ID,
+      controller.signal,
+    )).resolves.toMatchObject({ policy: { contextGraphId: CONTEXT_GRAPH_ID } });
+    expect(readSignal).toBeInstanceOf(AbortSignal);
+    const reason = new Error('caller stopped');
+    controller.abort(reason);
+    expect(readSignal).toMatchObject({ aborted: true, reason });
+  });
+
   it('opens the shared circuit when cold numeric binding discovery exhausts providers', async () => {
     const readAuthority = vi.fn();
     const edge = await startAgent({

--- a/packages/agent/vitest.rfc64-unit-tests.ts
+++ b/packages/agent/vitest.rfc64-unit-tests.ts
@@ -57,6 +57,7 @@ export const RFC64_UNIT_TESTS = [
   "test/rfc64-catalog-responsibility-registry-v1.test.ts",
   "test/rfc64-catalog-bootstrap-outcome-v1.test.ts",
   "test/rfc64-coalescing-supervisor-v1.test.ts",
+  "test/rfc64-authority-rpc-circuit-breaker-v1.test.ts",
   "test/rfc64-private-catalog-activation-config-v1.test.ts",
   "test/rfc64-private-sender-key-roster.test.ts",
   "test/rfc64-rollout-authority.integration.test.ts",

--- a/packages/chain/src/chain-rpc-transport-error.ts
+++ b/packages/chain/src/chain-rpc-transport-error.ts
@@ -50,9 +50,14 @@ export interface ChainRpcTransportErrorLike {
   message?: string;
   rpcUrls?: readonly string[];
   txHash?: string;
-  /** Shape of the final provider pass when every endpoint was exhausted. */
-  exhaustionKind?: 'all-throttled' | 'mixed';
-  /** Largest valid HTTP Retry-After hint observed during the provider pass. */
+}
+
+export type RpcEndpointExhaustionKind = 'all-throttled' | 'mixed';
+
+/** Narrow transport variant whose metadata is meaningful only for pool exhaustion. */
+export interface RpcEndpointsExhaustedErrorLike extends ChainRpcTransportErrorLike {
+  code: 'RPC_ENDPOINTS_EXHAUSTED';
+  exhaustionKind?: RpcEndpointExhaustionKind;
   retryAfterMs?: number;
 }
 
@@ -66,9 +71,6 @@ export class ChainRpcTransportError extends Error {
 
   readonly txHash?: string;
 
-  readonly exhaustionKind?: 'all-throttled' | 'mixed';
-
-  readonly retryAfterMs?: number;
   constructor(
     code: ChainRpcTransportCode,
     message: string,
@@ -76,8 +78,6 @@ export class ChainRpcTransportError extends Error {
       cause?: unknown;
       rpcUrls?: readonly string[];
       txHash?: string;
-      exhaustionKind?: 'all-throttled' | 'mixed';
-      retryAfterMs?: number;
     },
   ) {
     super(message, opts?.cause !== undefined ? { cause: opts.cause } : undefined);
@@ -85,9 +85,36 @@ export class ChainRpcTransportError extends Error {
     this.code = code;
     if (opts?.rpcUrls) this.rpcUrls = Object.freeze([...opts.rpcUrls]);
     if (opts?.txHash) this.txHash = opts.txHash;
+  }
+}
+
+export class RpcEndpointsExhaustedError
+  extends ChainRpcTransportError
+  implements RpcEndpointsExhaustedErrorLike {
+  declare readonly code: 'RPC_ENDPOINTS_EXHAUSTED';
+  readonly exhaustionKind?: RpcEndpointExhaustionKind;
+  readonly retryAfterMs?: number;
+
+  constructor(
+    message: string,
+    opts?: {
+      cause?: unknown;
+      rpcUrls?: readonly string[];
+      txHash?: string;
+      exhaustionKind?: RpcEndpointExhaustionKind;
+      retryAfterMs?: number;
+    },
+  ) {
+    super('RPC_ENDPOINTS_EXHAUSTED', message, opts);
     if (opts?.exhaustionKind) this.exhaustionKind = opts.exhaustionKind;
     if (opts?.retryAfterMs !== undefined) this.retryAfterMs = opts.retryAfterMs;
   }
+}
+
+export function isRpcEndpointsExhaustedError(
+  err: unknown,
+): err is RpcEndpointsExhaustedErrorLike {
+  return isChainRpcTransportError(err) && err.code === 'RPC_ENDPOINTS_EXHAUSTED';
 }
 
 /**

--- a/packages/chain/src/chain-rpc-transport-error.ts
+++ b/packages/chain/src/chain-rpc-transport-error.ts
@@ -50,6 +50,10 @@ export interface ChainRpcTransportErrorLike {
   message?: string;
   rpcUrls?: readonly string[];
   txHash?: string;
+  /** Shape of the final provider pass when every endpoint was exhausted. */
+  exhaustionKind?: 'all-throttled' | 'mixed';
+  /** Largest valid HTTP Retry-After hint observed during the provider pass. */
+  retryAfterMs?: number;
 }
 
 export class ChainRpcTransportError extends Error {
@@ -61,16 +65,28 @@ export class ChainRpcTransportError extends Error {
   readonly rpcUrls?: readonly string[];
 
   readonly txHash?: string;
+
+  readonly exhaustionKind?: 'all-throttled' | 'mixed';
+
+  readonly retryAfterMs?: number;
   constructor(
     code: ChainRpcTransportCode,
     message: string,
-    opts?: { cause?: unknown; rpcUrls?: readonly string[]; txHash?: string },
+    opts?: {
+      cause?: unknown;
+      rpcUrls?: readonly string[];
+      txHash?: string;
+      exhaustionKind?: 'all-throttled' | 'mixed';
+      retryAfterMs?: number;
+    },
   ) {
     super(message, opts?.cause !== undefined ? { cause: opts.cause } : undefined);
     this.name = 'ChainRpcTransportError';
     this.code = code;
     if (opts?.rpcUrls) this.rpcUrls = Object.freeze([...opts.rpcUrls]);
     if (opts?.txHash) this.txHash = opts.txHash;
+    if (opts?.exhaustionKind) this.exhaustionKind = opts.exhaustionKind;
+    if (opts?.retryAfterMs !== undefined) this.retryAfterMs = opts.retryAfterMs;
   }
 }
 

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -32,7 +32,6 @@ import { collectEvmErrorText, errorCode, errorMessage, errorStatus, isTooLowAllo
 import { resolveRpcUrls, boundedRetryFetchRequest, withTimeout, isRetryableRpcError, assertSuccessfulReceipt, sleep } from './evm-adapter-rpc.js';
 import { rpcHost } from './rpc-failover-log.js';
 import {
-  ChainRpcTransportError,
   RpcEndpointsExhaustedError,
 } from './chain-rpc-transport-error.js';
 import { RpcFailoverClient, type ReadOpts, type ReceiptLookupOptions } from './rpc-failover-client.js';

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -31,7 +31,10 @@ import { loadAbi } from './evm-adapter-abi.js';
 import { collectEvmErrorText, errorCode, errorMessage, errorStatus, isTooLowAllowanceError, enrichEvmError, getPcaLogicInterface, HUB_STALE_ERROR_MARKERS, isInsufficientFundsError, InsufficientPublisherFundsError, formatNoFundedPublisherWalletMessage, type PublisherWalletBalance } from './evm-adapter-errors.js';
 import { resolveRpcUrls, boundedRetryFetchRequest, withTimeout, isRetryableRpcError, assertSuccessfulReceipt, sleep } from './evm-adapter-rpc.js';
 import { rpcHost } from './rpc-failover-log.js';
-import { ChainRpcTransportError } from './chain-rpc-transport-error.js';
+import {
+  ChainRpcTransportError,
+  RpcEndpointsExhaustedError,
+} from './chain-rpc-transport-error.js';
 import { RpcFailoverClient, type ReadOpts, type ReceiptLookupOptions } from './rpc-failover-client.js';
 import { waitForReceiptWithDeadline } from './receipt-wait.js';
 import { RpcUsageTracker, createCountingJsonRpcProvider, type RpcUsageWindow } from './rpc-usage.js';
@@ -2839,8 +2842,7 @@ export class EVMChainAdapterBase {
       // non-RPC error (e.g. a genuine "contract not in Hub" misconfig) keeps
       // its original shape.
       if (isRetryableRpcError(err)) {
-        throw new ChainRpcTransportError(
-          'RPC_ENDPOINTS_EXHAUSTED',
+        throw new RpcEndpointsExhaustedError(
           `chain initialisation failed on all configured RPC endpoints (${this.rpcUrls.map(rpcHost).join(', ')}): ${errorMessage(err)}`,
           { cause: err, rpcUrls: this.rpcUrls },
         );

--- a/packages/chain/src/evm-adapter-errors.ts
+++ b/packages/chain/src/evm-adapter-errors.ts
@@ -66,22 +66,32 @@ export function errorCode(err: unknown): string {
   return String((err as any)?.code ?? (err as any)?.error?.code ?? '').toUpperCase();
 }
 
+/** One cycle/depth-bounded traversal for the wrapper graph shared by selectors. */
+function* wrappedRpcErrorRecords(err: unknown): Generator<Record<string, unknown>> {
+  const seen = new Set<unknown>();
+  const pending: Array<{ value: unknown; depth: number }> = [{ value: err, depth: 0 }];
+  while (pending.length > 0) {
+    const { value, depth } = pending.pop()!;
+    if (value == null || typeof value !== 'object' || depth > 6 || seen.has(value)) continue;
+    seen.add(value);
+    const record = value as Record<string, unknown>;
+    yield record;
+    // Reverse push preserves the established cause → info → error → response walk.
+    for (const key of ['response', 'error', 'info', 'cause']) {
+      pending.push({ value: record[key], depth: depth + 1 });
+    }
+  }
+}
+
 export function errorStatus(err: unknown): number | undefined {
   // Walk the nested wrapper chains ethers v6 / managed RPCs actually populate, so
   // a provider HTTP status buried at e.g. `err.cause.info.error.status` is still
   // found (a shallow one-level read misses it and the caller would misclassify a
   // 401/403/429 as a non-status error). Depth- and cycle-bounded.
-  const seen = new Set<unknown>();
-  const visit = (e: any, depth: number): number | undefined => {
-    if (e == null || typeof e !== 'object' || depth > 5 || seen.has(e)) return undefined;
-    seen.add(e);
+  for (const record of wrappedRpcErrorRecords(err)) {
     for (const raw of [
-      e.status,
-      e.statusCode,
-      e.response?.status,
-      e.response?.statusCode,
-      e.error?.status,
-      e.error?.statusCode,
+      record.status,
+      record.statusCode,
     ]) {
       // Numeric, OR a digit-only string ("429"/"401") — several wrapped RPC/fetch
       // errors serialize the HTTP status as a string, so coerce those too rather
@@ -89,13 +99,8 @@ export function errorStatus(err: unknown): number | undefined {
       if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
       if (typeof raw === 'string' && /^\d{3}$/.test(raw.trim())) return Number(raw);
     }
-    for (const k of ['cause', 'info', 'error', 'response']) {
-      const found = visit(e[k], depth + 1);
-      if (found !== undefined) return found;
-    }
-    return undefined;
-  };
-  return visit(err, 0);
+  }
+  return undefined;
 }
 
 /**
@@ -109,7 +114,6 @@ export function errorRetryAfterMs(
   nowMs: number = Date.now(),
 ): number | undefined {
   const delays: number[] = [];
-  const seen = new Set<unknown>();
 
   const record = (raw: unknown): void => {
     if (typeof raw !== 'string' && typeof raw !== 'number') return;
@@ -142,16 +146,9 @@ export function errorRetryAfterMs(
     }
   };
 
-  const visit = (value: unknown, depth: number): void => {
-    if (value == null || typeof value !== 'object' || depth > 6 || seen.has(value)) return;
-    seen.add(value);
-    const candidate = value as Record<string, unknown>;
+  for (const candidate of wrappedRpcErrorRecords(err)) {
     readHeaders(candidate.headers);
-    for (const key of ['cause', 'info', 'error', 'response']) {
-      visit(candidate[key], depth + 1);
-    }
-  };
-  visit(err, 0);
+  }
   return delays.length === 0 ? undefined : Math.max(...delays);
 }
 

--- a/packages/chain/src/evm-adapter-errors.ts
+++ b/packages/chain/src/evm-adapter-errors.ts
@@ -75,20 +75,84 @@ export function errorStatus(err: unknown): number | undefined {
   const visit = (e: any, depth: number): number | undefined => {
     if (e == null || typeof e !== 'object' || depth > 5 || seen.has(e)) return undefined;
     seen.add(e);
-    for (const raw of [e.status, e.statusCode, e.response?.status, e.error?.status, e.error?.statusCode]) {
+    for (const raw of [
+      e.status,
+      e.statusCode,
+      e.response?.status,
+      e.response?.statusCode,
+      e.error?.status,
+      e.error?.statusCode,
+    ]) {
       // Numeric, OR a digit-only string ("429"/"401") — several wrapped RPC/fetch
       // errors serialize the HTTP status as a string, so coerce those too rather
       // than missing them and falling back to message heuristics.
       if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
       if (typeof raw === 'string' && /^\d{3}$/.test(raw.trim())) return Number(raw);
     }
-    for (const k of ['cause', 'info', 'error']) {
+    for (const k of ['cause', 'info', 'error', 'response']) {
       const found = visit(e[k], depth + 1);
       if (found !== undefined) return found;
     }
     return undefined;
   };
   return visit(err, 0);
+}
+
+/**
+ * Extract a standard HTTP `Retry-After` delay from the wrapper shapes used by
+ * ethers, undici, and managed JSON-RPC providers. Both delta-seconds and HTTP
+ * dates are accepted. The result is deliberately only metadata: callers own
+ * their policy cap and must never sleep an unbounded provider-supplied value.
+ */
+export function errorRetryAfterMs(
+  err: unknown,
+  nowMs: number = Date.now(),
+): number | undefined {
+  const delays: number[] = [];
+  const seen = new Set<unknown>();
+
+  const record = (raw: unknown): void => {
+    if (typeof raw !== 'string' && typeof raw !== 'number') return;
+    const value = String(raw).trim();
+    if (value.length === 0) return;
+    if (/^\d+$/u.test(value)) {
+      const seconds = Number(value);
+      if (Number.isSafeInteger(seconds) && seconds >= 0) {
+        const delay = seconds * 1_000;
+        if (Number.isSafeInteger(delay)) delays.push(delay);
+      }
+      return;
+    }
+    const dateMs = Date.parse(value);
+    if (Number.isFinite(dateMs)) delays.push(Math.max(0, dateMs - nowMs));
+  };
+
+  const readHeaders = (headers: unknown): void => {
+    if (headers == null || typeof headers !== 'object') return;
+    const get = (headers as { get?: unknown }).get;
+    if (typeof get === 'function') {
+      try {
+        record(get.call(headers, 'retry-after'));
+      } catch {
+        // A foreign Headers-like object must not break RPC error handling.
+      }
+    }
+    for (const [key, value] of Object.entries(headers as Record<string, unknown>)) {
+      if (key.toLowerCase() === 'retry-after') record(value);
+    }
+  };
+
+  const visit = (value: unknown, depth: number): void => {
+    if (value == null || typeof value !== 'object' || depth > 6 || seen.has(value)) return;
+    seen.add(value);
+    const candidate = value as Record<string, unknown>;
+    readHeaders(candidate.headers);
+    for (const key of ['cause', 'info', 'error', 'response']) {
+      visit(candidate[key], depth + 1);
+    }
+  };
+  visit(err, 0);
+  return delays.length === 0 ? undefined : Math.max(...delays);
 }
 
 export const ERROR_ABI_CONTRACTS = [

--- a/packages/chain/src/index.ts
+++ b/packages/chain/src/index.ts
@@ -162,10 +162,14 @@ export {
 export { NoChainAdapter } from './no-chain-adapter.js';
 export {
   ChainRpcTransportError,
+  RpcEndpointsExhaustedError,
   isChainRpcTransportError,
+  isRpcEndpointsExhaustedError,
   createRpcTimeoutError,
   type ChainRpcTransportCode,
   type ChainRpcTransportErrorLike,
+  type RpcEndpointExhaustionKind,
+  type RpcEndpointsExhaustedErrorLike,
 } from './chain-rpc-transport-error.js';
 export {
   // Surfaced for the daemon /api/status counter + the CLI failover loop.

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -43,7 +43,7 @@ import type { SignedTransactionEnvelope } from './chain-adapter.js';
 import { JsonRpcProvider, Wallet, Contract, ethers } from 'ethers';
 import { withSpan, getMetrics } from '@origintrail-official/dkg-core';
 import { withTimeout, isRetryableRpcError, isThrottleRpcError, isKnownTransactionError, assertSuccessfulReceipt, sleep } from './evm-adapter-rpc.js';
-import { errorCode, errorMessage } from './evm-adapter-errors.js';
+import { errorCode, errorMessage, errorRetryAfterMs } from './evm-adapter-errors.js';
 import { noteRpcFailover, noteRpcExhaustion, notePreferredEndpoint, noteRpcServed, rpcHost } from './rpc-failover-log.js';
 import { EndpointStickiness, type StickinessIntent } from './endpoint-stickiness.js';
 import { ChainRpcTransportError, createRpcTimeoutError } from './chain-rpc-transport-error.js';
@@ -162,10 +162,10 @@ type ProviderSetExhaustionKind = 'all-throttled' | 'mixed';
 class ProviderSetExhaustedError extends ChainRpcTransportError {
   constructor(
     message: string,
-    readonly exhaustionKind: ProviderSetExhaustionKind,
-    opts: { cause: unknown; rpcUrls: readonly string[] },
+    exhaustionKind: ProviderSetExhaustionKind,
+    opts: { cause: unknown; rpcUrls: readonly string[]; retryAfterMs?: number },
   ) {
-    super('RPC_ENDPOINTS_EXHAUSTED', message, opts);
+    super('RPC_ENDPOINTS_EXHAUSTED', message, { ...opts, exhaustionKind });
   }
 }
 
@@ -750,6 +750,7 @@ export class RpcFailoverClient {
     const configuredAttemptTimeoutMs = options.attemptTimeoutMs(canonical.length);
     let lastRetryable: unknown;
     let allEndpointsThrottled = true;
+    let retryAfterMs: number | undefined;
     let sawEmpty = false;
     let lastEmpty: T | undefined;
     let deadlineExpiredBeforeAttempt = false;
@@ -804,7 +805,12 @@ export class RpcFailoverClient {
       } catch (err) {
         if (!options.isRetryable(err)) throw err;
         lastRetryable = err;
-        if (!isThrottleRpcError(err)) allEndpointsThrottled = false;
+        if (!isThrottleRpcError(err)) {
+          allEndpointsThrottled = false;
+        } else {
+          const hint = errorRetryAfterMs(err);
+          if (hint !== undefined) retryAfterMs = Math.max(retryAfterMs ?? 0, hint);
+        }
         attempt.recordFailure(); // de-prefer a failed backend
         const canTryNext = options.deadlineMs === undefined || Date.now() < options.deadlineMs;
         if (!isLast && canTryNext) {
@@ -833,6 +839,7 @@ export class RpcFailoverClient {
       throw new ProviderSetExhaustedError(message, allEndpointsThrottled ? 'all-throttled' : 'mixed', {
         cause: lastRetryable,
         rpcUrls: canonical.map((e) => e.rpcUrl),
+        ...(retryAfterMs === undefined ? {} : { retryAfterMs }),
       });
     }
     // Either every endpoint returned empty with no errors, or the caller's

--- a/packages/chain/src/rpc-failover-client.ts
+++ b/packages/chain/src/rpc-failover-client.ts
@@ -46,7 +46,12 @@ import { withTimeout, isRetryableRpcError, isThrottleRpcError, isKnownTransactio
 import { errorCode, errorMessage, errorRetryAfterMs } from './evm-adapter-errors.js';
 import { noteRpcFailover, noteRpcExhaustion, notePreferredEndpoint, noteRpcServed, rpcHost } from './rpc-failover-log.js';
 import { EndpointStickiness, type StickinessIntent } from './endpoint-stickiness.js';
-import { ChainRpcTransportError, createRpcTimeoutError } from './chain-rpc-transport-error.js';
+import {
+  ChainRpcTransportError,
+  RpcEndpointsExhaustedError,
+  createRpcTimeoutError,
+  type RpcEndpointExhaustionKind,
+} from './chain-rpc-transport-error.js';
 import { withRpcUsageConsumer } from './rpc-usage.js';
 import { withRpcRequestAbortSignal } from './rpc-request-transport.js';
 import {
@@ -156,16 +161,14 @@ interface ProviderPassOptions<T> {
   onServed: (endpoint: RpcEndpoint, value: T) => void;
 }
 
-type ProviderSetExhaustionKind = 'all-throttled' | 'mixed';
-
 /** Internal exhaustion detail used only while deciding whether to retry a pass. */
-class ProviderSetExhaustedError extends ChainRpcTransportError {
+class ProviderSetExhaustedError extends RpcEndpointsExhaustedError {
   constructor(
     message: string,
-    exhaustionKind: ProviderSetExhaustionKind,
+    exhaustionKind: RpcEndpointExhaustionKind,
     opts: { cause: unknown; rpcUrls: readonly string[]; retryAfterMs?: number },
   ) {
-    super('RPC_ENDPOINTS_EXHAUSTED', message, { ...opts, exhaustionKind });
+    super(message, { ...opts, exhaustionKind });
   }
 }
 
@@ -554,7 +557,7 @@ export class RpcFailoverClient {
     getMetrics().chainRpcFailoverTotal.add(1, {
       rpc_method: 'eth_estimateGas', chain_id: this.chainId(), reason: 'exhausted',
     });
-    throw new ChainRpcTransportError('RPC_ENDPOINTS_EXHAUSTED', message, {
+    throw new RpcEndpointsExhaustedError(message, {
       cause: lastRetryable,
       rpcUrls: canonical.map((e) => e.rpcUrl),
     });
@@ -628,8 +631,7 @@ export class RpcFailoverClient {
           // broadcast-time all-endpoints-exhausted failure maps to a retryable 503 at
           // the HTTP boundary, not a generic 500 — an exhaustion after a provider
           // populated/signed would otherwise surface code-less.
-          throw new ChainRpcTransportError(
-            'RPC_ENDPOINTS_EXHAUSTED',
+          throw new RpcEndpointsExhaustedError(
             `${label} broadcast failed on all configured RPC endpoints for tx ${txHash}: ${errorMessage(lastRetryable)}`,
             { cause: lastRetryable, rpcUrls: canonical.map((e) => e.rpcUrl), txHash },
           );
@@ -850,8 +852,7 @@ export class RpcFailoverClient {
     }
     // Unreachable when >=1 endpoint is configured (each iteration returns,
     // continues on empty, or throws / sets lastRetryable). Guard the 0-endpoint case.
-    throw new ChainRpcTransportError(
-      'RPC_ENDPOINTS_EXHAUSTED',
+    throw new RpcEndpointsExhaustedError(
       `${label} read failed: no configured RPC endpoints`,
       { rpcUrls: [] },
     );

--- a/packages/chain/test/chain-rpc-transport-error.test.ts
+++ b/packages/chain/test/chain-rpc-transport-error.test.ts
@@ -2,14 +2,16 @@
 import { describe, it, expect } from 'vitest';
 import {
   ChainRpcTransportError,
+  RpcEndpointsExhaustedError,
   isChainRpcTransportError,
+  isRpcEndpointsExhaustedError,
 } from '../src/chain-rpc-transport-error.js';
 import { withTimeout } from '../src/evm-adapter-rpc.js';
 
 describe('ChainRpcTransportError (typed transport boundary)', () => {
   it('carries code + message + optional rpcUrls/txHash and is an Error', () => {
     const cause = new Error('connect ECONNREFUSED');
-    const err = new ChainRpcTransportError('RPC_ENDPOINTS_EXHAUSTED', 'all endpoints failed', {
+    const err = new RpcEndpointsExhaustedError('all endpoints failed', {
       cause,
       rpcUrls: ['https://a.example', 'https://b.example'],
     });
@@ -24,7 +26,7 @@ describe('ChainRpcTransportError (typed transport boundary)', () => {
 
   it('defensively copies rpcUrls (caller cannot mutate the captured list)', () => {
     const urls = ['https://a.example'];
-    const err = new ChainRpcTransportError('RPC_ENDPOINTS_EXHAUSTED', 'm', { rpcUrls: urls });
+    const err = new RpcEndpointsExhaustedError('m', { rpcUrls: urls });
     urls.push('https://mutated.example');
     expect(err.rpcUrls).toEqual(['https://a.example']);
   });
@@ -60,6 +62,20 @@ describe('isChainRpcTransportError (one structural namespaced-code guard)', () =
     expect(isChainRpcTransportError('TIMEOUT')).toBe(false); // a bare string, not a coded error
     expect(isChainRpcTransportError(undefined)).toBe(false);
     expect(isChainRpcTransportError(null)).toBe(false);
+  });
+
+  it('narrows provider-pass metadata to endpoint exhaustion only', () => {
+    const exhausted = new RpcEndpointsExhaustedError('m', {
+      exhaustionKind: 'all-throttled',
+      retryAfterMs: 1_000,
+    });
+    expect(isRpcEndpointsExhaustedError(exhausted)).toBe(true);
+    expect(isRpcEndpointsExhaustedError({
+      code: 'RPC_ENDPOINTS_EXHAUSTED',
+      exhaustionKind: 'mixed',
+    })).toBe(true);
+    expect(isRpcEndpointsExhaustedError(new ChainRpcTransportError('RPC_TIMEOUT', 'm')))
+      .toBe(false);
   });
 });
 

--- a/packages/chain/test/chain-rpc-transport-error.typecheck.ts
+++ b/packages/chain/test/chain-rpc-transport-error.typecheck.ts
@@ -1,0 +1,14 @@
+import {
+  ChainRpcTransportError,
+  RpcEndpointsExhaustedError,
+} from '../src/chain-rpc-transport-error.js';
+
+new RpcEndpointsExhaustedError('provider pool exhausted', {
+  exhaustionKind: 'all-throttled',
+  retryAfterMs: 1_000,
+});
+
+new ChainRpcTransportError('RPC_TIMEOUT', 'timed out', {
+  // @ts-expect-error Provider-pool metadata is valid only on RpcEndpointsExhaustedError.
+  exhaustionKind: 'all-throttled',
+});

--- a/packages/chain/test/readwithfailover-loop.unit.test.ts
+++ b/packages/chain/test/readwithfailover-loop.unit.test.ts
@@ -179,6 +179,31 @@ describe('RpcFailoverClient.read — read-failover loop logic (bare-mock, #1336)
     expect(getRpcFailoverStats().exhaustions).toBe(1);
   });
 
+  it('surfaces the provider-pass shape and largest Retry-After hint', async () => {
+    const throttle = (seconds: number) => Object.assign(
+      new Error('server response 429 Too Many Requests'),
+      {
+        response: {
+          statusCode: 429,
+          headers: { 'retry-after': String(seconds) },
+        },
+      },
+    );
+    const primary = { read: recorder(async () => { throw throttle(3); }) };
+    const backup = { read: recorder(async () => { throw throttle(11); }) };
+    const client = makeClient(
+      [primary, backup],
+      ['https://primary.example', 'https://backup.example'],
+    );
+
+    await expect(client.read('authority history', (provider: any) => provider.read()))
+      .rejects.toMatchObject({
+        code: 'RPC_ENDPOINTS_EXHAUSTED',
+        exhaustionKind: 'all-throttled',
+        retryAfterMs: 11_000,
+      });
+  });
+
   it('does not retry a mixed timeout plus 429 endpoint exhaustion', async () => {
     const primary = { read: recorder(async () => { const error: any = new Error('timed out'); error.code = 'TIMEOUT'; throw error; }) };
     const backup = { read: recorder(async () => { throw retryable429(); }) };
@@ -189,7 +214,10 @@ describe('RpcFailoverClient.read — read-failover loop logic (bare-mock, #1336)
 
     await expect(client.read('getBlock', (provider: any) => provider.read(), {
       endpointSetRetry: 'all-throttled',
-    })).rejects.toMatchObject({ code: 'RPC_ENDPOINTS_EXHAUSTED' });
+    })).rejects.toMatchObject({
+      code: 'RPC_ENDPOINTS_EXHAUSTED',
+      exhaustionKind: 'mixed',
+    });
     expect(primary.read.calls).toHaveLength(1);
     expect(backup.read.calls).toHaveLength(1);
   });

--- a/packages/chain/test/rpc-retry-after.unit.test.ts
+++ b/packages/chain/test/rpc-retry-after.unit.test.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+
+import { errorRetryAfterMs, errorStatus } from '../src/evm-adapter-errors.js';
+
+describe('RPC Retry-After extraction', () => {
+  it('reads delta-seconds from the nested ethers FetchResponse shape', () => {
+    const error = {
+      code: 'SERVER_ERROR',
+      info: {
+        response: {
+          statusCode: 429,
+          headers: { 'retry-after': '17' },
+        },
+      },
+    };
+
+    expect(errorStatus(error)).toBe(429);
+    expect(errorRetryAfterMs(error)).toBe(17_000);
+  });
+
+  it('reads an HTTP date from a Headers-like wrapper', () => {
+    const now = Date.UTC(2026, 8, 10, 12, 0, 0);
+    const retryAt = new Date(now + 42_000).toUTCString();
+    const error = {
+      cause: {
+        response: {
+          headers: {
+            get(name: string) {
+              return name.toLowerCase() === 'retry-after' ? retryAt : null;
+            },
+          },
+        },
+      },
+    };
+
+    expect(errorRetryAfterMs(error, now)).toBe(42_000);
+  });
+
+  it('ignores malformed and unsafe values without throwing', () => {
+    const cyclic: Record<string, unknown> = {
+      headers: { 'Retry-After': 'not-a-date' },
+    };
+    cyclic.cause = cyclic;
+
+    expect(errorRetryAfterMs(cyclic)).toBeUndefined();
+    expect(errorRetryAfterMs({
+      response: { headers: { 'retry-after': '999999999999999999999' } },
+    })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

This PR prevents registered RFC-64 Context Graphs on one node from independently stampeding the same exhausted RPC provider pool.

It replaces the periodic loop's four-way authority-read concurrency with one node-local coordinator shared by authority binding discovery and finalized authority snapshot reads. When every configured endpoint is exhausted, the coordinator opens a circuit, defers queued graphs, and later admits one half-open probe. A successful probe closes the circuit; another exhaustion increases the backoff.

This is an RPC-load containment change. It preserves RFC-64's fail-closed authority checks and does not disable catalog workers or fall back to unauthenticated authority.

## Why

RFC-64 refreshes authority for every responsible registered CG. A cold authority read can perform a long historical `eth_getLogs` scan. Under provider throttling, several per-CG refresh lanes could concurrently walk the same provider list and then repeat the work on the next cadence.

Provider exhaustion is shared infrastructure state, not a graph-specific failure. Once one read proves that the whole configured pool is unavailable, immediately starting the same expensive path for every queued CG only amplifies traffic and delays recovery.

The previous `maxConcurrentReads=4` permit pool bounded operations, but it still allowed four large scans at once and did not share an exhaustion state with bootstrap reads outside the periodic loop.

## Exhaustion sequence

```mermaid
sequenceDiagram
    autonumber
    participant A as CG-A refresh
    participant C as Shared authority coordinator
    participant R as Configured RPC pool
    participant B as CG-B refresh
    participant N as CG-N refresh

    A->>C: request authority read
    C->>R: binding discovery + finalized snapshot
    R-->>C: RPC_ENDPOINTS_EXHAUSTED + optional Retry-After
    C-->>A: original exhaustion
    Note over C: Open circuit<br/>base 60 s, exponential backoff,<br/>20% jitter, maximum 30 min
    B->>C: request authority read
    C-->>B: RFC64_AUTHORITY_RPC_CIRCUIT_OPEN
    N->>C: request authority read
    C-->>N: RFC64_AUTHORITY_RPC_CIRCUIT_OPEN
    Note over R: No repeated provider walk from queued CGs
```

## Recovery sequence

```mermaid
sequenceDiagram
    autonumber
    participant C as Shared authority coordinator
    participant R as Configured RPC pool
    participant A as First eligible CG
    participant Q as Queued CG refreshes

    Note over C: Backoff deadline reached
    A->>C: request authority read
    C->>R: admit exactly one half-open probe
    alt Provider pool recovered
        R-->>C: verified authority result
        C-->>A: success
        Note over C: Close circuit and reset exhaustion count
        C->>R: release queued reads in FIFO order
        R-->>Q: normal verified results
    else Pool still exhausted
        R-->>C: RPC_ENDPOINTS_EXHAUSTED
        C-->>A: original exhaustion
        Note over C: Reopen with longer backoff<br/>queued reads remain deferred
    end
```

## Behavior

### One shared authority-read lane

- Serializes registered-CG authority reads at the point that covers both numeric on-chain binding discovery and finalized authority snapshot resolution.
- Shares the same coordinator across periodic reconciliation, lifecycle-triggered bootstrap, and public-catalog workload ownership.
- Removes the narrower four-permit pool from the periodic refresh loop so there is one concurrency/backpressure owner rather than overlapping controls.
- Preserves FIFO ordering; a cancelled waiter settles promptly but cannot allow later work to overtake an active predecessor.

### Typed provider-pool exhaustion

- Introduces a specific `RpcEndpointsExhaustedError` carrying `exhaustionKind` and optional `retryAfterMs`.
- Opens the circuit only for typed `RPC_ENDPOINTS_EXHAUSTED` failures.
- Does not trip on contract reverts, invalid authority, binding mismatches, malformed data, or other deterministic graph-specific failures.
- Preserves the original exhaustion for the read that encountered it; later deferrals use a distinct `RFC64_AUTHORITY_RPC_CIRCUIT_OPEN` code.

### Backoff policy

| Setting | Default |
|---|---:|
| Initial backoff | 60 seconds |
| Maximum local backoff | 30 minutes |
| Jitter | ±20% |
| Half-open concurrency | 1 probe |

The failover layer extracts standard `Retry-After` delta-seconds or HTTP-date values from bounded nested error wrappers and carries the largest hint from the exhausted provider pass. The coordinator uses the larger of its exponential delay and the provider hint, bounded by the configured 30-minute ceiling.

### Lifecycle and cancellation

- Caller cancellation propagates into binding discovery and authority snapshot reads.
- Shutdown aborts the coordinator and waits for its work to drain alongside catalog and refresh work.
- Restarting the catalog owner reopens its lifecycle coordinator cleanly.
- The circuit is node-local and intentionally resets on process restart; durable scan progress is owned by #2548.

## User and operator impact

When RPC providers are healthy, authority reads proceed serially and RFC-64 behavior remains fail-closed.

When the whole provider pool is unavailable:

- one CG discovers the outage;
- other CGs are deferred without repeating the same provider walk;
- the node performs one recovery probe after the cooldown; and
- publishing and other non-RFC-64 paths do not share this circuit.

This should materially reduce authority-scan amplification while providers are degraded or unavailable. It can also make initial authority warm-up slower because registered-CG reads are intentionally serialized. No SWM or VM payload is deleted, and no RFC-64 kill switch is changed by this PR.

## Security and correctness invariants

- Provider pressure never turns into an authorization bypass.
- No stale or unverified chain result is synthesized when the circuit is open.
- Deterministic graph failures remain visible and are not mislabeled as infrastructure outages.
- Private roster, ownership, name-binding, and finalized-snapshot validation remain downstream of the same verified read.
- Shutdown does not leave an authority read running outside the owning lifecycle.

## Non-goals and remaining limitations

This PR does **not**:

- impose a hard limit on the number of raw requests inside one admitted historical scan;
- reserve RPC capacity for foreground publishing or receipts;
- coordinate budgets between different machines sharing the same provider account;
- make a partially completed first scan resumable;
- replace per-CG history scans with a contract-wide authority index; or
- re-enable RFC-64 on nodes where operators have activated the kill switch.

Those are follow-up milestone items. In particular, a single admitted cold scan can still be expensive; this PR prevents many CGs from repeating it concurrently after shared exhaustion.

## Files changed

| Area | Purpose |
|---|---|
| `authority-rpc-circuit-breaker-v1.ts` | Shared FIFO coordinator, open/half-open/closed state, exponential backoff, jitter, cancellation and lifecycle behavior |
| `dkg-agent-rfc64-catalog.ts` | Route binding discovery and registered authority snapshots through the coordinator |
| `public-catalog-workload-owner-v1.ts` | Own coordinator startup, idle fencing, and shutdown |
| `catalog-authority-refresh-loop-v1.ts` | Remove the redundant four-way permit pool while preserving per-CG coalescing |
| Chain transport errors and failover | Typed endpoint exhaustion and bounded `Retry-After` propagation |
| Agent and chain tests | Circuit transitions, cancellation, integration wiring, transport classification, and retry hints |

## Validation

Automated coverage includes:

- one exhaustion opening a circuit shared by queued graphs;
- exactly one half-open probe;
- exponential reopening and successful recovery;
- deterministic failures leaving the circuit closed;
- jitter and provider `Retry-After` handling;
- prompt queued cancellation without FIFO overtaking;
- propagation of cancellation into the real authority reader;
- cold numeric binding discovery participating in the same circuit;
- shutdown waiting for stalled authority work;
- largest retry hint surviving a full provider pass; and
- mixed timeout/throttle exhaustion remaining distinguishable from all-throttled exhaustion.

Required before merge:

- [x] EVM integration gate on the retargeted `testnet-canary` PR
- [ ] Full CI gate on the retargeted `testnet-canary` PR
- [ ] Testnet confirmation that an exhausted provider pool produces one admitted authority scan/probe rather than one per responsible CG

## Review focus

Please pay particular attention to:

1. whether the coordinator encloses every registered-authority RPC entry point without serializing unrelated chain work;
2. the decision to serialize healthy authority reads rather than retain a small concurrency pool;
3. transport-exhaustion classification and `Retry-After` extraction across provider wrapper shapes;
4. the 60-second to 30-minute backoff policy and provider-hint cap; and
5. cancellation, close, and restart ordering.

## Related work

- #2540 — in-process incremental authority-history scans
- #2548 — durable authority-history checkpoints and bounded cold scans
- #2549 — raw `eth_getLogs` consumer and endpoint attribution
- #2551 — contract-wide durable authority-index foundation
