### PR TITLE
refactor(chain): complete authority index review follow-up

### DIFF
--- a/packages/chain/src/context-graph-authority-index-admission.ts
+++ b/packages/chain/src/context-graph-authority-index-admission.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ContextGraphAuthorityIndexCheckpoint } from
+  './context-graph-authority-index-checkpoint.js';
+import type { ContextGraphAuthorityIndexRepositoryRecord } from
+  './context-graph-authority-index-repository.js';
+
+export type ContextGraphAuthorityIndexAnchorObservation =
+  | Readonly<{ kind: 'unread' }>
+  | Readonly<{ kind: 'unavailable' }>
+  | Readonly<{ kind: 'available'; hash: string }>;
+
+export const UNREAD_CONTEXT_GRAPH_AUTHORITY_INDEX_ANCHOR:
+Readonly<ContextGraphAuthorityIndexAnchorObservation> = Object.freeze({ kind: 'unread' });
+
+export type ContextGraphAuthorityIndexAdmissionAction =
+  | Readonly<{
+      kind: 'accept';
+      checkpoint: ContextGraphAuthorityIndexCheckpoint;
+    }>
+  | Readonly<{
+      kind: 'rebuild';
+      reason: 'missing' | 'tombstone';
+    }>
+  | Readonly<{
+      kind: 'read-anchor';
+      blockNumber: number;
+    }>
+  | Readonly<{
+      kind: 'retry-provider';
+      reason: 'finalized-behind' | 'anchor-unavailable';
+      cursorBlockNumber: number;
+      finalizedBlockNumber: number;
+    }>
+  | Readonly<{
+      kind: 'invalidate';
+      reason: 'invalid-checkpoint' | 'deployment-changed' | 'anchor-replaced';
+    }>;
+
+export interface ContextGraphAuthorityIndexAdmissionInput {
+  readonly record: ContextGraphAuthorityIndexRepositoryRecord;
+  readonly deploymentBlockNumber: number;
+  readonly finalized: Readonly<{ number: number; hash: string }>;
+  readonly anchor: ContextGraphAuthorityIndexAnchorObservation;
+}
+
+/**
+ * Pure admission policy for one durable authority-index observation.
+ *
+ * The result names exactly one effect for the bounded driver to perform. It
+ * never reads RPC, decodes persistence, mutates cache state, or performs CAS.
+ */
+export function classifyContextGraphAuthorityIndexAdmission(
+  input: Readonly<ContextGraphAuthorityIndexAdmissionInput>,
+): ContextGraphAuthorityIndexAdmissionAction {
+  const { record, deploymentBlockNumber, finalized, anchor } = input;
+  if (record.kind === 'missing' || record.kind === 'tombstone') {
+    return Object.freeze({ kind: 'rebuild', reason: record.kind });
+  }
+  if (record.kind === 'invalid') {
+    return Object.freeze({ kind: 'invalidate', reason: 'invalid-checkpoint' });
+  }
+
+  const checkpoint = record.checkpoint;
+  if (checkpoint.cursor.deploymentBlockNumber !== deploymentBlockNumber) {
+    return Object.freeze({ kind: 'invalidate', reason: 'deployment-changed' });
+  }
+  if (checkpoint.cursor.throughBlockNumber > finalized.number) {
+    return Object.freeze({
+      kind: 'retry-provider',
+      reason: 'finalized-behind',
+      cursorBlockNumber: checkpoint.cursor.throughBlockNumber,
+      finalizedBlockNumber: finalized.number,
+    });
+  }
+
+  if (checkpoint.cursor.throughBlockNumber === finalized.number) {
+    return checkpoint.cursor.throughBlockHash === finalized.hash
+      ? Object.freeze({ kind: 'accept', checkpoint })
+      : Object.freeze({ kind: 'invalidate', reason: 'anchor-replaced' });
+  }
+  if (anchor.kind === 'unread') {
+    return Object.freeze({
+      kind: 'read-anchor',
+      blockNumber: checkpoint.cursor.throughBlockNumber,
+    });
+  }
+  if (anchor.kind === 'unavailable') {
+    return Object.freeze({
+      kind: 'retry-provider',
+      reason: 'anchor-unavailable',
+      cursorBlockNumber: checkpoint.cursor.throughBlockNumber,
+      finalizedBlockNumber: finalized.number,
+    });
+  }
+  return anchor.hash === checkpoint.cursor.throughBlockHash
+    ? Object.freeze({ kind: 'accept', checkpoint })
+    : Object.freeze({ kind: 'invalidate', reason: 'anchor-replaced' });
+}

--- a/packages/chain/src/context-graph-authority-index-admission.ts
+++ b/packages/chain/src/context-graph-authority-index-admission.ts
@@ -1,99 +1,92 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ContextGraphAuthorityIndexCheckpoint } from
-  './context-graph-authority-index-checkpoint.js';
-import type { ContextGraphAuthorityIndexRepositoryRecord } from
-  './context-graph-authority-index-repository.js';
+import { normalizeContextGraphAuthorityHash as normalizeHash } from
+  './context-graph-authority-generation.js';
+import {
+  ContextGraphAuthorityIndexRepository,
+  type ContextGraphAuthorityIndexRepositoryRecord,
+} from './context-graph-authority-index-repository.js';
 
-export type ContextGraphAuthorityIndexAnchorObservation =
-  | Readonly<{ kind: 'unread' }>
-  | Readonly<{ kind: 'unavailable' }>
-  | Readonly<{ kind: 'available'; hash: string }>;
+const MAX_CONTEXT_GRAPH_AUTHORITY_INDEX_LOST_INVALIDATIONS = 3;
 
-export const UNREAD_CONTEXT_GRAPH_AUTHORITY_INDEX_ANCHOR:
-Readonly<ContextGraphAuthorityIndexAnchorObservation> = Object.freeze({ kind: 'unread' });
+export class ContextGraphAuthorityIndexRetryableError extends Error {
+  override readonly name = 'ContextGraphAuthorityIndexRetryableError';
+}
 
-export type ContextGraphAuthorityIndexAdmissionAction =
-  | Readonly<{
-      kind: 'accept';
-      checkpoint: ContextGraphAuthorityIndexCheckpoint;
-    }>
-  | Readonly<{
-      kind: 'rebuild';
-      reason: 'missing' | 'tombstone';
-    }>
-  | Readonly<{
-      kind: 'read-anchor';
-      blockNumber: number;
-    }>
-  | Readonly<{
-      kind: 'retry-provider';
-      reason: 'finalized-behind' | 'anchor-unavailable';
-      cursorBlockNumber: number;
-      finalizedBlockNumber: number;
-    }>
-  | Readonly<{
-      kind: 'invalidate';
-      reason: 'invalid-checkpoint' | 'deployment-changed' | 'anchor-replaced';
-    }>;
+export function isContextGraphAuthorityIndexRetryableError(
+  error: unknown,
+): error is ContextGraphAuthorityIndexRetryableError {
+  return error instanceof ContextGraphAuthorityIndexRetryableError;
+}
+
+function retryableAuthorityIndexReadError(message: string): Error {
+  return new ContextGraphAuthorityIndexRetryableError(message);
+}
 
 export interface ContextGraphAuthorityIndexAdmissionInput {
-  readonly record: ContextGraphAuthorityIndexRepositoryRecord;
+  readonly repository: ContextGraphAuthorityIndexRepository;
+  readonly scope: string;
+  readonly initial: ContextGraphAuthorityIndexRepositoryRecord;
   readonly deploymentBlockNumber: number;
   readonly finalized: Readonly<{ number: number; hash: string }>;
-  readonly anchor: ContextGraphAuthorityIndexAnchorObservation;
+  readonly lifecycleSignal: AbortSignal;
+  readonly readBlockHash: (
+    blockNumber: number,
+    lifecycleSignal: AbortSignal,
+  ) => Promise<string | null>;
 }
 
 /**
- * Pure admission policy for one durable authority-index observation.
+ * Admit one durable observation through a direct, bounded recovery loop.
  *
- * The result names exactly one effect for the bounded driver to perform. It
- * never reads RPC, decodes persistence, mutates cache state, or performs CAS.
+ * Missing rows and tombstones rebuild immediately. Every rejected token gets
+ * one conditional invalidation; when another writer wins, its row is reloaded
+ * by the repository and classified here. Three lost invalidations therefore
+ * permit three winner reloads, but a fourth invalidation is never attempted.
  */
-export function classifyContextGraphAuthorityIndexAdmission(
+export async function admitContextGraphAuthorityIndexCheckpoint(
   input: Readonly<ContextGraphAuthorityIndexAdmissionInput>,
-): ContextGraphAuthorityIndexAdmissionAction {
-  const { record, deploymentBlockNumber, finalized, anchor } = input;
-  if (record.kind === 'missing' || record.kind === 'tombstone') {
-    return Object.freeze({ kind: 'rebuild', reason: record.kind });
-  }
-  if (record.kind === 'invalid') {
-    return Object.freeze({ kind: 'invalidate', reason: 'invalid-checkpoint' });
-  }
+): Promise<ContextGraphAuthorityIndexRepositoryRecord> {
+  let record = input.initial;
+  let lostInvalidations = 0;
 
-  const checkpoint = record.checkpoint;
-  if (checkpoint.cursor.deploymentBlockNumber !== deploymentBlockNumber) {
-    return Object.freeze({ kind: 'invalidate', reason: 'deployment-changed' });
-  }
-  if (checkpoint.cursor.throughBlockNumber > finalized.number) {
-    return Object.freeze({
-      kind: 'retry-provider',
-      reason: 'finalized-behind',
-      cursorBlockNumber: checkpoint.cursor.throughBlockNumber,
-      finalizedBlockNumber: finalized.number,
-    });
-  }
+  for (;;) {
+    input.lifecycleSignal.throwIfAborted();
+    if (record.kind === 'missing' || record.kind === 'tombstone') return record;
 
-  if (checkpoint.cursor.throughBlockNumber === finalized.number) {
-    return checkpoint.cursor.throughBlockHash === finalized.hash
-      ? Object.freeze({ kind: 'accept', checkpoint })
-      : Object.freeze({ kind: 'invalidate', reason: 'anchor-replaced' });
+    if (record.kind === 'checkpoint') {
+      const checkpoint = record.checkpoint;
+      if (checkpoint.cursor.deploymentBlockNumber === input.deploymentBlockNumber) {
+        if (checkpoint.cursor.throughBlockNumber > input.finalized.number) {
+          throw retryableAuthorityIndexReadError(
+            `Context Graph authority index finalized head ${input.finalized.number} is behind `
+            + `durable cursor ${checkpoint.cursor.throughBlockNumber}`,
+          );
+        }
+        const anchorHash = checkpoint.cursor.throughBlockNumber === input.finalized.number
+          ? input.finalized.hash
+          : normalizeHash(await input.readBlockHash(
+              checkpoint.cursor.throughBlockNumber,
+              input.lifecycleSignal,
+            ));
+        if (anchorHash === undefined) {
+          throw retryableAuthorityIndexReadError(
+            `Context Graph authority index anchor ${checkpoint.cursor.throughBlockNumber} `
+            + 'is unavailable',
+          );
+        }
+        if (anchorHash === checkpoint.cursor.throughBlockHash) return record;
+      }
+    }
+
+    if (lostInvalidations >= MAX_CONTEXT_GRAPH_AUTHORITY_INDEX_LOST_INVALIDATIONS) {
+      throw retryableAuthorityIndexReadError(
+        'Context Graph authority index changed repeatedly during checkpoint recovery',
+      );
+    }
+    const recovery = await input.repository.invalidateOrReloadWinner(input.scope, record);
+    if (recovery.kind === 'invalidated') return recovery.record;
+    lostInvalidations += 1;
+    record = recovery.record;
   }
-  if (anchor.kind === 'unread') {
-    return Object.freeze({
-      kind: 'read-anchor',
-      blockNumber: checkpoint.cursor.throughBlockNumber,
-    });
-  }
-  if (anchor.kind === 'unavailable') {
-    return Object.freeze({
-      kind: 'retry-provider',
-      reason: 'anchor-unavailable',
-      cursorBlockNumber: checkpoint.cursor.throughBlockNumber,
-      finalizedBlockNumber: finalized.number,
-    });
-  }
-  return anchor.hash === checkpoint.cursor.throughBlockHash
-    ? Object.freeze({ kind: 'accept', checkpoint })
-    : Object.freeze({ kind: 'invalidate', reason: 'anchor-replaced' });
 }

--- a/packages/chain/src/context-graph-authority-index-admission.ts
+++ b/packages/chain/src/context-graph-authority-index-admission.ts
@@ -3,29 +3,16 @@
 import { normalizeContextGraphAuthorityHash as normalizeHash } from
   './context-graph-authority-generation.js';
 import {
-  ContextGraphAuthorityIndexRepository,
+  type ContextGraphAuthorityIndexScopedRepository,
   type ContextGraphAuthorityIndexRepositoryRecord,
 } from './context-graph-authority-index-repository.js';
+import { ContextGraphAuthorityIndexRetryableError } from
+  './context-graph-authority-index-errors.js';
 
 const MAX_CONTEXT_GRAPH_AUTHORITY_INDEX_LOST_INVALIDATIONS = 3;
 
-export class ContextGraphAuthorityIndexRetryableError extends Error {
-  override readonly name = 'ContextGraphAuthorityIndexRetryableError';
-}
-
-export function isContextGraphAuthorityIndexRetryableError(
-  error: unknown,
-): error is ContextGraphAuthorityIndexRetryableError {
-  return error instanceof ContextGraphAuthorityIndexRetryableError;
-}
-
-function retryableAuthorityIndexReadError(message: string): Error {
-  return new ContextGraphAuthorityIndexRetryableError(message);
-}
-
 export interface ContextGraphAuthorityIndexAdmissionInput {
-  readonly repository: ContextGraphAuthorityIndexRepository;
-  readonly scope: string;
+  readonly repository: ContextGraphAuthorityIndexScopedRepository;
   readonly initial: ContextGraphAuthorityIndexRepositoryRecord;
   readonly deploymentBlockNumber: number;
   readonly finalized: Readonly<{ number: number; hash: string }>;
@@ -58,7 +45,7 @@ export async function admitContextGraphAuthorityIndexCheckpoint(
       const checkpoint = record.checkpoint;
       if (checkpoint.cursor.deploymentBlockNumber === input.deploymentBlockNumber) {
         if (checkpoint.cursor.throughBlockNumber > input.finalized.number) {
-          throw retryableAuthorityIndexReadError(
+          throw new ContextGraphAuthorityIndexRetryableError(
             `Context Graph authority index finalized head ${input.finalized.number} is behind `
             + `durable cursor ${checkpoint.cursor.throughBlockNumber}`,
           );
@@ -70,7 +57,7 @@ export async function admitContextGraphAuthorityIndexCheckpoint(
               input.lifecycleSignal,
             ));
         if (anchorHash === undefined) {
-          throw retryableAuthorityIndexReadError(
+          throw new ContextGraphAuthorityIndexRetryableError(
             `Context Graph authority index anchor ${checkpoint.cursor.throughBlockNumber} `
             + 'is unavailable',
           );
@@ -80,11 +67,11 @@ export async function admitContextGraphAuthorityIndexCheckpoint(
     }
 
     if (lostInvalidations >= MAX_CONTEXT_GRAPH_AUTHORITY_INDEX_LOST_INVALIDATIONS) {
-      throw retryableAuthorityIndexReadError(
+      throw new ContextGraphAuthorityIndexRetryableError(
         'Context Graph authority index changed repeatedly during checkpoint recovery',
       );
     }
-    const recovery = await input.repository.invalidateOrReloadWinner(input.scope, record);
+    const recovery = await input.repository.invalidateOrReloadWinner(record);
     if (recovery.kind === 'invalidated') return recovery.record;
     lostInvalidations += 1;
     record = recovery.record;

--- a/packages/chain/src/context-graph-authority-index-errors.ts
+++ b/packages/chain/src/context-graph-authority-index-errors.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/** Retryable authority-index failure that may succeed on another RPC reader. */
+export class ContextGraphAuthorityIndexRetryableError extends Error {
+  override readonly name = 'ContextGraphAuthorityIndexRetryableError';
+}
+
+export function isContextGraphAuthorityIndexRetryableError(
+  error: unknown,
+): error is ContextGraphAuthorityIndexRetryableError {
+  return error instanceof ContextGraphAuthorityIndexRetryableError;
+}

--- a/packages/chain/src/context-graph-authority-index-repository.ts
+++ b/packages/chain/src/context-graph-authority-index-repository.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  normalizeContextGraphAuthorityIndexCheckpoint,
+  type ContextGraphAuthorityIndexCheckpoint,
+  type ContextGraphAuthorityIndexStore,
+} from './context-graph-authority-index-checkpoint.js';
+
+export type ContextGraphAuthorityIndexRepositoryRecord =
+  | Readonly<{ kind: 'missing'; token: undefined }>
+  | Readonly<{ kind: 'tombstone'; token: number }>
+  | Readonly<{ kind: 'invalid'; token: number }>
+  | Readonly<{
+      kind: 'checkpoint';
+      token: number;
+      checkpoint: ContextGraphAuthorityIndexCheckpoint;
+    }>;
+
+type CacheableAuthorityIndexRecord = Exclude<
+  ContextGraphAuthorityIndexRepositoryRecord,
+  Readonly<{ kind: 'missing'; token: undefined }> | Readonly<{ kind: 'invalid'; token: number }>
+>;
+
+function assertAuthorityIndexToken(value: unknown): asserts value is number {
+  if (!Number.isSafeInteger(value) || Number(value) < 1) {
+    throw new Error('Context Graph authority index durable token is invalid');
+  }
+}
+
+/** Decode, cache and mutate opaque durable rows behind one CAS repository boundary. */
+export class ContextGraphAuthorityIndexRepository {
+  readonly #entries = new Map<string, CacheableAuthorityIndexRecord>();
+  #epoch = 0;
+
+  constructor(readonly store: ContextGraphAuthorityIndexStore) {}
+
+  get epoch(): number {
+    return this.#epoch;
+  }
+
+  clear(): void {
+    this.#epoch += 1;
+    this.#entries.clear();
+  }
+
+  async load(
+    scope: string,
+    options: Readonly<{ forceDurable?: boolean; epoch: number }>,
+  ): Promise<ContextGraphAuthorityIndexRepositoryRecord> {
+    const memory = options.forceDurable ? undefined : this.#entries.get(scope);
+    if (memory !== undefined) return memory;
+
+    const record = await this.store.load(scope);
+    if (record === undefined) return Object.freeze({ kind: 'missing', token: undefined });
+    assertAuthorityIndexToken(record.token);
+    if (record.value === null) {
+      const tombstone = Object.freeze({ kind: 'tombstone' as const, token: record.token });
+      this.#publish(scope, tombstone, options.epoch);
+      return tombstone;
+    }
+    const checkpoint = normalizeContextGraphAuthorityIndexCheckpoint(record.value);
+    if (checkpoint === undefined) {
+      return Object.freeze({ kind: 'invalid', token: record.token });
+    }
+    const admitted = Object.freeze({
+      kind: 'checkpoint' as const,
+      token: record.token,
+      checkpoint,
+    });
+    this.#publish(scope, admitted, options.epoch);
+    return admitted;
+  }
+
+  discardIfCurrent(scope: string, record: ContextGraphAuthorityIndexRepositoryRecord): void {
+    if (this.#entries.get(scope) === record) this.#entries.delete(scope);
+  }
+
+  async invalidate(
+    scope: string,
+    record: Exclude<ContextGraphAuthorityIndexRepositoryRecord, { token: undefined }>,
+    epoch: number,
+  ): Promise<ContextGraphAuthorityIndexRepositoryRecord | undefined> {
+    const token = await this.store.invalidate(scope, record.token);
+    if (token === undefined) return undefined;
+    assertAuthorityIndexToken(token);
+    const tombstone = Object.freeze({ kind: 'tombstone' as const, token });
+    this.#publish(scope, tombstone, epoch);
+    return tombstone;
+  }
+
+  async compareAndSwap(
+    scope: string,
+    previous: ContextGraphAuthorityIndexRepositoryRecord,
+    checkpoint: ContextGraphAuthorityIndexCheckpoint,
+    epoch: number,
+  ): Promise<ContextGraphAuthorityIndexRepositoryRecord | undefined> {
+    const token = await this.store.compareAndSwap(scope, previous.token, checkpoint);
+    if (token === undefined) return undefined;
+    assertAuthorityIndexToken(token);
+    const committed = Object.freeze({
+      kind: 'checkpoint' as const,
+      token,
+      checkpoint,
+    });
+    this.#publish(scope, committed, epoch);
+    return committed;
+  }
+
+  #publish(scope: string, record: CacheableAuthorityIndexRecord, epoch: number): void {
+    if (this.#epoch !== epoch) return;
+    const current = this.#entries.get(scope);
+    if (current === undefined || current.token <= record.token) {
+      this.#entries.set(scope, record);
+    }
+  }
+}

--- a/packages/chain/src/context-graph-authority-index-repository.ts
+++ b/packages/chain/src/context-graph-authority-index-repository.ts
@@ -6,7 +6,9 @@ import {
   type ContextGraphAuthorityIndexStore,
 } from './context-graph-authority-index-checkpoint.js';
 
-export type ContextGraphAuthorityIndexRepositoryRecord =
+declare const authorityIndexObservation: unique symbol;
+
+export type ContextGraphAuthorityIndexRepositoryRecord = (
   | Readonly<{ kind: 'missing'; token: undefined }>
   | Readonly<{ kind: 'tombstone'; token: number }>
   | Readonly<{ kind: 'invalid'; token: number }>
@@ -14,7 +16,8 @@ export type ContextGraphAuthorityIndexRepositoryRecord =
       kind: 'checkpoint';
       token: number;
       checkpoint: ContextGraphAuthorityIndexCheckpoint;
-    }>;
+    }>
+) & Readonly<{ [authorityIndexObservation]: true }>;
 
 type CacheableAuthorityIndexRecord = Exclude<
   ContextGraphAuthorityIndexRepositoryRecord,
@@ -46,6 +49,18 @@ export type ContextGraphAuthorityIndexCommitResult =
       record: ContextGraphAuthorityIndexRepositoryRecord;
     }>;
 
+export interface ContextGraphAuthorityIndexScopedRepository {
+  load(): Promise<ContextGraphAuthorityIndexRepositoryRecord>;
+  reload(): Promise<ContextGraphAuthorityIndexRepositoryRecord>;
+  invalidateOrReloadWinner(
+    record: TokenedAuthorityIndexRecord,
+  ): Promise<ContextGraphAuthorityIndexInvalidationResult>;
+  commitOrReloadWinner(
+    previous: ContextGraphAuthorityIndexRepositoryRecord,
+    checkpoint: ContextGraphAuthorityIndexCheckpoint,
+  ): Promise<ContextGraphAuthorityIndexCommitResult>;
+}
+
 function assertAuthorityIndexToken(value: unknown): asserts value is number {
   if (!Number.isSafeInteger(value) || Number(value) < 1) {
     throw new Error('Context Graph authority index durable token is invalid');
@@ -55,6 +70,7 @@ function assertAuthorityIndexToken(value: unknown): asserts value is number {
 /** Decode, cache and mutate opaque durable rows behind one CAS repository boundary. */
 export class ContextGraphAuthorityIndexRepository {
   readonly #entries = new Map<string, CacheableAuthorityIndexRecord>();
+  readonly #observationScopes = new WeakMap<object, string>();
   readonly #store: ContextGraphAuthorityIndexStore;
   #epoch = 0;
 
@@ -67,14 +83,28 @@ export class ContextGraphAuthorityIndexRepository {
     this.#entries.clear();
   }
 
-  async load(scope: string): Promise<ContextGraphAuthorityIndexRepositoryRecord> {
+  forScope(scope: string): ContextGraphAuthorityIndexScopedRepository {
+    return Object.freeze({
+      load: () => this.#load(scope),
+      reload: () => this.#reload(scope),
+      invalidateOrReloadWinner: (record: TokenedAuthorityIndexRecord) => (
+        this.#invalidateOrReloadWinner(scope, record)
+      ),
+      commitOrReloadWinner: (
+        previous: ContextGraphAuthorityIndexRepositoryRecord,
+        checkpoint: ContextGraphAuthorityIndexCheckpoint,
+      ) => this.#commitOrReloadWinner(scope, previous, checkpoint),
+    });
+  }
+
+  async #load(scope: string): Promise<ContextGraphAuthorityIndexRepositoryRecord> {
     const memory = this.#entries.get(scope);
     if (memory !== undefined) return memory;
 
     return this.#readDurable(scope, this.#epoch);
   }
 
-  async reload(scope: string): Promise<ContextGraphAuthorityIndexRepositoryRecord> {
+  async #reload(scope: string): Promise<ContextGraphAuthorityIndexRepositoryRecord> {
     const epoch = this.#epoch;
     return this.#reloadDurable(scope, epoch);
   }
@@ -84,10 +114,11 @@ export class ContextGraphAuthorityIndexRepository {
    * return its freshly decoded row so admission can continue without callers
    * sequencing cache eviction and a forced durable reload themselves.
    */
-  async invalidateOrReloadWinner(
+  async #invalidateOrReloadWinner(
     scope: string,
     record: TokenedAuthorityIndexRecord,
   ): Promise<ContextGraphAuthorityIndexInvalidationResult> {
+    this.#assertObservationScope(scope, record);
     const epoch = this.#epoch;
     this.#discardIfCurrent(scope, record);
     const token = await this.#store.invalidate(scope, record.token);
@@ -98,17 +129,21 @@ export class ContextGraphAuthorityIndexRepository {
       });
     }
     assertAuthorityIndexToken(token);
-    const tombstone = Object.freeze({ kind: 'tombstone' as const, token });
+    const tombstone = this.#observe(scope, Object.freeze({
+      kind: 'tombstone' as const,
+      token,
+    }));
     this.#publish(scope, tombstone, epoch);
     return Object.freeze({ kind: 'invalidated', record: tombstone });
   }
 
   /** Persist one reduced page, or atomically surface the durable CAS winner. */
-  async commitOrReloadWinner(
+  async #commitOrReloadWinner(
     scope: string,
     previous: ContextGraphAuthorityIndexRepositoryRecord,
     checkpoint: ContextGraphAuthorityIndexCheckpoint,
   ): Promise<ContextGraphAuthorityIndexCommitResult> {
+    this.#assertObservationScope(scope, previous);
     const epoch = this.#epoch;
     const token = await this.#store.compareAndSwap(scope, previous.token, checkpoint);
     if (token === undefined) {
@@ -118,11 +153,11 @@ export class ContextGraphAuthorityIndexRepository {
       });
     }
     assertAuthorityIndexToken(token);
-    const committed = Object.freeze({
+    const committed = this.#observe(scope, Object.freeze({
       kind: 'checkpoint' as const,
       token,
       checkpoint,
-    });
+    }));
     this.#publish(scope, committed, epoch);
     return Object.freeze({ kind: 'committed', record: committed });
   }
@@ -133,22 +168,27 @@ export class ContextGraphAuthorityIndexRepository {
   ): Promise<ContextGraphAuthorityIndexRepositoryRecord> {
     const record = await this.#store.load(scope);
 
-    if (record === undefined) return Object.freeze({ kind: 'missing', token: undefined });
+    if (record === undefined) {
+      return this.#observe(scope, Object.freeze({ kind: 'missing', token: undefined }));
+    }
     assertAuthorityIndexToken(record.token);
     if (record.value === null) {
-      const tombstone = Object.freeze({ kind: 'tombstone' as const, token: record.token });
+      const tombstone = this.#observe(scope, Object.freeze({
+        kind: 'tombstone' as const,
+        token: record.token,
+      }));
       this.#publish(scope, tombstone, epoch);
       return tombstone;
     }
     const checkpoint = normalizeContextGraphAuthorityIndexCheckpoint(record.value);
     if (checkpoint === undefined) {
-      return Object.freeze({ kind: 'invalid', token: record.token });
+      return this.#observe(scope, Object.freeze({ kind: 'invalid', token: record.token }));
     }
-    const admitted = Object.freeze({
+    const admitted = this.#observe(scope, Object.freeze({
       kind: 'checkpoint' as const,
       token: record.token,
       checkpoint,
-    });
+    }));
     this.#publish(scope, admitted, epoch);
     return admitted;
   }
@@ -172,6 +212,22 @@ export class ContextGraphAuthorityIndexRepository {
     const current = this.#entries.get(scope);
     if (current === undefined || current.token <= record.token) {
       this.#entries.set(scope, record);
+    }
+  }
+
+  #observe<T extends object>(scope: string, record: T): T & Readonly<{
+    [authorityIndexObservation]: true;
+  }> {
+    this.#observationScopes.set(record, scope);
+    return record as T & Readonly<{ [authorityIndexObservation]: true }>;
+  }
+
+  #assertObservationScope(
+    scope: string,
+    record: ContextGraphAuthorityIndexRepositoryRecord,
+  ): void {
+    if (this.#observationScopes.get(record) !== scope) {
+      throw new TypeError('Context Graph authority index observation belongs to another scope');
     }
   }
 }

--- a/packages/chain/src/context-graph-authority-index-repository.ts
+++ b/packages/chain/src/context-graph-authority-index-repository.ts
@@ -21,6 +21,31 @@ type CacheableAuthorityIndexRecord = Exclude<
   Readonly<{ kind: 'missing'; token: undefined }> | Readonly<{ kind: 'invalid'; token: number }>
 >;
 
+type TokenedAuthorityIndexRecord = Exclude<
+  ContextGraphAuthorityIndexRepositoryRecord,
+  Readonly<{ kind: 'missing'; token: undefined }>
+>;
+
+export type ContextGraphAuthorityIndexInvalidationResult =
+  | Readonly<{
+      kind: 'invalidated';
+      record: Extract<ContextGraphAuthorityIndexRepositoryRecord, { kind: 'tombstone' }>;
+    }>
+  | Readonly<{
+      kind: 'winner';
+      record: ContextGraphAuthorityIndexRepositoryRecord;
+    }>;
+
+export type ContextGraphAuthorityIndexCommitResult =
+  | Readonly<{
+      kind: 'committed';
+      record: Extract<ContextGraphAuthorityIndexRepositoryRecord, { kind: 'checkpoint' }>;
+    }>
+  | Readonly<{
+      kind: 'winner';
+      record: ContextGraphAuthorityIndexRepositoryRecord;
+    }>;
+
 function assertAuthorityIndexToken(value: unknown): asserts value is number {
   if (!Number.isSafeInteger(value) || Number(value) < 1) {
     throw new Error('Context Graph authority index durable token is invalid');
@@ -30,12 +55,11 @@ function assertAuthorityIndexToken(value: unknown): asserts value is number {
 /** Decode, cache and mutate opaque durable rows behind one CAS repository boundary. */
 export class ContextGraphAuthorityIndexRepository {
   readonly #entries = new Map<string, CacheableAuthorityIndexRecord>();
+  readonly #store: ContextGraphAuthorityIndexStore;
   #epoch = 0;
 
-  constructor(readonly store: ContextGraphAuthorityIndexStore) {}
-
-  get epoch(): number {
-    return this.#epoch;
+  constructor(store: ContextGraphAuthorityIndexStore) {
+    this.#store = store;
   }
 
   clear(): void {
@@ -43,19 +67,77 @@ export class ContextGraphAuthorityIndexRepository {
     this.#entries.clear();
   }
 
-  async load(
-    scope: string,
-    options: Readonly<{ forceDurable?: boolean; epoch: number }>,
-  ): Promise<ContextGraphAuthorityIndexRepositoryRecord> {
-    const memory = options.forceDurable ? undefined : this.#entries.get(scope);
+  async load(scope: string): Promise<ContextGraphAuthorityIndexRepositoryRecord> {
+    const memory = this.#entries.get(scope);
     if (memory !== undefined) return memory;
 
-    const record = await this.store.load(scope);
+    return this.#readDurable(scope, this.#epoch);
+  }
+
+  async reload(scope: string): Promise<ContextGraphAuthorityIndexRepositoryRecord> {
+    const epoch = this.#epoch;
+    return this.#reloadDurable(scope, epoch);
+  }
+
+  /**
+   * Conditionally tombstone one rejected observation. If another writer wins,
+   * return its freshly decoded row so admission can continue without callers
+   * sequencing cache eviction and a forced durable reload themselves.
+   */
+  async invalidateOrReloadWinner(
+    scope: string,
+    record: TokenedAuthorityIndexRecord,
+  ): Promise<ContextGraphAuthorityIndexInvalidationResult> {
+    const epoch = this.#epoch;
+    this.#discardIfCurrent(scope, record);
+    const token = await this.#store.invalidate(scope, record.token);
+    if (token === undefined) {
+      return Object.freeze({
+        kind: 'winner',
+        record: await this.#reloadDurable(scope, epoch),
+      });
+    }
+    assertAuthorityIndexToken(token);
+    const tombstone = Object.freeze({ kind: 'tombstone' as const, token });
+    this.#publish(scope, tombstone, epoch);
+    return Object.freeze({ kind: 'invalidated', record: tombstone });
+  }
+
+  /** Persist one reduced page, or atomically surface the durable CAS winner. */
+  async commitOrReloadWinner(
+    scope: string,
+    previous: ContextGraphAuthorityIndexRepositoryRecord,
+    checkpoint: ContextGraphAuthorityIndexCheckpoint,
+  ): Promise<ContextGraphAuthorityIndexCommitResult> {
+    const epoch = this.#epoch;
+    const token = await this.#store.compareAndSwap(scope, previous.token, checkpoint);
+    if (token === undefined) {
+      return Object.freeze({
+        kind: 'winner',
+        record: await this.#reloadDurable(scope, epoch),
+      });
+    }
+    assertAuthorityIndexToken(token);
+    const committed = Object.freeze({
+      kind: 'checkpoint' as const,
+      token,
+      checkpoint,
+    });
+    this.#publish(scope, committed, epoch);
+    return Object.freeze({ kind: 'committed', record: committed });
+  }
+
+  async #readDurable(
+    scope: string,
+    epoch: number,
+  ): Promise<ContextGraphAuthorityIndexRepositoryRecord> {
+    const record = await this.#store.load(scope);
+
     if (record === undefined) return Object.freeze({ kind: 'missing', token: undefined });
     assertAuthorityIndexToken(record.token);
     if (record.value === null) {
       const tombstone = Object.freeze({ kind: 'tombstone' as const, token: record.token });
-      this.#publish(scope, tombstone, options.epoch);
+      this.#publish(scope, tombstone, epoch);
       return tombstone;
     }
     const checkpoint = normalizeContextGraphAuthorityIndexCheckpoint(record.value);
@@ -67,43 +149,22 @@ export class ContextGraphAuthorityIndexRepository {
       token: record.token,
       checkpoint,
     });
-    this.#publish(scope, admitted, options.epoch);
+    this.#publish(scope, admitted, epoch);
     return admitted;
   }
 
-  discardIfCurrent(scope: string, record: ContextGraphAuthorityIndexRepositoryRecord): void {
+  #reloadDurable(
+    scope: string,
+    epoch: number,
+  ): Promise<ContextGraphAuthorityIndexRepositoryRecord> {
+    // A completion from before clear() must not evict a newer lifecycle's
+    // cache entry. The epoch guard also prevents its durable read publishing.
+    if (this.#epoch === epoch) this.#entries.delete(scope);
+    return this.#readDurable(scope, epoch);
+  }
+
+  #discardIfCurrent(scope: string, record: ContextGraphAuthorityIndexRepositoryRecord): void {
     if (this.#entries.get(scope) === record) this.#entries.delete(scope);
-  }
-
-  async invalidate(
-    scope: string,
-    record: Exclude<ContextGraphAuthorityIndexRepositoryRecord, { token: undefined }>,
-    epoch: number,
-  ): Promise<ContextGraphAuthorityIndexRepositoryRecord | undefined> {
-    const token = await this.store.invalidate(scope, record.token);
-    if (token === undefined) return undefined;
-    assertAuthorityIndexToken(token);
-    const tombstone = Object.freeze({ kind: 'tombstone' as const, token });
-    this.#publish(scope, tombstone, epoch);
-    return tombstone;
-  }
-
-  async compareAndSwap(
-    scope: string,
-    previous: ContextGraphAuthorityIndexRepositoryRecord,
-    checkpoint: ContextGraphAuthorityIndexCheckpoint,
-    epoch: number,
-  ): Promise<ContextGraphAuthorityIndexRepositoryRecord | undefined> {
-    const token = await this.store.compareAndSwap(scope, previous.token, checkpoint);
-    if (token === undefined) return undefined;
-    assertAuthorityIndexToken(token);
-    const committed = Object.freeze({
-      kind: 'checkpoint' as const,
-      token,
-      checkpoint,
-    });
-    this.#publish(scope, committed, epoch);
-    return committed;
   }
 
   #publish(scope: string, record: CacheableAuthorityIndexRecord, epoch: number): void {

--- a/packages/chain/src/context-graph-authority-index.ts
+++ b/packages/chain/src/context-graph-authority-index.ts
@@ -2,7 +2,6 @@
 
 import { ethers } from 'ethers';
 import {
-  normalizeContextGraphAuthorityIndexCheckpoint,
   type ContextGraphAuthorityIndexCheckpoint,
   type ContextGraphAuthorityIndexState,
   type ContextGraphAuthorityIndexStore,
@@ -15,6 +14,15 @@ import {
   reduceContextGraphAuthorityIndexPage,
   type ContextGraphAuthorityIndexEvent,
 } from './context-graph-authority-index-reducer.js';
+import {
+  classifyContextGraphAuthorityIndexAdmission,
+  UNREAD_CONTEXT_GRAPH_AUTHORITY_INDEX_ANCHOR,
+  type ContextGraphAuthorityIndexAnchorObservation,
+} from './context-graph-authority-index-admission.js';
+import {
+  ContextGraphAuthorityIndexRepository,
+  type ContextGraphAuthorityIndexRepositoryRecord,
+} from './context-graph-authority-index-repository.js';
 import { KeyedSingleFlight } from './keyed-ttl-single-flight-cache.js';
 
 export class ContextGraphAuthorityIndexRetryableError extends Error {
@@ -53,18 +61,8 @@ export interface ContextGraphAuthorityIndexScanInput {
   ) => Promise<readonly ContextGraphAuthorityIndexEvent[]>;
 }
 
-interface DurableAuthorityIndexState {
-  /** Store-owned non-repeating CAS identity; absent only before the first write. */
-  readonly token: number | undefined;
-  /** Absent when the durable row is missing or is an invalidation tombstone. */
-  readonly checkpoint?: ContextGraphAuthorityIndexCheckpoint;
-}
-
-function assertAuthorityIndexToken(value: unknown): asserts value is number {
-  if (!Number.isSafeInteger(value) || Number(value) < 1) {
-    throw new Error('Context Graph authority index durable token is invalid');
-  }
-}
+const MAX_CONTEXT_GRAPH_AUTHORITY_INDEX_RECOVERY_EFFECTS = 16;
+const MAX_CONTEXT_GRAPH_AUTHORITY_INDEX_WINNER_RELOADS = 3;
 
 /**
  * Process-local owner for the durable contract-wide authority index.
@@ -74,12 +72,13 @@ function assertAuthorityIndexToken(value: unknown): asserts value is number {
  * next block instead of repeating the already-covered contract prefix.
  */
 export class ContextGraphAuthorityIndex {
-  readonly #entries = new Map<string, DurableAuthorityIndexState>();
+  readonly #repository: ContextGraphAuthorityIndexRepository;
   readonly #singleFlight = new KeyedSingleFlight<string, object>();
-  #epoch = 0;
   #lifecycleAbort = new AbortController();
 
-  constructor(readonly localStore: ContextGraphAuthorityIndexStore) {}
+  constructor(readonly localStore: ContextGraphAuthorityIndexStore) {
+    this.#repository = new ContextGraphAuthorityIndexRepository(localStore);
+  }
 
   clear(): void {
     this.#lifecycleAbort.abort(new DOMException(
@@ -87,8 +86,7 @@ export class ContextGraphAuthorityIndex {
       'AbortError',
     ));
     this.#lifecycleAbort = new AbortController();
-    this.#epoch += 1;
-    this.#entries.clear();
+    this.#repository.clear();
     this.#singleFlight.invalidateAll();
   }
 
@@ -114,7 +112,7 @@ export class ContextGraphAuthorityIndex {
     }
     const scanKey = [scope, input.finalized.number, finalizedHash].join('\u0000');
     const pending = this.#singleFlight.run(scanKey, input.readScope, () => {
-      const epoch = this.#epoch;
+      const epoch = this.#repository.epoch;
       const lifecycleSignal = this.#lifecycleAbort.signal;
       return this.#scan({ ...input, scope, finalized: {
         number: input.finalized.number,
@@ -148,21 +146,21 @@ export class ContextGraphAuthorityIndex {
       throw new Error('Context Graph authority index scan bounds are invalid');
     }
 
-    let durable = await this.#load(scope);
-    if (durable.checkpoint !== undefined) {
-      durable = await this.#admitCheckpoint(
-        scope,
-        durable,
-        deploymentBlockNumber,
-        { number: finalizedNumber, hash: finalizedHash },
-        input.readBlockHash,
-        lifecycleSignal,
-      );
-    }
+    let durable = await this.#driveCheckpointAdmission(
+      scope,
+      await this.#repository.load(scope, { epoch }),
+      deploymentBlockNumber,
+      { number: finalizedNumber, hash: finalizedHash },
+      input.readBlockHash,
+      lifecycleSignal,
+      epoch,
+    );
 
     for (;;) {
       lifecycleSignal.throwIfAborted();
-      const checkpoint = durable.checkpoint;
+      const checkpoint = durable.kind === 'checkpoint'
+        ? durable.checkpoint
+        : undefined;
       if (checkpoint !== undefined && checkpoint.cursor.throughBlockNumber === finalizedNumber) {
         return checkpoint;
       }
@@ -198,177 +196,118 @@ export class ContextGraphAuthorityIndex {
       });
       const next = reduction.checkpoint;
 
-      const committedToken = await this.localStore.compareAndSwap(
+      const committed = await this.#repository.compareAndSwap(
         scope,
-        durable.token,
+        durable,
         next,
+        epoch,
       );
-      if (committedToken === undefined) {
+      if (committed === undefined) {
         // Another valid provider completion won the page. Reload its result
         // and continue from that cursor rather than overwriting or rescanning.
-        durable = await this.#admitCheckpoint(
+        durable = await this.#driveCheckpointAdmission(
           scope,
-          await this.#load(scope, true),
+          await this.#repository.load(scope, { forceDurable: true, epoch }),
           deploymentBlockNumber,
           { number: finalizedNumber, hash: finalizedHash },
           input.readBlockHash,
           lifecycleSignal,
+          epoch,
         );
         continue;
-      }
-      assertAuthorityIndexToken(committedToken);
-
-      const committed = Object.freeze({ token: committedToken, checkpoint: next });
-      const current = this.#entries.get(scope);
-      if (this.#epoch === epoch && (
-        current === undefined
-        || current.token === undefined
-        || current.token < committedToken
-      )) {
-        this.#entries.set(scope, committed);
       }
       // A newer cache entry can belong to a concurrently scanned provider
       // fork. Keep this attempt on the checkpoint it reduced and admitted;
       // if another token wins the next CAS, that value is reloaded through
-      // #admitCheckpoint before it can influence this attempt.
+      // the admission driver before it can influence this attempt.
       durable = committed;
     }
   }
 
-  async #load(
+  /** Apply pure admission actions through one bounded, non-recursive effect loop. */
+  async #driveCheckpointAdmission(
     scope: string,
-    forceDurable = false,
-  ): Promise<DurableAuthorityIndexState> {
-    const memory = forceDurable ? undefined : this.#entries.get(scope);
-    if (memory !== undefined) return memory;
+    initial: ContextGraphAuthorityIndexRepositoryRecord,
+    deploymentBlockNumber: number,
+    finalized: Readonly<{ number: number; hash: string }>,
+    readBlockHash: (
+      blockNumber: number,
+      lifecycleSignal: AbortSignal,
+    ) => Promise<string | null>,
+    lifecycleSignal: AbortSignal,
+    epoch: number,
+  ): Promise<ContextGraphAuthorityIndexRepositoryRecord> {
+    let record = initial;
+    let anchor: ContextGraphAuthorityIndexAnchorObservation =
+      UNREAD_CONTEXT_GRAPH_AUTHORITY_INDEX_ANCHOR;
+    let winnerReloads = 0;
 
-    // A bounded loop handles a concurrent winner without allowing malformed
-    // durable tokens to turn recovery into unbounded recursive reloads.
-    for (let attempt = 0; attempt < 3; attempt += 1) {
-      const record = await this.localStore.load(scope);
-      if (record === undefined) return Object.freeze({ token: undefined });
-      assertAuthorityIndexToken(record.token);
-      if (record.value === null) {
-        const tombstone = Object.freeze({ token: record.token });
-        this.#entries.set(scope, tombstone);
-        return tombstone;
-      }
-      const checkpoint = normalizeContextGraphAuthorityIndexCheckpoint(record.value);
-      if (checkpoint !== undefined) {
-        const admitted = Object.freeze({ token: record.token, checkpoint });
-        this.#entries.set(scope, admitted);
-        return admitted;
-      }
-      const invalidatedToken = await this.localStore.invalidate(scope, record.token);
-      if (invalidatedToken !== undefined) {
-        assertAuthorityIndexToken(invalidatedToken);
-        const tombstone = Object.freeze({ token: invalidatedToken });
-        this.#entries.set(scope, tombstone);
-        return tombstone;
+    for (
+      let effect = 0;
+      effect < MAX_CONTEXT_GRAPH_AUTHORITY_INDEX_RECOVERY_EFFECTS;
+      effect += 1
+    ) {
+      lifecycleSignal.throwIfAborted();
+      const action = classifyContextGraphAuthorityIndexAdmission({
+        record,
+        deploymentBlockNumber,
+        finalized,
+        anchor,
+      });
+      switch (action.kind) {
+        case 'accept':
+        case 'rebuild':
+          return record;
+        case 'read-anchor': {
+          const hash = normalizeHash(await readBlockHash(
+            action.blockNumber,
+            lifecycleSignal,
+          ));
+          anchor = hash === undefined
+            ? Object.freeze({ kind: 'unavailable' })
+            : Object.freeze({ kind: 'available', hash });
+          break;
+        }
+        case 'retry-provider':
+          if (action.reason === 'finalized-behind') {
+            throw retryableAuthorityIndexReadError(
+              `Context Graph authority index finalized head ${action.finalizedBlockNumber} is behind `
+              + `durable cursor ${action.cursorBlockNumber}`,
+            );
+          }
+          throw retryableAuthorityIndexReadError(
+            `Context Graph authority index anchor ${action.cursorBlockNumber} is unavailable`,
+          );
+        case 'invalidate': {
+          this.#repository.discardIfCurrent(scope, record);
+          if (record.token === undefined) {
+            // The pure policy never emits invalidate for a missing row. Keep
+            // this effect boundary total if a future action variant regresses.
+            return record;
+          }
+          const invalidated = await this.#repository.invalidate(
+            scope,
+            record,
+            epoch,
+          );
+          if (invalidated !== undefined) return invalidated;
+          winnerReloads += 1;
+          if (winnerReloads >= MAX_CONTEXT_GRAPH_AUTHORITY_INDEX_WINNER_RELOADS) {
+            throw retryableAuthorityIndexReadError(
+              'Context Graph authority index changed repeatedly during checkpoint recovery',
+            );
+          }
+          record = await this.#repository.load(scope, {
+            forceDurable: true,
+            epoch,
+          });
+          anchor = UNREAD_CONTEXT_GRAPH_AUTHORITY_INDEX_ANCHOR;
+          break;
+        }
       }
     }
     throw retryableAuthorityIndexReadError(
-      'Context Graph authority index durable value changed repeatedly during recovery',
-    );
-  }
-
-  async #admitCheckpoint(
-    scope: string,
-    durable: DurableAuthorityIndexState,
-    deploymentBlockNumber: number,
-    finalized: Readonly<{ number: number; hash: string }>,
-    readBlockHash: (
-      blockNumber: number,
-      lifecycleSignal: AbortSignal,
-    ) => Promise<string | null>,
-    lifecycleSignal: AbortSignal,
-    recoveryBudget = 3,
-  ): Promise<DurableAuthorityIndexState> {
-    const checkpoint = durable.checkpoint;
-    if (checkpoint === undefined) return durable;
-    if (
-      checkpoint.cursor.deploymentBlockNumber !== deploymentBlockNumber
-    ) {
-      return this.#discardOrReload(
-        scope,
-        durable,
-        deploymentBlockNumber,
-        finalized,
-        readBlockHash,
-        lifecycleSignal,
-        recoveryBudget,
-      );
-    }
-    if (checkpoint.cursor.throughBlockNumber > finalized.number) {
-      // A lagging provider/caller is not evidence that the durable prefix is
-      // invalid. Preserve the newer winner and let endpoint failover obtain a
-      // head that can serve it.
-      throw retryableAuthorityIndexReadError(
-        `Context Graph authority index finalized head ${finalized.number} is behind `
-        + `durable cursor ${checkpoint.cursor.throughBlockNumber}`,
-      );
-    }
-    const anchorHash = checkpoint.cursor.throughBlockNumber === finalized.number
-      ? finalized.hash
-      : normalizeHash(await readBlockHash(
-          checkpoint.cursor.throughBlockNumber,
-          lifecycleSignal,
-        ));
-    if (anchorHash === undefined) {
-      // A non-archive endpoint must not destroy a valid durable prefix. Let the
-      // adapter fail over to an endpoint that can revalidate it.
-      throw retryableAuthorityIndexReadError(
-        `Context Graph authority index anchor ${checkpoint.cursor.throughBlockNumber} is unavailable`,
-      );
-    }
-    if (anchorHash !== checkpoint.cursor.throughBlockHash) {
-      return this.#discardOrReload(
-        scope,
-        durable,
-        deploymentBlockNumber,
-        finalized,
-        readBlockHash,
-        lifecycleSignal,
-        recoveryBudget,
-      );
-    }
-    return durable;
-  }
-
-  async #discardOrReload(
-    scope: string,
-    durable: DurableAuthorityIndexState,
-    deploymentBlockNumber: number,
-    finalized: Readonly<{ number: number; hash: string }>,
-    readBlockHash: (
-      blockNumber: number,
-      lifecycleSignal: AbortSignal,
-    ) => Promise<string | null>,
-    lifecycleSignal: AbortSignal,
-    recoveryBudget: number,
-  ): Promise<DurableAuthorityIndexState> {
-    if (recoveryBudget < 1) {
-      throw retryableAuthorityIndexReadError(
-        'Context Graph authority index changed repeatedly during anchor recovery',
-      );
-    }
-    if (this.#entries.get(scope) === durable) this.#entries.delete(scope);
-    if (durable.token === undefined) return Object.freeze({ token: undefined });
-    const invalidatedToken = await this.localStore.invalidate(scope, durable.token);
-    if (invalidatedToken !== undefined) {
-      assertAuthorityIndexToken(invalidatedToken);
-      const tombstone = Object.freeze({ token: invalidatedToken });
-      this.#entries.set(scope, tombstone);
-      return tombstone;
-    }
-    return this.#admitCheckpoint(
-      scope,
-      await this.#load(scope, true),
-      deploymentBlockNumber,
-      finalized,
-      readBlockHash,
-      lifecycleSignal,
-      recoveryBudget - 1,
+      'Context Graph authority index exceeded its checkpoint recovery effect budget',
     );
   }
 

--- a/packages/chain/src/context-graph-authority-index.ts
+++ b/packages/chain/src/context-graph-authority-index.ts
@@ -15,25 +15,17 @@ import {
   type ContextGraphAuthorityIndexEvent,
 } from './context-graph-authority-index-reducer.js';
 import {
-  classifyContextGraphAuthorityIndexAdmission,
-  UNREAD_CONTEXT_GRAPH_AUTHORITY_INDEX_ANCHOR,
-  type ContextGraphAuthorityIndexAnchorObservation,
+  admitContextGraphAuthorityIndexCheckpoint,
+  ContextGraphAuthorityIndexRetryableError,
 } from './context-graph-authority-index-admission.js';
-import {
-  ContextGraphAuthorityIndexRepository,
-  type ContextGraphAuthorityIndexRepositoryRecord,
-} from './context-graph-authority-index-repository.js';
+import { ContextGraphAuthorityIndexRepository } from
+  './context-graph-authority-index-repository.js';
 import { KeyedSingleFlight } from './keyed-ttl-single-flight-cache.js';
 
-export class ContextGraphAuthorityIndexRetryableError extends Error {
-  override readonly name = 'ContextGraphAuthorityIndexRetryableError';
-}
-
-export function isContextGraphAuthorityIndexRetryableError(
-  error: unknown,
-): error is ContextGraphAuthorityIndexRetryableError {
-  return error instanceof ContextGraphAuthorityIndexRetryableError;
-}
+export {
+  ContextGraphAuthorityIndexRetryableError,
+  isContextGraphAuthorityIndexRetryableError,
+} from './context-graph-authority-index-admission.js';
 
 function retryableAuthorityIndexReadError(message: string): Error {
   return new ContextGraphAuthorityIndexRetryableError(message);
@@ -60,9 +52,6 @@ export interface ContextGraphAuthorityIndexScanInput {
     lifecycleSignal: AbortSignal,
   ) => Promise<readonly ContextGraphAuthorityIndexEvent[]>;
 }
-
-const MAX_CONTEXT_GRAPH_AUTHORITY_INDEX_RECOVERY_EFFECTS = 16;
-const MAX_CONTEXT_GRAPH_AUTHORITY_INDEX_WINNER_RELOADS = 3;
 
 /**
  * Process-local owner for the durable contract-wide authority index.
@@ -112,12 +101,11 @@ export class ContextGraphAuthorityIndex {
     }
     const scanKey = [scope, input.finalized.number, finalizedHash].join('\u0000');
     const pending = this.#singleFlight.run(scanKey, input.readScope, () => {
-      const epoch = this.#repository.epoch;
       const lifecycleSignal = this.#lifecycleAbort.signal;
       return this.#scan({ ...input, scope, finalized: {
         number: input.finalized.number,
         hash: finalizedHash,
-      } }, epoch, lifecycleSignal);
+      } }, lifecycleSignal);
     });
     const checkpoint = await waitForSharedAuthorityIndexScan(pending, input.signal);
     // Target lookup intentionally happens after the shared contract scan, so
@@ -127,7 +115,6 @@ export class ContextGraphAuthorityIndex {
 
   async #scan(
     input: ContextGraphAuthorityIndexScanInput,
-    epoch: number,
     lifecycleSignal: AbortSignal,
   ): Promise<ContextGraphAuthorityIndexCheckpoint> {
     const scope = input.scope;
@@ -146,15 +133,15 @@ export class ContextGraphAuthorityIndex {
       throw new Error('Context Graph authority index scan bounds are invalid');
     }
 
-    let durable = await this.#driveCheckpointAdmission(
+    let durable = await admitContextGraphAuthorityIndexCheckpoint({
+      repository: this.#repository,
       scope,
-      await this.#repository.load(scope, { epoch }),
+      initial: await this.#repository.load(scope),
       deploymentBlockNumber,
-      { number: finalizedNumber, hash: finalizedHash },
-      input.readBlockHash,
+      finalized: { number: finalizedNumber, hash: finalizedHash },
+      readBlockHash: input.readBlockHash,
       lifecycleSignal,
-      epoch,
-    );
+    });
 
     for (;;) {
       lifecycleSignal.throwIfAborted();
@@ -196,119 +183,31 @@ export class ContextGraphAuthorityIndex {
       });
       const next = reduction.checkpoint;
 
-      const committed = await this.#repository.compareAndSwap(
+      const commit = await this.#repository.commitOrReloadWinner(
         scope,
         durable,
         next,
-        epoch,
       );
-      if (committed === undefined) {
+      if (commit.kind === 'winner') {
         // Another valid provider completion won the page. Reload its result
         // and continue from that cursor rather than overwriting or rescanning.
-        durable = await this.#driveCheckpointAdmission(
+        durable = await admitContextGraphAuthorityIndexCheckpoint({
+          repository: this.#repository,
           scope,
-          await this.#repository.load(scope, { forceDurable: true, epoch }),
+          initial: commit.record,
           deploymentBlockNumber,
-          { number: finalizedNumber, hash: finalizedHash },
-          input.readBlockHash,
+          finalized: { number: finalizedNumber, hash: finalizedHash },
+          readBlockHash: input.readBlockHash,
           lifecycleSignal,
-          epoch,
-        );
+        });
         continue;
       }
       // A newer cache entry can belong to a concurrently scanned provider
       // fork. Keep this attempt on the checkpoint it reduced and admitted;
       // if another token wins the next CAS, that value is reloaded through
-      // the admission driver before it can influence this attempt.
-      durable = committed;
+      // admission before it can influence this attempt.
+      durable = commit.record;
     }
-  }
-
-  /** Apply pure admission actions through one bounded, non-recursive effect loop. */
-  async #driveCheckpointAdmission(
-    scope: string,
-    initial: ContextGraphAuthorityIndexRepositoryRecord,
-    deploymentBlockNumber: number,
-    finalized: Readonly<{ number: number; hash: string }>,
-    readBlockHash: (
-      blockNumber: number,
-      lifecycleSignal: AbortSignal,
-    ) => Promise<string | null>,
-    lifecycleSignal: AbortSignal,
-    epoch: number,
-  ): Promise<ContextGraphAuthorityIndexRepositoryRecord> {
-    let record = initial;
-    let anchor: ContextGraphAuthorityIndexAnchorObservation =
-      UNREAD_CONTEXT_GRAPH_AUTHORITY_INDEX_ANCHOR;
-    let winnerReloads = 0;
-
-    for (
-      let effect = 0;
-      effect < MAX_CONTEXT_GRAPH_AUTHORITY_INDEX_RECOVERY_EFFECTS;
-      effect += 1
-    ) {
-      lifecycleSignal.throwIfAborted();
-      const action = classifyContextGraphAuthorityIndexAdmission({
-        record,
-        deploymentBlockNumber,
-        finalized,
-        anchor,
-      });
-      switch (action.kind) {
-        case 'accept':
-        case 'rebuild':
-          return record;
-        case 'read-anchor': {
-          const hash = normalizeHash(await readBlockHash(
-            action.blockNumber,
-            lifecycleSignal,
-          ));
-          anchor = hash === undefined
-            ? Object.freeze({ kind: 'unavailable' })
-            : Object.freeze({ kind: 'available', hash });
-          break;
-        }
-        case 'retry-provider':
-          if (action.reason === 'finalized-behind') {
-            throw retryableAuthorityIndexReadError(
-              `Context Graph authority index finalized head ${action.finalizedBlockNumber} is behind `
-              + `durable cursor ${action.cursorBlockNumber}`,
-            );
-          }
-          throw retryableAuthorityIndexReadError(
-            `Context Graph authority index anchor ${action.cursorBlockNumber} is unavailable`,
-          );
-        case 'invalidate': {
-          this.#repository.discardIfCurrent(scope, record);
-          if (record.token === undefined) {
-            // The pure policy never emits invalidate for a missing row. Keep
-            // this effect boundary total if a future action variant regresses.
-            return record;
-          }
-          const invalidated = await this.#repository.invalidate(
-            scope,
-            record,
-            epoch,
-          );
-          if (invalidated !== undefined) return invalidated;
-          winnerReloads += 1;
-          if (winnerReloads >= MAX_CONTEXT_GRAPH_AUTHORITY_INDEX_WINNER_RELOADS) {
-            throw retryableAuthorityIndexReadError(
-              'Context Graph authority index changed repeatedly during checkpoint recovery',
-            );
-          }
-          record = await this.#repository.load(scope, {
-            forceDurable: true,
-            epoch,
-          });
-          anchor = UNREAD_CONTEXT_GRAPH_AUTHORITY_INDEX_ANCHOR;
-          break;
-        }
-      }
-    }
-    throw retryableAuthorityIndexReadError(
-      'Context Graph authority index exceeded its checkpoint recovery effect budget',
-    );
   }
 
   #requireState(

--- a/packages/chain/src/context-graph-authority-index.ts
+++ b/packages/chain/src/context-graph-authority-index.ts
@@ -16,8 +16,9 @@ import {
 } from './context-graph-authority-index-reducer.js';
 import {
   admitContextGraphAuthorityIndexCheckpoint,
-  ContextGraphAuthorityIndexRetryableError,
 } from './context-graph-authority-index-admission.js';
+import { ContextGraphAuthorityIndexRetryableError } from
+  './context-graph-authority-index-errors.js';
 import { ContextGraphAuthorityIndexRepository } from
   './context-graph-authority-index-repository.js';
 import { KeyedSingleFlight } from './keyed-ttl-single-flight-cache.js';
@@ -25,11 +26,7 @@ import { KeyedSingleFlight } from './keyed-ttl-single-flight-cache.js';
 export {
   ContextGraphAuthorityIndexRetryableError,
   isContextGraphAuthorityIndexRetryableError,
-} from './context-graph-authority-index-admission.js';
-
-function retryableAuthorityIndexReadError(message: string): Error {
-  return new ContextGraphAuthorityIndexRetryableError(message);
-}
+} from './context-graph-authority-index-errors.js';
 
 export interface ContextGraphAuthorityIndexScanInput {
   /** Deployment + physical ContextGraphStorage address; contains no secret. */
@@ -118,6 +115,7 @@ export class ContextGraphAuthorityIndex {
     lifecycleSignal: AbortSignal,
   ): Promise<ContextGraphAuthorityIndexCheckpoint> {
     const scope = input.scope;
+    const repository = this.#repository.forScope(scope);
     const deploymentBlockNumber = normalizeNonNegativeSafeInteger(input.deploymentBlockNumber);
     const finalizedNumber = normalizeNonNegativeSafeInteger(input.finalized.number);
     const finalizedHash = normalizeHash(input.finalized.hash);
@@ -134,9 +132,8 @@ export class ContextGraphAuthorityIndex {
     }
 
     let durable = await admitContextGraphAuthorityIndexCheckpoint({
-      repository: this.#repository,
-      scope,
-      initial: await this.#repository.load(scope),
+      repository,
+      initial: await repository.load(),
       deploymentBlockNumber,
       finalized: { number: finalizedNumber, hash: finalizedHash },
       readBlockHash: input.readBlockHash,
@@ -163,7 +160,7 @@ export class ContextGraphAuthorityIndex {
         ? finalizedHash
         : normalizeHash(await input.readBlockHash(throughBlockNumber, lifecycleSignal));
       if (throughBlockHash === undefined) {
-        throw retryableAuthorityIndexReadError(
+        throw new ContextGraphAuthorityIndexRetryableError(
           `Context Graph authority index block ${throughBlockNumber} is unavailable`,
         );
       }
@@ -183,8 +180,7 @@ export class ContextGraphAuthorityIndex {
       });
       const next = reduction.checkpoint;
 
-      const commit = await this.#repository.commitOrReloadWinner(
-        scope,
+      const commit = await repository.commitOrReloadWinner(
         durable,
         next,
       );
@@ -192,8 +188,7 @@ export class ContextGraphAuthorityIndex {
         // Another valid provider completion won the page. Reload its result
         // and continue from that cursor rather than overwriting or rescanning.
         durable = await admitContextGraphAuthorityIndexCheckpoint({
-          repository: this.#repository,
-          scope,
+          repository,
           initial: commit.record,
           deploymentBlockNumber,
           finalized: { number: finalizedNumber, hash: finalizedHash },

--- a/packages/chain/test/context-graph-authority-index-admission.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-index-admission.unit.test.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  classifyContextGraphAuthorityIndexAdmission,
+  UNREAD_CONTEXT_GRAPH_AUTHORITY_INDEX_ANCHOR,
+} from '../src/context-graph-authority-index-admission.js';
+import { createContextGraphAuthorityIndexCheckpoint } from
+  '../src/context-graph-authority-index-checkpoint.js';
+
+const HASH_20 = `0x${'20'.repeat(32)}`;
+const HASH_25 = `0x${'25'.repeat(32)}`;
+const REPLACEMENT_HASH = `0x${'ff'.repeat(32)}`;
+
+const checkpoint = createContextGraphAuthorityIndexCheckpoint({
+  deploymentBlockNumber: 10,
+  throughBlockNumber: 20,
+  throughBlockHash: HASH_20,
+}, []);
+
+const record = Object.freeze({
+  kind: 'checkpoint' as const,
+  token: 7,
+  checkpoint,
+});
+
+const input = (overrides: Record<string, unknown> = {}) => ({
+  record,
+  deploymentBlockNumber: 10,
+  finalized: { number: 25, hash: HASH_25 },
+  anchor: UNREAD_CONTEXT_GRAPH_AUTHORITY_INDEX_ANCHOR,
+  ...overrides,
+} as Parameters<typeof classifyContextGraphAuthorityIndexAdmission>[0]);
+
+describe('Context Graph authority index checkpoint admission policy', () => {
+  it('classifies missing, tombstone, and invalid durable rows without effects', () => {
+    expect(classifyContextGraphAuthorityIndexAdmission(input({
+      record: { kind: 'missing', token: undefined },
+    }))).toEqual({ kind: 'rebuild', reason: 'missing' });
+    expect(classifyContextGraphAuthorityIndexAdmission(input({
+      record: { kind: 'tombstone', token: 8 },
+    }))).toEqual({ kind: 'rebuild', reason: 'tombstone' });
+    expect(classifyContextGraphAuthorityIndexAdmission(input({
+      record: { kind: 'invalid', token: 8 },
+    }))).toEqual({ kind: 'invalidate', reason: 'invalid-checkpoint' });
+  });
+
+  it('requests only the anchor observation needed to accept a warm checkpoint', () => {
+    expect(classifyContextGraphAuthorityIndexAdmission(input())).toEqual({
+      kind: 'read-anchor',
+      blockNumber: 20,
+    });
+    expect(classifyContextGraphAuthorityIndexAdmission(input({
+      anchor: { kind: 'available', hash: HASH_20 },
+    }))).toEqual({ kind: 'accept', checkpoint });
+  });
+
+  it('keeps lagging and non-archive observations retryable without invalidation', () => {
+    expect(classifyContextGraphAuthorityIndexAdmission(input({
+      finalized: { number: 19, hash: HASH_25 },
+    }))).toEqual({
+      kind: 'retry-provider',
+      reason: 'finalized-behind',
+      cursorBlockNumber: 20,
+      finalizedBlockNumber: 19,
+    });
+    expect(classifyContextGraphAuthorityIndexAdmission(input({
+      anchor: { kind: 'unavailable' },
+    }))).toEqual({
+      kind: 'retry-provider',
+      reason: 'anchor-unavailable',
+      cursorBlockNumber: 20,
+      finalizedBlockNumber: 25,
+    });
+  });
+
+  it('invalidates only deployment changes and proven fork replacements', () => {
+    expect(classifyContextGraphAuthorityIndexAdmission(input({
+      deploymentBlockNumber: 11,
+    }))).toEqual({ kind: 'invalidate', reason: 'deployment-changed' });
+    expect(classifyContextGraphAuthorityIndexAdmission(input({
+      anchor: { kind: 'available', hash: REPLACEMENT_HASH },
+    }))).toEqual({ kind: 'invalidate', reason: 'anchor-replaced' });
+    expect(classifyContextGraphAuthorityIndexAdmission(input({
+      record: {
+        ...record,
+        checkpoint: createContextGraphAuthorityIndexCheckpoint({
+          deploymentBlockNumber: 10,
+          throughBlockNumber: 25,
+          throughBlockHash: HASH_20,
+        }, []),
+      },
+    }))).toEqual({ kind: 'invalidate', reason: 'anchor-replaced' });
+  });
+});

--- a/packages/chain/test/context-graph-authority-index-admission.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-index-admission.unit.test.ts
@@ -9,7 +9,6 @@ import { createContextGraphAuthorityIndexCheckpoint } from
   '../src/context-graph-authority-index-checkpoint.js';
 import {
   ContextGraphAuthorityIndexRepository,
-  type ContextGraphAuthorityIndexRepositoryRecord,
 } from '../src/context-graph-authority-index-repository.js';
 import { MemoryAuthorityIndexStore } from './helpers/context-graph-authority-index.js';
 
@@ -24,25 +23,18 @@ const checkpoint = createContextGraphAuthorityIndexCheckpoint({
   throughBlockHash: HASH_20,
 }, []);
 
-const checkpointRecord = Object.freeze({
-  kind: 'checkpoint' as const,
-  token: 7,
-  checkpoint,
-});
-
-function admit(
+async function admit(
   repository: ContextGraphAuthorityIndexRepository,
-  initial: ContextGraphAuthorityIndexRepositoryRecord,
   overrides: Readonly<{
     deploymentBlockNumber?: number;
     finalized?: Readonly<{ number: number; hash: string }>;
     readBlockHash?: () => Promise<string | null>;
   }> = {},
 ) {
+  const scoped = repository.forScope(SCOPE);
   return admitContextGraphAuthorityIndexCheckpoint({
-    repository,
-    scope: SCOPE,
-    initial,
+    repository: scoped,
+    initial: await scoped.load(),
     deploymentBlockNumber: overrides.deploymentBlockNumber ?? 10,
     finalized: overrides.finalized ?? { number: 25, hash: HASH_25 },
     lifecycleSignal: new AbortController().signal,
@@ -54,30 +46,29 @@ describe('Context Graph authority index checkpoint admission and recovery', () =
   it('rebuilds missing and tombstoned rows without durable effects', async () => {
     const store = new MemoryAuthorityIndexStore();
     const repository = new ContextGraphAuthorityIndexRepository(store);
-    await expect(admit(repository, { kind: 'missing', token: undefined }))
+    await expect(admit(repository))
       .resolves.toEqual({ kind: 'missing', token: undefined });
-    await expect(admit(repository, { kind: 'tombstone', token: 8 }))
+    store.record = { token: 8, value: null };
+    await expect(admit(new ContextGraphAuthorityIndexRepository(store)))
       .resolves.toEqual({ kind: 'tombstone', token: 8 });
     expect(store.invalidations).toEqual([]);
   });
 
   it('accepts a matching warm anchor and the requested finalized head', async () => {
-    const repository = new ContextGraphAuthorityIndexRepository(
-      new MemoryAuthorityIndexStore(),
-    );
-    await expect(admit(repository, checkpointRecord)).resolves.toBe(checkpointRecord);
+    const store = new MemoryAuthorityIndexStore();
+    store.record = { token: 7, value: checkpoint };
+    await expect(admit(new ContextGraphAuthorityIndexRepository(store)))
+      .resolves.toMatchObject({ kind: 'checkpoint', token: 7 });
 
     const finalizedCheckpoint = createContextGraphAuthorityIndexCheckpoint({
       deploymentBlockNumber: 10,
       throughBlockNumber: 25,
       throughBlockHash: HASH_25,
     }, []);
+    const finalizedStore = new MemoryAuthorityIndexStore();
+    finalizedStore.record = { token: 8, value: finalizedCheckpoint };
     let anchorReads = 0;
-    await expect(admit(repository, {
-      kind: 'checkpoint',
-      token: 8,
-      checkpoint: finalizedCheckpoint,
-    }, {
+    await expect(admit(new ContextGraphAuthorityIndexRepository(finalizedStore), {
       readBlockHash: async () => {
         anchorReads += 1;
         return HASH_25;
@@ -88,11 +79,11 @@ describe('Context Graph authority index checkpoint admission and recovery', () =
 
   it('keeps lagging and non-archive observations retryable without invalidation', async () => {
     const store = new MemoryAuthorityIndexStore();
-    const repository = new ContextGraphAuthorityIndexRepository(store);
-    await expect(admit(repository, checkpointRecord, {
+    store.record = { token: 7, value: checkpoint };
+    await expect(admit(new ContextGraphAuthorityIndexRepository(store), {
       finalized: { number: 19, hash: HASH_25 },
     })).rejects.toThrow('finalized head 19 is behind durable cursor 20');
-    await expect(admit(repository, checkpointRecord, {
+    await expect(admit(new ContextGraphAuthorityIndexRepository(store), {
       readBlockHash: async () => null,
     })).rejects.toThrow('anchor 20 is unavailable');
     expect(store.invalidations).toEqual([]);
@@ -100,22 +91,18 @@ describe('Context Graph authority index checkpoint admission and recovery', () =
 
   it('tombstones corrupt rows, deployment changes, and proven fork replacements', async () => {
     const scenarios: Array<Readonly<{
-      initial: ContextGraphAuthorityIndexRepositoryRecord;
       durableValue: unknown;
       deploymentBlockNumber?: number;
       readBlockHash?: () => Promise<string | null>;
     }>> = [
       {
-        initial: { kind: 'invalid', token: 7 },
         durableValue: { corrupt: true },
       },
       {
-        initial: checkpointRecord,
         durableValue: checkpoint,
         deploymentBlockNumber: 11,
       },
       {
-        initial: checkpointRecord,
         durableValue: checkpoint,
         readBlockHash: async () => REPLACEMENT_HASH,
       },
@@ -126,7 +113,6 @@ describe('Context Graph authority index checkpoint admission and recovery', () =
       store.record = { token: 7, value: scenario.durableValue };
       const result = await admit(
         new ContextGraphAuthorityIndexRepository(store),
-        scenario.initial,
         {
           deploymentBlockNumber: scenario.deploymentBlockNumber,
           readBlockHash: scenario.readBlockHash,

--- a/packages/chain/test/context-graph-authority-index-admission.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-index-admission.unit.test.ts
@@ -3,12 +3,17 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  classifyContextGraphAuthorityIndexAdmission,
-  UNREAD_CONTEXT_GRAPH_AUTHORITY_INDEX_ANCHOR,
+  admitContextGraphAuthorityIndexCheckpoint,
 } from '../src/context-graph-authority-index-admission.js';
 import { createContextGraphAuthorityIndexCheckpoint } from
   '../src/context-graph-authority-index-checkpoint.js';
+import {
+  ContextGraphAuthorityIndexRepository,
+  type ContextGraphAuthorityIndexRepositoryRecord,
+} from '../src/context-graph-authority-index-repository.js';
+import { MemoryAuthorityIndexStore } from './helpers/context-graph-authority-index.js';
 
+const SCOPE = 'evm:84532:hub:context-graph-storage';
 const HASH_20 = `0x${'20'.repeat(32)}`;
 const HASH_25 = `0x${'25'.repeat(32)}`;
 const REPLACEMENT_HASH = `0x${'ff'.repeat(32)}`;
@@ -19,78 +24,116 @@ const checkpoint = createContextGraphAuthorityIndexCheckpoint({
   throughBlockHash: HASH_20,
 }, []);
 
-const record = Object.freeze({
+const checkpointRecord = Object.freeze({
   kind: 'checkpoint' as const,
   token: 7,
   checkpoint,
 });
 
-const input = (overrides: Record<string, unknown> = {}) => ({
-  record,
-  deploymentBlockNumber: 10,
-  finalized: { number: 25, hash: HASH_25 },
-  anchor: UNREAD_CONTEXT_GRAPH_AUTHORITY_INDEX_ANCHOR,
-  ...overrides,
-} as Parameters<typeof classifyContextGraphAuthorityIndexAdmission>[0]);
+function admit(
+  repository: ContextGraphAuthorityIndexRepository,
+  initial: ContextGraphAuthorityIndexRepositoryRecord,
+  overrides: Readonly<{
+    deploymentBlockNumber?: number;
+    finalized?: Readonly<{ number: number; hash: string }>;
+    readBlockHash?: () => Promise<string | null>;
+  }> = {},
+) {
+  return admitContextGraphAuthorityIndexCheckpoint({
+    repository,
+    scope: SCOPE,
+    initial,
+    deploymentBlockNumber: overrides.deploymentBlockNumber ?? 10,
+    finalized: overrides.finalized ?? { number: 25, hash: HASH_25 },
+    lifecycleSignal: new AbortController().signal,
+    readBlockHash: overrides.readBlockHash ?? (async () => HASH_20),
+  });
+}
 
-describe('Context Graph authority index checkpoint admission policy', () => {
-  it('classifies missing, tombstone, and invalid durable rows without effects', () => {
-    expect(classifyContextGraphAuthorityIndexAdmission(input({
-      record: { kind: 'missing', token: undefined },
-    }))).toEqual({ kind: 'rebuild', reason: 'missing' });
-    expect(classifyContextGraphAuthorityIndexAdmission(input({
-      record: { kind: 'tombstone', token: 8 },
-    }))).toEqual({ kind: 'rebuild', reason: 'tombstone' });
-    expect(classifyContextGraphAuthorityIndexAdmission(input({
-      record: { kind: 'invalid', token: 8 },
-    }))).toEqual({ kind: 'invalidate', reason: 'invalid-checkpoint' });
+describe('Context Graph authority index checkpoint admission and recovery', () => {
+  it('rebuilds missing and tombstoned rows without durable effects', async () => {
+    const store = new MemoryAuthorityIndexStore();
+    const repository = new ContextGraphAuthorityIndexRepository(store);
+    await expect(admit(repository, { kind: 'missing', token: undefined }))
+      .resolves.toEqual({ kind: 'missing', token: undefined });
+    await expect(admit(repository, { kind: 'tombstone', token: 8 }))
+      .resolves.toEqual({ kind: 'tombstone', token: 8 });
+    expect(store.invalidations).toEqual([]);
   });
 
-  it('requests only the anchor observation needed to accept a warm checkpoint', () => {
-    expect(classifyContextGraphAuthorityIndexAdmission(input())).toEqual({
-      kind: 'read-anchor',
-      blockNumber: 20,
-    });
-    expect(classifyContextGraphAuthorityIndexAdmission(input({
-      anchor: { kind: 'available', hash: HASH_20 },
-    }))).toEqual({ kind: 'accept', checkpoint });
-  });
+  it('accepts a matching warm anchor and the requested finalized head', async () => {
+    const repository = new ContextGraphAuthorityIndexRepository(
+      new MemoryAuthorityIndexStore(),
+    );
+    await expect(admit(repository, checkpointRecord)).resolves.toBe(checkpointRecord);
 
-  it('keeps lagging and non-archive observations retryable without invalidation', () => {
-    expect(classifyContextGraphAuthorityIndexAdmission(input({
-      finalized: { number: 19, hash: HASH_25 },
-    }))).toEqual({
-      kind: 'retry-provider',
-      reason: 'finalized-behind',
-      cursorBlockNumber: 20,
-      finalizedBlockNumber: 19,
-    });
-    expect(classifyContextGraphAuthorityIndexAdmission(input({
-      anchor: { kind: 'unavailable' },
-    }))).toEqual({
-      kind: 'retry-provider',
-      reason: 'anchor-unavailable',
-      cursorBlockNumber: 20,
-      finalizedBlockNumber: 25,
-    });
-  });
-
-  it('invalidates only deployment changes and proven fork replacements', () => {
-    expect(classifyContextGraphAuthorityIndexAdmission(input({
-      deploymentBlockNumber: 11,
-    }))).toEqual({ kind: 'invalidate', reason: 'deployment-changed' });
-    expect(classifyContextGraphAuthorityIndexAdmission(input({
-      anchor: { kind: 'available', hash: REPLACEMENT_HASH },
-    }))).toEqual({ kind: 'invalidate', reason: 'anchor-replaced' });
-    expect(classifyContextGraphAuthorityIndexAdmission(input({
-      record: {
-        ...record,
-        checkpoint: createContextGraphAuthorityIndexCheckpoint({
-          deploymentBlockNumber: 10,
-          throughBlockNumber: 25,
-          throughBlockHash: HASH_20,
-        }, []),
+    const finalizedCheckpoint = createContextGraphAuthorityIndexCheckpoint({
+      deploymentBlockNumber: 10,
+      throughBlockNumber: 25,
+      throughBlockHash: HASH_25,
+    }, []);
+    let anchorReads = 0;
+    await expect(admit(repository, {
+      kind: 'checkpoint',
+      token: 8,
+      checkpoint: finalizedCheckpoint,
+    }, {
+      readBlockHash: async () => {
+        anchorReads += 1;
+        return HASH_25;
       },
-    }))).toEqual({ kind: 'invalidate', reason: 'anchor-replaced' });
+    })).resolves.toMatchObject({ kind: 'checkpoint', token: 8 });
+    expect(anchorReads).toBe(0);
+  });
+
+  it('keeps lagging and non-archive observations retryable without invalidation', async () => {
+    const store = new MemoryAuthorityIndexStore();
+    const repository = new ContextGraphAuthorityIndexRepository(store);
+    await expect(admit(repository, checkpointRecord, {
+      finalized: { number: 19, hash: HASH_25 },
+    })).rejects.toThrow('finalized head 19 is behind durable cursor 20');
+    await expect(admit(repository, checkpointRecord, {
+      readBlockHash: async () => null,
+    })).rejects.toThrow('anchor 20 is unavailable');
+    expect(store.invalidations).toEqual([]);
+  });
+
+  it('tombstones corrupt rows, deployment changes, and proven fork replacements', async () => {
+    const scenarios: Array<Readonly<{
+      initial: ContextGraphAuthorityIndexRepositoryRecord;
+      durableValue: unknown;
+      deploymentBlockNumber?: number;
+      readBlockHash?: () => Promise<string | null>;
+    }>> = [
+      {
+        initial: { kind: 'invalid', token: 7 },
+        durableValue: { corrupt: true },
+      },
+      {
+        initial: checkpointRecord,
+        durableValue: checkpoint,
+        deploymentBlockNumber: 11,
+      },
+      {
+        initial: checkpointRecord,
+        durableValue: checkpoint,
+        readBlockHash: async () => REPLACEMENT_HASH,
+      },
+    ];
+
+    for (const scenario of scenarios) {
+      const store = new MemoryAuthorityIndexStore();
+      store.record = { token: 7, value: scenario.durableValue };
+      const result = await admit(
+        new ContextGraphAuthorityIndexRepository(store),
+        scenario.initial,
+        {
+          deploymentBlockNumber: scenario.deploymentBlockNumber,
+          readBlockHash: scenario.readBlockHash,
+        },
+      );
+      expect(result).toEqual({ kind: 'tombstone', token: 8 });
+      expect(store.invalidations).toEqual([8]);
+    }
   });
 });

--- a/packages/chain/test/context-graph-authority-index-repository.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-index-repository.unit.test.ts
@@ -122,4 +122,25 @@ describe('ContextGraphAuthorityIndexRepository cache lifecycle', () => {
       .rejects.toThrow('observation belongs to another scope');
     expect(store.commits).toEqual([]);
   });
+
+  it('rejects cross-scope invalidation before touching the durable row', async () => {
+    const store = new MemoryAuthorityIndexStore();
+    const durable = checkpoint(20);
+    store.record = { token: 1, value: durable };
+    const repository = new ContextGraphAuthorityIndexRepository(store);
+    const first = repository.forScope('first');
+    const second = repository.forScope('second');
+    const foreignObservation = await first.load();
+    const secondScopeRow = await second.load();
+
+    await expect(second.invalidateOrReloadWinner(foreignObservation))
+      .rejects.toThrow('observation belongs to another scope');
+    expect(store.invalidations).toEqual([]);
+    await expect(second.load()).resolves.toBe(secondScopeRow);
+    expect(secondScopeRow).toMatchObject({
+      kind: 'checkpoint',
+      token: 1,
+      checkpoint: durable,
+    });
+  });
 });

--- a/packages/chain/test/context-graph-authority-index-repository.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-index-repository.unit.test.ts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+
+import { createContextGraphAuthorityIndexCheckpoint } from
+  '../src/context-graph-authority-index-checkpoint.js';
+import { ContextGraphAuthorityIndexRepository } from
+  '../src/context-graph-authority-index-repository.js';
+import { MemoryAuthorityIndexStore } from './helpers/context-graph-authority-index.js';
+
+const blockHash = (block: number): string => `0x${block.toString(16).padStart(64, '0')}`;
+
+const checkpoint = (throughBlockNumber: number) => createContextGraphAuthorityIndexCheckpoint({
+  deploymentBlockNumber: 10,
+  throughBlockNumber,
+  throughBlockHash: blockHash(throughBlockNumber),
+}, []);
+
+describe('ContextGraphAuthorityIndexRepository cache lifecycle', () => {
+  it('does not let a deferred pre-clear load republish stale cache state', async () => {
+    const store = new MemoryAuthorityIndexStore();
+    const staleCheckpoint = checkpoint(20);
+    const currentCheckpoint = checkpoint(25);
+    store.record = { token: 1, value: staleCheckpoint };
+
+    const firstLoadEntered = Promise.withResolvers<void>();
+    const releaseFirstLoad = Promise.withResolvers<void>();
+    const load = store.load.bind(store);
+    let loadCount = 0;
+    store.load = async () => {
+      loadCount += 1;
+      if (loadCount !== 1) return load();
+      const stale = await load();
+      firstLoadEntered.resolve();
+      await releaseFirstLoad.promise;
+      return stale;
+    };
+
+    const repository = new ContextGraphAuthorityIndexRepository(store);
+    const staleLoad = repository.load('scope');
+    await firstLoadEntered.promise;
+    repository.clear();
+    store.record = { token: 2, value: currentCheckpoint };
+    releaseFirstLoad.resolve();
+
+    await expect(staleLoad).resolves.toMatchObject({
+      kind: 'checkpoint',
+      token: 1,
+    });
+    const current = await repository.load('scope');
+    expect(current).toMatchObject({ kind: 'checkpoint', token: 2 });
+    await expect(repository.load('scope')).resolves.toBe(current);
+    expect(loadCount).toBe(2);
+  });
+
+  it('evicts a rejected cache entry and reloads an invalidation winner', async () => {
+    const store = new MemoryAuthorityIndexStore();
+    store.record = { token: 1, value: checkpoint(20) };
+    const load = store.load.bind(store);
+    let loadCount = 0;
+    store.load = async () => {
+      loadCount += 1;
+      return load();
+    };
+    const repository = new ContextGraphAuthorityIndexRepository(store);
+    const rejected = await repository.load('scope');
+    const winner = checkpoint(25);
+    store.invalidate = async (_scope, expectedToken) => {
+      expect(expectedToken).toBe(1);
+      store.record = { token: 2, value: winner };
+      return undefined;
+    };
+
+    const recovery = await repository.invalidateOrReloadWinner('scope', rejected);
+    expect(recovery).toMatchObject({
+      kind: 'winner',
+      record: { kind: 'checkpoint', token: 2, checkpoint: winner },
+    });
+    await expect(repository.load('scope')).resolves.toBe(recovery.record);
+    expect(loadCount).toBe(2);
+  });
+
+  it('reloads and caches the durable winner of a checkpoint CAS loss', async () => {
+    const store = new MemoryAuthorityIndexStore();
+    store.record = { token: 1, value: checkpoint(20) };
+    const load = store.load.bind(store);
+    let loadCount = 0;
+    store.load = async () => {
+      loadCount += 1;
+      return load();
+    };
+    const repository = new ContextGraphAuthorityIndexRepository(store);
+    const previous = await repository.load('scope');
+    const winner = checkpoint(25);
+    store.compareAndSwap = async (_scope, expectedToken) => {
+      expect(expectedToken).toBe(1);
+      store.record = { token: 2, value: winner };
+      return undefined;
+    };
+
+    const recovery = await repository.commitOrReloadWinner(
+      'scope',
+      previous,
+      checkpoint(21),
+    );
+    expect(recovery).toMatchObject({
+      kind: 'winner',
+      record: { kind: 'checkpoint', token: 2, checkpoint: winner },
+    });
+    await expect(repository.load('scope')).resolves.toBe(recovery.record);
+    expect(loadCount).toBe(2);
+  });
+});

--- a/packages/chain/test/context-graph-authority-index-repository.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-index-repository.unit.test.ts
@@ -37,7 +37,8 @@ describe('ContextGraphAuthorityIndexRepository cache lifecycle', () => {
     };
 
     const repository = new ContextGraphAuthorityIndexRepository(store);
-    const staleLoad = repository.load('scope');
+    const scoped = repository.forScope('scope');
+    const staleLoad = scoped.load();
     await firstLoadEntered.promise;
     repository.clear();
     store.record = { token: 2, value: currentCheckpoint };
@@ -47,9 +48,9 @@ describe('ContextGraphAuthorityIndexRepository cache lifecycle', () => {
       kind: 'checkpoint',
       token: 1,
     });
-    const current = await repository.load('scope');
+    const current = await scoped.load();
     expect(current).toMatchObject({ kind: 'checkpoint', token: 2 });
-    await expect(repository.load('scope')).resolves.toBe(current);
+    await expect(scoped.load()).resolves.toBe(current);
     expect(loadCount).toBe(2);
   });
 
@@ -63,7 +64,8 @@ describe('ContextGraphAuthorityIndexRepository cache lifecycle', () => {
       return load();
     };
     const repository = new ContextGraphAuthorityIndexRepository(store);
-    const rejected = await repository.load('scope');
+    const scoped = repository.forScope('scope');
+    const rejected = await scoped.load();
     const winner = checkpoint(25);
     store.invalidate = async (_scope, expectedToken) => {
       expect(expectedToken).toBe(1);
@@ -71,12 +73,12 @@ describe('ContextGraphAuthorityIndexRepository cache lifecycle', () => {
       return undefined;
     };
 
-    const recovery = await repository.invalidateOrReloadWinner('scope', rejected);
+    const recovery = await scoped.invalidateOrReloadWinner(rejected);
     expect(recovery).toMatchObject({
       kind: 'winner',
       record: { kind: 'checkpoint', token: 2, checkpoint: winner },
     });
-    await expect(repository.load('scope')).resolves.toBe(recovery.record);
+    await expect(scoped.load()).resolves.toBe(recovery.record);
     expect(loadCount).toBe(2);
   });
 
@@ -90,7 +92,8 @@ describe('ContextGraphAuthorityIndexRepository cache lifecycle', () => {
       return load();
     };
     const repository = new ContextGraphAuthorityIndexRepository(store);
-    const previous = await repository.load('scope');
+    const scoped = repository.forScope('scope');
+    const previous = await scoped.load();
     const winner = checkpoint(25);
     store.compareAndSwap = async (_scope, expectedToken) => {
       expect(expectedToken).toBe(1);
@@ -98,16 +101,25 @@ describe('ContextGraphAuthorityIndexRepository cache lifecycle', () => {
       return undefined;
     };
 
-    const recovery = await repository.commitOrReloadWinner(
-      'scope',
-      previous,
-      checkpoint(21),
-    );
+    const recovery = await scoped.commitOrReloadWinner(previous, checkpoint(21));
     expect(recovery).toMatchObject({
       kind: 'winner',
       record: { kind: 'checkpoint', token: 2, checkpoint: winner },
     });
-    await expect(repository.load('scope')).resolves.toBe(recovery.record);
+    await expect(scoped.load()).resolves.toBe(recovery.record);
     expect(loadCount).toBe(2);
+  });
+
+  it('rejects observations produced by another repository scope', async () => {
+    const store = new MemoryAuthorityIndexStore();
+    store.record = { token: 1, value: checkpoint(20) };
+    const repository = new ContextGraphAuthorityIndexRepository(store);
+    const first = repository.forScope('first');
+    const second = repository.forScope('second');
+    const observation = await first.load();
+
+    await expect(second.commitOrReloadWinner(observation, checkpoint(21)))
+      .rejects.toThrow('observation belongs to another scope');
+    expect(store.commits).toEqual([]);
   });
 });

--- a/packages/chain/test/context-graph-authority-index.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-index.unit.test.ts
@@ -8,6 +8,7 @@ import {
   reduceContextGraphAuthorityIndexPage,
   type ContextGraphAuthorityIndexEvent,
 } from '../src/context-graph-authority-index-reducer.js';
+import { MemoryAuthorityIndexStore } from './helpers/context-graph-authority-index.js';
 
 const OWNER = `0x${'11'.repeat(20)}`;
 const NEXT_OWNER = `0x${'22'.repeat(20)}`;
@@ -68,36 +69,6 @@ function creation(
     publishAuthority: AUTHORITY,
     publishAuthorityAccountId: 7n,
   });
-}
-
-class MemoryAuthorityIndexStore implements ContextGraphAuthorityIndexStore {
-  record: Readonly<{ token: number; value: unknown | null }> | undefined;
-  readonly commits: number[] = [];
-  readonly invalidations: number[] = [];
-
-  async load(): Promise<Readonly<{ token: number; value: unknown | null }> | undefined> {
-    return this.record;
-  }
-
-  async compareAndSwap(
-    _scope: string,
-    expectedToken: number | undefined,
-    value: unknown,
-  ): Promise<number | undefined> {
-    if (this.record?.token !== expectedToken) return undefined;
-    const nextToken = expectedToken === undefined ? 1 : expectedToken + 1;
-    this.record = Object.freeze({ token: nextToken, value });
-    this.commits.push(nextToken);
-    return nextToken;
-  }
-
-  async invalidate(_scope: string, expectedToken: number): Promise<number | undefined> {
-    if (this.record?.token !== expectedToken) return undefined;
-    const nextToken = expectedToken + 1;
-    this.record = Object.freeze({ token: nextToken, value: null });
-    this.invalidations.push(nextToken);
-    return nextToken;
-  }
 }
 
 describe('durable contract-wide Context Graph authority scanner', () => {
@@ -265,6 +236,31 @@ describe('durable contract-wide Context Graph authority scanner', () => {
     expect(state).toMatchObject({ contextGraphId: '10', policyVersion: 1 });
     expect(store.record?.token).toBe(rejectedToken + 1);
     expect(store.invalidations).toEqual([]);
+  });
+
+  it('bounds repeated invalidation losses without recursive recovery', async () => {
+    const store = new MemoryAuthorityIndexStore();
+    store.record = { token: 1, value: { corrupt: true } };
+    let invalidationAttempts = 0;
+    store.invalidate = async (_scope, expectedToken) => {
+      invalidationAttempts += 1;
+      store.record = { token: expectedToken + 1, value: { corrupt: true } };
+      return undefined;
+    };
+    let pageReads = 0;
+
+    await expect(new ContextGraphAuthorityIndex(store).resolve(makeInput(
+      9n,
+      {},
+      async () => {
+        pageReads += 1;
+        return [];
+      },
+    ))).rejects.toThrow(
+      'Context Graph authority index changed repeatedly during checkpoint recovery',
+    );
+    expect(invalidationAttempts).toBe(3);
+    expect(pageReads).toBe(0);
   });
 
   it('reloads the CAS winner and resumes from its suffix with concurrent providers', async () => {

--- a/packages/chain/test/context-graph-authority-index.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-index.unit.test.ts
@@ -263,6 +263,50 @@ describe('durable contract-wide Context Graph authority scanner', () => {
     expect(pageReads).toBe(0);
   });
 
+  it('accepts a valid checkpoint installed by the third invalidation winner', async () => {
+    const store = new MemoryAuthorityIndexStore();
+    const winner = reduceContextGraphAuthorityIndexPage({
+      deploymentBlockNumber: 10,
+      throughBlockNumber: 25,
+      throughBlockHash: blockHash(25),
+      events: allEvents.filter((entry) => entry.blockNumber <= 25),
+    }).checkpoint;
+    const replacedAnchor = reduceContextGraphAuthorityIndexPage({
+      deploymentBlockNumber: 10,
+      throughBlockNumber: 25,
+      throughBlockHash: blockHash(24),
+      events: allEvents.filter((entry) => entry.blockNumber <= 25),
+    }).checkpoint;
+    store.record = { token: 1, value: replacedAnchor };
+    let invalidationAttempts = 0;
+    store.invalidate = async (_scope, expectedToken) => {
+      invalidationAttempts += 1;
+      store.record = {
+        token: expectedToken + 1,
+        value: invalidationAttempts === 3 ? winner : replacedAnchor,
+      };
+      return undefined;
+    };
+    let blockReads = 0;
+    let pageReads = 0;
+    const input = makeInput(9n, {}, async () => {
+      pageReads += 1;
+      return [];
+    });
+
+    await expect(new ContextGraphAuthorityIndex(store).resolve({
+      ...input,
+      readBlockHash: async () => {
+        blockReads += 1;
+        return blockHash(25);
+      },
+    })).resolves.toMatchObject({ contextGraphId: '9' });
+    expect(invalidationAttempts).toBe(3);
+    expect(store.record).toEqual({ token: 4, value: winner });
+    expect(blockReads).toBe(0);
+    expect(pageReads).toBe(0);
+  });
+
   it('reloads the CAS winner and resumes from its suffix with concurrent providers', async () => {
     const store = new MemoryAuthorityIndexStore();
     const index = new ContextGraphAuthorityIndex(store);

--- a/packages/chain/test/context-graph-authority-indexed-snapshot.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-indexed-snapshot.unit.test.ts
@@ -1,0 +1,540 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { ethers } from 'ethers';
+import { describe, expect, it } from 'vitest';
+
+import { EVMChainAdapter } from '../src/evm-adapter.js';
+import {
+  createAbortableTipReader,
+  MemoryAuthorityIndexStore,
+} from './helpers/context-graph-authority-index.js';
+
+const OWNER = '0x1111111111111111111111111111111111111111';
+const MEMBER = '0x2222222222222222222222222222222222222222';
+const AUTHORITY = '0x3333333333333333333333333333333333333333';
+const GOVERNANCE = '0x4444444444444444444444444444444444444444';
+const SECOND_MEMBER = '0x5555555555555555555555555555555555555555';
+const SECOND_AUTHORITY = '0x6666666666666666666666666666666666666666';
+const FINALIZED_HASH = `0x${'55'.repeat(32)}`;
+const NEXT_FINALIZED_HASH = `0x${'56'.repeat(32)}`;
+const REPLACEMENT_FINALIZED_HASH = `0x${'cc'.repeat(32)}`;
+const CREATION_HASH = `0x${'66'.repeat(32)}`;
+const POLICY_HASH = `0x${'77'.repeat(32)}`;
+const NEXT_POLICY_HASH = `0x${'78'.repeat(32)}`;
+const NAME_HASH = `0x${'88'.repeat(32)}`;
+
+interface IndexedAuthorityEvidence {
+  readonly filters: Array<readonly [string, ...unknown[]]>;
+  readonly staticCalls: Array<readonly [bigint, { blockTag: number }]>;
+  readonly readOptions: Array<Readonly<{
+    policy?: string;
+    signal?: AbortSignal;
+    isRetryable?: (error: unknown) => boolean;
+  }>>;
+  readonly indexRanges: Array<readonly [number, number]>;
+  readonly indexTopicSets: string[][];
+  readonly indexAddresses: string[];
+  readonly indexInvalidations: number[];
+}
+
+interface IndexedAuthorityProvider {
+  getBlock(tag: string | number): Promise<Readonly<{
+    number: number;
+    hash: string;
+  }> | null>;
+  getNetwork(): Promise<Readonly<{ chainId: bigint }>>;
+  getLogs(filter: Readonly<{
+    address: string;
+    fromBlock: number;
+    toBlock: number;
+    topics: string[][];
+  }>): Promise<readonly unknown[]>;
+}
+
+interface IndexedAuthorityHarness {
+  readonly adapter: EVMChainAdapter;
+  readonly evidence: IndexedAuthorityEvidence;
+  readonly provider: IndexedAuthorityProvider;
+  advanceAuthorityHead(): void;
+  replaceAuthorityFork(): void;
+  holdBlockRead(tag: string | number): Readonly<{ entered: Promise<void>; release(): void }>;
+  holdIndexPageRead(): Readonly<{ entered: Promise<void>; release(): void }>;
+}
+
+function makeIndexedAuthorityAdapter(
+  options: Readonly<{ deactivated?: boolean }> = {},
+): IndexedAuthorityHarness {
+  const authorityIndexStore = new MemoryAuthorityIndexStore();
+  const adapter: any = new EVMChainAdapter({
+    rpcUrl: 'http://127.0.0.1:1',
+    hubAddress: GOVERNANCE,
+    privateKey: `0x${'11'.repeat(32)}`,
+    allowNoAdminSigner: true,
+    chainId: 'evm:31337',
+    localContextGraphAuthorityIndexStore: authorityIndexStore,
+  });
+  adapter.initialized = true;
+  adapter.init = async () => {};
+  adapter.cgRegistryScanPageSize = 10;
+
+  const evidence: IndexedAuthorityEvidence = {
+    filters: [],
+    staticCalls: [],
+    readOptions: [],
+    indexRanges: [],
+    indexTopicSets: [],
+    indexAddresses: [],
+    indexInvalidations: authorityIndexStore.invalidations,
+  };
+  let finalizedNumber = 30;
+  let finalizedHash = FINALIZED_HASH;
+  let cachedAnchorReplaced = false;
+  let replacementAuthorityFork = false;
+  let blockReadGate: Readonly<{
+    tag: string | number;
+    entered: PromiseWithResolvers<void>;
+    release: PromiseWithResolvers<void>;
+  }> | undefined;
+  let indexPageReadGate: Readonly<{
+    entered: PromiseWithResolvers<void>;
+    release: PromiseWithResolvers<void>;
+  }> | undefined;
+
+  const namedArgs = (values: readonly unknown[], names: Record<string, unknown>) => (
+    Object.assign([...values], names)
+  );
+  const contract = {
+    interface: {
+      getEvent: (name: string) => ({ topicHash: `topic:${name}` }),
+      parseLog: (log: { parsed: unknown }) => log.parsed,
+    },
+    filters: Object.fromEntries([
+      'ContextGraphCreated',
+      'ContextGraphDeactivated',
+      'Transfer',
+      'PublishPolicyUpdated',
+      'PublishAuthorityUpdated',
+      'AgentParticipantAdded',
+      'AgentParticipantRemoved',
+    ].map((name) => [
+      name,
+      (...args: readonly unknown[]) => {
+        evidence.filters.push([name, ...args]);
+        return { name, args };
+      },
+    ])),
+    queryFilter: async () => {
+      throw new Error('indexed authority snapshots must not use per-event queryFilter reads');
+    },
+    getContextGraph: {
+      staticCall: async (contextGraphId: bigint, readOptions: { blockTag: number }) => {
+        evidence.staticCalls.push([contextGraphId, readOptions]);
+        return Object.assign(
+          [OWNER, [MEMBER, OWNER], 0n, !options.deactivated, 0n, 1n, 0n, AUTHORITY, 7n],
+          {
+            owner: OWNER,
+            participantAgents: [MEMBER, OWNER],
+            active: !options.deactivated,
+            accessPolicy: 1n,
+            publishPolicy: 0n,
+            publishAuthority: AUTHORITY,
+            publishAuthorityAccountId: 7n,
+          },
+        );
+      },
+    },
+    getAddress: async () => GOVERNANCE,
+  };
+
+  const provider: IndexedAuthorityProvider = {
+    getBlock: async (tag) => {
+      const gate = blockReadGate;
+      if (gate?.tag === tag) {
+        blockReadGate = undefined;
+        gate.entered.resolve();
+        await gate.release.promise;
+      }
+      if (tag === 'finalized') return { number: finalizedNumber, hash: finalizedHash };
+      const historicalHash = tag === 30 && cachedAnchorReplaced
+        ? REPLACEMENT_FINALIZED_HASH
+        : tag === 30
+          ? FINALIZED_HASH
+          : finalizedHash;
+      return { number: Number(tag), hash: historicalHash };
+    },
+    getNetwork: async () => ({ chainId: 31337n }),
+    getLogs: async (filter) => {
+      expect(filter.address).toBe(GOVERNANCE);
+      evidence.indexAddresses.push(filter.address);
+      evidence.indexRanges.push([filter.fromBlock, filter.toBlock]);
+      evidence.indexTopicSets.push(filter.topics[0] ?? []);
+      const gate = indexPageReadGate;
+      if (gate !== undefined) {
+        indexPageReadGate = undefined;
+        gate.entered.resolve();
+        await gate.release.promise;
+      }
+      const forkOwner = replacementAuthorityFork ? MEMBER : SECOND_MEMBER;
+      const forkParticipants = replacementAuthorityFork
+        ? [MEMBER]
+        : [MEMBER, SECOND_MEMBER];
+      return [
+        {
+          blockNumber: 10,
+          blockHash: CREATION_HASH,
+          index: 1,
+          parsed: {
+            name: 'ContextGraphCreated',
+            args: namedArgs([
+              9n,
+              forkOwner,
+              NAME_HASH,
+              forkParticipants,
+              0n,
+              1n,
+              0n,
+              AUTHORITY,
+              7n,
+            ], {
+              contextGraphId: 9n,
+              owner: forkOwner,
+              nameHash: NAME_HASH,
+              participantAgents: forkParticipants,
+              accessPolicy: 1n,
+              publishPolicy: 0n,
+              publishAuthority: AUTHORITY,
+              publishAuthorityAccountId: 7n,
+            }),
+          },
+        },
+        {
+          blockNumber: 10,
+          blockHash: CREATION_HASH,
+          index: 0,
+          parsed: {
+            name: 'Transfer',
+            args: namedArgs([ethers.ZeroAddress, forkOwner, 9n], {
+              from: ethers.ZeroAddress,
+              to: forkOwner,
+              tokenId: 9n,
+            }),
+          },
+        },
+        {
+          blockNumber: 15,
+          blockHash: `0x${'99'.repeat(32)}`,
+          index: 0,
+          parsed: {
+            name: 'Transfer',
+            args: namedArgs([SECOND_MEMBER, OWNER, 9n], {
+              from: SECOND_MEMBER,
+              to: OWNER,
+              tokenId: 9n,
+            }),
+          },
+        },
+        {
+          blockNumber: 20,
+          blockHash: POLICY_HASH,
+          index: 0,
+          parsed: {
+            name: 'PublishPolicyUpdated',
+            args: namedArgs([9n, 0n, SECOND_AUTHORITY, 9n], {
+              contextGraphId: 9n,
+              publishPolicy: 0n,
+              publishAuthority: SECOND_AUTHORITY,
+              publishAuthorityAccountId: 9n,
+            }),
+          },
+        },
+        {
+          blockNumber: 21,
+          blockHash: POLICY_HASH,
+          index: 0,
+          parsed: {
+            name: 'PublishAuthorityUpdated',
+            args: namedArgs([9n, AUTHORITY, 7n], {
+              contextGraphId: 9n,
+              newAuthority: AUTHORITY,
+              newAuthorityAccountId: 7n,
+            }),
+          },
+        },
+        ...[
+          ['AgentParticipantAdded', 22, `0x${'aa'.repeat(32)}`, OWNER],
+          ['AgentParticipantRemoved', 23, `0x${'bb'.repeat(32)}`, SECOND_MEMBER],
+        ].map(([name, blockNumber, hash, agent]) => ({
+          blockNumber,
+          blockHash: hash,
+          index: 0,
+          parsed: {
+            name,
+            args: namedArgs([9n, agent], { contextGraphId: 9n, agent }),
+          },
+        })),
+        ...(options.deactivated ? [{
+          blockNumber: 24,
+          blockHash: `0x${'bc'.repeat(32)}`,
+          index: 0,
+          parsed: {
+            name: 'ContextGraphDeactivated',
+            args: namedArgs([9n], { contextGraphId: 9n }),
+          },
+        }] : []),
+        {
+          blockNumber: 33,
+          blockHash: NEXT_POLICY_HASH,
+          index: 0,
+          parsed: {
+            name: 'PublishPolicyUpdated',
+            args: namedArgs([9n, 1n, ethers.ZeroAddress, 0n], {
+              contextGraphId: 9n,
+              publishPolicy: 1n,
+              publishAuthority: ethers.ZeroAddress,
+              publishAuthorityAccountId: 0n,
+            }),
+          },
+        },
+      ].filter((entry) => {
+        if (
+          replacementAuthorityFork
+          && entry.parsed.name !== 'ContextGraphCreated'
+          && !(entry.parsed.name === 'Transfer' && entry.blockNumber === 10)
+        ) return false;
+        return Number(entry.blockNumber) >= filter.fromBlock
+          && Number(entry.blockNumber) <= filter.toBlock;
+      });
+    },
+  };
+
+  adapter.contracts = {
+    contextGraphStorage: { connect: () => contract },
+  };
+  adapter.readTipProvider = async (
+    _label: string,
+    read: (selectedProvider: IndexedAuthorityProvider) => Promise<unknown>,
+    readOptions: IndexedAuthorityEvidence['readOptions'][number],
+  ) => {
+    evidence.readOptions.push(readOptions);
+    return read(provider);
+  };
+  adapter.resolveContractDeployBlock = async () => ({
+    fromBlock: 7,
+    head: 30,
+    scanProviders: [],
+  });
+
+  return {
+    adapter: adapter as EVMChainAdapter,
+    evidence,
+    provider,
+    advanceAuthorityHead: () => {
+      finalizedNumber = 35;
+      finalizedHash = NEXT_FINALIZED_HASH;
+    },
+    replaceAuthorityFork: () => {
+      finalizedHash = REPLACEMENT_FINALIZED_HASH;
+      cachedAnchorReplaced = true;
+      replacementAuthorityFork = true;
+    },
+    holdBlockRead: (tag) => {
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      blockReadGate = { tag, entered, release };
+      return { entered: entered.promise, release: release.resolve };
+    },
+    holdIndexPageRead: () => {
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      indexPageReadGate = { entered, release };
+      return { entered: entered.promise, release: release.resolve };
+    },
+  };
+}
+
+function bindAbortableTipReader(harness: IndexedAuthorityHarness): void {
+  (harness.adapter as any).readTipProvider = createAbortableTipReader(
+    harness.provider,
+    (options) => { harness.evidence.readOptions.push(options); },
+  );
+}
+
+describe('RFC-64 indexed Context Graph authority snapshots', () => {
+  it('uses one combined contract-wide log request per page when the durable index is wired', async () => {
+    const { adapter, evidence } = makeIndexedAuthorityAdapter();
+
+    const snapshot = await adapter.getContextGraphAuthoritySnapshot(9n);
+    expect(snapshot).toMatchObject({
+      contextGraphId: '9',
+      owner: OWNER,
+      active: true,
+      accessPolicy: 1,
+      publishPolicy: 0,
+      publishAuthority: AUTHORITY,
+      publishAuthorityAccountId: '7',
+      participantAgents: [OWNER, MEMBER],
+      ownershipEra: '1',
+      policyVersion: '3',
+      rosterVersion: '3',
+      sourceBlockNumber: '21',
+    });
+    expect(evidence.indexRanges).toEqual([[7, 16], [17, 26], [27, 30]]);
+    expect(evidence.indexAddresses).toEqual(Array(3).fill(GOVERNANCE));
+    expect(evidence.filters).toEqual([]);
+    expect(evidence.indexTopicSets).toEqual(Array(3).fill([
+      'topic:ContextGraphCreated',
+      'topic:ContextGraphDeactivated',
+      'topic:Transfer',
+      'topic:PublishPolicyUpdated',
+      'topic:PublishAuthorityUpdated',
+      'topic:AgentParticipantAdded',
+      'topic:AgentParticipantRemoved',
+    ]));
+    expect(evidence.staticCalls).toEqual([]);
+
+    await adapter.getContextGraphAuthoritySnapshot(9n);
+    expect(evidence.indexRanges).toHaveLength(3);
+    expect(evidence.staticCalls).toEqual([]);
+  });
+
+  it('rejects an indexed reorg fence then invalidates and rebuilds the replacement fork', async () => {
+    const harness = makeIndexedAuthorityAdapter();
+    const stabilization = harness.holdBlockRead(30);
+    const stale = harness.adapter.getContextGraphAuthoritySnapshot(9n);
+
+    await stabilization.entered;
+    harness.replaceAuthorityFork();
+    stabilization.release();
+    await expect(stale).rejects.toThrow('anchor changed');
+
+    await expect(harness.adapter.getContextGraphAuthoritySnapshot(9n)).resolves.toMatchObject({
+      contextGraphId: '9',
+      owner: MEMBER,
+      participantAgents: [MEMBER],
+      ownershipEra: '0',
+      policyVersion: '0',
+      rosterVersion: '0',
+    });
+    expect(harness.evidence.indexInvalidations).toEqual([4]);
+    expect(harness.evidence.indexRanges).toEqual([
+      [7, 16], [17, 26], [27, 30],
+      [7, 16], [17, 26], [27, 30],
+    ]);
+  });
+
+  it.each([
+    ['finalized head', (harness: IndexedAuthorityHarness) => harness.holdBlockRead('finalized')],
+    ['stabilization fence', (harness: IndexedAuthorityHarness) => harness.holdBlockRead(30)],
+  ] as const)('keeps caller cancellation bound during the indexed %s read', async (
+    _stage,
+    hold,
+  ) => {
+    const harness = makeIndexedAuthorityAdapter();
+    bindAbortableTipReader(harness);
+    const gate = hold(harness);
+    const abort = new AbortController();
+    const pending = harness.adapter.getContextGraphAuthoritySnapshot(9n, {
+      signal: abort.signal,
+    });
+    await gate.entered;
+    abort.abort(new Error('snapshot caller left'));
+    await expect(pending).rejects.toThrow('snapshot caller left');
+    expect(harness.evidence.readOptions[0]?.signal).toBe(abort.signal);
+    gate.release();
+  });
+
+  it('detaches one cancelled waiter without aborting its shared indexed page read', async () => {
+    const harness = makeIndexedAuthorityAdapter();
+    bindAbortableTipReader(harness);
+    const gate = harness.holdIndexPageRead();
+    const abort = new AbortController();
+    const cancelled = harness.adapter.getContextGraphAuthoritySnapshot(9n, {
+      signal: abort.signal,
+    });
+    await gate.entered;
+    const survivor = harness.adapter.getContextGraphAuthoritySnapshot(9n);
+    abort.abort(new Error('one waiter left'));
+    await expect(cancelled).rejects.toThrow('one waiter left');
+    gate.release();
+    await expect(survivor).resolves.toMatchObject({ contextGraphId: '9' });
+  });
+
+  it('fails over when a provider cannot revalidate the durable authority anchor', async () => {
+    const { adapter, provider, advanceAuthorityHead } = makeIndexedAuthorityAdapter();
+    await adapter.getContextGraphAuthoritySnapshot(9n);
+    advanceAuthorityHead();
+
+    const attempts: string[] = [];
+    const lagging: IndexedAuthorityProvider = {
+      ...provider,
+      getBlock: async (tag) => {
+        if (tag === 30) return null;
+        return provider.getBlock(tag);
+      },
+    };
+    (adapter as any).readTipProvider = async (
+      _label: string,
+      read: (selected: IndexedAuthorityProvider) => Promise<unknown>,
+      options: Readonly<{ isRetryable?: (error: unknown) => boolean }>,
+    ) => {
+      try {
+        attempts.push('lagging');
+        return await read(lagging);
+      } catch (error) {
+        expect(options.isRetryable?.(error)).toBe(true);
+        attempts.push('healthy');
+        return read(provider);
+      }
+    };
+
+    await expect(adapter.getContextGraphAuthoritySnapshot(9n)).resolves.toMatchObject({
+      policyVersion: '4',
+      sourceBlockNumber: '33',
+    });
+    expect(attempts).toEqual(['lagging', 'healthy']);
+  });
+
+  it('fails over when a provider cannot supply an intermediate page anchor', async () => {
+    const { adapter, provider } = makeIndexedAuthorityAdapter();
+    const attempts: string[] = [];
+    const nonArchive: IndexedAuthorityProvider = {
+      ...provider,
+      getBlock: async (tag) => {
+        if (tag === 16) return null;
+        return provider.getBlock(tag);
+      },
+    };
+    (adapter as any).readTipProvider = async (
+      _label: string,
+      read: (selected: IndexedAuthorityProvider) => Promise<unknown>,
+      options: Readonly<{ isRetryable?: (error: unknown) => boolean }>,
+    ) => {
+      try {
+        attempts.push('non-archive');
+        return await read(nonArchive);
+      } catch (error) {
+        expect(options.isRetryable?.(error)).toBe(true);
+        attempts.push('healthy');
+        return read(provider);
+      }
+    };
+
+    await expect(adapter.getContextGraphAuthoritySnapshot(9n)).resolves.toMatchObject({
+      contextGraphId: '9',
+      policyVersion: '3',
+    });
+    expect(attempts).toEqual(['non-archive', 'healthy']);
+  });
+
+  it('materializes deactivation from the shared event index without a point read', async () => {
+    const { adapter, evidence } = makeIndexedAuthorityAdapter({ deactivated: true });
+
+    await expect(adapter.getContextGraphAuthoritySnapshot(9n)).resolves.toMatchObject({
+      contextGraphId: '9',
+      active: false,
+      owner: OWNER,
+      participantAgents: [OWNER, MEMBER],
+    });
+    expect(evidence.staticCalls).toEqual([]);
+  });
+});

--- a/packages/chain/test/context-graph-authority-indexed-snapshot.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-indexed-snapshot.unit.test.ts
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { ethers } from 'ethers';
 import { describe, expect, it } from 'vitest';
 
 import { EVMChainAdapter } from '../src/evm-adapter.js';
@@ -8,20 +7,13 @@ import {
   createAbortableTipReader,
   MemoryAuthorityIndexStore,
 } from './helpers/context-graph-authority-index.js';
-
-const OWNER = '0x1111111111111111111111111111111111111111';
-const MEMBER = '0x2222222222222222222222222222222222222222';
-const AUTHORITY = '0x3333333333333333333333333333333333333333';
-const GOVERNANCE = '0x4444444444444444444444444444444444444444';
-const SECOND_MEMBER = '0x5555555555555555555555555555555555555555';
-const SECOND_AUTHORITY = '0x6666666666666666666666666666666666666666';
-const FINALIZED_HASH = `0x${'55'.repeat(32)}`;
-const NEXT_FINALIZED_HASH = `0x${'56'.repeat(32)}`;
-const REPLACEMENT_FINALIZED_HASH = `0x${'cc'.repeat(32)}`;
-const CREATION_HASH = `0x${'66'.repeat(32)}`;
-const POLICY_HASH = `0x${'77'.repeat(32)}`;
-const NEXT_POLICY_HASH = `0x${'78'.repeat(32)}`;
-const NAME_HASH = `0x${'88'.repeat(32)}`;
+import {
+  AUTHORITY,
+  createAuthorityScenario,
+  GOVERNANCE,
+  MEMBER,
+  OWNER,
+} from './helpers/context-graph-authority-scenario.js';
 
 interface IndexedAuthorityEvidence {
   readonly filters: Array<readonly [string, ...unknown[]]>;
@@ -64,6 +56,7 @@ interface IndexedAuthorityHarness {
 function makeIndexedAuthorityAdapter(
   options: Readonly<{ deactivated?: boolean }> = {},
 ): IndexedAuthorityHarness {
+  const scenario = createAuthorityScenario(options);
   const authorityIndexStore = new MemoryAuthorityIndexStore();
   const adapter: any = new EVMChainAdapter({
     rpcUrl: 'http://127.0.0.1:1',
@@ -86,23 +79,11 @@ function makeIndexedAuthorityAdapter(
     indexAddresses: [],
     indexInvalidations: authorityIndexStore.invalidations,
   };
-  let finalizedNumber = 30;
-  let finalizedHash = FINALIZED_HASH;
-  let cachedAnchorReplaced = false;
-  let replacementAuthorityFork = false;
-  let blockReadGate: Readonly<{
-    tag: string | number;
-    entered: PromiseWithResolvers<void>;
-    release: PromiseWithResolvers<void>;
-  }> | undefined;
   let indexPageReadGate: Readonly<{
     entered: PromiseWithResolvers<void>;
     release: PromiseWithResolvers<void>;
   }> | undefined;
 
-  const namedArgs = (values: readonly unknown[], names: Record<string, unknown>) => (
-    Object.assign([...values], names)
-  );
   const contract = {
     interface: {
       getEvent: (name: string) => ({ topicHash: `topic:${name}` }),
@@ -129,39 +110,14 @@ function makeIndexedAuthorityAdapter(
     getContextGraph: {
       staticCall: async (contextGraphId: bigint, readOptions: { blockTag: number }) => {
         evidence.staticCalls.push([contextGraphId, readOptions]);
-        return Object.assign(
-          [OWNER, [MEMBER, OWNER], 0n, !options.deactivated, 0n, 1n, 0n, AUTHORITY, 7n],
-          {
-            owner: OWNER,
-            participantAgents: [MEMBER, OWNER],
-            active: !options.deactivated,
-            accessPolicy: 1n,
-            publishPolicy: 0n,
-            publishAuthority: AUTHORITY,
-            publishAuthorityAccountId: 7n,
-          },
-        );
+        return scenario.readCurrentState();
       },
     },
     getAddress: async () => GOVERNANCE,
   };
 
   const provider: IndexedAuthorityProvider = {
-    getBlock: async (tag) => {
-      const gate = blockReadGate;
-      if (gate?.tag === tag) {
-        blockReadGate = undefined;
-        gate.entered.resolve();
-        await gate.release.promise;
-      }
-      if (tag === 'finalized') return { number: finalizedNumber, hash: finalizedHash };
-      const historicalHash = tag === 30 && cachedAnchorReplaced
-        ? REPLACEMENT_FINALIZED_HASH
-        : tag === 30
-          ? FINALIZED_HASH
-          : finalizedHash;
-      return { number: Number(tag), hash: historicalHash };
-    },
+    getBlock: (tag) => scenario.getBlock(tag),
     getNetwork: async () => ({ chainId: 31337n }),
     getLogs: async (filter) => {
       expect(filter.address).toBe(GOVERNANCE);
@@ -174,136 +130,7 @@ function makeIndexedAuthorityAdapter(
         gate.entered.resolve();
         await gate.release.promise;
       }
-      const forkOwner = replacementAuthorityFork ? MEMBER : SECOND_MEMBER;
-      const forkParticipants = replacementAuthorityFork
-        ? [MEMBER]
-        : [MEMBER, SECOND_MEMBER];
-      return [
-        {
-          blockNumber: 10,
-          blockHash: CREATION_HASH,
-          index: 1,
-          parsed: {
-            name: 'ContextGraphCreated',
-            args: namedArgs([
-              9n,
-              forkOwner,
-              NAME_HASH,
-              forkParticipants,
-              0n,
-              1n,
-              0n,
-              AUTHORITY,
-              7n,
-            ], {
-              contextGraphId: 9n,
-              owner: forkOwner,
-              nameHash: NAME_HASH,
-              participantAgents: forkParticipants,
-              accessPolicy: 1n,
-              publishPolicy: 0n,
-              publishAuthority: AUTHORITY,
-              publishAuthorityAccountId: 7n,
-            }),
-          },
-        },
-        {
-          blockNumber: 10,
-          blockHash: CREATION_HASH,
-          index: 0,
-          parsed: {
-            name: 'Transfer',
-            args: namedArgs([ethers.ZeroAddress, forkOwner, 9n], {
-              from: ethers.ZeroAddress,
-              to: forkOwner,
-              tokenId: 9n,
-            }),
-          },
-        },
-        {
-          blockNumber: 15,
-          blockHash: `0x${'99'.repeat(32)}`,
-          index: 0,
-          parsed: {
-            name: 'Transfer',
-            args: namedArgs([SECOND_MEMBER, OWNER, 9n], {
-              from: SECOND_MEMBER,
-              to: OWNER,
-              tokenId: 9n,
-            }),
-          },
-        },
-        {
-          blockNumber: 20,
-          blockHash: POLICY_HASH,
-          index: 0,
-          parsed: {
-            name: 'PublishPolicyUpdated',
-            args: namedArgs([9n, 0n, SECOND_AUTHORITY, 9n], {
-              contextGraphId: 9n,
-              publishPolicy: 0n,
-              publishAuthority: SECOND_AUTHORITY,
-              publishAuthorityAccountId: 9n,
-            }),
-          },
-        },
-        {
-          blockNumber: 21,
-          blockHash: POLICY_HASH,
-          index: 0,
-          parsed: {
-            name: 'PublishAuthorityUpdated',
-            args: namedArgs([9n, AUTHORITY, 7n], {
-              contextGraphId: 9n,
-              newAuthority: AUTHORITY,
-              newAuthorityAccountId: 7n,
-            }),
-          },
-        },
-        ...[
-          ['AgentParticipantAdded', 22, `0x${'aa'.repeat(32)}`, OWNER],
-          ['AgentParticipantRemoved', 23, `0x${'bb'.repeat(32)}`, SECOND_MEMBER],
-        ].map(([name, blockNumber, hash, agent]) => ({
-          blockNumber,
-          blockHash: hash,
-          index: 0,
-          parsed: {
-            name,
-            args: namedArgs([9n, agent], { contextGraphId: 9n, agent }),
-          },
-        })),
-        ...(options.deactivated ? [{
-          blockNumber: 24,
-          blockHash: `0x${'bc'.repeat(32)}`,
-          index: 0,
-          parsed: {
-            name: 'ContextGraphDeactivated',
-            args: namedArgs([9n], { contextGraphId: 9n }),
-          },
-        }] : []),
-        {
-          blockNumber: 33,
-          blockHash: NEXT_POLICY_HASH,
-          index: 0,
-          parsed: {
-            name: 'PublishPolicyUpdated',
-            args: namedArgs([9n, 1n, ethers.ZeroAddress, 0n], {
-              contextGraphId: 9n,
-              publishPolicy: 1n,
-              publishAuthority: ethers.ZeroAddress,
-              publishAuthorityAccountId: 0n,
-            }),
-          },
-        },
-      ].filter((entry) => {
-        if (
-          replacementAuthorityFork
-          && entry.parsed.name !== 'ContextGraphCreated'
-          && !(entry.parsed.name === 'Transfer' && entry.blockNumber === 10)
-        ) return false;
-        return Number(entry.blockNumber) >= filter.fromBlock
-          && Number(entry.blockNumber) <= filter.toBlock;
-      });
+      return scenario.renderParsedLogs(filter.fromBlock, filter.toBlock);
     },
   };
 
@@ -328,21 +155,9 @@ function makeIndexedAuthorityAdapter(
     adapter: adapter as EVMChainAdapter,
     evidence,
     provider,
-    advanceAuthorityHead: () => {
-      finalizedNumber = 35;
-      finalizedHash = NEXT_FINALIZED_HASH;
-    },
-    replaceAuthorityFork: () => {
-      finalizedHash = REPLACEMENT_FINALIZED_HASH;
-      cachedAnchorReplaced = true;
-      replacementAuthorityFork = true;
-    },
-    holdBlockRead: (tag) => {
-      const entered = Promise.withResolvers<void>();
-      const release = Promise.withResolvers<void>();
-      blockReadGate = { tag, entered, release };
-      return { entered: entered.promise, release: release.resolve };
-    },
+    advanceAuthorityHead: scenario.advanceAuthorityHead,
+    replaceAuthorityFork: scenario.replaceAuthorityFork,
+    holdBlockRead: scenario.holdBlockRead,
     holdIndexPageRead: () => {
       const entered = Promise.withResolvers<void>();
       const release = Promise.withResolvers<void>();

--- a/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
@@ -36,10 +36,6 @@ interface AuthorityEvidence {
   readonly staticCalls: Array<readonly [bigint, { blockTag: number }]>;
   readonly deploymentReads: Array<readonly [string, string, string]>;
   readonly readOptions: Array<Readonly<{ policy?: string; signal?: AbortSignal }>>;
-  readonly indexRanges: Array<readonly [number, number]>;
-  readonly indexTopicSets: string[][];
-  readonly indexAddresses: string[];
-  readonly indexInvalidations: number[];
 }
 
 interface EvmAuthorityHarness {
@@ -49,10 +45,8 @@ interface EvmAuthorityHarness {
   advanceAuthorityHead(): void;
   replaceCachedAnchor(): void;
   replaceFinalizedHead(): void;
-  replaceAuthorityFork(): void;
   holdCurrentStateRead(): Readonly<{ entered: Promise<void>; release(): void }>;
   holdBlockRead(tag: string | number): Readonly<{ entered: Promise<void>; release(): void }>;
-  holdIndexPageRead(): Readonly<{ entered: Promise<void>; release(): void }>;
   setPublishAuthorityAccountId(value: unknown): void;
   rotateContextGraphStorage(): void;
 }
@@ -61,39 +55,14 @@ function makeEvmAuthorityAdapter(
   options: {
     reorg?: boolean;
     providerRangeLimit?: number;
-    sharedIndex?: boolean;
-    deactivated?: boolean;
   } = {},
 ): EvmAuthorityHarness {
-  let authorityIndexRecord: Readonly<{ token: number; value: unknown | null }> | undefined;
-  const indexInvalidations: number[] = [];
-  const authorityIndexStore = {
-    load: async () => authorityIndexRecord,
-    compareAndSwap: async (
-      _scope: string,
-      expectedToken: number | undefined,
-      value: unknown,
-    ) => {
-      if (authorityIndexRecord?.token !== expectedToken) return undefined;
-      const nextToken = expectedToken === undefined ? 1 : expectedToken + 1;
-      authorityIndexRecord = { token: nextToken, value };
-      return nextToken;
-    },
-    invalidate: async (_scope: string, expectedToken: number) => {
-      if (authorityIndexRecord?.token !== expectedToken) return undefined;
-      const nextToken = expectedToken + 1;
-      authorityIndexRecord = { token: nextToken, value: null };
-      indexInvalidations.push(nextToken);
-      return nextToken;
-    },
-  };
   const adapter: any = new EVMChainAdapter({
     rpcUrl: 'http://127.0.0.1:1',
     hubAddress: GOVERNANCE,
     privateKey: `0x${'11'.repeat(32)}`,
     allowNoAdminSigner: true,
     chainId: 'evm:31337',
-    ...(options.sharedIndex ? { localContextGraphAuthorityIndexStore: authorityIndexStore } : {}),
   });
   adapter.initialized = true;
   adapter.init = async () => {};
@@ -104,23 +73,14 @@ function makeEvmAuthorityAdapter(
     staticCalls: [] as Array<readonly [bigint, { blockTag: number }]>,
     deploymentReads: [] as Array<readonly [string, string, string]>,
     readOptions: [],
-    indexRanges: [],
-    indexTopicSets: [],
-    indexAddresses: [],
-    indexInvalidations,
   };
 
   let finalizedNumber = 30;
   let finalizedHash = FINALIZED_HASH;
   let cachedAnchorReplaced = false;
-  let replacementAuthorityFork = false;
   let currentReadGate: PromiseWithResolvers<void> | undefined;
   let blockReadGate: Readonly<{
     tag: string | number;
-    entered: PromiseWithResolvers<void>;
-    release: PromiseWithResolvers<void>;
-  }> | undefined;
-  let indexPageReadGate: Readonly<{
     entered: PromiseWithResolvers<void>;
     release: PromiseWithResolvers<void>;
   }> | undefined;
@@ -136,9 +96,6 @@ function makeEvmAuthorityAdapter(
       AUTHORITY,
       7n,
     ])],
-    ContextGraphDeactivated: options.deactivated
-      ? [event(24, 0, `0x${'bc'.repeat(32)}`, [9n])]
-      : [],
     Transfer: [
       event(10, 0, CREATION_HASH, [ethers.ZeroAddress, SECOND_MEMBER, 9n]),
       event(15, 0, `0x${'99'.repeat(32)}`, [SECOND_MEMBER, OWNER, 9n]),
@@ -151,11 +108,11 @@ function makeEvmAuthorityAdapter(
     AgentParticipantRemoved: [event(23, 0, `0x${'bb'.repeat(32)}`, [9n, SECOND_MEMBER])],
   };
   const current = Object.assign(
-    [OWNER, [MEMBER, OWNER], 0n, !options.deactivated, 0n, 1n, 0n, AUTHORITY, 7n],
+    [OWNER, [MEMBER, OWNER], 0n, true, 0n, 1n, 0n, AUTHORITY, 7n],
     {
       owner: OWNER,
       participantAgents: [MEMBER, OWNER],
-      active: !options.deactivated,
+      active: true,
       accessPolicy: 1n,
       publishPolicy: 0n,
       publishAuthority: AUTHORITY,
@@ -236,152 +193,6 @@ function makeEvmAuthorityAdapter(
       };
     },
     getNetwork: async () => ({ chainId: 31337n }),
-    getLogs: async (filter: {
-      address: string;
-      fromBlock: number;
-      toBlock: number;
-      topics: string[][];
-    }) => {
-      expect(filter.address).toBe(GOVERNANCE);
-      evidence.indexAddresses.push(filter.address);
-      evidence.indexRanges.push([filter.fromBlock, filter.toBlock]);
-      evidence.indexTopicSets.push(filter.topics[0] ?? []);
-      const gate = indexPageReadGate;
-      if (gate !== undefined) {
-        indexPageReadGate = undefined;
-        gate.entered.resolve();
-        await gate.release.promise;
-      }
-      const namedArgs = (values: readonly unknown[], names: Record<string, unknown>) => (
-        Object.assign([...values], names)
-      );
-      const forkOwner = replacementAuthorityFork ? MEMBER : SECOND_MEMBER;
-      const forkParticipants = replacementAuthorityFork
-        ? [MEMBER]
-        : [MEMBER, SECOND_MEMBER];
-      return [
-        {
-          blockNumber: 10,
-          blockHash: CREATION_HASH,
-          index: 1,
-          parsed: {
-            name: 'ContextGraphCreated',
-            args: namedArgs([
-              9n,
-              forkOwner,
-              NAME_HASH,
-              forkParticipants,
-              0n,
-              1n,
-              0n,
-              AUTHORITY,
-              7n,
-            ], {
-              contextGraphId: 9n,
-              owner: forkOwner,
-              nameHash: NAME_HASH,
-              participantAgents: forkParticipants,
-              accessPolicy: 1n,
-              publishPolicy: 0n,
-              publishAuthority: AUTHORITY,
-              publishAuthorityAccountId: 7n,
-            }),
-          },
-        },
-        {
-          blockNumber: 10,
-          blockHash: CREATION_HASH,
-          index: 0,
-          parsed: {
-            name: 'Transfer',
-            args: namedArgs([ethers.ZeroAddress, forkOwner, 9n], {
-              from: ethers.ZeroAddress, to: forkOwner, tokenId: 9n,
-            }),
-          },
-        },
-        {
-          blockNumber: 15,
-          blockHash: `0x${'99'.repeat(32)}`,
-          index: 0,
-          parsed: {
-            name: 'Transfer',
-            args: namedArgs([SECOND_MEMBER, OWNER, 9n], {
-              from: SECOND_MEMBER, to: OWNER, tokenId: 9n,
-            }),
-          },
-        },
-        {
-          blockNumber: 20,
-          blockHash: POLICY_HASH,
-          index: 0,
-          parsed: {
-            name: 'PublishPolicyUpdated',
-            args: namedArgs([9n, 0n, SECOND_AUTHORITY, 9n], {
-              contextGraphId: 9n,
-              publishPolicy: 0n,
-              publishAuthority: SECOND_AUTHORITY,
-              publishAuthorityAccountId: 9n,
-            }),
-          },
-        },
-        {
-          blockNumber: 21,
-          blockHash: POLICY_HASH,
-          index: 0,
-          parsed: {
-            name: 'PublishAuthorityUpdated',
-            args: namedArgs([9n, AUTHORITY, 7n], {
-              contextGraphId: 9n,
-              newAuthority: AUTHORITY,
-              newAuthorityAccountId: 7n,
-            }),
-          },
-        },
-        ...[
-          ['AgentParticipantAdded', 22, `0x${'aa'.repeat(32)}`, OWNER],
-          ['AgentParticipantRemoved', 23, `0x${'bb'.repeat(32)}`, SECOND_MEMBER],
-        ].map(([name, blockNumber, hash, agent]) => ({
-          blockNumber,
-          blockHash: hash,
-          index: 0,
-          parsed: {
-            name,
-            args: namedArgs([9n, agent], { contextGraphId: 9n, agent }),
-          },
-        })),
-        ...(options.deactivated ? [{
-          blockNumber: 24,
-          blockHash: `0x${'bc'.repeat(32)}`,
-          index: 0,
-          parsed: {
-            name: 'ContextGraphDeactivated',
-            args: namedArgs([9n], { contextGraphId: 9n }),
-          },
-        }] : []),
-        {
-          blockNumber: 33,
-          blockHash: NEXT_POLICY_HASH,
-          index: 0,
-          parsed: {
-            name: 'PublishPolicyUpdated',
-            args: namedArgs([9n, 1n, ethers.ZeroAddress, 0n], {
-              contextGraphId: 9n,
-              publishPolicy: 1n,
-              publishAuthority: ethers.ZeroAddress,
-              publishAuthorityAccountId: 0n,
-            }),
-          },
-        },
-      ].filter((entry) => {
-        if (
-          replacementAuthorityFork
-          && entry.parsed.name !== 'ContextGraphCreated'
-          && !(entry.parsed.name === 'Transfer' && entry.blockNumber === 10)
-        ) return false;
-        return Number(entry.blockNumber) >= filter.fromBlock
-          && Number(entry.blockNumber) <= filter.toBlock;
-      });
-    },
   };
   adapter.contracts = {
     contextGraphStorage: { connect: () => contract },
@@ -426,11 +237,6 @@ function makeEvmAuthorityAdapter(
       finalizedHash = REPLACEMENT_FINALIZED_HASH;
       cachedAnchorReplaced = true;
     },
-    replaceAuthorityFork: () => {
-      finalizedHash = REPLACEMENT_FINALIZED_HASH;
-      cachedAnchorReplaced = true;
-      replacementAuthorityFork = true;
-    },
     holdCurrentStateRead: () => {
       const entered = Promise.withResolvers<void>();
       const release = Promise.withResolvers<void>();
@@ -447,12 +253,6 @@ function makeEvmAuthorityAdapter(
       blockReadGate = { tag, entered, release };
       return { entered: entered.promise, release: release.resolve };
     },
-    holdIndexPageRead: () => {
-      const entered = Promise.withResolvers<void>();
-      const release = Promise.withResolvers<void>();
-      indexPageReadGate = { entered, release };
-      return { entered: entered.promise, release: release.resolve };
-    },
     setPublishAuthorityAccountId: (value) => {
       current.publishAuthorityAccountId = value;
       current[8] = value;
@@ -462,220 +262,6 @@ function makeEvmAuthorityAdapter(
 }
 
 describe('RFC-64 Context Graph authority snapshots', () => {
-  it('uses one combined contract-wide log request per page when the durable index is wired', async () => {
-    const { adapter, evidence } = makeEvmAuthorityAdapter({ sharedIndex: true });
-
-    const snapshot = await adapter.getContextGraphAuthoritySnapshot(9n);
-    expect(snapshot).toMatchObject({
-      contextGraphId: '9',
-      owner: OWNER,
-      active: true,
-      accessPolicy: 1,
-      publishPolicy: 0,
-      publishAuthority: AUTHORITY,
-      publishAuthorityAccountId: '7',
-      participantAgents: [OWNER, MEMBER],
-      ownershipEra: '1',
-      policyVersion: '3',
-      rosterVersion: '3',
-      sourceBlockNumber: '21',
-    });
-    expect(evidence.indexRanges).toEqual([[7, 16], [17, 26], [27, 30]]);
-    expect(evidence.indexAddresses).toEqual(Array(3).fill(GOVERNANCE));
-    expect(evidence.filters).toEqual([]);
-    expect(evidence.indexTopicSets).toEqual(Array(3).fill([
-      'topic:ContextGraphCreated',
-      'topic:ContextGraphDeactivated',
-      'topic:Transfer',
-      'topic:PublishPolicyUpdated',
-      'topic:PublishAuthorityUpdated',
-      'topic:AgentParticipantAdded',
-      'topic:AgentParticipantRemoved',
-    ]));
-    expect(evidence.staticCalls).toEqual([]);
-
-    await adapter.getContextGraphAuthoritySnapshot(9n);
-    expect(evidence.indexRanges).toHaveLength(3);
-    expect(evidence.staticCalls).toEqual([]);
-  });
-
-  it('rejects an indexed reorg fence then invalidates and rebuilds the replacement fork', async () => {
-    const harness = makeEvmAuthorityAdapter({ sharedIndex: true });
-    const stabilization = harness.holdBlockRead(30);
-    const stale = harness.adapter.getContextGraphAuthoritySnapshot(9n);
-
-    await stabilization.entered;
-    harness.replaceAuthorityFork();
-    stabilization.release();
-    await expect(stale).rejects.toThrow('anchor changed');
-
-    await expect(harness.adapter.getContextGraphAuthoritySnapshot(9n)).resolves.toMatchObject({
-      contextGraphId: '9',
-      owner: MEMBER,
-      participantAgents: [MEMBER],
-      ownershipEra: '0',
-      policyVersion: '0',
-      rosterVersion: '0',
-    });
-    expect(harness.evidence.indexInvalidations).toEqual([4]);
-    expect(harness.evidence.indexRanges).toEqual([
-      [7, 16], [17, 26], [27, 30],
-      [7, 16], [17, 26], [27, 30],
-    ]);
-  });
-
-  it.each([
-    ['finalized head', (harness: EvmAuthorityHarness) => harness.holdBlockRead('finalized')],
-    ['stabilization fence', (harness: EvmAuthorityHarness) => harness.holdBlockRead(30)],
-  ] as const)('keeps caller cancellation bound during the indexed %s read', async (
-    _stage,
-    hold,
-  ) => {
-    const harness = makeEvmAuthorityAdapter({ sharedIndex: true });
-    const adapter = harness.adapter as any;
-    adapter.readTipProvider = async (
-      _label: string,
-      read: (provider: EvmAuthorityHarness['provider']) => Promise<unknown>,
-      options: Readonly<{ signal?: AbortSignal }>,
-    ) => {
-      harness.evidence.readOptions.push(options);
-      const pending = read(harness.provider);
-      if (options.signal === undefined) return pending;
-      return new Promise((resolve, reject) => {
-        const onAbort = () => reject(options.signal!.reason);
-        options.signal!.addEventListener('abort', onAbort, { once: true });
-        void pending.then(resolve, reject).finally(() => {
-          options.signal!.removeEventListener('abort', onAbort);
-        });
-      });
-    };
-    const gate = hold(harness);
-    const abort = new AbortController();
-    const pending = harness.adapter.getContextGraphAuthoritySnapshot(9n, {
-      signal: abort.signal,
-    });
-    await gate.entered;
-    abort.abort(new Error('snapshot caller left'));
-    await expect(pending).rejects.toThrow('snapshot caller left');
-    expect(harness.evidence.readOptions[0]?.signal).toBe(abort.signal);
-    gate.release();
-  });
-
-  it('detaches one cancelled waiter without aborting its shared indexed page read', async () => {
-    const harness = makeEvmAuthorityAdapter({ sharedIndex: true });
-    const adapter = harness.adapter as any;
-    adapter.readTipProvider = async (
-      _label: string,
-      read: (provider: EvmAuthorityHarness['provider']) => Promise<unknown>,
-      options: Readonly<{ signal?: AbortSignal }>,
-    ) => {
-      const pending = read(harness.provider);
-      if (options.signal === undefined) return pending;
-      return new Promise((resolve, reject) => {
-        const onAbort = () => reject(options.signal!.reason);
-        options.signal!.addEventListener('abort', onAbort, { once: true });
-        void pending.then(resolve, reject).finally(() => {
-          options.signal!.removeEventListener('abort', onAbort);
-        });
-      });
-    };
-    const gate = harness.holdIndexPageRead();
-    const abort = new AbortController();
-    const cancelled = harness.adapter.getContextGraphAuthoritySnapshot(9n, {
-      signal: abort.signal,
-    });
-    await gate.entered;
-    const survivor = harness.adapter.getContextGraphAuthoritySnapshot(9n);
-    abort.abort(new Error('one waiter left'));
-    await expect(cancelled).rejects.toThrow('one waiter left');
-    gate.release();
-    await expect(survivor).resolves.toMatchObject({ contextGraphId: '9' });
-  });
-
-  it('fails over when a provider cannot revalidate the durable authority anchor', async () => {
-    const { adapter, provider, advanceAuthorityHead } = makeEvmAuthorityAdapter({
-      sharedIndex: true,
-    });
-    await adapter.getContextGraphAuthoritySnapshot(9n);
-    advanceAuthorityHead();
-
-    const attempts: string[] = [];
-    const lagging = {
-      ...provider,
-      getBlock: async (tag: string | number) => {
-        if (tag === 30) return null;
-        return (provider.getBlock as (block: string | number) => Promise<unknown>)(tag);
-      },
-    };
-    (adapter as any).readTipProvider = async (
-      _label: string,
-      read: (selected: typeof lagging) => Promise<unknown>,
-      options: Readonly<{ isRetryable?: (error: unknown) => boolean }>,
-    ) => {
-      try {
-        attempts.push('lagging');
-        return await read(lagging);
-      } catch (error) {
-        expect(options.isRetryable?.(error)).toBe(true);
-        attempts.push('healthy');
-        return read(provider as typeof lagging);
-      }
-    };
-
-    await expect(adapter.getContextGraphAuthoritySnapshot(9n)).resolves.toMatchObject({
-      policyVersion: '4',
-      sourceBlockNumber: '33',
-    });
-    expect(attempts).toEqual(['lagging', 'healthy']);
-  });
-
-  it('fails over when a provider cannot supply an intermediate page anchor', async () => {
-    const { adapter, provider } = makeEvmAuthorityAdapter({ sharedIndex: true });
-    const attempts: string[] = [];
-    const nonArchive = {
-      ...provider,
-      getBlock: async (tag: string | number) => {
-        if (tag === 16) return null;
-        return (provider.getBlock as (block: string | number) => Promise<unknown>)(tag);
-      },
-    };
-    (adapter as any).readTipProvider = async (
-      _label: string,
-      read: (selected: typeof nonArchive) => Promise<unknown>,
-      options: Readonly<{ isRetryable?: (error: unknown) => boolean }>,
-    ) => {
-      try {
-        attempts.push('non-archive');
-        return await read(nonArchive);
-      } catch (error) {
-        expect(options.isRetryable?.(error)).toBe(true);
-        attempts.push('healthy');
-        return read(provider as typeof nonArchive);
-      }
-    };
-
-    await expect(adapter.getContextGraphAuthoritySnapshot(9n)).resolves.toMatchObject({
-      contextGraphId: '9',
-      policyVersion: '3',
-    });
-    expect(attempts).toEqual(['non-archive', 'healthy']);
-  });
-
-  it('materializes deactivation from the shared event index without a point read', async () => {
-    const { adapter, evidence } = makeEvmAuthorityAdapter({
-      sharedIndex: true,
-      deactivated: true,
-    });
-
-    await expect(adapter.getContextGraphAuthoritySnapshot(9n)).resolves.toMatchObject({
-      contextGraphId: '9',
-      active: false,
-      owner: OWNER,
-      participantAgents: [OWNER, MEMBER],
-    });
-    expect(evidence.staticCalls).toEqual([]);
-  });
-
   it('reads one stable finalized EVM generation and derives monotonic epochs', async () => {
     const { adapter, evidence, advanceAuthorityHead } = makeEvmAuthorityAdapter();
     const snapshot = await adapter.getContextGraphAuthoritySnapshot(9n);

--- a/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
+++ b/packages/chain/test/context-graph-authority-snapshot.unit.test.ts
@@ -1,34 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from 'vitest';
-import { ethers } from 'ethers';
 
 import type { ContextGraphAuthoritySnapshot } from '../src/chain-adapter.js';
 import { EVMChainAdapter } from '../src/evm-adapter.js';
 import { MockChainAdapter } from '../src/mock-adapter.js';
-
-const OWNER = '0x1111111111111111111111111111111111111111';
-const MEMBER = '0x2222222222222222222222222222222222222222';
-const AUTHORITY = '0x3333333333333333333333333333333333333333';
-const GOVERNANCE = '0x4444444444444444444444444444444444444444';
-const SECOND_MEMBER = '0x5555555555555555555555555555555555555555';
-const SECOND_AUTHORITY = '0x6666666666666666666666666666666666666666';
-const FINALIZED_HASH = `0x${'55'.repeat(32)}`;
-const NEXT_FINALIZED_HASH = `0x${'56'.repeat(32)}`;
-const REPLACEMENT_FINALIZED_HASH = `0x${'cc'.repeat(32)}`;
-const CREATION_HASH = `0x${'66'.repeat(32)}`;
-const POLICY_HASH = `0x${'77'.repeat(32)}`;
-const NEXT_POLICY_HASH = `0x${'78'.repeat(32)}`;
-const NAME_HASH = `0x${'88'.repeat(32)}`;
-
-function event(
-  blockNumber: number,
-  index: number,
-  blockHash: string,
-  args: readonly unknown[] = [],
-) {
-  return { blockNumber, index, blockHash, args };
-}
+import {
+  AUTHORITY,
+  createAuthorityScenario,
+  FINALIZED_HASH,
+  GOVERNANCE,
+  MEMBER,
+  NAME_HASH,
+  NEXT_POLICY_HASH,
+  OWNER,
+  POLICY_HASH,
+  SECOND_AUTHORITY,
+  SECOND_MEMBER,
+} from './helpers/context-graph-authority-scenario.js';
 
 interface AuthorityEvidence {
   readonly filters: Array<readonly [string, ...unknown[]]>;
@@ -57,6 +46,7 @@ function makeEvmAuthorityAdapter(
     providerRangeLimit?: number;
   } = {},
 ): EvmAuthorityHarness {
+  const scenario = createAuthorityScenario({ reorg: options.reorg });
   const adapter: any = new EVMChainAdapter({
     rpcUrl: 'http://127.0.0.1:1',
     hubAddress: GOVERNANCE,
@@ -75,56 +65,19 @@ function makeEvmAuthorityAdapter(
     readOptions: [],
   };
 
-  let finalizedNumber = 30;
-  let finalizedHash = FINALIZED_HASH;
-  let cachedAnchorReplaced = false;
-  let currentReadGate: PromiseWithResolvers<void> | undefined;
-  let blockReadGate: Readonly<{
-    tag: string | number;
-    entered: PromiseWithResolvers<void>;
-    release: PromiseWithResolvers<void>;
-  }> | undefined;
-  const logs: Record<string, ReturnType<typeof event>[]> = {
-    ContextGraphCreated: [event(10, 1, CREATION_HASH, [
-      9n,
-      SECOND_MEMBER,
-      NAME_HASH,
-      [MEMBER, SECOND_MEMBER],
-      0n,
-      1n,
-      0n,
-      AUTHORITY,
-      7n,
-    ])],
-    Transfer: [
-      event(10, 0, CREATION_HASH, [ethers.ZeroAddress, SECOND_MEMBER, 9n]),
-      event(15, 0, `0x${'99'.repeat(32)}`, [SECOND_MEMBER, OWNER, 9n]),
-    ],
-    PublishPolicyUpdated: [event(20, 0, POLICY_HASH, [
-      9n, 0n, SECOND_AUTHORITY, 9n,
-    ])],
-    PublishAuthorityUpdated: [event(21, 0, POLICY_HASH, [9n, AUTHORITY, 7n])],
-    AgentParticipantAdded: [event(22, 0, `0x${'aa'.repeat(32)}`, [9n, OWNER])],
-    AgentParticipantRemoved: [event(23, 0, `0x${'bb'.repeat(32)}`, [9n, SECOND_MEMBER])],
-  };
-  const current = Object.assign(
-    [OWNER, [MEMBER, OWNER], 0n, true, 0n, 1n, 0n, AUTHORITY, 7n],
-    {
-      owner: OWNER,
-      participantAgents: [MEMBER, OWNER],
-      active: true,
-      accessPolicy: 1n,
-      publishPolicy: 0n,
-      publishAuthority: AUTHORITY,
-      publishAuthorityAccountId: 7n,
-    },
-  );
   const contract = {
     interface: {
       getEvent: (name: string) => ({ topicHash: `topic:${name}` }),
       parseLog: (log: { parsed: unknown }) => log.parsed,
     },
-    filters: Object.fromEntries(Object.keys(logs).map((name) => [
+    filters: Object.fromEntries([
+      'ContextGraphCreated',
+      'Transfer',
+      'PublishPolicyUpdated',
+      'PublishAuthorityUpdated',
+      'AgentParticipantAdded',
+      'AgentParticipantRemoved',
+    ].map((name) => [
       name,
       (...args: readonly unknown[]) => {
         evidence.filters.push([name, ...args]);
@@ -151,47 +104,20 @@ function makeEvmAuthorityAdapter(
           },
         };
       }
-      return (logs[filter.name] ?? []).filter(
-        (entry) => entry.blockNumber >= fromBlock && entry.blockNumber <= toBlock,
-      );
+      return scenario.renderQueryFilter(filter.name, fromBlock, toBlock);
     },
     getContextGraph: {
       staticCall: async (contextGraphId: bigint, readOptions: { blockTag: number }) => {
         evidence.staticCalls.push([contextGraphId, readOptions]);
         expect(contextGraphId).toBe(9n);
-        expect(readOptions).toEqual({ blockTag: finalizedNumber });
-        const gate = currentReadGate;
-        if (gate !== undefined) {
-          currentReadGate = undefined;
-          gate.resolve();
-          await gate.promise;
-        }
-        return current;
+        expect(readOptions).toEqual({ blockTag: scenario.finalizedNumber });
+        return scenario.readCurrentState();
       },
     },
     getAddress: async () => GOVERNANCE,
   };
   const provider = {
-    getBlock: async (tag: string | number) => {
-      const gate = blockReadGate;
-      if (gate?.tag === tag) {
-        blockReadGate = undefined;
-        gate.entered.resolve();
-        await gate.release.promise;
-      }
-      if (tag === 'finalized') return { number: finalizedNumber, hash: finalizedHash };
-      const historicalHash = tag === 30 && cachedAnchorReplaced
-        ? REPLACEMENT_FINALIZED_HASH
-        : tag === 30
-          ? FINALIZED_HASH
-          : finalizedHash;
-      return {
-        number: Number(tag),
-        hash: options.reorg && tag === finalizedNumber
-          ? `0x${'cc'.repeat(32)}`
-          : historicalHash,
-      };
-    },
+    getBlock: (tag: string | number) => scenario.getBlock(tag),
     getNetwork: async () => ({ chainId: 31337n }),
   };
   adapter.contracts = {
@@ -213,50 +139,16 @@ function makeEvmAuthorityAdapter(
     evidence.deploymentReads.push([address, operation, label]);
     return { fromBlock: 7, head: 30, scanProviders: [] };
   };
-  const advanceAuthorityHead = () => {
-    finalizedNumber = 35;
-    finalizedHash = NEXT_FINALIZED_HASH;
-    logs.PublishPolicyUpdated.push(event(33, 0, NEXT_POLICY_HASH));
-    current.publishPolicy = 1n;
-    current[6] = 1n;
-    current.publishAuthority = ethers.ZeroAddress;
-    current[7] = ethers.ZeroAddress;
-    current.publishAuthorityAccountId = 0n;
-    current[8] = 0n;
-  };
-  const replaceCachedAnchor = () => {
-    cachedAnchorReplaced = true;
-  };
   return {
     adapter: adapter as EVMChainAdapter,
     evidence,
     provider,
-    advanceAuthorityHead,
-    replaceCachedAnchor,
-    replaceFinalizedHead: () => {
-      finalizedHash = REPLACEMENT_FINALIZED_HASH;
-      cachedAnchorReplaced = true;
-    },
-    holdCurrentStateRead: () => {
-      const entered = Promise.withResolvers<void>();
-      const release = Promise.withResolvers<void>();
-      currentReadGate = {
-        promise: release.promise,
-        resolve: entered.resolve,
-        reject: release.reject,
-      };
-      return { entered: entered.promise, release: release.resolve };
-    },
-    holdBlockRead: (tag) => {
-      const entered = Promise.withResolvers<void>();
-      const release = Promise.withResolvers<void>();
-      blockReadGate = { tag, entered, release };
-      return { entered: entered.promise, release: release.resolve };
-    },
-    setPublishAuthorityAccountId: (value) => {
-      current.publishAuthorityAccountId = value;
-      current[8] = value;
-    },
+    advanceAuthorityHead: scenario.advanceAuthorityHead,
+    replaceCachedAnchor: scenario.replaceCachedAnchor,
+    replaceFinalizedHead: scenario.replaceFinalizedHead,
+    holdCurrentStateRead: scenario.holdCurrentStateRead,
+    holdBlockRead: scenario.holdBlockRead,
+    setPublishAuthorityAccountId: scenario.setPublishAuthorityAccountId,
     rotateContextGraphStorage: () => adapter.applyHubRotationEventName('ContextGraphStorage'),
   };
 }

--- a/packages/chain/test/helpers/context-graph-authority-index.ts
+++ b/packages/chain/test/helpers/context-graph-authority-index.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ContextGraphAuthorityIndexStore } from
+  '../../src/context-graph-authority-index-checkpoint.js';
+
+/** Small reusable CAS store; scenario-specific gates belong in their owning suite. */
+export class MemoryAuthorityIndexStore implements ContextGraphAuthorityIndexStore {
+  record: Readonly<{ token: number; value: unknown | null }> | undefined;
+  readonly commits: number[] = [];
+  readonly invalidations: number[] = [];
+
+  async load(): Promise<Readonly<{ token: number; value: unknown | null }> | undefined> {
+    return this.record;
+  }
+
+  async compareAndSwap(
+    _scope: string,
+    expectedToken: number | undefined,
+    value: unknown,
+  ): Promise<number | undefined> {
+    if (this.record?.token !== expectedToken) return undefined;
+    const nextToken = expectedToken === undefined ? 1 : expectedToken + 1;
+    this.record = Object.freeze({ token: nextToken, value });
+    this.commits.push(nextToken);
+    return nextToken;
+  }
+
+  async invalidate(_scope: string, expectedToken: number): Promise<number | undefined> {
+    if (this.record?.token !== expectedToken) return undefined;
+    const nextToken = expectedToken + 1;
+    this.record = Object.freeze({ token: nextToken, value: null });
+    this.invalidations.push(nextToken);
+    return nextToken;
+  }
+}
+
+export interface AbortableTipReaderOptions {
+  readonly signal?: AbortSignal;
+}
+
+/** Preserve caller cancellation while leaving the provider-owned read physically shared. */
+export function createAbortableTipReader<Provider>(
+  provider: Provider,
+  observeOptions: (options: AbortableTipReaderOptions) => void = () => undefined,
+) {
+  return async <T>(
+    _label: string,
+    read: (provider: Provider) => Promise<T>,
+    options: AbortableTipReaderOptions,
+  ): Promise<T> => {
+    observeOptions(options);
+    const pending = read(provider);
+    const signal = options.signal;
+    if (signal === undefined) return pending;
+    return new Promise<T>((resolve, reject) => {
+      const onAbort = () => reject(signal.reason);
+      signal.addEventListener('abort', onAbort, { once: true });
+      void pending.then(resolve, reject).finally(() => {
+        signal.removeEventListener('abort', onAbort);
+      });
+    });
+  };
+}

--- a/packages/chain/test/helpers/context-graph-authority-scenario.ts
+++ b/packages/chain/test/helpers/context-graph-authority-scenario.ts
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { ethers } from 'ethers';
+
+export const OWNER = '0x1111111111111111111111111111111111111111';
+export const MEMBER = '0x2222222222222222222222222222222222222222';
+export const AUTHORITY = '0x3333333333333333333333333333333333333333';
+export const GOVERNANCE = '0x4444444444444444444444444444444444444444';
+export const SECOND_MEMBER = '0x5555555555555555555555555555555555555555';
+export const SECOND_AUTHORITY = '0x6666666666666666666666666666666666666666';
+export const FINALIZED_HASH = `0x${'55'.repeat(32)}`;
+export const NEXT_FINALIZED_HASH = `0x${'56'.repeat(32)}`;
+export const REPLACEMENT_FINALIZED_HASH = `0x${'cc'.repeat(32)}`;
+export const CREATION_HASH = `0x${'66'.repeat(32)}`;
+export const POLICY_HASH = `0x${'77'.repeat(32)}`;
+export const NEXT_POLICY_HASH = `0x${'78'.repeat(32)}`;
+export const NAME_HASH = `0x${'88'.repeat(32)}`;
+
+interface AuthorityScenarioEvent {
+  readonly name: string;
+  readonly blockNumber: number;
+  readonly blockHash: string;
+  readonly index: number;
+  readonly positionalArgs: readonly unknown[];
+  readonly namedArgs: Readonly<Record<string, unknown>>;
+}
+
+export interface AuthorityScenarioOptions {
+  readonly deactivated?: boolean;
+  readonly reorg?: boolean;
+}
+
+export interface AuthorityScenarioGate {
+  readonly entered: Promise<void>;
+  release(): void;
+}
+
+/**
+ * Canonical protocol scenario shared by the legacy and indexed readers.
+ * Renderers below deliberately differ only at their RPC boundary shape.
+ */
+export function createAuthorityScenario(options: AuthorityScenarioOptions = {}) {
+  let finalizedNumber = 30;
+  let finalizedHash = FINALIZED_HASH;
+  let cachedAnchorReplaced = false;
+  let replacementAuthorityFork = false;
+  let currentReadGate: Readonly<{
+    entered: PromiseWithResolvers<void>;
+    release: PromiseWithResolvers<void>;
+  }> | undefined;
+  let blockReadGate: Readonly<{
+    tag: string | number;
+    entered: PromiseWithResolvers<void>;
+    release: PromiseWithResolvers<void>;
+  }> | undefined;
+
+  const current = Object.assign(
+    [OWNER, [MEMBER, OWNER], 0n, !options.deactivated, 0n, 1n, 0n, AUTHORITY, 7n],
+    {
+      owner: OWNER,
+      participantAgents: [MEMBER, OWNER],
+      active: !options.deactivated,
+      accessPolicy: 1n,
+      publishPolicy: 0n,
+      publishAuthority: AUTHORITY,
+      publishAuthorityAccountId: 7n as unknown,
+    },
+  );
+
+  const events = (): AuthorityScenarioEvent[] => {
+    const forkOwner = replacementAuthorityFork ? MEMBER : SECOND_MEMBER;
+    const forkParticipants = replacementAuthorityFork
+      ? [MEMBER]
+      : [MEMBER, SECOND_MEMBER];
+    const rows: AuthorityScenarioEvent[] = [
+      {
+        name: 'ContextGraphCreated',
+        blockNumber: 10,
+        blockHash: CREATION_HASH,
+        index: 1,
+        positionalArgs: [
+          9n,
+          forkOwner,
+          NAME_HASH,
+          forkParticipants,
+          0n,
+          1n,
+          0n,
+          AUTHORITY,
+          7n,
+        ],
+        namedArgs: {
+          contextGraphId: 9n,
+          owner: forkOwner,
+          nameHash: NAME_HASH,
+          participantAgents: forkParticipants,
+          accessPolicy: 1n,
+          publishPolicy: 0n,
+          publishAuthority: AUTHORITY,
+          publishAuthorityAccountId: 7n,
+        },
+      },
+      {
+        name: 'Transfer',
+        blockNumber: 10,
+        blockHash: CREATION_HASH,
+        index: 0,
+        positionalArgs: [ethers.ZeroAddress, forkOwner, 9n],
+        namedArgs: { from: ethers.ZeroAddress, to: forkOwner, tokenId: 9n },
+      },
+      {
+        name: 'Transfer',
+        blockNumber: 15,
+        blockHash: `0x${'99'.repeat(32)}`,
+        index: 0,
+        positionalArgs: [SECOND_MEMBER, OWNER, 9n],
+        namedArgs: { from: SECOND_MEMBER, to: OWNER, tokenId: 9n },
+      },
+      {
+        name: 'PublishPolicyUpdated',
+        blockNumber: 20,
+        blockHash: POLICY_HASH,
+        index: 0,
+        positionalArgs: [9n, 0n, SECOND_AUTHORITY, 9n],
+        namedArgs: {
+          contextGraphId: 9n,
+          publishPolicy: 0n,
+          publishAuthority: SECOND_AUTHORITY,
+          publishAuthorityAccountId: 9n,
+        },
+      },
+      {
+        name: 'PublishAuthorityUpdated',
+        blockNumber: 21,
+        blockHash: POLICY_HASH,
+        index: 0,
+        positionalArgs: [9n, AUTHORITY, 7n],
+        namedArgs: {
+          contextGraphId: 9n,
+          newAuthority: AUTHORITY,
+          newAuthorityAccountId: 7n,
+        },
+      },
+      {
+        name: 'AgentParticipantAdded',
+        blockNumber: 22,
+        blockHash: `0x${'aa'.repeat(32)}`,
+        index: 0,
+        positionalArgs: [9n, OWNER],
+        namedArgs: { contextGraphId: 9n, agent: OWNER },
+      },
+      {
+        name: 'AgentParticipantRemoved',
+        blockNumber: 23,
+        blockHash: `0x${'bb'.repeat(32)}`,
+        index: 0,
+        positionalArgs: [9n, SECOND_MEMBER],
+        namedArgs: { contextGraphId: 9n, agent: SECOND_MEMBER },
+      },
+      ...(options.deactivated ? [{
+        name: 'ContextGraphDeactivated',
+        blockNumber: 24,
+        blockHash: `0x${'bc'.repeat(32)}`,
+        index: 0,
+        positionalArgs: [9n],
+        namedArgs: { contextGraphId: 9n },
+      }] : []),
+      {
+        name: 'PublishPolicyUpdated',
+        blockNumber: 33,
+        blockHash: NEXT_POLICY_HASH,
+        index: 0,
+        positionalArgs: [9n, 1n, ethers.ZeroAddress, 0n],
+        namedArgs: {
+          contextGraphId: 9n,
+          publishPolicy: 1n,
+          publishAuthority: ethers.ZeroAddress,
+          publishAuthorityAccountId: 0n,
+        },
+      },
+    ];
+    if (!replacementAuthorityFork) return rows;
+    return rows.filter((row) => (
+      row.name === 'ContextGraphCreated'
+      || (row.name === 'Transfer' && row.blockNumber === 10)
+    ));
+  };
+
+  return {
+    get finalizedNumber() { return finalizedNumber; },
+    renderQueryFilter(name: string, fromBlock: number, toBlock: number) {
+      return events()
+        .filter((row) => (
+          row.name === name
+          && row.blockNumber >= fromBlock
+          && row.blockNumber <= toBlock
+        ))
+        .map((row) => ({
+          blockNumber: row.blockNumber,
+          blockHash: row.blockHash,
+          index: row.index,
+          args: [...row.positionalArgs],
+        }));
+    },
+    renderParsedLogs(fromBlock: number, toBlock: number) {
+      return events()
+        .filter((row) => row.blockNumber >= fromBlock && row.blockNumber <= toBlock)
+        .map((row) => ({
+          blockNumber: row.blockNumber,
+          blockHash: row.blockHash,
+          index: row.index,
+          parsed: {
+            name: row.name,
+            args: Object.assign([...row.positionalArgs], row.namedArgs),
+          },
+        }));
+    },
+    async readCurrentState() {
+      const gate = currentReadGate;
+      if (gate !== undefined) {
+        currentReadGate = undefined;
+        gate.entered.resolve();
+        await gate.release.promise;
+      }
+      return current;
+    },
+    async getBlock(tag: string | number) {
+      const gate = blockReadGate;
+      if (gate?.tag === tag) {
+        blockReadGate = undefined;
+        gate.entered.resolve();
+        await gate.release.promise;
+      }
+      if (tag === 'finalized') return { number: finalizedNumber, hash: finalizedHash };
+      const historicalHash = tag === 30 && cachedAnchorReplaced
+        ? REPLACEMENT_FINALIZED_HASH
+        : tag === 30
+          ? FINALIZED_HASH
+          : finalizedHash;
+      return {
+        number: Number(tag),
+        hash: options.reorg && tag === finalizedNumber
+          ? REPLACEMENT_FINALIZED_HASH
+          : historicalHash,
+      };
+    },
+    advanceAuthorityHead(): void {
+      finalizedNumber = 35;
+      finalizedHash = NEXT_FINALIZED_HASH;
+      current.publishPolicy = 1n;
+      current[6] = 1n;
+      current.publishAuthority = ethers.ZeroAddress;
+      current[7] = ethers.ZeroAddress;
+      current.publishAuthorityAccountId = 0n;
+      current[8] = 0n;
+    },
+    replaceCachedAnchor(): void {
+      cachedAnchorReplaced = true;
+    },
+    replaceFinalizedHead(): void {
+      finalizedHash = REPLACEMENT_FINALIZED_HASH;
+      cachedAnchorReplaced = true;
+    },
+    replaceAuthorityFork(): void {
+      finalizedHash = REPLACEMENT_FINALIZED_HASH;
+      cachedAnchorReplaced = true;
+      replacementAuthorityFork = true;
+    },
+    holdCurrentStateRead(): AuthorityScenarioGate {
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      currentReadGate = { entered, release };
+      return { entered: entered.promise, release: release.resolve };
+    },
+    holdBlockRead(tag: string | number): AuthorityScenarioGate {
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      blockReadGate = { tag, entered, release };
+      return { entered: entered.promise, release: release.resolve };
+    },
+    setPublishAuthorityAccountId(value: unknown): void {
+      current.publishAuthorityAccountId = value;
+      current[8] = value;
+    },
+  };
+}

--- a/packages/chain/test/helpers/context-graph-authority-scenario.ts
+++ b/packages/chain/test/helpers/context-graph-authority-scenario.ts
@@ -16,13 +16,154 @@ export const POLICY_HASH = `0x${'77'.repeat(32)}`;
 export const NEXT_POLICY_HASH = `0x${'78'.repeat(32)}`;
 export const NAME_HASH = `0x${'88'.repeat(32)}`;
 
-interface AuthorityScenarioEvent {
-  readonly name: string;
+interface AuthorityScenarioCurrentState {
+  owner: string;
+  participantAgents: readonly string[];
+  metadataBatchId: bigint;
+  active: boolean;
+  createdAt: bigint;
+  accessPolicy: bigint;
+  publishPolicy: bigint;
+  publishAuthority: string;
+  publishAuthorityAccountId: bigint;
+}
+
+interface AuthorityScenarioEventBase {
   readonly blockNumber: number;
   readonly blockHash: string;
   readonly index: number;
-  readonly positionalArgs: readonly unknown[];
-  readonly namedArgs: Readonly<Record<string, unknown>>;
+}
+
+type AuthorityScenarioEvent =
+  | (AuthorityScenarioEventBase & Readonly<{
+      name: 'ContextGraphCreated';
+      contextGraphId: bigint;
+      owner: string;
+      nameHash: string;
+      participantAgents: readonly string[];
+      accessPolicy: bigint;
+      publishPolicy: bigint;
+      publishAuthority: string;
+      publishAuthorityAccountId: bigint;
+    }>)
+  | (AuthorityScenarioEventBase & Readonly<{
+      name: 'ContextGraphDeactivated';
+      contextGraphId: bigint;
+    }>)
+  | (AuthorityScenarioEventBase & Readonly<{
+      name: 'Transfer';
+      from: string;
+      to: string;
+      tokenId: bigint;
+    }>)
+  | (AuthorityScenarioEventBase & Readonly<{
+      name: 'PublishPolicyUpdated';
+      contextGraphId: bigint;
+      publishPolicy: bigint;
+      publishAuthority: string;
+      publishAuthorityAccountId: bigint;
+    }>)
+  | (AuthorityScenarioEventBase & Readonly<{
+      name: 'PublishAuthorityUpdated';
+      contextGraphId: bigint;
+      newAuthority: string;
+      newAuthorityAccountId: bigint;
+    }>)
+  | (AuthorityScenarioEventBase & Readonly<{
+      name: 'AgentParticipantAdded' | 'AgentParticipantRemoved';
+      contextGraphId: bigint;
+      agent: string;
+    }>);
+
+function renderCurrentState(
+  state: AuthorityScenarioCurrentState,
+  publishAuthorityAccountId: unknown = state.publishAuthorityAccountId,
+) {
+  return Object.assign([
+    state.owner,
+    [...state.participantAgents],
+    state.metadataBatchId,
+    state.active,
+    state.createdAt,
+    state.accessPolicy,
+    state.publishPolicy,
+    state.publishAuthority,
+    publishAuthorityAccountId,
+  ], {
+    owner: state.owner,
+    participantAgents: [...state.participantAgents],
+    metadataBatchId: state.metadataBatchId,
+    active: state.active,
+    createdAt: state.createdAt,
+    accessPolicy: state.accessPolicy,
+    publishPolicy: state.publishPolicy,
+    publishAuthority: state.publishAuthority,
+    publishAuthorityAccountId,
+  });
+}
+
+function renderEventArgs(event: AuthorityScenarioEvent) {
+  switch (event.name) {
+    case 'ContextGraphCreated':
+      return Object.assign([
+        event.contextGraphId,
+        event.owner,
+        event.nameHash,
+        [...event.participantAgents],
+        0n,
+        event.accessPolicy,
+        event.publishPolicy,
+        event.publishAuthority,
+        event.publishAuthorityAccountId,
+      ], {
+        contextGraphId: event.contextGraphId,
+        owner: event.owner,
+        nameHash: event.nameHash,
+        participantAgents: [...event.participantAgents],
+        accessPolicy: event.accessPolicy,
+        publishPolicy: event.publishPolicy,
+        publishAuthority: event.publishAuthority,
+        publishAuthorityAccountId: event.publishAuthorityAccountId,
+      });
+    case 'ContextGraphDeactivated':
+      return Object.assign([event.contextGraphId], {
+        contextGraphId: event.contextGraphId,
+      });
+    case 'Transfer':
+      return Object.assign([event.from, event.to, event.tokenId], {
+        from: event.from,
+        to: event.to,
+        tokenId: event.tokenId,
+      });
+    case 'PublishPolicyUpdated':
+      return Object.assign([
+        event.contextGraphId,
+        event.publishPolicy,
+        event.publishAuthority,
+        event.publishAuthorityAccountId,
+      ], {
+        contextGraphId: event.contextGraphId,
+        publishPolicy: event.publishPolicy,
+        publishAuthority: event.publishAuthority,
+        publishAuthorityAccountId: event.publishAuthorityAccountId,
+      });
+    case 'PublishAuthorityUpdated':
+      return Object.assign([
+        event.contextGraphId,
+        event.newAuthority,
+        event.newAuthorityAccountId,
+      ], {
+        contextGraphId: event.contextGraphId,
+        newAuthority: event.newAuthority,
+        newAuthorityAccountId: event.newAuthorityAccountId,
+      });
+    case 'AgentParticipantAdded':
+    case 'AgentParticipantRemoved':
+      return Object.assign([event.contextGraphId, event.agent], {
+        contextGraphId: event.contextGraphId,
+        agent: event.agent,
+      });
+  }
 }
 
 export interface AuthorityScenarioOptions {
@@ -54,18 +195,18 @@ export function createAuthorityScenario(options: AuthorityScenarioOptions = {}) 
     release: PromiseWithResolvers<void>;
   }> | undefined;
 
-  const current = Object.assign(
-    [OWNER, [MEMBER, OWNER], 0n, !options.deactivated, 0n, 1n, 0n, AUTHORITY, 7n],
-    {
-      owner: OWNER,
-      participantAgents: [MEMBER, OWNER],
-      active: !options.deactivated,
-      accessPolicy: 1n,
-      publishPolicy: 0n,
-      publishAuthority: AUTHORITY,
-      publishAuthorityAccountId: 7n as unknown,
-    },
-  );
+  const current: AuthorityScenarioCurrentState = {
+    owner: OWNER,
+    participantAgents: [MEMBER, OWNER],
+    metadataBatchId: 0n,
+    active: !options.deactivated,
+    createdAt: 0n,
+    accessPolicy: 1n,
+    publishPolicy: 0n,
+    publishAuthority: AUTHORITY,
+    publishAuthorityAccountId: 7n,
+  };
+  let malformedPublishAuthorityAccountId: unknown | undefined;
 
   const events = (): AuthorityScenarioEvent[] => {
     const forkOwner = replacementAuthorityFork ? MEMBER : SECOND_MEMBER;
@@ -78,105 +219,84 @@ export function createAuthorityScenario(options: AuthorityScenarioOptions = {}) 
         blockNumber: 10,
         blockHash: CREATION_HASH,
         index: 1,
-        positionalArgs: [
-          9n,
-          forkOwner,
-          NAME_HASH,
-          forkParticipants,
-          0n,
-          1n,
-          0n,
-          AUTHORITY,
-          7n,
-        ],
-        namedArgs: {
-          contextGraphId: 9n,
-          owner: forkOwner,
-          nameHash: NAME_HASH,
-          participantAgents: forkParticipants,
-          accessPolicy: 1n,
-          publishPolicy: 0n,
-          publishAuthority: AUTHORITY,
-          publishAuthorityAccountId: 7n,
-        },
+        contextGraphId: 9n,
+        owner: forkOwner,
+        nameHash: NAME_HASH,
+        participantAgents: forkParticipants,
+        accessPolicy: 1n,
+        publishPolicy: 0n,
+        publishAuthority: AUTHORITY,
+        publishAuthorityAccountId: 7n,
       },
       {
         name: 'Transfer',
         blockNumber: 10,
         blockHash: CREATION_HASH,
         index: 0,
-        positionalArgs: [ethers.ZeroAddress, forkOwner, 9n],
-        namedArgs: { from: ethers.ZeroAddress, to: forkOwner, tokenId: 9n },
+        from: ethers.ZeroAddress,
+        to: forkOwner,
+        tokenId: 9n,
       },
       {
         name: 'Transfer',
         blockNumber: 15,
         blockHash: `0x${'99'.repeat(32)}`,
         index: 0,
-        positionalArgs: [SECOND_MEMBER, OWNER, 9n],
-        namedArgs: { from: SECOND_MEMBER, to: OWNER, tokenId: 9n },
+        from: SECOND_MEMBER,
+        to: OWNER,
+        tokenId: 9n,
       },
       {
         name: 'PublishPolicyUpdated',
         blockNumber: 20,
         blockHash: POLICY_HASH,
         index: 0,
-        positionalArgs: [9n, 0n, SECOND_AUTHORITY, 9n],
-        namedArgs: {
-          contextGraphId: 9n,
-          publishPolicy: 0n,
-          publishAuthority: SECOND_AUTHORITY,
-          publishAuthorityAccountId: 9n,
-        },
+        contextGraphId: 9n,
+        publishPolicy: 0n,
+        publishAuthority: SECOND_AUTHORITY,
+        publishAuthorityAccountId: 9n,
       },
       {
         name: 'PublishAuthorityUpdated',
         blockNumber: 21,
         blockHash: POLICY_HASH,
         index: 0,
-        positionalArgs: [9n, AUTHORITY, 7n],
-        namedArgs: {
-          contextGraphId: 9n,
-          newAuthority: AUTHORITY,
-          newAuthorityAccountId: 7n,
-        },
+        contextGraphId: 9n,
+        newAuthority: AUTHORITY,
+        newAuthorityAccountId: 7n,
       },
       {
         name: 'AgentParticipantAdded',
         blockNumber: 22,
         blockHash: `0x${'aa'.repeat(32)}`,
         index: 0,
-        positionalArgs: [9n, OWNER],
-        namedArgs: { contextGraphId: 9n, agent: OWNER },
+        contextGraphId: 9n,
+        agent: OWNER,
       },
       {
         name: 'AgentParticipantRemoved',
         blockNumber: 23,
         blockHash: `0x${'bb'.repeat(32)}`,
         index: 0,
-        positionalArgs: [9n, SECOND_MEMBER],
-        namedArgs: { contextGraphId: 9n, agent: SECOND_MEMBER },
+        contextGraphId: 9n,
+        agent: SECOND_MEMBER,
       },
       ...(options.deactivated ? [{
         name: 'ContextGraphDeactivated',
         blockNumber: 24,
         blockHash: `0x${'bc'.repeat(32)}`,
         index: 0,
-        positionalArgs: [9n],
-        namedArgs: { contextGraphId: 9n },
+        contextGraphId: 9n,
       }] : []),
       {
         name: 'PublishPolicyUpdated',
         blockNumber: 33,
         blockHash: NEXT_POLICY_HASH,
         index: 0,
-        positionalArgs: [9n, 1n, ethers.ZeroAddress, 0n],
-        namedArgs: {
-          contextGraphId: 9n,
-          publishPolicy: 1n,
-          publishAuthority: ethers.ZeroAddress,
-          publishAuthorityAccountId: 0n,
-        },
+        contextGraphId: 9n,
+        publishPolicy: 1n,
+        publishAuthority: ethers.ZeroAddress,
+        publishAuthorityAccountId: 0n,
       },
     ];
     if (!replacementAuthorityFork) return rows;
@@ -199,7 +319,7 @@ export function createAuthorityScenario(options: AuthorityScenarioOptions = {}) 
           blockNumber: row.blockNumber,
           blockHash: row.blockHash,
           index: row.index,
-          args: [...row.positionalArgs],
+          args: renderEventArgs(row),
         }));
     },
     renderParsedLogs(fromBlock: number, toBlock: number) {
@@ -211,7 +331,7 @@ export function createAuthorityScenario(options: AuthorityScenarioOptions = {}) 
           index: row.index,
           parsed: {
             name: row.name,
-            args: Object.assign([...row.positionalArgs], row.namedArgs),
+            args: renderEventArgs(row),
           },
         }));
     },
@@ -222,7 +342,7 @@ export function createAuthorityScenario(options: AuthorityScenarioOptions = {}) 
         gate.entered.resolve();
         await gate.release.promise;
       }
-      return current;
+      return renderCurrentState(current, malformedPublishAuthorityAccountId);
     },
     async getBlock(tag: string | number) {
       const gate = blockReadGate;
@@ -248,11 +368,8 @@ export function createAuthorityScenario(options: AuthorityScenarioOptions = {}) 
       finalizedNumber = 35;
       finalizedHash = NEXT_FINALIZED_HASH;
       current.publishPolicy = 1n;
-      current[6] = 1n;
       current.publishAuthority = ethers.ZeroAddress;
-      current[7] = ethers.ZeroAddress;
       current.publishAuthorityAccountId = 0n;
-      current[8] = 0n;
     },
     replaceCachedAnchor(): void {
       cachedAnchorReplaced = true;
@@ -279,8 +396,7 @@ export function createAuthorityScenario(options: AuthorityScenarioOptions = {}) 
       return { entered: entered.promise, release: release.resolve };
     },
     setPublishAuthorityAccountId(value: unknown): void {
-      current.publishAuthorityAccountId = value;
-      current[8] = value;
+      malformedPublishAuthorityAccountId = value;
     },
   };
 }


### PR DESCRIPTION
## Summary

This follow-up completes the post-merge authority-index review work without changing the RFC-64 authority feature set:

- durable checkpoint admission now uses one direct, explicitly bounded recovery loop rather than a tagged-action classifier/interpreter pair;
- repository intent operations own cache-epoch capture, current-record eviction, conditional invalidation, compare-and-swap, and durable-winner reloads;
- three lost invalidation races now allow all three durable winners to be reloaded and classified, while a fourth invalidation is prevented;
- repository lifecycle tests prove an old asynchronous load cannot republish stale cache state after `clear()`;
- indexed authority-snapshot scenarios remain isolated in their focused typed harness, separate from the legacy/current-state snapshot suite.

The externally visible behavior remains the same: daemon-backed authority lookups use the durable contract-wide index, SDK consumers without the local store retain the legacy per-graph path, and authority generations are derived by the same canonical reducer.

Review context:

- [Original checkpoint admission/recovery review](https://github.com/OriginTrail/dkg/pull/2554#discussion_r3984112514)
- [Original indexed snapshot-suite split review](https://github.com/OriginTrail/dkg/pull/2554#discussion_r3984221854)
- [Third-winner reload bound](https://github.com/OriginTrail/dkg/pull/2558#discussion_r3984479078)
- [Direct recovery-loop simplification](https://github.com/OriginTrail/dkg/pull/2558#discussion_r3984479090)
- [Repository cache-consistency boundary](https://github.com/OriginTrail/dkg/pull/2558#discussion_r3984479100)
- [Clear-during-deferred-load regression](https://github.com/OriginTrail/dkg/pull/2558#discussion_r3984479105)

## User and operator impact

There is no configuration, schema, public API, or RPC request-shape change. Existing durable checkpoints remain compatible and no reset or migration is required.

The operational effect is more predictable recovery under concurrency and lifecycle changes:

- a valid checkpoint installed by the third concurrent winner is accepted immediately, without starting a page scan;
- perpetually rejected winners terminate with a retryable error before a fourth invalidation can be attempted;
- lagging heads and endpoints that cannot serve an older anchor remain retryable observations and do not delete a valid durable prefix;
- lifecycle reset prevents work started in an earlier epoch from restoring stale process-cache state;
- callers no longer have to sequence internal epoch values, forced durable reads, reference-identity eviction, or winner reloads.

## Admission and recovery flow

The admission path has one loop and one concurrency bound. Terminal observations return immediately; rejected observations enter one repository-owned invalidate-or-reload operation.

```mermaid
flowchart TD
    A[Repository loads durable observation] --> B{Direct admission loop}
    B -->|missing or tombstone| C[Rebuild from deployment block]
    B -->|valid deployment and anchor| D[Accept checkpoint]
    B -->|head behind cursor| E[Retry another read path without mutation]
    B -->|anchor unavailable| E
    B -->|corrupt, deployment changed, or anchor replaced| F{Three lost invalidations already?}
    F -->|yes| G[Return retryable bounded failure]
    F -->|no| H[Repository invalidates observed token]
    H -->|invalidation wins| C
    H -->|another writer wins| I[Repository reloads durable winner]
    I --> B
```

The guard is evaluated only when another invalidation would be required. Consequently, the winner of the third lost invalidation is always reloaded and classified: a valid winner is accepted, while another rejected winner reaches the bound without a fourth mutation attempt.

## Repository boundary

```mermaid
sequenceDiagram
    participant S as Scanner / admission
    participant R as Authority-index repository
    participant D as Durable store

    S->>R: load(scope)
    Note over R: Capture current cache epoch
    R->>D: load(scope)
    D-->>R: token + durable value
    R-->>S: decoded record

    alt Record is rejected
        S->>R: invalidateOrReloadWinner(scope, record)
        Note over R: Evict only the observed cache identity
        R->>D: invalidate(scope, observed token)
        alt Conditional invalidation wins
            D-->>R: tombstone token
            R-->>S: invalidated tombstone
        else Another writer wins
            D-->>R: no token
            R->>D: forced durable reload
            D-->>R: winning token + value
            R-->>S: decoded winner
        end
    else Reduced page is ready
        S->>R: commitOrReloadWinner(scope, previous, checkpoint)
        R->>D: compareAndSwap(previous token, checkpoint)
        alt Commit wins
            D-->>R: committed token
            R-->>S: committed checkpoint
        else Another writer wins
            D-->>R: no token
            R->>D: forced durable reload
            R-->>S: decoded winner
        end
    end
```

Every asynchronous repository operation captures its own epoch before awaiting. Cache publication is permitted only if that epoch is still current, and an old-epoch reload cannot evict a newer lifecycle's cache entry.

## Safety and fallback behavior

- **ABA-safe persistence:** store-owned tokens remain positive and non-repeating; stale writers cannot reuse an invalidated record identity.
- **Winner preservation:** a lost invalidation or checkpoint CAS never overwrites the newer durable winner; repository operations reload and decode it before returning.
- **Bounded recovery:** exactly three lost invalidations may reload three winners. A fourth invalidation is never attempted.
- **Tombstone recovery:** corrupt payloads, changed deployments, and proven fork replacements are conditionally tombstoned before rebuilding.
- **Read-path safety:** a finalized head behind the cursor or an unavailable historical anchor is retryable and cannot invalidate the checkpoint.
- **Fork isolation:** an in-flight scan continues from the checkpoint it reduced and admitted; unrelated process-cache entries are not adopted implicitly.
- **Cancellation:** caller cancellation detaches only that waiter; lifecycle clear aborts shared transport and advances the repository epoch.
- **Cache lifecycle:** operations begun before clear may return to their already-running caller, but cannot publish into or evict entries from the new lifecycle cache.

## Focused test-suite split

`context-graph-authority-snapshot.unit.test.ts` contains only the legacy/current-state snapshot scenarios. The eight indexed-source scenarios live in `context-graph-authority-indexed-snapshot.unit.test.ts` behind the dedicated typed `IndexedAuthorityHarness`.

The split preserves assertions for combined contract-wide page reads, warm reuse, reorg fencing, conditional invalidation, replacement-fork rebuild, cancellation, detached waiters, lagging/non-archive read paths, and deactivation materialization. Shared helpers are limited to the reusable in-memory CAS store and abort-aware read fixture.

New repository and scanner regressions additionally cover:

- a valid canonical checkpoint installed by the third invalidation winner;
- three perpetually rejected winners followed by refusal of a fourth invalidation;
- invalidation-loss and checkpoint-CAS-loss winner reloads;
- an old deferred load completing after `clear()` without republishing token 1 over current token 2.

## Compatibility and rollback

- Durable checkpoint encoding, token semantics, SQLite schema, and `ContextGraphAuthorityIndexStore` remain unchanged.
- Existing checkpoints are decoded by the same validator and reduced through the same canonical transition model.
- SDK callers without a daemon-local index continue through the existing fallback path.
- No operator action is required for rollout.
- Rollback is code-only: reverting the follow-up commits restores the previous orchestration and test layout without changing persisted rows.

## Validation

Run with Node.js 22.23.1:

- Chain and affected dependency builds, including TypeScript type tests, passed.
- Focused admission, repository, scanner, legacy snapshot, and indexed snapshot suites: **39/39 passed**.
- Full chain unit suite: **1,235 passed, 1 existing skip** across 76 files.
- Real Hardhat authority-snapshot integration: **1/1 passed**.
- Agent chain-cursor wiring: **2/2 passed**.
- Node UI SQLite DB suite: **122/122 passed**.
- `pnpm lint` and `git diff --check` passed.

## Review guide

1. Start with `context-graph-authority-index-admission.ts` for the single bounded recovery loop and third-winner behavior.
2. Review `context-graph-authority-index-repository.ts` for epoch ownership and intent-level invalidate/CAS winner handling.
3. Review `context-graph-authority-index.ts` for the reduced scanner orchestration.
4. Review the scanner and repository regressions for concurrency, epoch, and retry-bound guarantees.
5. Review the separated snapshot suites and typed harness to confirm scenario ownership remains focused.
