### PR TITLE
feat(chain): materialize authority snapshots from shared index

### DIFF
--- a/packages/chain/src/context-graph-authority-index-checkpoint.ts
+++ b/packages/chain/src/context-graph-authority-index-checkpoint.ts
@@ -2,20 +2,14 @@
 
 import { ethers } from 'ethers';
 import {
-  contextGraphAuthorityGenerationIntegrityValues,
-  normalizeContextGraphAuthorityGenerationState,
-  normalizeContextGraphAuthorityHash,
-  normalizeContextGraphAuthorityNonNegativeSafeInteger,
-  type ContextGraphAuthorityGenerationState,
-} from './context-graph-authority-generation.js';
+  freezeContextGraphAuthorityIndexState,
+  MAX_CONTEXT_GRAPH_PARTICIPANT_AGENTS,
+  type ContextGraphAuthorityIndexState,
+} from './context-graph-authority-state.js';
 
-export const CONTEXT_GRAPH_AUTHORITY_INDEX_CHECKPOINT_VERSION = 1 as const;
+export type { ContextGraphAuthorityIndexState } from './context-graph-authority-state.js';
 
-/** One compact authority generation for a ContextGraphStorage token. */
-export interface ContextGraphAuthorityIndexState
-  extends ContextGraphAuthorityGenerationState {
-  readonly contextGraphId: string;
-}
+export const CONTEXT_GRAPH_AUTHORITY_INDEX_CHECKPOINT_VERSION = 2 as const;
 
 /** A contiguous, fully reduced contract-history prefix. */
 export interface ContextGraphAuthorityIndexCursor {
@@ -54,20 +48,66 @@ export interface ContextGraphAuthorityIndexStore {
   invalidate(scope: string, expectedToken: number): Promise<number | undefined>;
 }
 
+const HASH_PATTERN = /^0x[0-9a-f]{64}$/i;
+const ADDRESS_PATTERN = /^0x[0-9a-f]{40}$/i;
+const ZERO_ADDRESS = `0x${'0'.repeat(40)}`;
+
+export function normalizeAuthorityIndexHash(value: unknown): string | undefined {
+  return typeof value === 'string' && HASH_PATTERN.test(value)
+    ? value.toLowerCase()
+    : undefined;
+}
+
+export function normalizeAuthorityIndexNonNegativeSafeInteger(
+  value: unknown,
+): number | undefined {
+  return Number.isSafeInteger(value) && Number(value) >= 0 ? Number(value) : undefined;
+}
+
 function normalizePositiveDecimal(value: unknown): string | undefined {
   if (typeof value !== 'string' || !/^[1-9][0-9]*$/.test(value)) return undefined;
   const parsed = BigInt(value);
   return parsed <= ethers.MaxUint256 ? value : undefined;
 }
 
-function compareContextGraphIds(left: string, right: string): number {
-  return left.length - right.length || left.localeCompare(right);
+export function normalizeAuthorityIndexAddress(value: unknown): string | undefined {
+  return typeof value === 'string' && ADDRESS_PATTERN.test(value)
+    ? value.toLowerCase()
+    : undefined;
 }
 
-export function freezeContextGraphAuthorityIndexState(
-  state: ContextGraphAuthorityIndexState,
-): ContextGraphAuthorityIndexState {
-  return Object.freeze({ ...state });
+export function normalizeAuthorityIndexUint256(value: unknown): bigint | undefined {
+  return typeof value === 'bigint' && value >= 0n && value <= ethers.MaxUint256
+    ? value
+    : undefined;
+}
+
+function normalizeUint256Decimal(value: unknown): string | undefined {
+  if (typeof value !== 'string' || !/^(0|[1-9][0-9]*)$/.test(value)) return undefined;
+  const parsed = BigInt(value);
+  return parsed <= ethers.MaxUint256 ? value : undefined;
+}
+
+export function normalizeAuthorityIndexPolicy(value: unknown): number | undefined {
+  return value === 0 || value === 1 ? value : undefined;
+}
+
+export function normalizeAuthorityIndexParticipantAgents(
+  value: unknown,
+): readonly string[] | undefined {
+  if (!Array.isArray(value) || value.length > MAX_CONTEXT_GRAPH_PARTICIPANT_AGENTS) {
+    return undefined;
+  }
+  const agents = value.map(normalizeAuthorityIndexAddress);
+  if (agents.some((agent) => agent === undefined || agent === ZERO_ADDRESS)) return undefined;
+  const unique = new Set(agents as string[]);
+  return unique.size === agents.length
+    ? Object.freeze([...unique].sort())
+    : undefined;
+}
+
+function compareContextGraphIds(left: string, right: string): number {
+  return left.length - right.length || left.localeCompare(right);
 }
 
 export function sortAndFreezeContextGraphAuthorityIndexStates(
@@ -85,20 +125,41 @@ type ContextGraphAuthorityIndexIntegrityInput = Pick<
   'version' | 'cursor' | 'states'
 >;
 
+function stateIntegrityValues(
+  state: ContextGraphAuthorityIndexState,
+): readonly unknown[] {
+  // Adding a canonical state field is a compile-time failure here until the
+  // durable integrity encoding explicitly includes it.
+  const fields = {
+    contextGraphId: state.contextGraphId,
+    owner: state.owner,
+    active: state.active,
+    accessPolicy: state.accessPolicy,
+    publishPolicy: state.publishPolicy,
+    publishAuthority: state.publishAuthority,
+    publishAuthorityAccountId: state.publishAuthorityAccountId,
+    participantAgents: state.participantAgents,
+    nameHash: state.nameHash,
+    ownershipEra: state.ownershipEra,
+    policyVersion: state.policyVersion,
+    rosterVersion: state.rosterVersion,
+    sourceBlockNumber: state.sourceBlockNumber,
+    sourceBlockHash: state.sourceBlockHash,
+  } satisfies { [K in keyof ContextGraphAuthorityIndexState]: unknown };
+  return Object.values(fields);
+}
+
 function contextGraphAuthorityIndexIntegrity(
   checkpoint: ContextGraphAuthorityIndexIntegrityInput,
 ): string {
   const canonical = JSON.stringify([
-    'dkg-context-graph-authority-index-checkpoint-v1',
+    'dkg-context-graph-authority-index-checkpoint-v2',
     checkpoint.version,
     checkpoint.cursor.deploymentBlockNumber,
     checkpoint.cursor.throughBlockNumber,
     checkpoint.cursor.throughBlockHash,
     checkpoint.cursor.stateCount,
-    ...checkpoint.states.flatMap((state) => [
-      state.contextGraphId,
-      ...contextGraphAuthorityGenerationIntegrityValues(state),
-    ]),
+    ...checkpoint.states.flatMap(stateIntegrityValues),
   ]);
   return ethers.keccak256(ethers.toUtf8Bytes(canonical)).toLowerCase();
 }
@@ -110,18 +171,68 @@ function normalizeIndexState(
   if (value === null || typeof value !== 'object' || Array.isArray(value)) return undefined;
   const candidate = value as Partial<Record<keyof ContextGraphAuthorityIndexState, unknown>>;
   const contextGraphId = normalizePositiveDecimal(candidate.contextGraphId);
-  const generation = normalizeContextGraphAuthorityGenerationState(candidate);
+  const owner = normalizeAuthorityIndexAddress(candidate.owner);
+  const active = typeof candidate.active === 'boolean' ? candidate.active : undefined;
+  const accessPolicy = normalizeAuthorityIndexPolicy(candidate.accessPolicy);
+  const publishPolicy = normalizeAuthorityIndexPolicy(candidate.publishPolicy);
+  const publishAuthority = candidate.publishAuthority === null
+    ? null
+    : normalizeAuthorityIndexAddress(candidate.publishAuthority);
+  const publishAuthorityAccountId = normalizeUint256Decimal(
+    candidate.publishAuthorityAccountId,
+  );
+  const participantAgents = normalizeAuthorityIndexParticipantAgents(
+    candidate.participantAgents,
+  );
+  const nameHash = normalizeAuthorityIndexHash(candidate.nameHash);
+  const ownershipEra = normalizeAuthorityIndexNonNegativeSafeInteger(candidate.ownershipEra);
+  const policyVersion = normalizeAuthorityIndexNonNegativeSafeInteger(candidate.policyVersion);
+  const rosterVersion = normalizeAuthorityIndexNonNegativeSafeInteger(candidate.rosterVersion);
+  const sourceBlockNumber = normalizeAuthorityIndexNonNegativeSafeInteger(
+    candidate.sourceBlockNumber,
+  );
+  const sourceBlockHash = normalizeAuthorityIndexHash(candidate.sourceBlockHash);
   if (
     contextGraphId === undefined
-    || generation === undefined
-    || generation.sourceBlockNumber < cursor.deploymentBlockNumber
-    || generation.sourceBlockNumber > cursor.throughBlockNumber
-    || generation.policyVersion < generation.ownershipEra
-    || generation.rosterVersion < generation.ownershipEra
+    || owner === undefined
+    || owner === ZERO_ADDRESS
+    || active === undefined
+    || accessPolicy === undefined
+    || publishPolicy === undefined
+    || publishAuthority === undefined
+    || publishAuthority === ZERO_ADDRESS
+    || publishAuthorityAccountId === undefined
+    || participantAgents === undefined
+    || nameHash === undefined
+    || ownershipEra === undefined
+    || policyVersion === undefined
+    || rosterVersion === undefined
+    || sourceBlockNumber === undefined
+    || sourceBlockHash === undefined
+    || sourceBlockNumber < cursor.deploymentBlockNumber
+    || sourceBlockNumber > cursor.throughBlockNumber
+    || policyVersion < ownershipEra
+    || rosterVersion < ownershipEra
+    || (publishPolicy === 0 && publishAuthority === null)
+    || (publishPolicy === 1 && (
+      publishAuthority !== null || publishAuthorityAccountId !== '0'
+    ))
   ) return undefined;
   return freezeContextGraphAuthorityIndexState({
     contextGraphId,
-    ...generation,
+    owner,
+    active,
+    accessPolicy,
+    publishPolicy,
+    publishAuthority,
+    publishAuthorityAccountId,
+    participantAgents,
+    nameHash,
+    ownershipEra,
+    policyVersion,
+    rosterVersion,
+    sourceBlockNumber,
+    sourceBlockHash,
   });
 }
 
@@ -146,15 +257,15 @@ export function normalizeContextGraphAuthorityIndexCheckpoint(
   const rawCursor = candidate.cursor as Partial<
     Record<keyof ContextGraphAuthorityIndexCursor, unknown>
   >;
-  const deploymentBlockNumber = normalizeContextGraphAuthorityNonNegativeSafeInteger(
+  const deploymentBlockNumber = normalizeAuthorityIndexNonNegativeSafeInteger(
     rawCursor.deploymentBlockNumber,
   );
-  const throughBlockNumber = normalizeContextGraphAuthorityNonNegativeSafeInteger(
+  const throughBlockNumber = normalizeAuthorityIndexNonNegativeSafeInteger(
     rawCursor.throughBlockNumber,
   );
-  const throughBlockHash = normalizeContextGraphAuthorityHash(rawCursor.throughBlockHash);
-  const stateCount = normalizeContextGraphAuthorityNonNegativeSafeInteger(rawCursor.stateCount);
-  const integrity = normalizeContextGraphAuthorityHash(candidate.integrity);
+  const throughBlockHash = normalizeAuthorityIndexHash(rawCursor.throughBlockHash);
+  const stateCount = normalizeAuthorityIndexNonNegativeSafeInteger(rawCursor.stateCount);
+  const integrity = normalizeAuthorityIndexHash(candidate.integrity);
   if (
     deploymentBlockNumber === undefined
     || throughBlockNumber === undefined

--- a/packages/chain/src/context-graph-authority-index-checkpoint.ts
+++ b/packages/chain/src/context-graph-authority-index-checkpoint.ts
@@ -4,6 +4,8 @@ import { ethers } from 'ethers';
 import {
   freezeContextGraphAuthorityIndexState,
   MAX_CONTEXT_GRAPH_PARTICIPANT_AGENTS,
+  normalizeContextGraphAuthorityAccessPolicy,
+  normalizeContextGraphAuthorityPublishDomain,
   type ContextGraphAuthorityIndexState,
 } from './context-graph-authority-state.js';
 
@@ -74,22 +76,6 @@ export function normalizeAuthorityIndexAddress(value: unknown): string | undefin
   return typeof value === 'string' && ADDRESS_PATTERN.test(value)
     ? value.toLowerCase()
     : undefined;
-}
-
-export function normalizeAuthorityIndexUint256(value: unknown): bigint | undefined {
-  return typeof value === 'bigint' && value >= 0n && value <= ethers.MaxUint256
-    ? value
-    : undefined;
-}
-
-function normalizeUint256Decimal(value: unknown): string | undefined {
-  if (typeof value !== 'string' || !/^(0|[1-9][0-9]*)$/.test(value)) return undefined;
-  const parsed = BigInt(value);
-  return parsed <= ethers.MaxUint256 ? value : undefined;
-}
-
-export function normalizeAuthorityIndexPolicy(value: unknown): number | undefined {
-  return value === 0 || value === 1 ? value : undefined;
 }
 
 export function normalizeAuthorityIndexParticipantAgents(
@@ -173,12 +159,10 @@ function normalizeIndexState(
   const contextGraphId = normalizePositiveDecimal(candidate.contextGraphId);
   const owner = normalizeAuthorityIndexAddress(candidate.owner);
   const active = typeof candidate.active === 'boolean' ? candidate.active : undefined;
-  const accessPolicy = normalizeAuthorityIndexPolicy(candidate.accessPolicy);
-  const publishPolicy = normalizeAuthorityIndexPolicy(candidate.publishPolicy);
-  const publishAuthority = candidate.publishAuthority === null
-    ? null
-    : normalizeAuthorityIndexAddress(candidate.publishAuthority);
-  const publishAuthorityAccountId = normalizeUint256Decimal(
+  const accessPolicy = normalizeContextGraphAuthorityAccessPolicy(candidate.accessPolicy);
+  const publishDomain = normalizeContextGraphAuthorityPublishDomain(
+    candidate.publishPolicy,
+    candidate.publishAuthority,
     candidate.publishAuthorityAccountId,
   );
   const participantAgents = normalizeAuthorityIndexParticipantAgents(
@@ -198,10 +182,7 @@ function normalizeIndexState(
     || owner === ZERO_ADDRESS
     || active === undefined
     || accessPolicy === undefined
-    || publishPolicy === undefined
-    || publishAuthority === undefined
-    || publishAuthority === ZERO_ADDRESS
-    || publishAuthorityAccountId === undefined
+    || publishDomain === undefined
     || participantAgents === undefined
     || nameHash === undefined
     || ownershipEra === undefined
@@ -213,19 +194,13 @@ function normalizeIndexState(
     || sourceBlockNumber > cursor.throughBlockNumber
     || policyVersion < ownershipEra
     || rosterVersion < ownershipEra
-    || (publishPolicy === 0 && publishAuthority === null)
-    || (publishPolicy === 1 && (
-      publishAuthority !== null || publishAuthorityAccountId !== '0'
-    ))
   ) return undefined;
   return freezeContextGraphAuthorityIndexState({
     contextGraphId,
     owner,
     active,
     accessPolicy,
-    publishPolicy,
-    publishAuthority,
-    publishAuthorityAccountId,
+    ...publishDomain,
     participantAgents,
     nameHash,
     ownershipEra,

--- a/packages/chain/src/context-graph-authority-index-checkpoint.ts
+++ b/packages/chain/src/context-graph-authority-index-checkpoint.ts
@@ -2,6 +2,13 @@
 
 import { ethers } from 'ethers';
 import {
+  contextGraphAuthorityGenerationIntegrityValues,
+  normalizeContextGraphAuthorityGenerationState,
+  normalizeContextGraphAuthorityHash,
+  normalizeContextGraphAuthorityNonNegativeSafeInteger,
+  type ContextGraphAuthorityGenerationState,
+} from './context-graph-authority-generation.js';
+import {
   freezeContextGraphAuthorityIndexState,
   MAX_CONTEXT_GRAPH_PARTICIPANT_AGENTS,
   normalizeContextGraphAuthorityAccessPolicy,
@@ -50,21 +57,8 @@ export interface ContextGraphAuthorityIndexStore {
   invalidate(scope: string, expectedToken: number): Promise<number | undefined>;
 }
 
-const HASH_PATTERN = /^0x[0-9a-f]{64}$/i;
 const ADDRESS_PATTERN = /^0x[0-9a-f]{40}$/i;
 const ZERO_ADDRESS = `0x${'0'.repeat(40)}`;
-
-export function normalizeAuthorityIndexHash(value: unknown): string | undefined {
-  return typeof value === 'string' && HASH_PATTERN.test(value)
-    ? value.toLowerCase()
-    : undefined;
-}
-
-export function normalizeAuthorityIndexNonNegativeSafeInteger(
-  value: unknown,
-): number | undefined {
-  return Number.isSafeInteger(value) && Number(value) >= 0 ? Number(value) : undefined;
-}
 
 function normalizePositiveDecimal(value: unknown): string | undefined {
   if (typeof value !== 'string' || !/^[1-9][0-9]*$/.test(value)) return undefined;
@@ -114,8 +108,12 @@ type ContextGraphAuthorityIndexIntegrityInput = Pick<
 function stateIntegrityValues(
   state: ContextGraphAuthorityIndexState,
 ): readonly unknown[] {
-  // Adding a canonical state field is a compile-time failure here until the
-  // durable integrity encoding explicitly includes it.
+  type MaterializedField = Exclude<
+    keyof ContextGraphAuthorityIndexState,
+    keyof ContextGraphAuthorityGenerationState
+  >;
+  // Generation ordering is canonical across both durable formats. Adding a
+  // materialized field remains a compile-time failure until it is included.
   const fields = {
     contextGraphId: state.contextGraphId,
     owner: state.owner,
@@ -125,14 +123,11 @@ function stateIntegrityValues(
     publishAuthority: state.publishAuthority,
     publishAuthorityAccountId: state.publishAuthorityAccountId,
     participantAgents: state.participantAgents,
-    nameHash: state.nameHash,
-    ownershipEra: state.ownershipEra,
-    policyVersion: state.policyVersion,
-    rosterVersion: state.rosterVersion,
-    sourceBlockNumber: state.sourceBlockNumber,
-    sourceBlockHash: state.sourceBlockHash,
-  } satisfies { [K in keyof ContextGraphAuthorityIndexState]: unknown };
-  return Object.values(fields);
+  } satisfies { [K in MaterializedField]: unknown };
+  return Object.freeze([
+    ...Object.values(fields),
+    ...contextGraphAuthorityGenerationIntegrityValues(state),
+  ]);
 }
 
 function contextGraphAuthorityIndexIntegrity(
@@ -168,14 +163,7 @@ function normalizeIndexState(
   const participantAgents = normalizeAuthorityIndexParticipantAgents(
     candidate.participantAgents,
   );
-  const nameHash = normalizeAuthorityIndexHash(candidate.nameHash);
-  const ownershipEra = normalizeAuthorityIndexNonNegativeSafeInteger(candidate.ownershipEra);
-  const policyVersion = normalizeAuthorityIndexNonNegativeSafeInteger(candidate.policyVersion);
-  const rosterVersion = normalizeAuthorityIndexNonNegativeSafeInteger(candidate.rosterVersion);
-  const sourceBlockNumber = normalizeAuthorityIndexNonNegativeSafeInteger(
-    candidate.sourceBlockNumber,
-  );
-  const sourceBlockHash = normalizeAuthorityIndexHash(candidate.sourceBlockHash);
+  const generation = normalizeContextGraphAuthorityGenerationState(candidate);
   if (
     contextGraphId === undefined
     || owner === undefined
@@ -184,16 +172,11 @@ function normalizeIndexState(
     || accessPolicy === undefined
     || publishDomain === undefined
     || participantAgents === undefined
-    || nameHash === undefined
-    || ownershipEra === undefined
-    || policyVersion === undefined
-    || rosterVersion === undefined
-    || sourceBlockNumber === undefined
-    || sourceBlockHash === undefined
-    || sourceBlockNumber < cursor.deploymentBlockNumber
-    || sourceBlockNumber > cursor.throughBlockNumber
-    || policyVersion < ownershipEra
-    || rosterVersion < ownershipEra
+    || generation === undefined
+    || generation.sourceBlockNumber < cursor.deploymentBlockNumber
+    || generation.sourceBlockNumber > cursor.throughBlockNumber
+    || generation.policyVersion < generation.ownershipEra
+    || generation.rosterVersion < generation.ownershipEra
   ) return undefined;
   return freezeContextGraphAuthorityIndexState({
     contextGraphId,
@@ -202,12 +185,7 @@ function normalizeIndexState(
     accessPolicy,
     ...publishDomain,
     participantAgents,
-    nameHash,
-    ownershipEra,
-    policyVersion,
-    rosterVersion,
-    sourceBlockNumber,
-    sourceBlockHash,
+    ...generation,
   });
 }
 
@@ -232,15 +210,15 @@ export function normalizeContextGraphAuthorityIndexCheckpoint(
   const rawCursor = candidate.cursor as Partial<
     Record<keyof ContextGraphAuthorityIndexCursor, unknown>
   >;
-  const deploymentBlockNumber = normalizeAuthorityIndexNonNegativeSafeInteger(
+  const deploymentBlockNumber = normalizeContextGraphAuthorityNonNegativeSafeInteger(
     rawCursor.deploymentBlockNumber,
   );
-  const throughBlockNumber = normalizeAuthorityIndexNonNegativeSafeInteger(
+  const throughBlockNumber = normalizeContextGraphAuthorityNonNegativeSafeInteger(
     rawCursor.throughBlockNumber,
   );
-  const throughBlockHash = normalizeAuthorityIndexHash(rawCursor.throughBlockHash);
-  const stateCount = normalizeAuthorityIndexNonNegativeSafeInteger(rawCursor.stateCount);
-  const integrity = normalizeAuthorityIndexHash(candidate.integrity);
+  const throughBlockHash = normalizeContextGraphAuthorityHash(rawCursor.throughBlockHash);
+  const stateCount = normalizeContextGraphAuthorityNonNegativeSafeInteger(rawCursor.stateCount);
+  const integrity = normalizeContextGraphAuthorityHash(candidate.integrity);
   if (
     deploymentBlockNumber === undefined
     || throughBlockNumber === undefined

--- a/packages/chain/src/context-graph-authority-index-reducer.ts
+++ b/packages/chain/src/context-graph-authority-index-reducer.ts
@@ -7,13 +7,14 @@ import {
   normalizeAuthorityIndexHash,
   normalizeAuthorityIndexNonNegativeSafeInteger,
   normalizeAuthorityIndexParticipantAgents,
-  normalizeAuthorityIndexPolicy,
-  normalizeAuthorityIndexUint256,
   normalizeContextGraphAuthorityIndexCheckpoint,
   type ContextGraphAuthorityIndexCheckpoint,
 } from './context-graph-authority-index-checkpoint.js';
 import {
   applyContextGraphAuthorityStateEvent,
+  normalizeContextGraphAuthorityAccessPolicy,
+  normalizeContextGraphAuthorityPublishDomain,
+  normalizeContextGraphAuthorityPublishReference,
   type ContextGraphAuthorityIndexEvent,
   type ContextGraphAuthorityIndexState,
 } from './context-graph-authority-state.js';
@@ -83,10 +84,10 @@ function normalizePageEvent(
       const participantAgents = normalizeAuthorityIndexParticipantAgents(
         event.participantAgents,
       );
-      const accessPolicy = normalizeAuthorityIndexPolicy(event.accessPolicy);
-      const publishPolicy = normalizeAuthorityIndexPolicy(event.publishPolicy);
-      const publishAuthority = normalizeAuthorityIndexAddress(event.publishAuthority);
-      const publishAuthorityAccountId = normalizeAuthorityIndexUint256(
+      const accessPolicy = normalizeContextGraphAuthorityAccessPolicy(event.accessPolicy);
+      const publishDomain = normalizeContextGraphAuthorityPublishDomain(
+        event.publishPolicy,
+        event.publishAuthority,
         event.publishAuthorityAccountId,
       );
       if (
@@ -95,13 +96,7 @@ function normalizePageEvent(
         || nameHash === undefined
         || participantAgents === undefined
         || accessPolicy === undefined
-        || publishPolicy === undefined
-        || publishAuthority === undefined
-        || publishAuthorityAccountId === undefined
-        || (publishPolicy === 0 && publishAuthority === ZERO_ADDRESS)
-        || (publishPolicy === 1 && (
-          publishAuthority !== ZERO_ADDRESS || publishAuthorityAccountId !== 0n
-        ))
+        || publishDomain === undefined
       ) {
         throw new Error('Context Graph authority index creation event has invalid authority state');
       }
@@ -112,9 +107,7 @@ function normalizePageEvent(
         nameHash,
         participantAgents,
         accessPolicy,
-        publishPolicy,
-        publishAuthority,
-        publishAuthorityAccountId,
+        ...publishDomain,
       });
     }
     case 'Transfer': {
@@ -126,43 +119,32 @@ function normalizePageEvent(
       return Object.freeze({ ...base, name: event.name, from, to });
     }
     case 'PublishPolicyUpdated': {
-      const publishPolicy = normalizeAuthorityIndexPolicy(event.publishPolicy);
-      const publishAuthority = normalizeAuthorityIndexAddress(event.publishAuthority);
-      const publishAuthorityAccountId = normalizeAuthorityIndexUint256(
+      const publishDomain = normalizeContextGraphAuthorityPublishDomain(
+        event.publishPolicy,
+        event.publishAuthority,
         event.publishAuthorityAccountId,
       );
-      if (
-        publishPolicy === undefined
-        || publishAuthority === undefined
-        || publishAuthorityAccountId === undefined
-        || (publishPolicy === 0 && publishAuthority === ZERO_ADDRESS)
-        || (publishPolicy === 1 && (
-          publishAuthority !== ZERO_ADDRESS || publishAuthorityAccountId !== 0n
-        ))
-      ) {
+      if (publishDomain === undefined) {
         throw new Error('Context Graph authority index policy event has invalid authority state');
       }
       return Object.freeze({
         ...base,
         name: event.name,
-        publishPolicy,
-        publishAuthority,
-        publishAuthorityAccountId,
+        ...publishDomain,
       });
     }
     case 'PublishAuthorityUpdated': {
-      const publishAuthority = normalizeAuthorityIndexAddress(event.publishAuthority);
-      const publishAuthorityAccountId = normalizeAuthorityIndexUint256(
+      const publishReference = normalizeContextGraphAuthorityPublishReference(
+        event.publishAuthority,
         event.publishAuthorityAccountId,
       );
-      if (publishAuthority === undefined || publishAuthorityAccountId === undefined) {
+      if (publishReference === undefined) {
         throw new Error('Context Graph authority index publisher event has invalid authority state');
       }
       return Object.freeze({
         ...base,
         name: event.name,
-        publishAuthority,
-        publishAuthorityAccountId,
+        ...publishReference,
       });
     }
     case 'AgentParticipantAdded':

--- a/packages/chain/src/context-graph-authority-index-reducer.ts
+++ b/packages/chain/src/context-graph-authority-index-reducer.ts
@@ -2,53 +2,32 @@
 
 import { ethers } from 'ethers';
 import {
-  applyContextGraphAuthorityGenerationEvent,
-  normalizeContextGraphAuthorityHash,
-  normalizeContextGraphAuthorityNonNegativeSafeInteger,
-} from './context-graph-authority-generation.js';
-import {
   createContextGraphAuthorityIndexCheckpoint,
-  freezeContextGraphAuthorityIndexState,
+  normalizeAuthorityIndexAddress,
+  normalizeAuthorityIndexHash,
+  normalizeAuthorityIndexNonNegativeSafeInteger,
+  normalizeAuthorityIndexParticipantAgents,
+  normalizeAuthorityIndexPolicy,
+  normalizeAuthorityIndexUint256,
   normalizeContextGraphAuthorityIndexCheckpoint,
   type ContextGraphAuthorityIndexCheckpoint,
-  type ContextGraphAuthorityIndexState,
 } from './context-graph-authority-index-checkpoint.js';
+import {
+  applyContextGraphAuthorityStateEvent,
+  type ContextGraphAuthorityIndexEvent,
+  type ContextGraphAuthorityIndexState,
+} from './context-graph-authority-state.js';
 
-interface ContextGraphAuthorityIndexEventBase {
-  readonly contextGraphId: bigint;
-  readonly blockNumber: number;
-  readonly blockHash: string;
-  readonly index: number;
-}
-
-export interface ContextGraphAuthorityIndexCreationEvent
-  extends ContextGraphAuthorityIndexEventBase {
-  readonly name: 'ContextGraphCreated';
-  readonly nameHash: string;
-}
-
-export interface ContextGraphAuthorityIndexTransferEvent
-  extends ContextGraphAuthorityIndexEventBase {
-  readonly name: 'Transfer';
-  readonly from: string;
-  readonly to: string;
-}
-
-export interface ContextGraphAuthorityIndexPolicyEvent
-  extends ContextGraphAuthorityIndexEventBase {
-  readonly name: 'PublishPolicyUpdated' | 'PublishAuthorityUpdated';
-}
-
-export interface ContextGraphAuthorityIndexRosterEvent
-  extends ContextGraphAuthorityIndexEventBase {
-  readonly name: 'AgentParticipantAdded' | 'AgentParticipantRemoved';
-}
-
-export type ContextGraphAuthorityIndexEvent =
-  | ContextGraphAuthorityIndexCreationEvent
-  | ContextGraphAuthorityIndexTransferEvent
-  | ContextGraphAuthorityIndexPolicyEvent
-  | ContextGraphAuthorityIndexRosterEvent;
+export type {
+  ContextGraphAuthorityIndexCreationEvent,
+  ContextGraphAuthorityIndexDeactivationEvent,
+  ContextGraphAuthorityIndexEvent,
+  ContextGraphAuthorityIndexPolicyEvent,
+  ContextGraphAuthorityIndexPublishAuthorityEvent,
+  ContextGraphAuthorityIndexPublishPolicyEvent,
+  ContextGraphAuthorityIndexRosterEvent,
+  ContextGraphAuthorityIndexTransferEvent,
+} from './context-graph-authority-state.js';
 
 export interface ReduceContextGraphAuthorityIndexPageInput {
   readonly deploymentBlockNumber: number;
@@ -57,19 +36,11 @@ export interface ReduceContextGraphAuthorityIndexPageInput {
   readonly previous?: ContextGraphAuthorityIndexCheckpoint;
   readonly events: readonly ContextGraphAuthorityIndexEvent[];
 }
-
 export interface ContextGraphAuthorityIndexPageReduction {
   readonly checkpoint: ContextGraphAuthorityIndexCheckpoint;
 }
 
-const ADDRESS_PATTERN = /^0x[0-9a-f]{40}$/i;
 const ZERO_ADDRESS = `0x${'0'.repeat(40)}`;
-
-function normalizeAddress(value: unknown): string | undefined {
-  return typeof value === 'string' && ADDRESS_PATTERN.test(value)
-    ? value.toLowerCase()
-    : undefined;
-}
 
 function normalizePageEvent(
   event: ContextGraphAuthorityIndexEvent,
@@ -84,9 +55,9 @@ function normalizePageEvent(
   ) {
     throw new Error('Context Graph authority index event has an invalid context graph id');
   }
-  const blockNumber = normalizeContextGraphAuthorityNonNegativeSafeInteger(event.blockNumber);
-  const blockHash = normalizeContextGraphAuthorityHash(event.blockHash);
-  const index = normalizeContextGraphAuthorityNonNegativeSafeInteger(event.index);
+  const blockNumber = normalizeAuthorityIndexNonNegativeSafeInteger(event.blockNumber);
+  const blockHash = normalizeAuthorityIndexHash(event.blockHash);
+  const index = normalizeAuthorityIndexNonNegativeSafeInteger(event.index);
   if (
     blockNumber === undefined
     || blockNumber < fromBlockNumber
@@ -107,24 +78,102 @@ function normalizePageEvent(
   };
   switch (event.name) {
     case 'ContextGraphCreated': {
-      const nameHash = normalizeContextGraphAuthorityHash(event.nameHash);
-      if (nameHash === undefined) {
-        throw new Error('Context Graph authority index creation event has an invalid name hash');
+      const owner = normalizeAuthorityIndexAddress(event.owner);
+      const nameHash = normalizeAuthorityIndexHash(event.nameHash);
+      const participantAgents = normalizeAuthorityIndexParticipantAgents(
+        event.participantAgents,
+      );
+      const accessPolicy = normalizeAuthorityIndexPolicy(event.accessPolicy);
+      const publishPolicy = normalizeAuthorityIndexPolicy(event.publishPolicy);
+      const publishAuthority = normalizeAuthorityIndexAddress(event.publishAuthority);
+      const publishAuthorityAccountId = normalizeAuthorityIndexUint256(
+        event.publishAuthorityAccountId,
+      );
+      if (
+        owner === undefined
+        || owner === ZERO_ADDRESS
+        || nameHash === undefined
+        || participantAgents === undefined
+        || accessPolicy === undefined
+        || publishPolicy === undefined
+        || publishAuthority === undefined
+        || publishAuthorityAccountId === undefined
+        || (publishPolicy === 0 && publishAuthority === ZERO_ADDRESS)
+        || (publishPolicy === 1 && (
+          publishAuthority !== ZERO_ADDRESS || publishAuthorityAccountId !== 0n
+        ))
+      ) {
+        throw new Error('Context Graph authority index creation event has invalid authority state');
       }
-      return Object.freeze({ ...base, name: event.name, nameHash });
+      return Object.freeze({
+        ...base,
+        name: event.name,
+        owner,
+        nameHash,
+        participantAgents,
+        accessPolicy,
+        publishPolicy,
+        publishAuthority,
+        publishAuthorityAccountId,
+      });
     }
     case 'Transfer': {
-      const from = normalizeAddress(event.from);
-      const to = normalizeAddress(event.to);
+      const from = normalizeAuthorityIndexAddress(event.from);
+      const to = normalizeAuthorityIndexAddress(event.to);
       if (from === undefined || to === undefined) {
         throw new Error('Context Graph authority index transfer event has an invalid address');
       }
       return Object.freeze({ ...base, name: event.name, from, to });
     }
-    case 'PublishPolicyUpdated':
-    case 'PublishAuthorityUpdated':
+    case 'PublishPolicyUpdated': {
+      const publishPolicy = normalizeAuthorityIndexPolicy(event.publishPolicy);
+      const publishAuthority = normalizeAuthorityIndexAddress(event.publishAuthority);
+      const publishAuthorityAccountId = normalizeAuthorityIndexUint256(
+        event.publishAuthorityAccountId,
+      );
+      if (
+        publishPolicy === undefined
+        || publishAuthority === undefined
+        || publishAuthorityAccountId === undefined
+        || (publishPolicy === 0 && publishAuthority === ZERO_ADDRESS)
+        || (publishPolicy === 1 && (
+          publishAuthority !== ZERO_ADDRESS || publishAuthorityAccountId !== 0n
+        ))
+      ) {
+        throw new Error('Context Graph authority index policy event has invalid authority state');
+      }
+      return Object.freeze({
+        ...base,
+        name: event.name,
+        publishPolicy,
+        publishAuthority,
+        publishAuthorityAccountId,
+      });
+    }
+    case 'PublishAuthorityUpdated': {
+      const publishAuthority = normalizeAuthorityIndexAddress(event.publishAuthority);
+      const publishAuthorityAccountId = normalizeAuthorityIndexUint256(
+        event.publishAuthorityAccountId,
+      );
+      if (publishAuthority === undefined || publishAuthorityAccountId === undefined) {
+        throw new Error('Context Graph authority index publisher event has invalid authority state');
+      }
+      return Object.freeze({
+        ...base,
+        name: event.name,
+        publishAuthority,
+        publishAuthorityAccountId,
+      });
+    }
     case 'AgentParticipantAdded':
-    case 'AgentParticipantRemoved':
+    case 'AgentParticipantRemoved': {
+      const agent = normalizeAuthorityIndexAddress(event.agent);
+      if (agent === undefined || agent === ZERO_ADDRESS) {
+        throw new Error('Context Graph authority index roster event has an invalid agent');
+      }
+      return Object.freeze({ ...base, name: event.name, agent });
+    }
+    case 'ContextGraphDeactivated':
       return Object.freeze({ ...base, name: event.name });
     default:
       throw new Error('Context Graph authority index event has an unsupported name');
@@ -135,13 +184,13 @@ function normalizePageEvent(
 export function reduceContextGraphAuthorityIndexPage(
   input: ReduceContextGraphAuthorityIndexPageInput,
 ): ContextGraphAuthorityIndexPageReduction {
-  const deploymentBlockNumber = normalizeContextGraphAuthorityNonNegativeSafeInteger(
+  const deploymentBlockNumber = normalizeAuthorityIndexNonNegativeSafeInteger(
     input.deploymentBlockNumber,
   );
-  const throughBlockNumber = normalizeContextGraphAuthorityNonNegativeSafeInteger(
+  const throughBlockNumber = normalizeAuthorityIndexNonNegativeSafeInteger(
     input.throughBlockNumber,
   );
-  const throughBlockHash = normalizeContextGraphAuthorityHash(input.throughBlockHash);
+  const throughBlockHash = normalizeAuthorityIndexHash(input.throughBlockHash);
   if (
     deploymentBlockNumber === undefined
     || throughBlockNumber === undefined
@@ -189,20 +238,8 @@ export function reduceContextGraphAuthorityIndexPage(
   );
   for (const event of normalizedEvents) {
     const contextGraphId = event.contextGraphId.toString(10);
-    const prior = states.get(contextGraphId);
-    if (
-      event.name === 'Transfer'
-      && (event.from === ZERO_ADDRESS || event.to === ZERO_ADDRESS || event.from === event.to)
-    ) continue;
-    const next = applyContextGraphAuthorityGenerationEvent(
-      prior,
-      event,
-      `Context Graph ${contextGraphId}`,
-    );
-    states.set(contextGraphId, freezeContextGraphAuthorityIndexState({
-      contextGraphId,
-      ...next,
-    }));
+    const next = applyContextGraphAuthorityStateEvent(states.get(contextGraphId), event);
+    if (next !== undefined) states.set(contextGraphId, next);
   }
 
   return Object.freeze({

--- a/packages/chain/src/context-graph-authority-index-reducer.ts
+++ b/packages/chain/src/context-graph-authority-index-reducer.ts
@@ -2,10 +2,12 @@
 
 import { ethers } from 'ethers';
 import {
+  normalizeContextGraphAuthorityHash,
+  normalizeContextGraphAuthorityNonNegativeSafeInteger,
+} from './context-graph-authority-generation.js';
+import {
   createContextGraphAuthorityIndexCheckpoint,
   normalizeAuthorityIndexAddress,
-  normalizeAuthorityIndexHash,
-  normalizeAuthorityIndexNonNegativeSafeInteger,
   normalizeAuthorityIndexParticipantAgents,
   normalizeContextGraphAuthorityIndexCheckpoint,
   type ContextGraphAuthorityIndexCheckpoint,
@@ -56,9 +58,9 @@ function normalizePageEvent(
   ) {
     throw new Error('Context Graph authority index event has an invalid context graph id');
   }
-  const blockNumber = normalizeAuthorityIndexNonNegativeSafeInteger(event.blockNumber);
-  const blockHash = normalizeAuthorityIndexHash(event.blockHash);
-  const index = normalizeAuthorityIndexNonNegativeSafeInteger(event.index);
+  const blockNumber = normalizeContextGraphAuthorityNonNegativeSafeInteger(event.blockNumber);
+  const blockHash = normalizeContextGraphAuthorityHash(event.blockHash);
+  const index = normalizeContextGraphAuthorityNonNegativeSafeInteger(event.index);
   if (
     blockNumber === undefined
     || blockNumber < fromBlockNumber
@@ -80,7 +82,7 @@ function normalizePageEvent(
   switch (event.name) {
     case 'ContextGraphCreated': {
       const owner = normalizeAuthorityIndexAddress(event.owner);
-      const nameHash = normalizeAuthorityIndexHash(event.nameHash);
+      const nameHash = normalizeContextGraphAuthorityHash(event.nameHash);
       const participantAgents = normalizeAuthorityIndexParticipantAgents(
         event.participantAgents,
       );
@@ -166,13 +168,13 @@ function normalizePageEvent(
 export function reduceContextGraphAuthorityIndexPage(
   input: ReduceContextGraphAuthorityIndexPageInput,
 ): ContextGraphAuthorityIndexPageReduction {
-  const deploymentBlockNumber = normalizeAuthorityIndexNonNegativeSafeInteger(
+  const deploymentBlockNumber = normalizeContextGraphAuthorityNonNegativeSafeInteger(
     input.deploymentBlockNumber,
   );
-  const throughBlockNumber = normalizeAuthorityIndexNonNegativeSafeInteger(
+  const throughBlockNumber = normalizeContextGraphAuthorityNonNegativeSafeInteger(
     input.throughBlockNumber,
   );
-  const throughBlockHash = normalizeAuthorityIndexHash(input.throughBlockHash);
+  const throughBlockHash = normalizeContextGraphAuthorityHash(input.throughBlockHash);
   if (
     deploymentBlockNumber === undefined
     || throughBlockNumber === undefined

--- a/packages/chain/src/context-graph-authority-index.ts
+++ b/packages/chain/src/context-graph-authority-index.ts
@@ -45,7 +45,7 @@ export interface ContextGraphAuthorityIndexScanInput {
     blockNumber: number,
     lifecycleSignal: AbortSignal,
   ) => Promise<string | null>;
-  /** Read all six indexed authority event signatures for one inclusive range. */
+  /** Read all seven indexed authority event signatures for one inclusive range. */
   readonly readPage: (
     fromBlockNumber: number,
     throughBlockNumber: number,

--- a/packages/chain/src/context-graph-authority-state.ts
+++ b/packages/chain/src/context-graph-authority-state.ts
@@ -1,25 +1,42 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ContextGraphAuthorityGenerationState } from './context-graph-authority-generation.js';
+import {
+  assertContextGraphAccessPolicyV1,
+  assertContextGraphPublishPolicyV1,
+  snapshotContextGraphPublishDomainV1,
+  type ContextGraphAccessPolicyV1,
+  type ContextGraphPublishDomainV1,
+  type ContextGraphPublishPolicyV1,
+  type DecimalU256V1,
+  type EvmAddressV1,
+} from '@origintrail-official/dkg-core';
+import {
+  applyContextGraphAuthorityGenerationEvent,
+  type ContextGraphAuthorityGenerationState,
+} from './context-graph-authority-generation.js';
 
 export const MAX_CONTEXT_GRAPH_PARTICIPANT_AGENTS = 256;
 
 const ZERO_ADDRESS = `0x${'0'.repeat(40)}`;
+const ADDRESS_PATTERN = /^0x[0-9a-f]{40}$/i;
+
+export type ContextGraphAuthorityPublishReference = Readonly<{
+  publishAuthority: EvmAddressV1 | null;
+  publishAuthorityAccountId: DecimalU256V1;
+}>;
 
 /** Canonical materialized authority state, including its generation counters. */
-export interface ContextGraphAuthorityState extends ContextGraphAuthorityGenerationState {
-  readonly owner: string;
-  readonly active: boolean;
-  readonly accessPolicy: number;
-  readonly publishPolicy: number;
-  readonly publishAuthority: string | null;
-  readonly publishAuthorityAccountId: string;
-  readonly participantAgents: readonly string[];
-}
+export type ContextGraphAuthorityState = ContextGraphAuthorityGenerationState & Readonly<{
+  owner: string;
+  active: boolean;
+  accessPolicy: ContextGraphAccessPolicyV1;
+  participantAgents: readonly string[];
+}> & ContextGraphPublishDomainV1;
+
 /** One graph's state inside the contract-wide materialized index. */
-export interface ContextGraphAuthorityIndexState extends ContextGraphAuthorityState {
-  readonly contextGraphId: string;
-}
+export type ContextGraphAuthorityIndexState = ContextGraphAuthorityState & Readonly<{
+  contextGraphId: string;
+}>;
 
 interface ContextGraphAuthorityIndexEventBase {
   readonly contextGraphId: bigint;
@@ -28,17 +45,16 @@ interface ContextGraphAuthorityIndexEventBase {
   readonly index: number;
 }
 
-export interface ContextGraphAuthorityIndexCreationEvent
-  extends ContextGraphAuthorityIndexEventBase {
-  readonly name: 'ContextGraphCreated';
-  readonly owner: string;
-  readonly nameHash: string;
-  readonly participantAgents: readonly string[];
-  readonly accessPolicy: number;
-  readonly publishPolicy: number;
-  readonly publishAuthority: string;
-  readonly publishAuthorityAccountId: bigint;
-}
+export type ContextGraphAuthorityIndexCreationEvent =
+  ContextGraphAuthorityIndexEventBase
+  & Readonly<{
+    name: 'ContextGraphCreated';
+    owner: string;
+    nameHash: string;
+    participantAgents: readonly string[];
+    accessPolicy: ContextGraphAccessPolicyV1;
+  }>
+  & ContextGraphPublishDomainV1;
 
 export interface ContextGraphAuthorityIndexTransferEvent
   extends ContextGraphAuthorityIndexEventBase {
@@ -47,19 +63,14 @@ export interface ContextGraphAuthorityIndexTransferEvent
   readonly to: string;
 }
 
-export interface ContextGraphAuthorityIndexPublishPolicyEvent
-  extends ContextGraphAuthorityIndexEventBase {
-  readonly name: 'PublishPolicyUpdated';
-  readonly publishPolicy: number;
-  readonly publishAuthority: string;
-  readonly publishAuthorityAccountId: bigint;
-}
+export type ContextGraphAuthorityIndexPublishPolicyEvent =
+  ContextGraphAuthorityIndexEventBase
+  & Readonly<{ name: 'PublishPolicyUpdated' }>
+  & ContextGraphPublishDomainV1;
 
 export interface ContextGraphAuthorityIndexPublishAuthorityEvent
-  extends ContextGraphAuthorityIndexEventBase {
+  extends ContextGraphAuthorityIndexEventBase, ContextGraphAuthorityPublishReference {
   readonly name: 'PublishAuthorityUpdated';
-  readonly publishAuthority: string;
-  readonly publishAuthorityAccountId: bigint;
 }
 
 export type ContextGraphAuthorityIndexPolicyEvent =
@@ -85,6 +96,93 @@ export type ContextGraphAuthorityIndexEvent =
   | ContextGraphAuthorityIndexRosterEvent
   | ContextGraphAuthorityIndexDeactivationEvent;
 
+export function normalizeContextGraphAuthorityAccessPolicy(
+  value: unknown,
+): ContextGraphAccessPolicyV1 | undefined {
+  try {
+    assertContextGraphAccessPolicyV1(value);
+    return value;
+  } catch {
+    return undefined;
+  }
+}
+
+export function normalizeContextGraphAuthorityPublishPolicy(
+  value: unknown,
+): ContextGraphPublishPolicyV1 | undefined {
+  try {
+    assertContextGraphPublishPolicyV1(value);
+    return value;
+  } catch {
+    return undefined;
+  }
+}
+
+export function normalizeContextGraphAuthorityPublishReference(
+  publishAuthority: unknown,
+  publishAuthorityAccountId: unknown,
+): ContextGraphAuthorityPublishReference | undefined {
+  const authority = typeof publishAuthority === 'string' && ADDRESS_PATTERN.test(publishAuthority)
+    ? publishAuthority.toLowerCase()
+    : publishAuthority;
+  const normalizedAuthority = authority === ZERO_ADDRESS ? null : authority;
+  const normalizedAccountId = typeof publishAuthorityAccountId === 'bigint'
+    ? publishAuthorityAccountId.toString(10)
+    : publishAuthorityAccountId;
+  try {
+    // Policy 0 admits every non-null canonical authority/account pair, so it
+    // provides the canonical scalar validation without inventing another codec.
+    const domain = snapshotContextGraphPublishDomainV1(
+      0,
+      normalizedAuthority,
+      normalizedAccountId,
+    );
+    return Object.freeze({
+      publishAuthority: domain.publishAuthority,
+      publishAuthorityAccountId: domain.publishAuthorityAccountId,
+    });
+  } catch {
+    if (normalizedAuthority !== null) return undefined;
+    // Null is a valid normalized reference only for the open domain. Validate
+    // its account scalar there; the caller supplies the actual policy later.
+    try {
+      const domain = snapshotContextGraphPublishDomainV1(
+        1,
+        normalizedAuthority,
+        normalizedAccountId,
+      );
+      return Object.freeze({
+        publishAuthority: domain.publishAuthority,
+        publishAuthorityAccountId: domain.publishAuthorityAccountId,
+      });
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+export function normalizeContextGraphAuthorityPublishDomain(
+  publishPolicy: unknown,
+  publishAuthority: unknown,
+  publishAuthorityAccountId: unknown,
+): ContextGraphPublishDomainV1 | undefined {
+  const policy = normalizeContextGraphAuthorityPublishPolicy(publishPolicy);
+  const reference = normalizeContextGraphAuthorityPublishReference(
+    publishAuthority,
+    publishAuthorityAccountId,
+  );
+  if (policy === undefined || reference === undefined) return undefined;
+  try {
+    return snapshotContextGraphPublishDomainV1(
+      policy,
+      reference.publishAuthority,
+      reference.publishAuthorityAccountId,
+    );
+  } catch {
+    return undefined;
+  }
+}
+
 export function freezeContextGraphAuthorityIndexState(
   state: ContextGraphAuthorityIndexState,
 ): ContextGraphAuthorityIndexState {
@@ -94,15 +192,7 @@ export function freezeContextGraphAuthorityIndexState(
   });
 }
 
-function increment(value: number, label: string): number {
-  const next = value + 1;
-  if (!Number.isSafeInteger(next)) {
-    throw new Error(`Context Graph authority ${label} exceeds the safe integer range`);
-  }
-  return next;
-}
-
-/** Apply one normalized event to authority fields and generation counters together. */
+/** Apply materialized-field patches around the one canonical generation reducer. */
 export function applyContextGraphAuthorityStateEvent(
   previous: ContextGraphAuthorityIndexState | undefined,
   event: ContextGraphAuthorityIndexEvent,
@@ -110,79 +200,75 @@ export function applyContextGraphAuthorityStateEvent(
   const contextGraphId = event.contextGraphId.toString(10);
   const subject = `Context Graph ${contextGraphId}`;
 
-  if (event.name === 'ContextGraphCreated') {
-    if (previous !== undefined) throw new Error(`${subject} has more than one creation event`);
-    return freezeContextGraphAuthorityIndexState({
-      contextGraphId,
-      owner: event.owner,
-      active: true,
-      accessPolicy: event.accessPolicy,
-      publishPolicy: event.publishPolicy,
-      publishAuthority: event.publishAuthority === ZERO_ADDRESS
-        ? null
-        : event.publishAuthority,
-      publishAuthorityAccountId: event.publishAuthorityAccountId.toString(10),
-      participantAgents: event.participantAgents,
-      nameHash: event.nameHash,
-      ownershipEra: 0,
-      policyVersion: 0,
-      rosterVersion: 0,
-      sourceBlockNumber: event.blockNumber,
-      sourceBlockHash: event.blockHash,
-    });
-  }
   if (event.name === 'Transfer' && event.from === ZERO_ADDRESS) return previous;
-  if (previous === undefined) throw new Error(`${subject} authority event precedes creation`);
+  if (event.name === 'ContextGraphDeactivated') {
+    if (previous === undefined) throw new Error(`${subject} authority event precedes creation`);
+    return freezeContextGraphAuthorityIndexState({ ...previous, active: false });
+  }
   if (event.name === 'Transfer' && event.to === ZERO_ADDRESS) {
     throw new Error(`${subject} authority index cannot materialize a burned token`);
   }
   if (event.name === 'Transfer' && event.from === event.to) return previous;
 
+  const generation = applyContextGraphAuthorityGenerationEvent(previous, event, subject);
   switch (event.name) {
-    case 'ContextGraphDeactivated':
-      return freezeContextGraphAuthorityIndexState({ ...previous, active: false });
+    case 'ContextGraphCreated': {
+      const domain = normalizeContextGraphAuthorityPublishDomain(
+        event.publishPolicy,
+        event.publishAuthority,
+        event.publishAuthorityAccountId,
+      );
+      if (domain === undefined) {
+        throw new Error(`${subject} creation event violates its publish policy`);
+      }
+      return freezeContextGraphAuthorityIndexState({
+        contextGraphId,
+        owner: event.owner,
+        active: true,
+        accessPolicy: event.accessPolicy,
+        participantAgents: event.participantAgents,
+        ...domain,
+        ...generation,
+      });
+    }
     case 'Transfer':
       return freezeContextGraphAuthorityIndexState({
-        ...previous,
+        ...previous!,
+        ...generation,
         owner: event.to,
-        ownershipEra: increment(previous.ownershipEra, 'ownership era'),
-        policyVersion: increment(previous.policyVersion, 'policy version'),
-        rosterVersion: increment(previous.rosterVersion, 'roster version'),
-        sourceBlockNumber: event.blockNumber,
-        sourceBlockHash: event.blockHash,
       });
-    case 'PublishPolicyUpdated':
+    case 'PublishPolicyUpdated': {
+      const domain = normalizeContextGraphAuthorityPublishDomain(
+        event.publishPolicy,
+        event.publishAuthority,
+        event.publishAuthorityAccountId,
+      );
+      if (domain === undefined) {
+        throw new Error(`${subject} policy event violates its publish policy`);
+      }
       return freezeContextGraphAuthorityIndexState({
-        ...previous,
-        publishPolicy: event.publishPolicy,
-        publishAuthority: event.publishAuthority === ZERO_ADDRESS
-          ? null
-          : event.publishAuthority,
-        publishAuthorityAccountId: event.publishAuthorityAccountId.toString(10),
-        policyVersion: increment(previous.policyVersion, 'policy version'),
-        sourceBlockNumber: event.blockNumber,
-        sourceBlockHash: event.blockHash,
+        ...previous!,
+        ...generation,
+        ...domain,
       });
+    }
     case 'PublishAuthorityUpdated': {
-      if (
-        (previous.publishPolicy === 0 && event.publishAuthority === ZERO_ADDRESS)
-        || (previous.publishPolicy === 1 && (
-          event.publishAuthority !== ZERO_ADDRESS || event.publishAuthorityAccountId !== 0n
-        ))
-      ) throw new Error(`${subject} publisher event violates its publish policy`);
+      const domain = normalizeContextGraphAuthorityPublishDomain(
+        previous!.publishPolicy,
+        event.publishAuthority,
+        event.publishAuthorityAccountId,
+      );
+      if (domain === undefined) {
+        throw new Error(`${subject} publisher event violates its publish policy`);
+      }
       return freezeContextGraphAuthorityIndexState({
-        ...previous,
-        publishAuthority: event.publishAuthority === ZERO_ADDRESS
-          ? null
-          : event.publishAuthority,
-        publishAuthorityAccountId: event.publishAuthorityAccountId.toString(10),
-        policyVersion: increment(previous.policyVersion, 'policy version'),
-        sourceBlockNumber: event.blockNumber,
-        sourceBlockHash: event.blockHash,
+        ...previous!,
+        ...generation,
+        ...domain,
       });
     }
     case 'AgentParticipantAdded': {
-      const participantAgents = new Set(previous.participantAgents);
+      const participantAgents = new Set(previous!.participantAgents);
       if (participantAgents.has(event.agent)) {
         throw new Error(`${subject} adds an existing participant agent`);
       }
@@ -191,20 +277,20 @@ export function applyContextGraphAuthorityStateEvent(
       }
       participantAgents.add(event.agent);
       return freezeContextGraphAuthorityIndexState({
-        ...previous,
+        ...previous!,
+        ...generation,
         participantAgents: [...participantAgents].sort(),
-        rosterVersion: increment(previous.rosterVersion, 'roster version'),
       });
     }
     case 'AgentParticipantRemoved': {
-      const participantAgents = new Set(previous.participantAgents);
+      const participantAgents = new Set(previous!.participantAgents);
       if (!participantAgents.delete(event.agent)) {
         throw new Error(`${subject} removes an unknown participant agent`);
       }
       return freezeContextGraphAuthorityIndexState({
-        ...previous,
+        ...previous!,
+        ...generation,
         participantAgents: [...participantAgents].sort(),
-        rosterVersion: increment(previous.rosterVersion, 'roster version'),
       });
     }
   }

--- a/packages/chain/src/context-graph-authority-state.ts
+++ b/packages/chain/src/context-graph-authority-state.ts
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  assertCanonicalDecimalU256,
+  assertCanonicalEvmAddress,
   assertContextGraphAccessPolicyV1,
   assertContextGraphPublishPolicyV1,
   snapshotContextGraphPublishDomainV1,
@@ -130,34 +132,16 @@ export function normalizeContextGraphAuthorityPublishReference(
     ? publishAuthorityAccountId.toString(10)
     : publishAuthorityAccountId;
   try {
-    // Policy 0 admits every non-null canonical authority/account pair, so it
-    // provides the canonical scalar validation without inventing another codec.
-    const domain = snapshotContextGraphPublishDomainV1(
-      0,
-      normalizedAuthority,
-      normalizedAccountId,
-    );
+    if (normalizedAuthority !== null) {
+      assertCanonicalEvmAddress(normalizedAuthority, 'publishAuthority');
+    }
+    assertCanonicalDecimalU256(normalizedAccountId, 'publishAuthorityAccountId');
     return Object.freeze({
-      publishAuthority: domain.publishAuthority,
-      publishAuthorityAccountId: domain.publishAuthorityAccountId,
+      publishAuthority: normalizedAuthority,
+      publishAuthorityAccountId: normalizedAccountId,
     });
   } catch {
-    if (normalizedAuthority !== null) return undefined;
-    // Null is a valid normalized reference only for the open domain. Validate
-    // its account scalar there; the caller supplies the actual policy later.
-    try {
-      const domain = snapshotContextGraphPublishDomainV1(
-        1,
-        normalizedAuthority,
-        normalizedAccountId,
-      );
-      return Object.freeze({
-        publishAuthority: domain.publishAuthority,
-        publishAuthorityAccountId: domain.publishAuthorityAccountId,
-      });
-    } catch {
-      return undefined;
-    }
+    return undefined;
   }
 }
 

--- a/packages/chain/src/context-graph-authority-state.ts
+++ b/packages/chain/src/context-graph-authority-state.ts
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ContextGraphAuthorityGenerationState } from './context-graph-authority-generation.js';
+
+export const MAX_CONTEXT_GRAPH_PARTICIPANT_AGENTS = 256;
+
+const ZERO_ADDRESS = `0x${'0'.repeat(40)}`;
+
+/** Canonical materialized authority state, including its generation counters. */
+export interface ContextGraphAuthorityState extends ContextGraphAuthorityGenerationState {
+  readonly owner: string;
+  readonly active: boolean;
+  readonly accessPolicy: number;
+  readonly publishPolicy: number;
+  readonly publishAuthority: string | null;
+  readonly publishAuthorityAccountId: string;
+  readonly participantAgents: readonly string[];
+}
+/** One graph's state inside the contract-wide materialized index. */
+export interface ContextGraphAuthorityIndexState extends ContextGraphAuthorityState {
+  readonly contextGraphId: string;
+}
+
+interface ContextGraphAuthorityIndexEventBase {
+  readonly contextGraphId: bigint;
+  readonly blockNumber: number;
+  readonly blockHash: string;
+  readonly index: number;
+}
+
+export interface ContextGraphAuthorityIndexCreationEvent
+  extends ContextGraphAuthorityIndexEventBase {
+  readonly name: 'ContextGraphCreated';
+  readonly owner: string;
+  readonly nameHash: string;
+  readonly participantAgents: readonly string[];
+  readonly accessPolicy: number;
+  readonly publishPolicy: number;
+  readonly publishAuthority: string;
+  readonly publishAuthorityAccountId: bigint;
+}
+
+export interface ContextGraphAuthorityIndexTransferEvent
+  extends ContextGraphAuthorityIndexEventBase {
+  readonly name: 'Transfer';
+  readonly from: string;
+  readonly to: string;
+}
+
+export interface ContextGraphAuthorityIndexPublishPolicyEvent
+  extends ContextGraphAuthorityIndexEventBase {
+  readonly name: 'PublishPolicyUpdated';
+  readonly publishPolicy: number;
+  readonly publishAuthority: string;
+  readonly publishAuthorityAccountId: bigint;
+}
+
+export interface ContextGraphAuthorityIndexPublishAuthorityEvent
+  extends ContextGraphAuthorityIndexEventBase {
+  readonly name: 'PublishAuthorityUpdated';
+  readonly publishAuthority: string;
+  readonly publishAuthorityAccountId: bigint;
+}
+
+export type ContextGraphAuthorityIndexPolicyEvent =
+  | ContextGraphAuthorityIndexPublishPolicyEvent
+  | ContextGraphAuthorityIndexPublishAuthorityEvent;
+
+export interface ContextGraphAuthorityIndexRosterEvent
+  extends ContextGraphAuthorityIndexEventBase {
+  readonly name: 'AgentParticipantAdded' | 'AgentParticipantRemoved';
+  readonly agent: string;
+}
+
+export interface ContextGraphAuthorityIndexDeactivationEvent
+  extends ContextGraphAuthorityIndexEventBase {
+  readonly name: 'ContextGraphDeactivated';
+}
+
+export type ContextGraphAuthorityIndexEvent =
+  | ContextGraphAuthorityIndexCreationEvent
+  | ContextGraphAuthorityIndexTransferEvent
+  | ContextGraphAuthorityIndexPublishPolicyEvent
+  | ContextGraphAuthorityIndexPublishAuthorityEvent
+  | ContextGraphAuthorityIndexRosterEvent
+  | ContextGraphAuthorityIndexDeactivationEvent;
+
+export function freezeContextGraphAuthorityIndexState(
+  state: ContextGraphAuthorityIndexState,
+): ContextGraphAuthorityIndexState {
+  return Object.freeze({
+    ...state,
+    participantAgents: Object.freeze([...state.participantAgents]),
+  });
+}
+
+function increment(value: number, label: string): number {
+  const next = value + 1;
+  if (!Number.isSafeInteger(next)) {
+    throw new Error(`Context Graph authority ${label} exceeds the safe integer range`);
+  }
+  return next;
+}
+
+/** Apply one normalized event to authority fields and generation counters together. */
+export function applyContextGraphAuthorityStateEvent(
+  previous: ContextGraphAuthorityIndexState | undefined,
+  event: ContextGraphAuthorityIndexEvent,
+): ContextGraphAuthorityIndexState | undefined {
+  const contextGraphId = event.contextGraphId.toString(10);
+  const subject = `Context Graph ${contextGraphId}`;
+
+  if (event.name === 'ContextGraphCreated') {
+    if (previous !== undefined) throw new Error(`${subject} has more than one creation event`);
+    return freezeContextGraphAuthorityIndexState({
+      contextGraphId,
+      owner: event.owner,
+      active: true,
+      accessPolicy: event.accessPolicy,
+      publishPolicy: event.publishPolicy,
+      publishAuthority: event.publishAuthority === ZERO_ADDRESS
+        ? null
+        : event.publishAuthority,
+      publishAuthorityAccountId: event.publishAuthorityAccountId.toString(10),
+      participantAgents: event.participantAgents,
+      nameHash: event.nameHash,
+      ownershipEra: 0,
+      policyVersion: 0,
+      rosterVersion: 0,
+      sourceBlockNumber: event.blockNumber,
+      sourceBlockHash: event.blockHash,
+    });
+  }
+  if (event.name === 'Transfer' && event.from === ZERO_ADDRESS) return previous;
+  if (previous === undefined) throw new Error(`${subject} authority event precedes creation`);
+  if (event.name === 'Transfer' && event.to === ZERO_ADDRESS) {
+    throw new Error(`${subject} authority index cannot materialize a burned token`);
+  }
+  if (event.name === 'Transfer' && event.from === event.to) return previous;
+
+  switch (event.name) {
+    case 'ContextGraphDeactivated':
+      return freezeContextGraphAuthorityIndexState({ ...previous, active: false });
+    case 'Transfer':
+      return freezeContextGraphAuthorityIndexState({
+        ...previous,
+        owner: event.to,
+        ownershipEra: increment(previous.ownershipEra, 'ownership era'),
+        policyVersion: increment(previous.policyVersion, 'policy version'),
+        rosterVersion: increment(previous.rosterVersion, 'roster version'),
+        sourceBlockNumber: event.blockNumber,
+        sourceBlockHash: event.blockHash,
+      });
+    case 'PublishPolicyUpdated':
+      return freezeContextGraphAuthorityIndexState({
+        ...previous,
+        publishPolicy: event.publishPolicy,
+        publishAuthority: event.publishAuthority === ZERO_ADDRESS
+          ? null
+          : event.publishAuthority,
+        publishAuthorityAccountId: event.publishAuthorityAccountId.toString(10),
+        policyVersion: increment(previous.policyVersion, 'policy version'),
+        sourceBlockNumber: event.blockNumber,
+        sourceBlockHash: event.blockHash,
+      });
+    case 'PublishAuthorityUpdated': {
+      if (
+        (previous.publishPolicy === 0 && event.publishAuthority === ZERO_ADDRESS)
+        || (previous.publishPolicy === 1 && (
+          event.publishAuthority !== ZERO_ADDRESS || event.publishAuthorityAccountId !== 0n
+        ))
+      ) throw new Error(`${subject} publisher event violates its publish policy`);
+      return freezeContextGraphAuthorityIndexState({
+        ...previous,
+        publishAuthority: event.publishAuthority === ZERO_ADDRESS
+          ? null
+          : event.publishAuthority,
+        publishAuthorityAccountId: event.publishAuthorityAccountId.toString(10),
+        policyVersion: increment(previous.policyVersion, 'policy version'),
+        sourceBlockNumber: event.blockNumber,
+        sourceBlockHash: event.blockHash,
+      });
+    }
+    case 'AgentParticipantAdded': {
+      const participantAgents = new Set(previous.participantAgents);
+      if (participantAgents.has(event.agent)) {
+        throw new Error(`${subject} adds an existing participant agent`);
+      }
+      if (participantAgents.size >= MAX_CONTEXT_GRAPH_PARTICIPANT_AGENTS) {
+        throw new Error(`${subject} participant-agent limit exceeded`);
+      }
+      participantAgents.add(event.agent);
+      return freezeContextGraphAuthorityIndexState({
+        ...previous,
+        participantAgents: [...participantAgents].sort(),
+        rosterVersion: increment(previous.rosterVersion, 'roster version'),
+      });
+    }
+    case 'AgentParticipantRemoved': {
+      const participantAgents = new Set(previous.participantAgents);
+      if (!participantAgents.delete(event.agent)) {
+        throw new Error(`${subject} removes an unknown participant agent`);
+      }
+      return freezeContextGraphAuthorityIndexState({
+        ...previous,
+        participantAgents: [...participantAgents].sort(),
+        rosterVersion: increment(previous.rosterVersion, 'roster version'),
+      });
+    }
+  }
+}

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -1100,14 +1100,12 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
         const snapshot: ContextGraphAuthoritySnapshot = Object.freeze({
           chainId,
           governanceContract: contractAddress,
+          ...authority.state,
           contextGraphId: contextGraphId.toString(10),
-          ...authority.current,
-          nameHash: authority.generation.nameHash,
-          ownershipEra: authority.generation.ownershipEra.toString(10),
-          policyVersion: authority.generation.policyVersion.toString(10),
-          rosterVersion: authority.generation.rosterVersion.toString(10),
-          sourceBlockNumber: authority.generation.sourceBlockNumber.toString(10),
-          sourceBlockHash: authority.generation.sourceBlockHash,
+          ownershipEra: authority.state.ownershipEra.toString(10),
+          policyVersion: authority.state.policyVersion.toString(10),
+          rosterVersion: authority.state.rosterVersion.toString(10),
+          sourceBlockNumber: authority.state.sourceBlockNumber.toString(10),
         });
         // Verify the combined current-state + generation view only after both
         // reads settle. The legacy reader publishes its checkpoint here; the

--- a/packages/chain/src/evm-adapter-context-graph.ts
+++ b/packages/chain/src/evm-adapter-context-graph.ts
@@ -956,8 +956,7 @@ export class ContextGraphMethods extends EVMChainAdapterBase {
           const authorityTopics = contextGraphAuthorityEventTopics(contract.interface);
           return Object.freeze({
             kind: 'indexed' as const,
-            readCurrent: readCurrentState,
-            readGeneration: () => this.contextGraphAuthorityIndex!.resolve({
+            readSnapshot: () => this.contextGraphAuthorityIndex!.resolve({
               scope: [this.deploymentId, contractAddress].join(':'),
               contextGraphId,
               readScope: provider,

--- a/packages/chain/src/evm-context-graph-authority-source.ts
+++ b/packages/chain/src/evm-context-graph-authority-source.ts
@@ -10,6 +10,7 @@ import type { ContextGraphAuthorityIndexEvent } from './context-graph-authority-
 
 export const CONTEXT_GRAPH_AUTHORITY_EVENT_NAMES = Object.freeze([
   'ContextGraphCreated',
+  'ContextGraphDeactivated',
   'Transfer',
   'PublishPolicyUpdated',
   'PublishAuthorityUpdated',
@@ -39,8 +40,7 @@ export interface EvmContextGraphAuthoritySourceResult {
 export type EvmContextGraphAuthoritySource =
   | Readonly<{
       kind: 'indexed';
-      readCurrent(): Promise<unknown>;
-      readGeneration(): Promise<ContextGraphAuthorityIndexState>;
+      readSnapshot(): Promise<ContextGraphAuthorityIndexState>;
       stabilize(): Promise<void>;
     }>
   | Readonly<{
@@ -105,13 +105,18 @@ export async function resolveEvmContextGraphAuthoritySource(
   source: EvmContextGraphAuthoritySource,
 ): Promise<EvmContextGraphAuthoritySourceResult> {
   if (source.kind === 'indexed') {
-    const [rawCurrent, generation] = await Promise.all([
-      source.readCurrent(),
-      source.readGeneration(),
-    ]);
+    const indexed = await source.readSnapshot();
     return Object.freeze({
-      current: normalizeEvmContextGraphCurrentAuthorityState(rawCurrent),
-      generation,
+      current: Object.freeze({
+        owner: indexed.owner,
+        active: indexed.active,
+        accessPolicy: indexed.accessPolicy,
+        publishPolicy: indexed.publishPolicy,
+        publishAuthority: indexed.publishAuthority,
+        publishAuthorityAccountId: indexed.publishAuthorityAccountId,
+        participantAgents: indexed.participantAgents,
+      }),
+      generation: indexed,
       stabilize: source.stabilize,
     });
   }
@@ -154,7 +159,17 @@ export function normalizeContextGraphAuthorityIndexLog(
         ...base,
         name: parsed.name,
         contextGraphId: BigInt(parsed.args.contextGraphId ?? parsed.args[0]),
+        owner: String(parsed.args.owner ?? parsed.args[1]),
         nameHash: String(parsed.args.nameHash ?? parsed.args[2]),
+        participantAgents: [
+          ...(parsed.args.participantAgents ?? parsed.args[3]),
+        ].map((address) => String(address)),
+        accessPolicy: Number(BigInt(parsed.args.accessPolicy ?? parsed.args[5])),
+        publishPolicy: Number(BigInt(parsed.args.publishPolicy ?? parsed.args[6])),
+        publishAuthority: String(parsed.args.publishAuthority ?? parsed.args[7]),
+        publishAuthorityAccountId: BigInt(
+          parsed.args.publishAuthorityAccountId ?? parsed.args[8],
+        ),
       };
     case 'Transfer':
       return {
@@ -165,9 +180,35 @@ export function normalizeContextGraphAuthorityIndexLog(
         to: String(parsed.args.to ?? parsed.args[1]),
       };
     case 'PublishPolicyUpdated':
+      return {
+        ...base,
+        name: parsed.name,
+        contextGraphId: BigInt(parsed.args.contextGraphId ?? parsed.args[0]),
+        publishPolicy: Number(BigInt(parsed.args.publishPolicy ?? parsed.args[1])),
+        publishAuthority: String(parsed.args.publishAuthority ?? parsed.args[2]),
+        publishAuthorityAccountId: BigInt(
+          parsed.args.publishAuthorityAccountId ?? parsed.args[3],
+        ),
+      };
     case 'PublishAuthorityUpdated':
+      return {
+        ...base,
+        name: parsed.name,
+        contextGraphId: BigInt(parsed.args.contextGraphId ?? parsed.args[0]),
+        publishAuthority: String(parsed.args.newAuthority ?? parsed.args[1]),
+        publishAuthorityAccountId: BigInt(
+          parsed.args.newAuthorityAccountId ?? parsed.args[2],
+        ),
+      };
     case 'AgentParticipantAdded':
     case 'AgentParticipantRemoved':
+      return {
+        ...base,
+        name: parsed.name,
+        contextGraphId: BigInt(parsed.args.contextGraphId ?? parsed.args[0]),
+        agent: String(parsed.args.agent ?? parsed.args[1]),
+      };
+    case 'ContextGraphDeactivated':
       return {
         ...base,
         name: parsed.name,

--- a/packages/chain/src/evm-context-graph-authority-source.ts
+++ b/packages/chain/src/evm-context-graph-authority-source.ts
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ethers } from 'ethers';
-import type { ContextGraphAuthorityGenerationState } from './context-graph-authority-generation.js';
+import type { ContextGraphPublishDomainV1 } from '@origintrail-official/dkg-core';
 import type { ContextGraphAuthorityHistoryResolution } from './context-graph-authority-history.js';
 import type {
   ContextGraphAuthorityIndexState,
 } from './context-graph-authority-index-checkpoint.js';
 import type { ContextGraphAuthorityIndexEvent } from './context-graph-authority-index-reducer.js';
+import {
+  normalizeContextGraphAuthorityAccessPolicy,
+  normalizeContextGraphAuthorityPublishDomain,
+  normalizeContextGraphAuthorityPublishReference,
+  type ContextGraphAuthorityState,
+} from './context-graph-authority-state.js';
 
 export const CONTEXT_GRAPH_AUTHORITY_EVENT_NAMES = Object.freeze([
   'ContextGraphCreated',
@@ -18,21 +24,15 @@ export const CONTEXT_GRAPH_AUTHORITY_EVENT_NAMES = Object.freeze([
   'AgentParticipantRemoved',
 ] as const);
 
-export interface EvmContextGraphCurrentAuthorityState {
-  readonly owner: string;
-  readonly active: boolean;
-  readonly accessPolicy: number;
-  readonly publishPolicy: number;
-  readonly publishAuthority: string | null;
-  readonly publishAuthorityAccountId: string;
-  readonly participantAgents: readonly string[];
-}
-
-export type EvmContextGraphAuthorityGeneration = ContextGraphAuthorityGenerationState;
+export type EvmContextGraphCurrentAuthorityState = Readonly<{
+  owner: string;
+  active: boolean;
+  accessPolicy: ContextGraphAuthorityState['accessPolicy'];
+  participantAgents: readonly string[];
+}> & ContextGraphPublishDomainV1;
 
 export interface EvmContextGraphAuthoritySourceResult {
-  readonly current: EvmContextGraphCurrentAuthorityState;
-  readonly generation: EvmContextGraphAuthorityGeneration;
+  readonly state: ContextGraphAuthorityState;
   /** Final cross-read fence or legacy checkpoint publication. */
   stabilize(): Promise<void>;
 }
@@ -54,14 +54,6 @@ function tupleField(value: unknown, name: string, index: number): unknown {
   const named = (value as Record<string, unknown>)[name];
   if (named !== undefined) return named;
   return Array.isArray(value) ? value[index] : undefined;
-}
-
-function normalizePolicy(value: unknown, label: string): number {
-  const policy = Number(BigInt(value as ethers.BigNumberish));
-  if (!Number.isSafeInteger(policy) || policy < 0) {
-    throw new Error(`Context Graph ${label} is invalid`);
-  }
-  return policy;
 }
 
 /** Normalize the ethers named tuple once, at the reader boundary. */
@@ -89,13 +81,21 @@ export function normalizeEvmContextGraphCurrentAuthorityState(
   if (accountId < 0n || accountId > ethers.MaxUint256) {
     throw new Error('Context Graph publish authority account id is invalid');
   }
+  const accessPolicy = normalizeContextGraphAuthorityAccessPolicy(
+    Number(BigInt(tupleField(value, 'accessPolicy', 5) as ethers.BigNumberish)),
+  );
+  if (accessPolicy === undefined) throw new Error('Context Graph access policy is invalid');
+  const publishDomain = normalizeContextGraphAuthorityPublishDomain(
+    Number(BigInt(tupleField(value, 'publishPolicy', 6) as ethers.BigNumberish)),
+    authority,
+    accountId,
+  );
+  if (publishDomain === undefined) throw new Error('Context Graph publish policy is invalid');
   return Object.freeze({
     owner,
     active: Boolean(tupleField(value, 'active', 3)),
-    accessPolicy: normalizePolicy(tupleField(value, 'accessPolicy', 5), 'access policy'),
-    publishPolicy: normalizePolicy(tupleField(value, 'publishPolicy', 6), 'publish policy'),
-    publishAuthority: authority === ethers.ZeroAddress ? null : authority,
-    publishAuthorityAccountId: accountId.toString(10),
+    accessPolicy,
+    ...publishDomain,
     participantAgents: Object.freeze(participantAgents),
   });
 }
@@ -107,16 +107,7 @@ export async function resolveEvmContextGraphAuthoritySource(
   if (source.kind === 'indexed') {
     const indexed = await source.readSnapshot();
     return Object.freeze({
-      current: Object.freeze({
-        owner: indexed.owner,
-        active: indexed.active,
-        accessPolicy: indexed.accessPolicy,
-        publishPolicy: indexed.publishPolicy,
-        publishAuthority: indexed.publishAuthority,
-        publishAuthorityAccountId: indexed.publishAuthorityAccountId,
-        participantAgents: indexed.participantAgents,
-      }),
-      generation: indexed,
+      state: indexed,
       stabilize: source.stabilize,
     });
   }
@@ -124,9 +115,14 @@ export async function resolveEvmContextGraphAuthoritySource(
     source.readCurrent(),
     source.readHistory(),
   ]);
+  const { throughBlockNumber: _number, throughBlockHash: _hash, ...generation } =
+    history.state;
   return Object.freeze({
-    current: normalizeEvmContextGraphCurrentAuthorityState(rawCurrent),
-    generation: history.state,
+    state: Object.freeze(Object.assign(
+      {},
+      normalizeEvmContextGraphCurrentAuthorityState(rawCurrent),
+      generation,
+    )),
     stabilize: history.publish,
   });
 }
@@ -154,7 +150,18 @@ export function normalizeContextGraphAuthorityIndexLog(
     index: log.index,
   };
   switch (parsed.name) {
-    case 'ContextGraphCreated':
+    case 'ContextGraphCreated': {
+      const accessPolicy = normalizeContextGraphAuthorityAccessPolicy(
+        Number(BigInt(parsed.args.accessPolicy ?? parsed.args[5])),
+      );
+      const publishDomain = normalizeContextGraphAuthorityPublishDomain(
+        Number(BigInt(parsed.args.publishPolicy ?? parsed.args[6])),
+        String(parsed.args.publishAuthority ?? parsed.args[7]),
+        BigInt(parsed.args.publishAuthorityAccountId ?? parsed.args[8]),
+      );
+      if (accessPolicy === undefined || publishDomain === undefined) {
+        throw new Error('ContextGraphStorage returned an invalid creation authority domain');
+      }
       return {
         ...base,
         name: parsed.name,
@@ -164,13 +171,10 @@ export function normalizeContextGraphAuthorityIndexLog(
         participantAgents: [
           ...(parsed.args.participantAgents ?? parsed.args[3]),
         ].map((address) => String(address)),
-        accessPolicy: Number(BigInt(parsed.args.accessPolicy ?? parsed.args[5])),
-        publishPolicy: Number(BigInt(parsed.args.publishPolicy ?? parsed.args[6])),
-        publishAuthority: String(parsed.args.publishAuthority ?? parsed.args[7]),
-        publishAuthorityAccountId: BigInt(
-          parsed.args.publishAuthorityAccountId ?? parsed.args[8],
-        ),
+        accessPolicy,
+        ...publishDomain,
       };
+    }
     case 'Transfer':
       return {
         ...base,
@@ -179,27 +183,37 @@ export function normalizeContextGraphAuthorityIndexLog(
         from: String(parsed.args.from ?? parsed.args[0]),
         to: String(parsed.args.to ?? parsed.args[1]),
       };
-    case 'PublishPolicyUpdated':
+    case 'PublishPolicyUpdated': {
+      const publishDomain = normalizeContextGraphAuthorityPublishDomain(
+        Number(BigInt(parsed.args.publishPolicy ?? parsed.args[1])),
+        String(parsed.args.publishAuthority ?? parsed.args[2]),
+        BigInt(parsed.args.publishAuthorityAccountId ?? parsed.args[3]),
+      );
+      if (publishDomain === undefined) {
+        throw new Error('ContextGraphStorage returned an invalid publish-policy domain');
+      }
       return {
         ...base,
         name: parsed.name,
         contextGraphId: BigInt(parsed.args.contextGraphId ?? parsed.args[0]),
-        publishPolicy: Number(BigInt(parsed.args.publishPolicy ?? parsed.args[1])),
-        publishAuthority: String(parsed.args.publishAuthority ?? parsed.args[2]),
-        publishAuthorityAccountId: BigInt(
-          parsed.args.publishAuthorityAccountId ?? parsed.args[3],
-        ),
+        ...publishDomain,
       };
-    case 'PublishAuthorityUpdated':
+    }
+    case 'PublishAuthorityUpdated': {
+      const publishReference = normalizeContextGraphAuthorityPublishReference(
+        String(parsed.args.newAuthority ?? parsed.args[1]),
+        BigInt(parsed.args.newAuthorityAccountId ?? parsed.args[2]),
+      );
+      if (publishReference === undefined) {
+        throw new Error('ContextGraphStorage returned an invalid publish-authority reference');
+      }
       return {
         ...base,
         name: parsed.name,
         contextGraphId: BigInt(parsed.args.contextGraphId ?? parsed.args[0]),
-        publishAuthority: String(parsed.args.newAuthority ?? parsed.args[1]),
-        publishAuthorityAccountId: BigInt(
-          parsed.args.newAuthorityAccountId ?? parsed.args[2],
-        ),
+        ...publishReference,
       };
+    }
     case 'AgentParticipantAdded':
     case 'AgentParticipantRemoved':
       return {

--- a/packages/chain/test/context-graph-authority-index-reducer.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-index-reducer.unit.test.ts
@@ -91,6 +91,13 @@ const validCursor = Object.freeze({
 
 const validState = Object.freeze({
   contextGraphId: '9',
+  owner: OWNER,
+  active: true,
+  accessPolicy: 1 as const,
+  publishPolicy: 0 as const,
+  publishAuthority: AUTHORITY,
+  publishAuthorityAccountId: '7',
+  participantAgents: Object.freeze([OWNER]),
   nameHash: NAME_9,
   ownershipEra: 0,
   policyVersion: 0,

--- a/packages/chain/test/context-graph-authority-index-reducer.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-index-reducer.unit.test.ts
@@ -15,7 +15,10 @@ import {
   reduceContextGraphAuthorityIndexPage,
   type ContextGraphAuthorityIndexEvent,
 } from '../src/context-graph-authority-index-reducer.js';
-import { applyContextGraphAuthorityGenerationEvent } from '../src/context-graph-authority-generation.js';
+import {
+  applyContextGraphAuthorityStateEvent,
+  type ContextGraphAuthorityIndexState,
+} from '../src/context-graph-authority-state.js';
 
 const ZERO = `0x${'0'.repeat(40)}`;
 const OWNER = `0x${'11'.repeat(20)}`;
@@ -503,18 +506,29 @@ describe('contract-wide Context Graph authority index reducer', () => {
       .toBeUndefined();
   });
 
-  it('rejects counter overflow before a checkpoint can be emitted', () => {
-    expect(() => applyContextGraphAuthorityGenerationEvent({
-      nameHash: NAME_9,
-      ownershipEra: 0,
-      policyVersion: Number.MAX_SAFE_INTEGER,
-      rosterVersion: 0,
-      sourceBlockNumber: 10,
-      sourceBlockHash: blockHash(10),
-    }, {
-      name: 'PublishPolicyUpdated',
-      blockNumber: 22,
-      blockHash: blockHash(22),
-    }, 'Context Graph 9')).toThrow('safe integer range');
+  it.each([
+    ['ownership', 'ownershipEra', event('Transfer', 9n, 22, 0, {
+      from: OWNER, to: NEXT_OWNER,
+    })],
+    ['policy', 'policyVersion', event('PublishAuthorityUpdated', 9n, 22, 0)],
+    ['roster', 'rosterVersion', event('AgentParticipantAdded', 9n, 22, 0)],
+  ] as const)('rejects %s counter overflow in the production state transition', (
+    _label,
+    field,
+    transition,
+  ) => {
+    const initial = reduceContextGraphAuthorityIndexPage({
+      deploymentBlockNumber: 10,
+      throughBlockNumber: 10,
+      throughBlockHash: blockHash(10),
+      events: [creation(9n, 10, 1, NAME_9)],
+    }).checkpoint.states[0]!;
+    const overflowing = {
+      ...initial,
+      [field]: Number.MAX_SAFE_INTEGER,
+    } as ContextGraphAuthorityIndexState;
+
+    expect(() => applyContextGraphAuthorityStateEvent(overflowing, transition))
+      .toThrow('safe integer range');
   });
 });

--- a/packages/chain/test/context-graph-authority-index-reducer.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-index-reducer.unit.test.ts
@@ -20,6 +20,7 @@ import { applyContextGraphAuthorityGenerationEvent } from '../src/context-graph-
 const ZERO = `0x${'0'.repeat(40)}`;
 const OWNER = `0x${'11'.repeat(20)}`;
 const NEXT_OWNER = `0x${'22'.repeat(20)}`;
+const AUTHORITY = `0x${'33'.repeat(20)}`;
 const NAME_9 = `0x${'99'.repeat(32)}`;
 const NAME_10 = `0x${'aa'.repeat(32)}`;
 
@@ -32,12 +33,31 @@ function event(
   index: number,
   extra: Record<string, unknown> = {},
 ): ContextGraphAuthorityIndexEvent {
+  const defaults: Record<string, unknown> = (() => {
+    switch (name) {
+      case 'PublishPolicyUpdated':
+        return {
+          publishPolicy: 0,
+          publishAuthority: NEXT_OWNER,
+          publishAuthorityAccountId: 0n,
+        };
+      case 'PublishAuthorityUpdated':
+        return { publishAuthority: NEXT_OWNER, publishAuthorityAccountId: 0n };
+      case 'AgentParticipantAdded':
+        return { agent: NEXT_OWNER };
+      case 'AgentParticipantRemoved':
+        return { agent: OWNER };
+      default:
+        return {};
+    }
+  })();
   return {
     name,
     contextGraphId,
     blockNumber,
     blockHash: blockHash(blockNumber),
     index,
+    ...defaults,
     ...extra,
   } as ContextGraphAuthorityIndexEvent;
 }
@@ -48,7 +68,15 @@ function creation(
   index: number,
   nameHash: string,
 ): ContextGraphAuthorityIndexEvent {
-  return event('ContextGraphCreated', contextGraphId, blockNumber, index, { nameHash });
+  return event('ContextGraphCreated', contextGraphId, blockNumber, index, {
+    owner: OWNER,
+    nameHash,
+    participantAgents: [OWNER],
+    accessPolicy: 1,
+    publishPolicy: 0,
+    publishAuthority: AUTHORITY,
+    publishAuthorityAccountId: 7n,
+  });
 }
 
 const validCursor = Object.freeze({
@@ -94,6 +122,13 @@ describe('contract-wide Context Graph authority index reducer', () => {
     expect(result.checkpoint.states).toEqual([
       {
         contextGraphId: '9',
+        owner: NEXT_OWNER,
+        active: true,
+        accessPolicy: 1,
+        publishPolicy: 0,
+        publishAuthority: NEXT_OWNER,
+        publishAuthorityAccountId: '0',
+        participantAgents: [NEXT_OWNER],
         nameHash: NAME_9,
         ownershipEra: 1,
         policyVersion: 2,
@@ -103,6 +138,13 @@ describe('contract-wide Context Graph authority index reducer', () => {
       },
       {
         contextGraphId: '10',
+        owner: OWNER,
+        active: true,
+        accessPolicy: 1,
+        publishPolicy: 0,
+        publishAuthority: AUTHORITY,
+        publishAuthorityAccountId: '7',
+        participantAgents: [OWNER],
         nameHash: NAME_10,
         ownershipEra: 0,
         policyVersion: 0,
@@ -154,7 +196,17 @@ describe('contract-wide Context Graph authority index reducer', () => {
         PublishPolicyUpdated: [],
       })[name],
     });
-    const { contextGraphId: _, ...indexGeneration } = index;
+    const {
+      contextGraphId: _,
+      owner: _owner,
+      active: _active,
+      accessPolicy: _accessPolicy,
+      publishPolicy: _publishPolicy,
+      publishAuthority: _publishAuthority,
+      publishAuthorityAccountId: _publishAuthorityAccountId,
+      participantAgents: _participantAgents,
+      ...indexGeneration
+    } = index;
     const { throughBlockNumber: _number, throughBlockHash: _hash, ...legacyGeneration } =
       history.state;
     expect(indexGeneration).toEqual(legacyGeneration);
@@ -196,7 +248,45 @@ describe('contract-wide Context Graph authority index reducer', () => {
     expect(emptySuffix.checkpoint.cursor.stateCount).toBe(2);
   });
 
-  it('ignores mint, burn, and self-transfer logs', () => {
+  it('materializes every mutable authority field from ordered contract events', () => {
+    const result = reduceContextGraphAuthorityIndexPage({
+      deploymentBlockNumber: 10,
+      throughBlockNumber: 20,
+      throughBlockHash: blockHash(20),
+      events: [
+        creation(9n, 10, 1, NAME_9),
+        event('Transfer', 9n, 11, 0, { from: OWNER, to: NEXT_OWNER }),
+        event('PublishPolicyUpdated', 9n, 12, 0, {
+          publishPolicy: 1,
+          publishAuthority: ZERO,
+          publishAuthorityAccountId: 0n,
+        }),
+        event('AgentParticipantRemoved', 9n, 13, 0, { agent: OWNER }),
+        event('AgentParticipantAdded', 9n, 14, 0, { agent: AUTHORITY }),
+        event('ContextGraphDeactivated', 9n, 15, 0),
+      ],
+    });
+
+    expect(result.checkpoint.states[0]).toEqual({
+      contextGraphId: '9',
+      owner: NEXT_OWNER,
+      active: false,
+      accessPolicy: 1,
+      publishPolicy: 1,
+      publishAuthority: null,
+      publishAuthorityAccountId: '0',
+      participantAgents: [AUTHORITY],
+      nameHash: NAME_9,
+      ownershipEra: 1,
+      policyVersion: 2,
+      rosterVersion: 3,
+      sourceBlockNumber: 12,
+      sourceBlockHash: blockHash(12),
+    });
+    expect(Object.isFrozen(result.checkpoint.states[0]!.participantAgents)).toBe(true);
+  });
+
+  it('ignores mint and self-transfer logs but fails closed on an unexpected burn', () => {
     const result = reduceContextGraphAuthorityIndexPage({
       deploymentBlockNumber: 10,
       throughBlockNumber: 15,
@@ -205,7 +295,6 @@ describe('contract-wide Context Graph authority index reducer', () => {
         event('Transfer', 9n, 10, 0, { from: ZERO, to: OWNER }),
         creation(9n, 10, 1, NAME_9),
         event('Transfer', 9n, 11, 0, { from: OWNER, to: OWNER }),
-        event('Transfer', 9n, 12, 0, { from: OWNER, to: ZERO }),
       ],
     });
     expect(result.checkpoint.states[0]).toMatchObject({
@@ -214,6 +303,15 @@ describe('contract-wide Context Graph authority index reducer', () => {
       rosterVersion: 0,
       sourceBlockNumber: 10,
     });
+    expect(() => reduceContextGraphAuthorityIndexPage({
+      deploymentBlockNumber: 10,
+      throughBlockNumber: 15,
+      throughBlockHash: blockHash(15),
+      events: [
+        creation(9n, 10, 1, NAME_9),
+        event('Transfer', 9n, 12, 0, { from: OWNER, to: ZERO }),
+      ],
+    })).toThrow('cannot materialize a burned token');
   });
 
   it('fails closed on gaps, overlaps, deployment changes, and malformed prior state', () => {
@@ -314,6 +412,8 @@ describe('contract-wide Context Graph authority index reducer', () => {
       events: [creation(9n, 10, 1, NAME_9.toUpperCase().replace('0X', '0x'))],
     }).checkpoint;
     expect(normalizeContextGraphAuthorityIndexCheckpoint(valid)).toEqual(valid);
+    expect(normalizeContextGraphAuthorityIndexCheckpoint({ ...valid, version: 1 }))
+      .toBeUndefined();
     expect(normalizeContextGraphAuthorityIndexCheckpoint({
       ...valid,
       cursor: { ...valid.cursor, stateCount: 2 },
@@ -343,6 +443,26 @@ describe('contract-wide Context Graph authority index reducer', () => {
       ...valid,
       states: [{ ...valid.states[0], contextGraphId: (1n << 256n).toString(10) }],
     })).toBeUndefined();
+
+    const integrityMutations: ReadonlyArray<readonly [string, Record<string, unknown>]> = [
+      ['owner', { owner: NEXT_OWNER }],
+      ['active', { active: false }],
+      ['access policy', { accessPolicy: 0 }],
+      ['publish policy', {
+        publishPolicy: 1,
+        publishAuthority: null,
+        publishAuthorityAccountId: '0',
+      }],
+      ['publish authority', { publishAuthority: NEXT_OWNER }],
+      ['publish authority account id', { publishAuthorityAccountId: '8' }],
+      ['participant roster', { participantAgents: [OWNER, NEXT_OWNER] }],
+    ];
+    for (const [label, mutation] of integrityMutations) {
+      expect(normalizeContextGraphAuthorityIndexCheckpoint({
+        ...valid,
+        states: [{ ...valid.states[0], ...mutation }],
+      }), `${label} mutation must invalidate the unchanged integrity seal`).toBeUndefined();
+    }
   });
 
   it.each([

--- a/packages/chain/test/context-graph-authority-index-reducer.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-index-reducer.unit.test.ts
@@ -17,6 +17,7 @@ import {
 } from '../src/context-graph-authority-index-reducer.js';
 import {
   applyContextGraphAuthorityStateEvent,
+  normalizeContextGraphAuthorityPublishReference,
   type ContextGraphAuthorityIndexState,
 } from '../src/context-graph-authority-state.js';
 
@@ -501,6 +502,56 @@ describe('contract-wide Context Graph authority index reducer', () => {
       mutate(validState),
     );
     expect(normalizeContextGraphAuthorityIndexCheckpoint(malformed)).toBeUndefined();
+  });
+
+  it.each([
+    ['zero owner', { owner: ZERO }],
+    ['malformed owner', { owner: 'bad' }],
+    ['unsupported access policy', { accessPolicy: 2 }],
+    ['unsupported publish policy', { publishPolicy: 2 }],
+    ['curated domain without authority', {
+      publishPolicy: 0, publishAuthority: null, publishAuthorityAccountId: '0',
+    }],
+    ['open domain with authority', {
+      publishPolicy: 1, publishAuthority: AUTHORITY, publishAuthorityAccountId: '0',
+    }],
+    ['duplicate participants', { participantAgents: [OWNER, OWNER] }],
+    ['zero participant', { participantAgents: [ZERO] }],
+    ['malformed participant', { participantAgents: ['bad'] }],
+    ['over-limit participants', {
+      participantAgents: Array.from(
+        { length: 257 },
+        (_entry, index) => `0x${(index + 1).toString(16).padStart(40, '0')}`,
+      ),
+    }],
+  ] as const)('rejects sealed malformed materialized state: %s', (_label, mutation) => {
+    const malformed = createContextGraphAuthorityIndexCheckpoint(validCursor, [{
+      ...validState,
+      ...mutation,
+    } as ContextGraphAuthorityIndexState]);
+    expect(normalizeContextGraphAuthorityIndexCheckpoint(malformed)).toBeUndefined();
+  });
+
+  it.each([
+    ['canonical authority', AUTHORITY, 7n, {
+      publishAuthority: AUTHORITY, publishAuthorityAccountId: '7',
+    }],
+    ['null sentinel', null, '7', {
+      publishAuthority: null, publishAuthorityAccountId: '7',
+    }],
+    ['zero-address sentinel', ZERO, 7n, {
+      publishAuthority: null, publishAuthorityAccountId: '7',
+    }],
+    ['malformed authority', 'bad', 7n, undefined],
+    ['u256 overflow', AUTHORITY, 1n << 256n, undefined],
+  ] as const)('normalizes publish reference scalars: %s', (
+    _label,
+    authority,
+    accountId,
+    expected,
+  ) => {
+    expect(normalizeContextGraphAuthorityPublishReference(authority, accountId))
+      .toEqual(expected);
   });
 
   it('decodes opaque durable reads only at the chain-owned boundary', async () => {

--- a/packages/chain/test/context-graph-authority-index.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-index.unit.test.ts
@@ -11,6 +11,7 @@ import {
 
 const OWNER = `0x${'11'.repeat(20)}`;
 const NEXT_OWNER = `0x${'22'.repeat(20)}`;
+const AUTHORITY = `0x${'33'.repeat(20)}`;
 const NAME_9 = `0x${'99'.repeat(32)}`;
 const NAME_10 = `0x${'aa'.repeat(32)}`;
 
@@ -23,12 +24,31 @@ function event(
   index: number,
   extra: Record<string, unknown> = {},
 ): ContextGraphAuthorityIndexEvent {
+  const defaults: Record<string, unknown> = (() => {
+    switch (name) {
+      case 'PublishPolicyUpdated':
+        return {
+          publishPolicy: 0,
+          publishAuthority: NEXT_OWNER,
+          publishAuthorityAccountId: 0n,
+        };
+      case 'PublishAuthorityUpdated':
+        return { publishAuthority: NEXT_OWNER, publishAuthorityAccountId: 0n };
+      case 'AgentParticipantAdded':
+        return { agent: NEXT_OWNER };
+      case 'AgentParticipantRemoved':
+        return { agent: OWNER };
+      default:
+        return {};
+    }
+  })();
   return {
     name,
     contextGraphId,
     blockNumber,
     blockHash: blockHash(blockNumber),
     index,
+    ...defaults,
     ...extra,
   } as ContextGraphAuthorityIndexEvent;
 }
@@ -39,7 +59,15 @@ function creation(
   index: number,
   nameHash: string,
 ): ContextGraphAuthorityIndexEvent {
-  return event('ContextGraphCreated', contextGraphId, blockNumber, index, { nameHash });
+  return event('ContextGraphCreated', contextGraphId, blockNumber, index, {
+    owner: OWNER,
+    nameHash,
+    participantAgents: [OWNER],
+    accessPolicy: 1,
+    publishPolicy: 0,
+    publishAuthority: AUTHORITY,
+    publishAuthorityAccountId: 7n,
+  });
 }
 
 class MemoryAuthorityIndexStore implements ContextGraphAuthorityIndexStore {

--- a/packages/chain/test/context-graph-authority-snapshot.e2e.test.ts
+++ b/packages/chain/test/context-graph-authority-snapshot.e2e.test.ts
@@ -2,12 +2,14 @@
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { Contract, ethers, Wallet } from 'ethers';
+import { EVMChainAdapter } from '../src/evm-adapter.js';
+import type { ContextGraphAuthorityIndexStore } from '../src/context-graph-authority-index-checkpoint.js';
 
 import {
-  createEVMAdapter,
   createProvider,
   getSharedContext,
   HARDHAT_KEYS,
+  makeAdapterConfig,
   revertSnapshot,
   takeSnapshot,
 } from './evm-test-context.js';
@@ -23,9 +25,29 @@ describe('EVM Context Graph authority snapshot ABI integration', () => {
     await revertSnapshot(fileSnapshotId);
   });
 
-  it('reads current tuple and all authority event generations at finalized anchors', async () => {
-    const adapter = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+  it('materializes current authority and every generation from finalized events', async () => {
     const provider = createProvider();
+    const { rpcUrl, hubAddress } = getSharedContext();
+    let checkpoint: Readonly<{ token: number; value: unknown | null }> | undefined;
+    const store: ContextGraphAuthorityIndexStore = {
+      load: async () => checkpoint,
+      compareAndSwap: async (_scope, expectedToken, value) => {
+        if (checkpoint?.token !== expectedToken) return undefined;
+        const nextToken = expectedToken === undefined ? 1 : expectedToken + 1;
+        checkpoint = Object.freeze({ token: nextToken, value });
+        return nextToken;
+      },
+      invalidate: async (_scope, expectedToken) => {
+        if (checkpoint?.token !== expectedToken) return undefined;
+        const nextToken = expectedToken + 1;
+        checkpoint = Object.freeze({ token: nextToken, value: null });
+        return nextToken;
+      },
+    };
+    const adapter = new EVMChainAdapter({
+      ...makeAdapterConfig(rpcUrl, hubAddress, HARDHAT_KEYS.CORE_OP),
+      localContextGraphAuthorityIndexStore: store,
+    });
     const owner = adapter.getSignerAddress();
     const retainedAgent = new Wallet(HARDHAT_KEYS.EXTRA1).address;
     const removedAgent = new Wallet(HARDHAT_KEYS.EXTRA2).address;
@@ -208,5 +230,24 @@ describe('EVM Context Graph authority snapshot ABI integration', () => {
     expect(finalized?.hash).toBe(transferReceipt.blockHash);
     expect(BigInt(afterTransfer.sourceBlockNumber))
       .toBeLessThanOrEqual(BigInt(finalized!.number));
+
+    const deactivator = new Contract(
+      await hub.getAssetStorageAddress('ContextGraphStorage'),
+      ['function deactivateContextGraph(uint256 contextGraphId) external'],
+      new Wallet(HARDHAT_KEYS.DEPLOYER, provider),
+    );
+    await (await deactivator.deactivateContextGraph(created.contextGraphId)).wait();
+    const afterDeactivation = await adapter.getContextGraphAuthoritySnapshot(
+      created.contextGraphId,
+    );
+    expect(afterDeactivation).toMatchObject({
+      active: false,
+      owner: newOwner.toLowerCase(),
+      ownershipEra: afterTransfer.ownershipEra,
+      policyVersion: afterTransfer.policyVersion,
+      rosterVersion: afterTransfer.rosterVersion,
+      sourceBlockNumber: afterTransfer.sourceBlockNumber,
+      sourceBlockHash: afterTransfer.sourceBlockHash,
+    });
   }, 120_000);
 });

--- a/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
@@ -55,7 +55,12 @@ interface EvmAuthorityHarness {
 }
 
 function makeEvmAuthorityAdapter(
-  options: { reorg?: boolean; providerRangeLimit?: number; sharedIndex?: boolean } = {},
+  options: {
+    reorg?: boolean;
+    providerRangeLimit?: number;
+    sharedIndex?: boolean;
+    deactivated?: boolean;
+  } = {},
 ): EvmAuthorityHarness {
   let authorityIndexRecord: Readonly<{ token: number; value: unknown | null }> | undefined;
   const authorityIndexStore = {
@@ -113,22 +118,37 @@ function makeEvmAuthorityAdapter(
     release: PromiseWithResolvers<void>;
   }> | undefined;
   const logs: Record<string, ReturnType<typeof event>[]> = {
-    ContextGraphCreated: [event(10, 1, CREATION_HASH, [9n, OWNER, NAME_HASH])],
+    ContextGraphCreated: [event(10, 1, CREATION_HASH, [
+      9n,
+      SECOND_MEMBER,
+      NAME_HASH,
+      [MEMBER, SECOND_MEMBER],
+      0n,
+      1n,
+      0n,
+      AUTHORITY,
+      7n,
+    ])],
+    ContextGraphDeactivated: options.deactivated
+      ? [event(24, 0, `0x${'bc'.repeat(32)}`, [9n])]
+      : [],
     Transfer: [
-      event(10, 0, CREATION_HASH, [ethers.ZeroAddress, OWNER, 9n]),
+      event(10, 0, CREATION_HASH, [ethers.ZeroAddress, SECOND_MEMBER, 9n]),
       event(15, 0, `0x${'99'.repeat(32)}`, [SECOND_MEMBER, OWNER, 9n]),
     ],
-    PublishPolicyUpdated: [event(20, 0, POLICY_HASH)],
-    PublishAuthorityUpdated: [event(21, 0, POLICY_HASH)],
-    AgentParticipantAdded: [event(22, 0, `0x${'aa'.repeat(32)}`)],
-    AgentParticipantRemoved: [event(23, 0, `0x${'bb'.repeat(32)}`)],
+    PublishPolicyUpdated: [event(20, 0, POLICY_HASH, [
+      9n, 0n, SECOND_AUTHORITY, 9n,
+    ])],
+    PublishAuthorityUpdated: [event(21, 0, POLICY_HASH, [9n, AUTHORITY, 7n])],
+    AgentParticipantAdded: [event(22, 0, `0x${'aa'.repeat(32)}`, [9n, OWNER])],
+    AgentParticipantRemoved: [event(23, 0, `0x${'bb'.repeat(32)}`, [9n, SECOND_MEMBER])],
   };
   const current = Object.assign(
-    [OWNER, [MEMBER, OWNER], 0n, true, 0n, 1n, 0n, AUTHORITY, 7n],
+    [OWNER, [MEMBER, OWNER], 0n, !options.deactivated, 0n, 1n, 0n, AUTHORITY, 7n],
     {
       owner: OWNER,
       participantAgents: [MEMBER, OWNER],
-      active: true,
+      active: !options.deactivated,
       accessPolicy: 1n,
       publishPolicy: 0n,
       publishAuthority: AUTHORITY,
@@ -235,8 +255,25 @@ function makeEvmAuthorityAdapter(
           index: 1,
           parsed: {
             name: 'ContextGraphCreated',
-            args: namedArgs([9n, OWNER, NAME_HASH], {
-              contextGraphId: 9n, owner: OWNER, nameHash: NAME_HASH,
+            args: namedArgs([
+              9n,
+              SECOND_MEMBER,
+              NAME_HASH,
+              [MEMBER, SECOND_MEMBER],
+              0n,
+              1n,
+              0n,
+              AUTHORITY,
+              7n,
+            ], {
+              contextGraphId: 9n,
+              owner: SECOND_MEMBER,
+              nameHash: NAME_HASH,
+              participantAgents: [MEMBER, SECOND_MEMBER],
+              accessPolicy: 1n,
+              publishPolicy: 0n,
+              publishAuthority: AUTHORITY,
+              publishAuthorityAccountId: 7n,
             }),
           },
         },
@@ -246,8 +283,8 @@ function makeEvmAuthorityAdapter(
           index: 0,
           parsed: {
             name: 'Transfer',
-            args: namedArgs([ethers.ZeroAddress, OWNER, 9n], {
-              from: ethers.ZeroAddress, to: OWNER, tokenId: 9n,
+            args: namedArgs([ethers.ZeroAddress, SECOND_MEMBER, 9n], {
+              from: ethers.ZeroAddress, to: SECOND_MEMBER, tokenId: 9n,
             }),
           },
         },
@@ -262,21 +299,68 @@ function makeEvmAuthorityAdapter(
             }),
           },
         },
+        {
+          blockNumber: 20,
+          blockHash: POLICY_HASH,
+          index: 0,
+          parsed: {
+            name: 'PublishPolicyUpdated',
+            args: namedArgs([9n, 0n, SECOND_AUTHORITY, 9n], {
+              contextGraphId: 9n,
+              publishPolicy: 0n,
+              publishAuthority: SECOND_AUTHORITY,
+              publishAuthorityAccountId: 9n,
+            }),
+          },
+        },
+        {
+          blockNumber: 21,
+          blockHash: POLICY_HASH,
+          index: 0,
+          parsed: {
+            name: 'PublishAuthorityUpdated',
+            args: namedArgs([9n, AUTHORITY, 7n], {
+              contextGraphId: 9n,
+              newAuthority: AUTHORITY,
+              newAuthorityAccountId: 7n,
+            }),
+          },
+        },
         ...[
-          ['PublishPolicyUpdated', 20, 0, POLICY_HASH],
-          ['PublishAuthorityUpdated', 21, 0, POLICY_HASH],
-          ['AgentParticipantAdded', 22, 0, `0x${'aa'.repeat(32)}`],
-          ['AgentParticipantRemoved', 23, 0, `0x${'bb'.repeat(32)}`],
-          ['PublishPolicyUpdated', 33, 0, NEXT_POLICY_HASH],
-        ].map(([name, blockNumber, index, hash]) => ({
+          ['AgentParticipantAdded', 22, `0x${'aa'.repeat(32)}`, OWNER],
+          ['AgentParticipantRemoved', 23, `0x${'bb'.repeat(32)}`, SECOND_MEMBER],
+        ].map(([name, blockNumber, hash, agent]) => ({
           blockNumber,
           blockHash: hash,
-          index,
+          index: 0,
           parsed: {
             name,
-            args: namedArgs([9n], { contextGraphId: 9n }),
+            args: namedArgs([9n, agent], { contextGraphId: 9n, agent }),
           },
         })),
+        ...(options.deactivated ? [{
+          blockNumber: 24,
+          blockHash: `0x${'bc'.repeat(32)}`,
+          index: 0,
+          parsed: {
+            name: 'ContextGraphDeactivated',
+            args: namedArgs([9n], { contextGraphId: 9n }),
+          },
+        }] : []),
+        {
+          blockNumber: 33,
+          blockHash: NEXT_POLICY_HASH,
+          index: 0,
+          parsed: {
+            name: 'PublishPolicyUpdated',
+            args: namedArgs([9n, 1n, ethers.ZeroAddress, 0n], {
+              contextGraphId: 9n,
+              publishPolicy: 1n,
+              publishAuthority: ethers.ZeroAddress,
+              publishAuthorityAccountId: 0n,
+            }),
+          },
+        },
       ].filter((entry) => (
         Number(entry.blockNumber) >= filter.fromBlock
         && Number(entry.blockNumber) <= filter.toBlock
@@ -308,6 +392,10 @@ function makeEvmAuthorityAdapter(
     logs.PublishPolicyUpdated.push(event(33, 0, NEXT_POLICY_HASH));
     current.publishPolicy = 1n;
     current[6] = 1n;
+    current.publishAuthority = ethers.ZeroAddress;
+    current[7] = ethers.ZeroAddress;
+    current.publishAuthorityAccountId = 0n;
+    current[8] = 0n;
   };
   const replaceCachedAnchor = () => {
     cachedAnchorReplaced = true;
@@ -359,6 +447,13 @@ describe('RFC-64 Context Graph authority snapshots', () => {
     const snapshot = await adapter.getContextGraphAuthoritySnapshot(9n);
     expect(snapshot).toMatchObject({
       contextGraphId: '9',
+      owner: OWNER,
+      active: true,
+      accessPolicy: 1,
+      publishPolicy: 0,
+      publishAuthority: AUTHORITY,
+      publishAuthorityAccountId: '7',
+      participantAgents: [OWNER, MEMBER],
       ownershipEra: '1',
       policyVersion: '3',
       rosterVersion: '3',
@@ -369,20 +464,22 @@ describe('RFC-64 Context Graph authority snapshots', () => {
     expect(evidence.filters).toEqual([]);
     expect(evidence.indexTopicSets).toEqual(Array(3).fill([
       'topic:ContextGraphCreated',
+      'topic:ContextGraphDeactivated',
       'topic:Transfer',
       'topic:PublishPolicyUpdated',
       'topic:PublishAuthorityUpdated',
       'topic:AgentParticipantAdded',
       'topic:AgentParticipantRemoved',
     ]));
+    expect(evidence.staticCalls).toEqual([]);
 
     await adapter.getContextGraphAuthoritySnapshot(9n);
     expect(evidence.indexRanges).toHaveLength(3);
+    expect(evidence.staticCalls).toEqual([]);
   });
 
   it.each([
     ['finalized head', (harness: EvmAuthorityHarness) => harness.holdBlockRead('finalized')],
-    ['current state', (harness: EvmAuthorityHarness) => harness.holdCurrentStateRead()],
     ['stabilization fence', (harness: EvmAuthorityHarness) => harness.holdBlockRead(30)],
   ] as const)('keeps caller cancellation bound during the indexed %s read', async (
     _stage,
@@ -486,36 +583,19 @@ describe('RFC-64 Context Graph authority snapshots', () => {
     expect(attempts).toEqual(['lagging', 'healthy']);
   });
 
-  it('fails over when a provider cannot supply an intermediate page anchor', async () => {
-    const { adapter, provider } = makeEvmAuthorityAdapter({ sharedIndex: true });
-    const attempts: string[] = [];
-    const nonArchive = {
-      ...provider,
-      getBlock: async (tag: string | number) => {
-        if (tag === 16) return null;
-        return (provider.getBlock as (block: string | number) => Promise<unknown>)(tag);
-      },
-    };
-    (adapter as any).readTipProvider = async (
-      _label: string,
-      read: (selected: typeof nonArchive) => Promise<unknown>,
-      options: Readonly<{ isRetryable?: (error: unknown) => boolean }>,
-    ) => {
-      try {
-        attempts.push('non-archive');
-        return await read(nonArchive);
-      } catch (error) {
-        expect(options.isRetryable?.(error)).toBe(true);
-        attempts.push('healthy');
-        return read(provider as typeof nonArchive);
-      }
-    };
+  it('materializes deactivation from the shared event index without a point read', async () => {
+    const { adapter, evidence } = makeEvmAuthorityAdapter({
+      sharedIndex: true,
+      deactivated: true,
+    });
 
     await expect(adapter.getContextGraphAuthoritySnapshot(9n)).resolves.toMatchObject({
       contextGraphId: '9',
-      policyVersion: '3',
+      active: false,
+      owner: OWNER,
+      participantAgents: [OWNER, MEMBER],
     });
-    expect(attempts).toEqual(['non-archive', 'healthy']);
+    expect(evidence.staticCalls).toEqual([]);
   });
 
   it('reads one stable finalized EVM generation and derives monotonic epochs', async () => {

--- a/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
@@ -807,10 +807,10 @@ describe('RFC-64 Context Graph authority snapshots', () => {
     harness.advanceAuthorityHead();
     harness.setPublishAuthorityAccountId('not-a-uint256');
     await expect(harness.adapter.getContextGraphAuthoritySnapshot(9n)).rejects.toThrow();
-    harness.setPublishAuthorityAccountId(7n);
+    harness.setPublishAuthorityAccountId(0n);
 
     await expect(harness.adapter.getContextGraphAuthoritySnapshot(9n)).resolves.toMatchObject({
-      publishAuthorityAccountId: '7',
+      publishAuthorityAccountId: '0',
       policyVersion: '4',
     });
     expect(harness.evidence.ranges.slice(18)).toEqual(Array(10).fill([31, 35]));

--- a/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
@@ -583,6 +583,38 @@ describe('RFC-64 Context Graph authority snapshots', () => {
     expect(attempts).toEqual(['lagging', 'healthy']);
   });
 
+  it('fails over when a provider cannot supply an intermediate page anchor', async () => {
+    const { adapter, provider } = makeEvmAuthorityAdapter({ sharedIndex: true });
+    const attempts: string[] = [];
+    const nonArchive = {
+      ...provider,
+      getBlock: async (tag: string | number) => {
+        if (tag === 16) return null;
+        return (provider.getBlock as (block: string | number) => Promise<unknown>)(tag);
+      },
+    };
+    (adapter as any).readTipProvider = async (
+      _label: string,
+      read: (selected: typeof nonArchive) => Promise<unknown>,
+      options: Readonly<{ isRetryable?: (error: unknown) => boolean }>,
+    ) => {
+      try {
+        attempts.push('non-archive');
+        return await read(nonArchive);
+      } catch (error) {
+        expect(options.isRetryable?.(error)).toBe(true);
+        attempts.push('healthy');
+        return read(provider as typeof nonArchive);
+      }
+    };
+
+    await expect(adapter.getContextGraphAuthoritySnapshot(9n)).resolves.toMatchObject({
+      contextGraphId: '9',
+      policyVersion: '3',
+    });
+    expect(attempts).toEqual(['non-archive', 'healthy']);
+  });
+
   it('materializes deactivation from the shared event index without a point read', async () => {
     const { adapter, evidence } = makeEvmAuthorityAdapter({
       sharedIndex: true,

--- a/packages/chain/test/evm-context-graph-authority-source.unit.test.ts
+++ b/packages/chain/test/evm-context-graph-authority-source.unit.test.ts
@@ -46,22 +46,40 @@ describe('ContextGraphStorage authority ABI source', () => {
     ['ContextGraphCreated', [
       9n, OWNER, NAME_HASH, [AGENT], 0n, 1, 0, AUTHORITY, 7n,
     ], {
-      name: 'ContextGraphCreated', contextGraphId: 9n, nameHash: NAME_HASH,
+      name: 'ContextGraphCreated',
+      contextGraphId: 9n,
+      owner: OWNER,
+      nameHash: NAME_HASH,
+      participantAgents: [AGENT],
+      accessPolicy: 1,
+      publishPolicy: 0,
+      publishAuthority: AUTHORITY,
+      publishAuthorityAccountId: '7',
     }],
     ['Transfer', [OWNER, NEXT_OWNER, 9n], {
       name: 'Transfer', contextGraphId: 9n, from: OWNER, to: NEXT_OWNER,
     }],
     ['PublishPolicyUpdated', [9n, 1, ethers.ZeroAddress, 0n], {
-      name: 'PublishPolicyUpdated', contextGraphId: 9n,
+      name: 'PublishPolicyUpdated',
+      contextGraphId: 9n,
+      publishPolicy: 1,
+      publishAuthority: null,
+      publishAuthorityAccountId: '0',
     }],
     ['PublishAuthorityUpdated', [9n, AUTHORITY, 7n], {
-      name: 'PublishAuthorityUpdated', contextGraphId: 9n,
+      name: 'PublishAuthorityUpdated',
+      contextGraphId: 9n,
+      publishAuthority: AUTHORITY,
+      publishAuthorityAccountId: '7',
     }],
     ['AgentParticipantAdded', [9n, AGENT], {
-      name: 'AgentParticipantAdded', contextGraphId: 9n,
+      name: 'AgentParticipantAdded', contextGraphId: 9n, agent: AGENT,
     }],
     ['AgentParticipantRemoved', [9n, AGENT], {
-      name: 'AgentParticipantRemoved', contextGraphId: 9n,
+      name: 'AgentParticipantRemoved', contextGraphId: 9n, agent: AGENT,
+    }],
+    ['ContextGraphDeactivated', [9n], {
+      name: 'ContextGraphDeactivated', contextGraphId: 9n,
     }],
   ] as const)('decodes a real %s log into the closed index event', (
     name,


### PR DESCRIPTION
## Summary

This is the M3 vertical slice of the RFC-64 authority-read optimization stack. It builds on #2554 and promotes the durable contract-wide authority index from generation counters to a complete finalized authority materialization.

The indexed daemon path now derives these fields from one ordered event stream:

- owner and active state
- access and publish policy
- publish authority and PCA account ID
- participant-agent roster
- name binding and the existing ownership/policy/roster generations

As a result, `getContextGraphAuthoritySnapshot()` no longer calls `ContextGraphStorage.getContextGraph()` once per Context Graph when the durable index is available. SDK consumers without the local store retain the existing direct-read path.

## User impact

RFC-64 catalog authority remains live and finalized-chain-backed while producing less recurring RPC traffic. Operators do not need to change configuration.

At a stable finalized head, the indexed authority path changes from approximately three point requests per Context Graph to two:

| Request | M2 | M3 |
| --- | ---: | ---: |
| Read finalized head | 1 | 1 |
| `getContextGraph` `eth_call` | 1 | 0 |
| Revalidate finalized anchor | 1 | 1 |
| Total point requests per CG refresh | 3 | 2 |

That is a deterministic **33.3% reduction inside the steady-state authority snapshot path**, plus removal of a comparatively expensive dynamic-array `eth_call`. It is not a claim of a 33.3% reduction in total node RPC usage; the whole-node result depends on graph count, refresh cadence, suffix scans, and unrelated chain workloads.

## Before and after

```mermaid
sequenceDiagram
    participant Loop as RFC-64 refresh loop
    participant Adapter as Chain adapter
    participant Index as Shared authority index
    participant RPC as RPC endpoint

    rect rgb(255, 245, 235)
        Note over Loop,RPC: M2
        Loop->>Adapter: refresh CG A
        Adapter->>RPC: finalized head
        par Current state
            Adapter->>RPC: eth_call getContextGraph(A)
        and Shared history
            Adapter->>Index: resolve(A, finalized)
            Index->>RPC: one shared event suffix scan if needed
        end
        Adapter->>RPC: revalidate finalized anchor
        Adapter-->>Loop: finalized authority snapshot
    end

    rect rgb(235, 250, 240)
        Note over Loop,RPC: M3
        Loop->>Adapter: refresh CG A
        Adapter->>RPC: finalized head
        Adapter->>Index: resolve(A, finalized)
        Index->>RPC: one shared event suffix scan if needed
        Index-->>Adapter: complete authority materialization
        Adapter->>RPC: revalidate finalized anchor
        Adapter-->>Loop: finalized authority snapshot
    end
```

## Event materialization

```mermaid
sequenceDiagram
    participant RPC as ContextGraphStorage logs
    participant Reducer as Ordered reducer
    participant Store as SQLite checkpoint CAS
    participant Reader as Snapshot reader

    RPC-->>Reducer: ContextGraphCreated(full initial authority)
    RPC-->>Reducer: Transfer / policy / authority / roster events
    RPC-->>Reducer: ContextGraphDeactivated
    Reducer->>Reducer: validate order, payloads, policy invariants
    Reducer->>Store: CAS checkpoint v2 after each complete page
    Store-->>Reader: owner + policy + roster + generations
    Reader->>Reader: freeze and expose canonical snapshot
```

One canonical full-state transition module consumes seven event signatures in chain order. The v2 checkpoint codec, pure page reducer, and durable scan coordinator remain separate modules:

1. `ContextGraphCreated`
2. `ContextGraphDeactivated`
3. `Transfer`
4. `PublishPolicyUpdated`
5. `PublishAuthorityUpdated`
6. `AgentParticipantAdded`
7. `AgentParticipantRemoved`

`ContextGraphCreated` is the complete initial state. Later events update only their owned fields. Participant addresses are normalized, deduplicated, bounded to the contract maximum, sorted, and deeply frozen. Deactivation changes liveness without inventing a new policy generation.

## Safety and failure behavior

- Reads remain pinned to a finalized block and revalidate that anchor before returning.
- Malformed IDs, addresses, policies, account IDs, event positions, and rosters fail closed. Parameterized integrity regressions mutate every newly persisted authority field without updating its seal.
- Legacy and indexed readers resolve through one typed source model; ethers tuple decoding and indexed-log decoding are isolated at that boundary.
- Impossible policy/authority combinations fail closed.
- Duplicate creation, pre-creation mutations, duplicate roster additions, unknown removals, and unexpected token burns fail closed.
- Page checkpoints remain integrity-protected and compare-and-swap persisted.
- Caller cancellation remains detached from a shared scan; adapter lifecycle invalidation still aborts owned transport.
- Provider lag, reorg detection, restart resume, and CAS-winner behavior are inherited from M2.

## Checkpoint migration

The authority-index checkpoint moves from version 1 to version 2 because it now contains complete authority state. A v1 checkpoint is rejected at the chain-owned codec boundary, conditionally invalidated with a non-repeating durable tombstone, and rebuilt from the deployment block. This produces one deliberate cold rebuild after rollout; subsequent restarts resume the v2 prefix normally.

The tradeoff is a larger opaque checkpoint and correspondingly larger SQLite CAS writes because participant rosters are now materialized locally. The contract bounds each roster at 256 addresses, and the index stores one canonical state per Context Graph.

## Compatibility

- No contract or ABI change.
- No daemon configuration change.
- No RPC-provider-specific behavior.
- The legacy per-CG reader remains available when no local authority-index store is wired.
- The previously exported combined policy-event type remains as a deprecated compatibility alias.

## Verification

- `pnpm --filter @origintrail-official/dkg-chain run build`
  - source typecheck passed
  - public type tests passed
- Focused authority tests: **102 passed**
- Real Hardhat/ABI authority integration: **1 passed**
- Repository lint passed with no new baseline or disabled-test findings
- `git diff --check` passed

The real-contract integration test runs the indexed path through creation, participant add/remove, authority rotation, policy rotation, self-transfer, ownership transfer, and authorized on-chain deactivation, asserting the complete finalized snapshot after each transition.

## Stack and follow-up

- Base: #2554 (M2 shared durable contract-wide scan)
- This PR: M3 full event-materialized authority snapshots
- Follow-up milestone: use index deltas to schedule refreshes only for changed Context Graphs while retaining periodic safety revalidation
